### PR TITLE
fix(ai): skeleton the Ask suggestion chips while they generate

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -121,14 +121,6 @@
     }
 }
 
-.chipReserved {
-    visibility: hidden;
-}
-
-.chipTrayReserve {
-    min-height: rem(50px);
-}
-
 .threadChipFlow {
     margin-bottom: rem(8px);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.suggestions.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.suggestions.test.tsx
@@ -1,0 +1,105 @@
+import { screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { store } from '../../store';
+import { AgentChatInput } from './AgentChatInput';
+
+const { useAgentSuggestionsMock } = vi.hoisted(() => ({
+    useAgentSuggestionsMock: vi.fn(),
+}));
+
+vi.mock('../../hooks/useAgentSuggestions', () => ({
+    useAgentSuggestions: useAgentSuggestionsMock,
+}));
+
+vi.mock('../../hooks/useDeepResearch', () => ({
+    useHasActiveDeepResearchRun: () => false,
+}));
+
+const agent = {
+    uuid: 'agent-1',
+    name: 'Aurora',
+    imageUrl: null,
+    adminOnly: false,
+};
+
+const renderEmptyStateInput = () =>
+    renderWithProviders(
+        <Provider store={store}>
+            <MemoryRouter>
+                <AgentChatInput
+                    onSubmit={vi.fn()}
+                    projectUuid="project-1"
+                    agentUuid="agent-1"
+                    agents={[agent]}
+                    selectedAgent={agent}
+                />
+            </MemoryRouter>
+        </Provider>,
+    );
+
+describe('AgentChatInput suggestions', () => {
+    it('shows a skeleton while the suggestions are generated', () => {
+        useAgentSuggestionsMock.mockReturnValue({
+            data: undefined,
+            isError: false,
+            isLoading: true,
+            isFetching: true,
+        });
+
+        renderEmptyStateInput();
+
+        expect(
+            screen.getByTestId('agent-suggestion-chips-skeleton'),
+        ).toBeInTheDocument();
+    });
+
+    it('replaces the skeleton with the generated suggestions', () => {
+        useAgentSuggestionsMock.mockReturnValue({
+            data: {
+                chips: [
+                    {
+                        kind: 'prompt',
+                        label: 'Revenue by customer tier',
+                        tool: 'generateVisualization',
+                        defaults: {
+                            explore: null,
+                            dimensions: [],
+                            metrics: [],
+                            timeframe: null,
+                        },
+                    },
+                ],
+            },
+            isError: false,
+            isLoading: false,
+            isFetching: false,
+        });
+
+        renderEmptyStateInput();
+
+        expect(
+            screen.queryByTestId('agent-suggestion-chips-skeleton'),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Revenue by customer tier' }),
+        ).toBeInTheDocument();
+    });
+
+    it('shows nothing when the suggestions fail to load', () => {
+        useAgentSuggestionsMock.mockReturnValue({
+            data: undefined,
+            isError: true,
+            isLoading: false,
+            isFetching: false,
+        });
+
+        renderEmptyStateInput();
+
+        expect(
+            screen.queryByTestId('agent-suggestion-chips-skeleton'),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -48,7 +48,10 @@ import {
     type AgentComposerMode,
 } from '../DeepResearch/DeepResearchModeControl';
 import styles from './AgentChatInput.module.css';
-import { AgentSuggestionChips } from './AgentSuggestionChips';
+import {
+    AgentSuggestionChips,
+    AgentSuggestionChipsSkeleton,
+} from './AgentSuggestionChips';
 import {
     createContentMentionExtension,
     extractContentMentionContext,
@@ -634,22 +637,22 @@ export const AgentChatInput = ({
         handleImpression,
         isThreadInput,
     ]);
-    const shouldReserveEmptyStateSuggestions =
+    const showEmptyStateSuggestionsSkeleton =
         !isThreadInput &&
         emptyStateMode &&
         !chipRow &&
         !suggestionsQuery.isError &&
         (suggestionsQuery.isLoading || suggestionsQuery.isFetching);
 
-    const renderChipRow = (extraClassName = '', reserve = false) =>
-        (chipRow || reserve) && (
+    const renderChipRow = (extraClassName = '', showSkeleton = false) =>
+        (chipRow || showSkeleton) && (
             <Box
                 className={`${styles.chipReveal} ${extraClassName} ${
                     chipsNearBottom ? '' : styles.chipHidden
-                } ${!chipRow ? styles.chipReserved : ''}`}
+                }`}
                 aria-hidden={!chipsNearBottom || !chipRow}
             >
-                {chipRow ?? <Box className={styles.chipTrayReserve} />}
+                {chipRow ?? <AgentSuggestionChipsSkeleton />}
             </Box>
         );
 
@@ -814,7 +817,7 @@ export const AgentChatInput = ({
                 {!isThreadInput &&
                     renderChipRow(
                         styles.chipTray,
-                        shouldReserveEmptyStateSuggestions,
+                        showEmptyStateSuggestionsSkeleton,
                     )}
 
                 {showDisabledBanner && (
@@ -903,7 +906,7 @@ export const AgentChatInput = ({
             {!isThreadInput &&
                 renderChipRow(
                     styles.chipTray,
-                    shouldReserveEmptyStateSuggestions,
+                    showEmptyStateSuggestionsSkeleton,
                 )}
 
             {showDisabledBanner && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.module.css
@@ -95,6 +95,11 @@
     }
 }
 
+.chipSkeleton {
+    height: 22px;
+    border-radius: 6px;
+}
+
 .fadeIn {
     animation: chipCascade 340ms cubic-bezier(0.22, 1, 0.36, 1) both;
     animation-delay: calc(var(--chip-idx, 0) * 45ms);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips.tsx
@@ -1,5 +1,5 @@
 import type { AgentSuggestion } from '@lightdash/common';
-import { Box, Button } from '@mantine/core';
+import { Box, Button, Skeleton } from '@mantine/core';
 import { IconArrowUpRight } from '@tabler/icons-react';
 import { useEffect, useRef } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -30,6 +30,19 @@ const renderRightIcon = (
     if (chip.kind !== 'prompt' || !showPromptAffordance) return undefined;
     return <MantineIcon icon={IconArrowUpRight} size={12} stroke={1.75} />;
 };
+
+// Suggestions are generated per project, so they land a beat after the
+// composer. Stand in for them with chip-shaped skeletons rather than generic
+// example prompts, which read as real suggestions until they're swapped out.
+const SKELETON_CHIP_WIDTHS = [148, 108, 176];
+
+export const AgentSuggestionChipsSkeleton = () => (
+    <Box className={styles.row} data-testid="agent-suggestion-chips-skeleton">
+        {SKELETON_CHIP_WIDTHS.map((width) => (
+            <Skeleton key={width} className={styles.chipSkeleton} w={width} />
+        ))}
+    </Box>
+);
 
 export const AgentSuggestionChips = ({
     chips,


### PR DESCRIPTION
### Description:

On the Ask empty state the suggestion chips are generated per project, so they land a beat after the composer. Until now the row just reserved an invisible slot while that happened, so whatever landed first read as a real suggestion. It now renders three chip-shaped skeletons for the whole loading/refetch window, and still collapses to nothing if the generation errors.

Added a small render test covering the three states (loading → skeleton, loaded → chips, error → nothing).

### Risk assessment:

- [ ] This is a high-risk change
