### PR TITLE
fix(embed): skip charts with missing explores in availableFilters

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -806,18 +806,24 @@ export class EmbedService extends BaseService {
         }
 
         const exploreCacheKeys: Record<string, boolean> = {};
-        const exploreCache: Record<string, Explore | ExploreError> = {};
+        const exploreCache: Record<string, Explore | ExploreError | undefined> =
+            {};
 
         const explorePromises = savedCharts.reduce<
-            Promise<{ key: string; explore: Explore | ExploreError }>[]
+            Promise<{ key: string; explore: Explore | ExploreError | undefined }>[]
         >((acc, chart) => {
             const key = chart.tableName;
             if (!exploreCacheKeys[key]) {
                 const exploreId = chart.tableName;
-                const cachedExplore = this.projectModel.getExploreFromCache(
-                    projectUuid,
-                    exploreId,
-                );
+                const cachedExplore = this.projectModel
+                    .getExploreFromCache(projectUuid, exploreId)
+                    // A chart pointing at a deleted/renamed explore must not
+                    // fail the whole request; it contributes no filters, same
+                    // as the direct-app path (ProjectService.findExplores).
+                    .catch((e) => {
+                        if (e instanceof NotFoundError) return undefined;
+                        throw e;
+                    });
                 acc.push(cachedExplore.then((explore) => ({ key, explore })));
                 exploreCacheKeys[key] = true;
             }
@@ -834,7 +840,7 @@ export class EmbedService extends BaseService {
 
         const filterPromises = savedCharts.map(async (savedChart) => {
             const explore = exploreCache[savedChart.tableName];
-            if (isExploreError(explore))
+            if (!explore || isExploreError(explore))
                 return { uuid: savedChart.uuid, filters: [] };
             const filters = getDimensions(explore).filter(
                 (field) => isFilterableDimension(field) && !field.hidden,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -810,7 +810,10 @@ export class EmbedService extends BaseService {
             {};
 
         const explorePromises = savedCharts.reduce<
-            Promise<{ key: string; explore: Explore | ExploreError | undefined }>[]
+            Promise<{
+                key: string;
+                explore: Explore | ExploreError | undefined;
+            }>[]
         >((acc, chart) => {
             const key = chart.tableName;
             if (!exploreCacheKeys[key]) {


### PR DESCRIPTION
## Description

Fixes #27719.

`EmbedService.getAvailableFiltersForSavedQueries` builds its explore cache with `projectModel.getExploreFromCache()` per chart, and a single chart referencing a deleted/renamed explore rejects the whole request with a 404. The embed then renders **every** dashboard filter as "Invalid filter (unknown field id)" even though the fields exist and all other tiles are healthy. The direct-app path (`ProjectService.getAvailableFiltersForSavedQueries` via `findExplores`) already degrades gracefully, so the same dashboard shows working filters in the app and all-invalid filters in the embed.

This catches `NotFoundError` per explore and treats the affected charts like charts with an `ExploreError`: they contribute no filters, everything else works. Other error types still propagate.

## How was it tested

- Reproduced locally: pointed one chart on an embedded dashboard at a nonexistent explore. Before: embed `availableFilters` returns 404 (`Explore "x" does not exist.`) and both dashboard filters render as "Invalid filter", while the direct app returns 200 and working filters for the identical dashboard. After: embed returns 200, real filter chips render, and only the broken tile itself errors - matching the direct-app behavior.
- `pnpm -F backend typecheck && pnpm -F backend lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
