### PR TITLE
fix: make validator summary chips match the filtered table

### DIFF
--- a/packages/backend/src/controllers/v2/ValidationController.ts
+++ b/packages/backend/src/controllers/v2/ValidationController.ts
@@ -44,6 +44,7 @@ export class ValidationControllerV2 extends BaseController {
      * @param sourceTypes comma-separated list of source types to filter by
      * @param errorTypes comma-separated list of error types to filter by
      * @param tableName filter to errors caused by this model/table
+     * @param fieldName filter to errors caused by this field
      * @param includeChartConfigWarnings whether to include chart configuration warnings
      * @param fromSettings boolean for analytics tracking
      */
@@ -62,6 +63,7 @@ export class ValidationControllerV2 extends BaseController {
         @Query() sourceTypes?: string,
         @Query() errorTypes?: string,
         @Query() tableName?: string,
+        @Query() fieldName?: string,
         @Query() includeChartConfigWarnings?: boolean,
         @Query() fromSettings?: boolean,
     ): Promise<ApiPaginatedValidateResponse> {
@@ -101,6 +103,7 @@ export class ValidationControllerV2 extends BaseController {
                     sourceTypes: parsedSourceTypes,
                     errorTypes: parsedErrorTypes,
                     tableName,
+                    fieldName,
                     includeChartConfigWarnings,
                     fromSettings,
                 },

--- a/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
@@ -125,7 +125,7 @@ describe('ValidationModel', () => {
             tracker.reset();
         });
 
-        it('matches the table name recovered from the error message, and filters by field', async () => {
+        it('matches the table name rows without table_name still expose, and filters by field', async () => {
             tracker.on.select(({ sql }) => sql.length > 0).response([]);
 
             await model.getPaginated(
@@ -135,8 +135,13 @@ describe('ValidationModel', () => {
             );
 
             const [query] = tracker.history.select;
-            expect(query.sql).toContain('COALESCE(');
+            // Dashboards recover the table from the error message, table and
+            // data app rows from model_name
+            expect(query.sql).toContain("WHEN source = 'dashboard'");
             expect(query.sql).toContain('substring(error from');
+            expect(query.sql).toContain(
+                'ELSE COALESCE(table_name, model_name)',
+            );
             expect(query.bindings).toContain('orders');
             expect(query.sql).toContain('"field_name" = ');
             expect(query.bindings).toContain('orders_status');

--- a/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
@@ -112,6 +112,37 @@ describe('ValidationModel', () => {
         });
     });
 
+    describe('getPaginated filters', () => {
+        const database = knex({ client: MockClient, dialect: 'pg' });
+        const model = new ValidationModel({ database });
+        let tracker: Tracker;
+
+        beforeAll(() => {
+            tracker = getTracker();
+        });
+
+        afterEach(() => {
+            tracker.reset();
+        });
+
+        it('matches the table name recovered from the error message, and filters by field', async () => {
+            tracker.on.select(({ sql }) => sql.length > 0).response([]);
+
+            await model.getPaginated(
+                '22222222-2222-4222-8222-222222222222',
+                { page: 1, pageSize: 20 },
+                { tableName: 'orders', fieldName: 'orders_status' },
+            );
+
+            const [query] = tracker.history.select;
+            expect(query.sql).toContain('COALESCE(');
+            expect(query.sql).toContain('substring(error from');
+            expect(query.bindings).toContain('orders');
+            expect(query.sql).toContain('"field_name" = ');
+            expect(query.bindings).toContain('orders_status');
+        });
+    });
+
     describe('parseDashboardFilterError', () => {
         it('Should parse "table not used by any chart" error', () => {
             const error =

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -276,17 +276,22 @@ export class ValidationModel {
             .delete();
     }
 
-    // Dashboard rows written before `table_name` was populated only carry the
-    // table in their error message, and `parseDashboardFilterError` recovers it
-    // for the response. Filtering by table has to see the same value, or a
-    // summary chip built from it matches no rows. Keep the patterns in sync.
-    private static readonly EFFECTIVE_TABLE_NAME_SQL = `COALESCE(
+    // `table_name` is only populated for rows written since it was added, so
+    // responses recover the model another way: from the error message for
+    // dashboards (`parseDashboardFilterError`), and from `model_name` for table
+    // and data app rows. Filtering by table has to see the same value, or a
+    // summary chip built from it matches no rows. Dashboards are excluded from
+    // the `model_name` fallback — there it holds the dashboard's name, not a
+    // model. Keep the patterns in sync with `parseDashboardFilterError`.
+    private static readonly EFFECTIVE_TABLE_NAME_SQL = `CASE WHEN source = '${
+        ValidationSourceType.Dashboard
+    }' THEN COALESCE(
         table_name,
         substring(error from $re$references table '([^']+)' which is not used by any chart on this dashboard$re$),
         substring(error from $re$Table '([^']+)' no longer exists$re$),
         substring(error from $re$the field '[^']+' does not match table '([^']+)'$re$),
         substring(error from $re$the field '[^']+' on table '([^']+)' no longer exists$re$)
-    )`;
+    ) ELSE COALESCE(table_name, model_name) END`;
 
     public static parseDashboardFilterError(error: string): {
         tableName?: string;

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -276,6 +276,18 @@ export class ValidationModel {
             .delete();
     }
 
+    // Dashboard rows written before `table_name` was populated only carry the
+    // table in their error message, and `parseDashboardFilterError` recovers it
+    // for the response. Filtering by table has to see the same value, or a
+    // summary chip built from it matches no rows. Keep the patterns in sync.
+    private static readonly EFFECTIVE_TABLE_NAME_SQL = `COALESCE(
+        table_name,
+        substring(error from $re$references table '([^']+)' which is not used by any chart on this dashboard$re$),
+        substring(error from $re$Table '([^']+)' no longer exists$re$),
+        substring(error from $re$the field '[^']+' does not match table '([^']+)'$re$),
+        substring(error from $re$the field '[^']+' on table '([^']+)' no longer exists$re$)
+    )`;
+
     public static parseDashboardFilterError(error: string): {
         tableName?: string;
         dashboardFilterErrorType?: DashboardFilterValidationErrorType;
@@ -990,6 +1002,7 @@ export class ValidationModel {
             sourceTypes?: ValidationSourceType[];
             errorTypes?: ValidationErrorType[];
             tableName?: string;
+            fieldName?: string;
             includeChartConfigWarnings?: boolean;
             allowedSpaceUuids?: string[] | 'all';
             allowedAppUuids?: string[] | 'all';
@@ -1003,6 +1016,7 @@ export class ValidationModel {
             sourceTypes,
             errorTypes,
             tableName,
+            fieldName,
             includeChartConfigWarnings = false,
             allowedSpaceUuids = 'all',
             allowedAppUuids = 'all',
@@ -1301,7 +1315,13 @@ export class ValidationModel {
                         void qb.whereIn('error_type', errorTypes);
                     }
                     if (tableName) {
-                        void qb.where('table_name', tableName);
+                        void qb.whereRaw(
+                            `${ValidationModel.EFFECTIVE_TABLE_NAME_SQL} = ?`,
+                            [tableName],
+                        );
+                    }
+                    if (fieldName) {
+                        void qb.where('field_name', fieldName);
                     }
                     if (!includeChartConfigWarnings) {
                         void qb.whereNot((inner) => {

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -1249,7 +1249,7 @@ describe('ValidationService.groupValidationsByRootCause', () => {
         expect(summary.totalAffectedItems).toBe(1);
     });
 
-    it('excludes chart configuration warnings and keeps masked private content in counts', () => {
+    it('excludes chart configuration warnings and keeps content without a uuid in counts', () => {
         const summary = ValidationService.groupValidationsByRootCause([
             chartModelError('chart-1', 'Chart one', 0),
             chartModelError(undefined, 'Private content', 0),
@@ -1381,5 +1381,54 @@ describe('ValidationService.getValidationSummary', () => {
                 'projectUuid',
             ),
         ).rejects.toThrowError(ForbiddenError);
+    });
+
+    it('excludes content in spaces the user cannot see, so chip counts match the table', async () => {
+        const chartError = (
+            chartUuid: string,
+            name: string,
+            spaceUuid: string,
+        ) => ({
+            validationId: null,
+            createdAt: new Date(),
+            projectUuid: 'projectUuid',
+            validationUuid: `validation-${chartUuid}`,
+            source: ValidationSourceType.Chart,
+            name,
+            error: "Model error: the model 'orders' no longer exists",
+            errorType: ValidationErrorType.Model,
+            chartUuid,
+            chartViews: 0,
+            tableName: 'orders',
+            spaceUuid,
+        });
+        (validationModel.get as import('vitest').Mock).mockImplementationOnce(
+            async () => [
+                chartError('chart-public', 'Public chart', 'public-space'),
+                chartError('chart-private', 'Private chart', 'private-space'),
+            ],
+        );
+        spaceModel.find.mockResolvedValueOnce([
+            { uuid: 'public-space' },
+            { uuid: 'private-space' },
+        ] as AnyType);
+        spacePermissionService.getAccessibleSpaceUuids.mockResolvedValueOnce([
+            'public-space',
+        ] as AnyType);
+
+        const summary = await validationService.getValidationSummary(
+            { ...user, role: OrganizationMemberRole.DEVELOPER },
+            'projectUuid',
+        );
+
+        expect(summary.totalErrors).toBe(1);
+        expect(summary.totalAffectedItems).toBe(1);
+        expect(summary.groups[0]).toMatchObject({
+            errorCount: 1,
+            affectedCharts: 1,
+        });
+        expect(
+            summary.groups[0]!.affectedContent.map((content) => content.uuid),
+        ).toEqual(['chart-public']);
     });
 });

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -1252,6 +1252,75 @@ export class ValidationService extends BaseService {
         }
     }
 
+    private async resolveAllowedContent(
+        user: SessionUser,
+        projectUuid: string,
+        organizationUuid: string,
+    ): Promise<{
+        allowedSpaceUuids: string[] | 'all';
+        allowedAppUuids: string[] | 'all';
+    }> {
+        if (user.role === OrganizationMemberRole.ADMIN) {
+            return { allowedSpaceUuids: 'all', allowedAppUuids: 'all' };
+        }
+
+        const spaces = await this.spaceModel.find({ projectUuid });
+        const allowedSpaceUuids =
+            await this.spacePermissionService.getAccessibleSpaceUuids(
+                'view',
+                user,
+                spaces.map((s) => s.uuid),
+            );
+
+        return {
+            allowedSpaceUuids,
+            allowedAppUuids: await this.resolveAllowedAppUuids(
+                user,
+                projectUuid,
+                organizationUuid,
+                allowedSpaceUuids,
+            ),
+        };
+    }
+
+    // Drops the validations the paginated list hides, so summary counts and the
+    // table agree. `hidePrivateContent` masks names instead, for callers that
+    // return every row.
+    static filterInaccessibleContent(
+        validations: ValidationResponse[],
+        {
+            allowedSpaceUuids,
+            allowedAppUuids,
+        }: {
+            allowedSpaceUuids: string[] | 'all';
+            allowedAppUuids: string[] | 'all';
+        },
+    ): ValidationResponse[] {
+        return validations.filter((validation) => {
+            if (isDataAppValidationError(validation)) {
+                return (
+                    allowedAppUuids === 'all' ||
+                    (validation.appUuid !== undefined &&
+                        allowedAppUuids.includes(validation.appUuid))
+                );
+            }
+
+            if (
+                isChartValidationError(validation) ||
+                isDashboardValidationError(validation)
+            ) {
+                return (
+                    allowedSpaceUuids === 'all' ||
+                    (validation.spaceUuid !== undefined &&
+                        allowedSpaceUuids.includes(validation.spaceUuid))
+                );
+            }
+
+            // Table validations are project-level, not space-specific.
+            return true;
+        });
+    }
+
     async hidePrivateContent(
         user: SessionUser,
         projectUuid: string,
@@ -1259,22 +1328,12 @@ export class ValidationService extends BaseService {
     ): Promise<ValidationResponse[]> {
         if (user.role === OrganizationMemberRole.ADMIN) return validations;
 
-        const spaces = await this.spaceModel.find({ projectUuid });
-        const spaceUuids = spaces.map((s) => s.uuid);
-
-        const allowedSpaceUuids =
-            await this.spacePermissionService.getAccessibleSpaceUuids(
-                'view',
+        const { allowedSpaceUuids, allowedAppUuids } =
+            await this.resolveAllowedContent(
                 user,
-                spaceUuids,
+                projectUuid,
+                user.organizationUuid!,
             );
-
-        const allowedAppUuids = await this.resolveAllowedAppUuids(
-            user,
-            projectUuid,
-            user.organizationUuid!,
-            allowedSpaceUuids,
-        );
         const allowedAppUuidSet = new Set(
             allowedAppUuids === 'all' ? [] : allowedAppUuids,
         );
@@ -1320,11 +1379,10 @@ export class ValidationService extends BaseService {
                     };
                 }
 
-                const space = spaces.find(
-                    (s) => s.uuid === validation.spaceUuid,
-                );
                 const hasAccess =
-                    space && allowedSpaceUuids.includes(space.uuid);
+                    allowedSpaceUuids === 'all' ||
+                    (validation.spaceUuid !== undefined &&
+                        allowedSpaceUuids.includes(validation.spaceUuid));
                 if (hasAccess) return validation;
 
                 return {
@@ -1617,13 +1675,18 @@ export class ValidationService extends BaseService {
         const allValidations = await this.validationModel.get(projectUuid);
         const validations =
             ValidationService.filterOrphanedValidations(allValidations);
-        const maskedValidations = await this.hidePrivateContent(
+        const allowedContent = await this.resolveAllowedContent(
             user,
             projectUuid,
-            validations,
+            organizationUuid!,
         );
 
-        return ValidationService.groupValidationsByRootCause(maskedValidations);
+        return ValidationService.groupValidationsByRootCause(
+            ValidationService.filterInaccessibleContent(
+                validations,
+                allowedContent,
+            ),
+        );
     }
 
     async get(
@@ -1748,6 +1811,7 @@ export class ValidationService extends BaseService {
             sourceTypes?: ValidationSourceType[];
             errorTypes?: ValidationErrorType[];
             tableName?: string;
+            fieldName?: string;
             includeChartConfigWarnings?: boolean;
             fromSettings?: boolean;
             jobId?: string;
@@ -1774,26 +1838,12 @@ export class ValidationService extends BaseService {
             throw new ForbiddenError();
         }
 
-        let allowedSpaceUuids: string[] | 'all' = 'all';
-
-        if (user.role !== OrganizationMemberRole.ADMIN) {
-            const spaces = await this.spaceModel.find({ projectUuid });
-            const spaceUuids = spaces.map((s) => s.uuid);
-
-            allowedSpaceUuids =
-                await this.spacePermissionService.getAccessibleSpaceUuids(
-                    'view',
-                    user,
-                    spaceUuids,
-                );
-        }
-
-        const allowedAppUuids = await this.resolveAllowedAppUuids(
-            user,
-            projectUuid,
-            projectSummary.organizationUuid,
-            allowedSpaceUuids,
-        );
+        const { allowedSpaceUuids, allowedAppUuids } =
+            await this.resolveAllowedContent(
+                user,
+                projectUuid,
+                projectSummary.organizationUuid,
+            );
 
         const result = await this.validationModel.getPaginated(
             projectUuid,
@@ -1805,6 +1855,7 @@ export class ValidationService extends BaseService {
                 sourceTypes: options?.sourceTypes,
                 errorTypes: options?.errorTypes,
                 tableName: options?.tableName,
+                fieldName: options?.fieldName,
                 includeChartConfigWarnings: options?.includeChartConfigWarnings,
                 allowedSpaceUuids,
                 allowedAppUuids,

--- a/packages/frontend/src/components/SettingsValidator/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/index.tsx
@@ -75,6 +75,7 @@ export const SettingsValidator: FC<{
                 sourceTypeFilter.length > 0 ? sourceTypeFilter : undefined,
             errorTypes: activeGroup ? [activeGroup.errorType] : undefined,
             tableName: activeGroup?.tableName ?? undefined,
+            fieldName: activeGroup?.fieldName ?? undefined,
             includeChartConfigWarnings: showConfigWarnings,
         });
 
@@ -166,7 +167,10 @@ export const SettingsValidator: FC<{
 
     // Check if filters are active to determine if we should always show the table
     const hasActiveFilters =
-        searchQuery !== '' || sourceTypeFilter.length > 0 || showConfigWarnings;
+        searchQuery !== '' ||
+        sourceTypeFilter.length > 0 ||
+        showConfigWarnings ||
+        activeGroup !== null;
 
     const content = (
         <>

--- a/packages/frontend/src/hooks/validation/useValidation.ts
+++ b/packages/frontend/src/hooks/validation/useValidation.ts
@@ -176,6 +176,7 @@ const getPaginatedValidation = async (
         sourceTypes?: ValidationSourceType[];
         errorTypes?: ValidationErrorType[];
         tableName?: string;
+        fieldName?: string;
         includeChartConfigWarnings?: boolean;
         fromSettings?: boolean;
     },
@@ -194,6 +195,7 @@ const getPaginatedValidation = async (
     if (options?.errorTypes?.length)
         params.set('errorTypes', options.errorTypes.join(','));
     if (options?.tableName) params.set('tableName', options.tableName);
+    if (options?.fieldName) params.set('fieldName', options.fieldName);
     if (options?.includeChartConfigWarnings != null)
         params.set(
             'includeChartConfigWarnings',
@@ -221,6 +223,7 @@ export const usePaginatedValidation = (
         sourceTypes?: ValidationSourceType[];
         errorTypes?: ValidationErrorType[];
         tableName?: string;
+        fieldName?: string;
         includeChartConfigWarnings?: boolean;
     },
 ) => {
@@ -246,6 +249,7 @@ export const usePaginatedValidation = (
             options?.sourceTypes,
             options?.errorTypes,
             options?.tableName,
+            options?.fieldName,
             options?.includeChartConfigWarnings,
         ],
         queryFn: async ({ pageParam = 1 }) =>
@@ -256,6 +260,7 @@ export const usePaginatedValidation = (
                 sourceTypes: options?.sourceTypes,
                 errorTypes: options?.errorTypes,
                 tableName: options?.tableName,
+                fieldName: options?.fieldName,
                 includeChartConfigWarnings: options?.includeChartConfigWarnings,
                 fromSettings: true,
             }),


### PR DESCRIPTION
Closes: lightdash/lightdash#27695

### Description:

Clicking a validator summary chip could show "No validation errors found" even though the chip counted errors. Three ways the chip counts and the filtered table disagreed:

* **Space visibility**: `getValidationSummary` masked private content names but kept those rows in the counts, while `ValidationModel.getPaginated` excludes them for non-org-admins. The summary now drops content the user can't see (new `filterInaccessibleContent`), so counts reflect the table. The allowed-space/app resolution is shared by `hidePrivateContent`, `getPaginated` and the summary.
* **Rows without** `table_name`: the column was added without a backfill, so rows written before the upgrade are null until the next validation run. Responses still expose a model for them — parsed from the error message for dashboards, `model_name` for table and data app rows — but the chip filtered on the raw column and matched nothing. Filtering now recovers the same value in SQL (dashboards excluded from the `model_name` fallback, where it holds the dashboard's name).
* **Field-level chips**: they filtered by error type + table only, so they listed a superset of their group. Added a `fieldName` filter (new optional query param on `GET /api/v2/projects/{uuid}/validate`) and pass it from the chip.

Also treats an active group as an active filter in the frontend, so a filtered-but-empty result keeps the table (and its toolbar) visible instead of the success empty state.

**Worth a reviewer's opinion**: the summary now hides errors in content the user can't see, rather than counting them under a masked name. That matches the table, but it does mean a non-admin no longer sees that *something* is broken in a space they lack access to.

Verified with unit tests in `ValidationService.test.ts` (summary excludes inaccessible spaces) and `ValidationModel.test.ts` (filter SQL), plus an ad-hoc run of the generated filter expression against Postgres over rows covering every legacy message form — including a dashboard *named* like a model, which correctly does not match.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.