### PR TITLE
feat(mcp): expose hash generator

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -25,6 +25,7 @@ import {
     FeatureFlags,
     findContentToolDefinition,
     ForbiddenError,
+    generateHashesToolDefinition,
     getAiWritebackStatusToolDefinition,
     getAiWritebackTaskStatusMessage,
     getContextToolDefinition,
@@ -40,6 +41,7 @@ import {
     getTotalFilterRules,
     getValidAiQueryLimit,
     grepFieldsToolDefinition,
+    hashStringToBase36,
     ItemsMap,
     listAgentsToolDefinition,
     listContentToolDefinition,
@@ -176,6 +178,7 @@ import {
 
 export enum McpToolName {
     GET_LIGHTDASH_VERSION = 'get_lightdash_version',
+    GENERATE_HASHES = 'generate_hashes',
     LIST_EXPLORES = 'list_explores',
     GREP_FIELDS = 'grep_fields',
     GET_METADATA = 'get_metadata',
@@ -210,6 +213,7 @@ export enum McpToolName {
 
 const projectIndependentMcpToolNames = new Set<string>([
     McpToolName.GET_LIGHTDASH_VERSION,
+    McpToolName.GENERATE_HASHES,
     McpToolName.LIST_PROJECTS,
     McpToolName.GET_CONTEXT,
     McpToolName.GET_CURRENT_PROJECT,
@@ -267,6 +271,7 @@ const mcpGetAiWritebackStatusTool = withProjectUuidInput(
     getAiWritebackStatusToolDefinition.for('mcp'),
 );
 const mcpGetLightdashVersionTool = getLightdashVersionToolDefinition.for('mcp');
+const mcpGenerateHashesTool = generateHashesToolDefinition.for('mcp');
 const mcpListExploresTool = withProjectScopeInput(
     listExploresToolDefinition.for('mcp'),
 );
@@ -1903,6 +1908,26 @@ export class McpService extends BaseService {
                         },
                     ],
                 };
+            },
+        );
+
+        this.registerTrackedTool(
+            mcpGenerateHashesTool.name,
+            {
+                title: mcpGenerateHashesTool.title,
+                description: mcpGenerateHashesTool.description,
+                inputSchema: mcpGenerateHashesTool.inputSchema.shape,
+                outputSchema: mcpGenerateHashesTool.outputSchema.shape,
+                annotations: mcpGenerateHashesTool.annotations,
+            },
+            ({ inputs }) => {
+                const structuredContent = {
+                    hashes: inputs.map(hashStringToBase36),
+                };
+                return mcpGenerateHashesTool.result.structured(
+                    JSON.stringify(structuredContent),
+                    structuredContent,
+                );
             },
         );
 

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -110,6 +110,55 @@ Use table calculations for:
         "openWorldHint": false,
         "readOnlyHint": true,
       },
+      "description": "Generate deterministic base-36 hashes for input strings.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "inputs": {
+            "description": "Input strings to hash.",
+            "items": {
+              "type": "string",
+            },
+            "maxItems": 20,
+            "minItems": 1,
+            "type": "array",
+          },
+        },
+        "required": [
+          "inputs",
+        ],
+        "type": "object",
+      },
+      "name": "generate_hashes",
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "hashes": {
+            "description": "Base-36 hashes in the same order as the input strings.",
+            "items": {
+              "pattern": "^[0-9a-z]{6}$",
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "hashes",
+        ],
+        "type": "object",
+      },
+      "title": "Generate hashes",
+    },
+    {
+      "agentName": null,
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true,
+      },
       "description": "Tool: list_explores
 
 Purpose:
@@ -8983,6 +9032,7 @@ exports[`MCP tool contracts > matches the shared MCP tool definition names snaps
   "render_chart",
   "grep_fields",
   "get_metadata",
+  "generate_hashes",
   "read_content",
   "resolve_url",
   "edit_content",

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -225,6 +225,17 @@ describe('MCP tool contracts', () => {
         expect({ prompts, tools }).toMatchSnapshot();
     });
 
+    it('registers generate_hashes without project scope', async () => {
+        const mcpService = makeMcpService();
+
+        await mcpService.createServer();
+
+        expect(mockRegisteredMcpTools.map(({ name }) => name)).toContain(
+            McpToolName.GENERATE_HASHES,
+        );
+        expect(isProjectScopedMcpTool(McpToolName.GENERATE_HASHES)).toBe(false);
+    });
+
     it('requires projectUuid on every project-scoped tool', async () => {
         const mcpService = makeMcpService();
 

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills.test.ts
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills.test.ts
@@ -34,14 +34,20 @@ describe('BuiltInSkills', () => {
             name: 'developing-in-lightdash',
             resourcePath: 'dashboard-reference.md',
         });
+        const periodReference = await BuiltInSkills.readSkillToolResource({
+            name: 'developing-in-lightdash',
+            resourcePath: 'period-over-period-reference.md',
+        });
 
         expect(skill?.body).toContain('`read_content`');
         expect(skill?.body).toContain('`grep_fields` and `get_metadata`');
         expect(skill?.body).toContain('`run_metric_query`');
+        expect(skill?.body).toContain('`generate_hashes`');
         expect(skill?.body).not.toContain('`discoverFields`');
         expect(dashboardReference?.body).toContain(
             'MCP clients must generate standard UUID v4 values locally',
         );
+        expect(periodReference?.body).toContain('`generate_hashes` (MCP)');
     });
 
     it('matches skill names case-insensitively and trims input', async () => {

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/SKILL.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/SKILL.md
@@ -13,6 +13,7 @@ This skill is shared with Lightdash's native agent, so its workflows use camelCa
 
 - Use `read_content`, `edit_content`, and `create_content` for `readContent`, `editContent`, and `createContent`.
 - Use `grep_fields` and `get_metadata` for native `grepFields` and `getMetadata`.
+- Use `generate_hashes` for native `generateHashes`.
 - Replace `runContentQuery` with `run_metric_query` to validate a chart's governed semantic-layer `metricQuery`. Do not use `run_sql` for this validation.
 
 ## What You Can Do

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/period-over-period-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/period-over-period-reference.md
@@ -96,7 +96,7 @@ Where `<hash>` is a base-36 hash of `<timeDimensionId>|<granularity>|<periodOffs
 
 ### Computing the Hash
 
-Use `generateHashes` with inputs formatted as `<timeDimensionId>|<granularity>|<periodOffset>`:
+Use `generateHashes` (native agent) or `generate_hashes` (MCP) with inputs formatted as `<timeDimensionId>|<granularity>|<periodOffset>`:
 
 ```json
 {

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -201,6 +201,7 @@ describe('defineTool', () => {
             .sort();
 
         expect(structuredMcpToolNames).toEqual([
+            'generate_hashes',
             'get_ai_writeback_status',
             'get_context',
             'get_metadata',

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -134,6 +134,7 @@ import {
     toolFindFieldsOutputSchema,
 } from './toolFindFieldsArgs';
 import {
+    mcpGenerateHashesStructuredOutputSchema,
     TOOL_GENERATE_HASHES_DESCRIPTION,
     toolGenerateHashesArgsSchema,
     toolGenerateHashesOutputSchema,
@@ -730,18 +731,23 @@ export const generateUuidsToolDefinition: ToolDefinitionWithoutMcpOutput<
     agent: { outputSchema: toolGenerateUuidsOutputSchema },
 });
 
-export const generateHashesToolDefinition: ToolDefinitionWithoutMcpOutput<
+export const generateHashesToolDefinition: ToolDefinitionWithMcpOutput<
     'generateHashes',
     typeof toolGenerateHashesArgsSchema,
     typeof toolGenerateHashesArgsSchema,
-    typeof toolGenerateHashesOutputSchema
+    typeof toolGenerateHashesOutputSchema,
+    typeof mcpGenerateHashesStructuredOutputSchema
 > = defineTool({
     name: 'generateHashes',
     title: 'Generate hashes',
     description: TOOL_GENERATE_HASHES_DESCRIPTION,
-    availability: ['agent'],
+    availability: ['agent', 'mcp'],
     inputSchema: toolGenerateHashesArgsSchema,
     agent: { outputSchema: toolGenerateHashesOutputSchema },
+    mcp: {
+        annotations: readOnlyAnnotations,
+        structuredContentSchema: mcpGenerateHashesStructuredOutputSchema,
+    },
 });
 
 export const getDashboardChartsToolDefinition: ToolDefinitionWithoutMcpOutput<

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateHashesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateHashesArgs.ts
@@ -17,6 +17,12 @@ export const toolGenerateHashesOutputSchema = z.object({
     metadata: baseOutputMetadataSchema,
 });
 
+export const mcpGenerateHashesStructuredOutputSchema = z.object({
+    hashes: z
+        .array(z.string().regex(/^[0-9a-z]{6}$/))
+        .describe('Base-36 hashes in the same order as the input strings.'),
+});
+
 export type ToolGenerateHashesArgs = z.infer<
     typeof toolGenerateHashesArgsSchema
 >;

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -416,6 +416,50 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
+            "description": "Generate deterministic base-36 hashes for input strings.",
+            "inputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                    "inputs": {
+                        "description": "Input strings to hash.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "maxItems": 20,
+                        "minItems": 1,
+                        "type": "array"
+                    }
+                },
+                "required": ["inputs"],
+                "type": "object"
+            },
+            "name": "generate_hashes",
+            "outputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                    "hashes": {
+                        "description": "Base-36 hashes in the same order as the input strings.",
+                        "items": {
+                            "pattern": "^[0-9a-z]{6}$",
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["hashes"],
+                "type": "object"
+            },
+            "title": "Generate hashes"
+        },
+        {
+            "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": false,
+                "readOnlyHint": true
+            },
             "description": "Tool: get_ai_writeback_status\n\nPurpose:\nCheck the status of a writeback run started by run_ai_writeback, and get the pull request URL once it's ready.\n\nImportant:\n- Poll every 10-15 seconds rather than immediately looping — a run typically takes a few minutes.\n- \"status\" is either \"pending\" (not yet picked up), an in-progress pipeline stage (e.g. \"sandbox\", \"agent\", \"pull_request\"), or a terminal value: \"ready\" (finished — check prUrl), \"error\" (finished — check errorMessage; this also covers the \"more than one dbt source\" case described in run_ai_writeback), or \"cancelled\" (stopped before finishing).\n\nParameters:\n- aiWritebackRunUuid: The id returned by run_ai_writeback.\n\nResponse shape (MCP CallToolResult):\n- content: [{ type: \"text\", text: \"<human-readable status summary>\" }]\n- structuredContent: {\n    status:       string,        // \"pending\" | a pipeline stage | \"ready\" | \"error\" | \"cancelled\"\n    prUrl:        string | null, // set once status is \"ready\" and a PR was opened\n    errorMessage: string | null  // set once status is \"error\"\n  }\n",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
Exposes deterministic base-36 hash generation over MCP and documents its PoP workflow.

Risk: low — Adds a project-independent read-only helper with no data access or side effects.