### PR TITLE
fix(ci): verify release safety comment stamps

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -49,6 +49,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 
@@ -159,24 +160,59 @@ jobs:
         with:
           script: |
             const marker = '<!-- release-safety-marker -->';
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
-            const existing = comments.find((c) => c.body.includes(marker));
-            // SPK-1017: `gate` is part of the stamp because this check is
-            // required. A job skipped by an `if:` reports SKIPPED, and SKIPPED
-            // satisfies a required check — so reusing a FAILED verdict would
-            // turn a red gate green by editing the PR title. Only a verdict
-            // that passed may be short-circuited.
-            const m = existing?.body.match(
-              /<!-- release-safety-describes head:([0-9a-f]{7,40}) base:([0-9a-f]{7,40}) gate:(pass|fail) -->/,
-            );
-            core.setOutput('head', m ? m[1] : '');
-            core.setOutput('base', m ? m[2] : '');
-            core.setOutput('gate', m ? m[3] : '');
+            core.setOutput('head', '');
+            core.setOutput('base', '');
+            core.setOutput('gate', '');
+
+            try {
+              const { viewer } = await github.graphql(`query { viewer { login } }`);
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              });
+              const existing = comments.find(
+                (c) => c.user?.login === viewer.login && c.body?.includes(marker),
+              );
+              const stamp = existing?.body?.match(
+                /<!-- release-safety-describes head:([0-9a-f]{7,40}) base:([0-9a-f]{7,40}) gate:(pass|fail) run:([1-9][0-9]*) -->/,
+              );
+              if (!stamp) {
+                core.info('No verified describes-stamp was found.');
+                return;
+              }
+
+              const [{ data: run }, { data: workflow }] = await Promise.all([
+                github.rest.actions.getWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: Number(stamp[4]),
+                }),
+                github.rest.actions.getWorkflow({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'release-safety-pr.yml',
+                }),
+              ]);
+              const verified =
+                run.workflow_id === workflow.id &&
+                run.status === 'completed' &&
+                run.conclusion === 'success' &&
+                run.event === 'pull_request' &&
+                run.head_sha === stamp[1] &&
+                run.pull_requests.some((pr) => pr.number === context.issue.number);
+              if (!verified) {
+                core.info('The describes-stamp does not name a successful run for this pull request.');
+                return;
+              }
+
+              core.setOutput('head', stamp[1]);
+              core.setOutput('base', stamp[2]);
+              core.setOutput('gate', stamp[3]);
+            } catch (error) {
+              core.warning(`Could not verify the describes-stamp: ${error.message}`);
+            }
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.watched.outputs.watched == 'true'
@@ -283,7 +319,10 @@ jobs:
               issue_number: context.issue.number,
               per_page: 100,
             });
-            const existing = comments.find((c) => c.body.includes(marker));
+            const { viewer } = await github.graphql(`query { viewer { login } }`);
+            const existing = comments.find(
+              (c) => c.user?.login === viewer.login && c.body?.includes(marker),
+            );
 
             if (existing) {
               await github.rest.issues.updateComment({
@@ -561,6 +600,7 @@ jobs:
             --base "${{ github.event.pull_request.base.ref }} (${{ needs.changes.outputs.base_short }})" \
             --head-sha "${{ github.event.pull_request.head.sha }}" \
             --base-sha "${{ needs.changes.outputs.base_sha }}" \
+            --run-id "${{ github.run_id }}" \
             --rest-status "${{ steps.rest-result.outputs.status }}" \
             ${{ steps.marker.outputs.draft == 'true' && '--draft' || '' }} \
             ${{ steps.lint.outputs.breaking == 'true' && '--linter-breaking' || '--no-linter-breaking' }} \
@@ -613,7 +653,10 @@ jobs:
               issue_number: context.issue.number,
               per_page: 100,
             });
-            const existing = comments.find((c) => c.body.includes(marker));
+            const { viewer } = await github.graphql(`query { viewer { login } }`);
+            const existing = comments.find(
+              (c) => c.user?.login === viewer.login && c.body?.includes(marker),
+            );
 
             if (existing) {
               await github.rest.issues.updateComment({
@@ -684,7 +727,10 @@ jobs:
               issue_number: context.issue.number,
               per_page: 100,
             });
-            const existing = comments.find((c) => c.body.includes(marker));
+            const { viewer } = await github.graphql(`query { viewer { login } }`);
+            const existing = comments.find(
+              (c) => c.user?.login === viewer.login && c.body?.includes(marker),
+            );
             if (!existing) {
               core.info('No sticky comment to retract.');
               return;

--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -237,18 +237,30 @@ test('raw v2 JSON is embedded for machines', () => {
 
 const HEAD = '4146779f7a801f252b99ddfa68a5e8217d08fefb';
 const BASE = 'd92d59798a4f0207927eea6c1ac31eafb6b1090e';
+const RUN_ID = '182736455';
 
 test('a passing verdict stamps the revision it describes', () => {
-    const body = renderPrComment(baseMarker(), { headSha: HEAD, baseSha: BASE });
+    const body = renderPrComment(baseMarker(), {
+        headSha: HEAD,
+        baseSha: BASE,
+        runId: RUN_ID,
+    });
     assert.match(
         body,
-        new RegExp(`<!-- release-safety-describes head:${HEAD} base:${BASE} gate:pass -->`),
+        new RegExp(
+            `<!-- release-safety-describes head:${HEAD} base:${BASE} gate:pass run:${RUN_ID} -->`,
+        ),
     );
 });
 
 test('a failed gate stamps gate:fail so it can never be short-circuited', () => {
-    const body = renderPrComment(baseMarker(), { headSha: HEAD, baseSha: BASE, gateFailed: true });
-    assert.match(body, /release-safety-describes .* gate:fail -->/);
+    const body = renderPrComment(baseMarker(), {
+        headSha: HEAD,
+        baseSha: BASE,
+        runId: RUN_ID,
+        gateFailed: true,
+    });
+    assert.match(body, /release-safety-describes .* gate:fail run:[1-9][0-9]* -->/);
     assert.doesNotMatch(body, /gate:pass/);
 });
 
@@ -258,22 +270,31 @@ test('the stamp is omitted when the revision is unknown', () => {
         renderPrComment(baseMarker(), { headSha: HEAD }),
         /release-safety-describes/,
     );
+    assert.doesNotMatch(
+        renderPrComment(baseMarker(), { headSha: HEAD, baseSha: BASE }),
+        /release-safety-describes/,
+    );
 });
 
 test('the stamp matches the regex the workflow reads it with', () => {
     const workflow = fs.readFileSync('.github/workflows/release-safety-pr.yml', 'utf-8');
     const declared = workflow.match(
-        /\/<!-- release-safety-describes head:\(\[0-9a-f\]\{7,40\}\) base:\(\[0-9a-f\]\{7,40\}\) gate:\(pass\|fail\) -->\//,
+        /\/<!-- release-safety-describes head:\(\[0-9a-f\]\{7,40\}\) base:\(\[0-9a-f\]\{7,40\}\) gate:\(pass\|fail\) run:\(\[1-9\]\[0-9\]\*\) -->\//,
     );
     assert.ok(declared, 'the workflow reader regex is not in the expected form');
 
     const reader =
-        /<!-- release-safety-describes head:([0-9a-f]{7,40}) base:([0-9a-f]{7,40}) gate:(pass|fail) -->/;
-    const emitted = renderPrComment(baseMarker(), { headSha: HEAD, baseSha: BASE }).match(reader);
+        /<!-- release-safety-describes head:([0-9a-f]{7,40}) base:([0-9a-f]{7,40}) gate:(pass|fail) run:([1-9][0-9]*) -->/;
+    const emitted = renderPrComment(baseMarker(), {
+        headSha: HEAD,
+        baseSha: BASE,
+        runId: RUN_ID,
+    }).match(reader);
     assert.ok(emitted, 'the rendered stamp does not match the reader regex');
     assert.strictEqual(emitted[1], HEAD);
     assert.strictEqual(emitted[2], BASE);
     assert.strictEqual(emitted[3], 'pass');
+    assert.strictEqual(emitted[4], RUN_ID);
 });
 
 if (failures.length > 0) {

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -60,6 +60,7 @@ export interface RenderOpts {
      */
     headSha?: string;
     baseSha?: string;
+    runId?: string;
     /**
      * Whether the release-safety gates failed for this revision. The stamp
      * carries it because the check is required: a skipped job reports SKIPPED,
@@ -253,11 +254,11 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     const baseLine = opts.baseLabel ? `> Comparing against \`${opts.baseLabel}\`.\n` : '';
     const rawJson = JSON.stringify(marker, null, 2);
     const describes =
-        opts.headSha && opts.baseSha
+        opts.headSha && opts.baseSha && opts.runId
             ? [
                   `<!-- release-safety-describes head:${opts.headSha} base:${opts.baseSha} gate:${
                       opts.gateFailed ? 'fail' : 'pass'
-                  } -->`,
+                  } run:${opts.runId} -->`,
               ]
             : [];
 
@@ -307,6 +308,7 @@ function main(): void {
         declarationGateFailed: process.argv.includes('--declaration-gate-failed'),
         headSha: arg('head-sha'),
         baseSha: arg('base-sha'),
+        runId: arg('run-id'),
         gateFailed: process.argv.includes('--gate-failed'),
         draft: process.argv.includes('--draft'),
         linterBreaking: process.argv.includes('--linter-breaking')

--- a/scripts/release-safety-workflow-shape.test.ts
+++ b/scripts/release-safety-workflow-shape.test.ts
@@ -99,6 +99,66 @@ assert.ok(
     'the describes-stamp reader must capture the gate outcome (SPK-1017)',
 );
 
+const commentLookups = [
+    ...workflow.matchAll(/const existing = comments\.find\(([\s\S]*?)\n\s*\);/g),
+];
+assert.strictEqual(
+    commentLookups.length,
+    4,
+    `expected four sticky comment lookups; found ${commentLookups.length}`,
+);
+for (const lookup of commentLookups) {
+    assert.ok(
+        lookup[1].includes('c.user?.login === viewer.login') &&
+            lookup[1].includes('c.body?.includes(marker)'),
+        'every sticky comment lookup must match the authenticated workflow author and marker',
+    );
+}
+assert.strictEqual(
+    workflow.match(/query \{ viewer \{ login \} \}/g)?.length,
+    commentLookups.length,
+    'every sticky comment lookup must derive its author from the authenticated workflow token',
+);
+
+const stampReader = workflow.slice(
+    workflow.indexOf("- name: Read the sticky comment's describes-stamp"),
+    workflow.indexOf(
+        '- uses: actions/checkout@',
+        workflow.indexOf("- name: Read the sticky comment's describes-stamp"),
+    ),
+);
+for (const required of [
+    'run:([1-9][0-9]*)',
+    'github.rest.actions.getWorkflowRun',
+    'github.rest.actions.getWorkflow',
+    'run.workflow_id === workflow.id',
+    "run.status === 'completed'",
+    "run.conclusion === 'success'",
+    "run.event === 'pull_request'",
+    'run.head_sha === stamp[1]',
+    'pr.number === context.issue.number',
+]) {
+    assert.ok(stampReader.includes(required), `the describes-stamp reader must verify ${required}`);
+}
+assert.ok(
+    workflow.includes('actions: read'),
+    'the workflow needs read access to verify the stamped workflow run',
+);
+assert.ok(
+    workflow.includes('--run-id "${{ github.run_id }}"'),
+    'the rendered describes-stamp must include the current workflow run ID',
+);
+for (const output of ['head', 'base', 'gate']) {
+    assert.ok(
+        stampReader.indexOf(`core.setOutput('${output}', '');`) < stampReader.indexOf('try {'),
+        `the ${output} output must fail closed before stamp verification starts`,
+    );
+}
+assert.ok(
+    stampReader.includes('catch (error)'),
+    'stamp verification errors must fail closed instead of stopping the full preview',
+);
+
 // The condition deciding "did the gates fail" now appears twice: once to fail
 // the job, once to stamp the comment. They must stay identical, or the stamp
 // will claim a pass the job did not give.


### PR DESCRIPTION
## Summary

- Identify the workflow comment by its authenticated author.
- Verify each stamp against the successful workflow run that wrote it.
- Add regression tests for the workflow shape.

Linear: SPK-1160