### PR TITLE
fix(upgrade-automation): do not fail when the pull request is already mergeable

### DIFF
--- a/examples/upgrade-automation/scripts/plan.sh
+++ b/examples/upgrade-automation/scripts/plan.sh
@@ -90,10 +90,11 @@ current_mapped=$(read_bump_value)
 current_public=$(public_version "$current_mapped" "${TAG_SUFFIX:-}")
 index_file=$(mktemp)
 gate_error=$(mktemp)
+merge_error=$(mktemp)
 body_file=$(mktemp)
 summary_file=$(mktemp)
 bump_file_before=$(mktemp)
-trap 'rm -f "$index_file" "$gate_error" "$body_file" "$summary_file" "$bump_file_before"' EXIT
+trap 'rm -f "$index_file" "$gate_error" "$merge_error" "$body_file" "$summary_file" "$bump_file_before"' EXIT
 
 curl --connect-timeout 10 --max-time 60 --fail --silent --show-error "$RELEASE_INDEX_URL" --output "$index_file"
 jq -e '.schemaVersion == "1" and (.entries | type == "array")' "$index_file" >/dev/null
@@ -375,7 +376,15 @@ if [[ "$pr_created" == "true" ]]; then
 fi
 
 if [[ "$selected_green" == "true" && "${AUTO_MERGE:-false}" == "true" ]]; then
-    gh pr merge "$pr_url" --auto --squash
+    if ! gh pr merge "$pr_url" --auto --squash 2>"$merge_error"; then
+        merge_state=$(gh pr view "$pr_url" --json mergeStateStatus --jq '.mergeStateStatus' || true)
+        if [[ "$merge_state" == "CLEAN" ]]; then
+            gh pr merge "$pr_url" --squash
+        else
+            cat "$merge_error" >&2
+            exit 1
+        fi
+    fi
 elif [[ "$selected_green" != "true" && "$pr_created" == "true" ]]; then
     stops=$(jq -r '.requiredStops | if length == 0 then "none" else join(", ") end' <<<"$selected_json")
     post_slack "[upgrade-hold] $pr_url | $current_public -> $selected_version | gate: $hold_reason | required stops: $stops | $plain_reason"

--- a/examples/upgrade-automation/scripts/plan.test.sh
+++ b/examples/upgrade-automation/scripts/plan.test.sh
@@ -333,3 +333,203 @@ if [[ "$output" != *'branch_prefix must match ^[A-Za-z0-9][A-Za-z0-9._-]*$'* ]];
 fi
 
 printf 'plan invalid branch prefix test passed\n'
+
+run_auto_merge_test() {
+    local test_name=$1
+    local auto_merge=$2
+    local auto_merge_result=$3
+    local merge_state=$4
+    local expected_status=$5
+    local expected_auto_merge=$6
+    local expected_state_view=$7
+    local expected_plain_merge=$8
+    local expected_error=$9
+    local scenario_dir
+    local output
+    local status
+    local auto_merge_call
+    local state_view_call
+    local plain_merge_call
+    local auto_merge_env=()
+
+    scenario_dir=$(mktemp -d)
+    mkdir -p "$scenario_dir/bin"
+    printf 'image:\n  tag: 1.0.0\n' >"$scenario_dir/values.yml"
+    cat >"$scenario_dir/index.json" <<'EOF'
+{
+  "schemaVersion": "1",
+  "entries": [
+    {"version": "1.0.0"},
+    {"version": "1.0.1"}
+  ]
+}
+EOF
+    : >"$scenario_dir/gh.log"
+
+    cat >"$scenario_dir/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+out=
+prev=
+for arg in "$@"; do
+    if [[ "$prev" == "--output" ]]; then out=$arg; fi
+    prev=$arg
+done
+cp "$TEST_SCENARIO_DIR/index.json" "$out"
+EOF
+
+    cat >"$scenario_dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$TEST_SCENARIO_DIR/gh.log"
+
+if [[ "$*" == "issue list"* ]]; then
+    printf '0\n'
+    exit 0
+fi
+
+if [[ "$*" == *'repos/example/upgrade-test --jq .default_branch'* ]]; then
+    printf 'main\n'
+    exit 0
+fi
+
+if [[ "$*" == *'git/ref/heads/main'* ]]; then
+    printf '1111111111111111111111111111111111111111\n'
+    exit 0
+fi
+
+if [[ "$*" == *'git/ref/heads/'* ]]; then
+    exit 1
+fi
+
+if [[ "$*" == *'git/refs'* ]]; then
+    printf '{}\n'
+    exit 0
+fi
+
+if [[ "$*" == *graphql* ]]; then
+    cat >/dev/null
+    printf '{"data":{"createCommitOnBranch":{"commit":{"oid":"2222222222222222222222222222222222222222","url":"https://example.test/c"}}}}\n'
+    exit 0
+fi
+
+if [[ "$*" == "pr list"* ]]; then
+    exit 0
+fi
+
+if [[ "$*" == "pr create"* ]]; then
+    printf 'https://example.test/pr/1\n'
+    exit 0
+fi
+
+if [[ "$*" == "pr view"*'--json mergeStateStatus'* ]]; then
+    printf '%s\n' "$GH_MERGE_STATE"
+    exit 0
+fi
+
+if [[ "$*" == "pr view"* ]]; then
+    printf '{"number":1,"url":"https://example.test/pr/1"}\n'
+    exit 0
+fi
+
+if [[ "$*" == "pr comment"* ]]; then
+    exit 0
+fi
+
+if [[ "$*" == "pr merge"*'--auto --squash'* ]]; then
+    if [[ "$GH_AUTO_MERGE_RESULT" == "failure" ]]; then
+        printf 'GraphQL: original auto merge error\n' >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+if [[ "$*" == "pr merge"*'--squash'* ]]; then
+    exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+EOF
+
+    chmod +x "$scenario_dir/bin/curl" "$scenario_dir/bin/gh"
+
+    if [[ "$auto_merge" == "true" ]]; then
+        auto_merge_env=(AUTO_MERGE=true)
+    fi
+
+    set +e
+    output=$(cd "$scenario_dir" && env -u AUTO_MERGE \
+        PATH="$scenario_dir/bin:$PATH" \
+        TEST_SCENARIO_DIR="$scenario_dir" \
+        GH_AUTO_MERGE_RESULT="$auto_merge_result" \
+        GH_MERGE_STATE="$merge_state" \
+        "${auto_merge_env[@]}" \
+        GITHUB_REPOSITORY=example/upgrade-test \
+        BUMP_TARGET=values.yml#image.tag \
+        SAFETY_GATE=false \
+        FREEZE_LABEL=upgrade-freeze \
+        GH_TOKEN=test-token \
+        "${BASH:-bash}" "$root/examples/upgrade-automation/scripts/plan.sh" 2>"$scenario_dir/stderr")
+    status=$?
+    set -e
+
+    if [[ $status -ne $expected_status ]]; then
+        printf 'expected %s to exit %s, got %s:\n%s\n' "$test_name" "$expected_status" "$status" "$output" >&2
+        cat "$scenario_dir/stderr" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+
+    auto_merge_call='pr merge https://example.test/pr/1 --auto --squash'
+    state_view_call='pr view https://example.test/pr/1 --json mergeStateStatus --jq .mergeStateStatus'
+    plain_merge_call='pr merge https://example.test/pr/1 --squash'
+
+    if [[ "$expected_auto_merge" == "true" ]] && ! grep -Fxq "$auto_merge_call" "$scenario_dir/gh.log"; then
+        printf 'expected %s to attempt auto merge, gh calls were:\n%s\n' "$test_name" "$(cat "$scenario_dir/gh.log")" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    elif [[ "$expected_auto_merge" == "false" ]] && grep -Fxq "$auto_merge_call" "$scenario_dir/gh.log"; then
+        printf 'expected %s not to attempt auto merge, gh calls were:\n%s\n' "$test_name" "$(cat "$scenario_dir/gh.log")" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+
+    if [[ "$expected_state_view" == "true" ]] && ! grep -Fxq "$state_view_call" "$scenario_dir/gh.log"; then
+        printf 'expected %s to read merge state, gh calls were:\n%s\n' "$test_name" "$(cat "$scenario_dir/gh.log")" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    elif [[ "$expected_state_view" == "false" ]] && grep -Fxq "$state_view_call" "$scenario_dir/gh.log"; then
+        printf 'expected %s not to read merge state, gh calls were:\n%s\n' "$test_name" "$(cat "$scenario_dir/gh.log")" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+
+    if [[ "$expected_plain_merge" == "true" ]] && ! grep -Fxq "$plain_merge_call" "$scenario_dir/gh.log"; then
+        printf 'expected %s to merge directly, gh calls were:\n%s\n' "$test_name" "$(cat "$scenario_dir/gh.log")" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    elif [[ "$expected_plain_merge" == "false" ]] && grep -Fxq "$plain_merge_call" "$scenario_dir/gh.log"; then
+        printf 'expected %s not to merge directly, gh calls were:\n%s\n' "$test_name" "$(cat "$scenario_dir/gh.log")" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+
+    if [[ "$expected_error" == "true" ]] && ! grep -Fq 'GraphQL: original auto merge error' "$scenario_dir/stderr"; then
+        printf 'expected %s to preserve the original error, stderr was:\n%s\n' "$test_name" "$(cat "$scenario_dir/stderr")" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+
+    rm -rf "$scenario_dir"
+    printf '%s test passed\n' "$test_name"
+}
+
+run_auto_merge_test 'plan auto merge success' true success CLEAN 0 true false false false
+run_auto_merge_test 'plan clean auto merge fallback' true failure CLEAN 0 true true true false
+run_auto_merge_test 'plan non-clean auto merge failure' true failure DIRTY 1 true true false true
+run_auto_merge_test 'plan auto merge disabled' false success CLEAN 0 false false false false


### PR DESCRIPTION
## What breaks

The planner opens the version pull request, then asks GitHub to auto merge it:

```bash
gh pr merge "$pr_url" --auto --squash
```

under `set -euo pipefail`. GitHub refuses to enable auto merge on a pull request that is already mergeable:

```
GraphQL: Pull request is in clean status (enablePullRequestAutoMerge)
```

The step fails, the job fails, and the version bump stalls until somebody notices. Observed in production on 2026-08-19.

## Why it happens

Auto merge means "merge when the requirements are met". The consumer repository has no required status checks, so there are no requirements to wait for. As soon as GitHub finishes computing mergeability the pull request is `CLEAN`, and auto merge cannot be enabled.

The planner is therefore racing GitHub's mergeability computation, and it usually wins:

```
open branch + pull request
      ↓   GitHub computes mergeability ────── UNKNOWN
gh pr merge --auto     ← succeeds only inside this window
      ↓   computation finishes ─────────────── CLEAN
gh pr merge --auto     ← refused
```

That is why the failure looks rare. It is timing, not input.

## What changes

The planner reacts to the outcome instead of predicting the state. On failure it re-reads the merge state, merges directly when the state is clean, and fails loudly for anything else.

Three choices here are deliberate:

**It does not read the state first and branch on it.** That moves the same race one layer up, because the state can change between the read and the call. Reacting to the actual failure is race-free by construction.

**It does not match on the error text.** That works until GitHub rewords the message. Re-reading the state on the failure path costs one API call and cannot rot.

**It does not swallow the error.** The pull request would stay open and the bump would stall silently, which is worse than a red job.

The fallback is not weaker than auto merge. `CLEAN` means every requirement is already satisfied, so a direct merge does exactly what auto merge would have done the instant it was enabled.

## Tests

`plan.test.sh` gains four cases: auto merge succeeds and no fallback is attempted; auto merge fails on a clean state and a direct merge follows; auto merge fails on a non-clean state and NO merge is issued, the original error reaches stderr, and the script exits non-zero; auto merge disabled and neither call is attempted.

The third case is the important one. Without it, "handle the failure" could quietly become "merge whatever GitHub refused", which would be a worse bug than the one being fixed.

Both halves are mutation-checked. Dropping the clean-state guard fails the non-clean case; reverting to the original unguarded call fails the fallback case. All suites pass, and shellcheck reports no new findings.

## Not addressed here

Whether these merges should be gated at all is a separate question. On a repository with no required checks, `--auto` never withholds a merge — this change makes the merge reliable, not gated.

Linear: SPK-1165