### PR TITLE
feat(merge-queries): merge existing query results by queryUuid

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -558,12 +558,16 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await this.services.getProjectService().compileMergeQuery({
-                account: req.account!,
-                projectUuid,
-                mergeQuery: body.mergeQuery,
-                parameters: body.parameters,
-            }),
+            // The async query service, not the base project service: result
+            // sources resolve from query history, which only it can reach
+            results: await this.services
+                .getAsyncQueryService()
+                .compileMergeQuery({
+                    account: req.account!,
+                    projectUuid,
+                    mergeQuery: body.mergeQuery,
+                    parameters: body.parameters,
+                }),
         };
     }
 

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -27,6 +27,7 @@ import {
     type ApiDownloadAsyncQueryResults,
     type ApiDownloadAsyncQueryResultsAsCsv,
     type ApiDownloadAsyncQueryResultsAsXlsx,
+    type ApiExecuteAsyncComposeMergeQueryRequest,
     type ApiExecuteAsyncMergeQueryRequest,
     type ApiExecuteAsyncMergeQueryResults,
     type ApiExecuteAsyncMetricQueryResults,
@@ -258,6 +259,40 @@ export class QueryController extends BaseController {
     @OperationId('executeAsyncMergeQuery')
     async executeAsyncMergeQuery(
         @Body() body: ApiExecuteAsyncMergeQueryRequest,
+        @Path() projectUuid: UUID,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccess<ApiExecuteAsyncMergeQueryResults>> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results = await this.services
+            .getAsyncQueryService()
+            .executeAsyncMergeQuery({
+                account: req.account,
+                projectUuid,
+                mergeQuery: body.mergeQuery,
+                context:
+                    body.context ??
+                    getContextFromHeader(req) ??
+                    QueryExecutionContext.API,
+                invalidateCache: body.invalidateCache,
+                parameters: body.parameters,
+                mode: body.mode ?? { type: 'interactive' },
+                chart: body.chart,
+            });
+
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Validates and executes a merge on the compose engine as one asynchronous query request. Unlike Execute merge query, sources may reference existing query results by queryUuid; each referenced query is authorized with the same access checks as fetching its results. Requires the merge-on-compose feature flag.
+     * @summary Execute compose merge query
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/compose-merge-query')
+    @OperationId('executeAsyncComposeMergeQuery')
+    async executeAsyncComposeMergeQuery(
+        @Body() body: ApiExecuteAsyncComposeMergeQueryRequest,
         @Path() projectUuid: UUID,
         @Request() req: express.Request,
     ): Promise<ApiSuccess<ApiExecuteAsyncMergeQueryResults>> {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -89,7 +89,7 @@ import {
     KnexPaginateArgs,
     KnexPaginatedData,
     LightdashUser,
-    MergeQuery,
+    MetricSourcedMergeQuery,
     NotFoundError,
     NotImplementedError,
     OpenIdIdentity,
@@ -2355,7 +2355,7 @@ export class AiAgentService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         toolArgs: ToolRunQueryArgsTransformed,
-    ): Promise<MergeQuery> {
+    ): Promise<MetricSourcedMergeQuery> {
         const exploreByName = Object.fromEntries(
             await Promise.all(
                 buildAiMergeSourceConfigs(toolArgs).map(

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -10,6 +10,7 @@ import {
     getSlackAiEchartsConfig,
     getTotalFilterRules,
     getValidAiQueryLimit,
+    isMergeMetricSource,
     isSlackPrompt,
     MERGE_TABLE_NAME,
     toolRunQueryArgsSchemaTransformed,
@@ -359,14 +360,16 @@ export const getRunQuery = ({
                                     name: part.name,
                                 }),
                         );
-                        const metricIds = mergeQuery.sources.flatMap((source) =>
-                            source.metricQuery.metrics.map((metricId) =>
-                                getItemId({
-                                    table: source.id,
-                                    name: metricId,
-                                }),
-                            ),
-                        );
+                        const metricIds = mergeQuery.sources
+                            .filter(isMergeMetricSource)
+                            .flatMap((source) =>
+                                source.metricQuery.metrics.map((metricId) =>
+                                    getItemId({
+                                        table: source.id,
+                                        name: metricId,
+                                    }),
+                                ),
+                            );
                         const selected = new Set([
                             ...dimensionIds,
                             ...metricIds,

--- a/packages/backend/src/ee/services/ai/utils/buildAiMergeQuery.ts
+++ b/packages/backend/src/ee/services/ai/utils/buildAiMergeQuery.ts
@@ -2,7 +2,7 @@ import {
     getValidAiQueryLimit,
     ParameterError,
     type Explore,
-    type MergeQuery,
+    type MetricSourcedMergeQuery,
     type ToolRunQueryArgsTransformed,
 } from '@lightdash/common';
 import {
@@ -51,7 +51,7 @@ export const buildAiMergeQuery = ({
     toolArgs: ToolRunQueryArgsTransformed;
     getExplore: (exploreName: string) => Explore;
     maxQueryLimit: number;
-}): MergeQuery => {
+}): MetricSourcedMergeQuery => {
     const { mergeConfig } = toolArgs;
     if (!mergeConfig) {
         throw new ParameterError('Merge config not found');

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -65,6 +65,7 @@ import {
     isJwtUser,
     isMergeResultSource,
     isMetric,
+    isMetricSourcedMergeQuery,
     isValidTimezone,
     isVizTableConfig,
     ItemsMap,
@@ -115,6 +116,7 @@ import {
     type CompiledCustomSqlDimension,
     type CompiledMetric,
     type CustomDimension,
+    type ExecuteAsyncComposeMergeQueryRequestParams,
     type ExecuteAsyncComposeSqlQueryRequestParams,
     type ExecuteAsyncDashboardChartRequestParams,
     type ExecuteAsyncFieldValueSearchRequestParams,
@@ -7330,6 +7332,13 @@ export class AsyncQueryService extends ProjectService {
                   }
                 : userAccessControls,
         );
+        // Routing guarantees this: merges with result sources never reach
+        // the warehouse path (they require the compose engine)
+        if (!isMetricSourcedMergeQuery(mergeQuery)) {
+            throw new UnexpectedServerError(
+                'A merge with result sources cannot run as a warehouse statement',
+            );
+        }
         const requestParameters: ExecuteAsyncMergeQueryRequestParams = {
             context,
             invalidateCache,
@@ -7544,7 +7553,7 @@ export class AsyncQueryService extends ProjectService {
             userUuid: account.user.id,
         });
 
-        const requestParameters: ExecuteAsyncMergeQueryRequestParams = {
+        const requestParameters: ExecuteAsyncComposeMergeQueryRequestParams = {
             context,
             invalidateCache,
             mergeQuery,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -63,6 +63,7 @@ import {
     isExploreError,
     isField,
     isJwtUser,
+    isMergeResultSource,
     isMetric,
     isValidTimezone,
     isVizTableConfig,
@@ -71,6 +72,7 @@ import {
     KnexPaginatedData,
     LightdashError,
     MergeQuery,
+    MergeQueryErrorKind,
     MetricQuery,
     MissingConfigError,
     normalizeIndexColumns,
@@ -283,6 +285,23 @@ const isRunnableCompiledMergeQuery = (
     compiled.coreSql !== null &&
     compiled.typedColumns !== null &&
     compiled.terminalWrapper !== null;
+
+/**
+ * A compiled merge the compose engine can run: no errors and full metadata.
+ * Unlike the warehouse-runnable narrowing it needs no statement — the
+ * compose path builds its own join over the sources' materialized results.
+ */
+type ComposableCompiledMergeQuery = ApiCompiledMergeQueryResults & {
+    typedColumns: NonNullable<ApiCompiledMergeQueryResults['typedColumns']>;
+    columns: NonNullable<ApiCompiledMergeQueryResults['columns']>;
+};
+
+const isComposableCompiledMergeQuery = (
+    compiled: ApiCompiledMergeQueryResults,
+): compiled is ComposableCompiledMergeQuery =>
+    compiled.errors.length === 0 &&
+    compiled.typedColumns !== null &&
+    compiled.columns !== null;
 
 type ExecuteCompiledAsyncMergeQueryArgs = Omit<
     ExecuteAsyncMergeQueryArgs,
@@ -7140,7 +7159,7 @@ export class AsyncQueryService extends ProjectService {
             parameters,
             userAttributeOverrides,
         });
-        if (!isRunnableCompiledMergeQuery(compiledMerge)) {
+        if (!isComposableCompiledMergeQuery(compiledMerge)) {
             return {
                 outcome: 'refused',
                 errors: compiledMerge.errors,
@@ -7184,6 +7203,33 @@ export class AsyncQueryService extends ProjectService {
             return {
                 outcome: 'started',
                 query: composeQuery,
+                parameterReferences: compiledMerge.parameterReferences,
+                fieldOrigins: compiledMerge.fieldOrigins,
+            };
+        }
+
+        // Result sources have no warehouse statement to fall back to
+        if (compiledMerge.requiresCompose) {
+            return {
+                outcome: 'refused',
+                errors: [
+                    {
+                        kind: MergeQueryErrorKind.COMPOSE_REQUIRED,
+                        sourceId: null,
+                        fieldIds: [],
+                        message:
+                            'This merge reads existing query results, which need the compose engine. It is not enabled or not available on this instance.',
+                    },
+                ],
+                parameterReferences: compiledMerge.parameterReferences,
+                fieldOrigins: compiledMerge.fieldOrigins,
+            };
+        }
+
+        if (!isRunnableCompiledMergeQuery(compiledMerge)) {
+            return {
+                outcome: 'refused',
+                errors: compiledMerge.errors,
                 parameterReferences: compiledMerge.parameterReferences,
                 fieldOrigins: compiledMerge.fieldOrigins,
             };
@@ -7352,7 +7398,7 @@ export class AsyncQueryService extends ProjectService {
         parameters: ParametersValuesMap | undefined;
         userAttributeOverrides: UserAttributeValueMap | undefined;
         pivotConfiguration: PivotConfiguration | undefined;
-        compiledMerge: RunnableCompiledMergeQuery;
+        compiledMerge: ComposableCompiledMergeQuery;
     }): Promise<ApiExecuteAsyncMetricQueryResults | null> {
         assertIsAccountWithOrg(account);
 
@@ -7381,10 +7427,15 @@ export class AsyncQueryService extends ProjectService {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         const sourceRowCap = this.lightdashConfig.query.maxLimit;
 
-        // Legs run whole: the merged statement sorts and limits, and a side
-        // is never silently truncated below the source row cap
+        // Metric sources run whole (the merged statement sorts and limits,
+        // and a side is never silently truncated below the source row cap);
+        // result sources are already materialized and join as they are —
+        // referencing them costs no warehouse query at all.
         const legs = await Promise.all(
             mergeQuery.sources.map(async (source) => {
+                if (isMergeResultSource(source)) {
+                    return [source.id, source.queryUuid] as const;
+                }
                 const leg = await this.executeAsyncMetricQuery({
                     account,
                     projectUuid,
@@ -7411,7 +7462,17 @@ export class AsyncQueryService extends ProjectService {
         const columnOrder = Object.values(compiledMerge.fieldIdByColumn);
         const { coreSql, terminalWrapper, referenceTableBySourceId } =
             buildComposeMergeSql({
-                mergeQuery,
+                sources: mergeQuery.sources.map((source) => ({
+                    id: source.id,
+                    valueColumns: Object.keys(
+                        compiledMerge.columns.valueColumnBySourceColumn[
+                            source.id
+                        ] ?? {},
+                    ),
+                })),
+                joinKey: mergeQuery.joinKey,
+                joinType: mergeQuery.joinType,
+                tableCalculations: mergeQuery.tableCalculations,
                 fieldTypes,
                 outputAliasByColumn: compiledMerge.fieldIdByColumn,
                 limit: Math.min(mergeQuery.limit, sourceRowCap),
@@ -7551,6 +7612,46 @@ export class AsyncQueryService extends ProjectService {
             parameterReferences: composer.getParameterReferences(),
             usedParametersValues: composer.getUsedParameters(),
             resolvedTimezone: composer.getDisplayTimezone(),
+        };
+    }
+
+    /**
+     * Result sources resolve from the caller's own query history: creator-
+     * scoped lookup, READY with unexpired results, and stored field metadata
+     * to validate and type the merge against. Failures phrase as fragments —
+     * the compiler prefixes them with the source at fault.
+     */
+    protected async getMergeResultSourceMetadata(
+        account: Account,
+        projectUuid: string,
+        queryUuid: string,
+    ): Promise<{ metricQuery: MetricQuery; fields: ItemsMap }> {
+        const queryHistory = await this.queryHistoryModel.get(
+            queryUuid,
+            projectUuid,
+            account,
+        );
+        if (queryHistory.status !== QueryHistoryStatus.READY) {
+            throw new ParameterError(
+                `its results are not ready (status: ${queryHistory.status}).`,
+            );
+        }
+        if (
+            queryHistory.resultsExpiresAt &&
+            queryHistory.resultsExpiresAt < new Date()
+        ) {
+            throw new ParameterError(
+                'its results have expired. Re-run the query and merge the new result.',
+            );
+        }
+        if (Object.keys(queryHistory.fields).length === 0) {
+            throw new ParameterError(
+                'its results carry no field metadata to merge on.',
+            );
+        }
+        return {
+            metricQuery: queryHistory.metricQuery,
+            fields: queryHistory.fields,
         };
     }
 

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.test.ts
@@ -1,4 +1,5 @@
 import {
+    isMergeMetricSource,
     MergeJoinType,
     type MergeQuery,
     type MetricQuery,
@@ -68,7 +69,10 @@ describe('merge query execution', () => {
                 csvCellsLimit: 60,
             }).limit,
         ).toBe(10);
-        expect(mergeQuery.sources[0].metricQuery.limit).toBe(500);
+        const [firstSource] = mergeQuery.sources;
+        expect(
+            isMergeMetricSource(firstSource) && firstSource.metricQuery.limit,
+        ).toBe(500);
     });
 
     test('leaves structural validation to compilation', () => {

--- a/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
+++ b/packages/backend/src/services/AsyncQueryService/mergeQueryExecution.ts
@@ -1,13 +1,17 @@
-import type { MergeQuery } from '@lightdash/common';
+import { isMergeMetricSource, type MergeQuery } from '@lightdash/common';
 
 export const getMergeOutputColumnCount = (mergeQuery: MergeQuery): number =>
     mergeQuery.joinKey.length +
     mergeQuery.tableCalculations.length +
     mergeQuery.sources.reduce(
         (count, source) =>
-            count +
-            source.metricQuery.metrics.length +
-            source.metricQuery.tableCalculations.length,
+            // A result source's column count lives in stored metadata; the
+            // compiler's cell-cap clamp still applies to the merged limit.
+            isMergeMetricSource(source)
+                ? count +
+                  source.metricQuery.metrics.length +
+                  source.metricQuery.tableCalculations.length
+                : count,
         0,
     );
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -118,6 +118,8 @@ import {
     isField,
     isFilterableDimension,
     isJwtUser,
+    isMergeMetricSource,
+    isMergeResultSource,
     isMetric,
     isNotNull,
     isReservedParameterName,
@@ -146,7 +148,7 @@ import {
     MergeQueryError,
     MergeQueryErrorKind,
     MergeQueryField,
-    MergeQuerySource,
+    MergeQueryMetricSource,
     mergeWarehouseCredentials,
     MetricQuery,
     MetricType,
@@ -5256,6 +5258,23 @@ export class ProjectService extends BaseService {
     }
 
     /**
+     * Metadata backing a merge result source: the stored fields and the
+     * metric query that produced them. The base service has no query-history
+     * access, so merges over existing results are only compilable through
+     * services that override this (AsyncQueryService).
+     */
+    // eslint-disable-next-line class-methods-use-this
+    protected async getMergeResultSourceMetadata(
+        _account: Account,
+        _projectUuid: string,
+        _queryUuid: string,
+    ): Promise<{ metricQuery: MetricQuery; fields: ItemsMap }> {
+        throw new ParameterError(
+            'Merging existing query results is not available on this endpoint',
+        );
+    }
+
+    /**
      * Join-key field metadata straight from a merge query, for callers that
      * need the key types without the full compile (the compose execution
      * path derives dialect-specific null placeholders from them).
@@ -5268,6 +5287,14 @@ export class ProjectService extends BaseService {
         const itemMapBySourceId = Object.fromEntries(
             await Promise.all(
                 mergeQuery.sources.map(async (source) => {
+                    if (isMergeResultSource(source)) {
+                        const stored = await this.getMergeResultSourceMetadata(
+                            account,
+                            projectUuid,
+                            source.queryUuid,
+                        );
+                        return [source.id, stored.fields] as const;
+                    }
                     const explore = await this.getExplore(
                         account,
                         projectUuid,
@@ -5295,7 +5322,7 @@ export class ProjectService extends BaseService {
      * calc compiles to a literal null column.
      */
     private static getUnsupportedTableCalculations(
-        source: MergeQuerySource,
+        source: MergeQueryMetricSource,
     ): string[] {
         return source.metricQuery.tableCalculations
             .filter((calculation) => {
@@ -5336,58 +5363,125 @@ export class ProjectService extends BaseService {
             userAttributeOverrides,
         } = args;
 
-        // One metadata load feeds validation, output typing and display labels.
-        // Query-defined fields belong in the same item map as explore fields,
-        // so custom dimensions and metrics follow the canonical lookup path.
+        const requiresCompose = mergeQuery.sources.some(isMergeResultSource);
+
+        // One metadata load feeds validation, output typing and display
+        // labels. Metric sources resolve through their explore (query-defined
+        // fields join the same item map, so custom dimensions and metrics
+        // follow the canonical lookup path); result sources resolve structure
+        // and fields from the stored query metadata, after which validation
+        // and typing treat both alike.
+        const resolutionErrors: MergeQueryError[] = [];
+        const maybeResolvedSources = await Promise.all(
+            mergeQuery.sources.map(async (source) => {
+                if (isMergeResultSource(source)) {
+                    try {
+                        const stored = await this.getMergeResultSourceMetadata(
+                            account,
+                            projectUuid,
+                            source.queryUuid,
+                        );
+                        return {
+                            id: source.id,
+                            metricQuery: stored.metricQuery,
+                            itemMap: stored.fields,
+                            explore: null,
+                        };
+                    } catch (e) {
+                        resolutionErrors.push({
+                            kind: MergeQueryErrorKind.RESULT_SOURCE_UNAVAILABLE,
+                            sourceId: source.id,
+                            fieldIds: [],
+                            message: `Query "${source.id}" cannot back a merge: ${getErrorMessage(
+                                e,
+                            )}`,
+                        });
+                        return null;
+                    }
+                }
+                const explore = await this.getExplore(
+                    account,
+                    projectUuid,
+                    source.metricQuery.exploreName,
+                );
+                return {
+                    id: source.id,
+                    metricQuery: source.metricQuery,
+                    itemMap: getItemMap(
+                        explore,
+                        source.metricQuery.additionalMetrics,
+                        source.metricQuery.tableCalculations,
+                        source.metricQuery.customDimensions,
+                    ),
+                    explore,
+                };
+            }),
+        );
+        if (resolutionErrors.length > 0) {
+            return {
+                sql: null,
+                coreSql: null,
+                typedColumns: null,
+                terminalWrapper: null,
+                columns: null,
+                fields: [],
+                itemsMap: {},
+                fieldOrigins: {},
+                parameterReferences: [],
+                usedParametersValues: {},
+                fieldIdByColumn: {},
+                requiresCompose,
+                errors: resolutionErrors,
+            };
+        }
+        const resolvedSources = maybeResolvedSources.filter(
+            (source): source is NonNullable<typeof source> => source !== null,
+        );
+        const resolvedMetricQueryBySourceId = Object.fromEntries(
+            resolvedSources.map((source) => [source.id, source.metricQuery]),
+        );
         const exploreBySourceId = Object.fromEntries(
-            await Promise.all(
-                mergeQuery.sources.map(
-                    async (source) =>
-                        [
-                            source.id,
-                            await this.getExplore(
-                                account,
-                                projectUuid,
-                                source.metricQuery.exploreName,
-                            ),
-                        ] as const,
-                ),
-            ),
+            resolvedSources.map((source) => [source.id, source.explore]),
         );
         const itemMapBySourceId = Object.fromEntries(
-            mergeQuery.sources.map((source) => [
-                source.id,
-                getItemMap(
-                    exploreBySourceId[source.id],
-                    source.metricQuery.additionalMetrics,
-                    source.metricQuery.tableCalculations,
-                    source.metricQuery.customDimensions,
-                ),
-            ]),
+            resolvedSources.map((source) => [source.id, source.itemMap]),
         );
+        // The resolved form: every source metric-query-shaped, so the checks
+        // a result source defers from the shared validator run here.
+        const resolvedMergeQuery: MergeQuery = {
+            ...mergeQuery,
+            sources: resolvedSources.map(({ id, metricQuery }) => ({
+                id,
+                metricQuery,
+            })),
+        };
         const fieldTypes = this.getMergeJoinFieldTypes(
-            mergeQuery,
+            resolvedMergeQuery,
             itemMapBySourceId,
         );
 
         const errors = [
-            ...validateMergeQuery(mergeQuery, fieldTypes),
-            ...mergeQuery.sources.flatMap((source) => {
-                const unsupported =
-                    ProjectService.getUnsupportedTableCalculations(source);
-                return unsupported.length === 0
-                    ? []
-                    : [
-                          {
-                              kind: MergeQueryErrorKind.UNSUPPORTED_TABLE_CALCULATION,
-                              sourceId: source.id,
-                              fieldIds: unsupported,
-                              message: `Query "${source.id}" uses ${unsupported.join(
-                                  ', ',
-                              )}, which depend on the rows of that query alone. Merging changes those rows, so the value cannot be carried across the join.`,
-                          },
-                      ];
-            }),
+            ...validateMergeQuery(resolvedMergeQuery, fieldTypes),
+            // Result sources are exempt: their calculations already ran, so
+            // the merged row carries materialized values, not re-compiled SQL.
+            ...mergeQuery.sources
+                .filter(isMergeMetricSource)
+                .flatMap((source) => {
+                    const unsupported =
+                        ProjectService.getUnsupportedTableCalculations(source);
+                    return unsupported.length === 0
+                        ? []
+                        : [
+                              {
+                                  kind: MergeQueryErrorKind.UNSUPPORTED_TABLE_CALCULATION,
+                                  sourceId: source.id,
+                                  fieldIds: unsupported,
+                                  message: `Query "${source.id}" uses ${unsupported.join(
+                                      ', ',
+                                  )}, which depend on the rows of that query alone. Merging changes those rows, so the value cannot be carried across the join.`,
+                              },
+                          ];
+                }),
         ];
         if (errors.length > 0) {
             return {
@@ -5402,6 +5496,7 @@ export class ProjectService extends BaseService {
                 parameterReferences: [],
                 usedParametersValues: {},
                 fieldIdByColumn: {},
+                requiresCompose,
                 errors,
             };
         }
@@ -5417,8 +5512,42 @@ export class ProjectService extends BaseService {
 
         const sources = await Promise.all(
             mergeQuery.sources.map(async (source) => {
-                // Each source compiles exactly as it would on its own, so a
-                // merged query inherits the same access rules, required
+                const resolvedMetricQuery =
+                    resolvedMetricQueryBySourceId[source.id];
+                const joinKeyColumnByName = Object.fromEntries(
+                    mergeQuery.joinKey.map((part) => [
+                        part.name,
+                        part.fieldIdBySourceId[source.id],
+                    ]),
+                );
+                const valueColumns = [
+                    ...resolvedMetricQuery.metrics,
+                    ...resolvedMetricQuery.tableCalculations.map(
+                        (calculation) => calculation.name,
+                    ),
+                ];
+                const originBySourceColumn = Object.fromEntries(
+                    valueColumns.map((column) => [column, { fieldId: column }]),
+                );
+
+                // A result source is already materialized: it contributes
+                // columns and rows, never SQL — only the compose engine can
+                // join it, which `requiresCompose` reports.
+                if (isMergeResultSource(source)) {
+                    return {
+                        id: source.id,
+                        sql: '',
+                        joinKeyColumnByName,
+                        valueColumns,
+                        missingParameters: [],
+                        parameterReferences: [],
+                        usedParametersValues: {},
+                        originBySourceColumn,
+                    };
+                }
+
+                // Each metric source compiles exactly as it would on its own,
+                // so a merged query inherits the same access rules, required
                 // filters and parameter handling as the query it was built
                 // from.
                 const compiled = await this.compileQuery({
@@ -5439,50 +5568,26 @@ export class ProjectService extends BaseService {
                     // limits once for the whole result.
                     asCteBody: true,
                 });
-                const sourceSql = compiled.query;
                 // The single-query path refuses to run with an unvalued
                 // parameter; the compile-for-embedding path only warns.
                 // Carry the gap so the merge refuses the same way instead
                 // of shipping a literal placeholder to the warehouse.
-                const missingParameters = Array.from(
-                    compiled.missingParameterReferences,
-                );
-                const parameterReferences = Array.from(
-                    compiled.parameterReferences,
-                );
-
-                const joinKeyColumnByName = Object.fromEntries(
-                    mergeQuery.joinKey.map((part) => [
-                        part.name,
-                        part.fieldIdBySourceId[source.id],
-                    ]),
-                );
-
                 // A compiled metric query aliases every output column by field
-                // id, so the field ids are the column names. Custom dimensions
-                // and custom metrics need no special case: their ids appear in
-                // dimensions/metrics like any other field.
-                const valueColumns = [
-                    ...source.metricQuery.metrics,
-                    ...source.metricQuery.tableCalculations.map(
-                        (calculation) => calculation.name,
-                    ),
-                ];
-
+                // id, so the field ids are the column names — value columns
+                // need no special case for custom dimensions or metrics.
                 return {
                     id: source.id,
-                    sql: sourceSql,
+                    sql: compiled.query,
                     joinKeyColumnByName,
                     valueColumns,
-                    missingParameters,
-                    parameterReferences,
-                    usedParametersValues: compiled.usedParameters,
-                    originBySourceColumn: Object.fromEntries(
-                        valueColumns.map((column) => [
-                            column,
-                            { fieldId: column },
-                        ]),
+                    missingParameters: Array.from(
+                        compiled.missingParameterReferences,
                     ),
+                    parameterReferences: Array.from(
+                        compiled.parameterReferences,
+                    ),
+                    usedParametersValues: compiled.usedParameters,
+                    originBySourceColumn,
                 };
             }),
         );
@@ -5521,6 +5626,7 @@ export class ProjectService extends BaseService {
                 parameterReferences,
                 usedParametersValues,
                 fieldIdByColumn: {},
+                requiresCompose,
                 errors: parameterErrors,
             };
         }
@@ -5610,6 +5716,7 @@ export class ProjectService extends BaseService {
                 parameterReferences,
                 usedParametersValues,
                 fieldIdByColumn: {},
+                requiresCompose,
                 errors: referenceErrors,
             };
         }
@@ -5618,9 +5725,7 @@ export class ProjectService extends BaseService {
         // formatted. Labels come from the field each column originated in;
         // a widened column also carries the value it holds, since one metric
         // becomes several columns and the name alone cannot say which is which.
-        const metricQueryBySourceId = Object.fromEntries(
-            mergeQuery.sources.map((source) => [source.id, source.metricQuery]),
-        );
+        const metricQueryBySourceId = resolvedMetricQueryBySourceId;
 
         // Custom dimensions and additional metrics are defined on the query
         // rather than the explore, so a lookup that only walks the explore
@@ -5799,7 +5904,7 @@ export class ProjectService extends BaseService {
         const exploreLabels = mergeQuery.sources.map(
             (source) =>
                 exploreBySourceId[source.id]?.label ??
-                source.metricQuery.exploreName,
+                resolvedMetricQueryBySourceId[source.id].exploreName,
         );
         const labelsCollide =
             new Set(exploreLabels).size < exploreLabels.length;
@@ -5949,18 +6054,27 @@ export class ProjectService extends BaseService {
                 parameterReferences,
                 usedParametersValues,
                 fieldIdByColumn: {},
+                requiresCompose,
                 errors: typeErrors,
             };
         }
 
         // Named by field id, so results are keyed by the same ids the
-        // items map is keyed by and every lookup downstream resolves.
-        const coreSql = mergeQueryBuilder.toCoreSql(fieldIdByColumn);
-        const terminalWrapper =
-            mergeQueryBuilder.buildTerminalWrapper(fieldIdByColumn);
+        // items map is keyed by and every lookup downstream resolves. A merge
+        // over result sources has no warehouse statement: the compose path
+        // builds its own join over the referenced results.
+        const coreSql = requiresCompose
+            ? null
+            : mergeQueryBuilder.toCoreSql(fieldIdByColumn);
+        const terminalWrapper = requiresCompose
+            ? null
+            : mergeQueryBuilder.buildTerminalWrapper(fieldIdByColumn);
 
         return {
-            sql: applyMergeTerminalWrapper(coreSql, terminalWrapper),
+            sql:
+                coreSql !== null && terminalWrapper !== null
+                    ? applyMergeTerminalWrapper(coreSql, terminalWrapper)
+                    : null,
             coreSql,
             typedColumns,
             terminalWrapper,
@@ -5973,6 +6087,7 @@ export class ProjectService extends BaseService {
             parameterReferences,
             usedParametersValues,
             fieldIdByColumn,
+            requiresCompose,
             errors: [],
         };
     }

--- a/packages/backend/src/utils/QueryBuilder/composeMergeSql.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeSql.test.ts
@@ -10,9 +10,7 @@ import {
     VizIndexType,
     type ItemsMap,
     type MergeFieldTypes,
-    type MergeQuery,
     type MergeTypedColumn,
-    type MetricQuery,
     type WarehouseClient,
 } from '@lightdash/common';
 import { buildComposeMergeSql } from './composeMergeSql';
@@ -91,49 +89,12 @@ const typedColumns: MergeTypedColumn[] = [
     },
 ];
 
-const metricQuery = (
-    exploreName: string,
-    dimensions: string[],
-    metrics: string[],
-): MetricQuery => ({
-    exploreName,
-    dimensions,
-    metrics,
-    filters: {},
-    sorts: [],
-    limit: 500,
-    tableCalculations: [],
-});
-
-const mergeQuery: MergeQuery = {
-    sources: [
-        {
-            id: 'a',
-            metricQuery: metricQuery(
-                'orders',
-                ['orders_month'],
-                ['orders_count'],
-            ),
-        },
-        {
-            id: 'b',
-            metricQuery: metricQuery(
-                'payments',
-                ['payments_month'],
-                ['payments_sum'],
-            ),
-        },
-    ],
-    joinKey: [
-        {
-            name: 'month',
-            fieldIdBySourceId: { a: 'orders_month', b: 'payments_month' },
-        },
-    ],
-    joinType: MergeJoinType.FULL,
-    tableCalculations: [],
-    limit: 500,
-};
+const joinKey = [
+    {
+        name: 'month',
+        fieldIdBySourceId: { a: 'orders_month', b: 'payments_month' },
+    },
+];
 
 const fieldTypes: MergeFieldTypes = {
     a: {
@@ -154,7 +115,13 @@ const build = (
     overrides: Partial<Parameters<typeof buildComposeMergeSql>[0]> = {},
 ) =>
     buildComposeMergeSql({
-        mergeQuery,
+        sources: [
+            { id: 'a', valueColumns: ['orders_count'] },
+            { id: 'b', valueColumns: ['payments_sum'] },
+        ],
+        joinKey,
+        joinType: MergeJoinType.FULL,
+        tableCalculations: [],
         fieldTypes,
         outputAliasByColumn,
         limit: 500,
@@ -273,11 +240,7 @@ describe('buildComposeMergeSql', () => {
 
     test('left join keeps only the first source keys', async () => {
         const rows = await runOnDuckdb(
-            toSql(
-                build({
-                    mergeQuery: { ...mergeQuery, joinType: MergeJoinType.LEFT },
-                }),
-            ),
+            toSql(build({ joinType: MergeJoinType.LEFT })),
             SETUP,
         );
         expect(rows.map((row) => row.merge_month)).toEqual([
@@ -289,14 +252,7 @@ describe('buildComposeMergeSql', () => {
 
     test('inner join keeps only shared keys', async () => {
         const rows = await runOnDuckdb(
-            toSql(
-                build({
-                    mergeQuery: {
-                        ...mergeQuery,
-                        joinType: MergeJoinType.INNER,
-                    },
-                }),
-            ),
+            toSql(build({ joinType: MergeJoinType.INNER })),
             SETUP,
         );
         expect(
@@ -320,16 +276,13 @@ describe('buildComposeMergeSql', () => {
         const rows = await runOnDuckdb(
             toSql(
                 build({
-                    mergeQuery: {
-                        ...mergeQuery,
-                        tableCalculations: [
-                            {
-                                name: 'combined',
-                                displayName: 'Combined',
-                                sql: 'COALESCE(${a.orders_count}, 0) + COALESCE(${b.payments_sum}, 0)',
-                            },
-                        ],
-                    },
+                    tableCalculations: [
+                        {
+                            name: 'combined',
+                            displayName: 'Combined',
+                            sql: 'COALESCE(${a.orders_count}, 0) + COALESCE(${b.payments_sum}, 0)',
+                        },
+                    ],
                 }),
             ),
             SETUP,

--- a/packages/backend/src/utils/QueryBuilder/composeMergeSql.ts
+++ b/packages/backend/src/utils/QueryBuilder/composeMergeSql.ts
@@ -1,7 +1,9 @@
 import {
     SupportedDbtAdapter,
     type MergeFieldTypes,
-    type MergeQuery,
+    type MergeJoinKeyPart,
+    type MergeJoinType,
+    type MergeTableCalculation,
     type MergeTerminalWrapper,
 } from '@lightdash/common';
 import { warehouseSqlBuilderFromType } from '@lightdash/warehouses';
@@ -15,7 +17,7 @@ export type ComposeMergeSql = {
     coreSql: string;
     /** Terminal stage (sort, limit, truncation guard) for the run path to attach. */
     terminalWrapper: MergeTerminalWrapper;
-    /** Reference table name per source id, for binding to leg queryUuids. */
+    /** Reference table name per source id, for binding to result queryUuids. */
     referenceTableBySourceId: Record<string, string>;
 };
 
@@ -27,14 +29,19 @@ export const composeMergeReferenceTable = (sourceIndex: number): string =>
  * The compose form of a merge: the same MergeQueryBuilder assembly as the
  * warehouse statement, but in the DuckDB dialect over reference tables —
  * each source is `SELECT * FROM merge_source_N`, bound at execution time to
- * that source's already-materialized results. The join semantics (coalesced
- * keys, typed null placeholders, string casts, per-source row caps with
- * truncation detection) are identical by construction because the builder
- * and the key-option derivation are shared; only the dialect and where the
- * source rows come from differ.
+ * that source's already-materialized results (a freshly-run leg or an
+ * existing result referenced by queryUuid; the builder cannot tell and does
+ * not care). The join semantics (coalesced keys, typed null placeholders,
+ * string casts, per-source row caps with truncation detection) are identical
+ * by construction because the builder and the key-option derivation are
+ * shared; only the dialect and where the source rows come from differ.
  */
 export const buildComposeMergeSql = (args: {
-    mergeQuery: MergeQuery;
+    /** Sources in merge order; value columns in the compile's column order. */
+    sources: Array<{ id: string; valueColumns: string[] }>;
+    joinKey: MergeJoinKeyPart[];
+    joinType: MergeJoinType;
+    tableCalculations: MergeTableCalculation[];
     fieldTypes: MergeFieldTypes;
     /** Output field-id alias per internal column, from the merge compile. */
     outputAliasByColumn: Record<string, string>;
@@ -43,53 +50,52 @@ export const buildComposeMergeSql = (args: {
     /** Most rows one source may contribute; reaching it is reported, not trimmed. */
     sourceRowCap: number;
 }): ComposeMergeSql => {
-    const { mergeQuery, fieldTypes, outputAliasByColumn, limit, sourceRowCap } =
-        args;
+    const {
+        sources,
+        joinKey,
+        joinType,
+        tableCalculations,
+        fieldTypes,
+        outputAliasByColumn,
+        limit,
+        sourceRowCap,
+    } = args;
     const warehouseSqlBuilder = warehouseSqlBuilderFromType(
         SupportedDbtAdapter.DUCKDB,
     );
     const quoteChar = warehouseSqlBuilder.getFieldQuoteChar();
 
     const referenceTableBySourceId = Object.fromEntries(
-        mergeQuery.sources.map((source, index) => [
+        sources.map((source, index) => [
             source.id,
             composeMergeReferenceTable(index),
         ]),
     );
 
-    const sources = mergeQuery.sources.map((source) => ({
+    const builderSources = sources.map((source) => ({
         id: source.id,
         sql: `SELECT * FROM ${quoteChar}${
             referenceTableBySourceId[source.id]
         }${quoteChar}`,
         joinKeyColumnByName: Object.fromEntries(
-            mergeQuery.joinKey.map((part) => [
+            joinKey.map((part) => [
                 part.name,
                 part.fieldIdBySourceId[source.id],
             ]),
         ),
-        valueColumns: [
-            ...source.metricQuery.metrics,
-            ...source.metricQuery.tableCalculations.map(
-                (calculation) => calculation.name,
-            ),
-        ],
+        valueColumns: source.valueColumns,
     }));
 
     const { nullPlaceholderByKeyName, stringJoinKeyNames } =
-        getMergeJoinKeySqlOptions(
-            mergeQuery.joinKey,
-            fieldTypes,
-            warehouseSqlBuilder,
-        );
+        getMergeJoinKeySqlOptions(joinKey, fieldTypes, warehouseSqlBuilder);
 
     const builder = new MergeQueryBuilder({
-        sources,
-        joinKeyNames: mergeQuery.joinKey.map((part) => part.name),
-        joinType: mergeQuery.joinType,
+        sources: builderSources,
+        joinKeyNames: joinKey.map((part) => part.name),
+        joinType,
         warehouseSqlBuilder,
         limit,
-        tableCalculations: mergeQuery.tableCalculations,
+        tableCalculations,
         nullPlaceholderByKeyName,
         stringJoinKeyNames,
         sourceRowCap,

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -8,7 +8,7 @@ import type {
     CacheMetadata,
     ItemsMap,
     KnexPaginatedData,
-    MergeQuery,
+    MetricSourcedMergeQuery,
     ToolDashboardArgs,
     ToolName,
     ToolRunQueryArgs,
@@ -870,7 +870,7 @@ export type ApiAiAgentThreadMessageVizQuery = {
     type: AiResultType;
     query: ApiExecuteAsyncMetricQueryResults;
     /** The executed merge, so clients need not re-derive it from tool args. */
-    mergeQuery: MergeQuery | null;
+    mergeQuery: MetricSourcedMergeQuery | null;
     metadata: AiVizMetadata;
 };
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -102,6 +102,7 @@ import type { DashboardPreAggregateAudit } from '../ee/preAggregates/audit';
 import type { PivotValuesColumn } from '../visualizations/types';
 import {
     type ApiUserActivityDownloadCsv,
+    type QueryExecutionContext,
     type UserActivity,
     type ViewStatistics,
 } from './analytics';
@@ -112,7 +113,7 @@ import {
     type ApiGetComments,
 } from './api/comments';
 import { type Email } from './api/email';
-import type { ExecuteAsyncComposeMergeQueryRequestParams } from './api/paginatedQuery';
+import type { ExecuteAsyncMergeQueryRequestParams } from './api/paginatedQuery';
 import {
     type ApiGetProjectParametersListResults,
     type ApiGetProjectParametersResults,
@@ -205,6 +206,7 @@ import { type ApiImpersonationOrganizationSettingsResponse } from './impersonati
 import {
     type ApiCompiledMergeQueryResults,
     type MergeFieldOrigins,
+    type MergeQuery,
     type MergeQueryError,
 } from './mergeQuery';
 import { type MetricQuery, type QueryWarning } from './metricQuery';
@@ -924,12 +926,24 @@ export type MergeQueryChart = {
 
 /** One-call merge execution request. Derived pivot SQL remains server-owned. */
 export type ApiExecuteAsyncMergeQueryRequest = Omit<
-    // The compose variant: requests accept the full MergeQuerySource union
-    // (including result sources); only the stored request-parameters echo
-    // distinguishes strict from compose merges.
-    ExecuteAsyncComposeMergeQueryRequestParams,
+    ExecuteAsyncMergeQueryRequestParams,
     'pivotConfiguration' | 'usePreAggregateCache'
 > & {
+    mode?: MergeQueryExecutionMode;
+    chart?: MergeQueryChart;
+};
+
+/**
+ * Merge execution request for the compose endpoint, which accepts the full
+ * MergeQuerySource union (including references to existing query results).
+ * A separate endpoint keeps the original merge-query contract untouched for
+ * existing clients while compose-only capabilities evolve on their own path.
+ */
+export type ApiExecuteAsyncComposeMergeQueryRequest = {
+    context?: QueryExecutionContext;
+    invalidateCache?: boolean;
+    parameters?: ParametersValuesMap;
+    mergeQuery: MergeQuery;
     mode?: MergeQueryExecutionMode;
     chart?: MergeQueryChart;
 };

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -112,7 +112,7 @@ import {
     type ApiGetComments,
 } from './api/comments';
 import { type Email } from './api/email';
-import type { ExecuteAsyncMergeQueryRequestParams } from './api/paginatedQuery';
+import type { ExecuteAsyncComposeMergeQueryRequestParams } from './api/paginatedQuery';
 import {
     type ApiGetProjectParametersListResults,
     type ApiGetProjectParametersResults,
@@ -924,7 +924,10 @@ export type MergeQueryChart = {
 
 /** One-call merge execution request. Derived pivot SQL remains server-owned. */
 export type ApiExecuteAsyncMergeQueryRequest = Omit<
-    ExecuteAsyncMergeQueryRequestParams,
+    // The compose variant: requests accept the full MergeQuerySource union
+    // (including result sources); only the stored request-parameters echo
+    // distinguishes strict from compose merges.
+    ExecuteAsyncComposeMergeQueryRequestParams,
     'pivotConfiguration' | 'usePreAggregateCache'
 > & {
     mode?: MergeQueryExecutionMode;

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -3,7 +3,7 @@ import type { QueryExecutionContext } from '../analytics';
 import type { ConditionalFormattingConfig } from '../conditionalFormatting';
 import type { DownloadFileType } from '../downloadFile';
 import type { AndFilterGroup, DashboardFilters, Filters } from '../filter';
-import { type MergeQuery } from '../mergeQuery';
+import { type MergeQuery, type MetricSourcedMergeQuery } from '../mergeQuery';
 import type { MetricQueryRequest, SortField } from '../metricQuery';
 import type { PivotConfig } from '../pivot';
 import type { DateGranularity } from '../timeFrames';
@@ -60,6 +60,19 @@ export type ExecuteAsyncDashboardChartRequestParams =
 
 /** A merge run: the spec that produced it, recorded verbatim. */
 export type ExecuteAsyncMergeQueryRequestParams =
+    CommonExecuteQueryRequestParams & {
+        /**
+         * Warehouse-side merges are metric-sourced by construction, so this
+         * member keeps the strict shape it always had; merges that reference
+         * existing results record as ExecuteAsyncComposeMergeQueryRequestParams
+         * instead (expand-only: the echo in query history only gains branches).
+         */
+        mergeQuery: MetricSourcedMergeQuery;
+        pivotConfiguration?: PivotConfiguration;
+    };
+
+/** A compose-engine merge run, which may reference existing results. */
+export type ExecuteAsyncComposeMergeQueryRequestParams =
     CommonExecuteQueryRequestParams & {
         mergeQuery: MergeQuery;
         pivotConfiguration?: PivotConfiguration;
@@ -178,6 +191,7 @@ export type ExecuteAsyncFieldValueSearchRequestParams =
 export type ExecuteAsyncQueryRequestParams =
     | ExecuteAsyncMetricQueryRequestParams
     | ExecuteAsyncMergeQueryRequestParams
+    | ExecuteAsyncComposeMergeQueryRequestParams
     | ExecuteAsyncSqlQueryRequestParams
     | ExecuteAsyncComposeSqlQueryRequestParams
     | ExecuteAsyncSavedChartRequestParams

--- a/packages/common/src/types/mergeQuery.test.ts
+++ b/packages/common/src/types/mergeQuery.test.ts
@@ -343,6 +343,40 @@ describe('join key comparability', () => {
     });
 });
 
+describe('result sources', () => {
+    const resultSource = { id: 'b', queryUuid: 'existing-query-uuid' };
+
+    test('defer structural checks the validator cannot see to the compiler', () => {
+        const errors = validateMergeQuery(
+            mergeQuery({ sources: [queryA(), resultSource] }),
+        );
+        // No fan-out or join-key-not-selected errors for the result source:
+        // its structure lives in stored metadata the compiler resolves.
+        expect(errors).toEqual([]);
+    });
+
+    test('still validates join key coverage for result sources', () => {
+        const errors = validateMergeQuery(
+            mergeQuery({
+                sources: [queryA(), resultSource],
+                joinKey: [
+                    {
+                        name: 'date_day',
+                        fieldIdBySourceId: { a: 'followers_created_date' },
+                    },
+                ],
+            }),
+        );
+        expect(errors.map((error) => error.kind)).toContain(
+            MergeQueryErrorKind.JOIN_KEY_COVERAGE,
+        );
+    });
+
+    test('contribute no unaccounted dimensions', () => {
+        expect(getUnaccountedDimensions(resultSource, dateJoinKey)).toEqual([]);
+    });
+});
+
 describe('getUnaccountedDimensions', () => {
     it('reports the dimension that would fan the merge out', () => {
         expect(

--- a/packages/common/src/types/mergeQuery.ts
+++ b/packages/common/src/types/mergeQuery.ts
@@ -52,8 +52,14 @@ export type MergeQuerySource = MergeQueryMetricSource | MergeQueryResultSource;
  * run/compile requests accept the wider MergeQuerySource union
  * (expand-only: requests widen, responses do not).
  */
-export type MetricSourcedMergeQuery = Omit<MergeQuery, 'sources'> & {
+export type MetricSourcedMergeQuery = {
+    // Spelled out rather than derived with Omit: TSOA drops required
+    // markers on mapped types, which reads as a breaking response change.
     sources: MergeQueryMetricSource[];
+    joinKey: MergeJoinKeyPart[];
+    joinType: MergeJoinType;
+    tableCalculations: MergeTableCalculation[];
+    limit: number;
 };
 
 export const isMergeResultSource = (
@@ -63,6 +69,11 @@ export const isMergeResultSource = (
 export const isMergeMetricSource = (
     source: MergeQuerySource,
 ): source is MergeQueryMetricSource => 'metricQuery' in source;
+
+export const isMetricSourcedMergeQuery = (
+    mergeQuery: MergeQuery,
+): mergeQuery is MetricSourcedMergeQuery =>
+    mergeQuery.sources.every(isMergeMetricSource);
 
 /**
  * One column of the join key. Sources name the same real-world key differently

--- a/packages/common/src/types/mergeQuery.ts
+++ b/packages/common/src/types/mergeQuery.ts
@@ -21,12 +21,37 @@ export enum MergeJoinType {
     INNER = 'inner',
 }
 
-/** One side of a merge: a metric query. */
-export type MergeQuerySource = {
+/** One side of a merge: a metric query compiled and run as part of the merge. */
+export type MergeQueryMetricSource = {
     /** Stable id. Names the CTE, and the table its merged fields belong to. */
     id: string;
     metricQuery: MetricQuery;
 };
+
+/**
+ * One side of a merge: an existing query result, referenced by queryUuid and
+ * joined as the rows it already holds — nothing re-runs. Its structure and
+ * types resolve at compile time from the stored query metadata, and the join
+ * executes on the compose engine (`requiresCompose` on the compiled merge),
+ * so a merge with a result source is refused where that engine is
+ * unavailable. Results are creator-scoped and expire; an expired reference
+ * is re-submitted as a query, not refreshed by handle.
+ */
+export type MergeQueryResultSource = {
+    /** Stable id. Names the CTE, and the table its merged fields belong to. */
+    id: string;
+    queryUuid: string;
+};
+
+export type MergeQuerySource = MergeQueryMetricSource | MergeQueryResultSource;
+
+export const isMergeResultSource = (
+    source: MergeQuerySource,
+): source is MergeQueryResultSource => 'queryUuid' in source;
+
+export const isMergeMetricSource = (
+    source: MergeQuerySource,
+): source is MergeQueryMetricSource => 'metricQuery' in source;
 
 /**
  * One column of the join key. Sources name the same real-world key differently
@@ -202,6 +227,17 @@ export enum MergeQueryErrorKind {
      * text — the same refusal the query makes when it runs on its own.
      */
     MISSING_PARAMETERS = 'missing_parameters',
+    /**
+     * The merge references existing query results, which only the compose
+     * engine can join — there is no warehouse statement to fall back to.
+     */
+    COMPOSE_REQUIRED = 'compose_required',
+    /**
+     * A referenced query result cannot back a merge source: not found, not
+     * the caller's, not ready, or expired. The remedy is re-running the
+     * referenced query, not retrying the merge.
+     */
+    RESULT_SOURCE_UNAVAILABLE = 'result_source_unavailable',
 }
 
 export type MergeQueryError = {
@@ -233,6 +269,9 @@ export const getUnaccountedDimensions = (
     source: MergeQuerySource,
     joinKey: MergeJoinKeyPart[],
 ): FieldId[] => {
+    // A result source's structure lives in stored query metadata; the
+    // compiler resolves it and re-runs this check on the resolved form.
+    if (isMergeResultSource(source)) return [];
     const accounted = new Set([
         ...getJoinKeyFieldIdsForSource(joinKey, source.id),
     ]);
@@ -331,8 +370,12 @@ export const validateMergeQuery = (
             }
             // The join compiles against the source's own output columns, so a
             // key naming a field the source does not select produces SQL that
-            // references a column the warehouse has never heard of.
-            if (!source.metricQuery.dimensions.includes(fieldId)) {
+            // references a column the warehouse has never heard of. Result
+            // sources defer this to the compiler, which has their structure.
+            if (
+                isMergeMetricSource(source) &&
+                !source.metricQuery.dimensions.includes(fieldId)
+            ) {
                 errors.push({
                     kind: MergeQueryErrorKind.JOIN_KEY_NOT_SELECTED,
                     sourceId: source.id,
@@ -523,6 +566,12 @@ export type ApiCompiledMergeQueryResults = {
      * before anything downstream sees them.
      */
     fieldIdByColumn: Record<string, FieldId>;
+    /**
+     * The merge references existing query results, so it has no warehouse
+     * statement (`sql`/`coreSql` stay null without that being an error) and
+     * only the compose engine can run it.
+     */
+    requiresCompose: boolean;
     errors: MergeQueryError[];
 };
 

--- a/packages/common/src/types/mergeQuery.ts
+++ b/packages/common/src/types/mergeQuery.ts
@@ -45,6 +45,17 @@ export type MergeQueryResultSource = {
 
 export type MergeQuerySource = MergeQueryMetricSource | MergeQueryResultSource;
 
+/**
+ * A merge whose sources are all metric queries — what AI-built artifacts
+ * hold and their endpoints return. Response contracts use this so
+ * `metricQuery` stays required on every returned source, while the
+ * run/compile requests accept the wider MergeQuerySource union
+ * (expand-only: requests widen, responses do not).
+ */
+export type MetricSourcedMergeQuery = Omit<MergeQuery, 'sources'> & {
+    sources: MergeQueryMetricSource[];
+};
+
 export const isMergeResultSource = (
     source: MergeQuerySource,
 ): source is MergeQueryResultSource => 'queryUuid' in source;

--- a/packages/frontend/src/ee/features/aiCopilot/utils/canonicalizeAiMerge.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/canonicalizeAiMerge.ts
@@ -1,7 +1,9 @@
 import {
     getItemId,
+    isMergeMetricSource,
     MERGE_TABLE_NAME,
     type MergeQuery,
+    type MergeQueryMetricSource,
 } from '@lightdash/common';
 import {
     DEFAULT_ADDITIONAL_SOURCE_ID,
@@ -10,7 +12,7 @@ import {
 } from '../../../../features/mergeQuery/constants';
 
 export type CanonicalAiMerge = {
-    mergeQuery: MergeQuery;
+    mergeQuery: MergeQuery & { sources: MergeQueryMetricSource[] };
     /** Merged output column ids under the AI's names to their canonical ids. */
     fieldIdByAiFieldId: Record<string, string>;
 };
@@ -30,14 +32,18 @@ export const canonicalizeAiMerge = (
     mergeQuery: MergeQuery,
 ): CanonicalAiMerge | null => {
     if (mergeQuery.sources.length !== 2) return null;
-    const [primary, additional] = mergeQuery.sources;
+    // AI merges are built from metric queries; a merge over existing results
+    // has no canonical editor form to rename into.
+    const metricSources = mergeQuery.sources.filter(isMergeMetricSource);
+    if (metricSources.length !== 2) return null;
+    const [primary, additional] = metricSources;
     const idBySourceId: Record<string, string> = {
         [primary.id]: PRIMARY_SOURCE_ID,
         [additional.id]: DEFAULT_ADDITIONAL_SOURCE_ID,
     };
 
     const fieldIdByAiFieldId: Record<string, string> = {};
-    mergeQuery.sources.forEach((source) => {
+    metricSources.forEach((source) => {
         const canonicalId = idBySourceId[source.id];
         [
             ...source.metricQuery.metrics,
@@ -66,7 +72,7 @@ export const canonicalizeAiMerge = (
 
     return {
         mergeQuery: {
-            sources: mergeQuery.sources.map((source) => ({
+            sources: metricSources.map((source) => ({
                 id: idBySourceId[source.id],
                 metricQuery: source.metricQuery,
             })),

--- a/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useMergeQuery.ts
@@ -1,8 +1,9 @@
 import {
     type ApiCompiledMergeQueryResults,
-    type ApiExecuteAsyncMergeQueryRequest,
+    type ApiExecuteAsyncComposeMergeQueryRequest,
     type ApiExecuteAsyncMergeQueryResults,
     type CompileMergeQueryRequest,
+    isMetricSourcedMergeQuery,
     type MergeQuery,
     type ParametersValuesMap,
     QueryExecutionContext,
@@ -36,7 +37,10 @@ const runMergeQuery = (
     csvLimit?: number | null,
 ) =>
     lightdashApi<ApiExecuteAsyncMergeQueryResults>({
-        url: `/projects/${projectUuid}/query/merge-query`,
+        // Merges referencing existing query results need the compose endpoint
+        url: isMetricSourcedMergeQuery(mergeQuery)
+            ? `/projects/${projectUuid}/query/merge-query`
+            : `/projects/${projectUuid}/query/compose-merge-query`,
         version: 'v2',
         method: 'POST',
         body: JSON.stringify({
@@ -48,7 +52,7 @@ const runMergeQuery = (
                     ? { type: 'interactive' }
                     : { type: 'export', limit: csvLimit },
             chart: savedChart,
-        } satisfies ApiExecuteAsyncMergeQueryRequest),
+        } satisfies ApiExecuteAsyncComposeMergeQueryRequest),
     });
 
 /**

--- a/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.ts
+++ b/packages/frontend/src/features/mergeQuery/hooks/useSavedMerge.ts
@@ -1,4 +1,8 @@
-import { type MergeQuery, type SavedMergeQuery } from '@lightdash/common';
+import {
+    isMergeMetricSource,
+    type MergeQuery,
+    type SavedMergeQuery,
+} from '@lightdash/common';
 import { useMemo } from 'react';
 import { PRIMARY_SOURCE_ID } from '../constants';
 import { useMergeSetup } from './useMergeSetup';
@@ -9,18 +13,26 @@ export const toSavedMerge = (mergeQuery: MergeQuery): SavedMergeQuery => {
     }
     return {
         primarySourceId: PRIMARY_SOURCE_ID,
-        sources: mergeQuery.sources.map((source) =>
-            source.id === PRIMARY_SOURCE_ID
-                ? {
-                      id: source.id,
-                      kind: 'chart' as const,
-                  }
-                : {
-                      id: source.id,
-                      kind: 'query' as const,
-                      metricQuery: source.metricQuery,
-                  },
-        ),
+        sources: mergeQuery.sources.map((source) => {
+            if (source.id === PRIMARY_SOURCE_ID) {
+                return {
+                    id: source.id,
+                    kind: 'chart' as const,
+                };
+            }
+            // Result sources reference ephemeral query results, which a
+            // saved chart cannot re-run — the editor never produces them.
+            if (!isMergeMetricSource(source)) {
+                throw new Error(
+                    'A merge over existing query results cannot be saved to a chart.',
+                );
+            }
+            return {
+                id: source.id,
+                kind: 'query' as const,
+                metricQuery: source.metricQuery,
+            };
+        }),
         joinKey: mergeQuery.joinKey.map((part) => ({
             name: part.name,
             fieldIdBySourceId: part.fieldIdBySourceId,


### PR DESCRIPTION
Third slice of merge-on-compose (stacked on #27699): merge sources can reference **existing query results by queryUuid** — the zero-warehouse merge. Merging two visualizations that just rendered re-runs nothing: the compose engine binds each reference to the already-materialized result, and the whole merge costs one `query_history` row.

## What this does

- `MergeQuerySource` becomes a union: `{ id, metricQuery }` (unchanged) | `{ id, queryUuid }` (new). Guards `isMergeMetricSource` / `isMergeResultSource` discriminate; TSOA emits the `anyOf` and validates both shapes.
- **Compile-time resolution**: `compileMergeQuery` resolves every source to a metric-query shape — result sources via a creator-scoped query-history lookup (READY, unexpired, with stored field metadata), exposed as a protected template-method hook that base `ProjectService` refuses and `AsyncQueryService` implements (the compile endpoint now routes through the latter). The existing validation/typing/naming pipeline then runs unchanged on the resolved form, so join-key comparability, granularity, fan-out and type resolution all apply to result sources using their **stored** structure.
- The shared validator defers the two checks it cannot see without stored metadata (join-key-selected, fan-out) and keeps everything structural. Stored table calculations are exempt from the row-set rule: their values are materialized data, frozen by design — which is the semantic point of merging a result.
- A merge with result sources compiles with `requiresCompose: true` and no warehouse statement; executing it without the flag/engine refuses with the new `compose_required` error, and a missing/foreign/unready/expired reference refuses with `result_source_unavailable` naming the remedy (re-run the referenced query).
- Execution: result sources skip leg submission entirely — the reference map binds their queryUuid directly; the standard reference authorization and wait apply. `buildComposeMergeSql` decouples from the source union (ids + value columns in compile order).
- Frontend surfaces that only operate on metric sources guard explicitly with unchanged behavior: the AI canonicalizer types its output as metric sources, saved merges refuse result sources (ephemeral references have no re-runnable form to persist), export cell-cap counting skips them.

## Regression analysis

- Metric-source merges compile through the identical pipeline (the resolution phase is an identity transform for them); the compiled output differs only by the additive `requiresCompose: false`. Full backend suite green (**7117 tests**), common suite green incl. new validator cases, frontend typecheck clean.
- Live on a seeded instance: merge of two existing queryUuids → **26 rows, 0 diffs vs the warehouse-side merge of the same queries, exactly one new query_history row**; mixed metric+result merge → 26 rows; flag off → `refused` with `compose_required`; TSOA union verified in generated OpenAPI (not committed).
- The new error kinds are additive; existing error consumers see the same shapes.

## Still ahead in the stack

Parity harness + rollout mechanics (final slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrPvhrUr7VWeotEPwkAJcE
