### PR TITLE
feat(merge-queries): pivoted merges on the compose engine

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -7168,28 +7168,25 @@ export class AsyncQueryService extends ProjectService {
             return undefined;
         })();
 
-        // The pivot stage still compiles in the warehouse dialect, so pivoted
-        // merges stay on the single-statement path for now.
-        if (pivotConfiguration === undefined) {
-            const composeQuery = await this.tryExecuteComposeMergeQuery({
-                account,
-                projectUuid,
-                organizationUuid,
-                mergeQuery: effectiveMergeQuery,
-                context,
-                invalidateCache,
-                parameters,
-                userAttributeOverrides,
-                compiledMerge,
-            });
-            if (composeQuery !== null) {
-                return {
-                    outcome: 'started',
-                    query: composeQuery,
-                    parameterReferences: compiledMerge.parameterReferences,
-                    fieldOrigins: compiledMerge.fieldOrigins,
-                };
-            }
+        const composeQuery = await this.tryExecuteComposeMergeQuery({
+            account,
+            projectUuid,
+            organizationUuid,
+            mergeQuery: effectiveMergeQuery,
+            context,
+            invalidateCache,
+            parameters,
+            userAttributeOverrides,
+            pivotConfiguration,
+            compiledMerge,
+        });
+        if (composeQuery !== null) {
+            return {
+                outcome: 'started',
+                query: composeQuery,
+                parameterReferences: compiledMerge.parameterReferences,
+                fieldOrigins: compiledMerge.fieldOrigins,
+            };
         }
 
         const query = await this.executeCompiledAsyncMergeQuery({
@@ -7343,6 +7340,7 @@ export class AsyncQueryService extends ProjectService {
         invalidateCache,
         parameters,
         userAttributeOverrides,
+        pivotConfiguration,
         compiledMerge,
     }: {
         account: Account;
@@ -7353,6 +7351,7 @@ export class AsyncQueryService extends ProjectService {
         invalidateCache: boolean | undefined;
         parameters: ParametersValuesMap | undefined;
         userAttributeOverrides: UserAttributeValueMap | undefined;
+        pivotConfiguration: PivotConfiguration | undefined;
         compiledMerge: RunnableCompiledMergeQuery;
     }): Promise<ApiExecuteAsyncMetricQueryResults | null> {
         assertIsAccountWithOrg(account);
@@ -7409,13 +7408,35 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             mergeQuery,
         );
-        const { sql, referenceTableBySourceId } = buildComposeMergeSql({
-            mergeQuery,
-            fieldTypes,
-            outputAliasByColumn: compiledMerge.fieldIdByColumn,
-            limit: Math.min(mergeQuery.limit, sourceRowCap),
-            sourceRowCap,
+        const columnOrder = Object.values(compiledMerge.fieldIdByColumn);
+        const { coreSql, terminalWrapper, referenceTableBySourceId } =
+            buildComposeMergeSql({
+                mergeQuery,
+                fieldTypes,
+                outputAliasByColumn: compiledMerge.fieldIdByColumn,
+                limit: Math.min(mergeQuery.limit, sourceRowCap),
+                sourceRowCap,
+            });
+
+        // The same composer as the warehouse merge, with the compose engine
+        // as the dialect: the pivot stage and terminal wrapper compile for
+        // DuckDB through the one shared seam
+        const composer = new MergeQueryComposer({
+            coreSql,
+            terminalWrapper,
+            itemsMap: compiledMerge.itemsMap,
+            typedColumns: compiledMerge.typedColumns,
+            columnOrder,
+            limit: mergeQuery.limit,
+            parameterReferences: compiledMerge.parameterReferences,
+            usedParametersValues: compiledMerge.usedParametersValues,
+            warehouseClient,
+            pivotConfiguration,
         });
+        const sql = composer.getSql({
+            columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+        });
+        const fieldsMap = composer.getFields();
 
         // Merge table calculations carry user-authored SQL into the DuckDB
         // statement, so the same file-access block as raw compose SQL applies
@@ -7440,12 +7461,6 @@ export class AsyncQueryService extends ProjectService {
             references,
         });
 
-        const columnOrder = Object.values(compiledMerge.fieldIdByColumn);
-        const resultMetricQuery = buildMergeResultMetricQuery({
-            itemsMap: compiledMerge.itemsMap,
-            columnOrder,
-            limit: mergeQuery.limit,
-        });
         const originalColumns: ResultColumns = Object.fromEntries(
             compiledMerge.typedColumns.map((column) => [
                 column.reference,
@@ -7473,7 +7488,7 @@ export class AsyncQueryService extends ProjectService {
             invalidateCache,
             mergeQuery,
             parameters,
-            pivotConfiguration: undefined,
+            pivotConfiguration,
         };
 
         const queryCreatedAt = new Date();
@@ -7481,12 +7496,12 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             organizationUuid,
             context,
-            fields: compiledMerge.itemsMap,
+            fields: fieldsMap,
             compiledSql: sql,
             requestParameters,
-            metricQuery: resultMetricQuery,
+            metricQuery: composer.getMetricQuery(),
             cacheKey,
-            pivotConfiguration: null,
+            pivotConfiguration: pivotConfiguration ?? null,
             originalColumns,
         });
         this.prometheusMetrics?.trackQueryStateTransition(
@@ -7516,7 +7531,8 @@ export class AsyncQueryService extends ProjectService {
             queryCreatedAt,
             cacheKey,
             context,
-            fieldsMap: compiledMerge.itemsMap,
+            fieldsMap,
+            pivotConfiguration,
             originalColumns,
         }).catch((e) => {
             this.logger.error(
@@ -7529,12 +7545,12 @@ export class AsyncQueryService extends ProjectService {
         return {
             queryUuid,
             cacheMetadata: { cacheHit: false },
-            metricQuery: resultMetricQuery,
-            fields: compiledMerge.itemsMap,
-            warnings: [],
-            parameterReferences: compiledMerge.parameterReferences,
-            usedParametersValues: compiledMerge.usedParametersValues,
-            resolvedTimezone: null,
+            metricQuery: composer.getMetricQuery(),
+            fields: fieldsMap,
+            warnings: composer.getWarnings(),
+            parameterReferences: composer.getParameterReferences(),
+            usedParametersValues: composer.getUsedParameters(),
+            resolvedTimezone: composer.getDisplayTimezone(),
         };
     }
 
@@ -7560,6 +7576,7 @@ export class AsyncQueryService extends ProjectService {
         cacheKey,
         context,
         fieldsMap,
+        pivotConfiguration,
         originalColumns,
     }: {
         account: Account;
@@ -7576,6 +7593,7 @@ export class AsyncQueryService extends ProjectService {
         cacheKey: string;
         context: QueryExecutionContext;
         fieldsMap: ItemsMap;
+        pivotConfiguration: PivotConfiguration | undefined;
         originalColumns: ResultColumns;
     }): Promise<void> {
         try {
@@ -7615,6 +7633,7 @@ export class AsyncQueryService extends ProjectService {
                 query,
                 fieldsMap,
                 cacheKey,
+                pivotConfiguration,
                 originalColumns,
                 queryCreatedAt,
                 displayTimezone: null,

--- a/packages/backend/src/utils/QueryBuilder/composeMergeSql.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeSql.test.ts
@@ -1,13 +1,95 @@
 import { DuckDBInstance } from '@duckdb/node-api';
 import {
     DimensionType,
+    FieldType,
     MERGE_TRUNCATED_COLUMN,
     MergeJoinType,
+    MetricType,
+    SupportedDbtAdapter,
+    VizAggregationOptions,
+    VizIndexType,
+    type ItemsMap,
     type MergeFieldTypes,
     type MergeQuery,
+    type MergeTypedColumn,
     type MetricQuery,
+    type WarehouseClient,
 } from '@lightdash/common';
 import { buildComposeMergeSql } from './composeMergeSql';
+import { applyMergeTerminalWrapper } from './MergeQueryBuilder';
+import { MergeQueryComposer } from './MergeQueryComposer';
+
+const duckdbWarehouseClient = {
+    getFieldQuoteChar: () => '"',
+    getAdapterType: () => SupportedDbtAdapter.DUCKDB,
+    getStartOfWeek: () => undefined,
+    getStringQuoteChar: () => "'",
+    escapeString: (value: string) => value.replaceAll("'", "''"),
+    supportsCteMaterialization: () => true,
+    credentials: { type: 'duckdb' },
+} as unknown as WarehouseClient;
+
+const itemsMap = {
+    merge_month: {
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.DATE,
+        name: 'month',
+        label: 'Month',
+        table: 'merge',
+        tableLabel: 'Merged',
+        sql: '',
+        hidden: false,
+    },
+    a_orders_count: {
+        fieldType: FieldType.METRIC,
+        type: MetricType.COUNT_DISTINCT,
+        name: 'orders_count',
+        label: 'Orders',
+        table: 'a',
+        tableLabel: 'Query A',
+        sql: '',
+        hidden: false,
+    },
+    b_payments_sum: {
+        fieldType: FieldType.METRIC,
+        type: MetricType.SUM,
+        name: 'payments_sum',
+        label: 'Payments',
+        table: 'b',
+        tableLabel: 'Query B',
+        sql: '',
+        hidden: false,
+    },
+} as ItemsMap;
+
+const typedColumns: MergeTypedColumn[] = [
+    {
+        reference: 'merge_month',
+        type: DimensionType.DATE,
+        origin: {
+            kind: 'joinKey',
+            fieldIdBySourceId: { a: 'orders_month', b: 'payments_month' },
+        },
+    },
+    {
+        reference: 'a_orders_count',
+        type: DimensionType.NUMBER,
+        origin: {
+            kind: 'source',
+            sourceId: 'a',
+            sourceFieldId: 'orders_count',
+        },
+    },
+    {
+        reference: 'b_payments_sum',
+        type: DimensionType.NUMBER,
+        origin: {
+            kind: 'source',
+            sourceId: 'b',
+            sourceFieldId: 'payments_sum',
+        },
+    },
+];
 
 const metricQuery = (
     exploreName: string,
@@ -80,6 +162,10 @@ const build = (
         ...overrides,
     });
 
+/** The runnable statement: the core with its terminal stage attached. */
+const toSql = (result: ReturnType<typeof buildComposeMergeSql>) =>
+    applyMergeTerminalWrapper(result.coreSql, result.terminalWrapper);
+
 /**
  * Executes the generated statement on a real in-memory DuckDB with the
  * reference tables predefined — exactly how the compose engine sees it,
@@ -129,7 +215,9 @@ const SETUP = [
 
 describe('buildComposeMergeSql', () => {
     test('reads each source from its reference table', () => {
-        const { sql, referenceTableBySourceId } = build();
+        const built = build();
+        const sql = toSql(built);
+        const { referenceTableBySourceId } = built;
         expect(referenceTableBySourceId).toEqual({
             a: 'merge_source_0',
             b: 'merge_source_1',
@@ -139,7 +227,7 @@ describe('buildComposeMergeSql', () => {
     });
 
     test('joins with the shared null-safe semantics and typed placeholder', () => {
-        const { sql } = build();
+        const sql = toSql(build());
         expect(sql).toContain('FULL OUTER JOIN');
         expect(sql).toContain('IS NULL) = (');
         // The DATE-typed placeholder from the shared key-option derivation
@@ -147,14 +235,14 @@ describe('buildComposeMergeSql', () => {
     });
 
     test('guards truncation by counting the capped reference tables', () => {
-        const { sql } = build({ sourceRowCap: 100 });
+        const sql = toSql(build({ sourceRowCap: 100 }));
         expect(sql).toContain(MERGE_TRUNCATED_COLUMN);
         expect(sql).toMatch(/SELECT COUNT\(\*\) FROM \(\s*SELECT \* FROM \(/);
         expect(sql).toContain('> 100');
     });
 
     test('full outer join merges on the key, keeps unmatched sides and matches null keys', async () => {
-        const rows = await runOnDuckdb(build().sql, SETUP);
+        const rows = await runOnDuckdb(toSql(build()), SETUP);
         expect(
             rows.map((row) => [
                 row.merge_month,
@@ -174,7 +262,10 @@ describe('buildComposeMergeSql', () => {
     });
 
     test('reports truncation when a source reaches the row cap', async () => {
-        const rows = await runOnDuckdb(build({ sourceRowCap: 2 }).sql, SETUP);
+        const rows = await runOnDuckdb(
+            toSql(build({ sourceRowCap: 2 })),
+            SETUP,
+        );
         expect(
             rows.every((row) => row[MERGE_TRUNCATED_COLUMN] === 'true'),
         ).toBe(true);
@@ -182,9 +273,11 @@ describe('buildComposeMergeSql', () => {
 
     test('left join keeps only the first source keys', async () => {
         const rows = await runOnDuckdb(
-            build({
-                mergeQuery: { ...mergeQuery, joinType: MergeJoinType.LEFT },
-            }).sql,
+            toSql(
+                build({
+                    mergeQuery: { ...mergeQuery, joinType: MergeJoinType.LEFT },
+                }),
+            ),
             SETUP,
         );
         expect(rows.map((row) => row.merge_month)).toEqual([
@@ -196,9 +289,14 @@ describe('buildComposeMergeSql', () => {
 
     test('inner join keeps only shared keys', async () => {
         const rows = await runOnDuckdb(
-            build({
-                mergeQuery: { ...mergeQuery, joinType: MergeJoinType.INNER },
-            }).sql,
+            toSql(
+                build({
+                    mergeQuery: {
+                        ...mergeQuery,
+                        joinType: MergeJoinType.INNER,
+                    },
+                }),
+            ),
             SETUP,
         );
         expect(
@@ -214,24 +312,26 @@ describe('buildComposeMergeSql', () => {
     });
 
     test('applies the merged-result limit', async () => {
-        const rows = await runOnDuckdb(build({ limit: 2 }).sql, SETUP);
+        const rows = await runOnDuckdb(toSql(build({ limit: 2 })), SETUP);
         expect(rows).toHaveLength(2);
     });
 
     test('compiles merge table calculations over the merged row', async () => {
         const rows = await runOnDuckdb(
-            build({
-                mergeQuery: {
-                    ...mergeQuery,
-                    tableCalculations: [
-                        {
-                            name: 'combined',
-                            displayName: 'Combined',
-                            sql: 'COALESCE(${a.orders_count}, 0) + COALESCE(${b.payments_sum}, 0)',
-                        },
-                    ],
-                },
-            }).sql,
+            toSql(
+                build({
+                    mergeQuery: {
+                        ...mergeQuery,
+                        tableCalculations: [
+                            {
+                                name: 'combined',
+                                displayName: 'Combined',
+                                sql: 'COALESCE(${a.orders_count}, 0) + COALESCE(${b.payments_sum}, 0)',
+                            },
+                        ],
+                    },
+                }),
+            ),
             SETUP,
         );
         expect(
@@ -245,22 +345,69 @@ describe('buildComposeMergeSql', () => {
     });
 
     test('casts string keys before coalescing', () => {
-        const { sql } = build({
-            fieldTypes: {
-                a: {
-                    orders_month: {
-                        type: DimensionType.STRING,
-                        timeInterval: null,
+        const sql = toSql(
+            build({
+                fieldTypes: {
+                    a: {
+                        orders_month: {
+                            type: DimensionType.STRING,
+                            timeInterval: null,
+                        },
+                    },
+                    b: {
+                        payments_month: {
+                            type: DimensionType.STRING,
+                            timeInterval: null,
+                        },
                     },
                 },
-                b: {
-                    payments_month: {
-                        type: DimensionType.STRING,
-                        timeInterval: null,
-                    },
+            }),
+        );
+        expect(sql).toContain('AS VARCHAR');
+    });
+
+    test('pivots the merged result through the composer on the compose engine', async () => {
+        const built = build();
+        const composer = new MergeQueryComposer({
+            coreSql: built.coreSql,
+            terminalWrapper: built.terminalWrapper,
+            itemsMap,
+            typedColumns,
+            columnOrder: ['merge_month', 'a_orders_count', 'b_payments_sum'],
+            limit: 500,
+            parameterReferences: [],
+            usedParametersValues: {},
+            warehouseClient: duckdbWarehouseClient,
+            // Indexed pivot (groupByColumns present), so the DENSE_RANK
+            // row/column-index pipeline compiles for the DuckDB dialect —
+            // the shape a pivoted merged visualization sends
+            pivotConfiguration: {
+                indexColumn: {
+                    reference: 'merge_month',
+                    type: VizIndexType.TIME,
                 },
+                valuesColumns: [
+                    {
+                        reference: 'b_payments_sum',
+                        aggregation: VizAggregationOptions.ANY,
+                    },
+                ],
+                groupByColumns: [{ reference: 'a_orders_count' }],
+                sortBy: undefined,
             },
         });
-        expect(sql).toContain('AS VARCHAR');
+        const sql = composer.getSql({ columnLimit: 100 });
+        expect(sql).toContain('row_index');
+        expect(sql).toContain('column_index');
+
+        const rows = await runOnDuckdb(sql, SETUP);
+        // One pivot row per index value, tagged for the two-phase transform
+        expect(rows.map((row) => [row.merge_month, row.row_index])).toEqual([
+            ['2024-01-01', '1'],
+            ['2024-02-01', '2'],
+            ['2024-03-01', '3'],
+            [null, '4'],
+        ]);
+        expect(rows.every((row) => Number(row.column_index) >= 1)).toBe(true);
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/composeMergeSql.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeSql.ts
@@ -2,6 +2,7 @@ import {
     SupportedDbtAdapter,
     type MergeFieldTypes,
     type MergeQuery,
+    type MergeTerminalWrapper,
 } from '@lightdash/common';
 import { warehouseSqlBuilderFromType } from '@lightdash/warehouses';
 import {
@@ -10,8 +11,10 @@ import {
 } from './MergeQueryBuilder';
 
 export type ComposeMergeSql = {
-    /** The DuckDB join statement, terminal wrapper (sort, limit, truncation guard) included. */
-    sql: string;
+    /** The composable DuckDB join core — no ORDER BY, LIMIT or guard column. */
+    coreSql: string;
+    /** Terminal stage (sort, limit, truncation guard) for the run path to attach. */
+    terminalWrapper: MergeTerminalWrapper;
     /** Reference table name per source id, for binding to leg queryUuids. */
     referenceTableBySourceId: Record<string, string>;
 };
@@ -93,7 +96,8 @@ export const buildComposeMergeSql = (args: {
     });
 
     return {
-        sql: builder.toSql(outputAliasByColumn),
+        coreSql: builder.toCoreSql(outputAliasByColumn),
+        terminalWrapper: builder.buildTerminalWrapper(outputAliasByColumn),
         referenceTableBySourceId,
     };
 };


### PR DESCRIPTION
Second slice of merge-on-compose (stacked on #27698): pivoted merges now run on the compose engine too, so the flag covers the whole merge surface and a parity evaluation compares complete behavior.

## What this does

- Removes the pivot fallback guard: `tryExecuteComposeMergeQuery` accepts the derived `pivotConfiguration` (chart-derived or explicit legacy) and the compose path goes through **`MergeQueryComposer` with the compose engine client as its dialect** — the pivot stage (`PivotQueryBuilder`) and the terminal wrapper compile for DuckDB through the exact seam the warehouse merge uses. No parallel pivot implementation.
- `buildComposeMergeSql` returns `{ coreSql, terminalWrapper }` instead of a pre-assembled statement, so the composer owns terminal/pivot assembly for both engines (pivoted statements keep the truncation guard outermost, ordering owned by the pivot stage — `finalizeSql` semantics inherited).
- The query row now persists the composer's fields map (metric/dimension format overrides included) and the pivot configuration; `runAsyncWarehouseQuery` receives `pivotConfiguration`, so the two-phase row/column-index transform, pivot metadata (`pivot_values_columns`, `pivotDetails`) and pivoted pagination are all inherited from the shared pipeline.
- The response mirrors the warehouse path exactly: composer-derived `metricQuery`, `fields`, `warnings`, parameter references, display timezone.

## Regression analysis

- Flag off: no behavior change — the only touched shared code is `buildComposeMergeSql`'s return shape (compose-only) and the pass-through of `pivotConfiguration` into the compose-only background phase. Warehouse merge path untouched.
- Live parity on a seeded instance, same `mergeQuery/run` request with an explicit `pivotConfiguration`, flag toggled via org override: **26/26 pivoted rows, 0 value diffs, identical formatted values, identical `pivotDetails`** between warehouse and compose engines.
- Generator tests now execute an **indexed pivot** (DENSE_RANK row/column-index pipeline) over the composed merge on a real in-memory DuckDB, alongside the existing join-semantics suite (11 tests).
- Backend typecheck, oxlint, oxfmt clean; changed-file test run green.

## Still ahead in the stack

Reuse-by-queryUuid merge sources (zero-warehouse merges), then parity harness + rollout mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrPvhrUr7VWeotEPwkAJcE
