### PR TITLE
fix: serialize distinct_keys when copying charts to preview projects

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -3557,7 +3557,13 @@ export class ProjectModel {
             await copyChartVersionContent(
                 'saved_queries_version_additional_metrics',
                 ['saved_queries_version_additional_metric_id', 'uuid'],
-                { filters: (value: AnyType) => JSON.stringify(value) },
+                {
+                    filters: (value: AnyType) => JSON.stringify(value),
+                    // jsonb array — without stringify pg serializes it as a
+                    // postgres array literal, which is invalid json
+                    distinct_keys: (value: AnyType) =>
+                        value == null ? null : JSON.stringify(value),
+                },
             );
 
             // 8888b.     db    .dP"Y8 88  88 88""Yb  dP"Yb     db    88""Yb 8888b.  .dP"Y8


### PR DESCRIPTION
## Problem

Creating a preview project with content copying fails entirely — zero spaces, charts, or dashboards copied — when any chart in the source project has an ad-hoc `sum_distinct` / `average_distinct` custom metric (which always carries a deduplication key).

`ProjectModel.duplicateContent` re-inserts rows read via `select *`. node-postgres serializes a raw JS array as a Postgres array literal (`{"a","b"}`) instead of JSON, so the jsonb `distinct_keys` column (`string[]`) fails with `invalid input syntax for type json`. The column was added in Feb 2026 but never added to the copy path's `fieldPreprocess` map (the same map already stringifies the other array-shaped jsonb columns: `filters`, `custom_range`, `custom_groups`, `pivot_values`). The copy runs in one transaction, so a single such metric aborts the whole copy.

Audited every jsonb column across all tables the copy path touches — `distinct_keys` was the only array-shaped one missing preprocessing.

## Fix

Add `distinct_keys` to the `fieldPreprocess` map, guarding `null` so rows without keys keep SQL `NULL` (matching the write path, which omits the column when absent).

## Verification

Reproduced end-to-end locally: saved a chart version with a `sum_distinct` metric (`distinct_keys: ["id_status.order_id"]`), `POST /createPreview` with `copyContent: true` → 500, Postgres log shows `invalid input syntax for type json ... {"id_status.order_id"}`. After the fix, the same call copies 26 spaces / 79 charts / 10 dashboards, the metric row arrives as proper jsonb, and null `distinct_keys` remain SQL NULL.

Closes: PROD-10277
Closes: #27570

🤖 Generated with [Claude Code](https://claude.com/claude-code)