### PR TITLE
feat(merge-queries): run merges as composition behind a feature flag

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -135,6 +135,7 @@ import {
     type RunQueryTags,
     type SessionUser,
     type SpaceSummaryBase,
+    type UserAttributeValueMap,
     type WarehouseExecuteAsyncQuery,
     type WarehousePhaseTimings,
     type WarehouseResults,
@@ -186,6 +187,7 @@ import {
     processFieldsForExport,
     streamJsonlData,
 } from '../../utils/FileDownloadUtils/FileDownloadUtils';
+import { buildComposeMergeSql } from '../../utils/QueryBuilder/composeMergeSql';
 import { updateExploreWithDateZoom } from '../../utils/QueryBuilder/dateZoom';
 import {
     buildMergeResultMetricQuery,
@@ -6852,6 +6854,18 @@ export class AsyncQueryService extends ProjectService {
     /** How long a compose query waits for a referenced query's results. */
     private static readonly REFERENCE_WAIT_TIMEOUT_MS = 15 * 60 * 1000;
 
+    /** The wrap keeps reference CTEs valid for SQL that starts with its own WITH chain. */
+    private static wrapSqlWithReferenceCtes(
+        sql: string,
+        referenceCtes: string[],
+    ): string {
+        return referenceCtes.length > 0
+            ? `WITH ${referenceCtes.join(
+                  ',\n',
+              )}\nSELECT * FROM (\n${sql}\n) AS lightdash_user_query`
+            : sql;
+    }
+
     /**
      * Background phase of a compose query: wait for referenced results (the
      * whole of pipeline orchestration), build the reference CTEs, discover
@@ -6899,14 +6913,10 @@ export class AsyncQueryService extends ProjectService {
                   })
                 : [];
 
-            // The wrap keeps the reference CTEs valid for user SQL that
-            // starts with its own WITH chain.
-            const resolvedSql =
-                referenceCtes.length > 0
-                    ? `WITH ${referenceCtes.join(
-                          ',\n',
-                      )}\nSELECT * FROM (\n${sql}\n) AS lightdash_user_query`
-                    : sql;
+            const resolvedSql = AsyncQueryService.wrapSqlWithReferenceCtes(
+                sql,
+                referenceCtes,
+            );
 
             // Column discovery (LIMIT 1) also validates the SQL
             const columns: { name: string; type: DimensionType }[] = [];
@@ -7158,6 +7168,30 @@ export class AsyncQueryService extends ProjectService {
             return undefined;
         })();
 
+        // The pivot stage still compiles in the warehouse dialect, so pivoted
+        // merges stay on the single-statement path for now.
+        if (pivotConfiguration === undefined) {
+            const composeQuery = await this.tryExecuteComposeMergeQuery({
+                account,
+                projectUuid,
+                organizationUuid,
+                mergeQuery: effectiveMergeQuery,
+                context,
+                invalidateCache,
+                parameters,
+                userAttributeOverrides,
+                compiledMerge,
+            });
+            if (composeQuery !== null) {
+                return {
+                    outcome: 'started',
+                    query: composeQuery,
+                    parameterReferences: compiledMerge.parameterReferences,
+                    fieldOrigins: compiledMerge.fieldOrigins,
+                };
+            }
+        }
+
         const query = await this.executeCompiledAsyncMergeQuery({
             account,
             projectUuid,
@@ -7285,6 +7319,321 @@ export class AsyncQueryService extends ProjectService {
             usedParametersValues: composer.getUsedParameters(),
             resolvedTimezone: composer.getDisplayTimezone(),
         };
+    }
+
+    /**
+     * Runs a merge as composition when the merge-on-compose flag is on and
+     * the compose engine is available; returns null to fall back to the
+     * single-statement warehouse merge otherwise.
+     *
+     * Each source executes as its own metric query — inheriting that query's
+     * access rules and the metric-query result cache — and the DuckDB
+     * compose engine joins the materialized results. The join is the same
+     * MergeQueryBuilder assembly as the warehouse statement, in the DuckDB
+     * dialect over reference tables, so join semantics are shared by
+     * construction. Submission never blocks on the legs: the background
+     * phase waits for their results through the standard reference wait.
+     */
+    private async tryExecuteComposeMergeQuery({
+        account,
+        projectUuid,
+        organizationUuid,
+        mergeQuery,
+        context,
+        invalidateCache,
+        parameters,
+        userAttributeOverrides,
+        compiledMerge,
+    }: {
+        account: Account;
+        projectUuid: string;
+        organizationUuid: string;
+        mergeQuery: MergeQuery;
+        context: QueryExecutionContext;
+        invalidateCache: boolean | undefined;
+        parameters: ParametersValuesMap | undefined;
+        userAttributeOverrides: UserAttributeValueMap | undefined;
+        compiledMerge: RunnableCompiledMergeQuery;
+    }): Promise<ApiExecuteAsyncMetricQueryResults | null> {
+        assertIsAccountWithOrg(account);
+
+        const { enabled } = await this.featureFlagModel.get({
+            user: {
+                userUuid: account.user.id,
+                organizationUuid: account.organization.organizationUuid,
+            },
+            featureFlagId: FeatureFlags.MergeOnCompose,
+        });
+        if (!enabled) return null;
+
+        let warehouseClient: WarehouseClient;
+        try {
+            warehouseClient =
+                this.preAggregateStrategy.createExecutionWarehouseClient();
+        } catch (e) {
+            this.logger.debug(
+                `Merge-on-compose unavailable, using the warehouse merge: ${getErrorMessage(
+                    e,
+                )}`,
+            );
+            return null;
+        }
+
+        const projectSummary = await this.projectModel.getSummary(projectUuid);
+        const sourceRowCap = this.lightdashConfig.query.maxLimit;
+
+        // Legs run whole: the merged statement sorts and limits, and a side
+        // is never silently truncated below the source row cap
+        const legs = await Promise.all(
+            mergeQuery.sources.map(async (source) => {
+                const leg = await this.executeAsyncMetricQuery({
+                    account,
+                    projectUuid,
+                    context,
+                    invalidateCache,
+                    parameters,
+                    userAttributeOverrides,
+                    metricQuery: {
+                        ...source.metricQuery,
+                        sorts: [],
+                        limit: sourceRowCap,
+                    },
+                });
+                return [source.id, leg.queryUuid] as const;
+            }),
+        );
+        const legQueryUuidBySourceId = Object.fromEntries(legs);
+
+        const fieldTypes = await this.getMergeFieldTypesForQuery(
+            account,
+            projectUuid,
+            mergeQuery,
+        );
+        const { sql, referenceTableBySourceId } = buildComposeMergeSql({
+            mergeQuery,
+            fieldTypes,
+            outputAliasByColumn: compiledMerge.fieldIdByColumn,
+            limit: Math.min(mergeQuery.limit, sourceRowCap),
+            sourceRowCap,
+        });
+
+        // Merge table calculations carry user-authored SQL into the DuckDB
+        // statement, so the same file-access block as raw compose SQL applies
+        try {
+            DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
+        } catch (e) {
+            throw new ParameterError(getErrorMessage(e));
+        }
+
+        const references = Object.fromEntries(
+            Object.entries(referenceTableBySourceId).map(
+                ([sourceId, tableName]) => [
+                    tableName,
+                    legQueryUuidBySourceId[sourceId],
+                ],
+            ),
+        );
+        await this.authorizeQueryReferences({
+            account,
+            projectUuid,
+            organizationUuid,
+            references,
+        });
+
+        const columnOrder = Object.values(compiledMerge.fieldIdByColumn);
+        const resultMetricQuery = buildMergeResultMetricQuery({
+            itemsMap: compiledMerge.itemsMap,
+            columnOrder,
+            limit: mergeQuery.limit,
+        });
+        const originalColumns: ResultColumns = Object.fromEntries(
+            compiledMerge.typedColumns.map((column) => [
+                column.reference,
+                { reference: column.reference, type: column.type },
+            ]),
+        );
+
+        const queryTags: RunQueryTags = {
+            ...this.getUserQueryTags(account),
+            ...AsyncQueryService.getSchedulerQueryTags(),
+            organization_uuid: organizationUuid,
+            project_uuid: projectUuid,
+            query_context: context,
+        };
+
+        // Keyed to the user: legs compile under per-user attributes, so the
+        // merged result is per-user too
+        const cacheKey = QueryHistoryModel.getCacheKey(projectUuid, {
+            sql: JSON.stringify({ mergeSql: sql, references }),
+            userUuid: account.user.id,
+        });
+
+        const requestParameters: ExecuteAsyncMergeQueryRequestParams = {
+            context,
+            invalidateCache,
+            mergeQuery,
+            parameters,
+            pivotConfiguration: undefined,
+        };
+
+        const queryCreatedAt = new Date();
+        const { queryUuid } = await this.queryHistoryModel.create(account, {
+            projectUuid,
+            organizationUuid,
+            context,
+            fields: compiledMerge.itemsMap,
+            compiledSql: sql,
+            requestParameters,
+            metricQuery: resultMetricQuery,
+            cacheKey,
+            pivotConfiguration: null,
+            originalColumns,
+        });
+        this.prometheusMetrics?.trackQueryStateTransition(
+            'new',
+            QueryHistoryStatus.PENDING,
+            context,
+        );
+
+        const onboardingFlow = await this.getOnboardingFlow({
+            userUuid: account.user.id,
+            organizationUuid,
+        });
+
+        void this.runComposeMergeQuery({
+            account,
+            projectUuid,
+            organizationUuid,
+            isPreviewProject:
+                projectSummary.type === ProjectType.PREVIEW ||
+                projectSummary.provisioningSource === 'playground',
+            onboardingFlow,
+            queryUuid,
+            sql,
+            references,
+            warehouseClient,
+            queryTags,
+            queryCreatedAt,
+            cacheKey,
+            context,
+            fieldsMap: compiledMerge.itemsMap,
+            originalColumns,
+        }).catch((e) => {
+            this.logger.error(
+                `Async compose merge query ${queryUuid} failed: ${getErrorMessage(
+                    e,
+                )}`,
+            );
+        });
+
+        return {
+            queryUuid,
+            cacheMetadata: { cacheHit: false },
+            metricQuery: resultMetricQuery,
+            fields: compiledMerge.itemsMap,
+            warnings: [],
+            parameterReferences: compiledMerge.parameterReferences,
+            usedParametersValues: compiledMerge.usedParametersValues,
+            resolvedTimezone: null,
+        };
+    }
+
+    /**
+     * Background phase of a compose-mode merge: wait for the legs' results
+     * (the standard reference wait), bind them as reference CTEs, then run
+     * the join on the compose engine through the standard async pipeline.
+     * The merge fields and columns are known at submit time, so unlike raw
+     * compose SQL there is no column discovery and no metadata overwrite.
+     */
+    private async runComposeMergeQuery({
+        account,
+        projectUuid,
+        organizationUuid,
+        isPreviewProject,
+        onboardingFlow,
+        queryUuid,
+        sql,
+        references,
+        warehouseClient,
+        queryTags,
+        queryCreatedAt,
+        cacheKey,
+        context,
+        fieldsMap,
+        originalColumns,
+    }: {
+        account: Account;
+        projectUuid: string;
+        organizationUuid: string;
+        isPreviewProject: boolean;
+        onboardingFlow: OnboardingFlow;
+        queryUuid: string;
+        sql: string;
+        references: Record<string, string>;
+        warehouseClient: WarehouseClient;
+        queryTags: RunQueryTags;
+        queryCreatedAt: Date;
+        cacheKey: string;
+        context: QueryExecutionContext;
+        fieldsMap: ItemsMap;
+        originalColumns: ResultColumns;
+    }): Promise<void> {
+        try {
+            const referenceCtes = await this.buildQueryReferenceCtes({
+                account,
+                projectUuid,
+                references,
+            });
+            const query = AsyncQueryService.wrapSqlWithReferenceCtes(
+                sql,
+                referenceCtes,
+            );
+            await this.queryHistoryModel.update(
+                queryUuid,
+                projectUuid,
+                { compiled_sql: query },
+                account,
+            );
+
+            this.prometheusMetrics?.trackQueryStateTransition(
+                QueryHistoryStatus.PENDING,
+                QueryHistoryStatus.EXECUTING,
+                context,
+            );
+            this.prometheusMetrics?.observeQueueWaitDuration(0, context);
+
+            await this.runAsyncWarehouseQuery({
+                userUuid: account.user.id,
+                organizationUuid,
+                isPreviewProject,
+                isRegisteredUser: account.isRegisteredUser(),
+                isServiceAccount: account.isServiceAccount(),
+                onboardingFlow,
+                projectUuid,
+                queryUuid,
+                queryTags,
+                query,
+                fieldsMap,
+                cacheKey,
+                originalColumns,
+                queryCreatedAt,
+                displayTimezone: null,
+                warehouseClientOverride: warehouseClient,
+                warehouseCredentialsTypeOverride:
+                    warehouseClient.credentials.type,
+            });
+        } catch (e) {
+            await this.queryHistoryModel.update(
+                queryUuid,
+                projectUuid,
+                {
+                    status: QueryHistoryStatus.ERROR,
+                    error: getErrorMessage(e),
+                    errored_at: new Date(),
+                },
+                account,
+            );
+        }
     }
 
     private async prepareSqlChartAsyncQueryArgs({

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -320,7 +320,7 @@ import { omitDbtEnvironment } from '../../utils/dbtProjectConfig';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     applyMergeTerminalWrapper,
-    getMergeNullPlaceholder,
+    getMergeJoinKeySqlOptions,
     MergeQueryBuilder,
 } from '../../utils/QueryBuilder/MergeQueryBuilder';
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
@@ -5256,6 +5256,39 @@ export class ProjectService extends BaseService {
     }
 
     /**
+     * Join-key field metadata straight from a merge query, for callers that
+     * need the key types without the full compile (the compose execution
+     * path derives dialect-specific null placeholders from them).
+     */
+    protected async getMergeFieldTypesForQuery(
+        account: Account,
+        projectUuid: string,
+        mergeQuery: MergeQuery,
+    ): Promise<MergeFieldTypes> {
+        const itemMapBySourceId = Object.fromEntries(
+            await Promise.all(
+                mergeQuery.sources.map(async (source) => {
+                    const explore = await this.getExplore(
+                        account,
+                        projectUuid,
+                        source.metricQuery.exploreName,
+                    );
+                    return [
+                        source.id,
+                        getItemMap(
+                            explore,
+                            source.metricQuery.additionalMetrics,
+                            source.metricQuery.tableCalculations,
+                            source.metricQuery.customDimensions,
+                        ),
+                    ] as const;
+                }),
+            ),
+        );
+        return this.getMergeJoinFieldTypes(mergeQuery, itemMapBySourceId);
+    }
+
+    /**
      * Table calculations whose value depends on the query's whole row set.
      * Merging changes that row set, so they cannot be carried across it: a
      * running total would be frozen at its pre-merge value and a pivot-function
@@ -5496,23 +5529,12 @@ export class ProjectService extends BaseService {
         // landing as two unmatched rows. Safe because the join also compares
         // null-ness: a real value equal to the placeholder can never pair with
         // a null.
-        const nullPlaceholderByKeyName = Object.fromEntries(
-            mergeQuery.joinKey.flatMap((part) => {
-                const meta = Object.entries(part.fieldIdBySourceId)
-                    .map(
-                        ([sourceId, fieldId]) =>
-                            fieldTypes[sourceId]?.[fieldId],
-                    )
-                    .find((candidate) => candidate !== undefined);
-                if (meta === undefined) return [];
-                return [
-                    [
-                        part.name,
-                        getMergeNullPlaceholder(meta, warehouseSqlBuilder),
-                    ],
-                ];
-            }),
-        );
+        const { nullPlaceholderByKeyName, stringJoinKeyNames } =
+            getMergeJoinKeySqlOptions(
+                mergeQuery.joinKey,
+                fieldTypes,
+                warehouseSqlBuilder,
+            );
 
         const mergeQueryBuilder = new MergeQueryBuilder({
             sources,
@@ -5528,15 +5550,7 @@ export class ProjectService extends BaseService {
             ),
             tableCalculations: mergeQuery.tableCalculations,
             nullPlaceholderByKeyName,
-            stringJoinKeyNames: mergeQuery.joinKey.flatMap((part) => {
-                const meta = Object.entries(part.fieldIdBySourceId)
-                    .map(
-                        ([sourceId, fieldId]) =>
-                            fieldTypes[sourceId]?.[fieldId],
-                    )
-                    .find((candidate) => candidate !== undefined);
-                return meta?.type === DimensionType.STRING ? [part.name] : [];
-            }),
+            stringJoinKeyNames,
             // Each query is bounded, but reaching the bound is reported rather
             // than trimmed: a join over a trimmed side returns numbers that
             // look complete and are not.

--- a/packages/backend/src/utils/QueryBuilder/MergeQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MergeQueryBuilder.ts
@@ -7,6 +7,8 @@ import {
     MergeJoinType,
     SupportedDbtAdapter,
     type MergeFieldMeta,
+    type MergeFieldTypes,
+    type MergeJoinKeyPart,
     type MergeQueryColumns,
     type MergeTableCalculation,
     type MergeTerminalWrapper,
@@ -90,6 +92,44 @@ export const getMergeNullPlaceholder = (
         default:
             return assertUnreachable(meta.type, 'Unknown join key type');
     }
+};
+
+/**
+ * Dialect-dependent join-key SQL options for a merge: a typed null
+ * placeholder per key so null keys match each other, and which keys need a
+ * string cast before coalescing. One derivation for every dialect a merge
+ * compiles to — the warehouse statement and the compose join must agree on
+ * what a null key means.
+ */
+export const getMergeJoinKeySqlOptions = (
+    joinKey: MergeJoinKeyPart[],
+    fieldTypes: MergeFieldTypes,
+    warehouseSqlBuilder: WarehouseSqlBuilder,
+): {
+    nullPlaceholderByKeyName: Record<string, string>;
+    stringJoinKeyNames: string[];
+} => {
+    const metaFor = (part: MergeJoinKeyPart): MergeFieldMeta | undefined =>
+        Object.entries(part.fieldIdBySourceId)
+            .map(([sourceId, fieldId]) => fieldTypes[sourceId]?.[fieldId])
+            .find((candidate) => candidate !== undefined);
+    return {
+        nullPlaceholderByKeyName: Object.fromEntries(
+            joinKey.flatMap((part) => {
+                const meta = metaFor(part);
+                if (meta === undefined) return [];
+                return [
+                    [
+                        part.name,
+                        getMergeNullPlaceholder(meta, warehouseSqlBuilder),
+                    ],
+                ];
+            }),
+        ),
+        stringJoinKeyNames: joinKey.flatMap((part) =>
+            metaFor(part)?.type === DimensionType.STRING ? [part.name] : [],
+        ),
+    };
 };
 
 /** One sort term over the merged result, naming a merged column. */

--- a/packages/backend/src/utils/QueryBuilder/composeMergeSql.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeSql.test.ts
@@ -1,0 +1,266 @@
+import { DuckDBInstance } from '@duckdb/node-api';
+import {
+    DimensionType,
+    MERGE_TRUNCATED_COLUMN,
+    MergeJoinType,
+    type MergeFieldTypes,
+    type MergeQuery,
+    type MetricQuery,
+} from '@lightdash/common';
+import { buildComposeMergeSql } from './composeMergeSql';
+
+const metricQuery = (
+    exploreName: string,
+    dimensions: string[],
+    metrics: string[],
+): MetricQuery => ({
+    exploreName,
+    dimensions,
+    metrics,
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+});
+
+const mergeQuery: MergeQuery = {
+    sources: [
+        {
+            id: 'a',
+            metricQuery: metricQuery(
+                'orders',
+                ['orders_month'],
+                ['orders_count'],
+            ),
+        },
+        {
+            id: 'b',
+            metricQuery: metricQuery(
+                'payments',
+                ['payments_month'],
+                ['payments_sum'],
+            ),
+        },
+    ],
+    joinKey: [
+        {
+            name: 'month',
+            fieldIdBySourceId: { a: 'orders_month', b: 'payments_month' },
+        },
+    ],
+    joinType: MergeJoinType.FULL,
+    tableCalculations: [],
+    limit: 500,
+};
+
+const fieldTypes: MergeFieldTypes = {
+    a: {
+        orders_month: { type: DimensionType.DATE, timeInterval: null },
+    },
+    b: {
+        payments_month: { type: DimensionType.DATE, timeInterval: null },
+    },
+};
+
+const outputAliasByColumn = {
+    month: 'merge_month',
+    c0_0: 'a_orders_count',
+    c1_0: 'b_payments_sum',
+};
+
+const build = (
+    overrides: Partial<Parameters<typeof buildComposeMergeSql>[0]> = {},
+) =>
+    buildComposeMergeSql({
+        mergeQuery,
+        fieldTypes,
+        outputAliasByColumn,
+        limit: 500,
+        sourceRowCap: 100,
+        ...overrides,
+    });
+
+/**
+ * Executes the generated statement on a real in-memory DuckDB with the
+ * reference tables predefined — exactly how the compose engine sees it,
+ * minus the S3 read_json binding. This is the dialect-validity proof: the
+ * FULL OUTER JOIN, typed null placeholders and truncation guard must run on
+ * the actual engine, not just look plausible.
+ */
+const runOnDuckdb = async (
+    sql: string,
+    setupStatements: string[],
+): Promise<Record<string, string | null>[]> => {
+    const instance = await DuckDBInstance.create(':memory:');
+    const connection = await instance.connect();
+    try {
+        for (const statement of setupStatements) {
+            // eslint-disable-next-line no-await-in-loop -- DDL runs in order
+            await connection.run(statement);
+        }
+        const reader = await connection.runAndReadAll(sql);
+        return reader
+            .getRowObjects()
+            .map((row) =>
+                Object.fromEntries(
+                    Object.entries(row).map(([key, value]) => [
+                        key,
+                        value === null ? null : String(value),
+                    ]),
+                ),
+            );
+    } finally {
+        connection.closeSync();
+    }
+};
+
+const SETUP = [
+    `CREATE TABLE merge_source_0 (orders_month DATE, orders_count BIGINT)`,
+    `INSERT INTO merge_source_0 VALUES
+        (DATE '2024-01-01', 5),
+        (DATE '2024-02-01', 7),
+        (NULL, 2)`,
+    `CREATE TABLE merge_source_1 (payments_month DATE, payments_sum DOUBLE)`,
+    `INSERT INTO merge_source_1 VALUES
+        (DATE '2024-02-01', 20.5),
+        (DATE '2024-03-01', 9),
+        (NULL, 4)`,
+];
+
+describe('buildComposeMergeSql', () => {
+    test('reads each source from its reference table', () => {
+        const { sql, referenceTableBySourceId } = build();
+        expect(referenceTableBySourceId).toEqual({
+            a: 'merge_source_0',
+            b: 'merge_source_1',
+        });
+        expect(sql).toContain('SELECT * FROM "merge_source_0"');
+        expect(sql).toContain('SELECT * FROM "merge_source_1"');
+    });
+
+    test('joins with the shared null-safe semantics and typed placeholder', () => {
+        const { sql } = build();
+        expect(sql).toContain('FULL OUTER JOIN');
+        expect(sql).toContain('IS NULL) = (');
+        // The DATE-typed placeholder from the shared key-option derivation
+        expect(sql).toContain('1970-01-01');
+    });
+
+    test('guards truncation by counting the capped reference tables', () => {
+        const { sql } = build({ sourceRowCap: 100 });
+        expect(sql).toContain(MERGE_TRUNCATED_COLUMN);
+        expect(sql).toMatch(/SELECT COUNT\(\*\) FROM \(\s*SELECT \* FROM \(/);
+        expect(sql).toContain('> 100');
+    });
+
+    test('full outer join merges on the key, keeps unmatched sides and matches null keys', async () => {
+        const rows = await runOnDuckdb(build().sql, SETUP);
+        expect(
+            rows.map((row) => [
+                row.merge_month,
+                row.a_orders_count,
+                row.b_payments_sum,
+            ]),
+        ).toEqual([
+            ['2024-01-01', '5', null],
+            ['2024-02-01', '7', '20.5'],
+            ['2024-03-01', null, '9'],
+            // Null keys match each other via the typed placeholder
+            [null, '2', '4'],
+        ]);
+        expect(
+            rows.every((row) => row[MERGE_TRUNCATED_COLUMN] === 'false'),
+        ).toBe(true);
+    });
+
+    test('reports truncation when a source reaches the row cap', async () => {
+        const rows = await runOnDuckdb(build({ sourceRowCap: 2 }).sql, SETUP);
+        expect(
+            rows.every((row) => row[MERGE_TRUNCATED_COLUMN] === 'true'),
+        ).toBe(true);
+    });
+
+    test('left join keeps only the first source keys', async () => {
+        const rows = await runOnDuckdb(
+            build({
+                mergeQuery: { ...mergeQuery, joinType: MergeJoinType.LEFT },
+            }).sql,
+            SETUP,
+        );
+        expect(rows.map((row) => row.merge_month)).toEqual([
+            '2024-01-01',
+            '2024-02-01',
+            null,
+        ]);
+    });
+
+    test('inner join keeps only shared keys', async () => {
+        const rows = await runOnDuckdb(
+            build({
+                mergeQuery: { ...mergeQuery, joinType: MergeJoinType.INNER },
+            }).sql,
+            SETUP,
+        );
+        expect(
+            rows.map((row) => [
+                row.merge_month,
+                row.a_orders_count,
+                row.b_payments_sum,
+            ]),
+        ).toEqual([
+            ['2024-02-01', '7', '20.5'],
+            [null, '2', '4'],
+        ]);
+    });
+
+    test('applies the merged-result limit', async () => {
+        const rows = await runOnDuckdb(build({ limit: 2 }).sql, SETUP);
+        expect(rows).toHaveLength(2);
+    });
+
+    test('compiles merge table calculations over the merged row', async () => {
+        const rows = await runOnDuckdb(
+            build({
+                mergeQuery: {
+                    ...mergeQuery,
+                    tableCalculations: [
+                        {
+                            name: 'combined',
+                            displayName: 'Combined',
+                            sql: 'COALESCE(${a.orders_count}, 0) + COALESCE(${b.payments_sum}, 0)',
+                        },
+                    ],
+                },
+            }).sql,
+            SETUP,
+        );
+        expect(
+            rows.map((row) => [row.merge_month, Number(row.combined)]),
+        ).toEqual([
+            ['2024-01-01', 5],
+            ['2024-02-01', 27.5],
+            ['2024-03-01', 9],
+            [null, 6],
+        ]);
+    });
+
+    test('casts string keys before coalescing', () => {
+        const { sql } = build({
+            fieldTypes: {
+                a: {
+                    orders_month: {
+                        type: DimensionType.STRING,
+                        timeInterval: null,
+                    },
+                },
+                b: {
+                    payments_month: {
+                        type: DimensionType.STRING,
+                        timeInterval: null,
+                    },
+                },
+            },
+        });
+        expect(sql).toContain('AS VARCHAR');
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/composeMergeSql.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeSql.ts
@@ -1,0 +1,99 @@
+import {
+    SupportedDbtAdapter,
+    type MergeFieldTypes,
+    type MergeQuery,
+} from '@lightdash/common';
+import { warehouseSqlBuilderFromType } from '@lightdash/warehouses';
+import {
+    getMergeJoinKeySqlOptions,
+    MergeQueryBuilder,
+} from './MergeQueryBuilder';
+
+export type ComposeMergeSql = {
+    /** The DuckDB join statement, terminal wrapper (sort, limit, truncation guard) included. */
+    sql: string;
+    /** Reference table name per source id, for binding to leg queryUuids. */
+    referenceTableBySourceId: Record<string, string>;
+};
+
+/** Table name a merge source's results are exposed under in the compose SQL. */
+export const composeMergeReferenceTable = (sourceIndex: number): string =>
+    `merge_source_${sourceIndex}`;
+
+/**
+ * The compose form of a merge: the same MergeQueryBuilder assembly as the
+ * warehouse statement, but in the DuckDB dialect over reference tables —
+ * each source is `SELECT * FROM merge_source_N`, bound at execution time to
+ * that source's already-materialized results. The join semantics (coalesced
+ * keys, typed null placeholders, string casts, per-source row caps with
+ * truncation detection) are identical by construction because the builder
+ * and the key-option derivation are shared; only the dialect and where the
+ * source rows come from differ.
+ */
+export const buildComposeMergeSql = (args: {
+    mergeQuery: MergeQuery;
+    fieldTypes: MergeFieldTypes;
+    /** Output field-id alias per internal column, from the merge compile. */
+    outputAliasByColumn: Record<string, string>;
+    /** Row cap for the merged result, already clamped to the instance limit. */
+    limit: number;
+    /** Most rows one source may contribute; reaching it is reported, not trimmed. */
+    sourceRowCap: number;
+}): ComposeMergeSql => {
+    const { mergeQuery, fieldTypes, outputAliasByColumn, limit, sourceRowCap } =
+        args;
+    const warehouseSqlBuilder = warehouseSqlBuilderFromType(
+        SupportedDbtAdapter.DUCKDB,
+    );
+    const quoteChar = warehouseSqlBuilder.getFieldQuoteChar();
+
+    const referenceTableBySourceId = Object.fromEntries(
+        mergeQuery.sources.map((source, index) => [
+            source.id,
+            composeMergeReferenceTable(index),
+        ]),
+    );
+
+    const sources = mergeQuery.sources.map((source) => ({
+        id: source.id,
+        sql: `SELECT * FROM ${quoteChar}${
+            referenceTableBySourceId[source.id]
+        }${quoteChar}`,
+        joinKeyColumnByName: Object.fromEntries(
+            mergeQuery.joinKey.map((part) => [
+                part.name,
+                part.fieldIdBySourceId[source.id],
+            ]),
+        ),
+        valueColumns: [
+            ...source.metricQuery.metrics,
+            ...source.metricQuery.tableCalculations.map(
+                (calculation) => calculation.name,
+            ),
+        ],
+    }));
+
+    const { nullPlaceholderByKeyName, stringJoinKeyNames } =
+        getMergeJoinKeySqlOptions(
+            mergeQuery.joinKey,
+            fieldTypes,
+            warehouseSqlBuilder,
+        );
+
+    const builder = new MergeQueryBuilder({
+        sources,
+        joinKeyNames: mergeQuery.joinKey.map((part) => part.name),
+        joinType: mergeQuery.joinType,
+        warehouseSqlBuilder,
+        limit,
+        tableCalculations: mergeQuery.tableCalculations,
+        nullPlaceholderByKeyName,
+        stringJoinKeyNames,
+        sourceRowCap,
+    });
+
+    return {
+        sql: builder.toSql(outputAliasByColumn),
+        referenceTableBySourceId,
+    };
+};

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -334,6 +334,14 @@ export enum FeatureFlags {
      * (GET /api/v2/projects/{projectUuid}/query/history). Off by default.
      */
     QueryHistory = 'query-history',
+
+    /**
+     * Run merges as composition: each source executes separately against
+     * the warehouse and the DuckDB compose engine joins the results. Falls
+     * back to the single-statement warehouse merge when the compose engine
+     * is unavailable or the merge needs a pivot. Off by default.
+     */
+    MergeOnCompose = 'merge-on-compose',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
First slice of moving merged visualizations from a single warehouse-side FULL OUTER JOIN statement to *composition*: each source runs as its own metric query and the DuckDB compose engine joins the materialized results. Proven equivalent live before this PR existed (26/26 rows, 0 value diffs, identical unmatched-key and null-key behavior on the jaffle dataset, both against Postgres) and re-proven with this implementation through the real `merge-query` endpoint — including formatted values, since the merge fields map is persisted on the compose row.

## What this does

Behind a new `merge-on-compose` feature flag (off by default, not in the preview set):

- `executeAsyncMergeQueryInternal` routes non-pivot merges to a compose execution when the flag is on and the compose engine is available; everything else — flag off, engine unavailable (`NotImplementedError`), or a pivot requested — falls back to the existing single-statement warehouse merge unchanged.
- Legs submit as ordinary `executeAsyncMetricQuery` calls (per-user attributes, required filters, and the metric-query result cache all apply), sorted/limited only by the merged statement: legs run at the source row cap so a side is never silently truncated below it.
- The join is generated by the **same `MergeQueryBuilder`** in the DuckDB dialect over reference tables (`SELECT * FROM merge_source_N`), with the null-placeholder/string-cast derivation extracted into a shared `getMergeJoinKeySqlOptions` — join semantics agree between the two engines by construction, not by parallel implementations.
- Submission never blocks on the legs: the background phase (`runComposeMergeQuery`) waits for leg results through the standard compose reference wait, binds them as **typed** `read_json` CTEs (DATE/TIMESTAMP keys join as dates, not strings), and executes through `runAsyncWarehouseQuery` — where the existing merge-guard consumption already strips `__merge_truncated`/`__merge_row_present` and enforces the row-cap error, so truncation behavior is inherited, not reimplemented.
- Merge table calculations ride into the DuckDB statement, so the raw-compose `validateUserSqlFileAccess` guard is applied to the generated SQL (they are user-authored).

## Regression analysis

- With the flag off (the default everywhere), the only behavioral deltas to existing code are: `compileMergeQuery` deriving its join-key SQL options through the extracted helper (same logic, moved), and `runComposeSqlQuery` using a shared CTE-wrap helper (same string, moved). The warehouse merge path, compose SQL runner endpoint, and all their tests are untouched — full backend suite green (7029 tests).
- The new generator is pinned by tests that execute on a **real in-memory DuckDB**: full/left/inner joins, typed null-key matching via placeholders, string-key casts, truncation reporting at the cap, merged-result limits, and merge table calculations over the merged row.
- Live verification on a seeded instance, same `merge-query` request with the flag toggled via an org override: identical rows, columns, and formatted values; the compose row's `compiled_sql` shows the typed `read_json` reference CTEs; leg queries appear in `query_history` as ordinary metric queries.
- Feature-flag surface: enum entry only; TSOA generation verified clean (generated files not committed).

## Deliberately not here (next slices)

- Pivoted merges (the pivot stage still compiles in the warehouse dialect) — compose-mode pivot lands separately; until then pivoted merges use the warehouse path even with the flag on.
- Reusing existing queryUuids as merge sources (the zero-warehouse merge for visualizations that just rendered) — needs its own API surface.
- Result caching of the merged join itself (legs already benefit from the metric-query cache; the join re-runs per submission).
- A systematized parity harness for the cutover decision.

No Linear ticket — follows from the merge-on-compose direction agreed after the TDCP design review; exploratory flag work confirmed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrPvhrUr7VWeotEPwkAJcE
