### PR TITLE
chore: prototype embedded chart type builder in Explorer

### DIFF
--- a/packages/frontend/src/stories/ExplorerChartGalleryPrototype.module.css
+++ b/packages/frontend/src/stories/ExplorerChartGalleryPrototype.module.css
@@ -34,6 +34,175 @@
     grid-template-columns: 292px minmax(600px, 1fr) 500px;
 }
 
+.embeddedBuilder {
+    position: relative;
+    min-width: 0;
+    height: 100%;
+    overflow: hidden;
+    background: light-dark(
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-8)
+    );
+}
+
+.builderHeader {
+    height: 58px;
+    padding: 0 var(--mantine-spacing-md);
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+}
+
+.builderSplitA,
+.builderSplitC {
+    display: grid;
+    height: calc(100% - 58px);
+    min-height: 0;
+}
+
+.builderSplitA {
+    grid-template-columns: minmax(540px, 1fr) 390px;
+}
+
+.builderSplitC {
+    grid-template-columns: 360px minmax(560px, 1fr);
+}
+
+.builderPreviewPanel {
+    min-width: 0;
+    height: 100%;
+    padding: var(--mantine-spacing-lg);
+    overflow: auto;
+}
+
+.builderChartCanvas {
+    position: relative;
+    min-height: 360px;
+    padding: var(--mantine-spacing-xl);
+    overflow: hidden;
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+}
+
+.buildingOverlay {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: light-dark(rgba(255, 255, 255, 0.9), rgba(26, 27, 30, 0.9));
+    backdrop-filter: blur(3px);
+}
+
+.builderConversation {
+    min-width: 0;
+    height: 100%;
+    padding: var(--mantine-spacing-md);
+    overflow: hidden;
+    border-left: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+}
+
+.builderSplitC .builderConversation {
+    border-right: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+    border-left: 0;
+}
+
+.conversationScroll {
+    flex: 1;
+    min-height: 120px;
+    overflow-y: auto;
+}
+
+.agentMessage {
+    margin-right: var(--mantine-spacing-lg);
+    background: light-dark(
+        var(--mantine-color-gray-1),
+        var(--mantine-color-dark-6)
+    );
+}
+
+.userMessage {
+    margin-left: var(--mantine-spacing-lg);
+    color: white;
+    background: var(--mantine-color-violet-7);
+}
+
+.readyMessage {
+    border-color: light-dark(
+        var(--mantine-color-green-4),
+        var(--mantine-color-green-8)
+    );
+    background: light-dark(
+        var(--mantine-color-green-0),
+        color-mix(in srgb, var(--mantine-color-green-9) 35%, transparent)
+    );
+}
+
+.staleResultsNotice,
+.queryChanged {
+    border-color: light-dark(
+        var(--mantine-color-yellow-5),
+        var(--mantine-color-yellow-8)
+    );
+    background: light-dark(
+        var(--mantine-color-yellow-0),
+        color-mix(in srgb, var(--mantine-color-yellow-9) 28%, transparent)
+    );
+}
+
+.builderCanvasB {
+    height: calc(100% - 58px);
+    padding: var(--mantine-spacing-md);
+    overflow: auto;
+}
+
+.builderCanvasB .builderPreviewPanel {
+    height: auto;
+    max-width: 1040px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 0;
+}
+
+.builderDockB {
+    width: min(920px, 100%);
+    min-height: 360px;
+    margin: 0 auto;
+    overflow: hidden;
+    box-shadow: var(--mantine-shadow-lg);
+}
+
+.builderDockB .builderConversation {
+    min-height: 360px;
+    border-left: 0;
+}
+
+.authoringState {
+    position: absolute;
+    z-index: 4;
+    right: 14px;
+    bottom: 14px;
+    width: 260px;
+    max-height: 190px;
+    overflow: auto;
+    opacity: 0.92;
+    pointer-events: none;
+    white-space: pre-wrap;
+    font-size: 9px;
+    line-height: 1.35;
+    box-shadow: var(--mantine-shadow-md);
+}
+
 .sidebar {
     min-width: 0;
     overflow: hidden;

--- a/packages/frontend/src/stories/ExplorerChartGalleryPrototype.module.css
+++ b/packages/frontend/src/stories/ExplorerChartGalleryPrototype.module.css
@@ -1,0 +1,522 @@
+.prototype {
+    min-width: 1180px;
+    min-height: 820px;
+    background: light-dark(
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-8)
+    );
+    color: light-dark(var(--mantine-color-gray-9), var(--mantine-color-gray-1));
+}
+
+.featureBar {
+    height: 52px;
+    padding: 0 var(--mantine-spacing-md);
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+}
+
+.workspace {
+    display: grid;
+    grid-template-columns: 292px minmax(660px, 1fr);
+    height: calc(100vh - 52px);
+    min-height: 768px;
+}
+
+.workspaceWithRightSidebar {
+    grid-template-columns: 292px minmax(620px, 1fr) 390px;
+}
+
+.workspaceWithWideRightSidebar {
+    grid-template-columns: 292px minmax(600px, 1fr) 500px;
+}
+
+.sidebar {
+    min-width: 0;
+    overflow: hidden;
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+}
+
+.leftSidebar {
+    border-right: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+}
+
+.rightSidebar {
+    border-left: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+}
+
+.sidebarHeader {
+    height: 58px;
+    padding: 0 var(--mantine-spacing-md);
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+}
+
+.sidebarScroll {
+    height: calc(100% - 58px);
+}
+
+.main {
+    min-width: 0;
+    overflow: auto;
+    padding: var(--mantine-spacing-md);
+}
+
+.toolbar {
+    min-height: 44px;
+}
+
+.sectionCard {
+    overflow: hidden;
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+}
+
+.sectionHeader {
+    min-height: 42px;
+    padding: 0 var(--mantine-spacing-sm);
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+}
+
+.chartStage {
+    height: 330px;
+    padding: var(--mantine-spacing-xl);
+}
+
+.chartPreview {
+    width: 100%;
+    height: 100%;
+}
+
+.barChart {
+    display: flex;
+    height: 100%;
+    align-items: end;
+    gap: clamp(16px, 7%, 72px);
+    padding: 28px 28px 34px;
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-4), var(--mantine-color-dark-4));
+    background-image: linear-gradient(
+        to bottom,
+        transparent 24%,
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5)) 25%,
+        transparent 26%,
+        transparent 49%,
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5)) 50%,
+        transparent 51%,
+        transparent 74%,
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5)) 75%,
+        transparent 76%
+    );
+}
+
+.barColumn {
+    position: relative;
+    flex: 1;
+    min-width: 26px;
+    max-width: 210px;
+    border-radius: 5px 5px 0 0;
+    transition: height 160ms ease;
+}
+
+.barLabel {
+    position: absolute;
+    bottom: -26px;
+    left: 50%;
+    width: 90px;
+    transform: translateX(-50%);
+    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-4));
+    font-size: 11px;
+    text-align: center;
+}
+
+.barValue {
+    position: absolute;
+    top: -20px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-4));
+    font-size: 10px;
+}
+
+.lineChart {
+    width: 100%;
+    height: 100%;
+    color: var(--chart-color);
+}
+
+.donutLayout {
+    display: flex;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    gap: 36px;
+}
+
+.donut {
+    width: min(210px, 48%);
+    aspect-ratio: 1;
+    border-radius: 50%;
+    background: conic-gradient(
+        var(--chart-color) 0 50.1%,
+        color-mix(in srgb, var(--chart-color) 70%, white) 50.1% 95%,
+        color-mix(in srgb, var(--chart-color) 38%, white) 95% 100%
+    );
+    mask: radial-gradient(circle at center, transparent 0 52%, black 53%);
+}
+
+.scorecard {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.horizontalBars {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    justify-content: center;
+    gap: 18px;
+    padding: 20px;
+}
+
+.horizontalTrack {
+    height: 26px;
+    overflow: hidden;
+    border-radius: var(--mantine-radius-sm);
+    background: light-dark(
+        var(--mantine-color-gray-1),
+        var(--mantine-color-dark-5)
+    );
+}
+
+.horizontalFill {
+    height: 100%;
+    border-radius: inherit;
+}
+
+.funnel {
+    width: 82%;
+    height: 100%;
+    margin: auto;
+}
+
+.treemap {
+    display: grid;
+    width: 100%;
+    height: 100%;
+    gap: 3px;
+    padding: 12px;
+    grid-template-columns: 1.45fr 1fr 0.8fr;
+    grid-template-rows: 1.2fr 1fr;
+    grid-template-areas:
+        'a b c'
+        'a d d';
+}
+
+.treemap > div {
+    border-radius: 3px;
+}
+
+.gaugeWrap {
+    position: relative;
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    padding-bottom: 12%;
+}
+
+.gauge {
+    width: min(240px, 75%);
+    aspect-ratio: 2 / 1;
+    border: 22px solid;
+    border-bottom: 0;
+    border-radius: 999px 999px 0 0;
+    opacity: 0.3;
+}
+
+.gaugeNeedle {
+    position: absolute;
+    bottom: 24%;
+    left: 50%;
+    width: 32%;
+    height: 4px;
+    border-radius: 4px;
+    transform: rotate(-34deg);
+    transform-origin: left center;
+}
+
+.sankey {
+    width: 100%;
+    height: 100%;
+    color: var(--chart-color);
+}
+
+.mapPreview {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    border-radius: var(--mantine-radius-sm);
+    background:
+        radial-gradient(
+            circle at 28% 42%,
+            transparent 0 18%,
+            rgba(255, 255, 255, 0.75) 19% 20%,
+            transparent 21%
+        ),
+        linear-gradient(135deg, #e7ecef 0%, #f7f8f9 100%);
+}
+
+.mapDot {
+    position: absolute;
+    border: 2px solid white;
+    border-radius: 50%;
+    box-shadow: var(--mantine-shadow-xs);
+}
+
+.tablePreview {
+    height: 100%;
+    justify-content: center;
+    padding: 12px;
+}
+
+.tablePreview > div {
+    padding-bottom: 6px;
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+}
+
+.vegaPreview {
+    display: flex;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    gap: var(--mantine-spacing-lg);
+    background: light-dark(#f8f7ff, #1f1b2d);
+}
+
+.vegaEditor {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11px;
+    line-height: 1.55;
+    background: light-dark(#fbfbfd, var(--mantine-color-dark-8));
+}
+
+.miniPreview {
+    height: 78px;
+    padding: 10px;
+    overflow: hidden;
+    background: light-dark(#f8f9fb, var(--mantine-color-dark-8));
+}
+
+.miniPreview .barChart {
+    gap: 7px;
+    padding: 12px 10px 8px;
+}
+
+.miniPreview .barLabel,
+.miniPreview .barValue {
+    display: none;
+}
+
+.miniPreview .donutLayout {
+    gap: 8px;
+}
+
+.miniPreview .donut {
+    width: 52px;
+}
+
+.miniPreview .horizontalBars {
+    gap: 6px;
+    padding: 4px;
+}
+
+.miniPreview .horizontalTrack {
+    height: 8px;
+}
+
+.miniPreview .gauge {
+    width: 58px;
+    border-width: 9px;
+}
+
+.miniPreview .gaugeNeedle {
+    bottom: 30%;
+    width: 30%;
+    height: 2px;
+}
+
+.miniPreview .treemap,
+.miniPreview .tablePreview {
+    padding: 2px;
+}
+
+.miniPreview .funnel {
+    width: 74%;
+}
+
+.chartTypeCard {
+    display: block;
+    width: 100%;
+    overflow: hidden;
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+    border-radius: var(--mantine-radius-md);
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+    text-align: left;
+    transition:
+        border-color 120ms ease,
+        box-shadow 120ms ease,
+        transform 120ms ease;
+}
+
+.chartTypeCard:hover {
+    transform: translateY(-1px);
+    box-shadow: var(--mantine-shadow-sm);
+}
+
+.chartTypeCardSelected {
+    border-color: var(--mantine-color-blue-5);
+    box-shadow: 0 0 0 2px
+        color-mix(in srgb, var(--mantine-color-blue-5) 20%, transparent);
+}
+
+.catalogRow {
+    width: 100%;
+    padding: var(--mantine-spacing-sm);
+    border: 1px solid transparent;
+    border-radius: var(--mantine-radius-md);
+    text-align: left;
+}
+
+.catalogRow:hover {
+    background: light-dark(
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-6)
+    );
+}
+
+.catalogRowSelected {
+    border-color: var(--mantine-color-blue-5);
+    background: light-dark(
+        var(--mantine-color-blue-0),
+        color-mix(in srgb, var(--mantine-color-blue-9) 26%, transparent)
+    );
+}
+
+.catalogThumbnail {
+    width: 86px;
+    flex: 0 0 86px;
+    overflow: hidden;
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+    border-radius: var(--mantine-radius-sm);
+}
+
+.railLayout {
+    display: grid;
+    grid-template-columns: 142px minmax(0, 1fr);
+    min-height: 100%;
+}
+
+.typeRail {
+    padding: var(--mantine-spacing-xs);
+    overflow-y: auto;
+    border-right: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+    background: light-dark(
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-8)
+    );
+}
+
+.railItem {
+    width: 100%;
+    padding: 9px 8px;
+    border-radius: var(--mantine-radius-md);
+    text-align: left;
+}
+
+.railItemSelected {
+    color: var(--mantine-color-blue-7);
+    background: light-dark(
+        var(--mantine-color-blue-0),
+        var(--mantine-color-blue-9)
+    );
+}
+
+.inspectorPreview {
+    height: 150px;
+    overflow: hidden;
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+    border-radius: var(--mantine-radius-md);
+}
+
+.fieldItem {
+    padding: 9px 10px;
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+    border-radius: var(--mantine-radius-sm);
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+}
+
+.resultTable {
+    font-size: 12px;
+}
+
+.resultTable th {
+    background: light-dark(
+        var(--mantine-color-indigo-0),
+        var(--mantine-color-dark-6)
+    );
+}
+
+.stateBlock {
+    white-space: pre-wrap;
+    font-size: 10px;
+    line-height: 1.45;
+}
+
+.prototypeSwitcher {
+    position: fixed;
+    z-index: 10001;
+    bottom: 18px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: white;
+    background: #15171a;
+    box-shadow: var(--mantine-shadow-xl);
+}
+
+.switcherButton {
+    color: white;
+}
+
+.switcherButton:hover {
+    background: rgba(255, 255, 255, 0.12);
+}

--- a/packages/frontend/src/stories/ExplorerChartGalleryPrototype.module.css
+++ b/packages/frontend/src/stories/ExplorerChartGalleryPrototype.module.css
@@ -52,77 +52,6 @@
     );
 }
 
-.builderPreviewPanel {
-    min-width: 0;
-    height: 100%;
-    padding: var(--mantine-spacing-lg);
-    overflow: auto;
-}
-
-.builderChartCanvas {
-    position: relative;
-    min-height: 360px;
-    padding: var(--mantine-spacing-xl);
-    overflow: hidden;
-    background: light-dark(
-        var(--mantine-color-white),
-        var(--mantine-color-dark-7)
-    );
-}
-
-.buildingOverlay {
-    position: absolute;
-    inset: 0;
-    display: grid;
-    place-items: center;
-    background: light-dark(rgba(255, 255, 255, 0.9), rgba(26, 27, 30, 0.9));
-    backdrop-filter: blur(3px);
-}
-
-.builderConversation {
-    min-width: 0;
-    height: 100%;
-    padding: var(--mantine-spacing-md);
-    overflow: hidden;
-    border-left: 1px solid
-        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
-    background: light-dark(
-        var(--mantine-color-white),
-        var(--mantine-color-dark-7)
-    );
-}
-
-.conversationScroll {
-    flex: 1;
-    min-height: 120px;
-    overflow-y: auto;
-}
-
-.agentMessage {
-    margin-right: var(--mantine-spacing-lg);
-    background: light-dark(
-        var(--mantine-color-gray-1),
-        var(--mantine-color-dark-6)
-    );
-}
-
-.userMessage {
-    margin-left: var(--mantine-spacing-lg);
-    color: white;
-    background: var(--mantine-color-violet-7);
-}
-
-.readyMessage {
-    border-color: light-dark(
-        var(--mantine-color-green-4),
-        var(--mantine-color-green-8)
-    );
-    background: light-dark(
-        var(--mantine-color-green-0),
-        color-mix(in srgb, var(--mantine-color-green-9) 35%, transparent)
-    );
-}
-
 .staleResultsNotice,
 .queryChanged {
     border-color: light-dark(
@@ -135,31 +64,222 @@
     );
 }
 
-.builderCanvasB {
+.builderBody {
+    display: flex;
+    flex-direction: column;
     height: calc(100% - 58px);
-    padding: var(--mantine-spacing-md);
+    min-height: 0;
+}
+
+.builderStart {
+    flex: 1;
+    min-height: 0;
+    justify-content: center;
+    padding: var(--mantine-spacing-xl) var(--mantine-spacing-xxl)
+        var(--mantine-spacing-md);
     overflow: auto;
+    transition: opacity 150ms ease;
 }
 
-.builderCanvasB .builderPreviewPanel {
-    height: auto;
-    max-width: 1040px;
-    width: 100%;
-    margin: 0 auto;
-    padding: 0;
+.builderStart[data-quiet='true'] {
+    opacity: 0.3;
+    pointer-events: none;
 }
 
-.builderDockB {
-    width: min(920px, 100%);
-    min-height: 360px;
-    margin: 0 auto;
+.builderExample {
+    display: flex;
+    width: 200px;
+    flex-direction: column;
+    gap: var(--mantine-spacing-sm);
+    padding: var(--mantine-spacing-sm);
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+    border-radius: var(--mantine-radius-md);
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+    text-align: left;
+    transition:
+        transform 150ms,
+        box-shadow 150ms,
+        border-color 150ms;
+}
+
+.builderExample:hover {
+    transform: translateY(-2px);
+    border-color: var(--mantine-color-gray-5);
+    box-shadow: var(--mantine-shadow-sm);
+}
+
+.builderExamplePreview {
+    height: 74px;
     overflow: hidden;
-    box-shadow: var(--mantine-shadow-lg);
 }
 
-.builderDockB .builderConversation {
-    min-height: 360px;
-    border-left: 0;
+.builderSkeleton {
+    height: 74px;
+}
+
+.builderSkeletonBar {
+    width: 22px;
+    border-radius: 3px;
+    background: var(--mantine-color-blue-6);
+    transform-origin: bottom;
+    animation: builderBar 1.15s ease-in-out infinite;
+}
+
+@keyframes builderBar {
+    0%,
+    100% {
+        transform: scaleY(0.5);
+        opacity: 0.3;
+    }
+
+    50% {
+        transform: scaleY(1);
+        opacity: 0.85;
+    }
+}
+
+.builderResult {
+    flex: 1;
+    min-height: 0;
+    width: 100%;
+    max-width: 1160px;
+    margin: 0 auto;
+    padding: var(--mantine-spacing-xl) var(--mantine-spacing-xxl)
+        var(--mantine-spacing-md);
+}
+
+.builderResultCard {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    overflow: visible;
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+    border-radius: var(--mantine-radius-md);
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+    box-shadow: var(--mantine-shadow-sm);
+}
+
+.builderOptionsPanel {
+    width: 264px;
+    flex: 0 0 264px;
+    min-height: 0;
+    padding: 0 var(--mantine-spacing-sm) var(--mantine-spacing-sm);
+    border-right: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+}
+
+.generatedChip {
+    align-self: flex-start;
+    margin: -9px 0 2px;
+    padding: 2px 10px;
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
+    border-radius: var(--mantine-radius-xl);
+    background: light-dark(
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-6)
+    );
+    color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-gray-4));
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.builderOptionTabs {
+    padding-bottom: var(--mantine-spacing-xs);
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+}
+
+.paletteSwatch {
+    width: 24px;
+    height: 18px;
+    border-radius: var(--mantine-radius-xs);
+}
+
+.builderResultPreview {
+    display: flex;
+    flex: 1;
+    min-width: 0;
+    flex-direction: column;
+    padding: var(--mantine-spacing-lg);
+    overflow: hidden;
+}
+
+.builderResultTitle {
+    flex: 0 0 auto;
+}
+
+.builderResultChart {
+    flex: 1;
+    min-height: 260px;
+    overflow: hidden;
+}
+
+.builderPromptWrap {
+    position: relative;
+    z-index: 10;
+    width: 620px;
+    max-width: 80%;
+    margin: 0 auto;
+    padding: 8px 0 22px;
+    flex-shrink: 0;
+}
+
+.builderPromptPill,
+.clarificationSheet,
+.builderStatusRow {
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+    box-shadow: var(--mantine-shadow-sm);
+}
+
+.builderPromptPill {
+    padding: 7px 9px 6px 12px;
+}
+
+.clarificationSheet,
+.builderStatusRow {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 8px);
+    left: 0;
+}
+
+.clarificationSheet {
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-xs);
+    padding: var(--mantine-spacing-sm);
+}
+
+.builderStatusRow {
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+}
+
+.builderStatusDot {
+    width: 12px;
+    height: 12px;
+    border: 2px solid var(--mantine-color-gray-3);
+    border-top-color: var(--mantine-color-blue-6);
+    border-radius: 50%;
+    animation: builderSpin 800ms linear infinite;
+}
+
+@keyframes builderSpin {
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 .authoringState {

--- a/packages/frontend/src/stories/ExplorerChartGalleryPrototype.module.css
+++ b/packages/frontend/src/stories/ExplorerChartGalleryPrototype.module.css
@@ -30,10 +30,6 @@
     grid-template-columns: 292px minmax(620px, 1fr) 390px;
 }
 
-.workspaceWithWideRightSidebar {
-    grid-template-columns: 292px minmax(600px, 1fr) 500px;
-}
-
 .embeddedBuilder {
     position: relative;
     min-width: 0;
@@ -54,21 +50,6 @@
         var(--mantine-color-white),
         var(--mantine-color-dark-7)
     );
-}
-
-.builderSplitA,
-.builderSplitC {
-    display: grid;
-    height: calc(100% - 58px);
-    min-height: 0;
-}
-
-.builderSplitA {
-    grid-template-columns: minmax(540px, 1fr) 390px;
-}
-
-.builderSplitC {
-    grid-template-columns: 360px minmax(560px, 1fr);
 }
 
 .builderPreviewPanel {
@@ -109,12 +90,6 @@
         var(--mantine-color-white),
         var(--mantine-color-dark-7)
     );
-}
-
-.builderSplitC .builderConversation {
-    border-right: 1px solid
-        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
-    border-left: 0;
 }
 
 .conversationScroll {
@@ -542,35 +517,6 @@
     width: 74%;
 }
 
-.chartTypeCard {
-    display: block;
-    width: 100%;
-    overflow: hidden;
-    border: 1px solid
-        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
-    border-radius: var(--mantine-radius-md);
-    background: light-dark(
-        var(--mantine-color-white),
-        var(--mantine-color-dark-7)
-    );
-    text-align: left;
-    transition:
-        border-color 120ms ease,
-        box-shadow 120ms ease,
-        transform 120ms ease;
-}
-
-.chartTypeCard:hover {
-    transform: translateY(-1px);
-    box-shadow: var(--mantine-shadow-sm);
-}
-
-.chartTypeCardSelected {
-    border-color: var(--mantine-color-blue-5);
-    box-shadow: 0 0 0 2px
-        color-mix(in srgb, var(--mantine-color-blue-5) 20%, transparent);
-}
-
 .catalogRow {
     width: 100%;
     padding: var(--mantine-spacing-sm);
@@ -603,46 +549,6 @@
     border-radius: var(--mantine-radius-sm);
 }
 
-.railLayout {
-    display: grid;
-    grid-template-columns: 142px minmax(0, 1fr);
-    min-height: 100%;
-}
-
-.typeRail {
-    padding: var(--mantine-spacing-xs);
-    overflow-y: auto;
-    border-right: 1px solid
-        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
-    background: light-dark(
-        var(--mantine-color-gray-0),
-        var(--mantine-color-dark-8)
-    );
-}
-
-.railItem {
-    width: 100%;
-    padding: 9px 8px;
-    border-radius: var(--mantine-radius-md);
-    text-align: left;
-}
-
-.railItemSelected {
-    color: var(--mantine-color-blue-7);
-    background: light-dark(
-        var(--mantine-color-blue-0),
-        var(--mantine-color-blue-9)
-    );
-}
-
-.inspectorPreview {
-    height: 150px;
-    overflow: hidden;
-    border: 1px solid
-        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-5));
-    border-radius: var(--mantine-radius-md);
-}
-
 .fieldItem {
     padding: 9px 10px;
     border: 1px solid
@@ -669,23 +575,4 @@
     white-space: pre-wrap;
     font-size: 10px;
     line-height: 1.45;
-}
-
-.prototypeSwitcher {
-    position: fixed;
-    z-index: 10001;
-    bottom: 18px;
-    left: 50%;
-    transform: translateX(-50%);
-    color: white;
-    background: #15171a;
-    box-shadow: var(--mantine-shadow-xl);
-}
-
-.switcherButton {
-    color: white;
-}
-
-.switcherButton:hover {
-    background: rgba(255, 255, 255, 0.12);
 }

--- a/packages/frontend/src/stories/ExplorerChartGalleryPrototype.stories.tsx
+++ b/packages/frontend/src/stories/ExplorerChartGalleryPrototype.stories.tsx
@@ -22,7 +22,9 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
     IconAdjustmentsHorizontal,
+    IconAlertCircle,
     IconArrowLeft,
+    IconArrowRight,
     IconChartArea,
     IconChartBar,
     IconChartDonut,
@@ -34,16 +36,20 @@ import {
     IconChevronLeft,
     IconChevronRight,
     IconCode,
+    IconCircleCheck,
     IconDeviceFloppy,
+    IconEdit,
     IconFilter,
     IconGauge,
     IconGitMerge,
     IconMap,
+    IconMessageCircle,
     IconPlayerPlay,
     IconPlus,
     IconRefresh,
     IconSearch,
     IconSettings,
+    IconSparkles,
     IconSquareNumber1,
     IconTable,
     IconX,
@@ -53,8 +59,9 @@ import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import MantineIcon from '../components/common/MantineIcon';
 import classes from './ExplorerChartGalleryPrototype.module.css';
 
-// PROTOTYPE — three Explorer chart-gallery interactions, switchable through
-// `?prototypeVariant=A|B|C`. Throw this story away after a direction is chosen.
+// PROTOTYPE — three complete Explorer -> embedded chart builder -> Explorer
+// interactions, switchable through `?prototypeVariant=A|B|C`. Throw this story
+// away after the authoring layout and state model are chosen.
 
 type QueryRow = {
     tier: 'Very high' | 'High' | 'Low';
@@ -63,6 +70,8 @@ type QueryRow = {
 };
 
 type PrototypeVariant = 'A' | 'B' | 'C';
+type ExplorerMode = 'explore' | 'authoring';
+type BuildStage = 'brief' | 'clarify' | 'building' | 'ready';
 type ChartPreviewKind =
     | 'bar'
     | 'horizontal'
@@ -267,6 +276,15 @@ const CHART_TYPES: ChartTypeOption[] = [
         source: 'project',
         kind: 'scorecard',
         icon: IconAdjustmentsHorizontal,
+    },
+    {
+        id: 'generated-waterfall',
+        label: 'Event change waterfall',
+        description: 'Generated waterfall · 3 fields',
+        group: 'Project',
+        source: 'project',
+        kind: 'bar',
+        icon: IconChartBar,
     },
 ];
 
@@ -697,7 +715,21 @@ const ChartPreview = ({
     );
 };
 
-const FieldsSidebar = () => (
+const FieldsSidebar = ({
+    extraFieldSelected,
+    queryDirty,
+    dataRevision,
+    authoring,
+    onToggleExtraField,
+    onRunQuery,
+}: {
+    extraFieldSelected: boolean;
+    queryDirty: boolean;
+    dataRevision: number;
+    authoring: boolean;
+    onToggleExtraField: () => void;
+    onRunQuery: () => void;
+}) => (
     <Box className={`${classes.sidebar} ${classes.leftSidebar}`}>
         <Group className={classes.sidebarHeader} justify="space-between">
             <Text fw={600}>Events</Text>
@@ -718,13 +750,16 @@ const FieldsSidebar = () => (
                             SELECTED FIELDS
                         </Text>
                         <Badge variant="light" size="xs">
-                            3
+                            {extraFieldSelected ? 4 : 3}
                         </Badge>
                     </Group>
                     {[
                         ['Abc', 'Event tier', 'blue'],
                         ['Abc', 'Event', 'blue'],
                         ['123', 'Count', 'orange'],
+                        ...(extraFieldSelected
+                            ? [['📅', 'Event date', 'grape']]
+                            : []),
                     ].map(([type, label, color]) => (
                         <Group
                             key={label}
@@ -747,14 +782,26 @@ const FieldsSidebar = () => (
                     <Text size="xs" fw={600} c="dimmed">
                         DIMENSIONS
                     </Text>
-                    {['Event source', 'Event date', 'User id'].map((field) => (
-                        <Group key={field} justify="space-between" px="xs">
-                            <Text size="sm">{field}</Text>
-                            <Button size="compact-xs" variant="subtle">
-                                +
-                            </Button>
-                        </Group>
-                    ))}
+                    {['Event source', 'Event date', 'User id'].map((field) => {
+                        const isInteractive = field === 'Event date';
+                        const isSelected = isInteractive && extraFieldSelected;
+                        return (
+                            <Group key={field} justify="space-between" px="xs">
+                                <Text size="sm">{field}</Text>
+                                <Button
+                                    size="compact-xs"
+                                    variant={isSelected ? 'light' : 'subtle'}
+                                    onClick={
+                                        isInteractive
+                                            ? onToggleExtraField
+                                            : undefined
+                                    }
+                                >
+                                    {isSelected ? 'Remove' : '+'}
+                                </Button>
+                            </Group>
+                        );
+                    })}
                 </Stack>
                 <Stack gap="xs">
                     <Text size="xs" fw={600} c="dimmed">
@@ -771,6 +818,46 @@ const FieldsSidebar = () => (
                         ),
                     )}
                 </Stack>
+                <Paper
+                    withBorder
+                    radius="md"
+                    p="sm"
+                    className={queryDirty ? classes.queryChanged : undefined}
+                >
+                    <Stack gap="xs">
+                        <Group justify="space-between">
+                            <Text size="xs" fw={600}>
+                                QUERY CONTEXT
+                            </Text>
+                            <Badge
+                                size="xs"
+                                color={queryDirty ? 'yellow' : 'green'}
+                                variant="light"
+                            >
+                                {queryDirty ? 'Changed' : `Run ${dataRevision}`}
+                            </Badge>
+                        </Group>
+                        <Text size="xs" c="dimmed">
+                            {queryDirty
+                                ? 'Run the query to refresh the chart and builder preview.'
+                                : authoring
+                                  ? 'The builder is using these executed results.'
+                                  : 'Chart previews use the latest executed results.'}
+                        </Text>
+                        <Button
+                            fullWidth
+                            size="xs"
+                            color={queryDirty ? 'blue' : 'gray'}
+                            variant={queryDirty ? 'filled' : 'default'}
+                            leftSection={
+                                <MantineIcon icon={IconPlayerPlay} size={14} />
+                            }
+                            onClick={onRunQuery}
+                        >
+                            {queryDirty ? 'Run updated query' : 'Run query'}
+                        </Button>
+                    </Stack>
+                </Paper>
             </Stack>
         </ScrollArea>
     </Box>
@@ -782,12 +869,14 @@ const ConfigControls = ({
     setPalette,
     showLabels,
     setShowLabels,
+    onEditProjectChart,
 }: {
     selectedChart: ChartTypeOption;
     palette: Palette;
     setPalette: (palette: Palette) => void;
     showLabels: boolean;
     setShowLabels: (show: boolean) => void;
+    onEditProjectChart?: () => void;
 }) => {
     const mappingLabels =
         selectedChart.id === 'volume-scorecard'
@@ -892,8 +981,15 @@ const ConfigControls = ({
                                 {selectedChart.description}
                             </Text>
                         </Stack>
-                        <Button size="compact-xs" variant="subtle">
-                            Edit ↗
+                        <Button
+                            size="compact-xs"
+                            variant="subtle"
+                            leftSection={
+                                <MantineIcon icon={IconEdit} size={13} />
+                            }
+                            onClick={onEditProjectChart}
+                        >
+                            Edit
                         </Button>
                     </Group>
                 </Paper>
@@ -1133,6 +1229,8 @@ type RightSidebarProps = {
     setPalette: (palette: Palette) => void;
     showLabels: boolean;
     setShowLabels: (show: boolean) => void;
+    onCreateChartType: () => void;
+    onEditProjectChart: () => void;
 };
 
 const RightSidebarVariantA = ({
@@ -1143,6 +1241,8 @@ const RightSidebarVariantA = ({
     setPalette,
     showLabels,
     setShowLabels,
+    onCreateChartType,
+    onEditProjectChart,
 }: RightSidebarProps) => {
     const [search, setSearch] = useState('');
     const [group, setGroup] = useState<'All' | ChartGroup>('All');
@@ -1202,6 +1302,7 @@ const RightSidebarVariantA = ({
                     variant="subtle"
                     size="xs"
                     leftSection={<MantineIcon icon={IconPlus} />}
+                    onClick={onCreateChartType}
                 >
                     Create new chart type
                 </Button>
@@ -1215,6 +1316,7 @@ const RightSidebarVariantA = ({
                     setPalette={setPalette}
                     showLabels={showLabels}
                     setShowLabels={setShowLabels}
+                    onEditProjectChart={onEditProjectChart}
                 />
                 <Divider />
                 <PrototypeState
@@ -1236,6 +1338,8 @@ const RightSidebarVariantB = ({
     setPalette,
     showLabels,
     setShowLabels,
+    onCreateChartType,
+    onEditProjectChart,
 }: RightSidebarProps) => {
     const [step, setStep] = useState<'choose' | 'configure'>('choose');
 
@@ -1320,6 +1424,7 @@ const RightSidebarVariantB = ({
                         <Button
                             variant="default"
                             leftSection={<MantineIcon icon={IconPlus} />}
+                            onClick={onCreateChartType}
                         >
                             Create new chart type
                         </Button>
@@ -1366,6 +1471,7 @@ const RightSidebarVariantB = ({
                             setPalette={setPalette}
                             showLabels={showLabels}
                             setShowLabels={setShowLabels}
+                            onEditProjectChart={onEditProjectChart}
                         />
                         <Divider />
                         <PrototypeState
@@ -1389,6 +1495,8 @@ const RightSidebarVariantC = ({
     setPalette,
     showLabels,
     setShowLabels,
+    onCreateChartType,
+    onEditProjectChart,
 }: RightSidebarProps) => (
     <Box className={classes.railLayout}>
         <Stack className={classes.typeRail} gap={4}>
@@ -1444,6 +1552,7 @@ const RightSidebarVariantC = ({
                 size="compact-xs"
                 variant="subtle"
                 leftSection={<MantineIcon icon={IconPlus} />}
+                onClick={onCreateChartType}
             >
                 New
             </Button>
@@ -1484,6 +1593,7 @@ const RightSidebarVariantC = ({
                     setPalette={setPalette}
                     showLabels={showLabels}
                     setShowLabels={setShowLabels}
+                    onEditProjectChart={onEditProjectChart}
                 />
                 <Divider />
                 <PrototypeState
@@ -1517,6 +1627,416 @@ const RightSidebar = (props: RightSidebarProps) => (
         {props.variant === 'C' && <RightSidebarVariantC {...props} />}
     </Box>
 );
+
+type EmbeddedBuilderProps = {
+    variant: PrototypeVariant;
+    buildStage: BuildStage;
+    prompt: string;
+    queryDirty: boolean;
+    dataRevision: number;
+    extraFieldSelected: boolean;
+    executedExtraFieldSelected: boolean;
+    editingChart: boolean;
+    onPromptChange: (value: string) => void;
+    onAdvance: () => void;
+    onCancel: () => void;
+    onApply: () => void;
+    onRunQuery: () => void;
+};
+
+const BUILD_STAGE_LABELS: Record<BuildStage, string> = {
+    brief: 'Describe',
+    clarify: 'Clarify',
+    building: 'Build',
+    ready: 'Ready',
+};
+
+const BuilderPreview = ({
+    buildStage,
+    queryDirty,
+    dataRevision,
+    onRunQuery,
+}: Pick<
+    EmbeddedBuilderProps,
+    'buildStage' | 'queryDirty' | 'dataRevision' | 'onRunQuery'
+>) => (
+    <Stack className={classes.builderPreviewPanel} gap="md">
+        <Group justify="space-between">
+            <Stack gap={1}>
+                <Text fw={650}>Event change waterfall</Text>
+                <Text size="xs" c="dimmed">
+                    Previewing executed query · Run {dataRevision} · 10 rows
+                </Text>
+            </Stack>
+            <Badge
+                variant="light"
+                color={buildStage === 'ready' ? 'green' : 'violet'}
+                leftSection={
+                    <MantineIcon
+                        icon={
+                            buildStage === 'ready'
+                                ? IconCircleCheck
+                                : IconSparkles
+                        }
+                        size={12}
+                    />
+                }
+            >
+                {buildStage === 'ready' ? 'Ready to use' : 'Draft preview'}
+            </Badge>
+        </Group>
+
+        {queryDirty && (
+            <Paper
+                withBorder
+                radius="md"
+                p="sm"
+                className={classes.staleResultsNotice}
+            >
+                <Group justify="space-between" wrap="nowrap">
+                    <Group gap="xs" wrap="nowrap">
+                        <MantineIcon icon={IconAlertCircle} color="yellow" />
+                        <Stack gap={1}>
+                            <Text size="sm" fw={600}>
+                                Query fields changed
+                            </Text>
+                            <Text size="xs" c="dimmed">
+                                This preview still uses Run {dataRevision}.
+                            </Text>
+                        </Stack>
+                    </Group>
+                    <Button size="xs" onClick={onRunQuery}>
+                        Run updated query
+                    </Button>
+                </Group>
+            </Paper>
+        )}
+
+        <Paper withBorder radius="lg" className={classes.builderChartCanvas}>
+            <ChartPreview kind="bar" palette="grape" showLabels />
+            {buildStage === 'building' && (
+                <Box className={classes.buildingOverlay}>
+                    <Stack align="center" gap="xs">
+                        <MantineIcon
+                            icon={IconSparkles}
+                            size={34}
+                            color="violet"
+                        />
+                        <Text fw={650}>Building your chart type…</Text>
+                        <Text size="xs" c="dimmed">
+                            Generating components and checking field mappings
+                        </Text>
+                    </Stack>
+                </Box>
+            )}
+        </Paper>
+
+        <Group grow>
+            <Paper withBorder radius="md" p="sm">
+                <Text size="xs" c="dimmed">
+                    CATEGORY
+                </Text>
+                <Text size="sm" fw={600}>
+                    Event tier
+                </Text>
+            </Paper>
+            <Paper withBorder radius="md" p="sm">
+                <Text size="xs" c="dimmed">
+                    CHANGE
+                </Text>
+                <Text size="sm" fw={600}>
+                    Count
+                </Text>
+            </Paper>
+            <Paper withBorder radius="md" p="sm">
+                <Text size="xs" c="dimmed">
+                    BREAKDOWN
+                </Text>
+                <Text size="sm" fw={600}>
+                    Event
+                </Text>
+            </Paper>
+        </Group>
+    </Stack>
+);
+
+const BuilderConversation = ({
+    buildStage,
+    prompt,
+    queryDirty,
+    dataRevision,
+    extraFieldSelected,
+    executedExtraFieldSelected,
+    editingChart,
+    onPromptChange,
+    onAdvance,
+}: Omit<
+    EmbeddedBuilderProps,
+    'variant' | 'onCancel' | 'onApply' | 'onRunQuery'
+>) => {
+    const actionLabel: Record<BuildStage, string> = {
+        brief: 'Continue',
+        clarify: 'Build chart type',
+        building: 'Finish simulated build',
+        ready: 'Add another instruction',
+    };
+
+    return (
+        <Stack className={classes.builderConversation} gap="md">
+            <Group gap="xs">
+                <MantineIcon icon={IconMessageCircle} color="violet" />
+                <Stack gap={0}>
+                    <Text fw={650}>Chart type builder</Text>
+                    <Text size="xs" c="dimmed">
+                        Using the latest executed Explorer results
+                    </Text>
+                </Stack>
+            </Group>
+
+            <Paper withBorder radius="md" p="sm">
+                <Text size="xs" c="dimmed" mb={4}>
+                    EXPLORER CONTEXT
+                </Text>
+                <Group gap="xs">
+                    <Badge size="xs" variant="light">
+                        Run {dataRevision}
+                    </Badge>
+                    <Badge size="xs" variant="light">
+                        {executedExtraFieldSelected ? 4 : 3} executed fields
+                    </Badge>
+                    <Badge size="xs" variant="light">
+                        10 rows
+                    </Badge>
+                    {queryDirty && (
+                        <Badge size="xs" color="yellow" variant="light">
+                            Draft has {extraFieldSelected ? 4 : 3}
+                        </Badge>
+                    )}
+                </Group>
+            </Paper>
+
+            <Box className={classes.conversationScroll}>
+                <Stack gap="sm">
+                    <Paper radius="md" p="sm" className={classes.agentMessage}>
+                        <Text size="sm">
+                            {editingChart
+                                ? 'Tell me what you want to change about Event tier pulse.'
+                                : 'Describe the reusable chart type you want to build from these results.'}
+                        </Text>
+                    </Paper>
+
+                    <Paper radius="md" p="sm" className={classes.userMessage}>
+                        <Text size="sm">{prompt}</Text>
+                    </Paper>
+
+                    {buildStage !== 'brief' && (
+                        <Paper
+                            radius="md"
+                            p="sm"
+                            className={classes.agentMessage}
+                        >
+                            <Stack gap="xs">
+                                <Text size="sm">
+                                    Should increases and decreases use different
+                                    colors, and should the total appear at the
+                                    end?
+                                </Text>
+                                <Group grow>
+                                    <Button size="xs" variant="default">
+                                        Different colors
+                                    </Button>
+                                    <Button size="xs" variant="default">
+                                        Show final total
+                                    </Button>
+                                </Group>
+                            </Stack>
+                        </Paper>
+                    )}
+
+                    {(buildStage === 'building' || buildStage === 'ready') && (
+                        <Paper
+                            radius="md"
+                            p="sm"
+                            className={classes.agentMessage}
+                        >
+                            <Stack gap={6}>
+                                {[
+                                    'Read the executed query fields',
+                                    'Mapped category, change, and breakdown',
+                                    'Generated responsive waterfall layout',
+                                ].map((item) => (
+                                    <Group key={item} gap="xs" wrap="nowrap">
+                                        <MantineIcon
+                                            icon={IconCircleCheck}
+                                            color="green"
+                                            size={14}
+                                        />
+                                        <Text size="xs">{item}</Text>
+                                    </Group>
+                                ))}
+                            </Stack>
+                        </Paper>
+                    )}
+
+                    {buildStage === 'ready' && (
+                        <Paper
+                            withBorder
+                            radius="md"
+                            p="sm"
+                            className={classes.readyMessage}
+                        >
+                            <Group gap="xs" wrap="nowrap">
+                                <MantineIcon
+                                    icon={IconCircleCheck}
+                                    color="green"
+                                />
+                                <Stack gap={1}>
+                                    <Text size="sm" fw={650}>
+                                        Event change waterfall is ready
+                                    </Text>
+                                    <Text size="xs" c="dimmed">
+                                        Use it to return to this exact Explorer
+                                        query with the new chart selected.
+                                    </Text>
+                                </Stack>
+                            </Group>
+                        </Paper>
+                    )}
+                </Stack>
+            </Box>
+
+            {buildStage === 'brief' && (
+                <Textarea
+                    label="Your brief"
+                    minRows={4}
+                    value={prompt}
+                    onChange={(event) =>
+                        onPromptChange(event.currentTarget.value)
+                    }
+                />
+            )}
+
+            <Button
+                fullWidth
+                rightSection={<MantineIcon icon={IconArrowRight} size={14} />}
+                onClick={onAdvance}
+                variant={buildStage === 'ready' ? 'default' : 'filled'}
+            >
+                {actionLabel[buildStage]}
+            </Button>
+        </Stack>
+    );
+};
+
+const BuilderHeader = ({
+    buildStage,
+    editingChart,
+    onCancel,
+    onApply,
+}: Pick<
+    EmbeddedBuilderProps,
+    'buildStage' | 'editingChart' | 'onCancel' | 'onApply'
+>) => (
+    <Group className={classes.builderHeader} justify="space-between">
+        <Group gap="sm">
+            <Button
+                variant="subtle"
+                color="gray"
+                size="xs"
+                leftSection={<MantineIcon icon={IconArrowLeft} size={14} />}
+                onClick={onCancel}
+            >
+                Back to Explorer
+            </Button>
+            <Divider orientation="vertical" />
+            <Stack gap={0}>
+                <Text size="sm" fw={650}>
+                    {editingChart ? 'Edit chart type' : 'New chart type'}
+                </Text>
+                <Text size="xs" c="dimmed">
+                    Explorer remains active
+                </Text>
+            </Stack>
+        </Group>
+        <Group gap="xs">
+            {(Object.keys(BUILD_STAGE_LABELS) as BuildStage[]).map((stage) => (
+                <Badge
+                    key={stage}
+                    size="sm"
+                    variant={stage === buildStage ? 'filled' : 'light'}
+                    color={stage === buildStage ? 'violet' : 'gray'}
+                >
+                    {BUILD_STAGE_LABELS[stage]}
+                </Badge>
+            ))}
+            <Button
+                size="xs"
+                color="green"
+                disabled={buildStage !== 'ready'}
+                leftSection={<MantineIcon icon={IconCircleCheck} size={14} />}
+                onClick={onApply}
+            >
+                Use this chart
+            </Button>
+        </Group>
+    </Group>
+);
+
+const EmbeddedBuilderWorkspace = (props: EmbeddedBuilderProps) => {
+    const conversation = <BuilderConversation {...props} />;
+    const preview = <BuilderPreview {...props} />;
+
+    return (
+        <Box className={classes.embeddedBuilder}>
+            <BuilderHeader {...props} />
+            {props.variant === 'A' && (
+                <Box className={classes.builderSplitA}>
+                    {preview}
+                    {conversation}
+                </Box>
+            )}
+            {props.variant === 'B' && (
+                <Stack className={classes.builderCanvasB} gap="md">
+                    {preview}
+                    <Paper
+                        withBorder
+                        radius="lg"
+                        className={classes.builderDockB}
+                    >
+                        {conversation}
+                    </Paper>
+                </Stack>
+            )}
+            {props.variant === 'C' && (
+                <Box className={classes.builderSplitC}>
+                    {conversation}
+                    {preview}
+                </Box>
+            )}
+            <Code block className={classes.authoringState}>
+                {JSON.stringify(
+                    {
+                        mode: 'authoring',
+                        variant: props.variant,
+                        buildStage: props.buildStage,
+                        query: {
+                            executedRevision: props.dataRevision,
+                            draftChanged: props.queryDirty,
+                            selectedFields: props.extraFieldSelected ? 4 : 3,
+                            executedFields: props.executedExtraFieldSelected
+                                ? 4
+                                : 3,
+                        },
+                        previousChart: 'event-tier-pulse',
+                        draftChart: 'generated-waterfall',
+                    },
+                    null,
+                    2,
+                )}
+            </Code>
+        </Box>
+    );
+};
 
 const ResultsTable = () => (
     <ScrollArea>
@@ -1563,10 +2083,16 @@ const ExplorerMain = ({
     selectedChart,
     palette,
     showLabels,
+    queryDirty,
+    dataRevision,
+    onRunQuery,
 }: {
     selectedChart: ChartTypeOption;
     palette: Palette;
     showLabels: boolean;
+    queryDirty: boolean;
+    dataRevision: number;
+    onRunQuery: () => void;
 }) => (
     <Box className={classes.main}>
         <Stack gap="md">
@@ -1584,8 +2110,11 @@ const ExplorerMain = ({
                         size="xs"
                         leftSection={<MantineIcon icon={IconPlayerPlay} />}
                         rightSection={<MantineIcon icon={IconChevronDown} />}
+                        onClick={onRunQuery}
                     >
-                        Run query (500)
+                        {queryDirty
+                            ? 'Run updated query'
+                            : `Run query · ${dataRevision}`}
                     </Button>
                     <Button
                         variant="default"
@@ -1616,9 +2145,11 @@ const ExplorerMain = ({
                         <Text size="sm" fw={600}>
                             Chart
                         </Text>
-                        <Badge size="xs" variant="outline" color="yellow">
-                            Results may be incorrect
-                        </Badge>
+                        {queryDirty && (
+                            <Badge size="xs" variant="outline" color="yellow">
+                                Results are stale
+                            </Badge>
+                        )}
                         {selectedChart.source !== 'standard' && (
                             <Badge
                                 size="xs"
@@ -1685,9 +2216,9 @@ const ExplorerMain = ({
 );
 
 const VARIANT_LABELS: Record<PrototypeVariant, string> = {
-    A: 'Gallery + inline config',
-    B: 'Choose, then configure',
-    C: 'Type rail + live inspector',
+    A: 'Preview + conversation split',
+    B: 'Canvas + conversation dock',
+    C: 'Conversation + studio split',
 };
 
 const PrototypeSwitcher = ({
@@ -1768,6 +2299,19 @@ const ExplorerChartGalleryPrototype = ({
     const [selectedId, setSelectedId] = useState('event-tier-pulse');
     const [palette, setPalette] = useState<Palette>('navy');
     const [showLabels, setShowLabels] = useState(true);
+    const [mode, setMode] = useState<ExplorerMode>('explore');
+    const [buildStage, setBuildStage] = useState<BuildStage>('brief');
+    const [prompt, setPrompt] = useState(
+        'Build a waterfall chart that shows how event volume changes by tier, broken down by event.',
+    );
+    const [queryDirty, setQueryDirty] = useState(false);
+    const [dataRevision, setDataRevision] = useState(1);
+    const [extraFieldSelected, setExtraFieldSelected] = useState(false);
+    const [executedExtraFieldSelected, setExecutedExtraFieldSelected] =
+        useState(false);
+    const [previousSelectedId, setPreviousSelectedId] =
+        useState('event-tier-pulse');
+    const [editingChart, setEditingChart] = useState(false);
 
     useEffect(() => setFlagEnabled(featureFlagEnabled), [featureFlagEnabled]);
 
@@ -1781,6 +2325,47 @@ const ExplorerChartGalleryPrototype = ({
         writeVariant(nextVariant);
     };
 
+    const beginAuthoring = (editing: boolean) => {
+        setPreviousSelectedId(selectedId);
+        setEditingChart(editing);
+        setBuildStage('brief');
+        setMode('authoring');
+    };
+
+    const cancelAuthoring = () => {
+        setSelectedId(previousSelectedId);
+        setMode('explore');
+    };
+
+    const applyDraftChart = () => {
+        setSelectedId('generated-waterfall');
+        setMode('explore');
+    };
+
+    const advanceBuild = () => {
+        const nextStage: Record<BuildStage, BuildStage> = {
+            brief: 'clarify',
+            clarify: 'building',
+            building: 'ready',
+            ready: 'brief',
+        };
+        setBuildStage(nextStage[buildStage]);
+    };
+
+    const toggleExtraField = () => {
+        setExtraFieldSelected((selected) => {
+            const nextSelected = !selected;
+            setQueryDirty(nextSelected !== executedExtraFieldSelected);
+            return nextSelected;
+        });
+    };
+
+    const runQuery = () => {
+        setDataRevision((revision) => revision + 1);
+        setExecutedExtraFieldSelected(extraFieldSelected);
+        setQueryDirty(false);
+    };
+
     return (
         <Box className={classes.prototype}>
             <Group className={classes.featureBar} justify="space-between">
@@ -1790,10 +2375,14 @@ const ExplorerChartGalleryPrototype = ({
                     </Badge>
                     <Stack gap={0}>
                         <Text size="sm" fw={600}>
-                            Explorer chart selection
+                            {mode === 'authoring'
+                                ? 'Explorer · embedded chart authoring'
+                                : 'Explorer chart selection'}
                         </Text>
                         <Text fz={10} c="dimmed">
-                            Project chart types use the current query results
+                            {mode === 'authoring'
+                                ? 'Fields remain available · preview uses the latest executed results'
+                                : 'Project chart types use the current query results'}
                         </Text>
                     </Stack>
                 </Group>
@@ -1815,15 +2404,24 @@ const ExplorerChartGalleryPrototype = ({
 
             <Box
                 className={`${classes.workspace} ${
-                    flagEnabled ? classes.workspaceWithRightSidebar : ''
+                    flagEnabled && mode === 'explore'
+                        ? classes.workspaceWithRightSidebar
+                        : ''
                 } ${
-                    flagEnabled && variant === 'C'
+                    flagEnabled && mode === 'explore' && variant === 'C'
                         ? classes.workspaceWithWideRightSidebar
                         : ''
                 }`}
             >
                 {flagEnabled ? (
-                    <FieldsSidebar />
+                    <FieldsSidebar
+                        extraFieldSelected={extraFieldSelected}
+                        queryDirty={queryDirty}
+                        dataRevision={dataRevision}
+                        authoring={mode === 'authoring'}
+                        onToggleExtraField={toggleExtraField}
+                        onRunQuery={runQuery}
+                    />
                 ) : (
                     <LegacyConfigSidebar
                         selectedId={selectedId}
@@ -1834,21 +2432,46 @@ const ExplorerChartGalleryPrototype = ({
                         setShowLabels={setShowLabels}
                     />
                 )}
-                <ExplorerMain
-                    selectedChart={selectedChart}
-                    palette={palette}
-                    showLabels={showLabels}
-                />
-                {flagEnabled && (
-                    <RightSidebar
+                {mode === 'authoring' ? (
+                    <EmbeddedBuilderWorkspace
                         variant={variant}
-                        selectedChart={selectedChart}
-                        setSelectedId={setSelectedId}
-                        palette={palette}
-                        setPalette={setPalette}
-                        showLabels={showLabels}
-                        setShowLabels={setShowLabels}
+                        buildStage={buildStage}
+                        prompt={prompt}
+                        queryDirty={queryDirty}
+                        dataRevision={dataRevision}
+                        extraFieldSelected={extraFieldSelected}
+                        executedExtraFieldSelected={executedExtraFieldSelected}
+                        editingChart={editingChart}
+                        onPromptChange={setPrompt}
+                        onAdvance={advanceBuild}
+                        onCancel={cancelAuthoring}
+                        onApply={applyDraftChart}
+                        onRunQuery={runQuery}
                     />
+                ) : (
+                    <>
+                        <ExplorerMain
+                            selectedChart={selectedChart}
+                            palette={palette}
+                            showLabels={showLabels}
+                            queryDirty={queryDirty}
+                            dataRevision={dataRevision}
+                            onRunQuery={runQuery}
+                        />
+                        {flagEnabled && (
+                            <RightSidebar
+                                variant={variant}
+                                selectedChart={selectedChart}
+                                setSelectedId={setSelectedId}
+                                palette={palette}
+                                setPalette={setPalette}
+                                showLabels={showLabels}
+                                setShowLabels={setShowLabels}
+                                onCreateChartType={() => beginAuthoring(false)}
+                                onEditProjectChart={() => beginAuthoring(true)}
+                            />
+                        )}
+                    </>
                 )}
             </Box>
 
@@ -1867,7 +2490,7 @@ const meta: Meta<typeof ExplorerChartGalleryPrototype> = {
         docs: {
             description: {
                 component:
-                    'Throwaway interaction prototype for moving chart selection and configuration to a gallery-style right sidebar while keeping Explorer fields on the left.',
+                    'Throwaway interaction prototype for selecting, creating, and editing chart types without leaving Explorer. Fields stay available on the left while three embedded authoring layouts exercise clarification, query refresh, build, apply, and cancel.',
             },
         },
     },

--- a/packages/frontend/src/stories/ExplorerChartGalleryPrototype.stories.tsx
+++ b/packages/frontend/src/stories/ExplorerChartGalleryPrototype.stories.tsx
@@ -10,7 +10,6 @@ import {
     ScrollArea,
     SegmentedControl,
     Select,
-    SimpleGrid,
     Stack,
     Switch,
     Table,
@@ -33,7 +32,6 @@ import {
     IconChartPie,
     IconChartTreemap,
     IconChevronDown,
-    IconChevronLeft,
     IconChevronRight,
     IconCode,
     IconCircleCheck,
@@ -59,9 +57,9 @@ import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import MantineIcon from '../components/common/MantineIcon';
 import classes from './ExplorerChartGalleryPrototype.module.css';
 
-// PROTOTYPE — three complete Explorer -> embedded chart builder -> Explorer
-// interactions, switchable through `?prototypeVariant=A|B|C`. Throw this story
-// away after the authoring layout and state model are chosen.
+// PROTOTYPE — complete Explorer -> embedded chart builder -> Explorer
+// interaction. Throw this story away after the authoring layout and state model
+// are chosen.
 
 type QueryRow = {
     tier: 'Very high' | 'High' | 'Low';
@@ -69,7 +67,6 @@ type QueryRow = {
     count: number;
 };
 
-type PrototypeVariant = 'A' | 'B' | 'C';
 type ExplorerMode = 'explore' | 'authoring';
 type BuildStage = 'brief' | 'clarify' | 'building' | 'ready';
 type ChartPreviewKind =
@@ -296,20 +293,6 @@ const PALETTES = {
 } as const;
 
 type Palette = keyof typeof PALETTES;
-
-const readVariant = (): PrototypeVariant => {
-    if (typeof window === 'undefined') return 'A';
-    const value = new URLSearchParams(window.location.search).get(
-        'prototypeVariant',
-    );
-    return value === 'B' || value === 'C' ? value : 'A';
-};
-
-const writeVariant = (variant: PrototypeVariant) => {
-    const url = new URL(window.location.href);
-    url.searchParams.set('prototypeVariant', variant);
-    window.history.replaceState({}, '', url);
-};
 
 const ChartPreview = ({
     kind,
@@ -1145,55 +1128,11 @@ const LegacyConfigSidebar = ({
     </Box>
 );
 
-const ChartTypeCard = ({
-    chart,
-    selected,
-    palette,
-    onSelect,
-}: {
-    chart: ChartTypeOption;
-    selected: boolean;
-    palette: Palette;
-    onSelect: () => void;
-}) => (
-    <UnstyledButton
-        className={`${classes.chartTypeCard} ${
-            selected ? classes.chartTypeCardSelected : ''
-        }`}
-        onClick={onSelect}
-    >
-        <ChartPreview kind={chart.kind} palette={palette} compact />
-        <Stack gap={2} p="xs">
-            <Group gap={5} wrap="nowrap">
-                <MantineIcon icon={chart.icon} size={13} />
-                <Text size="xs" fw={600} truncate>
-                    {chart.label}
-                </Text>
-                {chart.source !== 'standard' && (
-                    <Badge
-                        ml="auto"
-                        size="xs"
-                        variant="light"
-                        color={chart.source === 'project' ? 'violet' : 'gray'}
-                    >
-                        {chart.source === 'project' ? 'Project' : 'Vega'}
-                    </Badge>
-                )}
-            </Group>
-            <Text fz={10} c="dimmed" truncate>
-                {chart.description}
-            </Text>
-        </Stack>
-    </UnstyledButton>
-);
-
 const PrototypeState = ({
-    variant,
     selectedChart,
     palette,
     showLabels,
 }: {
-    variant: PrototypeVariant;
     selectedChart: ChartTypeOption;
     palette: Palette;
     showLabels: boolean;
@@ -1206,7 +1145,6 @@ const PrototypeState = ({
             {JSON.stringify(
                 {
                     featureFlag: 'new-explorer-chart-sidebar',
-                    variant,
                     selectedChart: selectedChart.id,
                     source: selectedChart.source,
                     resultRows: QUERY_ROWS.length,
@@ -1222,7 +1160,6 @@ const PrototypeState = ({
 );
 
 type RightSidebarProps = {
-    variant: PrototypeVariant;
     selectedChart: ChartTypeOption;
     setSelectedId: (id: string) => void;
     palette: Palette;
@@ -1233,105 +1170,7 @@ type RightSidebarProps = {
     onEditProjectChart: () => void;
 };
 
-const RightSidebarVariantA = ({
-    variant,
-    selectedChart,
-    setSelectedId,
-    palette,
-    setPalette,
-    showLabels,
-    setShowLabels,
-    onCreateChartType,
-    onEditProjectChart,
-}: RightSidebarProps) => {
-    const [search, setSearch] = useState('');
-    const [group, setGroup] = useState<'All' | ChartGroup>('All');
-    const visibleCharts = CHART_TYPES.filter(
-        (chart) =>
-            (group === 'All' || chart.group === group) &&
-            chart.label.toLowerCase().includes(search.toLowerCase()),
-    );
-
-    return (
-        <ScrollArea className={classes.sidebarScroll}>
-            <Stack p="md" gap="md">
-                <TextInput
-                    size="xs"
-                    value={search}
-                    onChange={(event) => setSearch(event.currentTarget.value)}
-                    placeholder="Search chart types"
-                    leftSection={<MantineIcon icon={IconSearch} />}
-                />
-                <SegmentedControl
-                    fullWidth
-                    size="xs"
-                    value={group}
-                    onChange={(value) => setGroup(value as 'All' | ChartGroup)}
-                    data={['All', 'Built in', 'Project']}
-                />
-                {(['Project', 'Built in'] as ChartGroup[]).map((chartGroup) => {
-                    const charts = visibleCharts.filter(
-                        ({ group: itemGroup }) => itemGroup === chartGroup,
-                    );
-                    if (charts.length === 0) return null;
-                    return (
-                        <Stack key={chartGroup} gap="xs">
-                            <Group justify="space-between">
-                                <Text size="xs" fw={600} c="dimmed">
-                                    {chartGroup.toUpperCase()}
-                                </Text>
-                                <Text size="xs" c="dimmed">
-                                    {charts.length}
-                                </Text>
-                            </Group>
-                            <SimpleGrid cols={2} spacing="xs">
-                                {charts.map((chart) => (
-                                    <ChartTypeCard
-                                        key={chart.id}
-                                        chart={chart}
-                                        selected={chart.id === selectedChart.id}
-                                        palette={palette}
-                                        onSelect={() => setSelectedId(chart.id)}
-                                    />
-                                ))}
-                            </SimpleGrid>
-                        </Stack>
-                    );
-                })}
-                <Button
-                    variant="subtle"
-                    size="xs"
-                    leftSection={<MantineIcon icon={IconPlus} />}
-                    onClick={onCreateChartType}
-                >
-                    Create new chart type
-                </Button>
-                <Divider
-                    label="Configure selected chart"
-                    labelPosition="left"
-                />
-                <ConfigControls
-                    selectedChart={selectedChart}
-                    palette={palette}
-                    setPalette={setPalette}
-                    showLabels={showLabels}
-                    setShowLabels={setShowLabels}
-                    onEditProjectChart={onEditProjectChart}
-                />
-                <Divider />
-                <PrototypeState
-                    variant={variant}
-                    selectedChart={selectedChart}
-                    palette={palette}
-                    showLabels={showLabels}
-                />
-            </Stack>
-        </ScrollArea>
-    );
-};
-
-const RightSidebarVariantB = ({
-    variant,
+const ChartGallerySidebar = ({
     selectedChart,
     setSelectedId,
     palette,
@@ -1475,7 +1314,6 @@ const RightSidebarVariantB = ({
                         />
                         <Divider />
                         <PrototypeState
-                            variant={variant}
                             selectedChart={selectedChart}
                             palette={palette}
                             showLabels={showLabels}
@@ -1486,126 +1324,6 @@ const RightSidebarVariantB = ({
         </ScrollArea>
     );
 };
-
-const RightSidebarVariantC = ({
-    variant,
-    selectedChart,
-    setSelectedId,
-    palette,
-    setPalette,
-    showLabels,
-    setShowLabels,
-    onCreateChartType,
-    onEditProjectChart,
-}: RightSidebarProps) => (
-    <Box className={classes.railLayout}>
-        <Stack className={classes.typeRail} gap={4}>
-            <Text size="xs" fw={600} c="dimmed" p="xs">
-                PROJECT
-            </Text>
-            {CHART_TYPES.filter(({ group }) => group === 'Project').map(
-                (chart) => (
-                    <UnstyledButton
-                        key={chart.id}
-                        className={`${classes.railItem} ${
-                            chart.id === selectedChart.id
-                                ? classes.railItemSelected
-                                : ''
-                        }`}
-                        onClick={() => setSelectedId(chart.id)}
-                    >
-                        <Group gap="xs" wrap="nowrap">
-                            <MantineIcon icon={chart.icon} />
-                            <Text size="xs" fw={500} lineClamp={2}>
-                                {chart.label}
-                            </Text>
-                        </Group>
-                    </UnstyledButton>
-                ),
-            )}
-            <Divider my="xs" />
-            <Text size="xs" fw={600} c="dimmed" p="xs">
-                BUILT IN
-            </Text>
-            {CHART_TYPES.filter(({ group }) => group === 'Built in').map(
-                (chart) => (
-                    <UnstyledButton
-                        key={chart.id}
-                        className={`${classes.railItem} ${
-                            chart.id === selectedChart.id
-                                ? classes.railItemSelected
-                                : ''
-                        }`}
-                        onClick={() => setSelectedId(chart.id)}
-                    >
-                        <Group gap="xs" wrap="nowrap">
-                            <MantineIcon icon={chart.icon} />
-                            <Text size="xs" fw={500}>
-                                {chart.label}
-                            </Text>
-                        </Group>
-                    </UnstyledButton>
-                ),
-            )}
-            <Button
-                mt="auto"
-                size="compact-xs"
-                variant="subtle"
-                leftSection={<MantineIcon icon={IconPlus} />}
-                onClick={onCreateChartType}
-            >
-                New
-            </Button>
-        </Stack>
-
-        <ScrollArea className={classes.sidebarScroll}>
-            <Stack p="md" gap="md">
-                <Stack gap={4}>
-                    <Group justify="space-between" wrap="nowrap">
-                        <Text fw={600}>{selectedChart.label}</Text>
-                        <Badge
-                            size="xs"
-                            variant="light"
-                            color={
-                                selectedChart.group === 'Project'
-                                    ? 'violet'
-                                    : 'gray'
-                            }
-                        >
-                            {selectedChart.group}
-                        </Badge>
-                    </Group>
-                    <Text size="xs" c="dimmed">
-                        Live preview with 10 query rows
-                    </Text>
-                </Stack>
-                <Box className={classes.inspectorPreview}>
-                    <ChartPreview
-                        kind={selectedChart.kind}
-                        palette={palette}
-                        showLabels={showLabels}
-                    />
-                </Box>
-                <Divider label="Field mapping" labelPosition="left" />
-                <ConfigControls
-                    selectedChart={selectedChart}
-                    palette={palette}
-                    setPalette={setPalette}
-                    showLabels={showLabels}
-                    setShowLabels={setShowLabels}
-                    onEditProjectChart={onEditProjectChart}
-                />
-                <Divider />
-                <PrototypeState
-                    variant={variant}
-                    selectedChart={selectedChart}
-                    palette={palette}
-                    showLabels={showLabels}
-                />
-            </Stack>
-        </ScrollArea>
-    </Box>
-);
 
 const RightSidebar = (props: RightSidebarProps) => (
     <Box className={`${classes.sidebar} ${classes.rightSidebar}`}>
@@ -1622,14 +1340,11 @@ const RightSidebar = (props: RightSidebarProps) => (
                 <MantineIcon icon={IconX} />
             </ActionIcon>
         </Group>
-        {props.variant === 'A' && <RightSidebarVariantA {...props} />}
-        {props.variant === 'B' && <RightSidebarVariantB {...props} />}
-        {props.variant === 'C' && <RightSidebarVariantC {...props} />}
+        <ChartGallerySidebar {...props} />
     </Box>
 );
 
 type EmbeddedBuilderProps = {
-    variant: PrototypeVariant;
     buildStage: BuildStage;
     prompt: string;
     queryDirty: boolean;
@@ -1770,10 +1485,7 @@ const BuilderConversation = ({
     editingChart,
     onPromptChange,
     onAdvance,
-}: Omit<
-    EmbeddedBuilderProps,
-    'variant' | 'onCancel' | 'onApply' | 'onRunQuery'
->) => {
+}: Omit<EmbeddedBuilderProps, 'onCancel' | 'onApply' | 'onRunQuery'>) => {
     const actionLabel: Record<BuildStage, string> = {
         brief: 'Continue',
         clarify: 'Build chart type',
@@ -1989,35 +1701,16 @@ const EmbeddedBuilderWorkspace = (props: EmbeddedBuilderProps) => {
     return (
         <Box className={classes.embeddedBuilder}>
             <BuilderHeader {...props} />
-            {props.variant === 'A' && (
-                <Box className={classes.builderSplitA}>
-                    {preview}
+            <Stack className={classes.builderCanvasB} gap="md">
+                {preview}
+                <Paper withBorder radius="lg" className={classes.builderDockB}>
                     {conversation}
-                </Box>
-            )}
-            {props.variant === 'B' && (
-                <Stack className={classes.builderCanvasB} gap="md">
-                    {preview}
-                    <Paper
-                        withBorder
-                        radius="lg"
-                        className={classes.builderDockB}
-                    >
-                        {conversation}
-                    </Paper>
-                </Stack>
-            )}
-            {props.variant === 'C' && (
-                <Box className={classes.builderSplitC}>
-                    {conversation}
-                    {preview}
-                </Box>
-            )}
+                </Paper>
+            </Stack>
             <Code block className={classes.authoringState}>
                 {JSON.stringify(
                     {
                         mode: 'authoring',
-                        variant: props.variant,
                         buildStage: props.buildStage,
                         query: {
                             executedRevision: props.dataRevision,
@@ -2215,87 +1908,12 @@ const ExplorerMain = ({
     </Box>
 );
 
-const VARIANT_LABELS: Record<PrototypeVariant, string> = {
-    A: 'Preview + conversation split',
-    B: 'Canvas + conversation dock',
-    C: 'Conversation + studio split',
-};
-
-const PrototypeSwitcher = ({
-    variant,
-    onChange,
-}: {
-    variant: PrototypeVariant;
-    onChange: (variant: PrototypeVariant) => void;
-}) => {
-    const variants: PrototypeVariant[] = ['A', 'B', 'C'];
-    const move = (offset: number) => {
-        const currentIndex = variants.indexOf(variant);
-        onChange(
-            variants[
-                (currentIndex + offset + variants.length) % variants.length
-            ],
-        );
-    };
-
-    useEffect(() => {
-        const onKeyDown = (event: KeyboardEvent) => {
-            const target = event.target as HTMLElement | null;
-            if (
-                target?.matches(
-                    'input, textarea, select, [contenteditable="true"]',
-                )
-            ) {
-                return;
-            }
-            if (event.key === 'ArrowLeft') move(-1);
-            if (event.key === 'ArrowRight') move(1);
-        };
-        window.addEventListener('keydown', onKeyDown);
-        return () => window.removeEventListener('keydown', onKeyDown);
-    });
-
-    if (import.meta.env.PROD) return null;
-
-    return (
-        <Paper className={classes.prototypeSwitcher} radius="xl" px={6} py={5}>
-            <Group gap={4} wrap="nowrap">
-                <ActionIcon
-                    className={classes.switcherButton}
-                    variant="subtle"
-                    aria-label="Previous prototype variant"
-                    onClick={() => move(-1)}
-                >
-                    <MantineIcon icon={IconChevronLeft} />
-                </ActionIcon>
-                <Stack gap={0} miw={190} align="center">
-                    <Text size="xs" fw={700} c="white">
-                        {variant} — {VARIANT_LABELS[variant]}
-                    </Text>
-                    <Text fz={9} c="gray.5">
-                        Use ← → to compare
-                    </Text>
-                </Stack>
-                <ActionIcon
-                    className={classes.switcherButton}
-                    variant="subtle"
-                    aria-label="Next prototype variant"
-                    onClick={() => move(1)}
-                >
-                    <MantineIcon icon={IconChevronRight} />
-                </ActionIcon>
-            </Group>
-        </Paper>
-    );
-};
-
 const ExplorerChartGalleryPrototype = ({
     featureFlagEnabled,
 }: {
     featureFlagEnabled: boolean;
 }) => {
     const [flagEnabled, setFlagEnabled] = useState(featureFlagEnabled);
-    const [variant, setVariant] = useState<PrototypeVariant>(readVariant);
     const [selectedId, setSelectedId] = useState('event-tier-pulse');
     const [palette, setPalette] = useState<Palette>('navy');
     const [showLabels, setShowLabels] = useState(true);
@@ -2319,11 +1937,6 @@ const ExplorerChartGalleryPrototype = ({
         () => CHART_TYPES.find(({ id }) => id === selectedId) ?? CHART_TYPES[0],
         [selectedId],
     );
-
-    const changeVariant = (nextVariant: PrototypeVariant) => {
-        setVariant(nextVariant);
-        writeVariant(nextVariant);
-    };
 
     const beginAuthoring = (editing: boolean) => {
         setPreviousSelectedId(selectedId);
@@ -2407,10 +2020,6 @@ const ExplorerChartGalleryPrototype = ({
                     flagEnabled && mode === 'explore'
                         ? classes.workspaceWithRightSidebar
                         : ''
-                } ${
-                    flagEnabled && mode === 'explore' && variant === 'C'
-                        ? classes.workspaceWithWideRightSidebar
-                        : ''
                 }`}
             >
                 {flagEnabled ? (
@@ -2434,7 +2043,6 @@ const ExplorerChartGalleryPrototype = ({
                 )}
                 {mode === 'authoring' ? (
                     <EmbeddedBuilderWorkspace
-                        variant={variant}
                         buildStage={buildStage}
                         prompt={prompt}
                         queryDirty={queryDirty}
@@ -2460,7 +2068,6 @@ const ExplorerChartGalleryPrototype = ({
                         />
                         {flagEnabled && (
                             <RightSidebar
-                                variant={variant}
                                 selectedChart={selectedChart}
                                 setSelectedId={setSelectedId}
                                 palette={palette}
@@ -2474,10 +2081,6 @@ const ExplorerChartGalleryPrototype = ({
                     </>
                 )}
             </Box>
-
-            {flagEnabled && (
-                <PrototypeSwitcher variant={variant} onChange={changeVariant} />
-            )}
         </Box>
     );
 };
@@ -2490,7 +2093,7 @@ const meta: Meta<typeof ExplorerChartGalleryPrototype> = {
         docs: {
             description: {
                 component:
-                    'Throwaway interaction prototype for selecting, creating, and editing chart types without leaving Explorer. Fields stay available on the left while three embedded authoring layouts exercise clarification, query refresh, build, apply, and cancel.',
+                    'Throwaway interaction prototype for selecting, creating, and editing chart types without leaving Explorer. Fields stay available on the left while the embedded authoring flow exercises clarification, query refresh, build, apply, and cancel.',
             },
         },
     },

--- a/packages/frontend/src/stories/ExplorerChartGalleryPrototype.stories.tsx
+++ b/packages/frontend/src/stories/ExplorerChartGalleryPrototype.stories.tsx
@@ -23,7 +23,7 @@ import {
     IconAdjustmentsHorizontal,
     IconAlertCircle,
     IconArrowLeft,
-    IconArrowRight,
+    IconArrowUp,
     IconChartArea,
     IconChartBar,
     IconChartDonut,
@@ -40,8 +40,10 @@ import {
     IconFilter,
     IconGauge,
     IconGitMerge,
+    IconHistory,
     IconMap,
-    IconMessageCircle,
+    IconPaperclip,
+    IconPencil,
     IconPlayerPlay,
     IconPlus,
     IconRefresh,
@@ -1359,48 +1361,92 @@ type EmbeddedBuilderProps = {
     onRunQuery: () => void;
 };
 
-const BUILD_STAGE_LABELS: Record<BuildStage, string> = {
-    brief: 'Describe',
-    clarify: 'Clarify',
-    building: 'Build',
-    ready: 'Ready',
-};
+const BUILDER_EXAMPLES: Pick<ChartTypeOption, 'kind' | 'label'>[] = [
+    { kind: 'area', label: 'A stream graph of share over time' },
+    { kind: 'funnel', label: 'A funnel of signup steps' },
+    { kind: 'treemap', label: 'A calendar heatmap of daily orders' },
+    { kind: 'bar', label: 'A waterfall of revenue changes' },
+];
 
-const BuilderPreview = ({
+const BuilderStartCanvas = ({
     buildStage,
+    onPickExample,
+}: {
+    buildStage: BuildStage;
+    onPickExample: (prompt: string) => void;
+}) => (
+    <Stack
+        className={classes.builderStart}
+        gap="xl"
+        align="center"
+        data-quiet={buildStage === 'clarify' || undefined}
+    >
+        {buildStage === 'building' ? (
+            <>
+                <Group className={classes.builderSkeleton} gap="xs" align="end">
+                    {[34, 54, 43, 68, 47, 61].map((height, index) => (
+                        <Box
+                            key={height}
+                            className={classes.builderSkeletonBar}
+                            h={height}
+                            style={{ animationDelay: `${index * 0.12}s` }}
+                        />
+                    ))}
+                </Group>
+                <Stack gap={4} align="center">
+                    <Text size="md" fw={600}>
+                        Building your chart type…
+                    </Text>
+                    <Text fz="xs" c="dimmed">
+                        Using the latest executed Explorer results
+                    </Text>
+                </Stack>
+            </>
+        ) : (
+            <>
+                <Stack gap="xs" align="center">
+                    <Text size="md" fw={600}>
+                        Start with a prompt
+                    </Text>
+                    <Text fz="xs" c="dimmed" ta="center">
+                        Describe the chart type you need. Iterate from there.
+                    </Text>
+                </Stack>
+                <Group gap="sm" align="stretch" justify="center">
+                    {BUILDER_EXAMPLES.map((example) => (
+                        <UnstyledButton
+                            key={example.label}
+                            className={classes.builderExample}
+                            onClick={() => onPickExample(example.label)}
+                        >
+                            <Box className={classes.builderExamplePreview}>
+                                <ChartPreview
+                                    kind={example.kind}
+                                    palette="blue"
+                                    compact
+                                    showLabels={false}
+                                />
+                            </Box>
+                            <Text fz={13} fw={500} lh={1.35}>
+                                {example.label}
+                            </Text>
+                        </UnstyledButton>
+                    ))}
+                </Group>
+            </>
+        )}
+    </Stack>
+);
+
+const BuilderResultCanvas = ({
     queryDirty,
     dataRevision,
     onRunQuery,
 }: Pick<
     EmbeddedBuilderProps,
-    'buildStage' | 'queryDirty' | 'dataRevision' | 'onRunQuery'
+    'queryDirty' | 'dataRevision' | 'onRunQuery'
 >) => (
-    <Stack className={classes.builderPreviewPanel} gap="md">
-        <Group justify="space-between">
-            <Stack gap={1}>
-                <Text fw={650}>Event change waterfall</Text>
-                <Text size="xs" c="dimmed">
-                    Previewing executed query · Run {dataRevision} · 10 rows
-                </Text>
-            </Stack>
-            <Badge
-                variant="light"
-                color={buildStage === 'ready' ? 'green' : 'violet'}
-                leftSection={
-                    <MantineIcon
-                        icon={
-                            buildStage === 'ready'
-                                ? IconCircleCheck
-                                : IconSparkles
-                        }
-                        size={12}
-                    />
-                }
-            >
-                {buildStage === 'ready' ? 'Ready to use' : 'Draft preview'}
-            </Badge>
-        </Group>
-
+    <Stack className={classes.builderResult} gap="sm">
         {queryDirty && (
             <Paper
                 withBorder
@@ -1411,232 +1457,199 @@ const BuilderPreview = ({
                 <Group justify="space-between" wrap="nowrap">
                     <Group gap="xs" wrap="nowrap">
                         <MantineIcon icon={IconAlertCircle} color="yellow" />
-                        <Stack gap={1}>
-                            <Text size="sm" fw={600}>
-                                Query fields changed
-                            </Text>
-                            <Text size="xs" c="dimmed">
-                                This preview still uses Run {dataRevision}.
-                            </Text>
-                        </Stack>
+                        <Text size="xs">
+                            The Explorer query changed. This preview still uses
+                            Run {dataRevision}.
+                        </Text>
                     </Group>
-                    <Button size="xs" onClick={onRunQuery}>
+                    <Button size="compact-xs" onClick={onRunQuery}>
                         Run updated query
                     </Button>
                 </Group>
             </Paper>
         )}
-
-        <Paper withBorder radius="lg" className={classes.builderChartCanvas}>
-            <ChartPreview kind="bar" palette="grape" showLabels />
-            {buildStage === 'building' && (
-                <Box className={classes.buildingOverlay}>
-                    <Stack align="center" gap="xs">
-                        <MantineIcon
-                            icon={IconSparkles}
-                            size={34}
-                            color="violet"
-                        />
-                        <Text fw={650}>Building your chart type…</Text>
-                        <Text size="xs" c="dimmed">
-                            Generating components and checking field mappings
-                        </Text>
-                    </Stack>
+        <Box className={classes.builderResultCard}>
+            <Stack className={classes.builderOptionsPanel} gap="sm">
+                <Text className={classes.generatedChip}>Generated options</Text>
+                <Group gap="xs" className={classes.builderOptionTabs}>
+                    <Text size="xs" fw={600} c="blue">
+                        Style
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                        Labels
+                    </Text>
+                </Group>
+                <Select
+                    size="xs"
+                    label="Layout"
+                    value="Waterfall"
+                    data={['Waterfall', 'Stacked', 'Grouped']}
+                    readOnly
+                />
+                <Select
+                    size="xs"
+                    label="Direction"
+                    value="Vertical"
+                    data={['Vertical', 'Horizontal']}
+                    readOnly
+                />
+                <Switch size="xs" label="Show final total" defaultChecked />
+                <Switch size="xs" label="Show value labels" defaultChecked />
+                <Stack gap={5}>
+                    <Text size="xs" fw={500}>
+                        Color palette
+                    </Text>
+                    <Group gap={5}>
+                        {['#228be6', '#12b886', '#fa5252', '#fab005'].map(
+                            (color) => (
+                                <Box
+                                    key={color}
+                                    className={classes.paletteSwatch}
+                                    bg={color}
+                                />
+                            ),
+                        )}
+                    </Group>
+                </Stack>
+            </Stack>
+            <Box className={classes.builderResultPreview}>
+                <Stack gap={2} className={classes.builderResultTitle}>
+                    <Text fw={600}>Event change waterfall</Text>
+                    <Text size="xs" c="dimmed">
+                        Run {dataRevision} · 10 rows
+                    </Text>
+                </Stack>
+                <Box className={classes.builderResultChart}>
+                    <ChartPreview kind="bar" palette="blue" showLabels />
                 </Box>
-            )}
-        </Paper>
-
-        <Group grow>
-            <Paper withBorder radius="md" p="sm">
-                <Text size="xs" c="dimmed">
-                    CATEGORY
-                </Text>
-                <Text size="sm" fw={600}>
-                    Event tier
-                </Text>
-            </Paper>
-            <Paper withBorder radius="md" p="sm">
-                <Text size="xs" c="dimmed">
-                    CHANGE
-                </Text>
-                <Text size="sm" fw={600}>
-                    Count
-                </Text>
-            </Paper>
-            <Paper withBorder radius="md" p="sm">
-                <Text size="xs" c="dimmed">
-                    BREAKDOWN
-                </Text>
-                <Text size="sm" fw={600}>
-                    Event
-                </Text>
-            </Paper>
-        </Group>
+            </Box>
+        </Box>
     </Stack>
 );
 
-const BuilderConversation = ({
+const BuilderPromptBar = ({
     buildStage,
     prompt,
-    queryDirty,
-    dataRevision,
-    extraFieldSelected,
-    executedExtraFieldSelected,
-    editingChart,
     onPromptChange,
     onAdvance,
-}: Omit<EmbeddedBuilderProps, 'onCancel' | 'onApply' | 'onRunQuery'>) => {
-    const actionLabel: Record<BuildStage, string> = {
-        brief: 'Continue',
-        clarify: 'Build chart type',
-        building: 'Finish simulated build',
-        ready: 'Add another instruction',
-    };
+}: Pick<
+    EmbeddedBuilderProps,
+    'buildStage' | 'prompt' | 'onPromptChange' | 'onAdvance'
+>) => {
+    const isLocked = buildStage === 'clarify' || buildStage === 'building';
+    const placeholder =
+        buildStage === 'clarify'
+            ? 'Answer the questions, or skip, to build…'
+            : buildStage === 'building'
+              ? 'Building your chart type…'
+              : buildStage === 'ready'
+                ? 'Ask for a change…'
+                : 'Describe a new chart type…';
 
     return (
-        <Stack className={classes.builderConversation} gap="md">
-            <Group gap="xs">
-                <MantineIcon icon={IconMessageCircle} color="violet" />
-                <Stack gap={0}>
-                    <Text fw={650}>Chart type builder</Text>
-                    <Text size="xs" c="dimmed">
-                        Using the latest executed Explorer results
-                    </Text>
-                </Stack>
-            </Group>
-
-            <Paper withBorder radius="md" p="sm">
-                <Text size="xs" c="dimmed" mb={4}>
-                    EXPLORER CONTEXT
-                </Text>
-                <Group gap="xs">
-                    <Badge size="xs" variant="light">
-                        Run {dataRevision}
-                    </Badge>
-                    <Badge size="xs" variant="light">
-                        {executedExtraFieldSelected ? 4 : 3} executed fields
-                    </Badge>
-                    <Badge size="xs" variant="light">
-                        10 rows
-                    </Badge>
-                    {queryDirty && (
-                        <Badge size="xs" color="yellow" variant="light">
-                            Draft has {extraFieldSelected ? 4 : 3}
-                        </Badge>
-                    )}
-                </Group>
-            </Paper>
-
-            <Box className={classes.conversationScroll}>
-                <Stack gap="sm">
-                    <Paper radius="md" p="sm" className={classes.agentMessage}>
-                        <Text size="sm">
-                            {editingChart
-                                ? 'Tell me what you want to change about Event tier pulse.'
-                                : 'Describe the reusable chart type you want to build from these results.'}
+        <Box className={classes.builderPromptWrap}>
+            {buildStage === 'clarify' && (
+                <Paper
+                    withBorder
+                    radius="lg"
+                    className={classes.clarificationSheet}
+                >
+                    <Group gap="xs" wrap="nowrap">
+                        <MantineIcon icon={IconSparkles} size={14} />
+                        <Text size="xs" fw={500} truncate flex={1}>
+                            {prompt}
                         </Text>
-                    </Paper>
-
-                    <Paper radius="md" p="sm" className={classes.userMessage}>
-                        <Text size="sm">{prompt}</Text>
-                    </Paper>
-
-                    {buildStage !== 'brief' && (
-                        <Paper
-                            radius="md"
-                            p="sm"
-                            className={classes.agentMessage}
+                        <ActionIcon variant="subtle" size="xs">
+                            <MantineIcon icon={IconPencil} size={13} />
+                        </ActionIcon>
+                    </Group>
+                    <TextInput
+                        size="xs"
+                        label="How should increases and decreases be colored?"
+                        placeholder="Use green for increases and red for decreases"
+                    />
+                    <TextInput
+                        size="xs"
+                        label="Should the final total be shown?"
+                        placeholder="Yes, include a total bar at the end"
+                    />
+                    <Group justify="space-between">
+                        <Button variant="subtle" color="gray" size="xs">
+                            Skip and build anyway
+                        </Button>
+                        <Button size="xs" onClick={onAdvance}>
+                            Build
+                        </Button>
+                    </Group>
+                </Paper>
+            )}
+            {buildStage === 'building' && (
+                <Paper
+                    withBorder
+                    radius="lg"
+                    className={classes.builderStatusRow}
+                >
+                    <Group justify="space-between" wrap="nowrap">
+                        <Group gap="xs" wrap="nowrap">
+                            <Box className={classes.builderStatusDot} />
+                            <Text size="xs" fw={600}>
+                                Building… 0:12
+                            </Text>
+                            <Text size="xs" c="dimmed" truncate>
+                                “{prompt}”
+                            </Text>
+                        </Group>
+                        <Button
+                            variant="subtle"
+                            color="gray"
+                            size="compact-xs"
+                            onClick={onAdvance}
                         >
-                            <Stack gap="xs">
-                                <Text size="sm">
-                                    Should increases and decreases use different
-                                    colors, and should the total appear at the
-                                    end?
-                                </Text>
-                                <Group grow>
-                                    <Button size="xs" variant="default">
-                                        Different colors
-                                    </Button>
-                                    <Button size="xs" variant="default">
-                                        Show final total
-                                    </Button>
-                                </Group>
-                            </Stack>
-                        </Paper>
-                    )}
-
-                    {(buildStage === 'building' || buildStage === 'ready') && (
-                        <Paper
-                            radius="md"
-                            p="sm"
-                            className={classes.agentMessage}
-                        >
-                            <Stack gap={6}>
-                                {[
-                                    'Read the executed query fields',
-                                    'Mapped category, change, and breakdown',
-                                    'Generated responsive waterfall layout',
-                                ].map((item) => (
-                                    <Group key={item} gap="xs" wrap="nowrap">
-                                        <MantineIcon
-                                            icon={IconCircleCheck}
-                                            color="green"
-                                            size={14}
-                                        />
-                                        <Text size="xs">{item}</Text>
-                                    </Group>
-                                ))}
-                            </Stack>
-                        </Paper>
-                    )}
-
-                    {buildStage === 'ready' && (
-                        <Paper
-                            withBorder
-                            radius="md"
-                            p="sm"
-                            className={classes.readyMessage}
-                        >
-                            <Group gap="xs" wrap="nowrap">
-                                <MantineIcon
-                                    icon={IconCircleCheck}
-                                    color="green"
-                                />
-                                <Stack gap={1}>
-                                    <Text size="sm" fw={650}>
-                                        Event change waterfall is ready
-                                    </Text>
-                                    <Text size="xs" c="dimmed">
-                                        Use it to return to this exact Explorer
-                                        query with the new chart selected.
-                                    </Text>
-                                </Stack>
-                            </Group>
-                        </Paper>
-                    )}
-                </Stack>
-            </Box>
-
-            {buildStage === 'brief' && (
+                            Finish simulated build
+                        </Button>
+                    </Group>
+                </Paper>
+            )}
+            <Paper withBorder radius="lg" className={classes.builderPromptPill}>
                 <Textarea
-                    label="Your brief"
-                    minRows={4}
-                    value={prompt}
+                    variant="unstyled"
+                    autosize
+                    minRows={1}
+                    maxRows={4}
+                    value={isLocked ? '' : prompt}
+                    placeholder={placeholder}
+                    disabled={isLocked}
                     onChange={(event) =>
                         onPromptChange(event.currentTarget.value)
                     }
                 />
-            )}
-
-            <Button
-                fullWidth
-                rightSection={<MantineIcon icon={IconArrowRight} size={14} />}
-                onClick={onAdvance}
-                variant={buildStage === 'ready' ? 'default' : 'filled'}
-            >
-                {actionLabel[buildStage]}
-            </Button>
-        </Stack>
+                <Group justify="space-between" wrap="nowrap">
+                    <Button variant="subtle" color="gray" size="compact-xs">
+                        Auto
+                    </Button>
+                    <Group gap={4} wrap="nowrap">
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            size="sm"
+                            aria-label="Attach"
+                        >
+                            <MantineIcon icon={IconPaperclip} />
+                        </ActionIcon>
+                        <ActionIcon
+                            color="blue"
+                            radius="xl"
+                            size="sm"
+                            aria-label="Send"
+                            disabled={isLocked || prompt.trim().length === 0}
+                            onClick={onAdvance}
+                        >
+                            <MantineIcon icon={IconArrowUp} />
+                        </ActionIcon>
+                    </Group>
+                </Group>
+            </Paper>
+        </Box>
     );
 };
 
@@ -1652,61 +1665,67 @@ const BuilderHeader = ({
     <Group className={classes.builderHeader} justify="space-between">
         <Group gap="sm">
             <Button
-                variant="subtle"
-                color="gray"
+                variant="default"
                 size="xs"
                 leftSection={<MantineIcon icon={IconArrowLeft} size={14} />}
                 onClick={onCancel}
             >
-                Back to Explorer
+                Explorer
             </Button>
             <Divider orientation="vertical" />
-            <Stack gap={0}>
-                <Text size="sm" fw={650}>
-                    {editingChart ? 'Edit chart type' : 'New chart type'}
-                </Text>
+            <Text size="sm" fw={650}>
+                {editingChart
+                    ? 'Event tier pulse'
+                    : buildStage === 'ready'
+                      ? 'Event change waterfall'
+                      : 'Untitled chart type'}
+            </Text>
+            {buildStage === 'ready' && (
                 <Text size="xs" c="dimmed">
-                    Explorer remains active
+                    Created by you · just now
                 </Text>
-            </Stack>
+            )}
         </Group>
         <Group gap="xs">
-            {(Object.keys(BUILD_STAGE_LABELS) as BuildStage[]).map((stage) => (
-                <Badge
-                    key={stage}
-                    size="sm"
-                    variant={stage === buildStage ? 'filled' : 'light'}
-                    color={stage === buildStage ? 'violet' : 'gray'}
+            {(editingChart || buildStage === 'ready') && (
+                <Button
+                    size="xs"
+                    variant="default"
+                    leftSection={<MantineIcon icon={IconHistory} size={14} />}
                 >
-                    {BUILD_STAGE_LABELS[stage]}
-                </Badge>
-            ))}
-            <Button
-                size="xs"
-                color="green"
-                disabled={buildStage !== 'ready'}
-                leftSection={<MantineIcon icon={IconCircleCheck} size={14} />}
-                onClick={onApply}
-            >
-                Use this chart
-            </Button>
+                    History
+                </Button>
+            )}
+            {buildStage === 'ready' && (
+                <Button
+                    size="xs"
+                    leftSection={
+                        <MantineIcon icon={IconCircleCheck} size={14} />
+                    }
+                    onClick={onApply}
+                >
+                    Preview in Explorer
+                </Button>
+            )}
         </Group>
     </Group>
 );
 
 const EmbeddedBuilderWorkspace = (props: EmbeddedBuilderProps) => {
-    const conversation = <BuilderConversation {...props} />;
-    const preview = <BuilderPreview {...props} />;
-
     return (
         <Box className={classes.embeddedBuilder}>
             <BuilderHeader {...props} />
-            <Stack className={classes.builderCanvasB} gap="md">
-                {preview}
-                <Paper withBorder radius="lg" className={classes.builderDockB}>
-                    {conversation}
-                </Paper>
-            </Stack>
+            <Box className={classes.builderBody}>
+                {props.buildStage === 'ready' ? (
+                    <BuilderResultCanvas {...props} />
+                ) : (
+                    <BuilderStartCanvas
+                        buildStage={props.buildStage}
+                        onPickExample={props.onPromptChange}
+                    />
+                )}
+                <BuilderPromptBar {...props} />
+            </Box>
             <Code block className={classes.authoringState}>
                 {JSON.stringify(
                     {
@@ -1941,7 +1960,7 @@ const ExplorerChartGalleryPrototype = ({
     const beginAuthoring = (editing: boolean) => {
         setPreviousSelectedId(selectedId);
         setEditingChart(editing);
-        setBuildStage('brief');
+        setBuildStage(editing ? 'ready' : 'brief');
         setMode('authoring');
     };
 
@@ -1960,8 +1979,9 @@ const ExplorerChartGalleryPrototype = ({
             brief: 'clarify',
             clarify: 'building',
             building: 'ready',
-            ready: 'brief',
+            ready: 'building',
         };
+        if (buildStage === 'building') setPrompt('');
         setBuildStage(nextStage[buildStage]);
     };
 

--- a/packages/frontend/src/stories/ExplorerChartGalleryPrototype.stories.tsx
+++ b/packages/frontend/src/stories/ExplorerChartGalleryPrototype.stories.tsx
@@ -1,0 +1,1888 @@
+import {
+    ActionIcon,
+    Badge,
+    Box,
+    Button,
+    Code,
+    Divider,
+    Group,
+    Paper,
+    ScrollArea,
+    SegmentedControl,
+    Select,
+    SimpleGrid,
+    Stack,
+    Switch,
+    Table,
+    Text,
+    TextInput,
+    Textarea,
+    UnstyledButton,
+} from '@mantine/core';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+    IconAdjustmentsHorizontal,
+    IconArrowLeft,
+    IconChartArea,
+    IconChartBar,
+    IconChartDonut,
+    IconChartDots,
+    IconChartLine,
+    IconChartPie,
+    IconChartTreemap,
+    IconChevronDown,
+    IconChevronLeft,
+    IconChevronRight,
+    IconCode,
+    IconDeviceFloppy,
+    IconFilter,
+    IconGauge,
+    IconGitMerge,
+    IconMap,
+    IconPlayerPlay,
+    IconPlus,
+    IconRefresh,
+    IconSearch,
+    IconSettings,
+    IconSquareNumber1,
+    IconTable,
+    IconX,
+    type Icon as TablerIcon,
+} from '@tabler/icons-react';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import MantineIcon from '../components/common/MantineIcon';
+import classes from './ExplorerChartGalleryPrototype.module.css';
+
+// PROTOTYPE — three Explorer chart-gallery interactions, switchable through
+// `?prototypeVariant=A|B|C`. Throw this story away after a direction is chosen.
+
+type QueryRow = {
+    tier: 'Very high' | 'High' | 'Low';
+    event: string;
+    count: number;
+};
+
+type PrototypeVariant = 'A' | 'B' | 'C';
+type ChartPreviewKind =
+    | 'bar'
+    | 'horizontal'
+    | 'line'
+    | 'area'
+    | 'scatter'
+    | 'donut'
+    | 'funnel'
+    | 'treemap'
+    | 'gauge'
+    | 'sankey'
+    | 'map'
+    | 'table'
+    | 'scorecard'
+    | 'vega';
+type ChartGroup = 'Built in' | 'Project';
+type ChartSource = 'standard' | 'vega' | 'project';
+
+type ChartTypeOption = {
+    id: string;
+    label: string;
+    description: string;
+    group: ChartGroup;
+    source: ChartSource;
+    kind: ChartPreviewKind;
+    icon: TablerIcon;
+};
+
+const QUERY_ROWS: QueryRow[] = [
+    { tier: 'Very high', event: 'playlist_deleted', count: 354 },
+    { tier: 'Very high', event: 'playlist_created', count: 329 },
+    { tier: 'Very high', event: 'song_played', count: 322 },
+    { tier: 'High', event: 'playlist_created', count: 315 },
+    { tier: 'High', event: 'song_played', count: 300 },
+    { tier: 'High', event: 'playlist_deleted', count: 285 },
+    { tier: 'Low', event: 'playlist_created', count: 35 },
+    { tier: 'Low', event: 'playlist_deleted', count: 35 },
+    { tier: 'Low', event: 'song_played', count: 30 },
+    { tier: 'Very high', event: '∅', count: 0 },
+];
+
+const TIER_ORDER: QueryRow['tier'][] = ['Very high', 'High', 'Low'];
+const TOTAL = QUERY_ROWS.reduce((sum, row) => sum + row.count, 0);
+const TIER_TOTALS = TIER_ORDER.map((tier) => ({
+    tier,
+    value: QUERY_ROWS.filter((row) => row.tier === tier).reduce(
+        (sum, row) => sum + row.count,
+        0,
+    ),
+}));
+
+const CHART_TYPES: ChartTypeOption[] = [
+    {
+        id: 'bar',
+        label: 'Bar chart',
+        description: 'Compare categories',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'bar',
+        icon: IconChartBar,
+    },
+    {
+        id: 'horizontal-bar',
+        label: 'Horizontal bar chart',
+        description: 'Compare ranked categories',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'horizontal',
+        icon: IconChartBar,
+    },
+    {
+        id: 'line',
+        label: 'Line chart',
+        description: 'Show a trend',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'line',
+        icon: IconChartLine,
+    },
+    {
+        id: 'area',
+        label: 'Area chart',
+        description: 'Compare magnitude over time',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'area',
+        icon: IconChartArea,
+    },
+    {
+        id: 'scatter',
+        label: 'Scatter chart',
+        description: 'Find relationships and outliers',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'scatter',
+        icon: IconChartDots,
+    },
+    {
+        id: 'pie',
+        label: 'Pie chart',
+        description: 'Show part-to-whole',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'donut',
+        icon: IconChartPie,
+    },
+    {
+        id: 'funnel',
+        label: 'Funnel chart',
+        description: 'Show stage conversion',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'funnel',
+        icon: IconFilter,
+    },
+    {
+        id: 'treemap',
+        label: 'Treemap',
+        description: 'Show hierarchical proportions',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'treemap',
+        icon: IconChartTreemap,
+    },
+    {
+        id: 'gauge',
+        label: 'Gauge',
+        description: 'Track progress toward a target',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'gauge',
+        icon: IconGauge,
+    },
+    {
+        id: 'sankey',
+        label: 'Sankey',
+        description: 'Show flow between categories',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'sankey',
+        icon: IconGitMerge,
+    },
+    {
+        id: 'map',
+        label: 'Map',
+        description: 'Plot geographic values',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'map',
+        icon: IconMap,
+    },
+    {
+        id: 'table',
+        label: 'Table',
+        description: 'Show every result row',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'table',
+        icon: IconTable,
+    },
+    {
+        id: 'big-value',
+        label: 'Big value',
+        description: 'Highlight a single metric',
+        group: 'Built in',
+        source: 'standard',
+        kind: 'scorecard',
+        icon: IconSquareNumber1,
+    },
+    {
+        id: 'vega',
+        label: 'Vega (JSON editor)',
+        description: 'Write Vega-Lite JSON by hand',
+        group: 'Built in',
+        source: 'vega',
+        kind: 'vega',
+        icon: IconCode,
+    },
+    {
+        id: 'event-tier-pulse',
+        label: 'Event tier pulse',
+        description: 'Reusable ranked bars · 2 fields',
+        group: 'Project',
+        source: 'project',
+        kind: 'horizontal',
+        icon: IconChartBar,
+    },
+    {
+        id: 'event-mix',
+        label: 'Event mix',
+        description: 'Branded distribution ring · 2 fields',
+        group: 'Project',
+        source: 'project',
+        kind: 'donut',
+        icon: IconChartDonut,
+    },
+    {
+        id: 'volume-scorecard',
+        label: 'Volume scorecard',
+        description: 'KPI tile with target · 1 field',
+        group: 'Project',
+        source: 'project',
+        kind: 'scorecard',
+        icon: IconAdjustmentsHorizontal,
+    },
+];
+
+const PALETTES = {
+    navy: '#213b60',
+    blue: '#228be6',
+    grape: '#7950f2',
+    teal: '#0ca678',
+} as const;
+
+type Palette = keyof typeof PALETTES;
+
+const readVariant = (): PrototypeVariant => {
+    if (typeof window === 'undefined') return 'A';
+    const value = new URLSearchParams(window.location.search).get(
+        'prototypeVariant',
+    );
+    return value === 'B' || value === 'C' ? value : 'A';
+};
+
+const writeVariant = (variant: PrototypeVariant) => {
+    const url = new URL(window.location.href);
+    url.searchParams.set('prototypeVariant', variant);
+    window.history.replaceState({}, '', url);
+};
+
+const ChartPreview = ({
+    kind,
+    palette,
+    compact = false,
+    showLabels = true,
+}: {
+    kind: ChartPreviewKind;
+    palette: Palette;
+    compact?: boolean;
+    showLabels?: boolean;
+}) => {
+    const color = PALETTES[palette];
+    const maxValue = Math.max(...TIER_TOTALS.map(({ value }) => value));
+    const style = { '--chart-color': color } as CSSProperties;
+
+    return (
+        <Box
+            className={`${classes.chartPreview} ${
+                compact ? classes.miniPreview : ''
+            }`}
+            style={style}
+        >
+            {kind === 'bar' && (
+                <Box className={classes.barChart}>
+                    {TIER_TOTALS.map(({ tier, value }) => (
+                        <Box
+                            key={tier}
+                            className={classes.barColumn}
+                            style={{
+                                height: `${Math.max(8, (value / maxValue) * 88)}%`,
+                                background: color,
+                            }}
+                        >
+                            {showLabels && (
+                                <>
+                                    <span className={classes.barValue}>
+                                        {value.toLocaleString()}
+                                    </span>
+                                    <span className={classes.barLabel}>
+                                        {tier}
+                                    </span>
+                                </>
+                            )}
+                        </Box>
+                    ))}
+                </Box>
+            )}
+
+            {kind === 'line' && (
+                <svg
+                    className={classes.lineChart}
+                    viewBox="0 0 400 190"
+                    preserveAspectRatio="none"
+                    role="img"
+                    aria-label="Line chart preview"
+                >
+                    {[40, 85, 130, 175].map((y) => (
+                        <line
+                            key={y}
+                            x1="20"
+                            x2="385"
+                            y1={y}
+                            y2={y}
+                            stroke="currentColor"
+                            strokeOpacity="0.12"
+                        />
+                    ))}
+                    <polyline
+                        points="35,44 200,57 365,166"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="7"
+                        strokeLinejoin="round"
+                        strokeLinecap="round"
+                    />
+                    {[
+                        ['35', '44'],
+                        ['200', '57'],
+                        ['365', '166'],
+                    ].map(([x, y]) => (
+                        <circle
+                            key={x}
+                            cx={x}
+                            cy={y}
+                            r="7"
+                            fill="currentColor"
+                        />
+                    ))}
+                </svg>
+            )}
+
+            {kind === 'area' && (
+                <svg
+                    className={classes.lineChart}
+                    viewBox="0 0 400 190"
+                    preserveAspectRatio="none"
+                    role="img"
+                    aria-label="Area chart preview"
+                >
+                    <defs>
+                        <linearGradient
+                            id="area-fill"
+                            x1="0"
+                            y1="0"
+                            x2="0"
+                            y2="1"
+                        >
+                            <stop
+                                offset="0"
+                                stopColor="currentColor"
+                                stopOpacity="0.72"
+                            />
+                            <stop
+                                offset="1"
+                                stopColor="currentColor"
+                                stopOpacity="0.12"
+                            />
+                        </linearGradient>
+                    </defs>
+                    <path
+                        d="M20 176 L20 72 L125 42 L235 88 L380 28 L380 176 Z"
+                        fill="url(#area-fill)"
+                    />
+                    <polyline
+                        points="20,72 125,42 235,88 380,28"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="5"
+                        strokeLinejoin="round"
+                    />
+                </svg>
+            )}
+
+            {kind === 'scatter' && (
+                <svg
+                    className={classes.lineChart}
+                    viewBox="0 0 400 190"
+                    preserveAspectRatio="none"
+                    role="img"
+                    aria-label="Scatter chart preview"
+                >
+                    {[
+                        [52, 135, 8],
+                        [88, 112, 10],
+                        [126, 128, 6],
+                        [166, 82, 9],
+                        [208, 94, 7],
+                        [254, 56, 11],
+                        [302, 72, 7],
+                        [346, 34, 9],
+                    ].map(([cx, cy, r]) => (
+                        <circle
+                            key={`${cx}-${cy}`}
+                            cx={cx}
+                            cy={cy}
+                            r={r}
+                            fill="currentColor"
+                            opacity="0.78"
+                        />
+                    ))}
+                </svg>
+            )}
+
+            {kind === 'donut' && (
+                <Box className={classes.donutLayout}>
+                    <Box className={classes.donut} />
+                    {!compact && (
+                        <Stack gap={5}>
+                            {TIER_TOTALS.map(({ tier, value }, index) => (
+                                <Group key={tier} gap="xs">
+                                    <Box
+                                        w={9}
+                                        h={9}
+                                        style={{
+                                            borderRadius: 2,
+                                            background: color,
+                                            opacity: 1 - index * 0.25,
+                                        }}
+                                    />
+                                    <Text size="xs">
+                                        {tier} · {value.toLocaleString()}
+                                    </Text>
+                                </Group>
+                            ))}
+                        </Stack>
+                    )}
+                </Box>
+            )}
+
+            {kind === 'scorecard' && (
+                <Box className={classes.scorecard}>
+                    <Text fw={700} fz={compact ? 24 : 48} style={{ color }}>
+                        {TOTAL.toLocaleString()}
+                    </Text>
+                    <Text size={compact ? 'xs' : 'sm'} c="dimmed">
+                        Total events
+                    </Text>
+                </Box>
+            )}
+
+            {kind === 'horizontal' && (
+                <Box className={classes.horizontalBars}>
+                    {TIER_TOTALS.map(({ tier, value }) => (
+                        <Group key={tier} gap="xs" wrap="nowrap">
+                            {!compact && (
+                                <Text size="xs" w={58} ta="right">
+                                    {tier}
+                                </Text>
+                            )}
+                            <Box className={classes.horizontalTrack} flex={1}>
+                                <Box
+                                    className={classes.horizontalFill}
+                                    style={{
+                                        width: `${Math.max(5, (value / maxValue) * 100)}%`,
+                                        background: color,
+                                    }}
+                                />
+                            </Box>
+                        </Group>
+                    ))}
+                </Box>
+            )}
+
+            {kind === 'funnel' && (
+                <Stack
+                    className={classes.funnel}
+                    align="center"
+                    justify="center"
+                    gap={compact ? 4 : 9}
+                >
+                    {[100, 76, 48].map((width, index) => (
+                        <Box
+                            key={width}
+                            h={compact ? 12 : 42}
+                            style={{
+                                width: `${width}%`,
+                                background: color,
+                                opacity: 1 - index * 0.22,
+                                clipPath:
+                                    'polygon(4% 0, 96% 0, 86% 100%, 14% 100%)',
+                            }}
+                        />
+                    ))}
+                </Stack>
+            )}
+
+            {kind === 'treemap' && (
+                <Box className={classes.treemap}>
+                    <Box style={{ background: color, gridArea: 'a' }} />
+                    <Box
+                        style={{
+                            background: color,
+                            opacity: 0.76,
+                            gridArea: 'b',
+                        }}
+                    />
+                    <Box
+                        style={{
+                            background: color,
+                            opacity: 0.52,
+                            gridArea: 'c',
+                        }}
+                    />
+                    <Box
+                        style={{
+                            background: color,
+                            opacity: 0.34,
+                            gridArea: 'd',
+                        }}
+                    />
+                </Box>
+            )}
+
+            {kind === 'gauge' && (
+                <Box className={classes.gaugeWrap}>
+                    <Box
+                        className={classes.gauge}
+                        style={{ borderColor: color }}
+                    />
+                    <Box
+                        className={classes.gaugeNeedle}
+                        style={{ background: color }}
+                    />
+                    {!compact && (
+                        <Text fw={700} fz={28}>
+                            78%
+                        </Text>
+                    )}
+                </Box>
+            )}
+
+            {kind === 'sankey' && (
+                <svg
+                    className={classes.sankey}
+                    viewBox="0 0 400 190"
+                    preserveAspectRatio="none"
+                    role="img"
+                    aria-label="Sankey chart preview"
+                >
+                    <path
+                        d="M50 48 C165 48 210 48 350 74"
+                        stroke="currentColor"
+                        strokeWidth="30"
+                        opacity="0.46"
+                        fill="none"
+                    />
+                    <path
+                        d="M50 132 C160 132 230 118 350 116"
+                        stroke="currentColor"
+                        strokeWidth="22"
+                        opacity="0.26"
+                        fill="none"
+                    />
+                    <rect
+                        x="38"
+                        y="28"
+                        width="18"
+                        height="124"
+                        rx="3"
+                        fill="currentColor"
+                    />
+                    <rect
+                        x="346"
+                        y="44"
+                        width="18"
+                        height="94"
+                        rx="3"
+                        fill="currentColor"
+                    />
+                </svg>
+            )}
+
+            {kind === 'map' && (
+                <Box className={classes.mapPreview}>
+                    {[
+                        ['18%', '28%', 11],
+                        ['45%', '36%', 8],
+                        ['68%', '24%', 13],
+                        ['61%', '67%', 9],
+                        ['31%', '72%', 6],
+                    ].map(([left, top, size]) => (
+                        <Box
+                            key={`${left}-${top}`}
+                            className={classes.mapDot}
+                            style={{
+                                left,
+                                top,
+                                width: size,
+                                height: size,
+                                background: color,
+                            }}
+                        />
+                    ))}
+                </Box>
+            )}
+
+            {kind === 'table' && (
+                <Stack className={classes.tablePreview} gap={compact ? 4 : 8}>
+                    {[100, 94, 82, 88, 70].map((width, index) => (
+                        <Group
+                            key={`${width}-${index}`}
+                            gap={compact ? 4 : 8}
+                            wrap="nowrap"
+                        >
+                            <Box
+                                w="32%"
+                                h={compact ? 5 : 12}
+                                bg={index === 0 ? color : 'gray.2'}
+                            />
+                            <Box
+                                w={`${width / 2}%`}
+                                h={compact ? 5 : 12}
+                                bg={index === 0 ? color : 'gray.2'}
+                            />
+                            <Box
+                                flex={1}
+                                h={compact ? 5 : 12}
+                                bg={index === 0 ? color : 'gray.2'}
+                            />
+                        </Group>
+                    ))}
+                </Stack>
+            )}
+
+            {kind === 'vega' && (
+                <Box className={classes.vegaPreview}>
+                    <MantineIcon
+                        icon={IconCode}
+                        size={compact ? 22 : 42}
+                        color="violet"
+                    />
+                    {!compact && (
+                        <Stack gap={4}>
+                            <Code>{'"mark": "bar"'}</Code>
+                            <Code>{'"x": "event_tier"'}</Code>
+                            <Code>{'"y": "count"'}</Code>
+                        </Stack>
+                    )}
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+const FieldsSidebar = () => (
+    <Box className={`${classes.sidebar} ${classes.leftSidebar}`}>
+        <Group className={classes.sidebarHeader} justify="space-between">
+            <Text fw={600}>Events</Text>
+            <ActionIcon variant="subtle" color="gray" aria-label="Close fields">
+                <MantineIcon icon={IconX} />
+            </ActionIcon>
+        </Group>
+        <ScrollArea className={classes.sidebarScroll}>
+            <Stack p="md" gap="lg">
+                <TextInput
+                    size="xs"
+                    placeholder="Search fields"
+                    leftSection={<MantineIcon icon={IconSearch} />}
+                />
+                <Stack gap="xs">
+                    <Group justify="space-between">
+                        <Text size="xs" fw={600} c="dimmed">
+                            SELECTED FIELDS
+                        </Text>
+                        <Badge variant="light" size="xs">
+                            3
+                        </Badge>
+                    </Group>
+                    {[
+                        ['Abc', 'Event tier', 'blue'],
+                        ['Abc', 'Event', 'blue'],
+                        ['123', 'Count', 'orange'],
+                    ].map(([type, label, color]) => (
+                        <Group
+                            key={label}
+                            className={classes.fieldItem}
+                            justify="space-between"
+                        >
+                            <Group gap="xs">
+                                <Text size="xs" fw={700} c={color}>
+                                    {type}
+                                </Text>
+                                <Text size="sm">{label}</Text>
+                            </Group>
+                            <Text c="dimmed" size="sm">
+                                ⋮⋮
+                            </Text>
+                        </Group>
+                    ))}
+                </Stack>
+                <Stack gap="xs">
+                    <Text size="xs" fw={600} c="dimmed">
+                        DIMENSIONS
+                    </Text>
+                    {['Event source', 'Event date', 'User id'].map((field) => (
+                        <Group key={field} justify="space-between" px="xs">
+                            <Text size="sm">{field}</Text>
+                            <Button size="compact-xs" variant="subtle">
+                                +
+                            </Button>
+                        </Group>
+                    ))}
+                </Stack>
+                <Stack gap="xs">
+                    <Text size="xs" fw={600} c="dimmed">
+                        METRICS
+                    </Text>
+                    {['Unique users', 'Average count', 'Count of events'].map(
+                        (field) => (
+                            <Group key={field} justify="space-between" px="xs">
+                                <Text size="sm">{field}</Text>
+                                <Button size="compact-xs" variant="subtle">
+                                    +
+                                </Button>
+                            </Group>
+                        ),
+                    )}
+                </Stack>
+            </Stack>
+        </ScrollArea>
+    </Box>
+);
+
+const ConfigControls = ({
+    selectedChart,
+    palette,
+    setPalette,
+    showLabels,
+    setShowLabels,
+}: {
+    selectedChart: ChartTypeOption;
+    palette: Palette;
+    setPalette: (palette: Palette) => void;
+    showLabels: boolean;
+    setShowLabels: (show: boolean) => void;
+}) => {
+    const mappingLabels =
+        selectedChart.id === 'volume-scorecard'
+            ? [['Metric', 'Count']]
+            : selectedChart.id === 'sankey'
+              ? [
+                    ['Source', 'Event tier'],
+                    ['Target', 'Event'],
+                    ['Weight', 'Count'],
+                ]
+              : selectedChart.id === 'map'
+                ? [
+                      ['Location', 'Event'],
+                      ['Value', 'Count'],
+                  ]
+                : selectedChart.id === 'table'
+                  ? [['Columns', 'Event tier, Event, Count']]
+                  : [
+                        ['Category', 'Event tier'],
+                        ['Value', 'Count'],
+                    ];
+
+    const paletteControl = (
+        <Stack gap={7}>
+            <Text size="xs" fw={500}>
+                Color palette
+            </Text>
+            <SegmentedControl
+                fullWidth
+                size="xs"
+                value={palette}
+                onChange={(value) => setPalette(value as Palette)}
+                data={Object.entries(PALETTES).map(([value, color]) => ({
+                    value,
+                    label: (
+                        <Box
+                            w={16}
+                            h={16}
+                            mx="auto"
+                            style={{ borderRadius: 4, background: color }}
+                        />
+                    ),
+                }))}
+            />
+        </Stack>
+    );
+
+    if (selectedChart.source === 'vega') {
+        return (
+            <Stack gap="md">
+                <Group justify="space-between">
+                    <Stack gap={1}>
+                        <Text size="sm" fw={600}>
+                            Vega-Lite JSON
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                            Built in · edits this chart only
+                        </Text>
+                    </Stack>
+                    <Button size="compact-xs" variant="default">
+                        Templates
+                    </Button>
+                </Group>
+                <Textarea
+                    classNames={{ input: classes.vegaEditor }}
+                    autosize
+                    minRows={12}
+                    defaultValue={`{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "mark": { "type": "bar", "cornerRadiusEnd": 4 },
+  "encoding": {
+    "x": { "field": "event_tier", "type": "nominal" },
+    "y": { "field": "count", "type": "quantitative" },
+    "color": { "value": "${PALETTES[palette]}" }
+  }
+}`}
+                />
+                {paletteControl}
+            </Stack>
+        );
+    }
+
+    return (
+        <Stack gap="md">
+            {selectedChart.source === 'project' && (
+                <Paper withBorder radius="md" p="sm">
+                    <Group
+                        justify="space-between"
+                        align="flex-start"
+                        wrap="nowrap"
+                    >
+                        <Stack gap={2}>
+                            <Group gap={6}>
+                                <Text size="sm" fw={600}>
+                                    {selectedChart.label}
+                                </Text>
+                                <Badge size="xs" variant="light" color="violet">
+                                    Project
+                                </Badge>
+                            </Group>
+                            <Text size="xs" c="dimmed">
+                                {selectedChart.description}
+                            </Text>
+                        </Stack>
+                        <Button size="compact-xs" variant="subtle">
+                            Edit ↗
+                        </Button>
+                    </Group>
+                </Paper>
+            )}
+
+            <Stack gap="xs">
+                <Text size="xs" fw={600} c="dimmed">
+                    FIELD MAPPING
+                </Text>
+                {mappingLabels.map(([label, value]) => (
+                    <Select
+                        key={label}
+                        label={label}
+                        size="xs"
+                        value={value}
+                        data={[
+                            'Event tier',
+                            'Event',
+                            'Count',
+                            'Event tier, Event, Count',
+                        ]}
+                    />
+                ))}
+            </Stack>
+
+            <Divider label="Display" labelPosition="left" />
+            {paletteControl}
+            <Group justify="space-between">
+                <Text size="sm">Show value labels</Text>
+                <Switch
+                    size="sm"
+                    checked={showLabels}
+                    onChange={(event) =>
+                        setShowLabels(event.currentTarget.checked)
+                    }
+                />
+            </Group>
+            {(selectedChart.id === 'bar' ||
+                selectedChart.id === 'horizontal-bar' ||
+                selectedChart.id === 'area') && (
+                <Group justify="space-between">
+                    <Text size="sm">Stack series</Text>
+                    <Switch size="sm" />
+                </Group>
+            )}
+            {selectedChart.source === 'project' && (
+                <Select
+                    label="Density"
+                    size="xs"
+                    value="Comfortable"
+                    data={['Compact', 'Comfortable', 'Spacious']}
+                />
+            )}
+        </Stack>
+    );
+};
+
+const LegacyConfigSidebar = ({
+    selectedId,
+    setSelectedId,
+    palette,
+    setPalette,
+    showLabels,
+    setShowLabels,
+}: {
+    selectedId: string;
+    setSelectedId: (id: string) => void;
+    palette: Palette;
+    setPalette: (palette: Palette) => void;
+    showLabels: boolean;
+    setShowLabels: (show: boolean) => void;
+}) => (
+    <Box className={`${classes.sidebar} ${classes.leftSidebar}`}>
+        <Group className={classes.sidebarHeader} justify="space-between">
+            <Text fw={600}>Configure chart</Text>
+            <ActionIcon
+                variant="subtle"
+                color="gray"
+                aria-label="Close configure"
+            >
+                <MantineIcon icon={IconX} />
+            </ActionIcon>
+        </Group>
+        <ScrollArea className={classes.sidebarScroll}>
+            <Stack p="md" gap="lg">
+                <Group align="end">
+                    <Select
+                        flex={1}
+                        label="Chart type"
+                        value={
+                            CHART_TYPES.find(({ id }) => id === selectedId)
+                                ?.source === 'standard'
+                                ? selectedId
+                                : 'custom'
+                        }
+                        onChange={(value) => {
+                            if (value === 'custom') {
+                                setSelectedId('event-tier-pulse');
+                            } else if (value) {
+                                setSelectedId(value);
+                            }
+                        }}
+                        data={[
+                            ...CHART_TYPES.filter(
+                                ({ source }) => source === 'standard',
+                            ).map(({ id, label }) => ({ value: id, label })),
+                            { value: 'custom', label: 'Custom' },
+                        ]}
+                    />
+                </Group>
+                {CHART_TYPES.find(({ id }) => id === selectedId)?.source !==
+                    'standard' && (
+                    <Select
+                        label="Custom chart type"
+                        placeholder="Search custom chart types…"
+                        value={selectedId}
+                        onChange={(value) => value && setSelectedId(value)}
+                        data={[
+                            {
+                                group: 'Built in',
+                                items: CHART_TYPES.filter(
+                                    ({ source }) => source === 'vega',
+                                ).map(({ id, label }) => ({
+                                    value: id,
+                                    label,
+                                })),
+                            },
+                            {
+                                group: 'Project',
+                                items: CHART_TYPES.filter(
+                                    ({ source }) => source === 'project',
+                                ).map(({ id, label }) => ({
+                                    value: id,
+                                    label,
+                                })),
+                            },
+                        ]}
+                    />
+                )}
+                <Divider />
+                <ConfigControls
+                    selectedChart={
+                        CHART_TYPES.find(({ id }) => id === selectedId) ??
+                        CHART_TYPES[0]
+                    }
+                    palette={palette}
+                    setPalette={setPalette}
+                    showLabels={showLabels}
+                    setShowLabels={setShowLabels}
+                />
+            </Stack>
+        </ScrollArea>
+    </Box>
+);
+
+const ChartTypeCard = ({
+    chart,
+    selected,
+    palette,
+    onSelect,
+}: {
+    chart: ChartTypeOption;
+    selected: boolean;
+    palette: Palette;
+    onSelect: () => void;
+}) => (
+    <UnstyledButton
+        className={`${classes.chartTypeCard} ${
+            selected ? classes.chartTypeCardSelected : ''
+        }`}
+        onClick={onSelect}
+    >
+        <ChartPreview kind={chart.kind} palette={palette} compact />
+        <Stack gap={2} p="xs">
+            <Group gap={5} wrap="nowrap">
+                <MantineIcon icon={chart.icon} size={13} />
+                <Text size="xs" fw={600} truncate>
+                    {chart.label}
+                </Text>
+                {chart.source !== 'standard' && (
+                    <Badge
+                        ml="auto"
+                        size="xs"
+                        variant="light"
+                        color={chart.source === 'project' ? 'violet' : 'gray'}
+                    >
+                        {chart.source === 'project' ? 'Project' : 'Vega'}
+                    </Badge>
+                )}
+            </Group>
+            <Text fz={10} c="dimmed" truncate>
+                {chart.description}
+            </Text>
+        </Stack>
+    </UnstyledButton>
+);
+
+const PrototypeState = ({
+    variant,
+    selectedChart,
+    palette,
+    showLabels,
+}: {
+    variant: PrototypeVariant;
+    selectedChart: ChartTypeOption;
+    palette: Palette;
+    showLabels: boolean;
+}) => (
+    <Stack gap={6}>
+        <Text size="xs" fw={600} c="dimmed">
+            PROTOTYPE STATE
+        </Text>
+        <Code block className={classes.stateBlock}>
+            {JSON.stringify(
+                {
+                    featureFlag: 'new-explorer-chart-sidebar',
+                    variant,
+                    selectedChart: selectedChart.id,
+                    source: selectedChart.source,
+                    resultRows: QUERY_ROWS.length,
+                    mappings: { category: 'Event tier', value: 'Count' },
+                    palette,
+                    showLabels,
+                },
+                null,
+                2,
+            )}
+        </Code>
+    </Stack>
+);
+
+type RightSidebarProps = {
+    variant: PrototypeVariant;
+    selectedChart: ChartTypeOption;
+    setSelectedId: (id: string) => void;
+    palette: Palette;
+    setPalette: (palette: Palette) => void;
+    showLabels: boolean;
+    setShowLabels: (show: boolean) => void;
+};
+
+const RightSidebarVariantA = ({
+    variant,
+    selectedChart,
+    setSelectedId,
+    palette,
+    setPalette,
+    showLabels,
+    setShowLabels,
+}: RightSidebarProps) => {
+    const [search, setSearch] = useState('');
+    const [group, setGroup] = useState<'All' | ChartGroup>('All');
+    const visibleCharts = CHART_TYPES.filter(
+        (chart) =>
+            (group === 'All' || chart.group === group) &&
+            chart.label.toLowerCase().includes(search.toLowerCase()),
+    );
+
+    return (
+        <ScrollArea className={classes.sidebarScroll}>
+            <Stack p="md" gap="md">
+                <TextInput
+                    size="xs"
+                    value={search}
+                    onChange={(event) => setSearch(event.currentTarget.value)}
+                    placeholder="Search chart types"
+                    leftSection={<MantineIcon icon={IconSearch} />}
+                />
+                <SegmentedControl
+                    fullWidth
+                    size="xs"
+                    value={group}
+                    onChange={(value) => setGroup(value as 'All' | ChartGroup)}
+                    data={['All', 'Built in', 'Project']}
+                />
+                {(['Project', 'Built in'] as ChartGroup[]).map((chartGroup) => {
+                    const charts = visibleCharts.filter(
+                        ({ group: itemGroup }) => itemGroup === chartGroup,
+                    );
+                    if (charts.length === 0) return null;
+                    return (
+                        <Stack key={chartGroup} gap="xs">
+                            <Group justify="space-between">
+                                <Text size="xs" fw={600} c="dimmed">
+                                    {chartGroup.toUpperCase()}
+                                </Text>
+                                <Text size="xs" c="dimmed">
+                                    {charts.length}
+                                </Text>
+                            </Group>
+                            <SimpleGrid cols={2} spacing="xs">
+                                {charts.map((chart) => (
+                                    <ChartTypeCard
+                                        key={chart.id}
+                                        chart={chart}
+                                        selected={chart.id === selectedChart.id}
+                                        palette={palette}
+                                        onSelect={() => setSelectedId(chart.id)}
+                                    />
+                                ))}
+                            </SimpleGrid>
+                        </Stack>
+                    );
+                })}
+                <Button
+                    variant="subtle"
+                    size="xs"
+                    leftSection={<MantineIcon icon={IconPlus} />}
+                >
+                    Create new chart type
+                </Button>
+                <Divider
+                    label="Configure selected chart"
+                    labelPosition="left"
+                />
+                <ConfigControls
+                    selectedChart={selectedChart}
+                    palette={palette}
+                    setPalette={setPalette}
+                    showLabels={showLabels}
+                    setShowLabels={setShowLabels}
+                />
+                <Divider />
+                <PrototypeState
+                    variant={variant}
+                    selectedChart={selectedChart}
+                    palette={palette}
+                    showLabels={showLabels}
+                />
+            </Stack>
+        </ScrollArea>
+    );
+};
+
+const RightSidebarVariantB = ({
+    variant,
+    selectedChart,
+    setSelectedId,
+    palette,
+    setPalette,
+    showLabels,
+    setShowLabels,
+}: RightSidebarProps) => {
+    const [step, setStep] = useState<'choose' | 'configure'>('choose');
+
+    return (
+        <ScrollArea className={classes.sidebarScroll}>
+            <Stack p="md" gap="md">
+                <SegmentedControl
+                    fullWidth
+                    value={step}
+                    onChange={(value) => setStep(value as typeof step)}
+                    data={[
+                        { value: 'choose', label: '1 · Choose type' },
+                        { value: 'configure', label: '2 · Configure' },
+                    ]}
+                />
+
+                {step === 'choose' ? (
+                    <>
+                        <TextInput
+                            size="xs"
+                            placeholder="Search the gallery"
+                            leftSection={<MantineIcon icon={IconSearch} />}
+                        />
+                        {(['Project', 'Built in'] as ChartGroup[]).map(
+                            (chartGroup) => (
+                                <Stack key={chartGroup} gap="xs">
+                                    <Group justify="space-between">
+                                        <Text size="xs" fw={600} c="dimmed">
+                                            {chartGroup.toUpperCase()}
+                                        </Text>
+                                        {chartGroup === 'Project' && (
+                                            <Badge size="xs" variant="light">
+                                                Uses these results
+                                            </Badge>
+                                        )}
+                                    </Group>
+                                    {CHART_TYPES.filter(
+                                        ({ group }) => group === chartGroup,
+                                    ).map((chart) => (
+                                        <UnstyledButton
+                                            key={chart.id}
+                                            className={`${classes.catalogRow} ${
+                                                chart.id === selectedChart.id
+                                                    ? classes.catalogRowSelected
+                                                    : ''
+                                            }`}
+                                            onClick={() => {
+                                                setSelectedId(chart.id);
+                                                setStep('configure');
+                                            }}
+                                        >
+                                            <Group wrap="nowrap" align="center">
+                                                <Box
+                                                    className={
+                                                        classes.catalogThumbnail
+                                                    }
+                                                >
+                                                    <ChartPreview
+                                                        kind={chart.kind}
+                                                        palette={palette}
+                                                        compact
+                                                    />
+                                                </Box>
+                                                <Stack gap={2} flex={1}>
+                                                    <Text size="sm" fw={600}>
+                                                        {chart.label}
+                                                    </Text>
+                                                    <Text size="xs" c="dimmed">
+                                                        {chart.description}
+                                                    </Text>
+                                                </Stack>
+                                                <MantineIcon
+                                                    icon={IconChevronRight}
+                                                    color="gray"
+                                                />
+                                            </Group>
+                                        </UnstyledButton>
+                                    ))}
+                                </Stack>
+                            ),
+                        )}
+                        <Button
+                            variant="default"
+                            leftSection={<MantineIcon icon={IconPlus} />}
+                        >
+                            Create new chart type
+                        </Button>
+                    </>
+                ) : (
+                    <>
+                        <Button
+                            variant="subtle"
+                            size="xs"
+                            px={0}
+                            leftSection={<MantineIcon icon={IconArrowLeft} />}
+                            onClick={() => setStep('choose')}
+                        >
+                            Back to chart types
+                        </Button>
+                        <Paper withBorder radius="md" p="sm">
+                            <Group wrap="nowrap">
+                                <Box className={classes.catalogThumbnail}>
+                                    <ChartPreview
+                                        kind={selectedChart.kind}
+                                        palette={palette}
+                                        compact
+                                    />
+                                </Box>
+                                <Stack gap={3}>
+                                    <Text fw={600}>{selectedChart.label}</Text>
+                                    <Badge
+                                        size="xs"
+                                        variant="light"
+                                        color={
+                                            selectedChart.group === 'Project'
+                                                ? 'violet'
+                                                : 'gray'
+                                        }
+                                    >
+                                        {selectedChart.group}
+                                    </Badge>
+                                </Stack>
+                            </Group>
+                        </Paper>
+                        <ConfigControls
+                            selectedChart={selectedChart}
+                            palette={palette}
+                            setPalette={setPalette}
+                            showLabels={showLabels}
+                            setShowLabels={setShowLabels}
+                        />
+                        <Divider />
+                        <PrototypeState
+                            variant={variant}
+                            selectedChart={selectedChart}
+                            palette={palette}
+                            showLabels={showLabels}
+                        />
+                    </>
+                )}
+            </Stack>
+        </ScrollArea>
+    );
+};
+
+const RightSidebarVariantC = ({
+    variant,
+    selectedChart,
+    setSelectedId,
+    palette,
+    setPalette,
+    showLabels,
+    setShowLabels,
+}: RightSidebarProps) => (
+    <Box className={classes.railLayout}>
+        <Stack className={classes.typeRail} gap={4}>
+            <Text size="xs" fw={600} c="dimmed" p="xs">
+                PROJECT
+            </Text>
+            {CHART_TYPES.filter(({ group }) => group === 'Project').map(
+                (chart) => (
+                    <UnstyledButton
+                        key={chart.id}
+                        className={`${classes.railItem} ${
+                            chart.id === selectedChart.id
+                                ? classes.railItemSelected
+                                : ''
+                        }`}
+                        onClick={() => setSelectedId(chart.id)}
+                    >
+                        <Group gap="xs" wrap="nowrap">
+                            <MantineIcon icon={chart.icon} />
+                            <Text size="xs" fw={500} lineClamp={2}>
+                                {chart.label}
+                            </Text>
+                        </Group>
+                    </UnstyledButton>
+                ),
+            )}
+            <Divider my="xs" />
+            <Text size="xs" fw={600} c="dimmed" p="xs">
+                BUILT IN
+            </Text>
+            {CHART_TYPES.filter(({ group }) => group === 'Built in').map(
+                (chart) => (
+                    <UnstyledButton
+                        key={chart.id}
+                        className={`${classes.railItem} ${
+                            chart.id === selectedChart.id
+                                ? classes.railItemSelected
+                                : ''
+                        }`}
+                        onClick={() => setSelectedId(chart.id)}
+                    >
+                        <Group gap="xs" wrap="nowrap">
+                            <MantineIcon icon={chart.icon} />
+                            <Text size="xs" fw={500}>
+                                {chart.label}
+                            </Text>
+                        </Group>
+                    </UnstyledButton>
+                ),
+            )}
+            <Button
+                mt="auto"
+                size="compact-xs"
+                variant="subtle"
+                leftSection={<MantineIcon icon={IconPlus} />}
+            >
+                New
+            </Button>
+        </Stack>
+
+        <ScrollArea className={classes.sidebarScroll}>
+            <Stack p="md" gap="md">
+                <Stack gap={4}>
+                    <Group justify="space-between" wrap="nowrap">
+                        <Text fw={600}>{selectedChart.label}</Text>
+                        <Badge
+                            size="xs"
+                            variant="light"
+                            color={
+                                selectedChart.group === 'Project'
+                                    ? 'violet'
+                                    : 'gray'
+                            }
+                        >
+                            {selectedChart.group}
+                        </Badge>
+                    </Group>
+                    <Text size="xs" c="dimmed">
+                        Live preview with 10 query rows
+                    </Text>
+                </Stack>
+                <Box className={classes.inspectorPreview}>
+                    <ChartPreview
+                        kind={selectedChart.kind}
+                        palette={palette}
+                        showLabels={showLabels}
+                    />
+                </Box>
+                <Divider label="Field mapping" labelPosition="left" />
+                <ConfigControls
+                    selectedChart={selectedChart}
+                    palette={palette}
+                    setPalette={setPalette}
+                    showLabels={showLabels}
+                    setShowLabels={setShowLabels}
+                />
+                <Divider />
+                <PrototypeState
+                    variant={variant}
+                    selectedChart={selectedChart}
+                    palette={palette}
+                    showLabels={showLabels}
+                />
+            </Stack>
+        </ScrollArea>
+    </Box>
+);
+
+const RightSidebar = (props: RightSidebarProps) => (
+    <Box className={`${classes.sidebar} ${classes.rightSidebar}`}>
+        <Group className={classes.sidebarHeader} justify="space-between">
+            <Group gap="xs">
+                <MantineIcon icon={IconSettings} />
+                <Text fw={600}>Configure chart</Text>
+            </Group>
+            <ActionIcon
+                variant="subtle"
+                color="gray"
+                aria-label="Close chart design"
+            >
+                <MantineIcon icon={IconX} />
+            </ActionIcon>
+        </Group>
+        {props.variant === 'A' && <RightSidebarVariantA {...props} />}
+        {props.variant === 'B' && <RightSidebarVariantB {...props} />}
+        {props.variant === 'C' && <RightSidebarVariantC {...props} />}
+    </Box>
+);
+
+const ResultsTable = () => (
+    <ScrollArea>
+        <Table
+            className={classes.resultTable}
+            striped
+            withTableBorder
+            withColumnBorders
+            highlightOnHover
+        >
+            <Table.Thead>
+                <Table.Tr>
+                    <Table.Th w={48}>#</Table.Th>
+                    <Table.Th>Event tier ···</Table.Th>
+                    <Table.Th>Event ···</Table.Th>
+                    <Table.Th ta="right">Count ···</Table.Th>
+                </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+                {QUERY_ROWS.map((row, index) => (
+                    <Table.Tr key={`${row.tier}-${row.event}`}>
+                        <Table.Td>{index + 1}</Table.Td>
+                        <Table.Td>{row.tier}</Table.Td>
+                        <Table.Td>{row.event}</Table.Td>
+                        <Table.Td ta="right">
+                            {row.count.toLocaleString()}
+                        </Table.Td>
+                    </Table.Tr>
+                ))}
+                <Table.Tr>
+                    <Table.Td colSpan={3} fw={600}>
+                        Total
+                    </Table.Td>
+                    <Table.Td ta="right" fw={700}>
+                        {TOTAL.toLocaleString()}
+                    </Table.Td>
+                </Table.Tr>
+            </Table.Tbody>
+        </Table>
+    </ScrollArea>
+);
+
+const ExplorerMain = ({
+    selectedChart,
+    palette,
+    showLabels,
+}: {
+    selectedChart: ChartTypeOption;
+    palette: Palette;
+    showLabels: boolean;
+}) => (
+    <Box className={classes.main}>
+        <Stack gap="md">
+            <Group className={classes.toolbar} justify="space-between">
+                <Button
+                    variant="default"
+                    size="xs"
+                    leftSection={<MantineIcon icon={IconRefresh} />}
+                >
+                    Refresh dbt
+                </Button>
+                <Group gap="xs">
+                    <Button
+                        color="dark"
+                        size="xs"
+                        leftSection={<MantineIcon icon={IconPlayerPlay} />}
+                        rightSection={<MantineIcon icon={IconChevronDown} />}
+                    >
+                        Run query (500)
+                    </Button>
+                    <Button
+                        variant="default"
+                        size="xs"
+                        leftSection={<MantineIcon icon={IconDeviceFloppy} />}
+                    >
+                        Save chart
+                    </Button>
+                </Group>
+            </Group>
+
+            <Paper className={classes.sectionCard} radius="md">
+                <Group className={classes.sectionHeader} gap="xs">
+                    <MantineIcon icon={IconChevronRight} />
+                    <Text size="sm" fw={600}>
+                        Filters
+                    </Text>
+                </Group>
+            </Paper>
+
+            <Paper className={classes.sectionCard} radius="md">
+                <Group
+                    className={classes.sectionHeader}
+                    justify="space-between"
+                >
+                    <Group gap="xs">
+                        <MantineIcon icon={IconChevronDown} />
+                        <Text size="sm" fw={600}>
+                            Chart
+                        </Text>
+                        <Badge size="xs" variant="outline" color="yellow">
+                            Results may be incorrect
+                        </Badge>
+                        {selectedChart.source !== 'standard' && (
+                            <Badge
+                                size="xs"
+                                variant="light"
+                                color={
+                                    selectedChart.source === 'project'
+                                        ? 'violet'
+                                        : 'gray'
+                                }
+                            >
+                                {selectedChart.label}
+                            </Badge>
+                        )}
+                    </Group>
+                    <Group gap="xs">
+                        <Text size="xs" c="dimmed">
+                            UTC
+                        </Text>
+                        <Button
+                            variant="default"
+                            size="compact-xs"
+                            rightSection={
+                                <MantineIcon icon={IconSettings} size={13} />
+                            }
+                        >
+                            Configure
+                        </Button>
+                    </Group>
+                </Group>
+                <Box className={classes.chartStage}>
+                    <ChartPreview
+                        kind={selectedChart.kind}
+                        palette={palette}
+                        showLabels={showLabels}
+                    />
+                </Box>
+            </Paper>
+
+            <Paper className={classes.sectionCard} radius="md">
+                <Group
+                    className={classes.sectionHeader}
+                    justify="space-between"
+                >
+                    <Group gap="xs">
+                        <MantineIcon icon={IconChevronDown} />
+                        <Text size="sm" fw={600}>
+                            Results
+                        </Text>
+                    </Group>
+                    <Button
+                        variant="default"
+                        size="compact-xs"
+                        leftSection={<MantineIcon icon={IconPlus} />}
+                    >
+                        Table calculation
+                    </Button>
+                </Group>
+                <Box p="xs">
+                    <ResultsTable />
+                </Box>
+            </Paper>
+        </Stack>
+    </Box>
+);
+
+const VARIANT_LABELS: Record<PrototypeVariant, string> = {
+    A: 'Gallery + inline config',
+    B: 'Choose, then configure',
+    C: 'Type rail + live inspector',
+};
+
+const PrototypeSwitcher = ({
+    variant,
+    onChange,
+}: {
+    variant: PrototypeVariant;
+    onChange: (variant: PrototypeVariant) => void;
+}) => {
+    const variants: PrototypeVariant[] = ['A', 'B', 'C'];
+    const move = (offset: number) => {
+        const currentIndex = variants.indexOf(variant);
+        onChange(
+            variants[
+                (currentIndex + offset + variants.length) % variants.length
+            ],
+        );
+    };
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            const target = event.target as HTMLElement | null;
+            if (
+                target?.matches(
+                    'input, textarea, select, [contenteditable="true"]',
+                )
+            ) {
+                return;
+            }
+            if (event.key === 'ArrowLeft') move(-1);
+            if (event.key === 'ArrowRight') move(1);
+        };
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    });
+
+    if (import.meta.env.PROD) return null;
+
+    return (
+        <Paper className={classes.prototypeSwitcher} radius="xl" px={6} py={5}>
+            <Group gap={4} wrap="nowrap">
+                <ActionIcon
+                    className={classes.switcherButton}
+                    variant="subtle"
+                    aria-label="Previous prototype variant"
+                    onClick={() => move(-1)}
+                >
+                    <MantineIcon icon={IconChevronLeft} />
+                </ActionIcon>
+                <Stack gap={0} miw={190} align="center">
+                    <Text size="xs" fw={700} c="white">
+                        {variant} — {VARIANT_LABELS[variant]}
+                    </Text>
+                    <Text fz={9} c="gray.5">
+                        Use ← → to compare
+                    </Text>
+                </Stack>
+                <ActionIcon
+                    className={classes.switcherButton}
+                    variant="subtle"
+                    aria-label="Next prototype variant"
+                    onClick={() => move(1)}
+                >
+                    <MantineIcon icon={IconChevronRight} />
+                </ActionIcon>
+            </Group>
+        </Paper>
+    );
+};
+
+const ExplorerChartGalleryPrototype = ({
+    featureFlagEnabled,
+}: {
+    featureFlagEnabled: boolean;
+}) => {
+    const [flagEnabled, setFlagEnabled] = useState(featureFlagEnabled);
+    const [variant, setVariant] = useState<PrototypeVariant>(readVariant);
+    const [selectedId, setSelectedId] = useState('event-tier-pulse');
+    const [palette, setPalette] = useState<Palette>('navy');
+    const [showLabels, setShowLabels] = useState(true);
+
+    useEffect(() => setFlagEnabled(featureFlagEnabled), [featureFlagEnabled]);
+
+    const selectedChart = useMemo(
+        () => CHART_TYPES.find(({ id }) => id === selectedId) ?? CHART_TYPES[0],
+        [selectedId],
+    );
+
+    const changeVariant = (nextVariant: PrototypeVariant) => {
+        setVariant(nextVariant);
+        writeVariant(nextVariant);
+    };
+
+    return (
+        <Box className={classes.prototype}>
+            <Group className={classes.featureBar} justify="space-between">
+                <Group gap="sm">
+                    <Badge variant="filled" color="dark">
+                        PROTOTYPE
+                    </Badge>
+                    <Stack gap={0}>
+                        <Text size="sm" fw={600}>
+                            Explorer chart selection
+                        </Text>
+                        <Text fz={10} c="dimmed">
+                            Project chart types use the current query results
+                        </Text>
+                    </Stack>
+                </Group>
+                <Group gap="xs">
+                    <Text size="xs" c="dimmed">
+                        new-explorer-chart-sidebar
+                    </Text>
+                    <Switch
+                        checked={flagEnabled}
+                        onChange={(event) =>
+                            setFlagEnabled(event.currentTarget.checked)
+                        }
+                        onLabel="ON"
+                        offLabel="OFF"
+                        size="md"
+                    />
+                </Group>
+            </Group>
+
+            <Box
+                className={`${classes.workspace} ${
+                    flagEnabled ? classes.workspaceWithRightSidebar : ''
+                } ${
+                    flagEnabled && variant === 'C'
+                        ? classes.workspaceWithWideRightSidebar
+                        : ''
+                }`}
+            >
+                {flagEnabled ? (
+                    <FieldsSidebar />
+                ) : (
+                    <LegacyConfigSidebar
+                        selectedId={selectedId}
+                        setSelectedId={setSelectedId}
+                        palette={palette}
+                        setPalette={setPalette}
+                        showLabels={showLabels}
+                        setShowLabels={setShowLabels}
+                    />
+                )}
+                <ExplorerMain
+                    selectedChart={selectedChart}
+                    palette={palette}
+                    showLabels={showLabels}
+                />
+                {flagEnabled && (
+                    <RightSidebar
+                        variant={variant}
+                        selectedChart={selectedChart}
+                        setSelectedId={setSelectedId}
+                        palette={palette}
+                        setPalette={setPalette}
+                        showLabels={showLabels}
+                        setShowLabels={setShowLabels}
+                    />
+                )}
+            </Box>
+
+            {flagEnabled && (
+                <PrototypeSwitcher variant={variant} onChange={changeVariant} />
+            )}
+        </Box>
+    );
+};
+
+const meta: Meta<typeof ExplorerChartGalleryPrototype> = {
+    title: 'Prototypes/Explorer/Chart gallery sidebar',
+    component: ExplorerChartGalleryPrototype,
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Throwaway interaction prototype for moving chart selection and configuration to a gallery-style right sidebar while keeping Explorer fields on the left.',
+            },
+        },
+    },
+    args: {
+        featureFlagEnabled: true,
+    },
+    argTypes: {
+        featureFlagEnabled: {
+            control: 'boolean',
+            description: 'Prototype stand-in for the production feature flag.',
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof ExplorerChartGalleryPrototype>;
+
+export const InteractionWorkbench: Story = {};


### PR DESCRIPTION
## What this is

Throwaway Storybook prototype for evaluating the complete Explorer chart flow before production implementation.

It keeps the Explorer field rail visible while users select a chart type, create or edit a project chart type through an embedded builder, and return to the same query. The embedded surface mirrors the existing Chart Type Builder rather than introducing a separate builder metaphor.

This PR is intentionally a product prototype, not production code.

## Try it

1. Run `pnpm -F frontend storybook`.
2. Open `http://localhost:6006/?path=/story/prototypes-explorer-chart-gallery-sidebar--interaction-workbench`.
3. In the right sidebar, choose a chart type and move between **Choose type** and **Configure**.
4. Click **Create new chart type**.
5. Send the prompt, answer or skip clarification, click **Build**, then **Finish simulated build**.
6. Inspect the generated options and preview, then click **Preview in Explorer**.
7. Try editing a project chart, canceling back to Explorer, changing a field, and rerunning the query.

## Product decisions reflected

- Keep the row-based **Choose type → Configure** sidebar.
- Keep Explorer fields available while authoring.
- Reuse the Chart Type Builder's starter examples, floating composer, clarification sheet, build state, generated-options panel, preview, and history language.
- Preserve draft query state until an explicit query run.

## Validation

- Frontend lint
- Frontend typecheck
- Storybook compilation and direct story HTTP check
- Rebased onto current `main`

Visual and interaction feedback is the purpose of this draft.
