### PR TITLE
fix(embed): keep defaultTimeDimensions in availableFilters response for SDK wire-compat

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -732,6 +732,7 @@ export class EmbedService extends BaseService {
                 allFilterableFields: [],
                 allFilterableMetrics: [],
                 savedQueryMetricFilters: {},
+                defaultTimeDimensions: {},
             };
         }
 
@@ -881,6 +882,7 @@ export class EmbedService extends BaseService {
             allFilterableFields,
             allFilterableMetrics: [],
             savedQueryMetricFilters: {},
+            defaultTimeDimensions: {},
         };
     }
 

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -1,6 +1,6 @@
 import { type ContentVerificationInfo } from './contentVerification';
 import { type FilterableDimension, type Metric } from './field';
-import { type DashboardFilters } from './filter';
+import { type DashboardFieldTarget, type DashboardFilters } from './filter';
 import { type KnexPaginatedData } from './knex-paginate';
 import { type DashboardParameters } from './parameters';
 import {
@@ -335,6 +335,10 @@ export type DashboardAvailableFilters = {
     allFilterableFields: FilterableDimension[];
     allFilterableMetrics: Metric[];
     savedQueryMetricFilters: Record<string, number[]>;
+    // Wire-compat with SDK bundles 1.64.0-1.197.x: those frontends call
+    // Object.entries() on this key unguarded, so it must stay present (empty)
+    // even though the auto-mapping feature it fed was removed in #27619.
+    defaultTimeDimensions?: Record<string, DashboardFieldTarget>;
 };
 
 export type SavedChartsInfoForDashboardAvailableFilters = {


### PR DESCRIPTION
## Description

Fixes #27718.

PR #27619 (the revert of the date-filter auto-mapping) removed `defaultTimeDimensions` from the `POST /embed/{projectUuid}/dashboard/availableFilters` response. SDK bundles **1.64.0-1.197.x** consume that key unguarded (`Object.entries(defaultTimeDimensions)` in `applyDefaultTimeDimensionTileTargets`), so against a backend ≥1.198.1 any embedded dashboard with a date/timestamp dimension filter crashes to the generic error screen with `TypeError: Cannot convert undefined or null to object`.

This restores the key as an **empty object** on both return paths of `EmbedService.getAvailableFiltersForSavedQueries`, and re-adds it as an optional field on `DashboardAvailableFilters` with a comment explaining why it must stay. An empty object is semantically correct for old bundles: their reducer over `{}` leaves each filter's `tileTargets` untouched, so no auto-mapping behavior comes back.

## How was it tested

- Reproduced locally: `@lightdash/sdk@1.146.3` embedding a dashboard with a date filter against a current backend crashes with the exact TypeError (stack through `applyDefaultTimeDimensionTileTargets`); with this patch the same embed renders fully, filters included.
- Verified `@lightdash/sdk@1.202.5` (post-revert bundle) is unaffected: it no longer reads the key.
- `pnpm -F common typecheck && pnpm -F backend typecheck && pnpm -F common lint && pnpm -F backend lint` pass.

Related: #24687 tracks the systemic version-mismatch signal; this PR only restores wire-compat for the removed key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
