### PR TITLE
fix(ai-agents): exclude service-account and eval threads from memory

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -11,3 +11,4 @@ collisions with other contexts' or repo-wide meanings.
 ## Contexts
 
 - [Pre-aggregates](./docs/pre-aggregates/CONTEXT.md) — user-defined, pre-computed summaries of explores that serve matching queries from materialized files instead of the warehouse
+- [AI agent memory](./docs/ai-agent-memory/CONTEXT.md) — per-user, per-project knowledge the AI analyst distills from a user's threads and recalls on their future threads

--- a/docs/ai-agent-memory/CONTEXT.md
+++ b/docs/ai-agent-memory/CONTEXT.md
@@ -1,0 +1,122 @@
+# AI agent memory
+
+Per-user, per-project knowledge the AI analyst learns from a user's own
+threads and recalls on their future threads. Memory is recall, not authority:
+current catalog truth and project context always outrank it.
+
+Two internal terms have different names in customer-facing copy: **distill**
+is "memory extraction" and **consolidation** is "dreaming". Code, docs, and
+telemetry use the internal terms; UI copy uses the customer-facing ones.
+
+## Language
+
+**Memory**:
+One durable piece of project knowledge distilled from a user's thread — a
+title, a body, retrieval terms, and the catalog objects it names. Owned by
+one user on one project; only that user's future threads recall it.
+_Avoid_: fact, note, learning, insight
+
+**Owner**:
+The user whose thread produced a memory and whose future threads recall it.
+Among eligible threads, selection, pull, ranking, and access filter on
+ownership alone.
+_Avoid_: author, creator
+
+**Eligible thread**:
+A thread whose origin qualifies it for memory — a human-owned web app or
+Slack thread. Service-account-owned, eval, and scheduler threads are outside
+memory: never distilled, never pulled into. Eligibility hangs off the
+thread's owner and origin, not off whoever prompts in a given turn.
+_Avoid_: human thread, real thread, memory-enabled thread
+
+**Distill** (customer copy: **memory extraction**):
+To read one sanitized thread and produce at most one memory plus a thread
+summary. Outcomes are memory, no-op, skipped, or failed; no-op is the
+expected outcome for most threads.
+_Avoid_: extract (in code), summarize, learn
+
+**Thread summary**:
+The short account of a thread produced alongside a distilled memory, kept as
+the memory's provenance.
+
+**Consolidation** (customer copy: **dreaming**):
+A curation pass over one partition's active memories that emits explicit
+operations — merge, supersede, retire, promote. An empty operation list is a
+valid, successful run and the expected outcome most of the time. A dry run
+records proposals without applying them.
+_Avoid_: cleanup, compaction, dedup, garbage collection
+
+**Partition**:
+The unit consolidation runs over: one owner's memories on one project.
+_Avoid_: batch, group
+
+**Merge**:
+A consolidation operation folding near-duplicate memories into one new
+memory; the sources become superseded.
+_Avoid_: combine, dedupe
+
+**Supersede**:
+A consolidation operation replacing a memory with another that newer grounded
+evidence supports. The loser keeps a pointer to its replacement.
+_Avoid_: replace, overwrite
+
+**Retire**:
+To take a memory out of recall because it is contradicted, stale, or its
+catalog objects no longer exist. Owners can retire manually; consolidation
+retires with a reason. A retired memory is the only closed status an owner
+can reopen.
+_Avoid_: delete, archive, deactivate
+
+**Status**:
+A memory's lifecycle state: active (recalled), superseded (replaced by
+another memory), retired (removed from recall), or promoted (graduated to
+project context).
+
+**Scope**:
+Whether a memory is a personal working preference (user) or knowledge that
+would hold for any analyst on the project (project). Scope never affects
+which memories are recalled; project scope means "nominate for review",
+never "safe to broadcast".
+_Avoid_: visibility, sharing level
+
+**Pull**:
+One injection of a memory into the agent's context for a thread. Counted per
+memory as a usage signal.
+_Avoid_: recall (as the counter), load, fetch
+
+**Cite**:
+The agent referencing a memory in an answer via its citation marker. Cited
+count is the evidence a memory earns support for promotion; it never
+justifies merge, supersede, or retire.
+_Avoid_: reference, use
+
+**Citation handle**:
+The memory's slug — the only identifier the agent and the consolidation
+curator ever see.
+_Avoid_: id (in prompts), uuid
+
+**Terms** (memory context):
+The retrieval words stored on a memory. Outside this context, qualify as
+"memory terms" — unqualified "terms" elsewhere means glossary terms.
+
+**Objects**:
+The catalog explores and fields a memory names, re-resolved against the
+current catalog. An unresolved object no longer exists in the catalog.
+_Avoid_: references, links
+
+**Nomination**:
+Putting a memory forward for promotion — manually by its owner or by a
+consolidation promote operation once the memory has enough citations. A
+nomination opens a review item on the review board.
+_Avoid_: proposal, submission
+
+**Promotion**:
+A nominated memory graduating into project context, so its knowledge applies
+to every analyst on the project. Completes when the review item's change is
+merged; the memory's status becomes promoted.
+_Avoid_: sharing, publishing, broadcasting
+
+**Provenance**:
+Where a memory came from: its source thread, or the set of source memories a
+merge consolidated.
+_Avoid_: history, origin (in code)

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -197,6 +197,7 @@ import {
     DbAiEvalRunResult,
     DbAiEvalRunResultAssessment,
 } from '../database/entities/aiEvals';
+import { ServiceAccountsTableName } from '../database/entities/serviceAccounts';
 import { type SqlApprovalDecision } from '../services/ai/tools/sqlApprovals';
 import { AiAgentReviewClassifierModel } from './AiAgentReviewClassifierModel';
 import { claimAiPromptExecutionMode } from './claimAiPromptExecutionMode';
@@ -3016,6 +3017,8 @@ export class AiAgentModel {
               projectUuid: string;
               agentUuid: string | null;
               ownerUserUuid: string | null;
+              createdFrom: AiThreadCreatedFrom;
+              ownerIsServiceAccount: boolean;
           }
         | undefined
     > {
@@ -3042,13 +3045,23 @@ export class AiAgentModel {
                     project_uuid: string;
                     agent_uuid: string | null;
                     owner_user_uuid: string | null;
+                    created_from: AiThreadCreatedFrom;
+                    owner_is_service_account: boolean;
                 }[]
             >(
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiThreadTableName}.project_uuid`,
                 `${AiThreadTableName}.agent_uuid`,
+                `${AiThreadTableName}.created_from`,
                 this.database.raw(
                     `COALESCE(first_prompt.created_by_user_uuid, ${AiWebAppThreadTableName}.user_uuid) as owner_user_uuid`,
+                ),
+                this.database.raw(
+                    `EXISTS (
+                        select 1 from ${ServiceAccountsTableName}
+                        where ${ServiceAccountsTableName}.service_account_user_uuid =
+                            COALESCE(first_prompt.created_by_user_uuid, ${AiWebAppThreadTableName}.user_uuid)
+                    ) as owner_is_service_account`,
                 ),
             )
             .first();
@@ -3059,6 +3072,8 @@ export class AiAgentModel {
             projectUuid: row.project_uuid,
             agentUuid: row.agent_uuid,
             ownerUserUuid: row.owner_user_uuid,
+            createdFrom: row.created_from,
+            ownerIsServiceAccount: row.owner_is_service_account,
         };
     }
 

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -213,6 +213,8 @@ describe('AiAgentMemoryService', () => {
             projectUuid: 'project-enabled',
             agentUuid: 'agent-1',
             ownerUserUuid: 'source-user',
+            createdFrom: 'web_app',
+            ownerIsServiceAccount: false,
         });
         const findUserInGroups = vi.fn().mockResolvedValue([]);
         const getProjectSummary = vi.fn(async (projectUuid: string) => ({
@@ -717,6 +719,8 @@ describe('AiAgentMemoryService', () => {
             projectUuid: 'project-enabled',
             agentUuid: 'agent-1',
             ownerUserUuid: 'first-prompter',
+            createdFrom: 'slack',
+            ownerIsServiceAccount: false,
         });
         distillCall.mockResolvedValue({
             result: {
@@ -810,6 +814,46 @@ describe('AiAgentMemoryService', () => {
         expect(upsertSourceThreadMemory).toHaveBeenCalledWith(
             expect.objectContaining({ userUuid: null }),
         );
+    });
+
+    it('skips a service-account-owned thread before paying for the LLM call', async () => {
+        const {
+            service,
+            findThreadForDistill,
+            findThreadOwnership,
+            upsertSourceThreadMemory,
+            upsertThreadDistill,
+            distillCall,
+        } = build();
+        const activity = new Date('2026-07-22T05:00:00.000Z');
+        findThreadForDistill.mockResolvedValue(distillableThread(activity));
+        findThreadOwnership.mockResolvedValue({
+            threadUuid: 'thread-enabled',
+            projectUuid: 'project-enabled',
+            agentUuid: 'agent-1',
+            ownerUserUuid: 'sa-user',
+            createdFrom: 'web_app',
+            ownerIsServiceAccount: true,
+        });
+
+        await expect(
+            service.distillThread({
+                organizationUuid: 'org-enabled',
+                projectUuid: 'project-enabled',
+                userUuid: 'system',
+                threadUuid: 'thread-enabled',
+                sweptUpdatedAt: activity.toISOString(),
+            }),
+        ).resolves.toBe('skipped');
+
+        expect(distillCall).not.toHaveBeenCalled();
+        expect(upsertSourceThreadMemory).not.toHaveBeenCalled();
+        expect(upsertThreadDistill).toHaveBeenCalledExactlyOnceWith({
+            aiThreadUuid: 'thread-enabled',
+            outcome: 'skipped',
+            distillPromptHash: null,
+            distilledUpTo: activity,
+        });
     });
 
     it('persists a project label without loosening ownership, and reports it', async () => {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -1754,6 +1754,18 @@ export class AiAgentMemoryService extends BaseService {
             return this.recordSkip(thread.threadUuid, distillUpTo);
         }
 
+        // The memory belongs to the thread's owner (its first prompter),
+        // not whoever happened to prompt last in a shared Slack thread.
+        // Service-account threads are automation, not a user learning — skip
+        // before paying for the LLM call.
+        const ownership = await this.aiAgentModel.findThreadOwnership({
+            organizationUuid: thread.organizationUuid,
+            threadUuid: thread.threadUuid,
+        });
+        if (ownership?.ownerIsServiceAccount) {
+            return this.recordSkip(thread.threadUuid, distillUpTo);
+        }
+
         // A thread whose memory was consolidated away or retired stops feeding
         // memory: the one-active-row index would let a re-distill insert a
         // second active row beside the row that replaced it.
@@ -1806,12 +1818,6 @@ export class AiAgentMemoryService extends BaseService {
             );
             abortSignal?.throwIfAborted();
             failureStage = 'persistence';
-            // The memory belongs to the thread's owner (its first prompter),
-            // not whoever happened to prompt last in a shared Slack thread.
-            const ownership = await this.aiAgentModel.findThreadOwnership({
-                organizationUuid: thread.organizationUuid,
-                threadUuid: thread.threadUuid,
-            });
             // Re-read: the status can flip while the LLM call is in flight, and
             // the upsert would then insert a second active row.
             if (

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -234,7 +234,10 @@ import { wrapSentryTransaction } from '../../../utils';
 import { validatePublicHttpUrl } from '../../../utils/ssrfProtection';
 import { type DbAiDeepResearchEvent } from '../../database/entities/aiDeepResearch';
 import { AiAgentDocumentModel } from '../../models/AiAgentDocumentModel';
-import { AiAgentMemoryModel } from '../../models/AiAgentMemoryModel';
+import {
+    AI_AGENT_MEMORY_THREAD_SOURCES,
+    AiAgentMemoryModel,
+} from '../../models/AiAgentMemoryModel';
 import {
     AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_ALLOW,
     AI_AGENT_MCP_SERVER_TOOL_PERMISSION_MODE_ALWAYS_DENY,
@@ -8773,7 +8776,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     /**
      * A memory belongs to the owner of the thread it came from, so every memory
      * read in a turn resolves to that owner rather than the current prompter.
-     * Null means the thread has no owner — such a thread sees no memories.
+     * Null means the thread sees no memories: it has no owner, its owner is a
+     * service account, or its source (evals/scheduler) is outside memory.
      */
     private async findThreadMemoryOwnerUuid(args: {
         organizationUuid: string;
@@ -8786,9 +8790,17 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             organizationUuid: args.organizationUuid,
             threadUuid: args.threadUuid,
         });
-        return ownership?.projectUuid === args.projectUuid
-            ? ownership.ownerUserUuid
-            : null;
+        if (
+            !ownership ||
+            ownership.projectUuid !== args.projectUuid ||
+            ownership.ownerIsServiceAccount ||
+            !AI_AGENT_MEMORY_THREAD_SOURCES.some(
+                (createdFrom) => createdFrom === ownership.createdFrom,
+            )
+        ) {
+            return null;
+        }
+        return ownership.ownerUserUuid;
     }
 
     // Memoizes the owner lookup for the life of one agent run.


### PR DESCRIPTION
## Problem

AI agent memory should only learn from, and recall into, a human user's own threads. Two automation origins leaked in:

- **Service-account threads were distilled.** An SA authenticates as its provisioned user and its API threads arrive as `web_app`, so the distill sweep paid for an LLM call and produced memories owned by the SA user that no human ever sees.
- **Eval and scheduler threads got memories injected.** They were excluded from distill but the triggering user's memories were still recalled at run time — non-reproducible evals and inflated pull counts.

## Fix

Eligibility is owner+origin based, decided at the ownership seam:

- `AiAgentModel.findThreadOwnership` also returns `createdFrom` and `ownerIsServiceAccount` (`EXISTS` on `service_accounts.service_account_user_uuid`). Additive; other callers unaffected.
- **Injection**: the thread-memory owner resolver in `AiAgentService` returns null for SA-owned threads and origins outside `AI_AGENT_MEMORY_THREAD_SOURCES` — no memories injected, no pulls counted. All run entry points share this resolver.
- **Distill**: `runDistillThread` fetches ownership before the LLM call and records a skip for SA-owned threads. The skip advances `distilled_up_to`, so the sweep doesn't re-enqueue until new activity.

Existing SA-owned memories are deliberately left in place (never pulled again; consolidation untouched). No per-agent toggle.

Also adds the AI agent memory glossary (`docs/ai-agent-memory/CONTEXT.md`) with the new **Eligible thread** term and registers it in `CONTEXT-MAP.md`.

Closes: #27710
Relates: ZAP-654
