### PR TITLE
feat(upgrade-automation): serve more than one instance from one repository

### DIFF
--- a/examples/upgrade-automation/plan/action.yml
+++ b/examples/upgrade-automation/plan/action.yml
@@ -4,6 +4,10 @@ inputs:
   bump_target:
     description: Relative YAML or JSON file and value path in file#path.to.version format
     required: true
+  branch_prefix:
+    description: Prefix used for upgrade branch names
+    required: false
+    default: lightdash-upgrade
   tag_suffix:
     description: Suffix appended to the public release version for the deployed image tag
     required: false
@@ -12,6 +16,10 @@ inputs:
     description: Optional OCI image repository whose mapped tag must exist before a pull request opens
     required: false
     default: ''
+  safety_gate:
+    description: Use the release-safety gate to select an upgrade target
+    required: false
+    default: 'true'
   auto_merge:
     description: Enable pull request auto-merge when the upgrade gate is green
     required: false
@@ -45,8 +53,10 @@ runs:
       shell: bash
       env:
         BUMP_TARGET: ${{ inputs.bump_target }}
+        BRANCH_PREFIX: ${{ inputs.branch_prefix }}
         TAG_SUFFIX: ${{ inputs.tag_suffix }}
         REGISTRY_CHECK: ${{ inputs.registry_check }}
+        SAFETY_GATE: ${{ inputs.safety_gate }}
         AUTO_MERGE: ${{ inputs.auto_merge }}
         ESCALATION: ${{ inputs.escalation }}
         FREEZE_LABEL: ${{ inputs.freeze_label }}

--- a/examples/upgrade-automation/scripts/common.sh
+++ b/examples/upgrade-automation/scripts/common.sh
@@ -27,6 +27,10 @@ public_version() {
     printf '%s\n' "$mapped_version"
 }
 
+safe_branch_version() {
+    tr -c 'A-Za-z0-9._-' '-' <<<"$1" | sed 's/-$//'
+}
+
 version_gte() {
     python3 - "$1" "$2" <<'PY'
 import sys

--- a/examples/upgrade-automation/scripts/plan.sh
+++ b/examples/upgrade-automation/scripts/plan.sh
@@ -70,6 +70,17 @@ require_value bump_target "${BUMP_TARGET:-}"
 require_value freeze_label "${FREEZE_LABEL:-}"
 require_value github_token "${GH_TOKEN:-}"
 
+branch_prefix=${BRANCH_PREFIX:-lightdash-upgrade}
+if [[ ! "$branch_prefix" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo "branch_prefix must match ^[A-Za-z0-9][A-Za-z0-9._-]*$" >&2
+    exit 1
+fi
+safety_gate=${SAFETY_GATE:-true}
+if [[ "$safety_gate" != "true" && "$safety_gate" != "false" ]]; then
+    echo "safety_gate must be true or false" >&2
+    exit 1
+fi
+
 if [[ "$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "$FREEZE_LABEL" --limit 1 --json number --jq 'length')" != "0" ]]; then
     echo "an open $FREEZE_LABEL issue is disarming the planner; nothing to do"
     exit 0
@@ -106,27 +117,106 @@ if [[ ${#candidates[@]} -eq 0 ]]; then
     exit 0
 fi
 
-cli_root=${RUNNER_TEMP:-$(mktemp -d)}/lightdash-upgrade-cli
-mkdir -p "$cli_root"
-cp "$ACTION_ROOT/cli/package.json" "$ACTION_ROOT/cli/package-lock.json" "$cli_root"
-npm ci --prefix "$cli_root" --ignore-scripts --silent
-cli_bin="$cli_root/node_modules/.bin/lightdash"
+select_target_with_gate() {
+    local cli_root
+    local cli_bin
+    local GATE_JSON=
+    local GATE_STATUS=0
+    local required_stop
+    local required_stop_only
+    local minimum
+    local minimum_met
+    local candidate
+    local next_index
+    local next_version
 
-GATE_JSON=
-GATE_STATUS=0
-run_gate() {
-    local target=$1
-    set +e
-    GATE_JSON=$("$cli_bin" upgrade-check \
-        --from "$current_public" \
-        --to "$target" \
-        --json 2>"$gate_error")
-    GATE_STATUS=$?
-    set -e
-    if ! printf '%s' "$GATE_JSON" | validate_verdict_json; then
-        return 2
+    cli_root=${RUNNER_TEMP:-$(mktemp -d)}/lightdash-upgrade-cli
+    mkdir -p "$cli_root"
+    cp "$ACTION_ROOT/cli/package.json" "$ACTION_ROOT/cli/package-lock.json" "$cli_root"
+    npm ci --prefix "$cli_root" --ignore-scripts --silent
+    cli_bin="$cli_root/node_modules/.bin/lightdash"
+
+    run_gate() {
+        local target=$1
+        set +e
+        GATE_JSON=$("$cli_bin" upgrade-check \
+            --from "$current_public" \
+            --to "$target" \
+            --json 2>"$gate_error")
+        GATE_STATUS=$?
+        set -e
+        if ! printf '%s' "$GATE_JSON" | validate_verdict_json; then
+            return 2
+        fi
+        return 0
+    }
+
+    gate_unusable() {
+        local target=$1
+        echo "the release-safety gate returned unusable output for $target" >&2
+        cat "$gate_error" >&2 || true
+    }
+
+    if ! run_gate "$newest"; then
+        gate_unusable "$newest"
+        exit 1
     fi
-    return 0
+    if [[ "$GATE_STATUS" == "0" ]] && [[ "$(jq -r '.safe' <<<"$GATE_JSON")" == "true" ]]; then
+        selected_version=$newest
+        selected_json=$GATE_JSON
+        selected_green=true
+    else
+        required_stop=$(jq -r '.requiredStops | map(split(".") | map(tonumber)) | sort | first // empty | map(tostring) | join(".")' <<<"$GATE_JSON")
+        if [[ -n "$required_stop" ]] && version_gt "$required_stop" "$current_public"; then
+            if run_gate "$required_stop"; then
+                required_stop_only=$(jq -r --arg stop "$required_stop" '
+                    .verdict == true and
+                    (.missingRanges | length == 0) and
+                    (.requiredStops | length == 1 and .[0] == $stop)
+                ' <<<"$GATE_JSON")
+                minimum=$(jq -r '.minPreviousVersion // empty' <<<"$GATE_JSON")
+                minimum_met=true
+                if [[ -n "$minimum" ]] && ! version_gte "$current_public" "$minimum"; then
+                    minimum_met=false
+                fi
+                if { [[ "$GATE_STATUS" == "0" ]] && [[ "$(jq -r '.safe' <<<"$GATE_JSON")" == "true" ]]; } || { [[ "$required_stop_only" == "true" ]] && [[ "$minimum_met" == "true" ]]; }; then
+                    selected_version=$required_stop
+                    selected_json=$GATE_JSON
+                    selected_green=true
+                fi
+            fi
+        fi
+    fi
+
+    if [[ -z "$selected_version" ]]; then
+        for candidate in "${candidates[@]}"; do
+            if ! run_gate "$candidate"; then
+                continue
+            fi
+            if [[ "$GATE_STATUS" == "0" ]] && [[ "$(jq -r '.safe' <<<"$GATE_JSON")" == "true" ]]; then
+                selected_version=$candidate
+                selected_json=$GATE_JSON
+                selected_green=true
+                break
+            fi
+        done
+    fi
+
+    if [[ -z "$selected_version" ]]; then
+        next_index=$((${#candidates[@]} - 1))
+        next_version=${candidates[$next_index]}
+        if ! run_gate "$next_version"; then
+            gate_unusable "$next_version"
+            exit 1
+        fi
+        selected_version=$next_version
+        selected_json=$GATE_JSON
+        if jq -e '.verdict == false' <<<"$GATE_JSON" >/dev/null; then
+            hold_reason=red
+        else
+            hold_reason=unknown
+        fi
+    fi
 }
 
 selected_version=
@@ -135,71 +225,25 @@ selected_green=false
 hold_reason=
 newest=${candidates[0]}
 
-gate_unusable() {
-    local target=$1
-    echo "the release-safety gate returned unusable output for $target" >&2
-    cat "$gate_error" >&2 || true
-}
-
-if ! run_gate "$newest"; then
-    gate_unusable "$newest"
-    exit 1
-fi
-if [[ "$GATE_STATUS" == "0" ]] && [[ "$(jq -r '.safe' <<<"$GATE_JSON")" == "true" ]]; then
+if [[ "$safety_gate" == "false" ]]; then
     selected_version=$newest
-    selected_json=$GATE_JSON
+    selected_json=$(jq -n \
+        --arg from_version "$current_public" \
+        --arg to_version "$selected_version" \
+        '{
+            coveredVersions: [],
+            direction: "forward",
+            fromVersion: $from_version,
+            minPreviousVersion: null,
+            missingRanges: [],
+            requiredStops: [],
+            safe: true,
+            toVersion: $to_version,
+            verdict: true
+        }')
     selected_green=true
 else
-    required_stop=$(jq -r '.requiredStops | map(split(".") | map(tonumber)) | sort | first // empty | map(tostring) | join(".")' <<<"$GATE_JSON")
-    if [[ -n "$required_stop" ]] && version_gt "$required_stop" "$current_public"; then
-        if run_gate "$required_stop"; then
-            required_stop_only=$(jq -r --arg stop "$required_stop" '
-                .verdict == true and
-                (.missingRanges | length == 0) and
-                (.requiredStops | length == 1 and .[0] == $stop)
-            ' <<<"$GATE_JSON")
-            minimum=$(jq -r '.minPreviousVersion // empty' <<<"$GATE_JSON")
-            minimum_met=true
-            if [[ -n "$minimum" ]] && ! version_gte "$current_public" "$minimum"; then
-                minimum_met=false
-            fi
-            if { [[ "$GATE_STATUS" == "0" ]] && [[ "$(jq -r '.safe' <<<"$GATE_JSON")" == "true" ]]; } || { [[ "$required_stop_only" == "true" ]] && [[ "$minimum_met" == "true" ]]; }; then
-                selected_version=$required_stop
-                selected_json=$GATE_JSON
-                selected_green=true
-            fi
-        fi
-    fi
-fi
-
-if [[ -z "$selected_version" ]]; then
-    for candidate in "${candidates[@]}"; do
-        if ! run_gate "$candidate"; then
-            continue
-        fi
-        if [[ "$GATE_STATUS" == "0" ]] && [[ "$(jq -r '.safe' <<<"$GATE_JSON")" == "true" ]]; then
-            selected_version=$candidate
-            selected_json=$GATE_JSON
-            selected_green=true
-            break
-        fi
-    done
-fi
-
-if [[ -z "$selected_version" ]]; then
-    next_index=$((${#candidates[@]} - 1))
-    next_version=${candidates[$next_index]}
-    if ! run_gate "$next_version"; then
-        gate_unusable "$next_version"
-        exit 1
-    fi
-    selected_version=$next_version
-    selected_json=$GATE_JSON
-    if jq -e '.verdict == false' <<<"$GATE_JSON" >/dev/null; then
-        hold_reason=red
-    else
-        hold_reason=unknown
-    fi
+    select_target_with_gate
 fi
 
 mapped_version="${selected_version}${TAG_SUFFIX:-}"
@@ -215,8 +259,7 @@ if [[ -n "${REGISTRY_CHECK:-}" ]]; then
 fi
 
 default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch')
-safe_branch_version=$(tr -c 'A-Za-z0-9._-' '-' <<<"$mapped_version" | sed 's/-$//')
-upgrade_branch="lightdash-upgrade-${safe_branch_version}"
+upgrade_branch="${branch_prefix}-$(safe_branch_version "$mapped_version")"
 bump_file=${BUMP_TARGET%%#*}
 
 cp "$bump_file" "$bump_file_before"
@@ -249,7 +292,9 @@ fi
 jq -e '.data.createCommitOnBranch.commit.oid | type == "string" and length > 0' <<<"$commit_response" >/dev/null
 
 plain_reason='The release-safety gate found a green upgrade path.'
-if [[ "$hold_reason" == "unknown" ]]; then
+if [[ "$safety_gate" == "false" ]]; then
+    plain_reason='The release-safety gate was not run for this instance.'
+elif [[ "$hold_reason" == "unknown" ]]; then
     plain_reason='The release-safety gate could not determine whether the next release hop is safe. This is not a known break: the safety data for that release is incomplete or inconclusive. This pull request is held for manual review and must not merge automatically.'
 elif [[ "$selected_green" != "true" ]]; then
     plain_reason='The next release hop is red. This pull request is held for manual review and must not merge automatically.'
@@ -307,11 +352,18 @@ write_output branch "$upgrade_branch"
 write_output pr_number "$pr_number"
 write_output pr_url "$pr_url"
 
+gate_summary=$hold_reason
+if [[ "$safety_gate" == "false" ]]; then
+    gate_summary='not run'
+elif [[ "$selected_green" == "true" ]]; then
+    gate_summary=green
+fi
+
 cat >"$summary_file" <<EOF
 ## Upgrade plan summary
 
 - Version: \`$current_mapped\` → \`$mapped_version\`
-- Gate: $([[ "$selected_green" == "true" ]] && printf 'green' || printf '%s' "$hold_reason")
+- Gate: $gate_summary
 - Registry check: $([[ -n "${REGISTRY_CHECK:-}" ]] && printf 'passed' || printf 'disabled')
 
 \`\`\`json

--- a/examples/upgrade-automation/scripts/plan.test.sh
+++ b/examples/upgrade-automation/scripts/plan.test.sh
@@ -48,6 +48,7 @@ EOF
 cat >"$test_dir/bin/npm" <<'EOF'
 #!/usr/bin/env bash
 
+printf '%s\n' "$*" >>"$TEST_SCENARIO_DIR/npm.log"
 exit 0
 EOF
 
@@ -55,6 +56,8 @@ cat >"$test_dir/runner-temp/lightdash-upgrade-cli/node_modules/.bin/lightdash" <
 #!/usr/bin/env bash
 
 set -euo pipefail
+
+printf '%s\n' "$*" >>"$TEST_SCENARIO_DIR/gate.log"
 
 from=
 to=
@@ -94,7 +97,7 @@ if [[ "\$*" == *'git/ref/heads/main'* ]]; then
     exit 0
 fi
 
-if [[ "\$*" == *'git/ref/heads/lightdash-upgrade-'* ]]; then
+if [[ "\$*" == *'git/ref/heads/'* ]]; then
     exit 1
 fi
 
@@ -114,6 +117,13 @@ if [[ "\$*" == "pr list"* ]]; then
 fi
 
 if [[ "\$*" == "pr create"* ]]; then
+    while [[ \$# -gt 0 ]]; do
+        if [[ "\$1" == '--body-file' ]]; then
+            cp "\$2" "$test_dir/pr-body"
+            break
+        fi
+        shift
+    done
     printf 'https://example.test/pr/1\n'
     exit 0
 fi
@@ -136,11 +146,14 @@ chmod +x "$test_dir/bin/curl" "$test_dir/bin/npm" "$test_dir/bin/gh" \
 
 : >"$test_dir/slack.log"
 : >"$test_dir/gh.log"
+: >"$test_dir/gate.log"
+: >"$test_dir/npm.log"
 
 cd "$test_dir"
 
 set +e
 output=$(PATH="$test_dir/bin:$PATH" \
+    TEST_SCENARIO_DIR="$test_dir" \
     RUNNER_TEMP="$test_dir/runner-temp" \
     GITHUB_REPOSITORY=example/upgrade-test \
     BUMP_TARGET=values.yml#image.tag \
@@ -182,4 +195,141 @@ else
     exit 1
 fi
 
+if ! grep -q 'ref=refs/heads/lightdash-upgrade-1.0.1' "$test_dir/gh.log"; then
+    printf 'expected the default branch prefix, gh calls were:\n%s\n' "$(cat "$test_dir/gh.log")" >&2
+    exit 1
+fi
+
+if [[ ! -s "$test_dir/gate.log" ]]; then
+    printf 'expected the default safety gate to run\n' >&2
+    exit 1
+fi
+
 printf 'plan unknown-verdict hold test passed\n'
+printf 'plan default inputs test passed\n'
+
+printf 'image:\n  tag: 1.0.0\n' >"$test_dir/values.yml"
+: >"$test_dir/gh.log"
+: >"$test_dir/gate.log"
+
+set +e
+output=$(PATH="$test_dir/bin:$PATH" \
+    TEST_SCENARIO_DIR="$test_dir" \
+    RUNNER_TEMP="$test_dir/runner-temp" \
+    GITHUB_REPOSITORY=example/upgrade-test \
+    BUMP_TARGET=values.yml#image.tag \
+    BRANCH_PREFIX=staging-upgrade \
+    FREEZE_LABEL=upgrade-freeze \
+    GH_TOKEN=test-token \
+    "${BASH:-bash}" "$root/examples/upgrade-automation/scripts/plan.sh" 2>&1)
+status=$?
+set -e
+
+if [[ $status -ne 0 ]]; then
+    printf 'expected a custom branch prefix to plan successfully, got status %s:\n%s\n' "$status" "$output" >&2
+    exit 1
+fi
+
+if ! grep -q 'ref=refs/heads/staging-upgrade-1.0.1' "$test_dir/gh.log"; then
+    printf 'expected the custom branch prefix, gh calls were:\n%s\n' "$(cat "$test_dir/gh.log")" >&2
+    exit 1
+fi
+
+printf 'plan custom branch prefix test passed\n'
+
+printf 'image:\n  tag: 1.0.0\n' >"$test_dir/values.yml"
+: >"$test_dir/gh.log"
+: >"$test_dir/gate.log"
+: >"$test_dir/npm.log"
+rm -f "$test_dir/pr-body"
+
+set +e
+output=$(PATH="$test_dir/bin:$PATH" \
+    TEST_SCENARIO_DIR="$test_dir" \
+    RUNNER_TEMP="$test_dir/runner-temp" \
+    GITHUB_REPOSITORY=example/upgrade-test \
+    BUMP_TARGET=values.yml#image.tag \
+    SAFETY_GATE=false \
+    FREEZE_LABEL=upgrade-freeze \
+    GH_TOKEN=test-token \
+    "${BASH:-bash}" "$root/examples/upgrade-automation/scripts/plan.sh" 2>&1)
+status=$?
+set -e
+
+if [[ $status -ne 0 ]]; then
+    printf 'expected planning without the safety gate to succeed, got status %s:\n%s\n' "$status" "$output" >&2
+    exit 1
+fi
+
+if [[ -s "$test_dir/gate.log" || -s "$test_dir/npm.log" ]]; then
+    printf 'expected safety_gate=false not to install or call the gate CLI\n' >&2
+    exit 1
+fi
+
+if ! grep -q 'ref=refs/heads/lightdash-upgrade-1.0.2' "$test_dir/gh.log"; then
+    printf 'expected safety_gate=false to select the newest candidate, gh calls were:\n%s\n' "$(cat "$test_dir/gh.log")" >&2
+    exit 1
+fi
+
+verdict_json=$(awk '/^```json$/ { capture=1; next } /^```$/ && capture { exit } capture' "$test_dir/pr-body")
+if ! printf '%s' "$verdict_json" | (source "$root/examples/upgrade-automation/scripts/common.sh"; validate_verdict_json); then
+    printf 'expected the synthesized verdict to pass validation, got:\n%s\n' "$verdict_json" >&2
+    exit 1
+fi
+
+if ! jq -e '
+    keys_unsorted == [
+        "coveredVersions",
+        "direction",
+        "fromVersion",
+        "minPreviousVersion",
+        "missingRanges",
+        "requiredStops",
+        "safe",
+        "toVersion",
+        "verdict"
+    ] and
+    .coveredVersions == [] and
+    .direction == "forward" and
+    .fromVersion == "1.0.0" and
+    .minPreviousVersion == null and
+    .missingRanges == [] and
+    .requiredStops == [] and
+    .safe == true and
+    .toVersion == "1.0.2" and
+    .verdict == true
+' <<<"$verdict_json" >/dev/null; then
+    printf 'expected the synthesized verdict to describe the newest candidate, got:\n%s\n' "$verdict_json" >&2
+    exit 1
+fi
+
+if ! grep -Fq 'The release-safety gate was not run for this instance.' "$test_dir/pr-body"; then
+    printf 'expected the pull request body to say the safety gate was not run, got:\n%s\n' "$(cat "$test_dir/pr-body")" >&2
+    exit 1
+fi
+
+printf 'plan disabled safety gate test passed\n'
+
+set +e
+output=$(PATH="$test_dir/bin:$PATH" \
+    TEST_SCENARIO_DIR="$test_dir" \
+    GITHUB_REPOSITORY=example/upgrade-test \
+    BUMP_TARGET=values.yml#image.tag \
+    BRANCH_PREFIX='invalid prefix' \
+    FREEZE_LABEL=upgrade-freeze \
+    GH_TOKEN=test-token \
+    "${BASH:-bash}" "$root/examples/upgrade-automation/scripts/plan.sh" 2>&1)
+status=$?
+set -e
+
+if [[ $status -eq 0 ]]; then
+    printf 'expected an invalid branch prefix to fail planning\n' >&2
+    exit 1
+fi
+
+if [[ "$output" != *'branch_prefix must match ^[A-Za-z0-9][A-Za-z0-9._-]*$'* ]]; then
+    printf 'expected a clear invalid branch prefix message, got:\n%s\n' "$output" >&2
+    exit 1
+fi
+
+printf 'plan invalid branch prefix test passed\n'

--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -13,8 +13,16 @@ require_value deploy_conclusion "${DEPLOY_CONCLUSION:-}"
 require_value deployed_sha "${DEPLOYED_SHA:-}"
 require_value github_token "${GH_TOKEN:-}"
 
+branch_prefix=${BRANCH_PREFIX:-lightdash-upgrade}
+if [[ ! "$branch_prefix" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo "branch_prefix must match ^[A-Za-z0-9][A-Za-z0-9._-]*$" >&2
+    exit 1
+fi
+
 pinned_mapped=$(read_bump_value)
 pinned_public=$(public_version "$pinned_mapped" "${TAG_SUFFIX:-}")
+UPGRADE_BRANCH="${branch_prefix}-$(safe_branch_version "$pinned_mapped")"
+export UPGRADE_BRANCH
 if ! default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch'); then
     echo "Unable to determine the default branch for upgrade verification." >&2
     exit 1
@@ -26,7 +34,7 @@ export VERIFY_COMMENT_AUTHOR
 if ! merged_upgrade_prs=$(gh api \
     --paginate \
     "repos/$GITHUB_REPOSITORY/pulls?state=closed&base=$default_branch&per_page=100" \
-    --jq '.[] | select(.merged_at != null and ((.head.ref // "") | startswith("lightdash-upgrade-"))) | [.number, (.merge_commit_sha // "")] | @tsv'); then
+    --jq '.[] | select(.merged_at != null and (.head.ref // "") == $ENV.UPGRADE_BRANCH) | [.number, (.merge_commit_sha // "")] | @tsv'); then
     echo "Unable to list merged upgrade pull requests; refusing to skip verification." >&2
     exit 1
 fi

--- a/examples/upgrade-automation/scripts/verify.test.sh
+++ b/examples/upgrade-automation/scripts/verify.test.sh
@@ -467,3 +467,110 @@ EOF
 
 run_freeze_cleanup_test marked 17 'marked freeze cleanup'
 run_freeze_cleanup_test unmarked '' 'unmarked freeze preservation'
+
+run_branch_match_test() {
+    local branch_prefix=$1
+    local exact_branch=$2
+    local other_branch=$3
+    local test_name=$4
+    local scenario_dir
+    scenario_dir=$(mktemp -d)
+    mkdir -p "$scenario_dir/bin"
+    printf 'image:\n  tag: 1.2.3\n' >"$scenario_dir/values.yml"
+    : >"$scenario_dir/gh.log"
+
+    jq -n \
+        --arg exact_branch "$exact_branch" \
+        --arg other_branch "$other_branch" \
+        '[
+            {
+                number: 123,
+                merged_at: "2026-08-19T12:00:00Z",
+                head: {ref: $other_branch},
+                merge_commit_sha: "3333333333333333333333333333333333333333"
+            },
+            {
+                number: 124,
+                merged_at: "2026-08-19T12:01:00Z",
+                head: {ref: $exact_branch},
+                merge_commit_sha: "4444444444444444444444444444444444444444"
+            }
+        ]' >"$scenario_dir/pulls.json"
+
+    cat >"$scenario_dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$TEST_SCENARIO_DIR/gh.log"
+
+case "$*" in
+    *'repos/example/upgrade-test --jq .default_branch'*) printf 'main\n' ;;
+    *'api user --jq .login'*) printf 'test-user\n' ;;
+    *'repos/example/upgrade-test/pulls?'*)
+        while [[ $# -gt 0 ]]; do
+            if [[ "$1" == '--jq' ]]; then
+                jq -r "$2" "$TEST_SCENARIO_DIR/pulls.json"
+                exit 0
+            fi
+            shift
+        done
+        exit 1
+        ;;
+    *'pr view 123'*'--json body --jq .body'*) printf '```json\n{"coveredVersions":[],"direction":"forward","fromVersion":"1.2.2","minPreviousVersion":null,"missingRanges":[],"requiredStops":[],"safe":true,"toVersion":"1.2.3","verdict":true}\n```\n' ;;
+    *'pr view 124'*'--json body --jq .body'*) printf '```json\n{"coveredVersions":[],"direction":"forward","fromVersion":"1.2.2","minPreviousVersion":null,"missingRanges":[],"requiredStops":[],"safe":true,"toVersion":"1.2.3","verdict":true}\n```\n' ;;
+    *'pr view 123'*'--json comments'*) printf 'true\n' ;;
+    *'pr view 124'*'--json comments'*) printf 'true\n' ;;
+    *) ;;
+esac
+EOF
+    cat >"$scenario_dir/bin/git" <<'EOF'
+#!/usr/bin/env bash
+
+if [[ "$1" == 'merge-base' ]]; then
+    exit 0
+fi
+
+exit 1
+EOF
+    chmod +x "$scenario_dir/bin"/*
+
+    set +e
+    output=$(cd "$scenario_dir" && PATH="$scenario_dir/bin:$PATH" \
+        TEST_SCENARIO_DIR="$scenario_dir" \
+        GITHUB_REPOSITORY=example/upgrade-test \
+        INSTANCE_URL=https://example.test \
+        BUMP_TARGET=values.yml#image.tag \
+        BRANCH_PREFIX="$branch_prefix" \
+        VERIFY_WINDOW=1s \
+        FREEZE_LABEL=upgrade-freeze \
+        DEPLOY_RUN_URL=https://example.test/run/1 \
+        DEPLOY_CONCLUSION=success \
+        DEPLOYED_SHA=5555555555555555555555555555555555555555 \
+        GH_TOKEN=test-token \
+        "$root/examples/upgrade-automation/scripts/verify.sh" 2>&1)
+    status=$?
+    set -e
+
+    if [[ $status -ne 0 ]]; then
+        printf 'expected %s to verify successfully, got status %s:\n%s\n' "$test_name" "$status" "$output" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+    if ! grep -Fq 'pr view 124' "$scenario_dir/gh.log"; then
+        printf 'expected %s to match the exact branch, gh calls were:\n%s\n' "$test_name" "$(cat "$scenario_dir/gh.log")" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+    if grep -Fq 'pr view 123' "$scenario_dir/gh.log"; then
+        printf 'expected %s not to match the other branch, gh calls were:\n%s\n' "$test_name" "$(cat "$scenario_dir/gh.log")" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+
+    printf 'verify %s test passed\n' "$test_name"
+    rm -rf "$scenario_dir"
+}
+
+run_branch_match_test staging-upgrade staging-upgrade-1.2.3 production-upgrade-1.2.3 'custom branch prefix match'
+run_branch_match_test lightdash-upgrade lightdash-upgrade-1.2.3 lightdash-upgrade-staging-1.2.3 'overlapping branch prefix isolation'

--- a/examples/upgrade-automation/verify/action.yml
+++ b/examples/upgrade-automation/verify/action.yml
@@ -7,6 +7,10 @@ inputs:
   bump_target:
     description: Relative YAML or JSON file and value path in file#path.to.version format
     required: true
+  branch_prefix:
+    description: Prefix used for upgrade branch names
+    required: false
+    default: lightdash-upgrade
   tag_suffix:
     description: Suffix appended to the public release version for the deployed image tag
     required: false
@@ -43,6 +47,7 @@ runs:
       env:
         INSTANCE_URL: ${{ inputs.instance_url }}
         BUMP_TARGET: ${{ inputs.bump_target }}
+        BRANCH_PREFIX: ${{ inputs.branch_prefix }}
         TAG_SUFFIX: ${{ inputs.tag_suffix }}
         VERIFY_WINDOW: ${{ inputs.verify_window }}
         ESCALATION: ${{ inputs.escalation }}


### PR DESCRIPTION
## Why

A consumer repository needs to run these actions for two instances: a production instance that keeps the release-safety gate, and a staging instance that should take the newest release with no gate at all. Today it cannot, so staging runs a forked copy of the planner and the checker. That fork is why the fix in #27677 reached only one of the two instances.

Two things block a straight swap.

**Branch names are not unique.** The planner names its branch from the version alone, so two instances tracking the same release fight over one name.

**The checker matches by a hard-coded prefix, then selects on version.** Both instances usually sit on the same version, so each checker can adjudicate the other instance's upgrade.

## What changes

**The checker matches the exact branch.** It reconstructs the name the planner would have created for the current pin and compares by equality. A prefix test cannot do this safely, because a prefix like `lightdash-upgrade-staging` also starts with `lightdash-upgrade` — the obvious name for a second stream is the broken one. The version transform moves into a shared `safe_branch_version` helper so the planner and the checker cannot drift apart.

**`branch_prefix`** names the stream. It applies to both actions, defaults to `lightdash-upgrade`, and is validated against `^[A-Za-z0-9][A-Za-z0-9._-]*$`.

**`safety_gate`** turns the gate off for one instance. Default `true`. When `false` the planner does not install or call the gate CLI, selects the newest candidate the release index offers, and writes the same verdict block the gate would have produced. The block is the contract between the planner and the checker, so keeping it means the checker needs no changes at all. The pull request body and the run summary both state that the gate did not run, so a reader is never misled into thinking the upgrade was gated.

Both inputs default to current behaviour. A consumer that sets neither is unaffected.

## Tests

`plan.test.sh` gains 5 cases and `verify.test.sh` gains 9, covering the default prefix, a custom prefix, an invalid prefix, gate on, gate off, and the synthesized block passing `validate_verdict_json`.

The case that matters most is overlapping-prefix isolation: a merged pull request on `lightdash-upgrade-staging-1.2.3` must not be matched when the prefix is `lightdash-upgrade`, even though its version matches the pin and its verdict is valid. Restoring the original `startswith("lightdash-upgrade-")` selector makes that case fail, so the test covers the real regression rather than restating the implementation.

All three suites pass. shellcheck reports no new findings: one added `SC2016` is the intended `$ENV.` idiom inside a single-quoted jq program, which the file already uses three times.

## Things worth knowing

- The checker reads values into its jq filter through `$ENV.` rather than string interpolation, matching the existing idiom in the same file. The prefix regex and the version transform already constrain both components, but a filter built by interpolation would make that a security property of a validator in another function.
- Skipping the gate does not skip the registry existence check. A pull request still waits for the image.
- The release index remains the source of candidate versions in both modes. Only the gate verdict is skipped.

Linear: SPK-1154