### PR TITLE
ci: gate preview DB snapshots on seed completion, not early artifacts

### DIFF
--- a/examples/full-jaffle-shop-demo/renderDeployHook.sh
+++ b/examples/full-jaffle-shop-demo/renderDeployHook.sh
@@ -63,6 +63,12 @@ else
     pnpm -F backend rollback-all-production
     pnpm -F backend migrate-production
     pnpm -F backend seed-production
+
+    # Mark the whole pipeline complete as the very last step. The snapshot
+    # builder (scripts/preview-db-snapshot.sh) gates on this row so it never
+    # snapshots a database mid-seed: checking early artifacts (demo user,
+    # jaffle tables) passes while later seed files are still inserting.
+    check_database "CREATE TABLE IF NOT EXISTS preview_seed_complete (seeded_at timestamptz NOT NULL DEFAULT now()); INSERT INTO preview_seed_complete DEFAULT VALUES"
 fi
 
 exec "$@"

--- a/scripts/preview-db-snapshot.sh
+++ b/scripts/preview-db-snapshot.sh
@@ -15,9 +15,14 @@ SUFFIX="${1:?usage: preview-db-snapshot.sh <suffix, e.g. short sha>}"
 COPIES=3
 KEEP=6
 
+# The seeder (renderDeployHook.sh) inserts a preview_seed_complete row as its
+# final step. Gate on that rather than on early artifacts (jaffle tables, demo
+# user): those exist while later seed files are still inserting, and a
+# snapshot cut in that window publishes a database with no seeded charts or
+# dashboards.
 is_seeded() {
     [ "$(kubectl -n "$NAMESPACE" exec statefulset/db-preview -- psql -U postgres -tAc \
-        "SELECT to_regclass('jaffle.orders') IS NOT NULL AND EXISTS (SELECT 1 FROM emails WHERE email = 'demo@lightdash.com')" \
+        "SELECT EXISTS (SELECT 1 FROM preview_seed_complete)" \
         2>/dev/null)" = "t" ]
 }
 


### PR DESCRIPTION
Relates: SPK-297

### Description:

The snapshot builder's `is_seeded()` gate checked `jaffle.orders` and the demo user's email row — both created at the *start* of the seed pipeline (dbt run + seed file 01). The remaining seed files keep inserting charts, dashboards and spaces for ~20s more, so a snapshot copy can be cut mid-seed and publish a database with no seeded content. Previews pick one of the newest copies at random, so an affected copy gives a PR fully red E2E on a fraction of its deploys.

This happened with today's 08:31 UTC snapshot build: copy #1 contains the org (created 08:48:44) but none of the seeded charts (first written 08:49:05), while copies #2–3 are complete. PR #27617 hit the bad copy on two of three preview deploys — every seeded-content-dependent spec (embed, contentAsCode, api-tests search/slugs/scheduler) failed, then passed after a redeploy landed on a good copy.

**Fix:** the seeder (`renderDeployHook.sh`) now inserts a `preview_seed_complete` row as the final step of the full dbt + migrate + seed path, and `scripts/preview-db-snapshot.sh` gates on that row instead of the early artifacts. If the marker write fails, the snapshot workflow times out and fails rather than publishing a partial copy.

The hook's own divert detection is deliberately unchanged, so existing environments and older (marker-less) snapshots keep their current boot behaviour.

Merging this touches a `preview-db-snapshot.yml` watched path, so a fresh snapshot build runs immediately and its complete copies displace today's bad one from the random selection window.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: CI/preview infrastructure only, no product code. Failure mode changes from "silently publish a partial snapshot" to "snapshot workflow fails loudly".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJpC3mbL1kznEDhAET6QFF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJpC3mbL1kznEDhAET6QFF)_