### PR TITLE
fix: preserve chart schema during SDK upgrades

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -13,6 +13,7 @@ import {
 import { subject, type Ability } from '@casl/ability';
 import {
     AlreadyExistsError,
+    APP_UPGRADE_PROMPT_LABEL,
     APP_VERSION_CANCELLED_BY_USER,
     assertEmbeddedAuth,
     assertUnreachable,
@@ -5206,8 +5207,12 @@ export class AppGenerateService extends BaseService {
 
         // Data app viz: persist the schema the generator declared as the run's
         // structured output.
-        if (isDataAppViz) {
+        if (isDataAppViz && !payload.isUpgrade) {
             await this.persistSchema(vizStructuredOutput, appUuid, version);
+        } else if (isDataAppViz) {
+            this.logger.info(
+                `Kept the copied schema for SDK upgrade of app ${appUuid} version ${version}; skipped structured schema regeneration`,
+            );
         }
 
         try {
@@ -5217,7 +5222,9 @@ export class AppGenerateService extends BaseService {
                 version,
                 'ready',
                 null,
-                isDataAppViz ? 'Visualization ready' : responseText,
+                isDataAppViz
+                    ? (payload.upgradeStatusMessage ?? 'Visualization ready')
+                    : responseText,
             );
             durations.dbMs = AppGenerateService.elapsed(dbStart);
             if (!updated) {
@@ -6438,8 +6445,6 @@ export class AppGenerateService extends BaseService {
         return latestDependencies;
     }
 
-    static readonly UPGRADE_PROMPT_LABEL = 'Upgrade to the latest app template';
-
     /**
      * The stored row prompt stays the short label (what chat history shows);
      * this composed instruction is what the pipeline actually sends —
@@ -6484,6 +6489,54 @@ export class AppGenerateService extends BaseService {
             '   It is for a non-technical app owner: never describe what you checked or how, never mention files, code, or APIs, and do not discuss features outside the bullet list.',
             '   Do not implement any of the features now.',
         ].join('\n');
+    }
+
+    private static buildDataAppVizUpgradeStatusMessage(
+        body: UpgradeAppRequestBody,
+    ): string {
+        const candidates = (body.candidateFeatures ?? []).slice(0, 20);
+        if (body.reportedFeatures === undefined) {
+            return [
+                'Upgraded to the latest chart SDK.',
+                '',
+                'This chart came from an older SDK that could not report its capabilities. Ask for a new capability in the prompt bar when you want the builder to add it.',
+            ].join('\n');
+        }
+        if (candidates.length === 0) {
+            return 'Upgraded to the latest chart SDK. This chart already had all currently reported capabilities.';
+        }
+        const nowActive = candidates.filter((feature) => !feature.wiring);
+        const askToAdd = candidates.filter((feature) => feature.wiring);
+        const sections = ['Upgraded to the latest chart SDK.'];
+        if (nowActive.length > 0) {
+            sections.push(
+                [
+                    'Now active:',
+                    '',
+                    ...nowActive.map(
+                        (feature) =>
+                            `- **${feature.label}** — ${feature.description}`,
+                    ),
+                ].join('\n'),
+            );
+        }
+        if (askToAdd.length > 0) {
+            const askCopy =
+                askToAdd.length === 1
+                    ? 'Newly available — ask me to add this in the prompt bar:'
+                    : 'Newly available — ask me to add any of these in the prompt bar:';
+            sections.push(
+                [
+                    askCopy,
+                    '',
+                    ...askToAdd.map(
+                        (feature) =>
+                            `- **${feature.label}** — ${feature.description}`,
+                    ),
+                ].join('\n'),
+            );
+        }
+        return sections.join('\n\n');
     }
 
     /**
@@ -6541,12 +6594,15 @@ export class AppGenerateService extends BaseService {
             appUuid,
             {
                 version: newVersion,
-                prompt: AppGenerateService.UPGRADE_PROMPT_LABEL,
+                prompt: APP_UPGRADE_PROMPT_LABEL,
             },
             'pending',
             user.userUuid,
             undefined,
             carriedDependencies,
+            app.template === DATA_APP_VIZ_TEMPLATE
+                ? (latestReady.viz_schema ?? undefined)
+                : undefined,
         );
 
         this.analytics.track({
@@ -6575,6 +6631,14 @@ export class AppGenerateService extends BaseService {
             prompt: AppGenerateService.buildUpgradePrompt(body),
             isIteration: true,
             isUpgrade: true,
+            ...(app.template === DATA_APP_VIZ_TEMPLATE
+                ? {
+                      upgradeStatusMessage:
+                          AppGenerateService.buildDataAppVizUpgradeStatusMessage(
+                              body,
+                          ),
+                  }
+                : {}),
             claudeEffort,
             designUuid: app.design_uuid,
         });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -29,19 +29,49 @@ const makeApp = (overrides: Record<string, unknown> = {}) => ({
     created_by_user_uuid: USER_UUID,
     sandbox_id: 'sandbox-registry-uuid',
     design_uuid: null,
+    template: 'data_app',
     ...overrides,
 });
 
-function buildService(opts: { canManage?: boolean } = {}) {
+const VIZ_SCHEMA = {
+    fields: [
+        {
+            name: 'category',
+            label: 'Category',
+            type: 'dimension' as const,
+            required: true,
+        },
+    ],
+    configOptions: [
+        {
+            name: 'showLabels',
+            label: 'Show labels',
+            type: 'boolean' as const,
+            default: true,
+            group: 'Display',
+        },
+    ],
+};
+
+function buildService(
+    opts: { canManage?: boolean; template?: 'data_app' | 'data_app_viz' } = {},
+) {
     const appModel = {
-        getApp: vi.fn().mockResolvedValue(makeApp()),
+        getApp: vi
+            .fn()
+            .mockResolvedValue(
+                makeApp({ template: opts.template ?? 'data_app' }),
+            ),
         getLatestVersion: vi.fn().mockResolvedValue({
             version: 4,
             status: 'ready',
             dependencies: null,
             created_at: new Date(),
         }),
-        getLatestReadyVersion: vi.fn().mockResolvedValue({ version: 4 }),
+        getLatestReadyVersion: vi.fn().mockResolvedValue({
+            version: 4,
+            viz_schema: opts.template === 'data_app_viz' ? VIZ_SCHEMA : null,
+        }),
         getVersionsWithDependencies: vi.fn().mockResolvedValue([]),
         createVersion: vi.fn().mockResolvedValue({ version: 5 }),
         updateSandboxUuid: vi.fn().mockResolvedValue(undefined),
@@ -149,6 +179,7 @@ describe('upgradeApp', () => {
             USER_UUID,
             undefined,
             undefined,
+            undefined,
         );
 
         const payload = schedulerClient.appGeneratePipeline.mock.calls[0][0];
@@ -169,6 +200,7 @@ describe('upgradeApp', () => {
         expect(payload.prompt).toContain('cannot run shell commands');
         expect(payload.prompt).toContain('Now active');
         expect(payload.prompt).not.toBe('Upgrade to the latest app template');
+        expect(payload.upgradeStatusMessage).toBeUndefined();
 
         expect(analytics.track).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -181,6 +213,69 @@ describe('upgradeApp', () => {
                     candidateFeatureKeys: ['drill-down', 'lineage'],
                 }),
             }),
+        );
+    });
+
+    it('preserves a chart type schema and queues a durable capability summary', async () => {
+        const { service, appModel, schedulerClient } = buildService({
+            template: 'data_app_viz',
+        });
+
+        await service.upgradeApp(makeUser(), PROJECT_UUID, APP_UUID, {
+            reportedSdkVersion: '1.68.0',
+            reportedFeatures: ['query'],
+            candidateFeatures: [
+                {
+                    key: 'metric-filters',
+                    label: 'Metric filters',
+                    description: 'Filter grouped results by metric values.',
+                    wiring: 'Pass metric filters to the query builder.',
+                },
+                {
+                    key: 'screenshot',
+                    label: 'In-app screenshots',
+                    description: 'Capture this chart for deliveries.',
+                },
+            ],
+        });
+
+        expect(appModel.createVersion).toHaveBeenCalledWith(
+            APP_UUID,
+            { version: 5, prompt: 'Upgrade to the latest app template' },
+            'pending',
+            USER_UUID,
+            undefined,
+            undefined,
+            VIZ_SCHEMA,
+        );
+        expect(
+            schedulerClient.appGeneratePipeline.mock.calls[0][0]
+                .upgradeStatusMessage,
+        ).toBe(
+            'Upgraded to the latest chart SDK.\n\nNow active:\n\n- **In-app screenshots** — Capture this chart for deliveries.\n\nNewly available — ask me to add this in the prompt bar:\n\n- **Metric filters** — Filter grouped results by metric values.',
+        );
+    });
+
+    it('uses a generic chart completion message when a legacy SDK cannot report an exact delta', async () => {
+        const { service, schedulerClient } = buildService({
+            template: 'data_app_viz',
+        });
+
+        await service.upgradeApp(makeUser(), PROJECT_UUID, APP_UUID, {
+            candidateFeatures: [
+                {
+                    key: 'metric-filters',
+                    label: 'Metric filters',
+                    description: 'Filter grouped results by metric values.',
+                },
+            ],
+        });
+
+        expect(
+            schedulerClient.appGeneratePipeline.mock.calls[0][0]
+                .upgradeStatusMessage,
+        ).toBe(
+            'Upgraded to the latest chart SDK.\n\nThis chart came from an older SDK that could not report its capabilities. Ask for a new capability in the prompt bar when you want the builder to add it.',
         );
     });
 

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -564,6 +564,8 @@ export type UpgradeCandidateFeature = {
     wiring?: string;
 };
 
+export const APP_UPGRADE_PROMPT_LABEL = 'Upgrade to the latest app template';
+
 /**
  * What the app's running bundle reported about itself via the SDK's
  * `lightdash:sdk:manifest` message. Both fields absent for legacy bundles

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -74,6 +74,9 @@ export type AppGeneratePipelineJobPayload = TraceTaskBase & {
     // the Claude session best-effort) so this run cold-starts on the current
     // template image. Absent on ordinary jobs.
     isUpgrade?: boolean;
+    /** Deterministic completion copy for upgrade surfaces that do not render
+     *  the coding agent's final response (currently reusable chart types). */
+    upgradeStatusMessage?: string;
     chartReferences?: ChartReference[];
     // Structural snapshot of the attached dashboard (tabs, tile layout,
     // filters). Written into the sandbox as a layout blueprint alongside the


### PR DESCRIPTION
### Description

- Preserve the latest ready reusable-chart schema when an SDK upgrade creates a new version.
- Skip structured schema regeneration only for SDK upgrades; normal chart generation is unchanged.
- Persist a durable completion summary that distinguishes capabilities that are now active from capabilities the author must ask the builder to add.

This is the safety layer for the stacked chart-builder UI PR #27683. Deploy this worker change before exposing that trigger.

### Verification

- 16 focused backend tests
- common and backend typechecks
- local end-to-end upgrade: previous ready render remained available, the new version completed, and its schema was JSON-identical to the source version

### Risk assessment

- [ ] This is a high-risk change

Low risk: no migration or new endpoint; scheduler additions are optional and existing jobs keep their fallback behavior.