### PR TITLE
feat: allow downloading Agent SQL results

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
@@ -323,6 +323,11 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                             savedSqlUuid={artifactData.savedSqlUuid}
                             sql={sqlVizQueryData.sql}
                             limit={sqlVizQueryData.limit}
+                            queryUuid={sqlVizQueryData.query.queryUuid}
+                            totalResults={
+                                queryResults.totalResults ??
+                                queryResults.rows.length
+                            }
                             title={title}
                             description={description}
                             columns={Object.values(queryResults.columns ?? {})}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -166,6 +166,11 @@ export const AiChartVisualization: FC<Props> = ({
                         savedSqlUuid={artifactData.savedSqlUuid}
                         sql={sqlVizQueryData.sql}
                         limit={sqlVizQueryData.limit}
+                        queryUuid={sqlVizQueryData.query.queryUuid}
+                        totalResults={
+                            queryResults.totalResults ??
+                            queryResults.rows.length
+                        }
                         title={sqlVizQueryData.metadata.title ?? 'SQL results'}
                         description={sqlVizQueryData.metadata.description}
                         columns={Object.values(queryResults.columns ?? {})}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSqlArtifactActions.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSqlArtifactActions.test.tsx
@@ -1,0 +1,68 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { AiSqlArtifactActions } from './AiSqlArtifactVisualization';
+
+vi.mock('../../../../../hooks/user/useCreateInAnySpaceAccess', () => ({
+    default: () => true,
+}));
+
+vi.mock('../../hooks/useProjectAiAgents', () => ({
+    useUpdateArtifactVersionSavedSql: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock(
+    '../../../../../features/sqlRunner/components/SaveSqlChartModal',
+    () => ({ SaveSqlChartModalContent: () => null }),
+);
+
+vi.mock('../../../../../hooks/user/useUser', () => ({
+    default: () => ({
+        data: { organizationUuid: 'organization-uuid' },
+    }),
+}));
+
+vi.mock('../../../../../providers/Ability', () => ({
+    Can: ({ children }: { children: ReactNode }) => children,
+}));
+
+describe('AiSqlArtifactActions', () => {
+    it('opens the shared export dialog from Download results', async () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <AiSqlArtifactActions
+                    projectUuid="project-uuid"
+                    agentUuid="agent-uuid"
+                    artifactUuid="artifact-uuid"
+                    versionUuid="version-uuid"
+                    savedSqlUuid={null}
+                    sql="select * from orders"
+                    limit={25}
+                    queryUuid="artifact-query-uuid"
+                    totalResults={25}
+                    title="SQL results"
+                    description={null}
+                    columns={[]}
+                />
+            </MemoryRouter>,
+        );
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'SQL artifact actions' }),
+        );
+        await userEvent.click(
+            await screen.findByRole('menuitem', {
+                name: 'Download results',
+            }),
+        );
+
+        expect(screen.getByRole('dialog')).toBeVisible();
+        expect(screen.getByText('Export Data')).toBeVisible();
+        expect(await screen.findByText('Table rows')).toBeVisible();
+        expect(screen.getByText('All results')).toBeVisible();
+        expect(screen.getByText('Custom')).toBeVisible();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSqlArtifactDownloadModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSqlArtifactDownloadModal.tsx
@@ -1,0 +1,50 @@
+import { useCallback, type FC } from 'react';
+import ExportDataModal from '../../../../../components/DashboardTiles/ExportDataModal';
+import { type Limit } from '../../../../../components/ExportResults/types';
+import { getAiSqlArtifactDownloadQueryUuid } from '../../utils/getAiSqlArtifactDownloadQueryUuid';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    queryUuid: string;
+    sql: string;
+    chartName: string;
+    totalResults: number;
+    columnOrder: string[];
+};
+
+export const AiSqlArtifactDownloadModal: FC<Props> = ({
+    opened,
+    onClose,
+    projectUuid,
+    queryUuid,
+    sql,
+    chartName,
+    totalResults,
+    columnOrder,
+}) => {
+    const getDownloadQueryUuid = useCallback(
+        (limit: number | null, limitType: Limit) =>
+            getAiSqlArtifactDownloadQueryUuid({
+                projectUuid,
+                queryUuid,
+                sql,
+                limit,
+                limitType,
+            }),
+        [projectUuid, queryUuid, sql],
+    );
+
+    return (
+        <ExportDataModal
+            isOpen={opened}
+            onClose={onClose}
+            projectUuid={projectUuid}
+            totalResults={totalResults}
+            getDownloadQueryUuid={getDownloadQueryUuid}
+            columnOrder={columnOrder}
+            chartName={chartName}
+        />
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSqlArtifactVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSqlArtifactVisualization.tsx
@@ -7,7 +7,12 @@ import {
     type VizTableConfig,
 } from '@lightdash/common';
 import { ActionIcon, Center, Loader, Menu, Paper, Stack } from '@mantine/core';
-import { IconDeviceFloppy, IconDots, IconTerminal2 } from '@tabler/icons-react';
+import {
+    IconDeviceFloppy,
+    IconDots,
+    IconDownload,
+    IconTerminal2,
+} from '@tabler/icons-react';
 import { useEffect, useMemo, useState, type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -18,6 +23,7 @@ import { type InfiniteQueryResults } from '../../../../../hooks/useQueryResults'
 import useCreateInAnySpaceAccess from '../../../../../hooks/user/useCreateInAnySpaceAccess';
 import useApp from '../../../../../providers/App/useApp';
 import { useUpdateArtifactVersionSavedSql } from '../../hooks/useProjectAiAgents';
+import { AiSqlArtifactDownloadModal } from './AiSqlArtifactDownloadModal';
 
 const unwrapRows = (rows: ResultRow[]): RawResultRow[] =>
     rows.map((row) =>
@@ -63,6 +69,8 @@ type ActionsProps = {
     savedSqlUuid: string | null;
     sql: string;
     limit: number;
+    queryUuid: string;
+    totalResults: number;
     title: string;
     description: string | null;
     columns: ResultColumn[];
@@ -76,12 +84,15 @@ export const AiSqlArtifactActions: FC<ActionsProps> = ({
     savedSqlUuid,
     sql,
     limit,
+    queryUuid,
+    totalResults,
     title,
     description,
     columns,
 }) => {
     const { user } = useApp();
     const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
+    const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
     const { mutateAsync: linkSavedSql } = useUpdateArtifactVersionSavedSql(
         projectUuid,
         agentUuid,
@@ -117,6 +128,12 @@ export const AiSqlArtifactActions: FC<ActionsProps> = ({
                 <Menu.Dropdown>
                     <Menu.Label>Quick actions</Menu.Label>
                     <Menu.Item
+                        onClick={() => setIsDownloadModalOpen(true)}
+                        leftSection={<MantineIcon icon={IconDownload} />}
+                    >
+                        Download results
+                    </Menu.Item>
+                    <Menu.Item
                         component={Link}
                         to={{
                             pathname: `/projects/${projectUuid}/sql-runner`,
@@ -135,6 +152,16 @@ export const AiSqlArtifactActions: FC<ActionsProps> = ({
                     </Menu.Item>
                 </Menu.Dropdown>
             </Menu>
+            <AiSqlArtifactDownloadModal
+                opened={isDownloadModalOpen}
+                onClose={() => setIsDownloadModalOpen(false)}
+                projectUuid={projectUuid}
+                queryUuid={queryUuid}
+                sql={sql}
+                chartName={title}
+                totalResults={totalResults}
+                columnOrder={columns.map((column) => column.reference)}
+            />
             <SaveSqlChartModalContent
                 key={`${isSaveModalOpen}-saveSqlArtifact`}
                 opened={isSaveModalOpen}

--- a/packages/frontend/src/ee/features/aiCopilot/utils/getAiSqlArtifactDownloadQueryUuid.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/getAiSqlArtifactDownloadQueryUuid.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Limit } from '../../../../components/ExportResults/types';
+import { executeSqlDownloadQuery } from '../../../../features/sqlRunner/utils/executeSqlDownloadQuery';
+import { getAiSqlArtifactDownloadQueryUuid } from './getAiSqlArtifactDownloadQueryUuid';
+
+vi.mock('../../../../features/sqlRunner/utils/executeSqlDownloadQuery', () => ({
+    executeSqlDownloadQuery: vi.fn(),
+}));
+
+describe('getAiSqlArtifactDownloadQueryUuid', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('reuses the artifact query for table rows', async () => {
+        await expect(
+            getAiSqlArtifactDownloadQueryUuid({
+                projectUuid: 'project-uuid',
+                queryUuid: 'artifact-query-uuid',
+                sql: 'select * from orders',
+                limit: 25,
+                limitType: Limit.TABLE,
+            }),
+        ).resolves.toBe('artifact-query-uuid');
+
+        expect(executeSqlDownloadQuery).not.toHaveBeenCalled();
+    });
+
+    it('reruns stored SQL without the artifact limit for all results', async () => {
+        vi.mocked(executeSqlDownloadQuery).mockResolvedValue(
+            'download-query-uuid',
+        );
+
+        await expect(
+            getAiSqlArtifactDownloadQueryUuid({
+                projectUuid: 'project-uuid',
+                queryUuid: 'artifact-query-uuid',
+                sql: 'select * from orders',
+                limit: null,
+                limitType: Limit.ALL,
+            }),
+        ).resolves.toBe('download-query-uuid');
+
+        expect(executeSqlDownloadQuery).toHaveBeenCalledWith({
+            projectUuid: 'project-uuid',
+            sql: 'select * from orders',
+            limit: null,
+        });
+    });
+
+    it('reruns stored SQL with the custom row limit', async () => {
+        vi.mocked(executeSqlDownloadQuery).mockResolvedValue(
+            'custom-download-query-uuid',
+        );
+
+        await expect(
+            getAiSqlArtifactDownloadQueryUuid({
+                projectUuid: 'project-uuid',
+                queryUuid: 'artifact-query-uuid',
+                sql: 'select * from orders',
+                limit: 42,
+                limitType: Limit.CUSTOM,
+            }),
+        ).resolves.toBe('custom-download-query-uuid');
+
+        expect(executeSqlDownloadQuery).toHaveBeenCalledWith({
+            projectUuid: 'project-uuid',
+            sql: 'select * from orders',
+            limit: 42,
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/utils/getAiSqlArtifactDownloadQueryUuid.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/getAiSqlArtifactDownloadQueryUuid.ts
@@ -1,0 +1,26 @@
+import { Limit } from '../../../../components/ExportResults/types';
+import { executeSqlDownloadQuery } from '../../../../features/sqlRunner/utils/executeSqlDownloadQuery';
+
+type GetAiSqlArtifactDownloadQueryUuidArgs = {
+    projectUuid: string;
+    queryUuid: string;
+    sql: string;
+    limit: number | null;
+    limitType: Limit;
+};
+
+export const getAiSqlArtifactDownloadQueryUuid = async ({
+    projectUuid,
+    queryUuid,
+    sql,
+    limit,
+    limitType,
+}: GetAiSqlArtifactDownloadQueryUuidArgs): Promise<string> => {
+    if (limitType === Limit.TABLE) return queryUuid;
+
+    return executeSqlDownloadQuery({
+        projectUuid,
+        sql,
+        limit,
+    });
+};

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -4,7 +4,6 @@ import {
     getParameterReferences,
     isVizBigNumberConfig,
     isVizTableConfig,
-    MAX_SAFE_INTEGER,
     type VizTableConfig,
     type VizTableHeaderSortConfig,
     formatSql,
@@ -60,7 +59,6 @@ import { useOrganization } from '../../../hooks/organization/useOrganization';
 import useToaster from '../../../hooks/toaster/useToaster';
 import useApp from '../../../providers/App/useApp';
 import { Parameters, useParameters } from '../../parameters';
-import { executeSqlQuery } from '../../queryRunner/executeQuery';
 import { DEFAULT_SQL_LIMIT } from '../constants';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import {
@@ -85,6 +83,7 @@ import {
     updateParameterValue,
 } from '../store/sqlRunnerSlice';
 import { prepareAndFetchChartData, runSqlQuery } from '../store/thunks';
+import { executeSqlDownloadQuery } from '../utils/executeSqlDownloadQuery';
 import { ChartDownload } from './Download/ChartDownload';
 import ResultsDownloadButton from './Download/ResultsDownloadButton';
 import styles from './ResizeHandle.module.css';
@@ -411,16 +410,12 @@ export const ContentPanel: FC = () => {
             // 2. limit is different from current query
             // 3. there is no fallback query uuid (in theory, never happens)
             if (!queryUuid || limit === null || limit !== downloadLimit) {
-                const newQuery = await executeSqlQuery(
+                return executeSqlDownloadQuery({
                     projectUuid,
                     sql,
-                    downloadLimit === null
-                        ? MAX_SAFE_INTEGER
-                        : (downloadLimit ?? limit),
+                    limit: downloadLimit,
                     parameterValues,
-                    true,
-                );
-                return newQuery.queryUuid;
+                });
             }
             return queryUuid;
         },

--- a/packages/frontend/src/features/sqlRunner/utils/executeSqlDownloadQuery.test.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/executeSqlDownloadQuery.test.ts
@@ -1,0 +1,58 @@
+import { MAX_SAFE_INTEGER } from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { executeSqlQuery } from '../../queryRunner/executeQuery';
+import { type ResultsAndColumns } from '../hooks/useSqlQueryRun';
+import { executeSqlDownloadQuery } from './executeSqlDownloadQuery';
+
+vi.mock('../../queryRunner/executeQuery', () => ({
+    executeSqlQuery: vi.fn(),
+}));
+
+const queryResult = {
+    queryUuid: 'download-query-uuid',
+    fileUrl: undefined,
+    results: [],
+    columns: [],
+} satisfies ResultsAndColumns;
+
+describe('executeSqlDownloadQuery', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.mocked(executeSqlQuery).mockResolvedValue(queryResult);
+    });
+
+    it('executes all results without the SQL Runner limit', async () => {
+        await expect(
+            executeSqlDownloadQuery({
+                projectUuid: 'project-uuid',
+                sql: 'select * from orders',
+                limit: null,
+            }),
+        ).resolves.toBe('download-query-uuid');
+
+        expect(executeSqlQuery).toHaveBeenCalledWith(
+            'project-uuid',
+            'select * from orders',
+            MAX_SAFE_INTEGER,
+            undefined,
+            true,
+        );
+    });
+
+    it('executes the requested custom row limit', async () => {
+        await executeSqlDownloadQuery({
+            projectUuid: 'project-uuid',
+            sql: 'select * from orders',
+            limit: 42,
+            parameterValues: { date_range: 'last 30 days' },
+        });
+
+        expect(executeSqlQuery).toHaveBeenCalledWith(
+            'project-uuid',
+            'select * from orders',
+            42,
+            { date_range: 'last 30 days' },
+            true,
+        );
+    });
+});

--- a/packages/frontend/src/features/sqlRunner/utils/executeSqlDownloadQuery.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/executeSqlDownloadQuery.ts
@@ -1,0 +1,26 @@
+import { MAX_SAFE_INTEGER, type ParametersValuesMap } from '@lightdash/common';
+import { executeSqlQuery } from '../../queryRunner/executeQuery';
+
+type ExecuteSqlDownloadQueryArgs = {
+    projectUuid: string;
+    sql: string;
+    limit: number | null;
+    parameterValues?: ParametersValuesMap;
+};
+
+export const executeSqlDownloadQuery = async ({
+    projectUuid,
+    sql,
+    limit,
+    parameterValues,
+}: ExecuteSqlDownloadQueryArgs): Promise<string> => {
+    const result = await executeSqlQuery(
+        projectUuid,
+        sql,
+        limit ?? MAX_SAFE_INTEGER,
+        parameterValues,
+        true,
+    );
+
+    return result.queryUuid;
+};


### PR DESCRIPTION
## Summary

- add Download results to Agent runSql artifacts
- reuse the shared export modal and scheduled-download backend
- reuse executed rows for table scope; rerun stored SQL for all/custom scopes
- share SQL download execution with SQL Runner

## Testing

- frontend Vitest: 361 files, 2,690 tests passed
- frontend typecheck passed
- Browser: approved a real runSql query and downloaded its 5-row CSV artifact

Closes: ZAP-899
Closes: https://linear.app/lightdash/issue/ZAP-899/allow-downloading-data-from-agent-sql-result-artifacts
Closes: #27709