### PR TITLE
fix(backend): escape identifiers in pivot query builder

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -2403,8 +2403,11 @@ export class MetricQueryBuilder {
                 requiresQueryInCTE = true;
 
                 fieldSort = sortMonthName(
-                    sortedDimension,
-                    warehouseSqlBuilder.getFieldQuoteChar(),
+                    quoteFieldReference(
+                        getItemId(sortedDimension),
+                        warehouseSqlBuilder.getFieldQuoteChar(),
+                        warehouseSqlBuilder.getAdapterType(),
+                    ),
                     sort.descending,
                 );
             } else if (
@@ -2416,9 +2419,12 @@ export class MetricQueryBuilder {
                 // for consistency, we do it for all warehouses
                 requiresQueryInCTE = true;
                 fieldSort = sortDayOfWeekName(
-                    sortedDimension,
+                    quoteFieldReference(
+                        getItemId(sortedDimension),
+                        warehouseSqlBuilder.getFieldQuoteChar(),
+                        warehouseSqlBuilder.getAdapterType(),
+                    ),
                     startOfWeek,
-                    warehouseSqlBuilder.getFieldQuoteChar(),
                     sort.descending,
                 );
             } else if (

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -1860,6 +1860,159 @@ describe('PivotQueryBuilder', () => {
         });
     });
 
+    describe('Identifier quoting', () => {
+        test('escapes dynamic identifiers through grouped aggregation and sorting', () => {
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                {
+                    indexColumn: [
+                        {
+                            reference: 'row"dim',
+                            type: VizIndexType.CATEGORY,
+                        },
+                    ],
+                    valuesColumns: [
+                        {
+                            reference: 'amount"value',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                    ],
+                    groupByColumns: [{ reference: 'group"dim' }],
+                    sortBy: [
+                        {
+                            reference: 'row"dim',
+                            direction: SortByDirection.ASC,
+                        },
+                    ],
+                },
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = replaceWhitespace(builder.toSql());
+
+            expect(result).toContain(
+                'SELECT "group""dim", "row""dim", sum("amount""value") AS "amount""value_sum"',
+            );
+            expect(result).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."row""dim" ASC)',
+            );
+            expect(result).not.toContain('g."row"dim" ASC');
+        });
+
+        test('quotes a custom-bin _order identifier after composing its name', () => {
+            const reference = 'amount"bin';
+            const binDimension: CustomBinDimension = {
+                id: reference,
+                name: reference,
+                table: 'orders',
+                type: CustomDimensionType.BIN,
+                dimensionId: 'orders_amount',
+                binType: BinType.FIXED_WIDTH,
+                binWidth: 10,
+            };
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                {
+                    indexColumn: [{ reference, type: VizIndexType.CATEGORY }],
+                    valuesColumns: [
+                        {
+                            reference: 'revenue',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                    ],
+                    groupByColumns: [{ reference: 'event_type' }],
+                    sortBy: [{ reference, direction: SortByDirection.ASC }],
+                },
+                mockWarehouseSqlBuilder,
+                500,
+                { [reference]: binDimension },
+            );
+
+            const result = replaceWhitespace(builder.toSql());
+
+            expect(result).toContain('"amount""bin_order"');
+            expect(result).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."amount""bin_order" ASC)',
+            );
+            expect(result).not.toContain('"amount""bin"_order');
+        });
+
+        test('quotes table-calculation _any aliases after composing their names', () => {
+            const calculationName = 'calc"name';
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                {
+                    indexColumn: [
+                        { reference: 'date', type: VizIndexType.TIME },
+                    ],
+                    valuesColumns: [
+                        {
+                            reference: 'metric1',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                        {
+                            reference: calculationName,
+                            aggregation: VizAggregationOptions.ANY,
+                        },
+                    ],
+                    groupByColumns: [{ reference: 'category' }],
+                    sortBy: [
+                        {
+                            reference: 'date',
+                            direction: SortByDirection.ASC,
+                        },
+                    ],
+                },
+                mockWarehouseSqlBuilder,
+                500,
+                {
+                    [calculationName]: {
+                        name: calculationName,
+                        table: 'table1',
+                        tableLabel: 'Table 1',
+                        type: TableCalculationType.NUMBER,
+                        displayName: 'Calculated name',
+                        sql: 'pivot_offset(${table1.metric1}, 0)',
+                    },
+                },
+            );
+
+            const result = builder.toSql();
+
+            expect(result).toContain('AS "calc""name_any"');
+            expect(result).not.toContain('AS "calc"name_any"');
+        });
+
+        test('uses BigQuery backtick and backslash escaping at pivot boundaries', () => {
+            const reference = 'row`dim\\path';
+            const bigQuerySqlBuilder = {
+                ...mockWarehouseSqlBuilder,
+                getFieldQuoteChar: () => '`',
+                getAdapterType: () => SupportedDbtAdapter.BIGQUERY,
+            } as unknown as WarehouseSqlBuilder;
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                {
+                    indexColumn: [{ reference, type: VizIndexType.CATEGORY }],
+                    valuesColumns: [
+                        {
+                            reference: 'revenue',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                    ],
+                    groupByColumns: undefined,
+                    sortBy: [{ reference, direction: SortByDirection.ASC }],
+                },
+                bigQuerySqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            expect(result).toContain('`row\\`dim\\\\path`');
+            expect(result).not.toContain('`row`dim\\path`');
+        });
+    });
+
     describe('SQL sanitization', () => {
         test('Should remove trailing semicolon from input SQL', () => {
             const pivotConfiguration = {
@@ -2967,6 +3120,56 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).toContain(
                 '"orders_month_name" = \'January\' THEN 1',
             );
+        });
+
+        test('Should preserve escaped field IDs in chronological sort expressions', () => {
+            const quotedNameDimensions: CompiledDimension[] = [
+                {
+                    ...monthNameDimension,
+                    name: 'month"name',
+                },
+                {
+                    ...dayNameDimension,
+                    name: 'month"name',
+                },
+                {
+                    ...quarterNameDimension,
+                    name: 'month"name',
+                },
+            ];
+            const markers = ['January', 'Sunday', 'Q1'];
+
+            quotedNameDimensions.forEach((dimension, index) => {
+                const reference = 'orders_month"name';
+                const builder = new PivotQueryBuilder(
+                    baseSql,
+                    {
+                        indexColumn: [
+                            { reference, type: VizIndexType.CATEGORY },
+                        ],
+                        valuesColumns: [
+                            {
+                                reference: 'revenue',
+                                aggregation: VizAggregationOptions.SUM,
+                            },
+                        ],
+                        groupByColumns: undefined,
+                        sortBy: [
+                            {
+                                reference,
+                                direction: SortByDirection.ASC,
+                            },
+                        ],
+                    },
+                    mockWarehouseSqlBuilder,
+                    500,
+                    { [reference]: dimension },
+                );
+
+                expect(builder.toSql()).toContain(
+                    `WHEN "orders_month""name" = '${markers[index]}'`,
+                );
+            });
         });
 
         test('Should sort MONTH_NAME in pivot query with groupBy columns', () => {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -14,6 +14,7 @@ import {
     normalizeIndexColumns,
     ParameterError,
     parseTableCalculationFunctions,
+    quoteFieldReference,
     renderFilterRuleSql,
     SortByDirection,
     SupportedDbtAdapter,
@@ -98,6 +99,18 @@ export class PivotQueryBuilder {
         this.itemsMap = itemsMap ?? {};
         this.pivotTableCalculations = this.identifyPivotTableCalculations();
         this.implicitMetricReferences = this.getImplicitMetricReferences();
+    }
+
+    private quoteIdentifier(reference: string): string {
+        return quoteFieldReference(
+            reference,
+            this.warehouseSqlBuilder.getFieldQuoteChar(),
+            this.warehouseSqlBuilder.getAdapterType(),
+        );
+    }
+
+    private qualifyIdentifier(alias: string, reference: string): string {
+        return `${alias}.${this.quoteIdentifier(reference)}`;
     }
 
     /**
@@ -248,15 +261,15 @@ export class PivotQueryBuilder {
         reference: string,
         alias: string,
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         let result = sortExpr.replaceAll(
-            `${q}${reference}${q}`,
-            `${alias}.${q}${reference}${q}`,
+            this.quoteIdentifier(reference),
+            this.qualifyIdentifier(alias, reference),
         );
         if (isCustomBinDimension(this.itemsMap[reference])) {
+            const orderReference = `${reference}_order`;
             result = result.replaceAll(
-                `${q}${reference}_order${q}`,
-                `${alias}.${q}${reference}_order${q}`,
+                this.quoteIdentifier(orderReference),
+                this.qualifyIdentifier(alias, orderReference),
             );
         }
         return result;
@@ -285,7 +298,6 @@ export class PivotQueryBuilder {
         descending: boolean,
         nullsFirst?: boolean,
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         const field = this.itemsMap[reference];
         const nullsClause = PivotQueryBuilder.getNullsFirstLast(nullsFirst);
 
@@ -297,32 +309,33 @@ export class PivotQueryBuilder {
                 (s) => s.reference === reference,
             );
             if (isSorted) {
-                return `${q}${reference}_order${q}${
+                return `${this.quoteIdentifier(`${reference}_order`)}${
                     descending ? ' DESC' : ' ASC'
                 }${nullsClause}`;
             }
         }
 
         if (!field || !isDimension(field)) {
-            return `${q}${reference}${q}${
+            return `${this.quoteIdentifier(reference)}${
                 descending ? ' DESC' : ' ASC'
             }${nullsClause}`;
         }
 
         const startOfWeek = this.warehouseSqlBuilder.getStartOfWeek();
+        const fieldSql = this.quoteIdentifier(getItemId(field));
 
         switch (field.timeInterval) {
             case TimeFrames.MONTH_NAME:
-                return sortMonthName(field, q, descending) + nullsClause;
+                return sortMonthName(fieldSql, descending) + nullsClause;
             case TimeFrames.DAY_OF_WEEK_NAME:
                 return (
-                    sortDayOfWeekName(field, startOfWeek, q, descending) +
+                    sortDayOfWeekName(fieldSql, startOfWeek, descending) +
                     nullsClause
                 );
             case TimeFrames.QUARTER_NAME:
-                return sortQuarterName(field, q, descending) + nullsClause;
+                return sortQuarterName(fieldSql, descending) + nullsClause;
             default:
-                return `${q}${reference}${q}${
+                return `${this.quoteIdentifier(reference)}${
                     descending ? ' DESC' : ' ASC'
                 }${nullsClause}`;
         }
@@ -402,7 +415,6 @@ export class PivotQueryBuilder {
         groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
         passthroughDimensions: PivotConfiguration['passthroughDimensions'],
     ): string[] {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         const names = [
             ...indexColumns.map((col) => col.reference),
             ...groupByColumns.map((col) => col.reference),
@@ -420,7 +432,7 @@ export class PivotQueryBuilder {
                 (tc) => `${tc.name}_any`,
             ),
         ];
-        return [...new Set(names)].map((name) => `${q}${name}${q}`);
+        return [...new Set(names)].map((name) => this.quoteIdentifier(name));
     }
 
     /**
@@ -445,25 +457,25 @@ export class PivotQueryBuilder {
         sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
         passthroughDimensions?: PivotConfiguration['passthroughDimensions'],
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
         const groupBySelectDimensions = [
-            ...(groupByColumns || []).map((col) => `${q}${col.reference}${q}`),
+            ...(groupByColumns || []).map((col) =>
+                this.quoteIdentifier(col.reference),
+            ),
             // Sort-only pivot dimensions must be in GROUP BY so their values
             // are available for column ORDER BY downstream. They are not
             // pivot-spread columns (not in groupByColumns), but they still
             // need to survive the aggregation pipeline.
-            ...(sortOnlyDimensions || []).map(
-                (col) => `${q}${col.reference}${q}`,
+            ...(sortOnlyDimensions || []).map((col) =>
+                this.quoteIdentifier(col.reference),
             ),
             // Passthrough dimensions: hidden non-sort pivot dims that need
             // to flow through to row data so cross-field templates can read
             // their values via row.<table>.<field>.raw. Like sortOnlyDimensions
             // they survive GROUP BY but do not affect any ORDER BY.
-            ...(passthroughDimensions || []).map(
-                (col) => `${q}${col.reference}${q}`,
+            ...(passthroughDimensions || []).map((col) =>
+                this.quoteIdentifier(col.reference),
             ),
-            ...indexColumns.map((col) => `${q}${col.reference}${q}`),
+            ...indexColumns.map((col) => this.quoteIdentifier(col.reference)),
         ];
 
         // Carry _order columns through for sorted custom bin dimensions.
@@ -476,7 +488,7 @@ export class PivotQueryBuilder {
             ...indexColumns,
         ]);
         for (const ref of sortedBinRefs) {
-            groupBySelectDimensions.push(`${q}${ref}_order${q}`);
+            groupBySelectDimensions.push(this.quoteIdentifier(`${ref}_order`));
         }
 
         const groupBySelectMetrics = (valuesColumns ?? []).map((col) => {
@@ -489,7 +501,7 @@ export class PivotQueryBuilder {
                 col.reference,
                 col.aggregation,
             );
-            return `${aggregationField} AS ${q}${fieldName}${q}`;
+            return `${aggregationField} AS ${this.quoteIdentifier(fieldName)}`;
         });
 
         // Carry implicit metrics through using ANY_VALUE — these are already
@@ -505,7 +517,7 @@ export class PivotQueryBuilder {
                           VizAggregationOptions.ANY,
                           ref,
                       );
-                      return `${passthrough} AS ${q}${ref}${q}`;
+                      return `${passthrough} AS ${this.quoteIdentifier(ref)}`;
                   })
                 : [];
 
@@ -545,7 +557,6 @@ export class PivotQueryBuilder {
      * @param valuesColumns - Value columns configuration
      * @param sortBy - Sort configuration for columns
      * @param metricFirstValueQueries - Map of CTE names to their definitions
-     * @param q - Quote character for field names
      * @param sortOnlyDimensions - Hidden pivot-column dims that drive column ORDER BY
      *   but are not pivot-spread columns. They participate in ORDER BY the same way
      *   as groupByColumns but are not included in the groupByColumns DISTINCT SELECT.
@@ -559,7 +570,6 @@ export class PivotQueryBuilder {
             string,
             { cteName: string; sql: string }
         >,
-        q: string,
         sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
     ): string {
         const orderByParts: string[] = [];
@@ -627,7 +637,10 @@ export class PivotQueryBuilder {
                         // The anchor value is folded into column_ranking's nested
                         // derived table (aliased `g`), so resolve against it.
                         acc.push(
-                            `g.${q}${colAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
+                            `${this.qualifyIdentifier(
+                                'g',
+                                `${colAnchorCteName}_value`,
+                            )}${sortDirection}${nullsClause}`,
                         );
                     }
                     return acc;
@@ -697,7 +710,9 @@ export class PivotQueryBuilder {
             // declared position when known (else original groupBy order).
             const dims = orderDimsByDeclaredPosition() ?? allOrderableDims;
             dims.forEach((col) => {
-                orderByParts.push(`g.${q}${col.reference}${q} ASC`);
+                orderByParts.push(
+                    `${this.qualifyIdentifier('g', col.reference)} ASC`,
+                );
             });
         }
 
@@ -713,7 +728,6 @@ export class PivotQueryBuilder {
      * @param valuesColumns - Value columns configuration
      * @param sortBy - Sort configuration for all columns
      * @param metricFirstValueQueries - Map of value column references to their CTE info
-     * @param q - Quote character for field names
      * @returns ORDER BY clause string for row index ordering
      */
     private buildRowIndexOrderBy(
@@ -724,12 +738,14 @@ export class PivotQueryBuilder {
             string,
             { cteName: string; sql: string }
         >,
-        q: string,
     ): string {
         if (!sortBy?.length) {
             // Default to all index columns with ASC direction
             return indexColumns
-                .map((col) => `g.${q}${col.reference}${q} ASC`)
+                .map(
+                    (col) =>
+                        `${this.qualifyIdentifier('g', col.reference)} ASC`,
+                )
                 .join(', ');
         }
 
@@ -759,7 +775,10 @@ export class PivotQueryBuilder {
                         sort.nullsFirst,
                     );
                     orderByParts.push(
-                        `g.${q}${rowAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
+                        `${this.qualifyIdentifier(
+                            'g',
+                            `${rowAnchorCteName}_value`,
+                        )}${sortDirection}${nullsClause}`,
                     );
                 }
             } else if (isIndexColumn) {
@@ -814,7 +833,6 @@ export class PivotQueryBuilder {
         groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
         sortBy: PivotConfiguration['sortBy'],
     ): Record<string, { cteName: string; sql: string }> {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         const result: Record<string, { cteName: string; sql: string }> = {};
 
         if (!valuesColumns || !sortBy) {
@@ -839,10 +857,13 @@ export class PivotQueryBuilder {
 
             const colAnchorCteName = `${valCol.reference}_ca`;
             const groupColumnReferences = groupByColumns
-                .map((col) => `${q}${col.reference}${q}`)
+                .map((col) => this.quoteIdentifier(col.reference))
                 .join(', ');
 
-            const colAnchorSql = `SELECT DISTINCT ${groupColumnReferences}, FIRST_VALUE(${q}${fieldName}${q}) OVER (PARTITION BY ${groupColumnReferences} ORDER BY ${q}${fieldName}${q} ${sortDirection}${nullsClause} ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS ${q}${colAnchorCteName}_value${q} FROM group_by_query`;
+            const quotedFieldName = this.quoteIdentifier(fieldName);
+            const colAnchorSql = `SELECT DISTINCT ${groupColumnReferences}, FIRST_VALUE(${quotedFieldName}) OVER (PARTITION BY ${groupColumnReferences} ORDER BY ${quotedFieldName} ${sortDirection}${nullsClause} ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS ${this.quoteIdentifier(
+                `${colAnchorCteName}_value`,
+            )} FROM group_by_query`;
 
             result[colAnchorCteName] = {
                 cteName: colAnchorCteName,
@@ -867,18 +888,16 @@ export class PivotQueryBuilder {
         sortBy: PivotConfiguration['sortBy'],
         sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
         const groupColumnReferences = groupByColumns
-            .map((col) => `${q}${col.reference}${q}`)
+            .map((col) => this.quoteIdentifier(col.reference))
             .join(', ');
 
         // Dims the outer ORDER BY references: visible groupBys, sort-only dims,
         // and the _order companion of any sorted custom-bin dim among them.
         const dimSelects = [
-            ...groupByColumns.map((col) => `${q}${col.reference}${q}`),
-            ...(sortOnlyDimensions || []).map(
-                (col) => `${q}${col.reference}${q}`,
+            ...groupByColumns.map((col) => this.quoteIdentifier(col.reference)),
+            ...(sortOnlyDimensions || []).map((col) =>
+                this.quoteIdentifier(col.reference),
             ),
         ];
         const sortedBinRefs = this.getSortedBinDimensionReferences([
@@ -886,7 +905,7 @@ export class PivotQueryBuilder {
             ...(sortOnlyDimensions || []),
         ]);
         for (const ref of sortedBinRefs) {
-            dimSelects.push(`${q}${ref}_order${q}`);
+            dimSelects.push(this.quoteIdentifier(`${ref}_order`));
         }
 
         const firstValueSelects = (valuesColumns ?? []).reduce<string[]>(
@@ -908,8 +927,11 @@ export class PivotQueryBuilder {
                     sortConfig.nullsFirst,
                 );
                 const colAnchorCteName = `${valCol.reference}_ca`;
+                const quotedFieldName = this.quoteIdentifier(fieldName);
                 acc.push(
-                    `FIRST_VALUE(${q}${fieldName}${q}) OVER (PARTITION BY ${groupColumnReferences} ORDER BY ${q}${fieldName}${q} ${sortDirection}${nullsClause} ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS ${q}${colAnchorCteName}_value${q}`,
+                    `FIRST_VALUE(${quotedFieldName}) OVER (PARTITION BY ${groupColumnReferences} ORDER BY ${quotedFieldName} ${sortDirection}${nullsClause} ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS ${this.quoteIdentifier(
+                        `${colAnchorCteName}_value`,
+                    )}`,
                 );
                 return acc;
             },
@@ -943,8 +965,6 @@ export class PivotQueryBuilder {
         columnAnchorCTEs: Record<string, { cteName: string; sql: string }>,
         sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
         // DISTINCT SELECT contains only visible groupBy columns so that each
         // pivot column header combination maps to exactly one col_idx.
         // sortOnlyDimensions are NOT included here — they are helper dims that
@@ -953,7 +973,10 @@ export class PivotQueryBuilder {
         const groupByRefs = groupByColumns
             .map(
                 (col) =>
-                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
+                    `${this.qualifyIdentifier(
+                        'g',
+                        col.reference,
+                    )} AS ${this.quoteIdentifier(col.reference)}`,
             )
             .join(', ');
 
@@ -965,7 +988,6 @@ export class PivotQueryBuilder {
             valuesColumns,
             sortBy,
             columnAnchorCTEs,
-            q,
             sortOnlyDimensions,
         );
 
@@ -984,7 +1006,9 @@ export class PivotQueryBuilder {
                   )}) g`
                 : 'group_by_query g';
 
-        return `SELECT DISTINCT ${groupByRefs}, DENSE_RANK() OVER (ORDER BY ${groupByOrderBy}) AS ${q}col_idx${q} FROM ${fromClause}`;
+        return `SELECT DISTINCT ${groupByRefs}, DENSE_RANK() OVER (ORDER BY ${groupByOrderBy}) AS ${this.quoteIdentifier(
+            'col_idx',
+        )} FROM ${fromClause}`;
     }
 
     /**
@@ -998,8 +1022,7 @@ export class PivotQueryBuilder {
         value: PivotSortAnchor['value'],
         alias: string = 'cr',
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-        const colSql = `${alias}.${q}${reference}${q}`;
+        const colSql = this.qualifyIdentifier(alias, reference);
 
         if (value === null) {
             return `(${colSql}) IS NULL`;
@@ -1052,8 +1075,7 @@ export class PivotQueryBuilder {
         groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
         alias: string = 'cr',
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-        const fallback = `${q}col_idx${q} = 1`;
+        const fallback = `${this.quoteIdentifier('col_idx')} = 1`;
         if (!pivotValues?.length) return fallback;
 
         const pinByRef = new Map(pivotValues.map((pv) => [pv.reference, pv]));
@@ -1091,13 +1113,14 @@ export class PivotQueryBuilder {
         sortBy: PivotConfiguration['sortBy'],
         pivotValues?: VizSortBy['pivotValues'],
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
         // Select each groupBy column with an alias for use in CROSS JOIN
         const selectParts = groupByColumns
             .map(
                 (col) =>
-                    `cr.${q}${col.reference}${q} AS ${q}anchor_${col.reference}${q}`,
+                    `${this.qualifyIdentifier(
+                        'cr',
+                        col.reference,
+                    )} AS ${this.quoteIdentifier(`anchor_${col.reference}`)}`,
             )
             .join(', ');
 
@@ -1106,7 +1129,7 @@ export class PivotQueryBuilder {
             const sort = sortBy?.find((s) => s.reference === col.reference);
             const direction =
                 sort?.direction === SortByDirection.DESC ? 'DESC' : 'ASC';
-            return `cr.${q}${col.reference}${q} ${direction}`;
+            return `${this.qualifyIdentifier('cr', col.reference)} ${direction}`;
         });
 
         const whereClause = this.buildAnchorWhereClause(
@@ -1136,7 +1159,6 @@ export class PivotQueryBuilder {
         sortBy: PivotConfiguration['sortBy'],
         perMetricAnchorCte?: Map<string, string>,
     ): Record<string, { cteName: string; sql: string }> {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         const result: Record<string, { cteName: string; sql: string }> = {};
 
         if (!valuesColumns || !sortBy || indexColumns.length === 0) {
@@ -1144,19 +1166,19 @@ export class PivotQueryBuilder {
         }
 
         const indexColumnRefs = indexColumns
-            .map((col) => `q.${q}${col.reference}${q}`)
+            .map((col) => this.qualifyIdentifier('q', col.reference))
             .join(', ');
 
         const indexColumnGroupBy = indexColumns
-            .map((col) => `q.${q}${col.reference}${q}`)
+            .map((col) => this.qualifyIdentifier('q', col.reference))
             .join(', ');
 
         // Build condition to match anchor column using CROSS JOIN alias.
         const anchorMatchConditions = groupByColumns
             .map((col) =>
                 this.warehouseSqlBuilder.getNullSafeEqualSql(
-                    `q.${q}${col.reference}${q}`,
-                    `ac.${q}anchor_${col.reference}${q}`,
+                    this.qualifyIdentifier('q', col.reference),
+                    this.qualifyIdentifier('ac', `anchor_${col.reference}`),
                 ),
             )
             .join(' AND ');
@@ -1178,7 +1200,12 @@ export class PivotQueryBuilder {
             if (this.isSortOnlyTableCalculation(valCol.reference)) {
                 result[rowAnchorCteName] = {
                     cteName: rowAnchorCteName,
-                    sql: `SELECT ${indexColumnRefs}, MAX(q.${q}${fieldName}${q}) AS ${q}${rowAnchorCteName}_value${q} FROM group_by_query q GROUP BY ${indexColumnGroupBy}`,
+                    sql: `SELECT ${indexColumnRefs}, MAX(${this.qualifyIdentifier(
+                        'q',
+                        fieldName,
+                    )}) AS ${this.quoteIdentifier(
+                        `${rowAnchorCteName}_value`,
+                    )} FROM group_by_query q GROUP BY ${indexColumnGroupBy}`,
                 };
                 return;
             }
@@ -1188,11 +1215,16 @@ export class PivotQueryBuilder {
             const anchorCteRef =
                 anchorCteName === 'anchor_column'
                     ? 'anchor_column'
-                    : `${q}${anchorCteName}${q}`;
+                    : this.quoteIdentifier(anchorCteName);
 
             // Use CROSS JOIN with anchor_column and conditional aggregation
             // MAX is used because there should be at most one value per (indexCols, anchorCol)
-            const rowAnchorSql = `SELECT ${indexColumnRefs}, MAX(CASE WHEN ${anchorMatchConditions} THEN q.${q}${fieldName}${q} END) AS ${q}${rowAnchorCteName}_value${q} FROM group_by_query q CROSS JOIN ${anchorCteRef} ac GROUP BY ${indexColumnGroupBy}`;
+            const rowAnchorSql = `SELECT ${indexColumnRefs}, MAX(CASE WHEN ${anchorMatchConditions} THEN ${this.qualifyIdentifier(
+                'q',
+                fieldName,
+            )} END) AS ${this.quoteIdentifier(
+                `${rowAnchorCteName}_value`,
+            )} FROM group_by_query q CROSS JOIN ${anchorCteRef} ac GROUP BY ${indexColumnGroupBy}`;
 
             result[rowAnchorCteName] = {
                 cteName: rowAnchorCteName,
@@ -1238,8 +1270,6 @@ export class PivotQueryBuilder {
             groupByColumns,
             sortBy,
         );
-
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
         // When sorting by a metric value, we need the column_ranking CTE so
         // that pivot_query can read col_idx from a precomputed scope instead
@@ -1311,7 +1341,7 @@ export class PivotQueryBuilder {
                             sortConfig.pivotValues,
                         );
                         anchorColumnCTEs.push(
-                            `${q}${anchorCteName}${q} AS (${anchorSQL})`,
+                            `${this.quoteIdentifier(anchorCteName)} AS (${anchorSQL})`,
                         );
                         perMetricAnchorCte.set(valCol.reference, anchorCteName);
                     });
@@ -1375,17 +1405,15 @@ export class PivotQueryBuilder {
         sortBy: PivotConfiguration['sortBy'],
         perMetricAnchorCte?: Map<string, string>,
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
         // Index columns (and the _order companion of any sorted custom-bin index
         // dim) carried through both SELECT and GROUP BY.
-        const indexRefs = indexColumns.map(
-            (col) => `q.${q}${col.reference}${q}`,
+        const indexRefs = indexColumns.map((col) =>
+            this.qualifyIdentifier('q', col.reference),
         );
         const sortedBinRefs =
             this.getSortedBinDimensionReferences(indexColumns);
         for (const ref of sortedBinRefs) {
-            indexRefs.push(`q.${q}${ref}_order${q}`);
+            indexRefs.push(this.qualifyIdentifier('q', `${ref}_order`));
         }
         const indexSelect = indexRefs.join(', ');
 
@@ -1421,7 +1449,7 @@ export class PivotQueryBuilder {
                 const ref =
                     name === 'anchor_column'
                         ? 'anchor_column'
-                        : `${q}${name}${q}`;
+                        : this.quoteIdentifier(name);
                 return ` CROSS JOIN ${ref} ${aliasByAnchor.get(name)}`;
             })
             .join('');
@@ -1432,7 +1460,10 @@ export class PivotQueryBuilder {
                 valCol.aggregation,
             );
             if (this.isSortOnlyTableCalculation(valCol.reference)) {
-                return `MAX(q.${q}${fieldName}${q}) AS ${q}${valCol.reference}_ra_value${q}`;
+                return `MAX(${this.qualifyIdentifier(
+                    'q',
+                    fieldName,
+                )}) AS ${this.quoteIdentifier(`${valCol.reference}_ra_value`)}`;
             }
             const alias = aliasByAnchor.get(
                 anchorByValCol.get(valCol.reference)!,
@@ -1440,12 +1471,18 @@ export class PivotQueryBuilder {
             const anchorMatch = groupByColumns
                 .map((col) =>
                     this.warehouseSqlBuilder.getNullSafeEqualSql(
-                        `q.${q}${col.reference}${q}`,
-                        `${alias}.${q}anchor_${col.reference}${q}`,
+                        this.qualifyIdentifier('q', col.reference),
+                        this.qualifyIdentifier(
+                            alias,
+                            `anchor_${col.reference}`,
+                        ),
                     ),
                 )
                 .join(' AND ');
-            return `MAX(CASE WHEN ${anchorMatch} THEN q.${q}${fieldName}${q} END) AS ${q}${valCol.reference}_ra_value${q}`;
+            return `MAX(CASE WHEN ${anchorMatch} THEN ${this.qualifyIdentifier(
+                'q',
+                fieldName,
+            )} END) AS ${this.quoteIdentifier(`${valCol.reference}_ra_value`)}`;
         });
 
         return `SELECT ${indexSelect}, ${maxCaseSelects.join(
@@ -1475,13 +1512,14 @@ export class PivotQueryBuilder {
         rowAnchorQueries: Record<string, { cteName: string; sql: string }>,
         perMetricAnchorCte?: Map<string, string>,
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
         // Alias to bare names for downstream resolution (ClickHouse multi-join scoping).
         const indexRefs = indexColumns
             .map(
                 (col) =>
-                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
+                    `${this.qualifyIdentifier(
+                        'g',
+                        col.reference,
+                    )} AS ${this.quoteIdentifier(col.reference)}`,
             )
             .join(', ');
 
@@ -1491,7 +1529,6 @@ export class PivotQueryBuilder {
             valuesColumns,
             sortBy,
             rowAnchorQueries,
-            q,
         );
 
         // The row source is aliased `g` — the same alias group_by_query carries
@@ -1510,7 +1547,9 @@ export class PivotQueryBuilder {
                   )}) g`
                 : 'group_by_query g';
 
-        return `SELECT DISTINCT ${indexRefs}, DENSE_RANK() OVER (ORDER BY ${rowIndexOrderBy}) AS ${q}row_index${q} FROM ${fromClause}`;
+        return `SELECT DISTINCT ${indexRefs}, DENSE_RANK() OVER (ORDER BY ${rowIndexOrderBy}) AS ${this.quoteIdentifier(
+            'row_index',
+        )} FROM ${fromClause}`;
     }
 
     /**
@@ -1533,10 +1572,8 @@ export class PivotQueryBuilder {
         sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
         passthroughDimensions?: PivotConfiguration['passthroughDimensions'],
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
         const groupColumnReferences = groupByColumns
-            .map((col) => `${q}${col.reference}${q}`)
+            .map((col) => this.quoteIdentifier(col.reference))
             .join(', ');
 
         // Layer 1 — column anchor: FIRST_VALUE per sorted value column.
@@ -1559,8 +1596,11 @@ export class PivotQueryBuilder {
                     sortConfig.nullsFirst,
                 );
                 const colAnchorCteName = `${valCol.reference}_ca`;
+                const quotedFieldName = this.quoteIdentifier(fieldName);
                 acc.push(
-                    `FIRST_VALUE(${q}${fieldName}${q}) OVER (PARTITION BY ${groupColumnReferences} ORDER BY ${q}${fieldName}${q} ${sortDirection}${nullsClause} ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS ${q}${colAnchorCteName}_value${q}`,
+                    `FIRST_VALUE(${quotedFieldName}) OVER (PARTITION BY ${groupColumnReferences} ORDER BY ${quotedFieldName} ${sortDirection}${nullsClause} ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS ${this.quoteIdentifier(
+                        `${colAnchorCteName}_value`,
+                    )}`,
                 );
                 return acc;
             },
@@ -1578,15 +1618,16 @@ export class PivotQueryBuilder {
             valuesColumns,
             sortBy,
             metricFirstValueQueries,
-            q,
             sortOnlyDimensions,
         );
-        const colIdxLayer = `SELECT g.*, DENSE_RANK() OVER (ORDER BY ${groupByOrderBy}) AS ${q}col_idx${q} FROM (${columnAnchorLayer}) g`;
+        const colIdxLayer = `SELECT g.*, DENSE_RANK() OVER (ORDER BY ${groupByOrderBy}) AS ${this.quoteIdentifier(
+            'col_idx',
+        )} FROM (${columnAnchorLayer}) g`;
 
         // Layer 3 — row anchor: metric value at each metric's anchor column
         // (col_idx = 1, or its rebased pin), constant per index combo.
         const indexPartition = indexColumns
-            .map((col) => `g.${q}${col.reference}${q}`)
+            .map((col) => this.qualifyIdentifier('g', col.reference))
             .join(', ');
         const maxCaseSelects = (valuesColumns ?? []).reduce<string[]>(
             (acc, valCol) => {
@@ -1602,7 +1643,12 @@ export class PivotQueryBuilder {
                 // Sort-only table calcs aggregate across ALL pivot columns — no anchor
                 if (this.isSortOnlyTableCalculation(valCol.reference)) {
                     acc.push(
-                        `MAX(g.${q}${fieldName}${q}) OVER (PARTITION BY ${indexPartition}) AS ${q}${valCol.reference}_ra_value${q}`,
+                        `MAX(${this.qualifyIdentifier(
+                            'g',
+                            fieldName,
+                        )}) OVER (PARTITION BY ${indexPartition}) AS ${this.quoteIdentifier(
+                            `${valCol.reference}_ra_value`,
+                        )}`,
                     );
                     return acc;
                 }
@@ -1612,7 +1658,12 @@ export class PivotQueryBuilder {
                     'g',
                 );
                 acc.push(
-                    `MAX(CASE WHEN ${anchorPredicate} THEN g.${q}${fieldName}${q} END) OVER (PARTITION BY ${indexPartition}) AS ${q}${valCol.reference}_ra_value${q}`,
+                    `MAX(CASE WHEN ${anchorPredicate} THEN ${this.qualifyIdentifier(
+                        'g',
+                        fieldName,
+                    )} END) OVER (PARTITION BY ${indexPartition}) AS ${this.quoteIdentifier(
+                        `${valCol.reference}_ra_value`,
+                    )}`,
                 );
                 return acc;
             },
@@ -1626,25 +1677,41 @@ export class PivotQueryBuilder {
         const selectReferences = [
             ...indexColumns.map(
                 (col) =>
-                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
+                    `${this.qualifyIdentifier(
+                        'g',
+                        col.reference,
+                    )} AS ${this.quoteIdentifier(col.reference)}`,
             ),
             ...groupByColumns.map(
                 (col) =>
-                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
+                    `${this.qualifyIdentifier(
+                        'g',
+                        col.reference,
+                    )} AS ${this.quoteIdentifier(col.reference)}`,
             ),
             ...(passthroughDimensions || []).map(
                 (col) =>
-                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
+                    `${this.qualifyIdentifier(
+                        'g',
+                        col.reference,
+                    )} AS ${this.quoteIdentifier(col.reference)}`,
             ),
             ...(valuesColumns || []).map((col) => {
                 const fieldName = PivotQueryBuilder.getValueColumnFieldName(
                     col.reference,
                     col.aggregation,
                 );
-                return `g.${q}${fieldName}${q} AS ${q}${fieldName}${q}`;
+                return `${this.qualifyIdentifier(
+                    'g',
+                    fieldName,
+                )} AS ${this.quoteIdentifier(fieldName)}`;
             }),
             ...this.implicitMetricReferences.map(
-                (ref) => `g.${q}${ref}${q} AS ${q}${ref}${q}`,
+                (ref) =>
+                    `${this.qualifyIdentifier(
+                        'g',
+                        ref,
+                    )} AS ${this.quoteIdentifier(ref)}`,
             ),
         ];
         const rowIndexOrderBy = this.buildRowIndexOrderBy(
@@ -1652,12 +1719,16 @@ export class PivotQueryBuilder {
             valuesColumns,
             sortBy,
             metricFirstValueQueries,
-            q,
         );
 
         return `SELECT ${selectReferences.join(
             ', ',
-        )}, DENSE_RANK() OVER (ORDER BY ${rowIndexOrderBy}) AS ${q}row_index${q}, g.${q}col_idx${q} AS ${q}column_index${q} FROM (${rowAnchorLayer}) g`;
+        )}, DENSE_RANK() OVER (ORDER BY ${rowIndexOrderBy}) AS ${this.quoteIdentifier(
+            'row_index',
+        )}, ${this.qualifyIdentifier(
+            'g',
+            'col_idx',
+        )} AS ${this.quoteIdentifier('column_index')} FROM (${rowAnchorLayer}) g`;
     }
 
     private getPivotQuerySQL(
@@ -1673,19 +1744,23 @@ export class PivotQueryBuilder {
         sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
         passthroughDimensions?: PivotConfiguration['passthroughDimensions'],
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
         // Alias to bare names so filtered_rows and the count subquery can
         // resolve them (ClickHouse exposes multi-join CTE columns only under
         // the `g.` qualifier).
         const selectReferences = [
             ...indexColumns.map(
                 (col) =>
-                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
+                    `${this.qualifyIdentifier(
+                        'g',
+                        col.reference,
+                    )} AS ${this.quoteIdentifier(col.reference)}`,
             ),
             ...groupByColumns.map(
                 (col) =>
-                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
+                    `${this.qualifyIdentifier(
+                        'g',
+                        col.reference,
+                    )} AS ${this.quoteIdentifier(col.reference)}`,
             ),
             // Passthrough dimensions: hidden non-sort pivot dims that need
             // to flow through to row data for cross-field richText/image
@@ -1694,18 +1769,28 @@ export class PivotQueryBuilder {
             // explicitly here so they reach the final SELECT.
             ...(passthroughDimensions || []).map(
                 (col) =>
-                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
+                    `${this.qualifyIdentifier(
+                        'g',
+                        col.reference,
+                    )} AS ${this.quoteIdentifier(col.reference)}`,
             ),
             ...(valuesColumns || []).map((col) => {
                 const fieldName = PivotQueryBuilder.getValueColumnFieldName(
                     col.reference,
                     col.aggregation,
                 );
-                return `g.${q}${fieldName}${q} AS ${q}${fieldName}${q}`;
+                return `${this.qualifyIdentifier(
+                    'g',
+                    fieldName,
+                )} AS ${this.quoteIdentifier(fieldName)}`;
             }),
             // Implicit metrics — carried under their original column name
             ...this.implicitMetricReferences.map(
-                (ref) => `g.${q}${ref}${q} AS ${q}${ref}${q}`,
+                (ref) =>
+                    `${this.qualifyIdentifier(
+                        'g',
+                        ref,
+                    )} AS ${this.quoteIdentifier(ref)}`,
             ),
         ];
 
@@ -1721,8 +1806,8 @@ export class PivotQueryBuilder {
                 const rowRankJoinConditions = indexColumns
                     .map((col) =>
                         this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
-                            `g.${q}${col.reference}${q}`,
-                            `rr.${q}${col.reference}${q}`,
+                            this.qualifyIdentifier('g', col.reference),
+                            this.qualifyIdentifier('rr', col.reference),
                         ),
                     )
                     .join(' AND ');
@@ -1734,8 +1819,8 @@ export class PivotQueryBuilder {
             const colRankJoinConditions = groupByColumns
                 .map((col) =>
                     this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
-                        `g.${q}${col.reference}${q}`,
-                        `cr.${q}${col.reference}${q}`,
+                        this.qualifyIdentifier('g', col.reference),
+                        this.qualifyIdentifier('cr', col.reference),
                     ),
                 )
                 .join(' AND ');
@@ -1748,9 +1833,18 @@ export class PivotQueryBuilder {
             }
 
             const rowIndexExpression =
-                indexColumns.length > 0 ? `rr.${q}row_index${q}` : '1';
+                indexColumns.length > 0
+                    ? this.qualifyIdentifier('rr', 'row_index')
+                    : '1';
 
-            return `SELECT ${selectReferences.join(', ')}, ${rowIndexExpression} AS ${q}row_index${q}, cr.${q}col_idx${q} AS ${q}column_index${q} FROM ${fromClause}`;
+            return `SELECT ${selectReferences.join(
+                ', ',
+            )}, ${rowIndexExpression} AS ${this.quoteIdentifier(
+                'row_index',
+            )}, ${this.qualifyIdentifier(
+                'cr',
+                'col_idx',
+            )} AS ${this.quoteIdentifier('column_index')} FROM ${fromClause}`;
         }
 
         // Original path: compute rankings inline with Window functions
@@ -1767,13 +1861,15 @@ export class PivotQueryBuilder {
                     const joinConditions = indexColumns
                         .map((col) =>
                             this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
-                                `g.${q}${col.reference}${q}`,
-                                `${q}${cteName}${q}.${q}${col.reference}${q}`,
+                                this.qualifyIdentifier('g', col.reference),
+                                `${this.quoteIdentifier(
+                                    cteName,
+                                )}.${this.quoteIdentifier(col.reference)}`,
                             ),
                         )
                         .join(' AND ');
                     joins.push(
-                        `LEFT JOIN ${q}${cteName}${q} ON ${joinConditions}`,
+                        `LEFT JOIN ${this.quoteIdentifier(cteName)} ON ${joinConditions}`,
                     );
                 }
             } else if (cteName.endsWith('_ca')) {
@@ -1781,12 +1877,16 @@ export class PivotQueryBuilder {
                 const joinConditions = groupByColumns
                     .map((col) =>
                         this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
-                            `g.${q}${col.reference}${q}`,
-                            `${q}${cteName}${q}.${q}${col.reference}${q}`,
+                            this.qualifyIdentifier('g', col.reference),
+                            `${this.quoteIdentifier(
+                                cteName,
+                            )}.${this.quoteIdentifier(col.reference)}`,
                         ),
                     )
                     .join(' AND ');
-                joins.push(`LEFT JOIN ${q}${cteName}${q} ON ${joinConditions}`);
+                joins.push(
+                    `LEFT JOIN ${this.quoteIdentifier(cteName)} ON ${joinConditions}`,
+                );
             }
         });
 
@@ -1800,7 +1900,6 @@ export class PivotQueryBuilder {
             valuesColumns,
             sortBy,
             metricFirstValueQueries,
-            q,
         );
 
         const groupByOrderBy = this.buildGroupByOrderBy(
@@ -1808,7 +1907,6 @@ export class PivotQueryBuilder {
             valuesColumns,
             sortBy,
             metricFirstValueQueries,
-            q,
             sortOnlyDimensions,
         );
 
@@ -1819,7 +1917,11 @@ export class PivotQueryBuilder {
 
         return `SELECT ${selectReferences.join(
             ', ',
-        )}, ${rowIndexExpression} AS ${q}row_index${q}, DENSE_RANK() OVER (ORDER BY ${groupByOrderBy}) AS ${q}column_index${q} FROM ${fromClause}`;
+        )}, ${rowIndexExpression} AS ${this.quoteIdentifier(
+            'row_index',
+        )}, DENSE_RANK() OVER (ORDER BY ${groupByOrderBy}) AS ${this.quoteIdentifier(
+            'column_index',
+        )} FROM ${fromClause}`;
     }
 
     /**
@@ -1832,7 +1934,6 @@ export class PivotQueryBuilder {
             return undefined;
         }
 
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         const compiler = new TableCalculationFunctionCompiler(
             this.warehouseSqlBuilder,
         );
@@ -1852,7 +1953,7 @@ export class PivotQueryBuilder {
                     this.replaceFieldReferencesWithAliases(processedSql);
 
                 pivotCalculations.push(
-                    `${processedSql} AS ${q}${tc.name}_any${q}`, // todo: can we handle dynamic aggregation? hardcode prefix for now.
+                    `${processedSql} AS ${this.quoteIdentifier(`${tc.name}_any`)}`, // todo: can we handle dynamic aggregation? hardcode prefix for now.
                 );
             }
         }
@@ -1872,8 +1973,6 @@ export class PivotQueryBuilder {
      * @returns SQL with field references replaced by their pivot_query aliases
      */
     private replaceFieldReferencesWithAliases(sql: string): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
         // Build a map of original field names to their aliased names
         const fieldAliasMap: Record<string, string> = {};
 
@@ -1918,7 +2017,7 @@ export class PivotQueryBuilder {
             const fieldId = getItemId({ table: refTable, name: refName });
             const alias = fieldAliasMap[fieldId] || fieldAliasMap[ref];
             if (alias) {
-                return `${q}${alias}${q}`;
+                return this.quoteIdentifier(alias);
             }
             return fullmatch;
         });
@@ -1947,7 +2046,6 @@ export class PivotQueryBuilder {
         sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
         passthroughDimensions?: PivotConfiguration['passthroughDimensions'],
     ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         const rowLimit = this.limit ?? DEFAULT_PIVOT_ROW_LIMIT;
 
         // Exclude Pivot table calculations from valuesColumns - they are handled separately
@@ -2043,7 +2141,9 @@ export class PivotQueryBuilder {
                     this.pivotConfiguration.metricsAsRows,
                 );
 
-            columnIndexFilterSql = ` WHERE ${q}column_index${q} <= ${maxColumnsPerValueColumn}`;
+            columnIndexFilterSql = ` WHERE ${this.quoteIdentifier(
+                'column_index',
+            )} <= ${maxColumnsPerValueColumn}`;
         }
 
         // Build CTEs in correct dependency order:
@@ -2078,7 +2178,9 @@ export class PivotQueryBuilder {
         }
 
         ctes.push(
-            `filtered_rows AS (SELECT * FROM ${pivotTableRef} WHERE ${q}row_index${q} <= ${rowLimit})`,
+            `filtered_rows AS (SELECT * FROM ${pivotTableRef} WHERE ${this.quoteIdentifier(
+                'row_index',
+            )} <= ${rowLimit})`,
         );
 
         // total_columns is the distinct groupBy-combination count (× valuesCount
@@ -2094,7 +2196,7 @@ export class PivotQueryBuilder {
             : '';
 
         const groupByPartition = groupByColumns
-            .map((col) => `${q}${col.reference}${q}`)
+            .map((col) => this.quoteIdentifier(col.reference))
             .join(', ');
 
         const outputColumns = this.getPivotOutputColumns(
@@ -2117,7 +2219,14 @@ export class PivotQueryBuilder {
             adapterType === SupportedDbtAdapter.ATHENA
                 ? ''
                 : ` ORDER BY ${groupByPartition}`;
-        const finalSelect = `SELECT ${outputColumns}, total_columns FROM (SELECT p.*, SUM(CASE WHEN p.${q}__grp_rn${q} = 1 THEN 1 ELSE 0 END) OVER ()${totalColumnsMultiplier} AS total_columns FROM (SELECT f.*, ROW_NUMBER() OVER (PARTITION BY ${groupByPartition}${grpRnOrderBy}) AS ${q}__grp_rn${q} FROM filtered_rows f) p) pivoted${columnIndexFilterSql} order by ${q}row_index${q}, ${q}column_index${q}`;
+        const finalSelect = `SELECT ${outputColumns}, total_columns FROM (SELECT p.*, SUM(CASE WHEN ${this.qualifyIdentifier(
+            'p',
+            '__grp_rn',
+        )} = 1 THEN 1 ELSE 0 END) OVER ()${totalColumnsMultiplier} AS total_columns FROM (SELECT f.*, ROW_NUMBER() OVER (PARTITION BY ${groupByPartition}${grpRnOrderBy}) AS ${this.quoteIdentifier(
+            '__grp_rn',
+        )} FROM filtered_rows f) p) pivoted${columnIndexFilterSql} order by ${this.quoteIdentifier(
+            'row_index',
+        )}, ${this.quoteIdentifier('column_index')}`;
 
         return PivotQueryBuilder.assembleSqlParts([
             PivotQueryBuilder.buildCtesSQL(ctes),

--- a/packages/backend/src/utils/QueryBuilder/utils.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.test.ts
@@ -18,8 +18,6 @@ import {
 import {
     bigqueryClientMock,
     COMPILED_DIMENSION,
-    COMPILED_MONTH_NAME_DIMENSION,
-    COMPILED_WEEK_NAME_DIMENSION,
     CUSTOM_SQL_DIMENSION,
     EXPLORE,
     INTRINSIC_USER_ATTRIBUTES,
@@ -43,6 +41,7 @@ import {
     replaceUserAttributesInSqlTable,
     sortDayOfWeekName,
     sortMonthName,
+    sortQuarterName,
 } from './utils';
 
 describe('getSumOfRowsTableCalculations', () => {
@@ -578,39 +577,25 @@ const ignoreIndentation = (sql: string) => sql.replace(/\s+/g, ' ');
 describe('Time frame sorting', () => {
     it('sortMonthName SQL', () => {
         expect(
-            ignoreIndentation(
-                sortMonthName(COMPILED_MONTH_NAME_DIMENSION, '"', false),
-            ),
+            ignoreIndentation(sortMonthName('"table1_dim1"', false)),
         ).toStrictEqual(ignoreIndentation(MONTH_NAME_SORT_SQL));
     });
     it('sortMonthName Descending SQL', () => {
         expect(
-            ignoreIndentation(
-                sortMonthName(COMPILED_MONTH_NAME_DIMENSION, '"', true),
-            ),
+            ignoreIndentation(sortMonthName('"table1_dim1"', true)),
         ).toStrictEqual(ignoreIndentation(MONTH_NAME_SORT_DESCENDING_SQL));
     });
     it('sortDayOfWeekName SQL for Saturday startOfWeek', () => {
         expect(
             ignoreIndentation(
-                sortDayOfWeekName(
-                    COMPILED_WEEK_NAME_DIMENSION,
-                    undefined,
-                    `"`,
-                    true,
-                ),
+                sortDayOfWeekName('"table1_dim1"', undefined, true),
             ),
         ).toStrictEqual(ignoreIndentation(WEEK_NAME_SORT_DESCENDING_SQL));
     });
     it('sortDayOfWeekName SQL for Sunday startOfWeek', () => {
         expect(
             ignoreIndentation(
-                sortDayOfWeekName(
-                    COMPILED_WEEK_NAME_DIMENSION,
-                    WeekDay.SUNDAY,
-                    `"`,
-                    false,
-                ),
+                sortDayOfWeekName('"table1_dim1"', WeekDay.SUNDAY, false),
             ),
         ).toStrictEqual(ignoreIndentation(WEEK_NAME_SORT_SQL)); // same as undefined
     });
@@ -618,12 +603,7 @@ describe('Time frame sorting', () => {
     it('sortDayOfWeekName SQL for Wednesday startOfWeek', () => {
         expect(
             ignoreIndentation(
-                sortDayOfWeekName(
-                    COMPILED_WEEK_NAME_DIMENSION,
-                    WeekDay.WEDNESDAY,
-                    `"`,
-                    false,
-                ),
+                sortDayOfWeekName('"table1_dim1"', WeekDay.WEDNESDAY, false),
             ),
         ).toStrictEqual(
             ignoreIndentation(`(
@@ -639,6 +619,18 @@ describe('Time frame sorting', () => {
             END
         )`),
         );
+    });
+
+    it('uses an already-rendered identifier without changing its escaping', () => {
+        const fieldSql = '"table1_""month"""';
+
+        const monthSql = sortMonthName(fieldSql, false);
+        const daySql = sortDayOfWeekName(fieldSql, undefined, false);
+        const quarterSql = sortQuarterName(fieldSql, false);
+
+        expect(monthSql.match(/"table1_""month"""/g)).toHaveLength(12);
+        expect(daySql.match(/"table1_""month"""/g)).toHaveLength(7);
+        expect(quarterSql.match(/"table1_""month"""/g)).toHaveLength(4);
     });
 });
 

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -446,71 +446,54 @@ export const getJoinType = (type: DbtModelJoinType = 'left') => {
     }
 };
 
-export const sortMonthName = (
-    dimension: Dimension,
-    fieldQuoteChar: string,
-    descending: Boolean,
-) => {
-    const fieldId = `${fieldQuoteChar}${getItemId(dimension)}${fieldQuoteChar}`;
-
-    return `(
+export const sortMonthName = (fieldSql: string, descending: boolean) => `(
         CASE
-            WHEN ${fieldId} = 'January' THEN 1
-            WHEN ${fieldId} = 'February' THEN 2
-            WHEN ${fieldId} = 'March' THEN 3
-            WHEN ${fieldId} = 'April' THEN 4
-            WHEN ${fieldId} = 'May' THEN 5
-            WHEN ${fieldId} = 'June' THEN 6
-            WHEN ${fieldId} = 'July' THEN 7
-            WHEN ${fieldId} = 'August' THEN 8
-            WHEN ${fieldId} = 'September' THEN 9
-            WHEN ${fieldId} = 'October' THEN 10
-            WHEN ${fieldId} = 'November' THEN 11
-            WHEN ${fieldId} = 'December' THEN 12
+            WHEN ${fieldSql} = 'January' THEN 1
+            WHEN ${fieldSql} = 'February' THEN 2
+            WHEN ${fieldSql} = 'March' THEN 3
+            WHEN ${fieldSql} = 'April' THEN 4
+            WHEN ${fieldSql} = 'May' THEN 5
+            WHEN ${fieldSql} = 'June' THEN 6
+            WHEN ${fieldSql} = 'July' THEN 7
+            WHEN ${fieldSql} = 'August' THEN 8
+            WHEN ${fieldSql} = 'September' THEN 9
+            WHEN ${fieldSql} = 'October' THEN 10
+            WHEN ${fieldSql} = 'November' THEN 11
+            WHEN ${fieldSql} = 'December' THEN 12
             ELSE 0
         END
     )${descending ? ' DESC' : ''}`;
-};
 export const sortDayOfWeekName = (
-    dimension: Dimension,
+    fieldSql: string,
     startOfWeek: WeekDay | null | undefined,
-    fieldQuoteChar: string,
-    descending: Boolean,
+    descending: boolean,
 ) => {
-    const fieldId = `${fieldQuoteChar}${getItemId(dimension)}${fieldQuoteChar}`;
     const calculateDayIndex = (dayNumber: number) => {
         if (startOfWeek === null || startOfWeek === undefined) return dayNumber; // startOfWeek can be 0, so don't do !startOfWeek
         return ((dayNumber + 7 - (startOfWeek + 2)) % 7) + 1;
     };
     return `(
         CASE
-            WHEN ${fieldId} = 'Sunday' THEN ${calculateDayIndex(1)}
-            WHEN ${fieldId} = 'Monday' THEN ${calculateDayIndex(2)}
-            WHEN ${fieldId} = 'Tuesday' THEN ${calculateDayIndex(3)}
-            WHEN ${fieldId} = 'Wednesday' THEN ${calculateDayIndex(4)}
-            WHEN ${fieldId} = 'Thursday' THEN ${calculateDayIndex(5)}
-            WHEN ${fieldId} = 'Friday' THEN ${calculateDayIndex(6)}
-            WHEN ${fieldId} = 'Saturday' THEN ${calculateDayIndex(7)}
+            WHEN ${fieldSql} = 'Sunday' THEN ${calculateDayIndex(1)}
+            WHEN ${fieldSql} = 'Monday' THEN ${calculateDayIndex(2)}
+            WHEN ${fieldSql} = 'Tuesday' THEN ${calculateDayIndex(3)}
+            WHEN ${fieldSql} = 'Wednesday' THEN ${calculateDayIndex(4)}
+            WHEN ${fieldSql} = 'Thursday' THEN ${calculateDayIndex(5)}
+            WHEN ${fieldSql} = 'Friday' THEN ${calculateDayIndex(6)}
+            WHEN ${fieldSql} = 'Saturday' THEN ${calculateDayIndex(7)}
             ELSE 0
         END
     )${descending ? ' DESC' : ''}`;
 };
-export const sortQuarterName = (
-    dimension: Dimension,
-    fieldQuoteChar: string,
-    descending: boolean,
-) => {
-    const fieldId = `${fieldQuoteChar}${getItemId(dimension)}${fieldQuoteChar}`;
-    return `(
+export const sortQuarterName = (fieldSql: string, descending: boolean) => `(
         CASE
-            WHEN ${fieldId} = 'Q1' THEN 1
-            WHEN ${fieldId} = 'Q2' THEN 2
-            WHEN ${fieldId} = 'Q3' THEN 3
-            WHEN ${fieldId} = 'Q4' THEN 4
+            WHEN ${fieldSql} = 'Q1' THEN 1
+            WHEN ${fieldSql} = 'Q2' THEN 2
+            WHEN ${fieldSql} = 'Q3' THEN 3
+            WHEN ${fieldSql} = 'Q4' THEN 4
             ELSE 0
         END
     )${descending ? ' DESC' : ''}`;
-};
 // Remove comments and limit clauses from SQL
 export const removeComments = (sql: string): string => {
     let s = sql.trim();

--- a/packages/common/src/utils/warehouse.test.ts
+++ b/packages/common/src/utils/warehouse.test.ts
@@ -1,4 +1,5 @@
 import { SupportedDbtAdapter } from '../types/dbt';
+import { ParameterError } from '../types/errors';
 import type { WarehouseSqlBuilder } from '../types/warehouse';
 import { VizAggregationOptions } from '../visualizations/types';
 import { getAggregatedField, quoteFieldReference } from './warehouse';
@@ -22,6 +23,29 @@ describe('quoteFieldReference', () => {
             ),
         ).toBe('`total\\`revenue\\\\path`');
     });
+
+    test.each([
+        SupportedDbtAdapter.POSTGRES,
+        SupportedDbtAdapter.REDSHIFT,
+        SupportedDbtAdapter.SNOWFLAKE,
+        SupportedDbtAdapter.TRINO,
+        SupportedDbtAdapter.ATHENA,
+        SupportedDbtAdapter.DUCKDB,
+        SupportedDbtAdapter.CLICKHOUSE,
+    ])('uses delimiter doubling for %s identifiers', (adapterType) => {
+        expect(quoteFieldReference('total"revenue', '"', adapterType)).toBe(
+            '"total""revenue"',
+        );
+    });
+
+    test.each([SupportedDbtAdapter.DATABRICKS, SupportedDbtAdapter.SPARK])(
+        'uses backtick doubling for %s identifiers',
+        (adapterType) => {
+            expect(quoteFieldReference('total`revenue', '`', adapterType)).toBe(
+                '`total``revenue`',
+            );
+        },
+    );
 });
 
 describe('getAggregatedField', () => {
@@ -38,5 +62,20 @@ describe('getAggregatedField', () => {
                 'total"revenue',
             ),
         ).toBe('sum("total""revenue")');
+    });
+
+    test('rejects aggregation function names outside VizAggregationOptions', () => {
+        const warehouseSqlBuilder = {
+            getFieldQuoteChar: () => '"',
+            getAdapterType: () => SupportedDbtAdapter.POSTGRES,
+        } as WarehouseSqlBuilder;
+
+        expect(() =>
+            getAggregatedField(
+                warehouseSqlBuilder,
+                'sum) FILTER (WHERE true); SELECT 1; --' as VizAggregationOptions,
+                'revenue',
+            ),
+        ).toThrow(ParameterError);
     });
 });

--- a/packages/common/src/utils/warehouse.ts
+++ b/packages/common/src/utils/warehouse.ts
@@ -1,4 +1,5 @@
 import { SupportedDbtAdapter } from '../types/dbt';
+import { ParameterError } from '../types/errors';
 import {
     DuckdbConnectionType,
     WarehouseTypes,
@@ -129,6 +130,12 @@ export const getAggregatedField = (
     aggregation: VizAggregationOptions,
     reference: string,
 ): string => {
+    if (!Object.values(VizAggregationOptions).includes(aggregation)) {
+        throw new ParameterError(
+            `Invalid visualization aggregation: ${aggregation}`,
+        );
+    }
+
     const adapterType = warehouseSqlBuilder.getAdapterType();
     const q = warehouseSqlBuilder.getFieldQuoteChar();
     const quotedReference = quoteFieldReference(reference, q, adapterType);


### PR DESCRIPTION
### Description

`PivotQueryBuilder` interpolated request-controlled pivot references and derived aliases directly between the warehouse field quote characters at many SQL-generation sites, so a reference containing the active quote character could break out of quoting. This routes every dynamic pivot identifier through the existing adapter-aware `quoteFieldReference`, so malicious references are rendered as one safely-quoted identifier (a missing column) rather than raw SQL.

Approach follows the reviewed design (a fresh, current-`main` implementation rather than reopening the stale #24046):

- Add `quoteIdentifier` / `qualifyIdentifier` helpers on `PivotQueryBuilder`; replace every dynamic `"<ref>"` interpolation with them. Fixed CTE names and SQL keywords stay literal.
- **Compose-then-quote** all derived names (`_order`, `_any`, aggregation output, `_ca_value`/`_ra_value` anchor and ranking columns, `getValueColumnFieldName`) so the suffix is part of the quoted identifier.
- Update the two rendered-expression consumers — `prefixSortExprWithAlias` and `replaceFieldReferencesWithAliases` — to build their search/replace tokens with the same renderer.
- Make the chronological-sort helpers (`sortMonthName` / `sortDayOfWeekName` / `sortQuarterName`) consume an already-rendered field identifier; both `PivotQueryBuilder` and `MetricQueryBuilder` render the raw field id with `quoteFieldReference` before calling them.
- Reject aggregation function names outside `VizAggregationOptions` in `getAggregatedField` before any SQL is built (the aggregation token is emitted as an executable function name, not an identifier).

Ordinary identifiers render byte-for-byte identically. Every per-method `const q` local was removed, so any missed interpolation site is a compile error.

### Verification

- `packages/common` `warehouse.test.ts`: aggregation-token rejection + adapter-family escaping (ANSI double-quote doubling; Databricks/Spark backtick doubling; BigQuery backslash).
- `packages/backend` `utils.test.ts` + `PivotQueryBuilder.test.ts`: hostile `category" DESC --` escaped through grouped aggregation + sorting; `_order`/`_any` compose-then-quote (broken append-after-quote forms asserted absent); BigQuery backslash escaping at pivot boundaries; chronological-sort field ids escaped.
- Live per-warehouse pivot matrix (Postgres, BigQuery, Snowflake, Databricks, Trino, ClickHouse, DuckDB) — in progress, results to follow in a comment.

Closes: PROD-9481