### PR TITLE
fix: scope release declarations to git ranges

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -130,6 +130,7 @@ jobs:
             watched:
               - 'packages/backend/**'
               - 'packages/common/**'
+              - 'release-safety.declarations.json'
               - 'release-safety.overrides.json'
               - 'scripts/gen-release-safety.ts'
               - 'scripts/ai-migration-review.ts'
@@ -137,6 +138,8 @@ jobs:
               - 'scripts/rest-api-diff.ts'
               - 'scripts/mcp-tools-diff.ts'
               - 'scripts/breaking-change-declarations.ts'
+              - 'scripts/release-safety-declarations.ts'
+              - 'scripts/release-safety-declarations.schema.json'
               - 'scripts/release-safety-pr-gate.ts'
               - 'scripts/upgrade-overrides.ts'
               - 'scripts/release-safety-pr-comment.ts'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,9 +181,13 @@ pnpm -F backend rollback-last
 `Release-safety preview` is a required check on `main`. It protects self-hosted upgrades: `unknown` means we could not confirm the change is safe, while `breaking` means we know it is incompatible. Both hold the upgrade, for different reasons.
 
 - For migration breaks, follow the detailed [migration release-safety declarations](packages/backend/src/database/migrations/CLAUDE.md#release-safety-declarations).
-- For API or type breaks, changed, non-test TypeScript source under `packages/backend/src` or `packages/common/src` may declare `export const breaking = { reason: '<operator-facing reason>', requiredStop: false }`. It must be a top-level, unannotated object literal with exactly those fields: `reason` is a non-empty string literal, `requiredStop` is a boolean literal, and API-gate reasons must be at least 24 characters, use more than one word, and not be placeholder text.
+- For API or type breaks, add a stable ID to `release-safety.declarations.json` with `reason` and `requiredStop`. The reason must be at least 24 characters, use more than one word, describe what breaks and for whom, and not use placeholder text. Omit `migration` for these entries.
 
-Never declare a break merely to make CI pass. Declaring a break advises every self-hosted customer to use the Recreate strategy. A release that ships as `breaking` or `unknown` stops the internal analytics instance upgrading; every later release inherits the block until someone moves the pin past it by hand.
+A declaration is active only for a Git range that adds its ID. The release generator compares the last release tag with the target ref. The pull request preview compares the merge base with the head. This makes the declaration expire after the release that first contains it. Do not remove it after release.
+
+The registry is append-only. Never edit, remove, rename, or reuse an existing ID. Add a new ID for every new break, even when it affects the same file or has similar reason text. A release may add `releasedIn` for documentation, but that value never controls activation.
+
+Never declare a break merely to make CI pass. Declaring a break advises every self-hosted customer to use the Recreate strategy. A release that ships as `breaking` or `unknown` stops the internal analytics instance upgrading. The declaration does not reactivate in later Git ranges.
 
 ## Merge Freeze — Holding `main` While a Release Is Cut
 

--- a/packages/backend/src/database/migrations/CLAUDE.md
+++ b/packages/backend/src/database/migrations/CLAUDE.md
@@ -36,8 +36,8 @@ For API and type breaks outside migrations, see the root [release-safety declara
 
 The release-safety gate applies these rules only to migration files changed by the pull request. Existing untouched migrations are grandfathered.
 
-- A migration containing a detected breaking operation must declare it in that file with the exact export `export const breaking = { reason: '<operator-facing reason>', requiredStop: <true | false> }`. The reason must be a non-empty string literal and `requiredStop` must be a boolean literal. The declaration records the break; it does not hide the detector finding.
-- Raw SQL that the static lint cannot classify must add `export const classification: { kind: 'safe' | 'breaking'; reason: string } = { kind: '<safe | breaking>', reason: '<why>' }`, or the equivalent unannotated object literal. A `breaking` classification also requires the `breaking` export.
+- A migration containing a detected breaking operation must add a stable ID to `release-safety.declarations.json`. Set `reason`, `requiredStop`, and `migration` to the full migration path. The declaration records the break; it does not hide the detector finding.
+- Raw SQL that the static lint cannot classify must add `export const classification: { kind: 'safe' | 'breaking'; reason: string } = { kind: '<safe | breaking>', reason: '<why>' }`, or the equivalent unannotated object literal. A `breaking` classification also requires a matching registry entry.
 - A `transaction: false` migration must be resumable after any completed statement. Concurrent index creation needs `IF NOT EXISTS`; backfills need bounded, state-guarded batches; inserts need conflict handling or another explicit idempotency guard.
 - `down()` must perform a real reversal or explicitly throw an error whose message starts with `irreversible:`. Missing and silently successful no-op `down()` functions fail the gate.
 - DDL should set a finite Postgres `lock_timeout` before requesting locks. DDL without one produces a warning because a waiting `ALTER` can queue later queries behind it indefinitely.
@@ -46,8 +46,10 @@ The release-safety gate applies these rules only to migration files changed by t
 When the gate detects a breaking pattern, use this decision tree:
 
 1. Attempt an expand-only redesign first, such as deprecating the old shape now and dropping it in a later release.
-2. Add `export const breaking` only after an engineer confirms the product and rollout decision. Its reason must describe what breaks and for whom; it must contain more than one word, use at least 24 characters, and must not reuse placeholder text.
+2. Add a registry entry only after an engineer confirms the product and rollout decision. Its reason must describe what breaks and for whom; it must contain more than one word, use at least 24 characters, and must not reuse placeholder text.
 3. Never add a breaking declaration merely to make CI pass. Declaring a break makes the release not rolling-safe and advises every self-hosted customer to use the Recreate strategy.
+
+A declaration is active only for a Git range that adds its ID. It expires after the first release that contains it and stays in the append-only registry as history. Never edit, remove, rename, or reuse an existing ID. Add a new ID for each new break. A release may add `releasedIn` for documentation, but that value never controls activation. The inline `classification` export stays in the migration because it classifies SQL for the linter and is not a breaking declaration.
 
 ## Runtime rollback granularity
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -318,11 +318,6 @@ import {
     toolVerticalBarOutputSchema,
 } from './toolVerticalBarArgs';
 
-export const breaking = {
-    reason: 'MCP clients must replace find_explores and find_fields with grep_fields and get_metadata.',
-    requiredStop: false,
-};
-
 const readOnlyAnnotations: McpToolAnnotations = {
     readOnlyHint: true,
     destructiveHint: false,

--- a/release-safety.declarations.json
+++ b/release-safety.declarations.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "./scripts/release-safety-declarations.schema.json",
+    "declarations": {}
+}

--- a/scripts/breaking-change-gate-policy.ts
+++ b/scripts/breaking-change-gate-policy.ts
@@ -38,6 +38,6 @@ export function breakingChangeDecisionBrief(
         `Detected at ${input.file}:${input.line}: ${input.pattern}`,
         'Path 1 — redesign: redesign to expand-only — e.g. deprecate-now-drop-later. Consequence: preserves a rolling-safe release.',
         `Path 2 — declare: declare — flips this release to not-rolling-safe, advises Recreate to every self-hosted customer. The declaration must be in ${input.declarationLocation}.`,
-        'Declaring is a product decision — confirm with a human before adding this export.',
+        'Declaring is a product decision — confirm with a human before adding a registry entry.',
     ].join('\n');
 }

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
 import {
     buildMarker,
-    declarationSourcePaths,
     detectMigrations,
     GitChange,
     MARKER_SCHEMA_VERSION,
@@ -136,9 +135,7 @@ test('detectMigrations surfaces deleted history without counting it', () => {
     ]);
     assert.strictEqual(result.present, false);
     assert.strictEqual(result.count, 0);
-    assert.deepStrictEqual(result.deletedHistorical, [
-        '20200101000000_old.ts',
-    ]);
+    assert.deepStrictEqual(result.deletedHistorical, ['20200101000000_old.ts']);
 });
 
 test('fully checked release without migrations is safe', () => {
@@ -197,6 +194,40 @@ test('definitive AI review can prove a migration safe', () => {
     assert.strictEqual(marker.compatibility.rollingUpdateSafe, true);
 });
 
+test('incomplete declaration metadata stays unknown after a definitive AI verdict', () => {
+    const marker = buildMarker({
+        ...base,
+        migrations: migration,
+        migrationDetails,
+        ...checkedSurfaces,
+        declarationMetadataComplete: false,
+        aiReview: {
+            rollingUpdateSafe: true,
+            recommendedStrategy: 'RollingUpdate',
+            summary: 'verified',
+        },
+    });
+    assert.strictEqual(marker.compatibility.rollingUpdateSafe, 'unknown');
+});
+
+test('a declared break stays unsafe when declaration metadata is incomplete', () => {
+    const marker = buildMarker({
+        ...base,
+        migrations: noMigrations,
+        migrationDetails: [],
+        ...checkedSurfaces,
+        declarationMetadataComplete: false,
+        declaredBreaks: [
+            {
+                id: 'old-workers-read-new-rows',
+                reason: 'Old workers cannot read the new rows.',
+                requiredStop: false,
+            },
+        ],
+    });
+    assert.strictEqual(marker.compatibility.rollingUpdateSafe, false);
+});
+
 test('config changes force an unsafe verdict', () => {
     const marker = buildMarker({
         ...base,
@@ -227,10 +258,10 @@ test('declared break uses the frozen shape and contributes a required stop', () 
         ...checkedSurfaces,
         declaredBreaks: [
             {
-                file: `${core}/${migration.files[0]}`,
-                line: 3,
+                id: 'old-workers-read-new-rows',
                 reason: 'old workers cannot read the new rows',
                 requiredStop: true,
+                migration: `${core}/${migration.files[0]}`,
             },
         ],
     });
@@ -238,20 +269,17 @@ test('declared break uses the frozen shape and contributes a required stop', () 
     assert.deepStrictEqual(marker.upgrade.requiredStops, ['1.115.0']);
 });
 
-test('declaration source paths match the gate production-source scope', () => {
-    assert.deepStrictEqual(
-        declarationSourcePaths([
-            change('M', 'packages/backend/src/controllers/project.ts'),
-            change('A', 'packages/common/src/types/api.ts'),
-            change('M', 'packages/backend/src/controllers/project.test.ts'),
-            change('D', 'packages/common/src/types/deleted.ts'),
-            change('M', 'packages/frontend/src/App.tsx'),
-        ]),
-        [
-            'packages/backend/src/controllers/project.ts',
-            'packages/common/src/types/api.ts',
-        ],
-    );
+test('a spent required stop is not pinned again by a later marker', () => {
+    const marker = buildMarker({
+        ...base,
+        version: '1.116.0',
+        migrations: noMigrations,
+        migrationDetails: [],
+        ...checkedSurfaces,
+        declaredBreaks: [],
+        requiredStops: ['1.115.0'],
+    });
+    assert.deepStrictEqual(marker.upgrade.requiredStops, ['1.115.0']);
 });
 
 test('schema v2 omits capabilities, notes, and per-migration transaction data', () => {

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -16,22 +16,17 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { isReleaseVersion } from '../packages/cli/src/releaseSafety';
 import { aiRollingUpdateReview } from './ai-migration-review';
-import {
-    collectChangeDeclarations,
-    formatChangeDeclarationDiagnostic,
-} from './breaking-change-declarations';
-import type { BreakingChangeDeclaration } from './breaking-change-declarations';
-import { lintMigrations, renderFindings, SqlLintFinding } from './sql-migration-lint';
 import { compareVersions, findExpandFloor } from './expand-version';
-import { diffRestApi, SPEC_PATH } from './rest-api-diff';
 import { diffMcpTools } from './mcp-tools-diff';
+import type { ConfigSurface } from './release-safety-config-diff';
+import { diffConfigBetweenRefs } from './release-safety-config-diff';
 import type {
     ApiSurface,
     ReleaseSafetyMarker,
     TriState,
 } from './release-safety-contract';
-import type { ConfigSurface } from './release-safety-config-diff';
-import { diffConfigBetweenRefs } from './release-safety-config-diff';
+import { collectBreakingChangeDeclarationsBetweenRefs } from './release-safety-declarations';
+import type { BreakingChangeDeclaration } from './release-safety-declarations';
 import {
     appendReleaseSafetyMarker,
     CONFIGURE_RELEASE_SAFETY_BACKFILL_FLOOR_VERSION,
@@ -39,7 +34,16 @@ import {
     writeReleaseSafetyIndex,
 } from './release-safety-index';
 import type { MigrationDetail } from './release-safety-migrations';
-import { isMigrationPath, readMigrationMetadata } from './release-safety-migrations';
+import {
+    isMigrationPath,
+    readMigrationMetadata,
+} from './release-safety-migrations';
+import { diffRestApi, SPEC_PATH } from './rest-api-diff';
+import {
+    lintMigrations,
+    renderFindings,
+    SqlLintFinding,
+} from './sql-migration-lint';
 import {
     CarriedFloor,
     carriedUpgradeFloor,
@@ -61,9 +65,6 @@ const MIGRATION_DIRS = [
 ] as const;
 
 const EE_MIGRATION_DIR = 'packages/backend/src/ee/database/migrations';
-const DECLARATION_DIRS = ['packages/backend', 'packages/common'] as const;
-const TYPESCRIPT_SOURCE = /^packages\/(backend|common)\/src\/.+\.tsx?$/;
-const TYPESCRIPT_TEST = /(^|\/)__tests__\/|\.(test|spec)\.tsx?$/;
 
 export interface GitChange {
     /** git --name-status code: A, M, D, R100, C75, ... */
@@ -220,7 +221,9 @@ export function ownExpandContractFloor(input: {
         input.sqlLint?.ran && input.sqlLint.breaking && present === true,
     );
     const cleared = Boolean(
-        linterFlagged && input.aiReview && input.aiReview.rollingUpdateSafe === true,
+        linterFlagged &&
+        input.aiReview &&
+        input.aiReview.rollingUpdateSafe === true,
     );
     if (!cleared) return null;
     return input.expandContractFloor || input.previousVersion || null;
@@ -262,12 +265,7 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
         rest.checked && mcp.checked && config.checked && metadataComplete;
 
     let rollingUpdateSafe: TriState = 'unknown';
-    if (
-        present === false &&
-        fullyChecked &&
-        !apiBreak &&
-        !deterministicBreak
-    ) {
+    if (present === false && fullyChecked && !apiBreak && !deterministicBreak) {
         rollingUpdateSafe = true;
     }
     if (linterFlagged || deterministicBreak) {
@@ -279,6 +277,9 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
         (present === true || apiBreak)
     ) {
         rollingUpdateSafe = input.aiReview.rollingUpdateSafe;
+    }
+    if (!metadataComplete) {
+        rollingUpdateSafe = 'unknown';
     }
     if (deterministicBreak) {
         rollingUpdateSafe = false;
@@ -387,16 +388,24 @@ export function parseArgs(argv: string[]): CliArgs {
     const mcpBaseSnapshot = get('mcp-base-snapshot') || null;
     const mcpNewSnapshot = get('mcp-new-snapshot') || null;
     if (Boolean(restBaseSpec) !== Boolean(restNewSpec)) {
-        throw new Error('--rest-base-spec and --rest-new-spec must be given together');
+        throw new Error(
+            '--rest-base-spec and --rest-new-spec must be given together',
+        );
     }
     if (restFromTag && restBaseSpec) {
-        throw new Error('--rest-from-tag cannot be combined with --rest-base-spec/--rest-new-spec');
+        throw new Error(
+            '--rest-from-tag cannot be combined with --rest-base-spec/--rest-new-spec',
+        );
     }
     if (restFromTag && restFromRefs) {
-        throw new Error('--rest-from-tag cannot be combined with --rest-from-refs');
+        throw new Error(
+            '--rest-from-tag cannot be combined with --rest-from-refs',
+        );
     }
     if (Boolean(mcpBaseSnapshot) !== Boolean(mcpNewSnapshot)) {
-        throw new Error('--mcp-base-snapshot and --mcp-new-snapshot must be given together');
+        throw new Error(
+            '--mcp-base-snapshot and --mcp-new-snapshot must be given together',
+        );
     }
     return {
         version,
@@ -438,33 +447,17 @@ function gitNameStatus(range: string, dirs: readonly string[]): GitChange[] {
 
 function isResolvableGitRef(ref: string): boolean {
     try {
-        execFileSync('git', ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], {
-            stdio: 'ignore',
-        });
+        execFileSync(
+            'git',
+            ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`],
+            {
+                stdio: 'ignore',
+            },
+        );
         return true;
     } catch {
         return false;
     }
-}
-
-export function declarationSourcePaths(changes: GitChange[]): string[] {
-    return changes
-        .filter(
-            (change) =>
-                /^[ACMR]/.test(change.status) &&
-                TYPESCRIPT_SOURCE.test(change.path) &&
-                !TYPESCRIPT_TEST.test(change.path),
-        )
-        .map((change) => change.path)
-        .sort();
-}
-
-function readFileAtRef(ref: string, filePath: string): string {
-    return execFileSync('git', ['show', `${ref}:${filePath}`], {
-        encoding: 'utf-8',
-        maxBuffer: 64 * 1024 * 1024,
-        stdio: ['ignore', 'pipe', 'pipe'],
-    });
 }
 
 /** IO: write JSON atomically (temp file + rename) so a crash never leaves a partial. */
@@ -494,7 +487,9 @@ export async function generateReleaseSafety(
 
     let migrations: MigrationsResult | null = null;
     let migrationPaths: string[] = [];
-    let declarationPaths: string[] = [];
+    let declarations = { added: [], diagnostics: [] } as ReturnType<
+        typeof collectBreakingChangeDeclarationsBetweenRefs
+    >;
     if (args.lastTag) {
         const range = `${args.lastTag}..${args.toRef}`;
         const unresolvableRefs = [args.lastTag, args.toRef].filter(
@@ -506,8 +501,9 @@ export async function generateReleaseSafety(
             );
         } else {
             const changes = gitNameStatus(range, MIGRATION_DIRS);
-            declarationPaths = declarationSourcePaths(
-                gitNameStatus(range, DECLARATION_DIRS),
+            declarations = collectBreakingChangeDeclarationsBetweenRefs(
+                args.lastTag,
+                args.toRef,
             );
             migrations = detectMigrations(changes);
             migrationPaths = changes
@@ -537,16 +533,9 @@ export async function generateReleaseSafety(
         log: (message) =>
             console.warn(`[release-safety-migrations] ${message}`),
     });
-    const declarations = collectChangeDeclarations(
-        declarationPaths,
-        (filePath) => readFileAtRef(args.toRef, filePath),
-    );
-    const declarationDiagnostics = declarations.diagnostics.filter(
-        (diagnostic) => diagnostic.declaration !== 'classification',
-    );
-    for (const diagnostic of declarationDiagnostics) {
+    for (const diagnostic of declarations.diagnostics) {
         console.warn(
-            `[release-safety-declarations] ${formatChangeDeclarationDiagnostic(diagnostic)}`,
+            `[release-safety-declarations] ${diagnostic.file}:${diagnostic.line} ${diagnostic.message}`,
         );
     }
 
@@ -572,7 +561,11 @@ export async function generateReleaseSafety(
             log: (m) => console.warn(`[sql-lint] ${m}`),
         });
         lintFindings = r.findings;
-        sqlLint = { ran: r.ran, breaking: r.breaking, findings: renderFindings(r.findings) };
+        sqlLint = {
+            ran: r.ran,
+            breaking: r.breaking,
+            findings: renderFindings(r.findings),
+        };
         console.warn(
             `[release-safety] SQL linter: ${r.breaking ? `BREAKING (${r.findings.length} finding(s))` : 'no breaking shapes found'}`,
         );
@@ -609,7 +602,9 @@ export async function generateReleaseSafety(
             log: (m) => console.warn(`[rest-api-diff] ${m}`),
         });
     } else if (args.restFromTag) {
-        console.warn('[release-safety] --rest-from-tag needs a previous tag; api.rest stays unchecked');
+        console.warn(
+            '[release-safety] --rest-from-tag needs a previous tag; api.rest stays unchecked',
+        );
     } else if (args.restFromRefs && args.lastTag) {
         restApi = diffRestApi({
             lastTag: args.lastTag,
@@ -617,9 +612,13 @@ export async function generateReleaseSafety(
             log: (m) => console.warn(`[rest-api-diff] ${m}`),
         });
     } else if (args.restFromRefs) {
-        console.warn('[release-safety] --rest-from-refs needs a previous tag; api.rest stays unchecked');
+        console.warn(
+            '[release-safety] --rest-from-refs needs a previous tag; api.rest stays unchecked',
+        );
     } else {
-        console.warn('[release-safety] no REST spec source given; api.rest stays unchecked');
+        console.warn(
+            '[release-safety] no REST spec source given; api.rest stays unchecked',
+        );
     }
 
     // P3: deterministic MCP tool-surface diff (committed snapshot between tags).
@@ -639,7 +638,9 @@ export async function generateReleaseSafety(
             log: (m) => console.warn(`[mcp-tools-diff] ${m}`),
         });
     } else {
-        console.warn('[release-safety] no MCP snapshot source given; api.mcp stays unchecked');
+        console.warn(
+            '[release-safety] no MCP snapshot source given; api.mcp stays unchecked',
+        );
     }
 
     // P6: gated AI rolling-update review — the VALIDATION layer over the
@@ -662,9 +663,13 @@ export async function generateReleaseSafety(
     if (wantAiReview && markerEnabled && reviewable && args.lastTag) {
         const apiKey = process.env.ANTHROPIC_API_KEY;
         if (!apiKey) {
-            console.warn('[release-safety] --ai-review requested but ANTHROPIC_API_KEY not set; rollingUpdateSafe stays "unknown"');
+            console.warn(
+                '[release-safety] --ai-review requested but ANTHROPIC_API_KEY not set; rollingUpdateSafe stays "unknown"',
+            );
         } else {
-            console.warn('[release-safety] running AI rolling-update review...');
+            console.warn(
+                '[release-safety] running AI rolling-update review...',
+            );
             const r = await aiRollingUpdateReview({
                 apiKey,
                 lastTag: args.lastTag,
@@ -688,7 +693,9 @@ export async function generateReleaseSafety(
                     `[release-safety] AI verdict: ${r.modelVerdict}/${r.confidence} (${r.toolCalls} tool calls) -> rollingUpdateSafe=${JSON.stringify(r.rollingUpdateSafe)}`,
                 );
             } else {
-                console.warn('[release-safety] AI review degraded; rollingUpdateSafe stays "unknown"');
+                console.warn(
+                    '[release-safety] AI review degraded; rollingUpdateSafe stays "unknown"',
+                );
             }
         }
     }
@@ -699,9 +706,20 @@ export async function generateReleaseSafety(
     // safe) upgrade floor than the conservative previousVersion. Best-effort;
     // null stays conservative.
     let expandContractFloor: string | null = null;
-    if (sqlLint?.breaking && aiReview?.rollingUpdateSafe === true && args.lastTag) {
+    if (
+        sqlLint?.breaking &&
+        aiReview?.rollingUpdateSafe === true &&
+        args.lastTag
+    ) {
         const objects = lintFindings
-            .filter((f) => ['drop-column', 'rename-column', 'drop-table', 'rename-table'].includes(f.rule))
+            .filter((f) =>
+                [
+                    'drop-column',
+                    'rename-column',
+                    'drop-table',
+                    'rename-table',
+                ].includes(f.rule),
+            )
             .map((f) => f.object)
             .filter((o): o is string => Boolean(o));
         if (objects.length > 0) {
@@ -711,7 +729,9 @@ export async function generateReleaseSafety(
                 log: (m) => console.warn(`[expand-version] ${m}`),
             });
             if (expandContractFloor) {
-                console.warn(`[release-safety] expand version traced: minPreviousVersion -> ${expandContractFloor}`);
+                console.warn(
+                    `[release-safety] expand version traced: minPreviousVersion -> ${expandContractFloor}`,
+                );
             }
         }
     }
@@ -742,8 +762,8 @@ export async function generateReleaseSafety(
         migrations,
         migrationDetails: migrationMetadata.migrations,
         migrationMetadataComplete: migrationMetadata.complete,
-        declarationMetadataComplete: declarationDiagnostics.length === 0,
-        declaredBreaks: declarations.breaking,
+        declarationMetadataComplete: declarations.diagnostics.length === 0,
+        declaredBreaks: declarations.added,
         config,
         aiReview,
         sqlLint,
@@ -770,7 +790,11 @@ export async function generateReleaseSafety(
         previousVersion: args.previousVersion,
     });
     if (markerEnabled && ownFloor) {
-        const wrote = recordDerivedFloor(args.overrides, args.version, ownFloor);
+        const wrote = recordDerivedFloor(
+            args.overrides,
+            args.version,
+            ownFloor,
+        );
         console.warn(
             wrote
                 ? `[release-safety] recorded upgrade floor in ${args.overrides}: ${args.version} -> minPreviousVersion ${ownFloor}`

--- a/scripts/release-safety-contract.ts
+++ b/scripts/release-safety-contract.ts
@@ -1,4 +1,4 @@
-import type { BreakingChangeDeclaration } from './breaking-change-declarations';
+import type { BreakingChangeDeclaration } from './release-safety-declarations';
 import type { ConfigSurface } from './release-safety-config-diff';
 import type { MigrationDetail } from './release-safety-migrations';
 

--- a/scripts/release-safety-declarations.schema.json
+++ b/scripts/release-safety-declarations.schema.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://lightdash.com/schemas/release-safety-declarations/v1.json",
+    "title": "Lightdash release-safety breaking change declarations",
+    "description": "Append-only breaking change declarations. A declaration is active only in a Git range that adds its stable ID.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["declarations"],
+    "properties": {
+        "$schema": { "type": "string" },
+        "declarations": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#/definitions/declaration" }
+        }
+    },
+    "definitions": {
+        "declaration": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["reason", "requiredStop"],
+            "properties": {
+                "reason": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Operator-facing explanation of what breaks and for whom."
+                },
+                "requiredStop": {
+                    "type": "boolean",
+                    "description": "True when operators must land on the release that consumes this declaration."
+                },
+                "migration": {
+                    "type": "string",
+                    "pattern": "^packages/backend/src/(ee/)?database/migrations/[0-9]{14}[^/]*\\.ts$",
+                    "description": "Migration path that this declaration acknowledges. Omit for API and type breaks."
+                },
+                "releasedIn": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Optional documentation stamp. Activation never depends on this value."
+                }
+            }
+        }
+    }
+}

--- a/scripts/release-safety-declarations.test.ts
+++ b/scripts/release-safety-declarations.test.ts
@@ -1,0 +1,246 @@
+import Ajv from 'ajv';
+import * as assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    collectBreakingChangeDeclarationsBetweenRefs,
+    diffBreakingChangeDeclarations,
+} from './release-safety-declarations';
+
+let passed = 0;
+const failures: string[] = [];
+
+function test(name: string, run: () => void): void {
+    try {
+        run();
+        passed += 1;
+    } catch (error) {
+        failures.push(
+            `${name}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+}
+
+const registry = (
+    declarations: Record<string, Record<string, unknown>>,
+): string => JSON.stringify({ declarations });
+
+const first = {
+    reason: 'Existing API clients still use the removed request field.',
+    requiredStop: false,
+};
+
+test('an ID added in a range is active', () => {
+    const result = diffBreakingChangeDeclarations(
+        registry({}),
+        registry({ 'remove-request-field': first }),
+    );
+    assert.deepStrictEqual(result.diagnostics, []);
+    assert.deepStrictEqual(result.added, [
+        { id: 'remove-request-field', ...first },
+    ]);
+});
+
+test('a stale declaration is not collected by a later range', () => {
+    const source = registry({ 'remove-request-field': first });
+    assert.deepStrictEqual(diffBreakingChangeDeclarations(source, source), {
+        added: [],
+        diagnostics: [],
+    });
+});
+
+test('a stacked PR does not collect an entry already present at its base', () => {
+    const base = registry({ 'remove-request-field': first });
+    const target = registry({
+        'remove-request-field': first,
+        'second-break': {
+            reason: 'Older workers cannot read the new job payload.',
+            requiredStop: true,
+        },
+    });
+    assert.deepStrictEqual(
+        diffBreakingChangeDeclarations(base, target).added.map(({ id }) => id),
+        ['second-break'],
+    );
+});
+
+test('editing a reason is an append-only violation and does not reactivate it', () => {
+    const result = diffBreakingChangeDeclarations(
+        registry({ 'remove-request-field': first }),
+        registry({
+            'remove-request-field': {
+                ...first,
+                reason: 'Changed reason text must use another ID.',
+            },
+        }),
+    );
+    assert.deepStrictEqual(result.added, []);
+    assert.ok(
+        result.diagnostics.some(({ message }) => message.includes('changed')),
+    );
+});
+
+test('renaming an ID fails as removal and duplicate content', () => {
+    const result = diffBreakingChangeDeclarations(
+        registry({ 'remove-request-field': first }),
+        registry({ 'renamed-request-field': first }),
+    );
+    assert.deepStrictEqual(result.added, []);
+    assert.ok(
+        result.diagnostics.some(({ message }) => message.includes('removed')),
+    );
+    assert.ok(
+        result.diagnostics.some(({ message }) =>
+            message.includes('duplicates'),
+        ),
+    );
+});
+
+test('adding duplicate content from the base ref is rejected', () => {
+    const result = diffBreakingChangeDeclarations(
+        registry({ 'remove-request-field': first }),
+        registry({
+            'remove-request-field': first,
+            'duplicate-request-field': first,
+        }),
+    );
+    assert.deepStrictEqual(result.added, []);
+    assert.ok(
+        result.diagnostics.some(({ message }) =>
+            message.includes('duplicates'),
+        ),
+    );
+});
+
+test('deleting an entry fails closed', () => {
+    const result = diffBreakingChangeDeclarations(
+        registry({ 'remove-request-field': first }),
+        registry({}),
+    );
+    assert.deepStrictEqual(result.added, []);
+    assert.ok(
+        result.diagnostics.some(({ message }) => message.includes('removed')),
+    );
+});
+
+test('a release documentation stamp does not reactivate an ID', () => {
+    const result = diffBreakingChangeDeclarations(
+        registry({ 'remove-request-field': first }),
+        registry({
+            'remove-request-field': { ...first, releasedIn: '1.198.0' },
+        }),
+    );
+    assert.deepStrictEqual(result, { added: [], diagnostics: [] });
+});
+
+test('an existing release documentation stamp is immutable', () => {
+    const result = diffBreakingChangeDeclarations(
+        registry({
+            'remove-request-field': { ...first, releasedIn: '1.198.0' },
+        }),
+        registry({
+            'remove-request-field': { ...first, releasedIn: '1.199.0' },
+        }),
+    );
+    assert.deepStrictEqual(result.added, []);
+    assert.ok(
+        result.diagnostics.some(({ message }) => message.includes('changed')),
+    );
+});
+
+test('migration entries retain their migration path', () => {
+    const migration =
+        'packages/backend/src/database/migrations/20260819000000_break.ts';
+    const result = diffBreakingChangeDeclarations(
+        registry({}),
+        registry({
+            'migration-break': {
+                ...first,
+                migration,
+            },
+        }),
+    );
+    assert.strictEqual(result.added[0]?.migration, migration);
+});
+
+test('the committed registry matches its schema', () => {
+    const schema = JSON.parse(
+        readFileSync(
+            join(__dirname, 'release-safety-declarations.schema.json'),
+            'utf8',
+        ),
+    ) as Record<string, unknown>;
+    const value = JSON.parse(
+        readFileSync(
+            join(__dirname, '..', 'release-safety.declarations.json'),
+            'utf8',
+        ),
+    );
+    const validate = new Ajv({ strict: false }).compile(schema);
+    assert.strictEqual(validate(value), true, JSON.stringify(validate.errors));
+});
+
+test('release and PR endpoint ranges activate the same ID after a squash', () => {
+    const directory = mkdtempSync(
+        join(tmpdir(), 'release-safety-declarations-'),
+    );
+    const previousCwd = process.cwd();
+    try {
+        execFileSync('git', ['init', '--quiet'], { cwd: directory });
+        execFileSync('git', ['config', 'user.email', 'test@lightdash.com'], {
+            cwd: directory,
+        });
+        execFileSync('git', ['config', 'user.name', 'Release Safety Test'], {
+            cwd: directory,
+        });
+        const file = join(directory, 'release-safety.declarations.json');
+        writeFileSync(file, registry({}));
+        execFileSync('git', ['add', 'release-safety.declarations.json'], {
+            cwd: directory,
+        });
+        execFileSync('git', ['commit', '--quiet', '-m', 'base'], {
+            cwd: directory,
+        });
+        execFileSync('git', ['update-ref', 'refs/tags/last-release', 'HEAD'], {
+            cwd: directory,
+        });
+        const mergeBase = execFileSync('git', ['rev-parse', 'HEAD'], {
+            cwd: directory,
+            encoding: 'utf8',
+        }).trim();
+        writeFileSync(file, registry({ 'remove-request-field': first }));
+        execFileSync('git', ['add', 'release-safety.declarations.json'], {
+            cwd: directory,
+        });
+        execFileSync('git', ['commit', '--quiet', '-m', 'squashed change'], {
+            cwd: directory,
+        });
+        process.chdir(directory);
+        const releaseRange = collectBreakingChangeDeclarationsBetweenRefs(
+            'last-release',
+            'HEAD',
+        );
+        const prRange = collectBreakingChangeDeclarationsBetweenRefs(
+            mergeBase,
+            'HEAD',
+        );
+        assert.deepStrictEqual(releaseRange, prRange);
+        assert.deepStrictEqual(
+            releaseRange.added.map(({ id }) => id),
+            ['remove-request-field'],
+        );
+    } finally {
+        process.chdir(previousCwd);
+        rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+if (failures.length > 0) {
+    console.error(`\n❌ ${failures.length} failed, ${passed} passed:\n`);
+    for (const failure of failures) console.error(`  - ${failure}`);
+    process.exit(1);
+}
+
+console.log(`✅ ${passed} tests passed`);

--- a/scripts/release-safety-declarations.ts
+++ b/scripts/release-safety-declarations.ts
@@ -1,0 +1,303 @@
+import { execFileSync } from 'child_process';
+
+export const DEFAULT_DECLARATIONS_PATH = 'release-safety.declarations.json';
+
+export interface BreakingChangeDeclarationEntry {
+    reason: string;
+    requiredStop: boolean;
+    migration?: string;
+    releasedIn?: string;
+}
+
+export interface BreakingChangeDeclaration extends BreakingChangeDeclarationEntry {
+    id: string;
+}
+
+export interface BreakingChangeDeclarationsFile {
+    $schema?: string;
+    declarations: Record<string, BreakingChangeDeclarationEntry>;
+}
+
+export interface BreakingChangeDeclarationDiagnostic {
+    file: string;
+    line: number;
+    message: string;
+}
+
+export interface BreakingChangeDeclarationDiff {
+    added: BreakingChangeDeclaration[];
+    diagnostics: BreakingChangeDeclarationDiagnostic[];
+}
+
+const allowedRootKeys = new Set(['$schema', 'declarations']);
+const allowedEntryKeys = new Set([
+    'reason',
+    'requiredStop',
+    'migration',
+    'releasedIn',
+]);
+const migrationPath =
+    /^packages\/backend\/src\/(ee\/)?database\/migrations\/\d{14}_.+\.(ts|js)$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function emptyDeclarations(): BreakingChangeDeclarationsFile {
+    return { declarations: {} };
+}
+
+export function parseBreakingChangeDeclarationsFile(
+    source: string | null,
+    file = DEFAULT_DECLARATIONS_PATH,
+): {
+    value: BreakingChangeDeclarationsFile;
+    diagnostics: BreakingChangeDeclarationDiagnostic[];
+} {
+    if (source === null) return { value: emptyDeclarations(), diagnostics: [] };
+
+    const diagnostics: BreakingChangeDeclarationDiagnostic[] = [];
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(source);
+    } catch (error) {
+        return {
+            value: emptyDeclarations(),
+            diagnostics: [
+                {
+                    file,
+                    line: 1,
+                    message: `registry is not valid JSON: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                },
+            ],
+        };
+    }
+
+    if (!isRecord(parsed)) {
+        return {
+            value: emptyDeclarations(),
+            diagnostics: [
+                {
+                    file,
+                    line: 1,
+                    message: 'registry root must be an object',
+                },
+            ],
+        };
+    }
+
+    for (const key of Object.keys(parsed)) {
+        if (!allowedRootKeys.has(key)) {
+            diagnostics.push({
+                file,
+                line: 1,
+                message: `registry has unsupported property ${JSON.stringify(key)}`,
+            });
+        }
+    }
+
+    if (!isRecord(parsed.declarations)) {
+        diagnostics.push({
+            file,
+            line: 1,
+            message: 'registry.declarations must be an object',
+        });
+        return { value: emptyDeclarations(), diagnostics };
+    }
+
+    const declarations: Record<string, BreakingChangeDeclarationEntry> = {};
+    for (const [id, rawEntry] of Object.entries(parsed.declarations)) {
+        const where = `registry.declarations[${JSON.stringify(id)}]`;
+        if (id.trim().length === 0) {
+            diagnostics.push({
+                file,
+                line: 1,
+                message: 'registry declaration IDs must not be empty',
+            });
+            continue;
+        }
+        if (!isRecord(rawEntry)) {
+            diagnostics.push({
+                file,
+                line: 1,
+                message: `${where} must be an object`,
+            });
+            continue;
+        }
+        for (const key of Object.keys(rawEntry)) {
+            if (!allowedEntryKeys.has(key)) {
+                diagnostics.push({
+                    file,
+                    line: 1,
+                    message: `${where} has unsupported property ${JSON.stringify(key)}`,
+                });
+            }
+        }
+        if (
+            typeof rawEntry.reason !== 'string' ||
+            rawEntry.reason.trim().length === 0
+        ) {
+            diagnostics.push({
+                file,
+                line: 1,
+                message: `${where}.reason must be a non-empty string`,
+            });
+        }
+        if (typeof rawEntry.requiredStop !== 'boolean') {
+            diagnostics.push({
+                file,
+                line: 1,
+                message: `${where}.requiredStop must be a boolean`,
+            });
+        }
+        if (
+            rawEntry.migration !== undefined &&
+            (typeof rawEntry.migration !== 'string' ||
+                !migrationPath.test(rawEntry.migration))
+        ) {
+            diagnostics.push({
+                file,
+                line: 1,
+                message: `${where}.migration must be a release-safety migration path`,
+            });
+        }
+        if (
+            rawEntry.releasedIn !== undefined &&
+            (typeof rawEntry.releasedIn !== 'string' ||
+                rawEntry.releasedIn.trim().length === 0)
+        ) {
+            diagnostics.push({
+                file,
+                line: 1,
+                message: `${where}.releasedIn must be a non-empty string`,
+            });
+        }
+        if (
+            typeof rawEntry.reason === 'string' &&
+            rawEntry.reason.trim().length > 0 &&
+            typeof rawEntry.requiredStop === 'boolean' &&
+            (rawEntry.migration === undefined ||
+                (typeof rawEntry.migration === 'string' &&
+                    migrationPath.test(rawEntry.migration))) &&
+            (rawEntry.releasedIn === undefined ||
+                (typeof rawEntry.releasedIn === 'string' &&
+                    rawEntry.releasedIn.trim().length > 0))
+        ) {
+            declarations[id] = {
+                reason: rawEntry.reason,
+                requiredStop: rawEntry.requiredStop,
+                ...(rawEntry.migration === undefined
+                    ? {}
+                    : { migration: rawEntry.migration }),
+                ...(rawEntry.releasedIn === undefined
+                    ? {}
+                    : { releasedIn: rawEntry.releasedIn }),
+            };
+        }
+    }
+
+    return { value: { declarations }, diagnostics };
+}
+
+function immutableEntry(entry: BreakingChangeDeclarationEntry): object {
+    return {
+        reason: entry.reason,
+        requiredStop: entry.requiredStop,
+        migration: entry.migration ?? null,
+    };
+}
+
+export function diffBreakingChangeDeclarations(
+    baseSource: string | null,
+    targetSource: string | null,
+    file = DEFAULT_DECLARATIONS_PATH,
+): BreakingChangeDeclarationDiff {
+    const base = parseBreakingChangeDeclarationsFile(baseSource, file);
+    const target = parseBreakingChangeDeclarationsFile(targetSource, file);
+    const diagnostics = [...base.diagnostics, ...target.diagnostics];
+    const added: BreakingChangeDeclaration[] = [];
+
+    for (const [id, baseEntry] of Object.entries(base.value.declarations)) {
+        const targetEntry = target.value.declarations[id];
+        if (!targetEntry) {
+            diagnostics.push({
+                file,
+                line: 1,
+                message: `declaration ${JSON.stringify(id)} was removed; declaration IDs are append-only`,
+            });
+            continue;
+        }
+        if (
+            JSON.stringify(immutableEntry(baseEntry)) !==
+                JSON.stringify(immutableEntry(targetEntry)) ||
+            (baseEntry.releasedIn !== undefined &&
+                baseEntry.releasedIn !== targetEntry.releasedIn)
+        ) {
+            diagnostics.push({
+                file,
+                line: 1,
+                message: `declaration ${JSON.stringify(id)} changed; add a new ID for a new breaking change`,
+            });
+        }
+    }
+
+    const baseContent = new Map<string, string>();
+    for (const [id, entry] of Object.entries(base.value.declarations)) {
+        baseContent.set(
+            JSON.stringify({
+                reason: entry.reason,
+                requiredStop: entry.requiredStop,
+            }),
+            id,
+        );
+    }
+    for (const [id, entry] of Object.entries(target.value.declarations)) {
+        if (base.value.declarations[id]) continue;
+        const duplicateId = baseContent.get(
+            JSON.stringify({
+                reason: entry.reason,
+                requiredStop: entry.requiredStop,
+            }),
+        );
+        if (duplicateId) {
+            diagnostics.push({
+                file,
+                line: 1,
+                message: `declaration ${JSON.stringify(id)} duplicates ${JSON.stringify(duplicateId)} from the base ref`,
+            });
+            continue;
+        }
+        added.push({ id, ...entry });
+    }
+
+    return {
+        added: added.sort((left, right) => left.id.localeCompare(right.id)),
+        diagnostics,
+    };
+}
+
+function readFileAtRef(ref: string, file: string): string | null {
+    try {
+        return execFileSync('git', ['show', `${ref}:${file}`], {
+            encoding: 'utf8',
+            maxBuffer: 16 * 1024 * 1024,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+    } catch {
+        return null;
+    }
+}
+
+export function collectBreakingChangeDeclarationsBetweenRefs(
+    baseRef: string,
+    targetRef: string,
+    file = DEFAULT_DECLARATIONS_PATH,
+): BreakingChangeDeclarationDiff {
+    return diffBreakingChangeDeclarations(
+        readFileAtRef(baseRef, file),
+        readFileAtRef(targetRef, file),
+        file,
+    );
+}

--- a/scripts/release-safety-notes.test.ts
+++ b/scripts/release-safety-notes.test.ts
@@ -55,10 +55,11 @@ const marker: ReleaseSafetyMarker = {
     },
     declaredBreaks: [
         {
-            file: 'packages/backend/src/database/migrations/20260810000000_users.ts',
-            line: 4,
+            id: 'coordinated-users-rollout',
             reason: 'requires a coordinated rollout',
             requiredStop: true,
+            migration:
+                'packages/backend/src/database/migrations/20260810000000_users.ts',
         },
     ],
 };

--- a/scripts/release-safety-notes.ts
+++ b/scripts/release-safety-notes.ts
@@ -29,8 +29,11 @@ export function renderReleaseSafetyNotes(
     if (marker.declaredBreaks.length > 0) {
         lines.push('', 'Declared breaking changes:');
         for (const declaredBreak of marker.declaredBreaks) {
+            const migration = declaredBreak.migration
+                ? ` (${declaredBreak.migration})`
+                : '';
             lines.push(
-                `- \`${declaredBreak.file}:${declaredBreak.line}\`: ${declaredBreak.reason}${declaredBreak.requiredStop ? ' (required stop)' : ''}`,
+                `- \`${declaredBreak.id}\`${migration}: ${declaredBreak.reason}${declaredBreak.requiredStop ? ' (required stop)' : ''}`,
             );
         }
     }

--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -99,8 +99,7 @@ test('a false declaration-only verdict explains the declared compatibility break
             },
             declaredBreaks: [
                 {
-                    file: 'packages/backend/src/changes.ts',
-                    line: 77,
+                    id: 'old-request-field-names',
                     reason: 'Existing API clients still rely on old request field names.',
                     requiredStop: false,
                 },
@@ -124,14 +123,12 @@ test('the declaration breaks row shows every reason and marks required stops', (
             },
             declaredBreaks: [
                 {
-                    file: 'packages/backend/src/a.ts',
-                    line: 12,
+                    id: 'first-break',
                     reason: 'first reason',
                     requiredStop: false,
                 },
                 {
-                    file: 'packages/backend/src/b.ts',
-                    line: 34,
+                    id: 'second-break',
                     reason: 'second reason',
                     requiredStop: true,
                 },
@@ -157,8 +154,7 @@ test('declaration reasons are escaped for markdown table rendering', () => {
             },
             declaredBreaks: [
                 {
-                    file: 'packages/backend/src/c.ts',
-                    line: 88,
+                    id: 'markdown-break',
                     reason: 'line with pipe | and newline\nin declaration',
                     requiredStop: false,
                 },

--- a/scripts/release-safety-pr-gate.test.ts
+++ b/scripts/release-safety-pr-gate.test.ts
@@ -1,5 +1,10 @@
 import * as assert from 'assert';
+import type {
+    BreakingChangeDeclaration,
+    BreakingChangeDeclarationDiff,
+} from './release-safety-declarations';
 import {
+    detectLegacyInlineBreakingDeclarations,
     evaluateReleaseSafetyGate,
     ReleaseSafetyGateMarker,
 } from './release-safety-pr-gate';
@@ -27,37 +32,43 @@ function marker(rest: boolean, mcp: boolean): ReleaseSafetyGateMarker {
     };
 }
 
-const declaration =
-    "export const breaking = { reason: 'Existing clients require a staged rollout', requiredStop: false };";
-const backendSource = 'packages/backend/src/controllers/example.ts';
-const commonSource = 'packages/common/src/types/example.ts';
-const migrationSource =
-    'packages/backend/src/database/migrations/20260810120000_example.ts';
 const markerPath = '/tmp/release-safety.json';
+const declaration: BreakingChangeDeclaration = {
+    id: 'remove-request-field',
+    reason: 'Existing clients require a staged rollout.',
+    requiredStop: false,
+};
+
+function changes(
+    added: BreakingChangeDeclaration[] = [],
+    diagnostics: BreakingChangeDeclarationDiff['diagnostics'] = [],
+): BreakingChangeDeclarationDiff {
+    return { added, diagnostics };
+}
 
 function evaluate(
     releaseMarker: ReleaseSafetyGateMarker,
-    changedFiles: string[],
-    sources: Record<string, string> = {},
+    declarationChanges: BreakingChangeDeclarationDiff = changes(),
+    inlineDeclarationDiagnostics: ReturnType<
+        typeof detectLegacyInlineBreakingDeclarations
+    > = [],
 ) {
     return evaluateReleaseSafetyGate({
         marker: releaseMarker,
         markerPath,
-        changedFiles,
-        readFile: (file) => sources[file] ?? '',
+        declarationChanges,
+        inlineDeclarationDiagnostics,
     });
 }
 
-test('breaking REST without a declaration fails', () => {
-    const diagnostics = evaluate(marker(true, false), [backendSource]);
-    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'error'));
+test('breaking REST without a new declaration fails', () => {
+    const diagnostics = evaluate(marker(true, false));
+    assert.ok(diagnostics.some(({ level }) => level === 'error'));
     assert.ok(
-        diagnostics.some((diagnostic) =>
-            diagnostic.message.includes('breaking REST'),
-        ),
+        diagnostics.some(({ message }) => message.includes('breaking REST')),
     );
-    const decisionBrief = diagnostics.find((diagnostic) =>
-        diagnostic.message.includes('BREAKING-CHANGE DECISION BRIEF'),
+    const decisionBrief = diagnostics.find(({ message }) =>
+        message.includes('BREAKING-CHANGE DECISION BRIEF'),
     );
     assert.ok(decisionBrief?.message.includes(`${markerPath}:1`));
     assert.ok(
@@ -70,79 +81,42 @@ test('breaking REST without a declaration fails', () => {
             'declare — flips this release to not-rolling-safe, advises Recreate to every self-hosted customer',
         ),
     );
-    assert.ok(
-        decisionBrief?.message.includes(
-            'Declaring is a product decision — confirm with a human before adding this export.',
-        ),
-    );
 });
 
-test('breaking REST with a valid changed declaration passes', () => {
+test('breaking REST with a valid added declaration passes', () => {
     assert.deepStrictEqual(
-        evaluate(marker(true, false), [backendSource], {
-            [backendSource]: declaration,
-        }),
+        evaluate(marker(true, false), changes([declaration])),
         [],
     );
 });
 
-test('breaking MCP without a declaration fails', () => {
-    const diagnostics = evaluate(marker(false, true), [commonSource]);
-    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'error'));
-    assert.ok(
-        diagnostics.some((diagnostic) =>
-            diagnostic.message.includes('breaking MCP'),
-        ),
-    );
-});
-
-test('breaking MCP with a valid changed declaration passes', () => {
+test('breaking MCP with a valid added declaration passes', () => {
     assert.deepStrictEqual(
-        evaluate(marker(false, true), [commonSource], {
-            [commonSource]: declaration,
-        }),
+        evaluate(marker(false, true), changes([declaration])),
         [],
     );
 });
 
-test('one declaration covers simultaneous REST and MCP breaks', () => {
+test('one added declaration covers simultaneous REST and MCP breaks', () => {
     assert.deepStrictEqual(
-        evaluate(marker(true, true), [backendSource], {
-            [backendSource]: declaration,
-        }),
+        evaluate(marker(true, true), changes([declaration])),
         [],
     );
 });
 
 test('a migration declaration is excluded from API coverage', () => {
-    const diagnostics = evaluate(marker(true, false), [migrationSource], {
-        [migrationSource]: declaration,
-    });
-    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'warning'));
-    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'error'));
-    assert.ok(diagnostics.every((diagnostic) => diagnostic.file.length > 0));
-});
-
-test('a malformed breaking declaration fails actionably', () => {
-    const diagnostics = evaluate(marker(false, true), [backendSource], {
-        [backendSource]:
-            "export const breaking = { reason: '', requiredStop: 'sometimes' };",
-    });
-    assert.ok(
-        diagnostics.some(
-            (diagnostic) =>
-                diagnostic.level === 'error' &&
-                diagnostic.file === backendSource,
-        ),
+    const diagnostics = evaluate(
+        marker(true, false),
+        changes([
+            {
+                ...declaration,
+                migration:
+                    'packages/backend/src/database/migrations/20260810120000_example.ts',
+            },
+        ]),
     );
-    assert.ok(
-        diagnostics.some((diagnostic) => diagnostic.message.includes('reason')),
-    );
-    assert.ok(
-        diagnostics.some((diagnostic) =>
-            diagnostic.message.includes('requiredStop'),
-        ),
-    );
+    assert.ok(diagnostics.some(({ level }) => level === 'warning'));
+    assert.ok(diagnostics.some(({ level }) => level === 'error'));
 });
 
 test('hollow declaration reasons do not satisfy the API gate', () => {
@@ -155,18 +129,19 @@ test('hollow declaration reasons do not satisfy the API gate', () => {
         '<operator-facing reason>',
     ];
     for (const reason of hollowReasons) {
-        const diagnostics = evaluate(marker(false, true), [backendSource], {
-            [backendSource]: `export const breaking = { reason: '${reason}', requiredStop: false };`,
-        });
+        const diagnostics = evaluate(
+            marker(false, true),
+            changes([{ ...declaration, reason }]),
+        );
         assert.ok(
-            diagnostics.some((diagnostic) =>
-                diagnostic.message.includes('describe what breaks and for whom'),
+            diagnostics.some(({ message }) =>
+                message.includes('describe what breaks and for whom'),
             ),
             `expected hollow reason to fail: ${JSON.stringify(reason)}`,
         );
         assert.ok(
-            diagnostics.some((diagnostic) =>
-                diagnostic.message.includes('BREAKING-CHANGE DECISION BRIEF'),
+            diagnostics.some(({ message }) =>
+                message.includes('BREAKING-CHANGE DECISION BRIEF'),
             ),
         );
     }
@@ -174,50 +149,91 @@ test('hollow declaration reasons do not satisfy the API gate', () => {
 
 test('a substantive declaration reason satisfies the API gate', () => {
     assert.deepStrictEqual(
-        evaluate(marker(true, false), [backendSource], {
-            [backendSource]:
-                "export const breaking = { reason: 'Existing API clients still send the removed request field.', requiredStop: false };",
-        }),
+        evaluate(
+            marker(true, false),
+            changes([
+                {
+                    ...declaration,
+                    reason: 'Existing API clients still send the removed request field.',
+                },
+            ]),
+        ),
         [],
     );
+});
+
+test('a spent declaration does not satisfy a later API gate', () => {
+    const diagnostics = evaluate(marker(true, false), changes());
+    assert.ok(
+        diagnostics.some(({ message }) =>
+            message.includes('BREAKING-CHANGE DECISION BRIEF'),
+        ),
+    );
+});
+
+test('registry violations fail before a clean API early return', () => {
+    const diagnostics = evaluate(
+        marker(false, false),
+        changes(
+            [],
+            [
+                {
+                    file: 'release-safety.declarations.json',
+                    line: 1,
+                    message: 'declaration "old-break" was removed',
+                },
+            ],
+        ),
+    );
+    assert.deepStrictEqual(diagnostics, [
+        {
+            level: 'error',
+            file: 'release-safety.declarations.json',
+            line: 1,
+            message: 'declaration "old-break" was removed',
+        },
+    ]);
+});
+
+test('a changed legacy inline declaration fails a clean API gate', () => {
+    const inlineDeclarationDiagnostics = detectLegacyInlineBreakingDeclarations(
+        [
+            {
+                file: 'packages/backend/src/services/example.ts',
+                source: `export const breaking = { reason: 'Old workers still call this service.', requiredStop: false };`,
+            },
+            {
+                file: 'packages/common/src/example.test.ts',
+                source: `export const breaking = { reason: 'Test fixture.', requiredStop: false };`,
+            },
+            {
+                file: 'packages/backend/src/database/migrations/20260819000000_example.ts',
+                source: `export const breaking = { reason: 'Migration declaration.', requiredStop: false };`,
+            },
+            {
+                file: 'packages/common/src/comment.ts',
+                source: `// export const breaking = { reason: 'Comment.', requiredStop: false };`,
+            },
+        ],
+    );
+    const diagnostics = evaluate(
+        marker(false, false),
+        changes(),
+        inlineDeclarationDiagnostics,
+    );
+    assert.deepStrictEqual(diagnostics, [
+        {
+            level: 'error',
+            file: 'packages/backend/src/services/example.ts',
+            line: 1,
+            message:
+                'inline export const breaking is not supported; add a new stable ID to release-safety.declarations.json',
+        },
+    ]);
 });
 
 test('a clean marker requires no declaration', () => {
-    assert.deepStrictEqual(evaluate(marker(false, false), [backendSource]), []);
-});
-
-test('a clean marker ignores malformed breaking declaration text', () => {
-    assert.deepStrictEqual(
-        evaluate(marker(false, false), [backendSource], {
-            [backendSource]:
-                "export const breaking = { reason: '', requiredStop: 'sometimes' };",
-        }),
-        [],
-    );
-});
-
-test('a declaration in an untouched file does not satisfy the gate', () => {
-    const diagnostics = evaluate(marker(true, false), [commonSource], {
-        [backendSource]: declaration,
-        [commonSource]: 'export const value = 1;',
-    });
-    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'error'));
-});
-
-test('a declaration in a changed test file does not satisfy the gate', () => {
-    const testSource = 'packages/backend/src/controllers/example.test.ts';
-    const testsDirectorySource =
-        'packages/common/src/types/__tests__/example.ts';
-    const diagnostics = evaluate(
-        marker(true, false),
-        [backendSource, testSource, testsDirectorySource],
-        {
-            [backendSource]: 'export const value = 1;',
-            [testSource]: declaration,
-            [testsDirectorySource]: declaration,
-        },
-    );
-    assert.ok(diagnostics.some((diagnostic) => diagnostic.level === 'error'));
+    assert.deepStrictEqual(evaluate(marker(false, false)), []);
 });
 
 if (failures.length > 0) {

--- a/scripts/release-safety-pr-gate.ts
+++ b/scripts/release-safety-pr-gate.ts
@@ -1,14 +1,17 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
-import {
-    collectBreakingChangeDeclarations,
-    formatChangeDeclarationDiagnostic,
-} from './breaking-change-declarations';
+import { parseChangeDeclarations } from './breaking-change-declarations';
 import {
     breakingChangeDecisionBrief,
     hollowBreakingReasonMessage,
     isSubstantiveBreakingReason,
 } from './breaking-change-gate-policy';
+import {
+    collectBreakingChangeDeclarationsBetweenRefs,
+    DEFAULT_DECLARATIONS_PATH,
+} from './release-safety-declarations';
+import type { BreakingChangeDeclarationDiff } from './release-safety-declarations';
+import { isMigrationPath } from './release-safety-migrations';
 
 interface ApiSurface {
     checked: boolean;
@@ -33,18 +36,63 @@ export interface GateDiagnostic {
 export interface EvaluateReleaseSafetyGateInput {
     marker: ReleaseSafetyGateMarker;
     markerPath: string;
-    changedFiles: readonly string[];
-    readFile?: (path: string) => string;
+    declarationChanges: BreakingChangeDeclarationDiff;
+    inlineDeclarationDiagnostics?: readonly GateDiagnostic[];
 }
 
-const TYPESCRIPT_SOURCE = /^packages\/(backend|common)\/src\/.+\.tsx?$/;
-const TYPESCRIPT_TEST = /(^|\/)__tests__\/|\.(test|spec)\.tsx?$/;
-const MIGRATION_SOURCE =
-    /^packages\/backend\/src\/(ee\/)?database\/migrations\//;
+export interface ChangedSourceFile {
+    file: string;
+    source: string;
+}
+
+const SOURCE_ROOTS = ['packages/backend/src/', 'packages/common/src/'] as const;
+
+function isNonTestTypeScriptSource(file: string): boolean {
+    const normalized = file.replaceAll('\\', '/');
+    return (
+        SOURCE_ROOTS.some((root) => normalized.startsWith(root)) &&
+        /\.(?:ts|tsx)$/.test(normalized) &&
+        !/(^|\/)__tests__(\/|$)/.test(normalized) &&
+        !/\.(?:test|spec)\.(?:ts|tsx)$/.test(normalized) &&
+        !isMigrationPath(normalized)
+    );
+}
+
+export function detectLegacyInlineBreakingDeclarations(
+    sources: readonly ChangedSourceFile[],
+): GateDiagnostic[] {
+    const diagnostics: GateDiagnostic[] = [];
+    for (const source of sources) {
+        if (!isNonTestTypeScriptSource(source.file)) continue;
+        const parsed = parseChangeDeclarations(source.source, source.file);
+        const malformedInlineDeclaration = parsed.diagnostics.find(
+            (diagnostic) =>
+                diagnostic.declaration === 'breaking' &&
+                diagnostic.message.includes('export const breaking'),
+        );
+        const line = parsed.breaking?.line ?? malformedInlineDeclaration?.line;
+        if (line === undefined) continue;
+        diagnostics.push({
+            level: 'error',
+            file: source.file,
+            line,
+            message: `inline export const breaking is not supported; add a new stable ID to ${DEFAULT_DECLARATIONS_PATH}`,
+        });
+    }
+    return diagnostics;
+}
 
 export function evaluateReleaseSafetyGate(
     input: EvaluateReleaseSafetyGateInput,
 ): GateDiagnostic[] {
+    const diagnostics: GateDiagnostic[] =
+        input.declarationChanges.diagnostics.map((diagnostic) => ({
+            level: 'error',
+            file: diagnostic.file,
+            line: diagnostic.line,
+            message: diagnostic.message,
+        }));
+    diagnostics.push(...(input.inlineDeclarationDiagnostics ?? []));
     const breakingSurfaces = [
         input.marker.api.rest.checked && input.marker.api.rest.breaking === true
             ? 'REST'
@@ -54,65 +102,30 @@ export function evaluateReleaseSafetyGate(
             : null,
     ].filter((surface): surface is string => surface !== null);
 
-    if (breakingSurfaces.length === 0) return [];
+    if (breakingSurfaces.length === 0) return diagnostics;
 
-    const sourceFiles = input.changedFiles.filter(
-        (file) => TYPESCRIPT_SOURCE.test(file) && !TYPESCRIPT_TEST.test(file),
-    );
-    const declarations = collectBreakingChangeDeclarations(
-        sourceFiles,
-        input.readFile,
-    );
-    const diagnostics: GateDiagnostic[] = declarations.diagnostics
-        .filter((diagnostic) => diagnostic.declaration !== 'classification')
-        .map((diagnostic) => ({
-            level: 'error',
-            file: diagnostic.file,
-            line: diagnostic.line,
-            message: formatChangeDeclarationDiagnostic(diagnostic),
-        }));
-    for (const diagnostic of declarations.diagnostics) {
-        if (
-            diagnostic.declaration === 'breaking' &&
-            diagnostic.message.includes('breaking.reason must not be empty')
-        ) {
-            diagnostics.push({
-                level: 'error',
-                file: diagnostic.file,
-                line: diagnostic.line,
-                message: hollowBreakingReasonMessage(
-                    diagnostic.file,
-                    diagnostic.line,
-                ),
-            });
-        }
-    }
-
-    const migrationDeclarations = declarations.breaking.filter((declaration) =>
-        MIGRATION_SOURCE.test(declaration.file),
+    const migrationDeclarations = input.declarationChanges.added.filter(
+        (declaration) => declaration.migration !== undefined,
     );
     for (const declaration of migrationDeclarations) {
         diagnostics.push({
             level: 'warning',
-            file: declaration.file,
-            line: declaration.line,
-            message: `${declaration.file}:${declaration.line} migration breaking declarations do not cover API surface changes`,
+            file: DEFAULT_DECLARATIONS_PATH,
+            line: 1,
+            message: `migration declaration ${JSON.stringify(declaration.id)} does not cover API surface changes`,
         });
     }
 
-    const apiDeclarations = declarations.breaking.filter(
-        (declaration) => !MIGRATION_SOURCE.test(declaration.file),
+    const apiDeclarations = input.declarationChanges.added.filter(
+        (declaration) => declaration.migration === undefined,
     );
     const substantiveApiDeclarations = apiDeclarations.filter((declaration) => {
         if (isSubstantiveBreakingReason(declaration.reason)) return true;
         diagnostics.push({
             level: 'error',
-            file: declaration.file,
-            line: declaration.line,
-            message: hollowBreakingReasonMessage(
-                declaration.file,
-                declaration.line,
-            ),
+            file: DEFAULT_DECLARATIONS_PATH,
+            line: 1,
+            message: hollowBreakingReasonMessage(DEFAULT_DECLARATIONS_PATH, 1),
         });
         return false;
     });
@@ -125,23 +138,12 @@ export function evaluateReleaseSafetyGate(
                 file: input.markerPath,
                 line: 1,
                 pattern: `breaking ${breakingSurfaces.join(' and ')} API surface change`,
-                declarationLocation:
-                    'a changed non-migration TypeScript source file under packages/backend or packages/common as export const breaking = { reason: string, requiredStop: boolean }',
+                declarationLocation: `a new stable ID in ${DEFAULT_DECLARATIONS_PATH} with reason and requiredStop`,
             }),
         });
     }
 
     return diagnostics;
-}
-
-function changedFiles(baseSha: string): string[] {
-    return execFileSync(
-        'git',
-        ['diff', '--name-only', '--diff-filter=ACMR', baseSha, 'HEAD', '--'],
-        { encoding: 'utf8' },
-    )
-        .split('\n')
-        .filter(Boolean);
 }
 
 function argument(name: string): string | undefined {
@@ -168,6 +170,31 @@ function emit(diagnostic: GateDiagnostic): void {
     );
 }
 
+function changedSourceFiles(baseSha: string): ChangedSourceFile[] {
+    const paths = execFileSync(
+        'git',
+        [
+            'diff',
+            '--name-only',
+            '-z',
+            baseSha,
+            'HEAD',
+            '--',
+            'packages/backend/src',
+            'packages/common/src',
+        ],
+        { encoding: 'utf8' },
+    )
+        .split('\0')
+        .filter(Boolean)
+        .filter(isNonTestTypeScriptSource)
+        .filter((file) => fs.existsSync(file));
+    return paths.map((file) => ({
+        file,
+        source: fs.readFileSync(file, 'utf8'),
+    }));
+}
+
 function main(): void {
     const baseSha = argument('base-sha');
     const markerPath = argument('marker');
@@ -179,7 +206,13 @@ function main(): void {
     const diagnostics = evaluateReleaseSafetyGate({
         marker,
         markerPath,
-        changedFiles: changedFiles(baseSha),
+        declarationChanges: collectBreakingChangeDeclarationsBetweenRefs(
+            baseSha,
+            'HEAD',
+        ),
+        inlineDeclarationDiagnostics: detectLegacyInlineBreakingDeclarations(
+            changedSourceFiles(baseSha),
+        ),
     });
     diagnostics.forEach(emit);
     const errors = diagnostics.filter(

--- a/scripts/release-safety-workflow-shape.test.ts
+++ b/scripts/release-safety-workflow-shape.test.ts
@@ -38,7 +38,10 @@ assert.deepStrictEqual(
 // present only in the trigger-level list, which made `retract` unreachable for
 // every other watched path.
 for (const required of [
+    'release-safety.declarations.json',
     'scripts/breaking-change-declarations.ts',
+    'scripts/release-safety-declarations.ts',
+    'scripts/release-safety-declarations.schema.json',
     'scripts/release-safety-pr-gate.ts',
     'scripts/gen-release-safety.ts',
     'packages/backend/**',

--- a/scripts/release-safety.schema.json
+++ b/scripts/release-safety.schema.json
@@ -181,12 +181,13 @@
             "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["file", "line", "reason", "requiredStop"],
+                "required": ["id", "reason", "requiredStop"],
                 "properties": {
-                    "file": { "type": "string" },
-                    "line": { "type": "integer", "minimum": 1 },
+                    "id": { "type": "string", "minLength": 1 },
                     "reason": { "type": "string", "minLength": 1 },
-                    "requiredStop": { "type": "boolean" }
+                    "requiredStop": { "type": "boolean" },
+                    "migration": { "type": "string" },
+                    "releasedIn": { "type": "string", "minLength": 1 }
                 }
             }
         }

--- a/scripts/sql-migration-lint.test.ts
+++ b/scripts/sql-migration-lint.test.ts
@@ -12,6 +12,7 @@ import {
     evaluateMigrationSource,
     lintSource,
 } from './sql-migration-lint';
+import type { BreakingChangeDeclaration } from './release-safety-declarations';
 
 let passed = 0;
 const failures: string[] = [];
@@ -190,7 +191,16 @@ test('line comment does not hide nor over-trigger on the next line', () => {
     assert.deepStrictEqual(rules(src), []);
 });
 
-const enforcement = (source: string) => evaluateMigrationSource(source, 'migration.ts');
+const migrationDeclaration: BreakingChangeDeclaration = {
+    id: 'migration-break',
+    reason: 'Deployments running the prior backend still read users.legacy.',
+    requiredStop: false,
+    migration: 'migration.ts',
+};
+const enforcement = (
+    source: string,
+    declarations: BreakingChangeDeclaration[] = [],
+) => evaluateMigrationSource(source, 'migration.ts', declarations);
 const enforcementRules = (source: string, severity?: 'error' | 'warning'): string[] =>
     enforcement(source)
         .filter((finding) => severity === undefined || finding.severity === severity)
@@ -216,7 +226,7 @@ export async function down(knex) { await knex.schema.alterTable('users', table =
     );
     assert.ok(
         undeclared?.message.includes(
-            'Declaring is a product decision — confirm with a human before adding this export.',
+            'Declaring is a product decision — confirm with a human before adding a registry entry.',
         ),
     );
 });
@@ -231,10 +241,11 @@ test('hollow breaking reasons do not satisfy migration enforcement', () => {
         '<operator-facing reason>',
     ];
     for (const reason of hollowReasons) {
-        const source = `export const breaking = { reason: '${reason}', requiredStop: false };
-export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
+        const source = `export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
 export async function down(knex) { await knex.schema.alterTable('users', table => table.string('legacy')); }`;
-        const findings = enforcement(source);
+        const findings = enforcement(source, [
+            { ...migrationDeclaration, reason },
+        ]);
         assert.ok(
             findings.some(
                 (finding) =>
@@ -254,26 +265,27 @@ export async function down(knex) { await knex.schema.alterTable('users', table =
 });
 
 test('a substantive breaking reason satisfies migration enforcement', () => {
-    const source = `export const breaking = { reason: 'Deployments running the prior backend still read users.legacy.', requiredStop: false };
-export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
+    const source = `export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
 export async function down(knex) { await knex.schema.alterTable('users', table => table.string('legacy')); }`;
-    assert.ok(!enforcement(source).some((finding) => finding.severity === 'error'));
+    assert.ok(
+        !enforcement(source, [migrationDeclaration]).some(
+            (finding) => finding.severity === 'error',
+        ),
+    );
 });
 
 test('declared breaking behavior passes enforcement while preserving the legacy finding', () => {
-    const source = `export const breaking = { reason: 'old pods still read legacy', requiredStop: false };
-export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
+    const source = `export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
 export async function down(knex) { await knex.schema.alterTable('users', table => table.string('legacy')); }`;
-    const findings = enforcement(source);
+    const findings = enforcement(source, [migrationDeclaration]);
     assert.ok(findings.some((finding) => finding.rule === 'drop-column' && finding.severity === 'warning'));
     assert.ok(!findings.some((finding) => finding.severity === 'error'));
 });
 
 test('raw breaking SQL with a valid breaking declaration needs no classification', () => {
-    const source = `export const breaking = { reason: 'old pods still read legacy', requiredStop: false };
-export async function up(knex) { await knex.raw('ALTER TABLE users DROP COLUMN legacy'); }
+    const source = `export async function up(knex) { await knex.raw('ALTER TABLE users DROP COLUMN legacy'); }
 export async function down(knex) { await knex.raw('ALTER TABLE users ADD COLUMN legacy text'); }`;
-    const findings = enforcement(source);
+    const findings = enforcement(source, [migrationDeclaration]);
     assert.ok(findings.some((finding) => finding.rule === 'raw-drop-column'));
     assert.ok(!findings.some((finding) => finding.rule === 'unclassified-knex-raw'));
     assert.ok(!findings.some((finding) => finding.severity === 'error'));
@@ -286,6 +298,23 @@ export async function down() { throw new Error('irreversible: test fixture'); }`
     const findings = enforcement(source);
     assert.ok(findings.some((finding) => finding.rule === 'malformed-breaking-declaration'));
     assert.ok(findings.some((finding) => finding.rule === 'undeclared-breaking-change'));
+});
+
+test('a valid inline breaking declaration does not satisfy migration enforcement', () => {
+    const source = `export const breaking = { reason: 'Deployments running the prior backend still read users.legacy.', requiredStop: false };
+export async function up(knex) { await knex.schema.alterTable('users', table => table.dropColumn('legacy')); }
+export async function down(knex) { await knex.schema.alterTable('users', table => table.string('legacy')); }`;
+    const findings = enforcement(source);
+    assert.ok(
+        findings.some(
+            (finding) => finding.rule === 'inline-breaking-declaration',
+        ),
+    );
+    assert.ok(
+        findings.some(
+            (finding) => finding.rule === 'undeclared-breaking-change',
+        ),
+    );
 });
 
 test('literal DML raw SQL requires explicit classification', () => {
@@ -325,10 +354,9 @@ export async function down() { throw new Error('irreversible: test fixture'); }`
 
 test('breaking classification with a declaration passes and remains visible', () => {
     const source = `export const classification = { kind: 'breaking', reason: 'rewrites a live contract' };
-export const breaking = { reason: 'old pods require the prior shape', requiredStop: true };
 export async function up(knex) { await knex.raw('VACUUM users'); }
 export async function down() { throw new Error('irreversible: test fixture'); }`;
-    const findings = enforcement(source);
+    const findings = enforcement(source, [migrationDeclaration]);
     assert.ok(findings.some((finding) => finding.rule === 'classified-breaking-change'));
     assert.ok(!findings.some((finding) => finding.severity === 'error'));
 });
@@ -481,6 +509,28 @@ export async function down() { throw new Error('irreversible: test fixture'); }`
     assert.strictEqual(result.ran, true);
     assert.strictEqual(result.passed, true);
     assert.deepStrictEqual(result.errors, []);
+});
+
+test('registry diagnostics fail migration enforcement without changed migrations', () => {
+    const result = evaluateMigrationEnforcement({
+        paths: [],
+        declarationChanges: {
+            added: [],
+            diagnostics: [
+                {
+                    file: 'release-safety.declarations.json',
+                    line: 1,
+                    message: 'declaration "old-break" was removed',
+                },
+            ],
+        },
+    });
+    assert.strictEqual(result.passed, false);
+    assert.ok(
+        result.errors.some(
+            (finding) => finding.rule === 'breaking-declaration-registry',
+        ),
+    );
 });
 
 if (failures.length > 0) {

--- a/scripts/sql-migration-lint.ts
+++ b/scripts/sql-migration-lint.ts
@@ -42,6 +42,14 @@ import {
     hollowBreakingReasonMessage,
     isSubstantiveBreakingReason,
 } from './breaking-change-gate-policy';
+import {
+    collectBreakingChangeDeclarationsBetweenRefs,
+    DEFAULT_DECLARATIONS_PATH,
+} from './release-safety-declarations';
+import type {
+    BreakingChangeDeclaration,
+    BreakingChangeDeclarationDiff,
+} from './release-safety-declarations';
 import { isMigrationPath } from './release-safety-migrations';
 
 export interface SqlLintFinding {
@@ -596,6 +604,7 @@ function downState(source: string): {
 export function evaluateMigrationSource(
     source: string,
     file = '<source>',
+    breakingDeclarations: readonly BreakingChangeDeclaration[] = [],
 ): SqlMigrationEnforcementFinding[] {
     const findings: SqlMigrationEnforcementFinding[] = [];
     const declarations = parseChangeDeclarations(source, file);
@@ -630,20 +639,37 @@ export function evaluateMigrationSource(
         }
     }
 
-    const substantiveBreakingDeclaration =
-        declarations.breaking !== null &&
-        isSubstantiveBreakingReason(declarations.breaking.reason);
-    if (declarations.breaking && !substantiveBreakingDeclaration) {
+    if (declarations.breaking) {
         findings.push(
             enforcementFinding(
                 file,
                 declarations.breaking.line,
-                'hollow-breaking-declaration',
-                hollowBreakingReasonMessage(file, declarations.breaking.line),
+                'inline-breaking-declaration',
+                `inline breaking declarations are not supported; add a stable ID to ${DEFAULT_DECLARATIONS_PATH}`,
                 'error',
             ),
         );
     }
+
+    const matchingDeclarations = breakingDeclarations.filter(
+        (declaration) => declaration.migration === file,
+    );
+    for (const declaration of matchingDeclarations) {
+        if (!isSubstantiveBreakingReason(declaration.reason)) {
+            findings.push(
+                enforcementFinding(
+                    DEFAULT_DECLARATIONS_PATH,
+                    1,
+                    'hollow-breaking-declaration',
+                    hollowBreakingReasonMessage(DEFAULT_DECLARATIONS_PATH, 1),
+                    'error',
+                ),
+            );
+        }
+    }
+    const substantiveBreakingDeclaration = matchingDeclarations.some(
+        (declaration) => isSubstantiveBreakingReason(declaration.reason),
+    );
 
     const legacy = lintSource(source);
     for (const finding of legacy) {
@@ -652,7 +678,7 @@ export function evaluateMigrationSource(
             file,
             severity: substantiveBreakingDeclaration ? 'warning' : 'error',
             message: substantiveBreakingDeclaration
-                ? `${finding.message}; acknowledged by export const breaking`
+                ? `${finding.message}; acknowledged by the release-safety declaration registry`
                 : `${finding.message}; breaking behavior is not declared by a substantive product decision`,
         });
     }
@@ -677,7 +703,7 @@ export function evaluateMigrationSource(
                     line: detectedLine,
                     pattern: detectedPattern,
                     declarationLocation:
-                        'this migration file as export const breaking = { reason: string, requiredStop: boolean }',
+                        `${DEFAULT_DECLARATIONS_PATH} as a new stable ID with reason, requiredStop, and migration set to ${file}`,
                 }),
                 'error',
             ),
@@ -873,6 +899,7 @@ export function changedMigrationPaths(base: string): string[] {
 export interface EvaluateMigrationEnforcementOptions {
     paths: readonly string[];
     readFile?: (path: string) => string;
+    declarationChanges?: BreakingChangeDeclarationDiff;
 }
 
 export function evaluateMigrationEnforcement(
@@ -881,9 +908,30 @@ export function evaluateMigrationEnforcement(
     const readFile = options.readFile ?? ((path: string) => fs.readFileSync(path, 'utf8'));
     const paths = [...options.paths];
     const findings: SqlMigrationEnforcementFinding[] = [];
+    const declarationChanges = options.declarationChanges ?? {
+        added: [],
+        diagnostics: [],
+    };
+    for (const diagnostic of declarationChanges.diagnostics) {
+        findings.push(
+            enforcementFinding(
+                diagnostic.file,
+                diagnostic.line,
+                'breaking-declaration-registry',
+                diagnostic.message,
+                'error',
+            ),
+        );
+    }
     for (const path of paths) {
         try {
-            findings.push(...evaluateMigrationSource(readFile(path), path));
+            findings.push(
+                ...evaluateMigrationSource(
+                    readFile(path),
+                    path,
+                    declarationChanges.added,
+                ),
+            );
         } catch (error) {
             findings.push(
                 enforcementFinding(
@@ -919,7 +967,13 @@ function main(): void {
     const lastTag = arg('last-tag') ?? arg('previous-version');
     if (!lastTag) throw new Error('--last-tag (or --previous-version) is required');
     if (process.argv.includes('--enforce')) {
-        const result = evaluateMigrationEnforcement({ paths: changedMigrationPaths(lastTag) });
+        const result = evaluateMigrationEnforcement({
+            paths: changedMigrationPaths(lastTag),
+            declarationChanges: collectBreakingChangeDeclarationsBetweenRefs(
+                lastTag,
+                'HEAD',
+            ),
+        });
         for (const finding of result.findings) {
             const output = `${finding.file}:${finding.line} ${finding.severity.toUpperCase()} ${finding.message} [${finding.rule}]`;
             if (finding.severity === 'error') console.error(output);


### PR DESCRIPTION
The release-safety registry activates entries only when a Git range adds their IDs.
The API and migration gates reject changed or removed entries.
Only new entries can require a release stop.
The PR workflow watches the registry files inside the job.
The workflow trigger remains unfiltered.

Linear: SPK-1156