### PR TITLE
feat: allow downloading Agent chart results

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
@@ -332,6 +332,7 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                             message={message}
                             projectUuid={artifact.projectUuid}
                             agentUuid={artifact.agentUuid}
+                            showDownloadResults
                             artifactData={artifactData}
                             saveChartOptions={{
                                 name: title,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartDownloadModal.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartDownloadModal.test.tsx
@@ -1,0 +1,89 @@
+import { ChartType, type MetricQuery } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { AiChartDownloadModal } from './AiChartDownloadModal';
+
+const mocks = vi.hoisted(() => ({
+    useVisualizationContext: vi.fn(),
+}));
+
+vi.mock(
+    '../../../../../components/LightdashVisualization/useVisualizationContext',
+    () => ({ useVisualizationContext: mocks.useVisualizationContext }),
+);
+
+vi.mock('../../../../../hooks/user/useUser', () => ({
+    default: () => ({
+        data: {
+            organizationUuid: '172a2270-000f-42be-9c68-c4752c23ae51',
+        },
+    }),
+}));
+
+vi.mock('../../../../../providers/Ability', () => ({
+    Can: ({ children }: { children: ReactNode }) => children,
+}));
+
+const metricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_status'],
+    metrics: ['orders_total'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+    additionalMetrics: [],
+    metricOverrides: {},
+} satisfies MetricQuery;
+
+describe('AiChartDownloadModal', () => {
+    beforeEach(() => {
+        mocks.useVisualizationContext.mockReturnValue({
+            chartConfig: { type: ChartType.TABLE, config: {} },
+            columnOrder: ['orders_status', 'orders_total'],
+            itemsMap: {},
+            parameters: {},
+            pivotDimensions: ['orders_status'],
+            resultsData: {
+                metricQuery,
+                totalResults: 25,
+            },
+            visualizationConfig: {
+                chartType: ChartType.TABLE,
+                chartConfig: {
+                    columnProperties: {},
+                    configuredRowFieldIds: [],
+                    validConfig: {},
+                    showTableNames: false,
+                    conditionalFormattings: [],
+                    showColumnCalculation: false,
+                },
+            },
+        });
+    });
+
+    it('shows the shared export controls in a dialog', async () => {
+        const onClose = vi.fn();
+        renderWithProviders(
+            <AiChartDownloadModal
+                opened
+                onClose={onClose}
+                projectUuid="project-uuid"
+                chartName="Orders"
+                mergeQuery={null}
+            />,
+        );
+
+        expect(screen.getByRole('dialog')).toBeVisible();
+        expect(screen.getByText('Export Data')).toBeVisible();
+        expect(await screen.findByText('Table rows')).toBeVisible();
+        expect(screen.getByText('Grouped')).toBeVisible();
+        expect(screen.getByText('Flat')).toBeVisible();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartDownloadModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartDownloadModal.tsx
@@ -1,0 +1,124 @@
+import {
+    ChartType,
+    getCustomLabelsFromColumnProperties,
+    getHiddenTableFields,
+    getPivotConfig,
+    type MergeQuery,
+} from '@lightdash/common';
+import { useCallback, type FC } from 'react';
+import ExportDataModal from '../../../../../components/DashboardTiles/ExportDataModal';
+import { type Limit } from '../../../../../components/ExportResults/types';
+import { isTableVisualizationConfig } from '../../../../../components/LightdashVisualization/types';
+import { useVisualizationContext } from '../../../../../components/LightdashVisualization/useVisualizationContext';
+import { executeAiChartDownloadQuery } from '../../utils/executeAiChartDownloadQuery';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    chartName: string | null;
+    mergeQuery: MergeQuery | null;
+};
+
+export const AiChartDownloadModal: FC<Props> = ({
+    opened,
+    onClose,
+    projectUuid,
+    chartName,
+    mergeQuery,
+}) => {
+    const {
+        chartConfig,
+        columnOrder,
+        itemsMap,
+        parameters,
+        pivotDimensions,
+        resultsData,
+        visualizationConfig,
+    } = useVisualizationContext();
+
+    const metricQuery = resultsData?.metricQuery;
+    const tableConfig = isTableVisualizationConfig(visualizationConfig)
+        ? visualizationConfig.chartConfig
+        : undefined;
+    const savedPivotConfig = pivotDimensions?.length
+        ? {
+              columns: pivotDimensions,
+              ...(tableConfig?.configuredRowFieldIds && {
+                  rows: tableConfig.configuredRowFieldIds,
+              }),
+          }
+        : undefined;
+    const downloadPivotConfig = metricQuery
+        ? getPivotConfig({
+              chartConfig,
+              pivotConfig: savedPivotConfig,
+              tableConfig: { columnOrder },
+              metricQuery,
+          })
+        : undefined;
+
+    const getDownloadQueryUuid = useCallback(
+        async (
+            limit: number | null,
+            _limitType: Limit,
+            exportPivotedData: boolean = true,
+        ) => {
+            if (!metricQuery || !itemsMap) {
+                throw new Error('Missing artifact query data');
+            }
+
+            return executeAiChartDownloadQuery({
+                projectUuid,
+                metricQuery,
+                parameters,
+                chartConfig,
+                pivotDimensions,
+                fields: itemsMap,
+                mergeQuery,
+                limit,
+                exportPivotedData,
+            });
+        },
+        [
+            chartConfig,
+            itemsMap,
+            mergeQuery,
+            metricQuery,
+            parameters,
+            pivotDimensions,
+            projectUuid,
+        ],
+    );
+
+    return (
+        <ExportDataModal
+            isOpen={opened}
+            onClose={onClose}
+            projectUuid={projectUuid}
+            totalResults={resultsData?.totalResults}
+            getDownloadQueryUuid={getDownloadQueryUuid}
+            columnOrder={columnOrder}
+            chartName={chartName ?? undefined}
+            pivotConfig={downloadPivotConfig}
+            customLabels={
+                tableConfig
+                    ? getCustomLabelsFromColumnProperties(
+                          tableConfig.columnProperties,
+                      )
+                    : undefined
+            }
+            hiddenFields={
+                tableConfig
+                    ? getHiddenTableFields({
+                          type: ChartType.TABLE,
+                          config: tableConfig.validConfig,
+                      })
+                    : undefined
+            }
+            showTableNames={tableConfig?.showTableNames}
+            conditionalFormattings={tableConfig?.conditionalFormattings}
+            showColumnTotals={tableConfig?.showColumnCalculation}
+        />
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -19,6 +19,7 @@ import {
     IconEye,
     IconLayoutDashboard,
     IconSend,
+    IconTableExport,
     IconTableShortcut,
     IconTerminal2,
 } from '@tabler/icons-react';
@@ -59,11 +60,13 @@ import {
     canonicalizeAiMerge,
     remapFieldIdsDeep,
 } from '../../utils/canonicalizeAiMerge';
+import { AiChartDownloadModal } from './AiChartDownloadModal';
 import { AiScheduleDeliveryModal } from './AiScheduleDeliveryModal';
 
 type Props = {
     projectUuid: string;
     agentUuid: string;
+    showDownloadResults: boolean;
     saveChartOptions?: {
         name: string | null;
         description: string | null;
@@ -82,6 +85,7 @@ type Props = {
 export const AiChartQuickOptions = ({
     projectUuid,
     agentUuid,
+    showDownloadResults,
     saveChartOptions = { name: '', description: '', linkToMessage: true },
     message,
     compiledSql,
@@ -112,6 +116,10 @@ export const AiChartQuickOptions = ({
     ] = useDisclosure(false);
     const [sqlModalOpened, { open: openSqlModal, close: closeSqlModal }] =
         useDisclosure(false);
+    const [
+        downloadModalOpened,
+        { open: openDownloadModal, close: closeDownloadModal },
+    ] = useDisclosure(false);
 
     const canCreateScheduledDeliveries = user.data?.ability?.can(
         'create',
@@ -130,6 +138,16 @@ export const AiChartQuickOptions = ({
             projectUuid,
         }),
     );
+    const canDownloadResults =
+        showDownloadResults &&
+        !isEmbed &&
+        user.data?.ability?.can(
+            'manage',
+            subject('ExportCsv', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        );
     const {
         visualizationConfig,
         columnOrder,
@@ -470,6 +488,7 @@ export const AiChartQuickOptions = ({
         : !isEmbed || canExploreFromEmbed;
     const hasSqlActions = !!compiledSql;
     const hasQuickActions =
+        canDownloadResults ||
         hasSavedChartAction ||
         hasSaveActions ||
         hasExploreAction ||
@@ -512,6 +531,16 @@ export const AiChartQuickOptions = ({
                     </Menu.Target>
                     <Menu.Dropdown>
                         <Menu.Label>Quick actions</Menu.Label>
+                        {canDownloadResults && (
+                            <Menu.Item
+                                leftSection={
+                                    <MantineIcon icon={IconTableExport} />
+                                }
+                                onClick={openDownloadModal}
+                            >
+                                Download results
+                            </Menu.Item>
+                        )}
                         {message.savedQueryUuid ? (
                             !isEmbed && (
                                 <>
@@ -644,6 +673,15 @@ export const AiChartQuickOptions = ({
                     />
                 )}
             </MantineModal>
+            {canDownloadResults && (
+                <AiChartDownloadModal
+                    opened={downloadModalOpened}
+                    onClose={closeDownloadModal}
+                    projectUuid={projectUuid}
+                    chartName={saveChartOptions.name}
+                    mergeQuery={merge?.query ?? null}
+                />
+            )}
             {!!compiledSql && (
                 <MantineModal
                     opened={sqlModalOpened}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -210,6 +210,7 @@ export const AiChartVisualization: FC<Props> = ({
                     message={message}
                     projectUuid={projectUuid}
                     agentUuid={agentUuid}
+                    showDownloadResults
                     artifactData={artifactData}
                     saveChartOptions={{
                         name: semanticVizQueryData.metadata.title,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualizationItem.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualizationItem.tsx
@@ -177,6 +177,7 @@ export const AiDashboardVisualizationItem: FC<Props> = memo(
                     <AiChartQuickOptions
                         projectUuid={projectUuid}
                         agentUuid={agentUuid}
+                        showDownloadResults={false}
                         saveChartOptions={{
                             name: visualization.title,
                             description: visualization.description ?? null,

--- a/packages/frontend/src/ee/features/aiCopilot/utils/executeAiChartDownloadQuery.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/executeAiChartDownloadQuery.test.ts
@@ -1,0 +1,143 @@
+import {
+    ChartType,
+    MergeJoinType,
+    QueryExecutionContext,
+    type ChartConfig,
+    type ItemsMap,
+    type MergeQuery,
+    type MetricQuery,
+} from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { executeAiChartDownloadQuery } from './executeAiChartDownloadQuery';
+
+const mocks = vi.hoisted(() => ({
+    executeQueryAndWaitForResults: vi.fn(),
+    executeMergeQuery: vi.fn(),
+}));
+
+vi.mock('../../../../hooks/useQueryResults', () => ({
+    executeQueryAndWaitForResults: mocks.executeQueryAndWaitForResults,
+}));
+
+vi.mock('../../../../features/mergeQuery/hooks/useMergeQuery', () => ({
+    executeMergeQuery: mocks.executeMergeQuery,
+}));
+
+const metricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_status'],
+    metrics: ['orders_total'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+    additionalMetrics: [],
+    metricOverrides: {},
+} satisfies MetricQuery;
+
+const chartConfig = {
+    type: ChartType.TABLE,
+    config: {},
+} satisfies ChartConfig;
+
+const mergeQuery = {
+    sources: [],
+    joinKey: [],
+    joinType: MergeJoinType.FULL,
+    limit: 500,
+    tableCalculations: [],
+} satisfies MergeQuery;
+
+const fields = {} satisfies ItemsMap;
+
+describe('executeAiChartDownloadQuery', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('executes a semantic artifact as an export for the requested row limit', async () => {
+        mocks.executeQueryAndWaitForResults.mockResolvedValue({
+            queryUuid: 'semantic-download-query',
+        });
+
+        await expect(
+            executeAiChartDownloadQuery({
+                projectUuid: 'project-uuid',
+                metricQuery,
+                parameters: { date_range: 'last 30 days' },
+                chartConfig,
+                pivotDimensions: undefined,
+                fields,
+                mergeQuery: null,
+                limit: 42,
+                exportPivotedData: false,
+            }),
+        ).resolves.toBe('semantic-download-query');
+
+        expect(mocks.executeQueryAndWaitForResults).toHaveBeenCalledWith({
+            projectUuid: 'project-uuid',
+            tableId: 'orders',
+            query: metricQuery,
+            csvLimit: 42,
+            context: QueryExecutionContext.AI,
+            parameters: { date_range: 'last 30 days' },
+            pivotConfiguration: undefined,
+        });
+    });
+
+    it('uses the merge export path and chart grouping for a merged artifact', async () => {
+        mocks.executeMergeQuery.mockResolvedValue({
+            outcome: 'started',
+            query: { queryUuid: 'merge-download-query' },
+        });
+
+        await expect(
+            executeAiChartDownloadQuery({
+                projectUuid: 'project-uuid',
+                metricQuery,
+                parameters: { date_range: 'last 30 days' },
+                chartConfig,
+                pivotDimensions: ['orders_status'],
+                fields,
+                mergeQuery,
+                limit: null,
+                exportPivotedData: true,
+            }),
+        ).resolves.toBe('merge-download-query');
+
+        expect(mocks.executeMergeQuery).toHaveBeenCalledWith(
+            'project-uuid',
+            mergeQuery,
+            { date_range: 'last 30 days' },
+            {
+                chartConfig,
+                pivotConfig: { columns: ['orders_status'] },
+            },
+            null,
+        );
+    });
+
+    it('surfaces merge export refusals', async () => {
+        mocks.executeMergeQuery.mockResolvedValue({
+            outcome: 'refused',
+            errors: [
+                { message: 'Join key missing' },
+                { message: 'Source unavailable' },
+            ],
+        });
+
+        await expect(
+            executeAiChartDownloadQuery({
+                projectUuid: 'project-uuid',
+                metricQuery,
+                parameters: undefined,
+                chartConfig,
+                pivotDimensions: undefined,
+                fields,
+                mergeQuery,
+                limit: 10,
+                exportPivotedData: false,
+            }),
+        ).rejects.toThrow('Join key missing Source unavailable');
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/utils/executeAiChartDownloadQuery.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/executeAiChartDownloadQuery.ts
@@ -1,0 +1,75 @@
+import {
+    QueryExecutionContext,
+    derivePivotConfigurationFromChart,
+    type ChartConfig,
+    type ItemsMap,
+    type MergeQuery,
+    type MetricQuery,
+    type ParametersValuesMap,
+} from '@lightdash/common';
+import { executeMergeQuery } from '../../../../features/mergeQuery/hooks/useMergeQuery';
+import { executeQueryAndWaitForResults } from '../../../../hooks/useQueryResults';
+
+type ExecuteAiChartDownloadQueryArgs = {
+    projectUuid: string;
+    metricQuery: MetricQuery;
+    parameters: ParametersValuesMap | undefined;
+    chartConfig: ChartConfig;
+    pivotDimensions: string[] | undefined;
+    fields: ItemsMap;
+    mergeQuery: MergeQuery | null;
+    limit: number | null;
+    exportPivotedData: boolean;
+};
+
+export const executeAiChartDownloadQuery = async ({
+    projectUuid,
+    metricQuery,
+    parameters,
+    chartConfig,
+    pivotDimensions,
+    fields,
+    mergeQuery,
+    limit,
+    exportPivotedData,
+}: ExecuteAiChartDownloadQueryArgs): Promise<string> => {
+    const pivotConfig = pivotDimensions?.length
+        ? { columns: pivotDimensions }
+        : undefined;
+
+    if (mergeQuery) {
+        const result = await executeMergeQuery(
+            projectUuid,
+            mergeQuery,
+            parameters,
+            exportPivotedData ? { chartConfig, pivotConfig } : undefined,
+            limit,
+        );
+
+        if (result.outcome === 'refused') {
+            throw new Error(
+                result.errors.map((error) => error.message).join(' '),
+            );
+        }
+
+        return result.query.queryUuid;
+    }
+
+    const result = await executeQueryAndWaitForResults({
+        projectUuid,
+        tableId: metricQuery.exploreName,
+        query: metricQuery,
+        csvLimit: limit,
+        context: QueryExecutionContext.AI,
+        parameters,
+        pivotConfiguration: exportPivotedData
+            ? derivePivotConfigurationFromChart(
+                  { chartConfig, pivotConfig },
+                  metricQuery,
+                  fields,
+              )
+            : undefined,
+    });
+
+    return result.queryUuid;
+};


### PR DESCRIPTION
## Summary

- add Download results to Agent chart and table artifacts
- support CSV/XLSX, formatted/raw, grouped/flat, and scoped exports
- add focused modal and query execution coverage

## Testing

- frontend Vitest: 358 files, 2,684 tests passed
- Browser: exported CSV from an Agent-generated grouped chart

Closes: ZAP-101
Closes: https://linear.app/lightdash/issue/ZAP-101/allow-downloading-data-from-agent-generated-charts-and-tables