### PR TITLE
feat: expose SDK upgrades in chart builder

### DIFF
--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -9,10 +9,7 @@ import {
     Badge,
     Divider,
     Indicator,
-    List,
     Menu,
-    Stack,
-    Text,
     Tooltip,
 } from '@mantine/core';
 import {
@@ -36,7 +33,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState, type FC, type ReactNode } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
-import MantineModal from '../../../components/common/MantineModal';
 import AppDeleteModal from '../../../components/common/modal/AppDeleteModal';
 import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
 import { ShareLinkButton } from '../../../components/common/ShareLinkButton';
@@ -54,7 +50,7 @@ import { useCanCreateDataApp } from '../hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../hooks/useCanEditDataApp';
 import { useDuplicateApp } from '../hooks/useDuplicateApp';
 import { type SdkUpgradeOffer } from '../hooks/useSdkUpgradeStatus';
-import { useUpgradeApp } from '../hooks/useUpgradeApp';
+import AppUpgradeModal from './AppUpgradeModal';
 import { MoveAppToSpaceModal } from './MoveAppToSpaceModal';
 import { PromoteAppModal } from './PromoteAppModal';
 
@@ -240,33 +236,10 @@ const AppHeaderActions: FC<Props> = ({
         );
     }, [duplicateMutate, navigate, projectUuid, appUuid]);
 
-    const { mutate: upgradeMutate, isLoading: isUpgrading } = useUpgradeApp();
     const upgradeAvailable =
         canEdit &&
         upgrade !== null &&
         (upgrade.status === 'stale' || upgrade.status === 'legacy');
-    const handleUpgrade = useCallback(() => {
-        if (!upgrade) return;
-        upgradeMutate(
-            {
-                projectUuid,
-                appUuid,
-                body: {
-                    ...(upgrade.reportedSdkVersion !== null
-                        ? { reportedSdkVersion: upgrade.reportedSdkVersion }
-                        : {}),
-                    ...(upgrade.reportedFeatures !== null
-                        ? { reportedFeatures: upgrade.reportedFeatures }
-                        : {}),
-                    ...(upgrade.candidateFeatures.length > 0
-                        ? { candidateFeatures: upgrade.candidateFeatures }
-                        : {}),
-                },
-            },
-            { onSuccess: () => setIsUpgradeModalOpen(false) },
-        );
-    }, [upgrade, upgradeMutate, projectUuid, appUuid]);
-
     return (
         <>
             {onEdit && (
@@ -407,7 +380,7 @@ const AppHeaderActions: FC<Props> = ({
                                     </Badge>
                                 ) : undefined
                             }
-                            disabled={upgrade.disabled || isUpgrading}
+                            disabled={upgrade.disabled}
                             onClick={() => setIsUpgradeModalOpen(true)}
                         >
                             Upgrade app
@@ -504,56 +477,14 @@ const AppHeaderActions: FC<Props> = ({
             </Menu>
 
             {isUpgradeModalOpen && upgrade && (
-                <MantineModal
+                <AppUpgradeModal
                     opened
                     onClose={() => setIsUpgradeModalOpen(false)}
-                    title="Upgrade app"
-                    icon={IconSparkles}
-                    confirmLabel="Upgrade"
-                    confirmLoading={isUpgrading}
-                    onConfirm={handleUpgrade}
-                >
-                    <Stack gap="sm">
-                        {upgrade.status === 'stale' ? (
-                            <>
-                                <Text size="sm">
-                                    Upgrading rebuilds this app on the latest
-                                    template. New since this app was built:
-                                </Text>
-                                <List spacing="xs" size="sm">
-                                    {upgrade.newFeatures.map((feature) => (
-                                        <List.Item key={feature.key}>
-                                            <Text size="sm" fw={500} span>
-                                                {feature.label}
-                                            </Text>{' '}
-                                            <Text size="sm" c="dimmed" span>
-                                                — {feature.description}
-                                            </Text>
-                                        </List.Item>
-                                    ))}
-                                </List>
-                                <Text size="sm" c="dimmed">
-                                    The agent fixes anything the new template
-                                    breaks, then offers these features in chat —
-                                    nothing is added until you ask.
-                                </Text>
-                            </>
-                        ) : upgrade.status === 'current' ? (
-                            <Text size="sm">
-                                This app is already on the latest SDK. Upgrading
-                                again rebuilds it on a fresh copy of the current
-                                template.
-                            </Text>
-                        ) : (
-                            <Text size="sm">
-                                This app was built on an older SDK. Upgrading
-                                rebuilds it on the latest template, and the
-                                agent will offer newly available features in
-                                chat — nothing is added until you ask.
-                            </Text>
-                        )}
-                    </Stack>
-                </MantineModal>
+                    projectUuid={projectUuid}
+                    appUuid={appUuid}
+                    offer={upgrade}
+                    resource="dataApp"
+                />
             )}
             {isUpdateModalOpen && (
                 <AppUpdateModal

--- a/packages/frontend/src/features/apps/components/AppUpgradeModal.test.tsx
+++ b/packages/frontend/src/features/apps/components/AppUpgradeModal.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { type SdkUpgradeOffer } from '../hooks/useSdkUpgradeStatus';
+import { useUpgradeApp } from '../hooks/useUpgradeApp';
+import AppUpgradeModal from './AppUpgradeModal';
+
+vi.mock('../hooks/useUpgradeApp', () => ({
+    useUpgradeApp: vi.fn(),
+}));
+
+const staleOffer: SdkUpgradeOffer = {
+    status: 'stale',
+    newFeatures: [
+        {
+            key: 'metric-filters',
+            label: 'Metric filters',
+            description: 'Filter grouped results by metric values.',
+            wiring: 'Pass metric filters to the query builder.',
+        },
+    ],
+    candidateFeatures: [
+        {
+            key: 'metric-filters',
+            label: 'Metric filters',
+            description: 'Filter grouped results by metric values.',
+            wiring: 'Pass metric filters to the query builder.',
+        },
+    ],
+    reportedSdkVersion: '1.68.0',
+    reportedFeatures: ['query'],
+};
+
+describe('AppUpgradeModal', () => {
+    it('submits the reported manifest and explains the chart type follow-up', () => {
+        const onClose = vi.fn();
+        const onStarted = vi.fn();
+        const mutate = vi.fn((_params, options) =>
+            options?.onSuccess?.({ appUuid: 'chart-1', version: 3 }),
+        );
+        vi.mocked(useUpgradeApp).mockReturnValue({
+            mutate,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useUpgradeApp>);
+
+        renderWithProviders(
+            <AppUpgradeModal
+                opened
+                onClose={onClose}
+                projectUuid="project-1"
+                appUuid="chart-1"
+                offer={staleOffer}
+                resource="chartType"
+                onStarted={onStarted}
+            />,
+        );
+
+        expect(screen.getByText('Upgrade chart type')).toBeInTheDocument();
+        expect(
+            screen.getByText(/ask for them in the prompt bar/i),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/fields, options and defaults stay unchanged/i),
+        ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Start upgrade' }));
+
+        expect(mutate).toHaveBeenCalledWith(
+            {
+                projectUuid: 'project-1',
+                appUuid: 'chart-1',
+                body: {
+                    reportedSdkVersion: '1.68.0',
+                    reportedFeatures: ['query'],
+                    candidateFeatures: staleOffer.candidateFeatures,
+                },
+            },
+            expect.objectContaining({ onSuccess: expect.any(Function) }),
+        );
+        expect(onStarted).toHaveBeenCalledWith({
+            appUuid: 'chart-1',
+            version: 3,
+        });
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('keeps the existing chat guidance for data apps', () => {
+        vi.mocked(useUpgradeApp).mockReturnValue({
+            mutate: vi.fn(),
+            isLoading: false,
+        } as unknown as ReturnType<typeof useUpgradeApp>);
+
+        renderWithProviders(
+            <AppUpgradeModal
+                opened
+                onClose={vi.fn()}
+                projectUuid="project-1"
+                appUuid="app-1"
+                offer={staleOffer}
+                resource="dataApp"
+            />,
+        );
+
+        expect(screen.getByText('Upgrade app')).toBeInTheDocument();
+        expect(screen.getByText(/ask for them in chat/i)).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/apps/components/AppUpgradeModal.tsx
+++ b/packages/frontend/src/features/apps/components/AppUpgradeModal.tsx
@@ -1,0 +1,123 @@
+import { type ApiUpgradeAppResponse } from '@lightdash/common';
+import { List, Stack, Text } from '@mantine/core';
+import { IconSparkles } from '@tabler/icons-react';
+import { useCallback, type FC } from 'react';
+import MantineModal from '../../../components/common/MantineModal';
+import { type SdkUpgradeOffer } from '../hooks/useSdkUpgradeStatus';
+import { useUpgradeApp } from '../hooks/useUpgradeApp';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    appUuid: string;
+    offer: SdkUpgradeOffer;
+    resource: 'dataApp' | 'chartType';
+    onStarted?: (result: ApiUpgradeAppResponse['results']) => void;
+};
+
+/**
+ * Owns the SDK upgrade request and confirmation copy. Data-app and chart-type
+ * surfaces provide only their trigger and what should happen once a new
+ * version starts.
+ */
+const AppUpgradeModal: FC<Props> = ({
+    opened,
+    onClose,
+    projectUuid,
+    appUuid,
+    offer,
+    resource,
+    onStarted,
+}) => {
+    const { mutate, isLoading } = useUpgradeApp();
+    const isChartType = resource === 'chartType';
+    const noun = isChartType ? 'chart type' : 'app';
+
+    const handleUpgrade = useCallback(() => {
+        mutate(
+            {
+                projectUuid,
+                appUuid,
+                body: {
+                    ...(offer.reportedSdkVersion !== null
+                        ? { reportedSdkVersion: offer.reportedSdkVersion }
+                        : {}),
+                    ...(offer.reportedFeatures !== null
+                        ? { reportedFeatures: offer.reportedFeatures }
+                        : {}),
+                    ...(offer.candidateFeatures.length > 0
+                        ? { candidateFeatures: offer.candidateFeatures }
+                        : {}),
+                },
+            },
+            {
+                onSuccess: (result) => {
+                    onStarted?.(result);
+                    onClose();
+                },
+            },
+        );
+    }, [appUuid, mutate, offer, onClose, onStarted, projectUuid]);
+
+    const followUpCopy = isChartType
+        ? 'When it is ready, Version History will show what is now active and what you can ask the builder to add. Ask for them in the prompt bar; nothing that changes your chart is added automatically.'
+        : 'When it is ready, chat will show what is now active and what you can ask the builder to add. Ask for them in chat; nothing that changes your app is added automatically.';
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title={`Upgrade ${noun}`}
+            icon={IconSparkles}
+            confirmLabel="Start upgrade"
+            confirmLoading={isLoading}
+            onConfirm={handleUpgrade}
+        >
+            <Stack gap="sm">
+                {offer.status === 'stale' ? (
+                    <>
+                        <Text size="sm">
+                            This creates a new version of the {noun} using the
+                            latest SDK. New since this version was built:
+                        </Text>
+                        <List spacing="xs" size="sm">
+                            {offer.newFeatures.map((feature) => (
+                                <List.Item key={feature.key}>
+                                    <Text size="sm" fw={500} span>
+                                        {feature.label}
+                                    </Text>{' '}
+                                    <Text size="sm" c="dimmed" span>
+                                        — {feature.description}
+                                    </Text>
+                                </List.Item>
+                            ))}
+                        </List>
+                    </>
+                ) : offer.status === 'current' ? (
+                    <Text size="sm">
+                        This {noun} is already on the latest SDK. Upgrading
+                        again creates a new version from the current template.
+                    </Text>
+                ) : (
+                    <Text size="sm">
+                        This {noun} was built on an older SDK that cannot report
+                        its exact capabilities. Upgrading creates a new version
+                        from the latest template.
+                    </Text>
+                )}
+                {isChartType && (
+                    <Text size="sm">
+                        The current chart remains available while the upgrade
+                        builds. Its fields, options and defaults stay unchanged.
+                    </Text>
+                )}
+                <Text size="sm" c="dimmed">
+                    {followUpCopy}
+                </Text>
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export default AppUpgradeModal;

--- a/packages/frontend/src/features/apps/hooks/useSdkUpgradeStatus.test.tsx
+++ b/packages/frontend/src/features/apps/hooks/useSdkUpgradeStatus.test.tsx
@@ -1,0 +1,140 @@
+import { SDK_FEATURES } from '@lightdash/common';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useSdkUpgradeStatus } from './useSdkUpgradeStatus';
+
+const ALL_FEATURES = SDK_FEATURES.map(({ key }) => key);
+const MISSING_FIRST = SDK_FEATURES.slice(1).map(({ key }) => key);
+
+describe('useSdkUpgradeStatus', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('classifies manifests and resets when the classified bundle changes', () => {
+        const { result, rerender } = renderHook(
+            ({ bundleKey }) =>
+                useSdkUpgradeStatus({
+                    bundleKey,
+                    renderedKey: bundleKey,
+                    isRendering: true,
+                }),
+            { initialProps: { bundleKey: 'app-1:1' } },
+        );
+
+        expect(result.current.offer.status).toBe('unknown');
+
+        act(() => {
+            result.current.onSdkManifest({
+                sdkVersion: '1.0.0',
+                features: MISSING_FIRST,
+            });
+        });
+        expect(result.current.offer.status).toBe('stale');
+        expect(result.current.offer.newFeatures).toEqual([SDK_FEATURES[0]]);
+
+        act(() => {
+            result.current.onSdkManifest({
+                sdkVersion: '2.0.0',
+                features: ALL_FEATURES,
+            });
+        });
+        expect(result.current.offer.status).toBe('current');
+
+        rerender({ bundleKey: 'app-1:2' });
+        expect(result.current.offer.status).toBe('unknown');
+    });
+
+    it('classifies a silent bundle as legacy', async () => {
+        vi.useFakeTimers();
+        const { result } = renderHook(() =>
+            useSdkUpgradeStatus({
+                bundleKey: 'app-1:1',
+                renderedKey: 'app-1:1',
+                isRendering: true,
+            }),
+        );
+
+        await act(async () => vi.advanceTimersByTime(5_000));
+
+        expect(result.current.offer.status).toBe('legacy');
+        expect(result.current.offer.candidateFeatures).toEqual(SDK_FEATURES);
+    });
+
+    it('ignores manifests reported while another version is on screen', () => {
+        const { result, rerender } = renderHook(
+            ({ isRendering }) =>
+                useSdkUpgradeStatus({
+                    bundleKey: 'app-1:3',
+                    renderedKey: 'app-1:3',
+                    isRendering,
+                }),
+            { initialProps: { isRendering: true } },
+        );
+
+        act(() => {
+            result.current.onSdkManifest({
+                sdkVersion: '2.0.0',
+                features: ALL_FEATURES,
+            });
+        });
+        expect(result.current.offer.status).toBe('current');
+
+        // The user views an older version: its bundle reports a smaller
+        // feature set, but the offer still describes the latest ready one.
+        rerender({ isRendering: false });
+        act(() => {
+            result.current.onSdkManifest({
+                sdkVersion: '1.0.0',
+                features: MISSING_FIRST,
+            });
+        });
+
+        expect(result.current.offer.status).toBe('current');
+        expect(result.current.offer.reportedSdkVersion).toBe('2.0.0');
+        // The bundle actually on screen is still reported for consumers that
+        // ask what the previewed app can do.
+        expect(result.current.renderedManifest?.sdkVersion).toBe('1.0.0');
+    });
+
+    it('clears the rendered manifest when the bundle on screen changes', () => {
+        const { result, rerender } = renderHook(
+            ({ renderedKey }) =>
+                useSdkUpgradeStatus({
+                    bundleKey: 'app-1:3',
+                    renderedKey,
+                    isRendering: renderedKey === 'app-1:3',
+                }),
+            { initialProps: { renderedKey: 'app-1:3' } },
+        );
+
+        act(() => {
+            result.current.onSdkManifest({
+                sdkVersion: '2.0.0',
+                features: ALL_FEATURES,
+            });
+        });
+        expect(result.current.renderedManifest?.sdkVersion).toBe('2.0.0');
+
+        // Pinning a silent legacy version must not inherit the previous
+        // bundle's capabilities.
+        rerender({ renderedKey: 'app-1:1' });
+        expect(result.current.renderedManifest).toBeNull();
+        expect(result.current.offer.status).toBe('current');
+    });
+
+    it('does not time out into legacy while another version is on screen', async () => {
+        vi.useFakeTimers();
+        const { result } = renderHook(() =>
+            useSdkUpgradeStatus({
+                bundleKey: 'app-1:3',
+                renderedKey: 'app-1:2',
+                isRendering: false,
+            }),
+        );
+
+        await act(async () => vi.advanceTimersByTime(5_000));
+
+        expect(result.current.offer.status).toBe('unknown');
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useSdkUpgradeStatus.ts
+++ b/packages/frontend/src/features/apps/hooks/useSdkUpgradeStatus.ts
@@ -1,8 +1,9 @@
 import { SDK_FEATURES, type SdkFeature } from '@lightdash/common';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { type SdkManifest } from './useAppSdkBridge';
 
-/** How long after a preview mounts before a silent bundle counts as legacy. */
+/** How long the classified bundle may render without reporting before it
+ *  counts as legacy. */
 const LEGACY_TIMEOUT_MS = 5000;
 
 export type SdkUpgradeStatus = 'unknown' | 'legacy' | 'current' | 'stale';
@@ -21,33 +22,70 @@ export type SdkUpgradeOffer = {
 };
 
 /**
- * Classifies the previewed app bundle against the current SDK feature
+ * Classifies an app's latest ready bundle against the current SDK feature
  * registry. The bundle self-reports via `lightdash:sdk:manifest`
  * (`onSdkManifest` feeds it in); a bundle that stays silent past the timeout
  * is `legacy` (built before feature reporting). Nothing is persisted — the
- * running bundle is the only source of truth, so restoring an old version
- * legitimately re-lights the offer.
+ * running bundle is the only source of truth, so a rollback that makes an
+ * older bundle the latest ready one legitimately re-lights the offer.
+ *
+ * The offer always describes the version an upgrade would actually rebuild
+ * from — `upgradeApp` restores the latest ready source regardless of what the
+ * user is previewing — so manifests from any other version are ignored.
  */
 export const useSdkUpgradeStatus = ({
-    resetKey,
+    bundleKey,
+    renderedKey,
+    isRendering,
 }: {
-    /** Identity of the previewed bundle (app + version); null = no preview.
-     *  A change resets the manifest so a rolled-back or newly deployed
-     *  version re-reports rather than inheriting the previous bundle's. */
-    resetKey: string | null;
+    /** Identity (app + version) of the bundle the offer describes: the latest
+     *  ready version, never the one the user happens to be viewing. A change
+     *  resets the manifest so the new bundle re-reports rather than inheriting
+     *  the previous one's. Null = nothing to classify. */
+    bundleKey: string | null;
+    /** Identity (app + version) of the bundle on screen; null = no preview.
+     *  A change clears the rendered manifest so the new bundle re-reports. */
+    renderedKey: string | null;
+    /** Whether the preview is currently running that bundle. While it is not,
+     *  the last classification stands: manifests belong to some other version
+     *  and the legacy timeout would fire against a bundle that never got the
+     *  chance to report. */
+    isRendering: boolean;
 }) => {
     const [manifest, setManifest] = useState<SdkManifest | null>(null);
+    const [renderedManifest, setRenderedManifest] =
+        useState<SdkManifest | null>(null);
     const [timedOut, setTimedOut] = useState(false);
+
+    const isRenderingRef = useRef(isRendering);
+    useEffect(() => {
+        isRenderingRef.current = isRendering;
+    }, [isRendering]);
+
+    useEffect(() => {
+        setManifest(null);
+        setTimedOut(false);
+    }, [bundleKey]);
+
+    useEffect(() => {
+        setRenderedManifest(null);
+    }, [renderedKey]);
 
     // The iframe is an external system — keyed reset + timeout is
     // synchronisation, not prop-mirroring.
     useEffect(() => {
-        setManifest(null);
-        setTimedOut(false);
-        if (resetKey === null) return undefined;
+        if (bundleKey === null || !isRendering) return undefined;
         const timer = setTimeout(() => setTimedOut(true), LEGACY_TIMEOUT_MS);
         return () => clearTimeout(timer);
-    }, [resetKey]);
+    }, [bundleKey, isRendering]);
+
+    // Stable identity: the bridge re-subscribes its window listener whenever
+    // this changes, so the gate reads a ref rather than closing over the flag.
+    const onSdkManifest = useCallback((reported: SdkManifest) => {
+        setRenderedManifest(reported);
+        if (!isRenderingRef.current) return;
+        setManifest(reported);
+    }, []);
 
     const offer = useMemo<SdkUpgradeOffer>(() => {
         if (manifest) {
@@ -74,5 +112,8 @@ export const useSdkUpgradeStatus = ({
         };
     }, [manifest, timedOut]);
 
-    return { offer, onSdkManifest: setManifest };
+    /** What the bundle on screen reports, whichever version that is. Answers
+     *  "can the app I am looking at do X?" — a different question from the
+     *  offer, which describes the version an upgrade would rebuild from. */
+    return { offer, renderedManifest, onSdkManifest };
 };

--- a/packages/frontend/src/features/chartTypes/builder/BuilderCanvas.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/BuilderCanvas.tsx
@@ -6,6 +6,7 @@ import { Box, Stack, Text } from '@mantine/core';
 import { type FC, type ReactNode } from 'react';
 import { useResolvedColorPalette } from '../../../hooks/appearance/useResolvedColorPalette';
 import AppPreview from '../../apps/components/AppPreview';
+import { type SdkManifest } from '../../apps/hooks/useAppSdkBridge';
 import classes from './BuilderCanvas.module.css';
 import BuilderPromptExamples from './BuilderPromptExamples';
 
@@ -29,6 +30,7 @@ type Props = {
     /** Fills the composer with a starter prompt; null while no composer is
      *  mounted to receive one. */
     onPickExample: ((prompt: string) => void) | null;
+    onSdkManifest: (manifest: SdkManifest) => void;
 };
 
 /** Same footprint and viewBox as an example card's thumbnail, so the canvas
@@ -82,6 +84,7 @@ const BuilderCanvas: FC<Props> = ({
     previewContext,
     configurePanel,
     onPickExample,
+    onSdkManifest,
 }) => {
     const hasPreview = appUuid !== null && previewVersion !== null;
     const isFirstBuild = isBuilding && !hasPreview;
@@ -102,6 +105,7 @@ const BuilderCanvas: FC<Props> = ({
                             version={previewVersion}
                             refreshKey={0}
                             dataAppVizContext={previewContext ?? undefined}
+                            onSdkManifest={onSdkManifest}
                         />
                     </Box>
                 </Box>

--- a/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.tsx
@@ -16,11 +16,14 @@ import {
     IconHistory,
     IconInfoCircle,
     IconPencil,
+    IconSparkles,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Link, type To } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
+import AppUpgradeModal from '../../apps/components/AppUpgradeModal';
+import { type SdkUpgradeOffer } from '../../apps/hooks/useSdkUpgradeStatus';
 import { getVersionAuthorName } from '../../apps/utils/versionsToChatMessages';
 import classes from './ChartTypeBuilderHeader.module.css';
 import VersionProvenance from './VersionProvenance';
@@ -41,6 +44,8 @@ type Props = {
     /** False while the visualization has no versions to look back through. */
     hasHistory: boolean;
     isHistoryOpen: boolean;
+    upgrade: (SdkUpgradeOffer & { disabled: boolean }) | null;
+    onUpgradeStarted: () => void;
     onToggleHistory: () => void;
     onPreviewInExplorer: () => void;
 };
@@ -54,10 +59,15 @@ const ChartTypeBuilderHeader: FC<Props> = ({
     hasOrigin,
     hasHistory,
     isHistoryOpen,
+    upgrade,
+    onUpgradeStarted,
     onToggleHistory,
     onPreviewInExplorer,
 }) => {
     const [isEditingDetails, setIsEditingDetails] = useState(false);
+    const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
+    const upgradeAvailable =
+        upgrade?.status === 'stale' || upgrade?.status === 'legacy';
 
     return (
         <Box className={classes.header} component="header">
@@ -129,6 +139,20 @@ const ChartTypeBuilderHeader: FC<Props> = ({
                 )}
             </Box>
             <Group gap="xs" wrap="nowrap">
+                {upgradeAvailable && (
+                    <Button
+                        size="xs"
+                        variant="light"
+                        color="blue"
+                        leftSection={
+                            <MantineIcon icon={IconSparkles} size={15} />
+                        }
+                        disabled={upgrade.disabled}
+                        onClick={() => setIsUpgradeModalOpen(true)}
+                    >
+                        Upgrade available
+                    </Button>
+                )}
                 {hasHistory && (
                     <Button
                         size="xs"
@@ -159,6 +183,17 @@ const ChartTypeBuilderHeader: FC<Props> = ({
                     initialDescription={app.description}
                     resourceLabel="Chart Type"
                     icon={IconPencil}
+                />
+            )}
+            {app && upgrade && isUpgradeModalOpen && (
+                <AppUpgradeModal
+                    opened
+                    onClose={() => setIsUpgradeModalOpen(false)}
+                    projectUuid={projectUuid}
+                    appUuid={app.appUuid}
+                    offer={upgrade}
+                    resource="chartType"
+                    onStarted={onUpgradeStarted}
                 />
             )}
         </Box>

--- a/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.module.css
+++ b/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.module.css
@@ -96,6 +96,21 @@
     padding: 6px 8px;
 }
 
+.upgradeSummary {
+    padding: 8px;
+    border: 1px solid var(--mantine-color-blue-2);
+    border-radius: var(--mantine-radius-sm);
+    background: light-dark(
+        var(--mantine-color-blue-0),
+        rgba(34, 139, 230, 0.12)
+    );
+}
+
+.upgradeSummaryMarkdown {
+    --ai-markdown-padding-left: 0;
+    --ai-markdown-font-size: 11px;
+}
+
 .buildDetails {
     border-top: 1px solid var(--mantine-color-ldGray-2);
 }

--- a/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.test.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.test.tsx
@@ -1,3 +1,4 @@
+import { APP_UPGRADE_PROMPT_LABEL } from '@lightdash/common';
 import { fireEvent, screen } from '@testing-library/react';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -212,6 +213,30 @@ describe('VersionHistoryPanel', () => {
         );
 
         expect(screen.queryByText('Build details')).not.toBeInTheDocument();
+    });
+
+    it('shows the durable summary for a completed SDK upgrade', () => {
+        renderWithProviders(
+            <VersionHistoryPanel
+                {...defaultProps}
+                versions={[
+                    appVersion({
+                        version: 3,
+                        prompt: APP_UPGRADE_PROMPT_LABEL,
+                        statusMessage:
+                            'Upgraded to the latest chart SDK.\n\nNewly available — ask me to add this in the prompt bar:\n\n- **Metric filters** — Filter grouped results.',
+                    }),
+                    ...twoVersions,
+                ]}
+                latestReadyVersion={3}
+            />,
+        );
+
+        expect(screen.getByText('Upgrade summary')).toBeInTheDocument();
+        expect(screen.getByText('Metric filters')).toBeInTheDocument();
+        expect(
+            screen.getByText(/ask me to add this in the prompt bar/i),
+        ).toBeInTheDocument();
     });
 
     it('loads earlier versions on demand', () => {

--- a/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.tsx
@@ -1,4 +1,5 @@
 import {
+    APP_UPGRADE_PROMPT_LABEL,
     isAppVersionInProgress,
     type ApiAppVersionSummary,
 } from '@lightdash/common';
@@ -15,6 +16,7 @@ import { IconChevronRight, IconX } from '@tabler/icons-react';
 import { format } from 'date-fns';
 import { useState, type FC } from 'react';
 import { LightdashUserAvatar } from '../../../components/Avatar';
+import { AiMarkdown } from '../../../components/common/AiMarkdown';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import AppVersionNarration from '../../apps/components/AppVersionNarration';
@@ -150,6 +152,7 @@ const VersionHistoryPanel: FC<Props> = ({
         const isCurrent = version.version === latestReadyVersion;
         const isActive = version.version === activeVersion;
         const label = `v${version.version}`;
+        const isUpgrade = version.prompt === APP_UPGRADE_PROMPT_LABEL;
 
         return (
             <Box
@@ -225,6 +228,17 @@ const VersionHistoryPanel: FC<Props> = ({
                 )}
 
                 {!isBuilding && <VersionBuildDetails version={version} />}
+
+                {isReady && isUpgrade && version.statusMessage && (
+                    <Box className={classes.upgradeSummary}>
+                        <Text fz={11} fw={600} c="blue.8" mb={4}>
+                            Upgrade summary
+                        </Text>
+                        <AiMarkdown className={classes.upgradeSummaryMarkdown}>
+                            {version.statusMessage}
+                        </AiMarkdown>
+                    </Box>
+                )}
 
                 <Box className={classes.row}>
                     <AuthorLine version={version} />

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1155,14 +1155,26 @@ const AppGenerate: FC = () => {
         return { appUuid: activeAppUuid, version: latestReadyVersion.version };
     }, [activeAppUuid, effectivePinnedVersion, latestReadyVersion]);
 
-    // Upgrade offer for the header menu, derived from the previewed bundle's
-    // SDK manifest. Keyed per app+version so rollbacks/deploys re-classify.
-    const { offer: sdkUpgradeOffer, onSdkManifest: handleSdkManifest } =
-        useSdkUpgradeStatus({
-            resetKey: previewApp
-                ? `${previewApp.appUuid}:${previewApp.version}`
+    // Upgrade offer for the header menu. Keyed to the latest ready bundle —
+    // the one an upgrade would rebuild from — not to whatever version the
+    // user has pinned the preview to.
+    const {
+        offer: sdkUpgradeOffer,
+        renderedManifest: renderedSdkManifest,
+        onSdkManifest: handleSdkManifest,
+    } = useSdkUpgradeStatus({
+        bundleKey:
+            activeAppUuid && latestReadyVersion !== null
+                ? `${activeAppUuid}:${latestReadyVersion.version}`
                 : null,
-        });
+        renderedKey: previewApp
+            ? `${previewApp.appUuid}:${previewApp.version}`
+            : null,
+        isRendering:
+            previewApp !== null &&
+            latestReadyVersion !== null &&
+            previewApp.version === latestReadyVersion.version,
+    });
 
     // Pin the preview to a specific version. Captures the current latest as
     // the "pinned-at" snapshot so the derived state can decide later when
@@ -3202,7 +3214,7 @@ const AppGenerate: FC = () => {
                                         lineageEnabled={lineageEnabled}
                                         lineageAvailable={lineageAvailable}
                                         lineageSupportedBySdk={
-                                            sdkUpgradeOffer.reportedFeatures?.includes(
+                                            renderedSdkManifest?.features.includes(
                                                 'lineage',
                                             ) ?? false
                                         }

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -15,6 +15,8 @@ import { useCanCreateDataApp } from '../features/apps/hooks/useCanCreateDataApp'
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
 import { useClarificationRound } from '../features/apps/hooks/useClarificationRound';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
+import { useSdkUpgradeStatus } from '../features/apps/hooks/useSdkUpgradeStatus';
+import { useUpgradeApp } from '../features/apps/hooks/useUpgradeApp';
 import { appVersion } from '../features/apps/testing/appVersionHistory';
 import { useDataAppVisualization } from '../features/chartTypes/hooks/useDataAppVisualization';
 import { useDataAppVizBuild } from '../features/chartTypes/hooks/useDataAppVizBuild';
@@ -36,6 +38,12 @@ vi.mock('../features/apps/hooks/useCanEditDataApp', () => ({
 }));
 vi.mock('../features/apps/hooks/useGetApp', () => ({
     useGetApp: vi.fn(),
+}));
+vi.mock('../features/apps/hooks/useSdkUpgradeStatus', () => ({
+    useSdkUpgradeStatus: vi.fn(),
+}));
+vi.mock('../features/apps/hooks/useUpgradeApp', () => ({
+    useUpgradeApp: vi.fn(),
 }));
 vi.mock('../features/apps/hooks/useAppVersionHistory', () => ({
     useAppVersionHistory: vi.fn(),
@@ -62,8 +70,30 @@ vi.mock('../hooks/appearance/useProjectColorPalette', () => ({
     useProjectColorPalette: () => ({ data: undefined }),
 }));
 vi.mock('../features/apps/components/AppPreview', () => ({
-    default: ({ version }: { version: number }) => (
-        <div data-testid="app-preview">{`preview-v${version}`}</div>
+    default: ({
+        version,
+        onSdkManifest,
+    }: {
+        version: number;
+        onSdkManifest?: (manifest: {
+            sdkVersion: string;
+            features: string[];
+        }) => void;
+    }) => (
+        <div data-testid="app-preview">
+            {`preview-v${version}`}
+            <button
+                type="button"
+                onClick={() =>
+                    onSdkManifest?.({
+                        sdkVersion: '1.68.0',
+                        features: ['query'],
+                    })
+                }
+            >
+                Report SDK manifest
+            </button>
+        </div>
     ),
 }));
 vi.mock('../components/common/PromptComposer/PromptComposer', () => ({
@@ -215,6 +245,28 @@ const mockedClarificationRound = vi.mocked(
     useClarificationRound<VizBuildRequest>,
 );
 
+const staleUpgradeOffer = {
+    status: 'stale' as const,
+    newFeatures: [
+        {
+            key: 'metric-filters',
+            label: 'Metric filters',
+            description: 'Filter grouped results by metric values.',
+            wiring: 'Pass metric filters to the query builder.',
+        },
+    ],
+    candidateFeatures: [
+        {
+            key: 'metric-filters',
+            label: 'Metric filters',
+            description: 'Filter grouped results by metric values.',
+            wiring: 'Pass metric filters to the query builder.',
+        },
+    ],
+    reportedSdkVersion: '1.68.0',
+    reportedFeatures: ['query'],
+};
+
 describe('ChartTypeBuilder', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -228,6 +280,15 @@ describe('ChartTypeBuilder', () => {
         } as ReturnType<typeof useDataAppVisualization>);
         setApp(null);
         vi.mocked(useAppVersionHistory).mockReturnValue(historyStub([], null));
+        vi.mocked(useSdkUpgradeStatus).mockReturnValue({
+            offer: staleUpgradeOffer,
+            renderedManifest: null,
+            onSdkManifest: vi.fn(),
+        });
+        vi.mocked(useUpgradeApp).mockReturnValue({
+            mutate: vi.fn(),
+            isLoading: false,
+        } as unknown as ReturnType<typeof useUpgradeApp>);
     });
 
     it('redirects home when data apps are disabled', () => {
@@ -638,6 +699,101 @@ describe('ChartTypeBuilder', () => {
             }),
         ).toBeInTheDocument();
         expect(screen.getByLabelText('View v1')).toBeInTheDocument();
+    });
+
+    it('offers the preview SDK upgrade and opens history after starting it', () => {
+        const onSdkManifest = vi.fn();
+        const mutate = vi.fn((_params, options) =>
+            options?.onSuccess?.({ appUuid: 'viz-1', version: 3 }),
+        );
+        vi.mocked(useSdkUpgradeStatus).mockReturnValue({
+            offer: staleUpgradeOffer,
+            renderedManifest: null,
+            onSdkManifest,
+        });
+        vi.mocked(useUpgradeApp).mockReturnValue({
+            mutate,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useUpgradeApp>);
+        setApp(appMeta());
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub([appVersion({ version: 2 })], 2),
+        );
+
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        fireEvent.click(screen.getByText('Report SDK manifest'));
+        expect(onSdkManifest).toHaveBeenCalledWith({
+            sdkVersion: '1.68.0',
+            features: ['query'],
+        });
+
+        fireEvent.click(
+            screen.getByRole('button', { name: /upgrade available/i }),
+        );
+        expect(screen.getByText('Upgrade chart type')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Start upgrade' }));
+
+        expect(mutate).toHaveBeenCalled();
+        expect(screen.getByLabelText('Version history')).toBeInTheDocument();
+    });
+
+    it('keys the upgrade offer to the latest ready version, not the viewed one', () => {
+        setApp(appMeta());
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [appVersion({ version: 2 }), appVersion({ version: 1 })],
+                2,
+            ),
+        );
+
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        const keyedToLatestReady = () =>
+            vi.mocked(useSdkUpgradeStatus).mock.lastCall?.[0];
+
+        expect(keyedToLatestReady()).toEqual({
+            bundleKey: 'viz-1:2',
+            renderedKey: 'viz-1:2',
+            isRendering: true,
+        });
+
+        fireEvent.click(screen.getByText('History'));
+        fireEvent.click(screen.getByLabelText('View v1'));
+
+        // An upgrade always rebuilds from v2, so the offer keeps describing
+        // it; the v1 bundle on screen must not be classified in its place.
+        expect(keyedToLatestReady()).toEqual({
+            bundleKey: 'viz-1:2',
+            renderedKey: 'viz-1:1',
+            isRendering: false,
+        });
+        expect(screen.getByText('preview-v1')).toBeInTheDocument();
+    });
+
+    it('disables SDK upgrades while another version is building', () => {
+        setApp(appMeta());
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [
+                    appVersion({ version: 3, status: 'generating' }),
+                    appVersion({ version: 2 }),
+                ],
+                2,
+            ),
+        );
+
+        renderBuilder(
+            '/projects/p1/chart-types/1e9a3b2c-0000-4000-8000-000000000001',
+        );
+
+        expect(
+            screen.getByRole('button', { name: /upgrade available/i }),
+        ).toBeDisabled();
     });
 
     it('previews a version picked from history and follows the current one again when the panel closes', () => {

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -39,6 +39,7 @@ import {
 import { useDataAppModelSelection } from '../features/apps/hooks/useDataAppModelSelection';
 import { useElapsedClock } from '../features/apps/hooks/useElapsedClock';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
+import { useSdkUpgradeStatus } from '../features/apps/hooks/useSdkUpgradeStatus';
 import { getVersionNarration } from '../features/apps/utils/versionNarration';
 import BuilderCanvas from '../features/chartTypes/builder/BuilderCanvas';
 import BuilderPromptBar, {
@@ -244,6 +245,20 @@ const ChartTypeBuilder: FC = () => {
     }, [pin, activeVizUuid, history.latestReadyVersion, history.versions]);
 
     const previewVersion = effectiveViewedVersion ?? history.latestReadyVersion;
+    const { offer: sdkUpgradeOffer, onSdkManifest: handleSdkManifest } =
+        useSdkUpgradeStatus({
+            bundleKey:
+                activeVizUuid && history.latestReadyVersion !== null
+                    ? `${activeVizUuid}:${history.latestReadyVersion}`
+                    : null,
+            renderedKey:
+                activeVizUuid && previewVersion !== null
+                    ? `${activeVizUuid}:${previewVersion}`
+                    : null,
+            isRendering:
+                previewVersion !== null &&
+                previewVersion === history.latestReadyVersion,
+        });
 
     // The schema follows the preview: the options beside a version are the ones
     // that version declares, and the sample data is built from its fields.
@@ -454,6 +469,12 @@ const ChartTypeBuilder: FC = () => {
                 hasOrigin={history.hasOrigin}
                 hasHistory={hasHistory}
                 isHistoryOpen={isHistoryOpen}
+                upgrade={
+                    activeVizUuid && history.latestReadyVersion !== null
+                        ? { ...sdkUpgradeOffer, disabled: isBuilding }
+                        : null
+                }
+                onUpgradeStarted={() => setIsHistoryOpen(true)}
                 onToggleHistory={() =>
                     isHistoryOpen
                         ? handleCloseHistory()
@@ -480,6 +501,7 @@ const ChartTypeBuilder: FC = () => {
                             onPickExample={
                                 isPromptBarMounted ? handlePickExample : null
                             }
+                            onSdkManifest={handleSdkManifest}
                         />
                         {isPromptBarMounted && (
                             <BuilderPromptBar


### PR DESCRIPTION
### Description

- Add the approved Upgrade available action to the reusable chart-type builder header.
- Reuse the existing manifest classifier, upgrade mutation, polling, and version history.
- Extract the data-app confirmation into a shared AppUpgradeModal built on MantineModal, with resource-specific chat or prompt-bar guidance.
- Open History after starting an upgrade and show the durable Now active / Newly available summary when it completes.
- Data apps change too, beyond the extraction: the upgrade offer is now classified from the latest ready version (the one an upgrade rebuilds from) rather than the version being previewed, the confirm button reads Start upgrade, and the confirmation copy is rewritten to share the chart-type wording. The lineage tooltip reads the manifest of the bundle on screen, which now resets whenever the previewed version changes.

Stacked on #27682, which preserves the chart schema and supplies the durable completion message.

### Verification

- 52 focused frontend tests
- frontend typecheck and targeted lint
- local end-to-end upgrade through the patched API and scheduler

<img width="1600" height="1000" alt="03-upgrade-available" src="https://github.com/user-attachments/assets/52465064-0ccf-48cb-adab-578d1d04a9ca" />
<img width="1600" height="1000" alt="04-upgrade-modal" src="https://github.com/user-attachments/assets/a15325c7-2961-4680-a484-6b9e6c456041" />
<img width="1600" height="1000" alt="05-building" src="https://github.com/user-attachments/assets/808c3fa0-cd8d-4ad1-833a-18a3206fd9a7" />
<img width="1600" height="1000" alt="06-history-ready-summary" src="https://github.com/user-attachments/assets/00601216-ccf7-499b-af59-821b35d7c5d8" />


### Risk assessment

- [ ] This is a high-risk change

Low risk: editors only, disabled during builds, no new polling or API surface, and current/unknown SDK states do not add header noise.
