### PR TITLE
feat(ai-agents): retire memories with unresolved objects deterministically

### DIFF
--- a/docs/ai-agent-memory/CONTEXT.md
+++ b/docs/ai-agent-memory/CONTEXT.md
@@ -62,10 +62,21 @@ _Avoid_: replace, overwrite
 
 **Retire**:
 To take a memory out of recall because it is contradicted, stale, or its
-catalog objects no longer exist. Owners can retire manually; consolidation
-retires with a reason. A retired memory is the only closed status an owner
-can reopen.
+catalog objects no longer exist. Owners can retire manually, consolidation
+retires at the curator's discretion, and the object sweep retires
+deterministically; every path records its reason on the row. A retired
+memory is the only closed status an owner can reopen.
 _Avoid_: delete, archive, deactivate
+
+**Object sweep**:
+The deterministic daily pass that retires an active memory when every object
+it names is unresolved. No LLM call and no partition floor, so it reaches
+partitions consolidation never curates. All objects unresolved is the bar —
+a partially stale memory is the curator's judgment call, and memories are
+routinely born with some unresolved objects. An errored explore or an empty
+catalog blocks retirement: a broken dbt compile hides objects without
+removing them.
+_Avoid_: cleanup, garbage collection
 
 **Status**:
 A memory's lifecycle state: active (recalled), superseded (replaced by

--- a/packages/backend/src/ee/database/entities/aiAgentMemory.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentMemory.ts
@@ -20,6 +20,12 @@ export type AiAgentThreadDistillOutcome =
     | 'skipped'
     | 'failed';
 
+/** Which path retired the row; null while the row is not retired. */
+export type AiAgentMemoryRetiredReason =
+    | 'owner'
+    | 'consolidation'
+    | 'unresolved_objects';
+
 export type DbAiAgentMemory = {
     ai_agent_memory_uuid: string;
     organization_uuid: string;
@@ -36,6 +42,7 @@ export type DbAiAgentMemory = {
     unresolved_objects: AiProjectContextTypedObjectRef[];
     status: AiAgentMemoryStatus;
     scope: AiAgentMemoryScope;
+    retired_reason: AiAgentMemoryRetiredReason | null;
     superseded_by_uuid: string | null;
     generated_at: Date;
     cited_count: number;
@@ -59,6 +66,7 @@ export type AiAgentMemoryTable = Knex.CompositeTableType<
         | keyof AiAgentMemoryJsonbWrite
         | 'ai_agent_memory_uuid'
         | 'status'
+        | 'retired_reason'
         | 'superseded_by_uuid'
         | 'cited_count'
         | 'last_cited_at'
@@ -72,6 +80,7 @@ export type AiAgentMemoryTable = Knex.CompositeTableType<
             Pick<
                 DbAiAgentMemory,
                 | 'status'
+                | 'retired_reason'
                 | 'superseded_by_uuid'
                 | 'cited_count'
                 | 'last_cited_at'

--- a/packages/backend/src/ee/database/migrations/20260820100000_add_retired_reason_to_ai_agent_memory.ts
+++ b/packages/backend/src/ee/database/migrations/20260820100000_add_retired_reason_to_ai_agent_memory.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const AiAgentMemoryTableName = 'ai_agent_memory';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiAgentMemoryTableName, (table) => {
+        table.text('retired_reason').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiAgentMemoryTableName, (table) => {
+        table.dropColumn('retired_reason');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -271,7 +271,7 @@ describe('AiAgentMemoryModel integration', () => {
         distillCall: AiAgentMemoryDistillCall,
         projectModel: Pick<
             ProjectModel,
-            'findExploresFromCache' | 'getSummary'
+            'findExploresFromCache' | 'getCachedExploreNames' | 'getSummary'
         > = getTestContext().app.getModels().getProjectModel(),
     ) =>
         new AiAgentMemoryService({
@@ -1821,6 +1821,8 @@ describe('AiAgentMemoryModel integration', () => {
         const projectModel = getTestContext().app.getModels().getProjectModel();
         const service = buildService(distillCall, {
             findExploresFromCache,
+            getCachedExploreNames:
+                projectModel.getCachedExploreNames.bind(projectModel),
             getSummary: projectModel.getSummary.bind(projectModel),
         });
 

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -150,6 +150,12 @@ export type AiAgentMemoryWithLineage = {
     replacement: Pick<DbAiAgentMemory, 'slug'> | null;
 };
 
+/** A project holding active memories that name catalog objects. */
+export type AiAgentMemoryObjectSweepCandidate = {
+    organizationUuid: UUID;
+    projectUuid: UUID;
+};
+
 /** A `(project, owner)` partition with enough active rows to be worth curating. */
 export type AiAgentMemoryConsolidationCandidate = {
     organizationUuid: UUID;
@@ -568,6 +574,7 @@ export class AiAgentMemoryModel {
                 'unresolved_objects',
                 'status',
                 'scope',
+                'retired_reason',
                 'superseded_by_uuid',
                 'generated_at',
                 'cited_count',
@@ -1035,10 +1042,55 @@ export class AiAgentMemoryModel {
             .whereIn('status', ['active', 'retired'])
             .update({
                 status: args.status,
+                retired_reason: args.status === 'retired' ? 'owner' : null,
                 updated_at: this.database.fn.now(),
             });
 
         return updated > 0;
+    }
+
+    async findObjectSweepCandidates(): Promise<
+        AiAgentMemoryObjectSweepCandidate[]
+    > {
+        return this.database<AiAgentMemoryTable>(AiAgentMemoryTableName)
+            .where('status', 'active')
+            .whereRaw('jsonb_array_length(objects) > 0')
+            .distinct<AiAgentMemoryObjectSweepCandidate[]>({
+                organizationUuid: 'organization_uuid',
+                projectUuid: 'project_uuid',
+            });
+    }
+
+    async findActiveObjectMemoriesByProject(
+        projectUuid: UUID,
+    ): Promise<
+        Array<Pick<DbAiAgentMemory, 'ai_agent_memory_uuid' | 'objects'>>
+    > {
+        return this.database<AiAgentMemoryTable>(AiAgentMemoryTableName)
+            .where('project_uuid', projectUuid)
+            .where('status', 'active')
+            .whereRaw('jsonb_array_length(objects) > 0')
+            .select('ai_agent_memory_uuid', 'objects');
+    }
+
+    /**
+     * The active-status guard makes the sweep race-safe against the curator: a
+     * row consolidation moved since selection is simply not retired here, and
+     * a row this retires is rejected as `row_moved` inside the curator's lock.
+     * `unresolved_objects` snapshots the full object list as the evidence.
+     */
+    async retireForUnresolvedObjects(memoryUuids: UUID[]): Promise<number> {
+        if (memoryUuids.length === 0) return 0;
+
+        return this.database<AiAgentMemoryTable>(AiAgentMemoryTableName)
+            .whereIn('ai_agent_memory_uuid', memoryUuids)
+            .where('status', 'active')
+            .update({
+                status: 'retired',
+                retired_reason: 'unresolved_objects',
+                unresolved_objects: this.database.raw('objects'),
+                updated_at: this.database.fn.now(),
+            } as never);
     }
 
     async incrementPulledForActiveMemories(args: {
@@ -1524,6 +1576,7 @@ export class AiAgentMemoryModel {
                             )
                             .update({
                                 status: 'retired',
+                                retired_reason: 'consolidation',
                                 updated_at: this.database.fn.now(),
                             });
                         applied.push(operation);

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -845,6 +845,9 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                         helpers.job.run_at,
                         payload,
                         async () => {
+                            // Retire first, so the curator selects from the
+                            // cleaned corpus.
+                            await this.aiAgentMemoryService.sweepUnresolvedObjectMemories();
                             await this.aiAgentMemoryService.sweepConsolidationPartitions();
                         },
                     ),

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryConsolidation.integration.test.ts
@@ -2047,4 +2047,85 @@ describe('AI agent memory consolidation integration', () => {
         // A partition that was never consolidated renders exactly as before.
         expect(await renderFor(otherOwnerUuid)).toEqual(beforeOther);
     });
+
+    describe('unresolved-object sweep', () => {
+        it('retires a one-memory partition whose only object left the catalog, with a recorded reason', async () => {
+            const renamedFieldObject = {
+                type: 'field' as const,
+                explore: resolvableExploreName,
+                fieldId: `${resolvableExploreName}_renamed_away`,
+            };
+            const [slug] = await seedPartition({
+                userUuid: ownerUuid,
+                count: 1,
+                prefix: 'objectsweep',
+                objects: [renamedFieldObject],
+            });
+
+            await buildService(cannedCall([])).sweepUnresolvedObjectMemories();
+
+            expect(await memoryBySlug(slug!)).toMatchObject({
+                status: 'retired',
+                retired_reason: 'unresolved_objects',
+                unresolved_objects: [renamedFieldObject],
+                superseded_by_uuid: null,
+            });
+            // Pull selection filters on active status, so the memory is gone
+            // from recall the moment the sweep commits.
+            const pulled = await model.findActiveForProject({
+                projectUuid: SEED_PROJECT.project_uuid,
+                userUuid: ownerUuid,
+            });
+            expect(pulled.map((row) => row.slug)).not.toContain(slug);
+        });
+
+        it('keeps memories with a resolving object or no objects at all', async () => {
+            const [partiallyStale] = await seedPartition({
+                userUuid: ownerUuid,
+                count: 1,
+                prefix: 'objectsweep-partial',
+                objects: [
+                    { type: 'explore', name: resolvableExploreName },
+                    {
+                        type: 'field',
+                        explore: resolvableExploreName,
+                        fieldId: `${resolvableExploreName}_renamed_away`,
+                    },
+                ],
+            });
+            const [objectless] = await seedPartition({
+                userUuid: ownerUuid,
+                count: 1,
+                prefix: 'objectsweep-none',
+            });
+
+            await buildService(cannedCall([])).sweepUnresolvedObjectMemories();
+
+            expect(await memoryBySlug(partiallyStale!)).toMatchObject({
+                status: 'active',
+                retired_reason: null,
+            });
+            expect(await memoryBySlug(objectless!)).toMatchObject({
+                status: 'active',
+                retired_reason: null,
+            });
+        });
+
+        it('never sweeps an organization with memory disabled', async () => {
+            const [slug] = await seedPartition({
+                userUuid: ownerUuid,
+                count: 1,
+                prefix: 'objectsweep-off',
+                objects: [{ type: 'explore', name: 'deleted_explore' }],
+            });
+            await setOrgMemoryEnabled(false);
+
+            await buildService(cannedCall([])).sweepUnresolvedObjectMemories();
+
+            expect(await memoryBySlug(slug!)).toMatchObject({
+                status: 'active',
+                retired_reason: null,
+            });
+        });
+    });
 });

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -103,7 +103,10 @@ import {
 } from './consolidationSchema';
 import { distillOutputSchema, type DistillOutput } from './distillSchema';
 import { reportAiAgentMemoryFailure } from './failureReporting';
-import { validateMemoryObjects } from './memoryObjects';
+import {
+    shouldRetireForUnresolvedObjects,
+    validateMemoryObjects,
+} from './memoryObjects';
 import {
     buildMemoryPromotionEntry,
     getMemoryPromotionFingerprint,
@@ -242,7 +245,10 @@ type Dependencies = {
     >;
     aiAgentModel: Pick<AiAgentModel, 'getAgent' | 'findThreadOwnership'>;
     groupsModel: Pick<GroupsModel, 'findUserInGroups'>;
-    projectModel: Pick<ProjectModel, 'findExploresFromCache' | 'getSummary'>;
+    projectModel: Pick<
+        ProjectModel,
+        'findExploresFromCache' | 'getCachedExploreNames' | 'getSummary'
+    >;
     projectContextModel: Pick<ProjectContextModel, 'getDocument'>;
     userModel: Pick<UserModel, 'findSessionUserAndOrgByUuid'>;
     featureFlagService: FeatureFlagService;
@@ -1033,6 +1039,90 @@ export class AiAgentMemoryService extends BaseService {
             sweptUpdatedAt: thread.latestActivity.toISOString(),
             force: true,
         });
+    }
+
+    /**
+     * Deterministic counterpart to the consolidation curator: retires every
+     * active memory whose objects have all left the catalog. Pure catalog
+     * resolution — no LLM call and no partition floor, so a one-memory
+     * partition is swept the same day as a large one. Runs before the
+     * consolidation sweep so the curator selects from the cleaned corpus.
+     */
+    async sweepUnresolvedObjectMemories(): Promise<number> {
+        const candidates =
+            await this.aiAgentMemoryModel.findObjectSweepCandidates();
+        const due = await this.filterByEnabledOrganizations(candidates);
+
+        let retired = 0;
+        for (const candidate of due) {
+            // eslint-disable-next-line no-await-in-loop
+            retired += await this.retireUnresolvedObjectMemoriesForProject(
+                candidate.projectUuid,
+            );
+        }
+        this.prometheusMetrics?.incrementAiAgentMemoryUnresolvedRetired(
+            retired,
+        );
+        return retired;
+    }
+
+    /** A project that cannot be swept is skipped, never the whole pass. */
+    private async retireUnresolvedObjectMemoriesForProject(
+        projectUuid: UUID,
+    ): Promise<number> {
+        try {
+            const memories =
+                await this.aiAgentMemoryModel.findActiveObjectMemoriesByProject(
+                    projectUuid,
+                );
+            if (memories.length === 0) return 0;
+
+            // An empty catalog — which a failed dbt refresh also produces —
+            // would read every object as unresolved; that is not evidence.
+            const catalogNames =
+                await this.projectModel.getCachedExploreNames(projectUuid);
+            if (catalogNames.length === 0) {
+                this.logger.warn(
+                    'Skipping AI agent memory object sweep: catalog is empty',
+                    { projectUuid },
+                );
+                return 0;
+            }
+
+            const explores = await this.projectModel.findExploresFromCache(
+                projectUuid,
+                'name',
+                memories.flatMap((memory) =>
+                    memory.objects.map((object) =>
+                        object.type === 'explore'
+                            ? object.name
+                            : object.explore,
+                    ),
+                ),
+            );
+            const toRetire = memories
+                .filter((memory) =>
+                    shouldRetireForUnresolvedObjects(memory.objects, explores),
+                )
+                .map((memory) => memory.ai_agent_memory_uuid);
+            if (toRetire.length === 0) return 0;
+
+            const retired =
+                await this.aiAgentMemoryModel.retireForUnresolvedObjects(
+                    toRetire,
+                );
+            this.logger.info(
+                'Retired AI agent memories with unresolved objects',
+                { projectUuid, retired },
+            );
+            return retired;
+        } catch (error) {
+            this.logger.warn('Dropping AI agent memory object sweep project', {
+                projectUuid,
+                error: getErrorMessage(error),
+            });
+            return 0;
+        }
     }
 
     /**

--- a/packages/backend/src/ee/services/AiAgentMemoryService/consolidation.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/consolidation.test.ts
@@ -81,6 +81,7 @@ const memoryRow = (
     unresolved_objects: [],
     status: 'active',
     scope: 'user',
+    retired_reason: null,
     superseded_by_uuid: null,
     generated_at: new Date('2026-07-20T10:00:00Z'),
     cited_count: 7,

--- a/packages/backend/src/ee/services/AiAgentMemoryService/memoryObjects.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/memoryObjects.test.ts
@@ -1,0 +1,146 @@
+import {
+    DimensionType,
+    FieldType,
+    SupportedDbtAdapter,
+    type Explore,
+    type ExploreError,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { shouldRetireForUnresolvedObjects } from './memoryObjects';
+
+const ordersExplore: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    spotlight: { visibility: 'show', categories: [] },
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'db',
+            schema: 'public',
+            sqlTable: 'orders',
+            sqlWhere: undefined,
+            uncompiledSqlWhere: undefined,
+            description: undefined,
+            requiredFilters: [],
+            dimensions: {
+                status: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'status',
+                    label: 'Status',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.status',
+                    hidden: false,
+                    source: undefined,
+                    compiledSql: 'orders.status',
+                    tablesReferences: ['orders'],
+                    description: undefined,
+                },
+            },
+            metrics: {},
+            lineageGraph: {},
+        },
+    },
+};
+
+const brokenExplore: ExploreError = {
+    name: 'broken',
+    label: 'Broken',
+    groupLabel: undefined,
+    groups: [],
+    errors: [],
+};
+
+const explores = { orders: ordersExplore, broken: brokenExplore };
+
+describe('shouldRetireForUnresolvedObjects', () => {
+    it('retires when the only named field no longer resolves', () => {
+        expect(
+            shouldRetireForUnresolvedObjects(
+                [
+                    {
+                        type: 'field',
+                        explore: 'orders',
+                        fieldId: 'orders_renamed_away',
+                    },
+                ],
+                explores,
+            ),
+        ).toBe(true);
+    });
+
+    it('retires when every named object left the catalog', () => {
+        expect(
+            shouldRetireForUnresolvedObjects(
+                [
+                    { type: 'explore', name: 'deleted_explore' },
+                    {
+                        type: 'field',
+                        explore: 'deleted_explore',
+                        fieldId: 'deleted_explore_field',
+                    },
+                ],
+                explores,
+            ),
+        ).toBe(true);
+    });
+
+    it('keeps a memory with any resolving object', () => {
+        expect(
+            shouldRetireForUnresolvedObjects(
+                [
+                    { type: 'explore', name: 'deleted_explore' },
+                    {
+                        type: 'field',
+                        explore: 'orders',
+                        fieldId: 'orders_status',
+                    },
+                ],
+                explores,
+            ),
+        ).toBe(false);
+    });
+
+    it('never retires a memory naming no objects', () => {
+        expect(shouldRetireForUnresolvedObjects([], explores)).toBe(false);
+    });
+
+    it('treats an errored explore as indeterminate, not gone', () => {
+        expect(
+            shouldRetireForUnresolvedObjects(
+                [
+                    {
+                        type: 'field',
+                        explore: 'broken',
+                        fieldId: 'broken_field',
+                    },
+                ],
+                explores,
+            ),
+        ).toBe(false);
+        expect(
+            shouldRetireForUnresolvedObjects(
+                [{ type: 'explore', name: 'broken' }],
+                explores,
+            ),
+        ).toBe(false);
+    });
+
+    it('an errored explore blocks retirement of sibling unresolved objects', () => {
+        expect(
+            shouldRetireForUnresolvedObjects(
+                [
+                    { type: 'explore', name: 'deleted_explore' },
+                    { type: 'explore', name: 'broken' },
+                ],
+                explores,
+            ),
+        ).toBe(false);
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentMemoryService/memoryObjects.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/memoryObjects.ts
@@ -32,6 +32,28 @@ export const resolveMemoryObjects = (
         };
     });
 
+/**
+ * Retirement licence for the deterministic sweep: retire only when every
+ * object the memory names has left the catalog. "All unresolved" rather than
+ * "any" — memories are routinely born with some unresolved objects, and a
+ * partially stale memory is the consolidation curator's judgment call; full
+ * unresolution is provable unmooring. An errored explore blocks retirement:
+ * a broken compile hides fields without removing them, so it is not evidence.
+ */
+export const shouldRetireForUnresolvedObjects = (
+    objects: AiProjectContextTypedObjectRef[],
+    explores: Record<string, Explore | ExploreError>,
+): boolean =>
+    objects.length > 0 &&
+    resolveMemoryObjects(objects, explores).every(
+        (result) => !result.resolved,
+    ) &&
+    objects.every((object) => {
+        const explore =
+            explores[object.type === 'explore' ? object.name : object.explore];
+        return explore === undefined || !isExploreError(explore);
+    });
+
 export const validateMemoryObjects = (
     objects: AiProjectContextTypedObjectRef[],
     explores: Record<string, Explore | ExploreError>,

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -148,6 +148,9 @@ export default class PrometheusMetrics {
 
     public aiAgentMemoryCitedCounter: prometheus.Counter | null = null;
 
+    public aiAgentMemoryUnresolvedRetiredCounter: prometheus.Counter | null =
+        null;
+
     public aiDeepResearchReportCleanupCounter: prometheus.Counter<'outcome'> | null =
         null;
 
@@ -620,6 +623,13 @@ export default class PrometheusMetrics {
                     ...rest,
                 });
 
+                this.aiAgentMemoryUnresolvedRetiredCounter =
+                    new prometheus.Counter({
+                        name: 'ai_agent_memory_unresolved_retired_total',
+                        help: 'Memories retired by the sweep because every object they name left the catalog',
+                        ...rest,
+                    });
+
                 this.aiDeepResearchReportCleanupCounter =
                     new prometheus.Counter({
                         name: 'ai_deep_research_report_cleanup_total',
@@ -829,6 +839,7 @@ export default class PrometheusMetrics {
                 this.aiAgentMemorySweepEnqueuedCounter?.inc(0);
                 this.aiAgentMemoryUnknownToolPolicyCounter?.inc(0);
                 this.aiAgentMemoryCitedCounter?.inc(0);
+                this.aiAgentMemoryUnresolvedRetiredCounter?.inc(0);
                 (['scanned', 'expired', 'failed'] as const).forEach(
                     (outcome) => {
                         this.aiDeepResearchReportCleanupCounter?.inc(
@@ -1817,6 +1828,10 @@ export default class PrometheusMetrics {
 
     public incrementAiAgentMemoryCited(count: number) {
         this.aiAgentMemoryCitedCounter?.inc(count);
+    }
+
+    public incrementAiAgentMemoryUnresolvedRetired(count: number) {
+        this.aiAgentMemoryUnresolvedRetiredCounter?.inc(count);
     }
 
     public incrementAiDeepResearchReportCleanup(


### PR DESCRIPTION
## Description

Memories anchor catalog objects (explores/fields). Until now the only path retiring a memory whose objects left the catalog was the consolidation curator — an LLM pass gated by a 30-row partition floor, so small partitions never got curated. A heavily-cited memory naming a since-renamed field could keep steering answers to the old field indefinitely.

This adds a deterministic **object sweep**: a daily pass (no LLM call, no partition floor) that resolves each active memory's objects against the current catalog and retires memories whose objects have **all** left the catalog. It runs in the existing consolidation cron, before the curator, so the curator selects from the cleaned corpus.

### Design decisions

- **Bar: all objects unresolved** (and at least one object). Memories are routinely born with some unresolved objects, and partial staleness stays the curator's judgment call; full unresolution is provable unmooring.
- **Broken catalog is never evidence**: an errored explore (failed dbt compile) blocks retirement, and an empty catalog skips the project — same reasoning the curator's catalog guard already uses.
- **Recorded reason**: new nullable `retired_reason` column — `unresolved_objects` (sweep, which also snapshots the object list into `unresolved_objects` as evidence), `owner` (manual), `consolidation` (curator); cleared on owner reactivation.
- Race-safe against the curator via the `status = 'active'` update guard; a row the sweep retires is rejected as `row_moved` inside the curator's lock.

### Changes

- Migration adding `retired_reason` (additive nullable column)
- `shouldRetireForUnresolvedObjects()` in `memoryObjects.ts`, reusing `resolveMemoryObjects`
- `AiAgentMemoryService.sweepUnresolvedObjectMemories()` + model queries, org-enablement gated, per-project failures skip the project not the pass
- Prometheus counter `ai_agent_memory_unresolved_retired_total`
- Glossary entry **Object sweep** in `docs/ai-agent-memory/CONTEXT.md`

### Tests

- Unit tests pin the bar: renamed field retires, any resolving object keeps, errored explore blocks
- Integration tests pin a partition of 1 memory: retired with reason, excluded from pull selection; partial/objectless memories kept; disabled org untouched

Closes: ZAP-904

🤖 Generated with [Claude Code](https://claude.com/claude-code)
