### PR TITLE
fix: show declared release breaks in PR comments

### DIFF
--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -51,6 +51,7 @@ test('safe v2 marker renders the sticky upgrade summary', () => {
     assert.ok(body.startsWith(COMMENT_MARKER));
     assert.match(body, /Safe to upgrade normally/);
     assert.match(body, /Database changes \| none/);
+    assert.match(body, /Declared breaking changes \| none/);
 });
 
 test('unknown verdict is rendered as unsafe for a ready PR', () => {
@@ -87,6 +88,88 @@ test('a failed gate never leaves a green headline above a red check', () => {
         assert.match(body, /The upgrade itself looks safe/);
         assert.match(body, /How to unblock this pull request/);
     }
+});
+
+test('a false declaration-only verdict explains the declared compatibility break and does not claim a DB change', () => {
+    const body = renderPrComment(
+        baseMarker({
+            compatibility: {
+                rollingUpdateSafe: false,
+                recommendedStrategy: 'Recreate',
+            },
+            declaredBreaks: [
+                {
+                    file: 'packages/backend/src/changes.ts',
+                    line: 77,
+                    reason: 'Existing API clients still rely on old request field names.',
+                    requiredStop: false,
+                },
+            ],
+        }),
+    );
+    assert.match(body, /Needs care on upgrade/);
+    assert.match(
+        body,
+        /declared as a breaking change: 1\) Existing API clients still rely on old request field names\./,
+    );
+    assert.doesNotMatch(body, /changes the database in a way/);
+});
+
+test('the declaration breaks row shows every reason and marks required stops', () => {
+    const body = renderPrComment(
+        baseMarker({
+            compatibility: {
+                rollingUpdateSafe: false,
+                recommendedStrategy: 'Recreate',
+            },
+            declaredBreaks: [
+                {
+                    file: 'packages/backend/src/a.ts',
+                    line: 12,
+                    reason: 'first reason',
+                    requiredStop: false,
+                },
+                {
+                    file: 'packages/backend/src/b.ts',
+                    line: 34,
+                    reason: 'second reason',
+                    requiredStop: true,
+                },
+            ],
+        }),
+    );
+    const declaredRow = body
+        .split('\n')
+        .find((line) => line.startsWith('| Declared breaking changes |'));
+    assert.ok(declaredRow);
+    assert.match(declaredRow, /2 declared breaking changes/);
+    assert.match(declaredRow, /first reason/);
+    assert.match(declaredRow, /second reason/);
+    assert.match(declaredRow, /\(required stop\)/);
+});
+
+test('declaration reasons are escaped for markdown table rendering', () => {
+    const body = renderPrComment(
+        baseMarker({
+            compatibility: {
+                rollingUpdateSafe: false,
+                recommendedStrategy: 'Recreate',
+            },
+            declaredBreaks: [
+                {
+                    file: 'packages/backend/src/c.ts',
+                    line: 88,
+                    reason: 'line with pipe | and newline\nin declaration',
+                    requiredStop: false,
+                },
+            ],
+        }),
+    );
+    const declaredRow = body
+        .split('\n')
+        .find((line) => line.startsWith('| Declared breaking changes |'));
+    assert.ok(declaredRow);
+    assert.match(declaredRow, /line with pipe \\| and newline<br\/>in declaration/);
 });
 
 test('a green marker with no failed gate keeps its safe headline', () => {

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -71,6 +71,34 @@ export interface RenderOpts {
 
 const SAFE_HEADLINE = '✅ **Safe to upgrade normally.** No downtime needed.';
 
+function escapeMarkdownTableCell(value: string): string {
+    return value
+        .replace(/\r/g, '')
+        .replace(/\n/g, '<br/>')
+        .replace(/\|/g, '\\|');
+}
+
+function renderDeclaredBreaksCell(marker: Marker): string {
+    if (marker.declaredBreaks.length === 0) return 'none';
+
+    const rendered = marker.declaredBreaks.map((declaredBreak, index) => {
+        const reason = escapeMarkdownTableCell(declaredBreak.reason);
+        const suffix = declaredBreak.requiredStop ? ' (required stop)' : '';
+        return `${index + 1}) ${reason}${suffix}`;
+    });
+
+    return `${rendered.length} declared breaking change${rendered.length === 1 ? '' : 's'}: ${rendered.join('; ')}`;
+}
+
+function renderDeclaredBreakReasons(marker: Marker): string {
+    return marker.declaredBreaks
+        .map((declaredBreak, index) => {
+            const required = declaredBreak.requiredStop ? ' (required stop)' : '';
+            return `${index + 1}) ${escapeMarkdownTableCell(declaredBreak.reason)}${required}`;
+        })
+        .join('; ');
+}
+
 /**
  * PURE. Render the sticky PR comment for a marker, in plain language aimed at the
  * PR author. It answers one question — "can self-hosted customers upgrade to this
@@ -91,6 +119,10 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     const clearedAsSafeDrop = lintFlagged && rollingUpdateSafe === true;
     // The risk comes from an API change (no DB migration) rather than the schema.
     const apiDriven = (restBreaking || mcpBreaking) && migrationsPresent !== true;
+    const declarationDriven =
+        migrationsPresent !== true &&
+        !apiDriven &&
+        marker.declaredBreaks.length > 0;
     // Any failed gate needs remediation text, or the downgraded headline below
     // names a problem the comment never explains.
     const needsUnblock =
@@ -108,11 +140,16 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     }
     if (rollingUpdateSafe === false) {
         head.push("⚠️ **Needs care on upgrade.** A normal (zero-downtime) upgrade would briefly break customers' running app.");
-        head.push(
-            apiDriven
-                ? 'This changes the API in a way the already-running version can’t handle. During an upgrade both the old and new versions are live for a moment, so requests would hit errors until it finishes.'
-                : 'When customers upgrade, the old version keeps serving traffic until the new one is fully live. This changes the database in a way the old version can’t handle, so its app would start erroring during that window.',
-        );
+        if (declarationDriven) {
+            const reasons = renderDeclaredBreakReasons(marker);
+            head.push(`This was declared as a breaking change: ${reasons}`);
+        } else {
+            head.push(
+                apiDriven
+                    ? 'This changes the API in a way the already-running version can’t handle. During an upgrade both the old and new versions are live for a moment, so requests would hit errors until it finishes.'
+                    : 'When customers upgrade, the old version keeps serving traffic until the new one is fully live. This changes the database in a way the old version can’t handle, so its app would start erroring during that window.',
+            );
+        }
     } else if (rollingUpdateSafe === 'unknown') {
         head.push('❓ **Couldn’t confirm it’s safe.** Treat it as needing care on upgrade until checked.');
         // Name what actually drove the verdict. An API break with no migration
@@ -210,6 +247,7 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         `| REST API | ${apiResult(marker.api.rest, restUncheckedReason)} |`,
         `| MCP tools | ${apiResult(marker.api.mcp)} |`,
         `| Config / environment | ${configResult} |`,
+        `| Declared breaking changes | ${renderDeclaredBreaksCell(marker)} |`,
         `| Upgrade notes | ${notesResult} |`,
     ].join('\n');
 


### PR DESCRIPTION
The release-safety comment now explains declaration-only breaks.
It lists declared breaks in the evidence table.
It escapes Markdown in declaration reasons.

Linear: SPK-1156