### PR TITLE
feat(ai-agent): formula table calculations in agent visualizations

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -111,7 +111,7 @@ import {
     ToolDashboardArgs,
     toolDashboardArgsSchema,
     ToolDashboardV2Args,
-    toolDashboardV2ArgsSchema,
+    toolDashboardV2ArgsSchemaPersisted,
     UnexpectedServerError,
     UpdateSlackResponse,
     UpdateWebAppResponse,
@@ -6727,10 +6727,12 @@ export class AiAgentService extends BaseService {
         }
 
         // We use base schema here because later we call `parseVizConfig` that uses transformed schem which takes base schema output as input
-        // Try to parse with v2 schema first, then fall back to v1
-        const dashboardConfigV2Parsed = toolDashboardV2ArgsSchema.safeParse(
-            artifact.dashboardConfig,
-        );
+        // Try to parse with v2 schema first, then fall back to v1. The wide
+        // persisted variant accepts legacy template table calcs.
+        const dashboardConfigV2Parsed =
+            toolDashboardV2ArgsSchemaPersisted.safeParse(
+                artifact.dashboardConfig,
+            );
         let dashboardConfig: ToolDashboardArgs | ToolDashboardV2Args;
         if (dashboardConfigV2Parsed.success) {
             dashboardConfig = dashboardConfigV2Parsed.data;

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -22,7 +22,7 @@ import {
     QueryExecutionContext,
     QueryHistoryStatus,
     sleep,
-    toolRunQueryArgsSchema,
+    toolRunQueryArgsSchemaPersisted,
     UnexpectedServerError,
     type Account,
     type AiAgentToolResult,
@@ -1757,7 +1757,9 @@ export class AiDeepResearchService extends BaseService {
                 };
             }
 
-            const parsedArgs = toolRunQueryArgsSchema.safeParse(toolArgs);
+            // Persisted args may predate the current advertised contract.
+            const parsedArgs =
+                toolRunQueryArgsSchemaPersisted.safeParse(toolArgs);
             const resolvedChart = resolveDeepResearchWarehouseChart(
                 toolArgs,
                 queryUuid,

--- a/packages/backend/src/ee/services/AiDeepResearchService/resolveDeepResearchWarehouseChart.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/resolveDeepResearchWarehouseChart.ts
@@ -1,7 +1,7 @@
 import {
     AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS,
     aiDeepResearchChartDefinitionSchema,
-    toolRunQueryArgsSchema,
+    toolRunQueryArgsSchemaPersisted,
     type AiDeepResearchWarehouseChart,
 } from '@lightdash/common';
 
@@ -9,7 +9,8 @@ export const resolveDeepResearchWarehouseChart = (
     toolArgs: unknown,
     queryUuid: string,
 ): { chart: AiDeepResearchWarehouseChart; description: string } | null => {
-    const parsedToolArgs = toolRunQueryArgsSchema.safeParse(toolArgs);
+    // Persisted args may predate the current advertised contract.
+    const parsedToolArgs = toolRunQueryArgsSchemaPersisted.safeParse(toolArgs);
     if (!parsedToolArgs.success || !parsedToolArgs.data.chartConfig) {
         return null;
     }

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -70,10 +70,11 @@ For a complete raw SQL query, follow step 0, then skip steps 1–3 and call \`ru
 - Always provide axis labels
 
 ### Table Calculations
-Use table calculations for:
-- Aggregating already-aggregated metrics (e.g., average of monthly totals)
-- Row comparisons: % of total, period-over-period change, rankings, running totals
-- "Top N per group" patterns: create \`row_number\` with \`partitionBy\`, then filter
+Author table calculations as type \`formula\` (the field's schema documents the syntax). Use them for:
+- Arithmetic across metrics: \`metric_a + metric_b\`, ratios \`metric_a / metric_b\`
+- Aggregating already-aggregated metrics (e.g., average of monthly totals): \`AVG(metric)\`
+- Row comparisons: % of total \`m / SUM(m)\`, period-over-period \`(m - LAG(m, ORDER BY date)) / LAG(m, ORDER BY date)\`, rankings \`RANK(...)\`, running totals \`RUNNING_TOTAL(m, ORDER BY date)\`, trailing 3-period average \`MOVING_AVG(m, 2, ORDER BY date)\`
+- "Top N per group" patterns: \`ROW_NUMBER(PARTITION BY group, ORDER BY m DESC)\`, then filter
 
 ### Custom Metrics
 - Use when the explore lacks a needed aggregation
@@ -5369,9 +5370,7 @@ Example B — "Revenue by month with year-over-year comparison"
                 "description": "
 Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
 
-**Available Types:**
-- Simple calculations: percent_change_from_previous, percent_of_previous_value, percent_of_column_total, rank_in_column, running_total
-- Advanced window_function: Supports row_number, percent_rank, sum, avg, count, min, max with optional partitioning, ordering, and frame clauses
+**Prefer type "formula"** — it expresses arithmetic across fields, ratios, comparisons, conditionals, and partitioned window calculations. The other types are legacy single-field templates kept for backwards compatibility.
 
 **Technical Requirements:**
 - Appear as additional columns in query results
@@ -5381,6 +5380,60 @@ Table calculations perform row-by-row calculations on query results without coll
 , ",
                 "items": {
                   "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "displayName": {
+                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                          "type": "string",
+                        },
+                        "format": {
+                          "description": "Display format. Use "percent" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to "number"., ",
+                          "enum": [
+                            "number",
+                            "percent",
+                          ],
+                          "type": "string",
+                        },
+                        "formula": {
+                          "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).
+Reference fields by their field id directly, e.g. \`orders_total_revenue / orders_order_count\`. No prefix, no braces, no leading \`=\`.
+Any selected dimension, metric, custom metric (\`<table>_<name>\`), or another table calculation name can be referenced.
+Operators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.
+Functions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).
+Window functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. \`LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)\`.
+MOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is \`MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)\`.
+All branches of an IF must return the same type.",
+                          "type": "string",
+                        },
+                        "name": {
+                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                          "type": "string",
+                        },
+                        "resultType": {
+                          "description": "Data type the formula evaluates to. null defaults to "number"., ",
+                          "enum": [
+                            "number",
+                            "string",
+                            "date",
+                            "timestamp",
+                            "boolean",
+                          ],
+                          "type": "string",
+                        },
+                        "type": {
+                          "const": "formula",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "name",
+                        "displayName",
+                        "type",
+                        "formula",
+                      ],
+                      "type": "object",
+                    },
                     {
                       "additionalProperties": false,
                       "properties": {

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -64,10 +64,11 @@ ${runSqlEnabled ? RUN_SQL_GUIDANCE : ''}### Time Filtering
 - Always provide axis labels
 
 ### Table Calculations
-Use table calculations for:
-- Aggregating already-aggregated metrics (e.g., average of monthly totals)
-- Row comparisons: % of total, period-over-period change, rankings, running totals
-- "Top N per group" patterns: create \`row_number\` with \`partitionBy\`, then filter
+Author table calculations as type \`formula\` (the field's schema documents the syntax). Use them for:
+- Arithmetic across metrics: \`metric_a + metric_b\`, ratios \`metric_a / metric_b\`
+- Aggregating already-aggregated metrics (e.g., average of monthly totals): \`AVG(metric)\`
+- Row comparisons: % of total \`m / SUM(m)\`, period-over-period \`(m - LAG(m, ORDER BY date)) / LAG(m, ORDER BY date)\`, rankings \`RANK(...)\`, running totals \`RUNNING_TOTAL(m, ORDER BY date)\`, trailing 3-period average \`MOVING_AVG(m, 2, ORDER BY date)\`
+- "Top N per group" patterns: \`ROW_NUMBER(PARTITION BY group, ORDER BY m DESC)\`, then filter
 
 ### Custom Metrics
 - Use when the explore lacks a needed aggregation

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -1,3 +1,5 @@
+import { FUNCTION_CATALOG } from '@lightdash/formula';
+
 export const SYSTEM_PROMPT_TEMPLATE = `You are {{agent_name}}, a data analytics assistant for Lightdash, the open source BI tool for modern data teams. You help users retrieve, visualize, and find data in their Lightdash project.
 
 Today is {{date}}. When querying data, always take this date into consideration: resolve every relative time expression ("last month", "this quarter", "past year") against it — never against dates observed in the data or your own assumptions about the current date. If a resolved time window returns no data, say so; do not silently shift the window to a period where data exists.
@@ -72,14 +74,21 @@ String dimension metadata has \`caseSensitiveFilters\` when case sensitivity app
 
 ## Table calculations (when to reach for them)
 
-Use a table calculation when the question requires row-by-row math over query results — anything the metric query alone can't express:
+Use a table calculation when the question requires row-by-row math over query results — anything the metric query alone can't express. Author them as spreadsheet-like formulas (\`tableCalculations\`, type \`formula\`; the field's schema documents the syntax):
 
-- **Aggregating already-aggregated metrics** (the primary case). You cannot aggregate a metric in the query itself; only a table calc can. E.g. "average of monthly revenue totals" → query monthly revenue, then \`window_function:avg\` with no orderBy and no frame.
-- **Ranking, top N per group, percentiles**: \`window_function:row_number\` or \`percent_rank\` with \`partitionBy\`. To return only the top N, add a filter on the table calc in \`filters.tableCalculations\` — without it you get every row with its rank.
-- **% of total, running totals, moving averages, period-over-period change**: prefer the simple types (\`percent_of_column_total\`, \`running_total\`, \`percent_change_from_previous\`) over \`window_function\` when they fit. They support \`partitionBy\` for per-group variants.
+- **Arithmetic across metrics** — the query itself cannot combine metrics; only a table calc can. Sums: \`metric_a + metric_b\`; ratios: \`metric_a / metric_b\` (format "percent" when it's a share); any mix: \`(metric_a + metric_b) / metric_c\`.
+- **Aggregating already-aggregated metrics**. E.g. "average of monthly revenue totals" → query monthly revenue, then \`AVG(orders_total_revenue)\`.
+- **% of total**: \`orders_total_revenue / SUM(orders_total_revenue)\`, format "percent".
+- **Period-over-period change**: \`(m - LAG(m, ORDER BY date_dim)) / LAG(m, ORDER BY date_dim)\`, format "percent". Partition for per-group variants: \`LAG(m, PARTITION BY group_dim, ORDER BY date_dim)\`.
+- **Running totals / moving averages**: \`RUNNING_TOTAL(m, ORDER BY date_dim)\`, \`MOVING_AVG(m, 2, ORDER BY date_dim)\` (the 2 counts preceding rows and the current row is included — a trailing 3-period average).
+- **Ranking, top N per group**: \`RANK(PARTITION BY group_dim, ORDER BY m DESC)\` or \`ROW_NUMBER(...)\`. To return only the top N, add a filter on the table calc in \`filters.tableCalculations\` — without it you get every row with its rank.
+- **Cohort rebasing / first-value comparisons**: \`m / FIRST(m, PARTITION BY cohort_dim, ORDER BY date_dim)\`.
+- **Row-level comparisons and conditionals**: \`date_a < date_b\` (resultType "boolean"), \`IF(m > 1000, "high", "low")\` (resultType "string").
 - Default the visualization to a table when the user wants to see the calculated values, unless they ask for a chart explicitly.
 
-Table calc parameter shapes (frames, partitionBy, orderBy) are documented in the generateVisualization schema.
+Available functions:
+
+${FUNCTION_CATALOG}
 
 ## Custom metrics
 

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -2972,444 +2972,74 @@ Example B — "Revenue by month with year-over-year comparison"
                     "anyOf": [
                       {
                         "items": {
-                          "anyOf": [
-                            {
-                              "additionalProperties": false,
-                              "properties": {
-                                "displayName": {
-                                  "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                                  "type": "string",
-                                },
-                                "fieldId": {
-                                  "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                  "type": "string",
-                                },
-                                "name": {
-                                  "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                                  "type": "string",
-                                },
-                                "orderBy": {
-                                  "description": "Specifies the order in which rows are processed by the table calculation.
-For time-series: typically order by date/time ascending.
-For rankings: order by the metric you want to rank, descending for highest-first.",
-                                  "items": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldId": {
-                                        "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "order": {
-                                        "anyOf": [
-                                          {
-                                            "enum": [
-                                              "asc",
-                                              "desc",
-                                            ],
-                                            "type": "string",
-                                          },
-                                          {
-                                            "type": "null",
-                                          },
-                                        ],
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "order",
-                                    ],
-                                    "type": "object",
-                                  },
-                                  "minItems": 1,
-                                  "type": "array",
-                                },
-                                "partitionBy": {
-                                  "anyOf": [
-                                    {
-                                      "items": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "type": "array",
-                                    },
-                                    {
-                                      "type": "null",
-                                    },
-                                  ],
-                                  "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                                },
-                                "type": {
-                                  "const": "percent_change_from_previous",
-                                  "type": "string",
-                                },
-                              },
-                              "required": [
-                                "name",
-                                "displayName",
-                                "type",
-                                "fieldId",
-                                "orderBy",
-                                "partitionBy",
-                              ],
-                              "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "displayName": {
+                              "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                              "type": "string",
                             },
-                            {
-                              "additionalProperties": false,
-                              "properties": {
-                                "displayName": {
-                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                                },
-                                "fieldId": {
-                                  "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                  "type": "string",
-                                },
-                                "name": {
-                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                                },
-                                "orderBy": {
-                                  "description": "Specifies the order in which rows are processed by the table calculation.
-For time-series: typically order by date/time ascending.
-For rankings: order by the metric you want to rank, descending for highest-first.",
-                                  "items": {
-                                    "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
-                                  },
-                                  "minItems": 1,
-                                  "type": "array",
-                                },
-                                "partitionBy": {
-                                  "anyOf": [
-                                    {
-                                      "items": {
-                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
-                                      },
-                                      "type": "array",
-                                    },
-                                    {
-                                      "type": "null",
-                                    },
-                                  ],
-                                  "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                                },
-                                "type": {
-                                  "const": "percent_of_previous_value",
-                                  "type": "string",
-                                },
-                              },
-                              "required": [
-                                "name",
-                                "displayName",
-                                "type",
-                                "fieldId",
-                                "orderBy",
-                                "partitionBy",
-                              ],
-                              "type": "object",
-                            },
-                            {
-                              "additionalProperties": false,
-                              "properties": {
-                                "displayName": {
-                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                                },
-                                "fieldId": {
-                                  "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                  "type": "string",
-                                },
-                                "name": {
-                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                                },
-                                "partitionBy": {
-                                  "anyOf": [
-                                    {
-                                      "items": {
-                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
-                                      },
-                                      "type": "array",
-                                    },
-                                    {
-                                      "type": "null",
-                                    },
-                                  ],
-                                  "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                                },
-                                "type": {
-                                  "const": "percent_of_column_total",
-                                  "type": "string",
-                                },
-                              },
-                              "required": [
-                                "name",
-                                "displayName",
-                                "type",
-                                "fieldId",
-                                "partitionBy",
-                              ],
-                              "type": "object",
-                            },
-                            {
-                              "additionalProperties": false,
-                              "properties": {
-                                "displayName": {
-                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                                },
-                                "fieldId": {
-                                  "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                  "type": "string",
-                                },
-                                "name": {
-                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                                },
-                                "type": {
-                                  "const": "rank_in_column",
-                                  "type": "string",
-                                },
-                              },
-                              "required": [
-                                "name",
-                                "displayName",
-                                "type",
-                                "fieldId",
-                              ],
-                              "type": "object",
-                            },
-                            {
-                              "additionalProperties": false,
-                              "properties": {
-                                "displayName": {
-                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                                },
-                                "fieldId": {
-                                  "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                  "type": "string",
-                                },
-                                "name": {
-                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                                },
-                                "type": {
-                                  "const": "running_total",
-                                  "type": "string",
-                                },
-                              },
-                              "required": [
-                                "name",
-                                "displayName",
-                                "type",
-                                "fieldId",
-                              ],
-                              "type": "object",
-                            },
-                            {
-                              "additionalProperties": false,
-                              "properties": {
-                                "displayName": {
-                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                                },
-                                "fieldId": {
-                                  "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                  "type": [
-                                    "string",
-                                    "null",
-                                  ],
-                                },
-                                "frame": {
-                                  "anyOf": [
-                                    {
-                                      "additionalProperties": false,
-                                      "properties": {
-                                        "end": {
-                                          "additionalProperties": false,
-                                          "description": "End boundary (required)",
-                                          "properties": {
-                                            "offset": {
-                                              "anyOf": [
-                                                {
-                                                  "exclusiveMinimum": 0,
-                                                  "type": "integer",
-                                                },
-                                                {
-                                                  "type": "null",
-                                                },
-                                              ],
-                                              "description": "Number of rows for PRECEDING/FOLLOWING",
-                                            },
-                                            "type": {
-                                              "enum": [
-                                                "unbounded_preceding",
-                                                "preceding",
-                                                "current_row",
-                                                "following",
-                                                "unbounded_following",
-                                              ],
-                                              "type": "string",
-                                            },
-                                          },
-                                          "required": [
-                                            "type",
-                                            "offset",
-                                          ],
-                                          "type": "object",
-                                        },
-                                        "frameType": {
-                                          "description": "Frame type:
-- rows: Physical row count
-- range: Logical value-based (includes peer rows with same ORDER BY value)",
-                                          "enum": [
-                                            "rows",
-                                            "range",
-                                          ],
-                                          "type": "string",
-                                        },
-                                        "start": {
-                                          "anyOf": [
-                                            {
-                                              "additionalProperties": false,
-                                              "properties": {
-                                                "offset": {
-                                                  "anyOf": [
-                                                    {
-                                                      "exclusiveMinimum": 0,
-                                                      "type": "integer",
-                                                    },
-                                                    {
-                                                      "type": "null",
-                                                    },
-                                                  ],
-                                                  "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING")",
-                                                },
-                                                "type": {
-                                                  "enum": [
-                                                    "unbounded_preceding",
-                                                    "preceding",
-                                                    "current_row",
-                                                    "following",
-                                                    "unbounded_following",
-                                                  ],
-                                                  "type": "string",
-                                                },
-                                              },
-                                              "required": [
-                                                "type",
-                                                "offset",
-                                              ],
-                                              "type": "object",
-                                            },
-                                            {
-                                              "type": "null",
-                                            },
-                                          ],
-                                          "description": "Start boundary. Null for single-boundary syntax.",
-                                        },
-                                      },
-                                      "required": [
-                                        "frameType",
-                                        "start",
-                                        "end",
-                                      ],
-                                      "type": "object",
-                                    },
-                                    {
-                                      "type": "null",
-                                    },
-                                  ],
-                                  "description": "Defines which rows to include in calculation. Null uses database defaults.
-
-**Common patterns:**
-- Moving average (N periods): {frameType: "rows", start: {type: "preceding", offset: N-1}, end: {type: "current_row"}}
-- Running total: {frameType: "rows", start: {type: "unbounded_preceding"}, end: {type: "current_row"}}
-- Centered window: {frameType: "rows", start: {type: "preceding", offset: 1}, end: {type: "following", offset: 1}}
-
-**Default when null:**
-- Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)
-- Aggregates WITHOUT ORDER BY: Entire partition (all rows)
-- Ranking functions: Always use entire partition (frame clause has no effect)",
-                                },
-                                "name": {
-                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                                },
-                                "orderBy": {
-                                  "anyOf": [
-                                    {
-                                      "items": {
-                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
-                                      },
-                                      "type": "array",
-                                    },
-                                    {
-                                      "type": "null",
-                                    },
-                                  ],
-                                  "description": "Specifies the order in which rows are processed by the table calculation.
-For time-series: typically order by date/time ascending.
-For rankings: order by the metric you want to rank, descending for highest-first.",
-                                },
-                                "partitionBy": {
-                                  "anyOf": [
-                                    {
-                                      "items": {
-                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
-                                      },
-                                      "type": "array",
-                                    },
-                                    {
-                                      "type": "null",
-                                    },
-                                  ],
-                                  "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                                },
-                                "type": {
-                                  "const": "window_function",
-                                  "type": "string",
-                                },
-                                "windowFunction": {
-                                  "description": "Type of window function to apply.
-
-**Ranking functions** (fieldId optional, ignored if provided):
-- row_number: Sequential numbering (1, 2, 3...)
-- percent_rank: Relative rank as percentage (0.0-1.0)
-- cume_dist: Cumulative distribution as percentage (0.0-1.0)
-- rank: Positional rank (1, 2, 3...) with ties
-
-**Aggregate functions** (fieldId required):
-- sum: Sum values within frame
-- avg: Average values within frame
-- count: Count values within frame
-- min: Minimum value within frame
-- max: Maximum value within frame",
+                            "format": {
+                              "anyOf": [
+                                {
                                   "enum": [
-                                    "row_number",
-                                    "percent_rank",
-                                    "cume_dist",
-                                    "rank",
-                                    "sum",
-                                    "avg",
-                                    "count",
-                                    "min",
-                                    "max",
+                                    "number",
+                                    "percent",
                                   ],
                                   "type": "string",
                                 },
-                              },
-                              "required": [
-                                "name",
-                                "displayName",
-                                "type",
-                                "windowFunction",
-                                "fieldId",
-                                "orderBy",
-                                "partitionBy",
-                                "frame",
+                                {
+                                  "type": "null",
+                                },
                               ],
-                              "type": "object",
+                              "description": "Display format. Use "percent" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to "number".",
                             },
+                            "formula": {
+                              "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).
+Reference fields by their field id directly, e.g. \`orders_total_revenue / orders_order_count\`. No prefix, no braces, no leading \`=\`.
+Any selected dimension, metric, custom metric (\`<table>_<name>\`), or another table calculation name can be referenced.
+Operators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.
+Functions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).
+Window functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. \`LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)\`.
+MOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is \`MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)\`.
+All branches of an IF must return the same type.",
+                              "type": "string",
+                            },
+                            "name": {
+                              "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                              "type": "string",
+                            },
+                            "resultType": {
+                              "anyOf": [
+                                {
+                                  "enum": [
+                                    "number",
+                                    "string",
+                                    "date",
+                                    "timestamp",
+                                    "boolean",
+                                  ],
+                                  "type": "string",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                              "description": "Data type the formula evaluates to. null defaults to "number".",
+                            },
+                            "type": {
+                              "const": "formula",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "name",
+                            "displayName",
+                            "type",
+                            "formula",
+                            "format",
+                            "resultType",
                           ],
+                          "type": "object",
                         },
                         "type": "array",
                       },
@@ -3418,17 +3048,15 @@ Empty array or null: single partition (calculations across all rows).",
                       },
                     ],
                     "description": "
-Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
+Table calculations perform row-by-row calculations on query results without collapsing rows, using spreadsheet-like formulas.
 
-**Available Types:**
-- Simple calculations: percent_change_from_previous, percent_of_previous_value, percent_of_column_total, rank_in_column, running_total
-- Advanced window_function: Supports row_number, percent_rank, sum, avg, count, min, max with optional partitioning, ordering, and frame clauses
+Use them whenever the question needs math the metric query alone can't express: arithmetic across metrics (\`metric_a + metric_b\`), ratios, percent of total, period-over-period change, running totals, moving averages, ranking, row-level comparisons, or aggregating already-aggregated metrics.
 
 **Technical Requirements:**
 - Appear as additional columns in query results
 - Can be used in sorts and filters alongside dimensions/metrics
-- Multiple calculations can be combined in a single query
-- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)
+- Multiple calculations can be combined in a single query; a formula can reference another table calculation by name
+- All fields referenced must be selected in the query (dimensions, metrics, custom metrics, or other table calculations)
 ",
                   },
                 },
@@ -6723,444 +6351,74 @@ Example B — "Revenue by month with year-over-year comparison"
               "anyOf": [
                 {
                   "items": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": false,
-                        "properties": {
-                          "displayName": {
-                            "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                            "type": "string",
-                          },
-                          "fieldId": {
-                            "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "name": {
-                            "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                            "type": "string",
-                          },
-                          "orderBy": {
-                            "description": "Specifies the order in which rows are processed by the table calculation.
-For time-series: typically order by date/time ascending.
-For rankings: order by the metric you want to rank, descending for highest-first.",
-                            "items": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "fieldId": {
-                                  "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                  "type": "string",
-                                },
-                                "order": {
-                                  "anyOf": [
-                                    {
-                                      "enum": [
-                                        "asc",
-                                        "desc",
-                                      ],
-                                      "type": "string",
-                                    },
-                                    {
-                                      "type": "null",
-                                    },
-                                  ],
-                                },
-                              },
-                              "required": [
-                                "fieldId",
-                                "order",
-                              ],
-                              "type": "object",
-                            },
-                            "minItems": 1,
-                            "type": "array",
-                          },
-                          "partitionBy": {
-                            "anyOf": [
-                              {
-                                "items": {
-                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                  "type": "string",
-                                },
-                                "type": "array",
-                              },
-                              {
-                                "type": "null",
-                              },
-                            ],
-                            "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                          },
-                          "type": {
-                            "const": "percent_change_from_previous",
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "name",
-                          "displayName",
-                          "type",
-                          "fieldId",
-                          "orderBy",
-                          "partitionBy",
-                        ],
-                        "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "displayName": {
+                        "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                        "type": "string",
                       },
-                      {
-                        "additionalProperties": false,
-                        "properties": {
-                          "displayName": {
-                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                          },
-                          "fieldId": {
-                            "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "name": {
-                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                          },
-                          "orderBy": {
-                            "description": "Specifies the order in which rows are processed by the table calculation.
-For time-series: typically order by date/time ascending.
-For rankings: order by the metric you want to rank, descending for highest-first.",
-                            "items": {
-                              "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
-                            },
-                            "minItems": 1,
-                            "type": "array",
-                          },
-                          "partitionBy": {
-                            "anyOf": [
-                              {
-                                "items": {
-                                  "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
-                                },
-                                "type": "array",
-                              },
-                              {
-                                "type": "null",
-                              },
-                            ],
-                            "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                          },
-                          "type": {
-                            "const": "percent_of_previous_value",
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "name",
-                          "displayName",
-                          "type",
-                          "fieldId",
-                          "orderBy",
-                          "partitionBy",
-                        ],
-                        "type": "object",
-                      },
-                      {
-                        "additionalProperties": false,
-                        "properties": {
-                          "displayName": {
-                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                          },
-                          "fieldId": {
-                            "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "name": {
-                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                          },
-                          "partitionBy": {
-                            "anyOf": [
-                              {
-                                "items": {
-                                  "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
-                                },
-                                "type": "array",
-                              },
-                              {
-                                "type": "null",
-                              },
-                            ],
-                            "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                          },
-                          "type": {
-                            "const": "percent_of_column_total",
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "name",
-                          "displayName",
-                          "type",
-                          "fieldId",
-                          "partitionBy",
-                        ],
-                        "type": "object",
-                      },
-                      {
-                        "additionalProperties": false,
-                        "properties": {
-                          "displayName": {
-                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                          },
-                          "fieldId": {
-                            "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "name": {
-                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                          },
-                          "type": {
-                            "const": "rank_in_column",
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "name",
-                          "displayName",
-                          "type",
-                          "fieldId",
-                        ],
-                        "type": "object",
-                      },
-                      {
-                        "additionalProperties": false,
-                        "properties": {
-                          "displayName": {
-                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                          },
-                          "fieldId": {
-                            "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "name": {
-                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                          },
-                          "type": {
-                            "const": "running_total",
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "name",
-                          "displayName",
-                          "type",
-                          "fieldId",
-                        ],
-                        "type": "object",
-                      },
-                      {
-                        "additionalProperties": false,
-                        "properties": {
-                          "displayName": {
-                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                          },
-                          "fieldId": {
-                            "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": [
-                              "string",
-                              "null",
-                            ],
-                          },
-                          "frame": {
-                            "anyOf": [
-                              {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "end": {
-                                    "additionalProperties": false,
-                                    "description": "End boundary (required)",
-                                    "properties": {
-                                      "offset": {
-                                        "anyOf": [
-                                          {
-                                            "exclusiveMinimum": 0,
-                                            "type": "integer",
-                                          },
-                                          {
-                                            "type": "null",
-                                          },
-                                        ],
-                                        "description": "Number of rows for PRECEDING/FOLLOWING",
-                                      },
-                                      "type": {
-                                        "enum": [
-                                          "unbounded_preceding",
-                                          "preceding",
-                                          "current_row",
-                                          "following",
-                                          "unbounded_following",
-                                        ],
-                                        "type": "string",
-                                      },
-                                    },
-                                    "required": [
-                                      "type",
-                                      "offset",
-                                    ],
-                                    "type": "object",
-                                  },
-                                  "frameType": {
-                                    "description": "Frame type:
-- rows: Physical row count
-- range: Logical value-based (includes peer rows with same ORDER BY value)",
-                                    "enum": [
-                                      "rows",
-                                      "range",
-                                    ],
-                                    "type": "string",
-                                  },
-                                  "start": {
-                                    "anyOf": [
-                                      {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                          "offset": {
-                                            "anyOf": [
-                                              {
-                                                "exclusiveMinimum": 0,
-                                                "type": "integer",
-                                              },
-                                              {
-                                                "type": "null",
-                                              },
-                                            ],
-                                            "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING")",
-                                          },
-                                          "type": {
-                                            "enum": [
-                                              "unbounded_preceding",
-                                              "preceding",
-                                              "current_row",
-                                              "following",
-                                              "unbounded_following",
-                                            ],
-                                            "type": "string",
-                                          },
-                                        },
-                                        "required": [
-                                          "type",
-                                          "offset",
-                                        ],
-                                        "type": "object",
-                                      },
-                                      {
-                                        "type": "null",
-                                      },
-                                    ],
-                                    "description": "Start boundary. Null for single-boundary syntax.",
-                                  },
-                                },
-                                "required": [
-                                  "frameType",
-                                  "start",
-                                  "end",
-                                ],
-                                "type": "object",
-                              },
-                              {
-                                "type": "null",
-                              },
-                            ],
-                            "description": "Defines which rows to include in calculation. Null uses database defaults.
-
-**Common patterns:**
-- Moving average (N periods): {frameType: "rows", start: {type: "preceding", offset: N-1}, end: {type: "current_row"}}
-- Running total: {frameType: "rows", start: {type: "unbounded_preceding"}, end: {type: "current_row"}}
-- Centered window: {frameType: "rows", start: {type: "preceding", offset: 1}, end: {type: "following", offset: 1}}
-
-**Default when null:**
-- Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)
-- Aggregates WITHOUT ORDER BY: Entire partition (all rows)
-- Ranking functions: Always use entire partition (frame clause has no effect)",
-                          },
-                          "name": {
-                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                          },
-                          "orderBy": {
-                            "anyOf": [
-                              {
-                                "items": {
-                                  "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
-                                },
-                                "type": "array",
-                              },
-                              {
-                                "type": "null",
-                              },
-                            ],
-                            "description": "Specifies the order in which rows are processed by the table calculation.
-For time-series: typically order by date/time ascending.
-For rankings: order by the metric you want to rank, descending for highest-first.",
-                          },
-                          "partitionBy": {
-                            "anyOf": [
-                              {
-                                "items": {
-                                  "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
-                                },
-                                "type": "array",
-                              },
-                              {
-                                "type": "null",
-                              },
-                            ],
-                            "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                          },
-                          "type": {
-                            "const": "window_function",
-                            "type": "string",
-                          },
-                          "windowFunction": {
-                            "description": "Type of window function to apply.
-
-**Ranking functions** (fieldId optional, ignored if provided):
-- row_number: Sequential numbering (1, 2, 3...)
-- percent_rank: Relative rank as percentage (0.0-1.0)
-- cume_dist: Cumulative distribution as percentage (0.0-1.0)
-- rank: Positional rank (1, 2, 3...) with ties
-
-**Aggregate functions** (fieldId required):
-- sum: Sum values within frame
-- avg: Average values within frame
-- count: Count values within frame
-- min: Minimum value within frame
-- max: Maximum value within frame",
+                      "format": {
+                        "anyOf": [
+                          {
                             "enum": [
-                              "row_number",
-                              "percent_rank",
-                              "cume_dist",
-                              "rank",
-                              "sum",
-                              "avg",
-                              "count",
-                              "min",
-                              "max",
+                              "number",
+                              "percent",
                             ],
                             "type": "string",
                           },
-                        },
-                        "required": [
-                          "name",
-                          "displayName",
-                          "type",
-                          "windowFunction",
-                          "fieldId",
-                          "orderBy",
-                          "partitionBy",
-                          "frame",
+                          {
+                            "type": "null",
+                          },
                         ],
-                        "type": "object",
+                        "description": "Display format. Use "percent" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to "number".",
                       },
+                      "formula": {
+                        "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).
+Reference fields by their field id directly, e.g. \`orders_total_revenue / orders_order_count\`. No prefix, no braces, no leading \`=\`.
+Any selected dimension, metric, custom metric (\`<table>_<name>\`), or another table calculation name can be referenced.
+Operators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.
+Functions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).
+Window functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. \`LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)\`.
+MOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is \`MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)\`.
+All branches of an IF must return the same type.",
+                        "type": "string",
+                      },
+                      "name": {
+                        "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                        "type": "string",
+                      },
+                      "resultType": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "number",
+                              "string",
+                              "date",
+                              "timestamp",
+                              "boolean",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "Data type the formula evaluates to. null defaults to "number".",
+                      },
+                      "type": {
+                        "const": "formula",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "displayName",
+                      "type",
+                      "formula",
+                      "format",
+                      "resultType",
                     ],
+                    "type": "object",
                   },
                   "type": "array",
                 },
@@ -7169,17 +6427,15 @@ Empty array or null: single partition (calculations across all rows).",
                 },
               ],
               "description": "
-Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
+Table calculations perform row-by-row calculations on query results without collapsing rows, using spreadsheet-like formulas.
 
-**Available Types:**
-- Simple calculations: percent_change_from_previous, percent_of_previous_value, percent_of_column_total, rank_in_column, running_total
-- Advanced window_function: Supports row_number, percent_rank, sum, avg, count, min, max with optional partitioning, ordering, and frame clauses
+Use them whenever the question needs math the metric query alone can't express: arithmetic across metrics (\`metric_a + metric_b\`), ratios, percent of total, period-over-period change, running totals, moving averages, ranking, row-level comparisons, or aggregating already-aggregated metrics.
 
 **Technical Requirements:**
 - Appear as additional columns in query results
 - Can be used in sorts and filters alongside dimensions/metrics
-- Multiple calculations can be combined in a single query
-- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)
+- Multiple calculations can be combined in a single query; a formula can reference another table calculation by name
+- All fields referenced must be selected in the query (dimensions, metrics, custom metrics, or other table calculations)
 ",
             },
           },

--- a/packages/backend/src/ee/services/ai/utils/formulaSchemaFunctionNames.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/formulaSchemaFunctionNames.test.ts
@@ -1,0 +1,16 @@
+import { FORMULA_SCHEMA_FUNCTION_NAMES } from '@lightdash/common';
+import { FUNCTION_DEFINITIONS } from '@lightdash/formula';
+import { describe, expect, it } from 'vitest';
+
+// The formula schema description in common lists function names as prose, but
+// common cannot depend on the private @lightdash/formula package. This guards
+// that list against drifting from the real catalog.
+describe('formula schema function names', () => {
+    it('only names functions that exist in the formula catalog', () => {
+        const catalog = new Set(FUNCTION_DEFINITIONS.map((f) => f.name));
+        const listed = Object.values(FORMULA_SCHEMA_FUNCTION_NAMES).flat();
+
+        const missing = listed.filter((name) => !catalog.has(name));
+        expect(missing).toEqual([]);
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/validateTableCalculations.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTableCalculations.test.ts
@@ -473,4 +473,195 @@ describe('validateTableCalculations', () => {
             ).toThrow(/requires a numeric metric.*has type "max"/);
         });
     });
+
+    describe('Formula table calculations', () => {
+        const formulaCalc = (
+            name: string,
+            formula: string,
+        ): NonNullable<TableCalcsSchema>[number] => ({
+            type: 'formula',
+            name,
+            displayName: name,
+            formula,
+            format: null,
+            resultType: null,
+        });
+
+        it('should not throw for a ratio across two selected metrics', () => {
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    [
+                        formulaCalc(
+                            'aov',
+                            'orders_total_revenue / orders_order_count',
+                        ),
+                    ],
+                    [],
+                    ['orders_total_revenue', 'orders_order_count'],
+                    null,
+                ),
+            ).not.toThrow();
+        });
+
+        it('should not throw for a formula referencing a selected dimension', () => {
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    [
+                        formulaCalc(
+                            'lagged',
+                            '(orders_total_revenue - LAG(orders_total_revenue, ORDER BY orders_order_date)) / LAG(orders_total_revenue, ORDER BY orders_order_date)',
+                        ),
+                    ],
+                    ['orders_order_date'],
+                    ['orders_total_revenue'],
+                    null,
+                ),
+            ).not.toThrow();
+        });
+
+        it('should not throw for a formula referencing another table calculation', () => {
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    [
+                        formulaCalc(
+                            'aov',
+                            'orders_total_revenue / orders_order_count',
+                        ),
+                        formulaCalc('aov_doubled', 'aov * 2'),
+                    ],
+                    [],
+                    ['orders_total_revenue', 'orders_order_count'],
+                    null,
+                ),
+            ).not.toThrow();
+        });
+
+        it('should not throw for a formula referencing a custom metric', () => {
+            const customMetrics: CustomMetricBaseTransformed[] = [
+                {
+                    name: 'custom_sum',
+                    label: 'Custom Sum',
+                    baseDimensionName: 'amount',
+                    table: 'orders',
+                    type: MetricType.SUM,
+                },
+            ];
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    [formulaCalc('doubled', 'orders_custom_sum * 2')],
+                    [],
+                    ['orders_total_revenue'],
+                    customMetrics,
+                ),
+            ).not.toThrow();
+        });
+
+        it('should throw for a formula referencing an unselected field', () => {
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    [
+                        formulaCalc(
+                            'aov',
+                            'orders_total_revenue / orders_order_count',
+                        ),
+                    ],
+                    [],
+                    ['orders_total_revenue'],
+                    null,
+                ),
+            ).toThrow(/references "orders_order_count" which is not selected/);
+        });
+
+        it('should throw for a formula with a parse error', () => {
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    [formulaCalc('broken', 'orders_total_revenue +')],
+                    [],
+                    ['orders_total_revenue'],
+                    null,
+                ),
+            ).toThrow(/invalid formula/);
+        });
+
+        // The refs-are-selected check would pass a self-reference (the calc's
+        // own name counts as selected); circular detection must catch it.
+        it('should throw for a formula referencing itself', () => {
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    [formulaCalc('self', 'self + 1')],
+                    [],
+                    ['orders_total_revenue'],
+                    null,
+                ),
+            ).toThrow(/[Cc]ircular/);
+        });
+
+        it('should throw for circular formula references', () => {
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    [
+                        formulaCalc('calc_a', 'calc_b + 1'),
+                        formulaCalc('calc_b', 'calc_a + 1'),
+                    ],
+                    [],
+                    ['orders_total_revenue'],
+                    null,
+                ),
+            ).toThrow(/[Cc]ircular/);
+        });
+
+        it('should not throw for a sum across metrics', () => {
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    [
+                        formulaCalc(
+                            'combined',
+                            'orders_total_revenue + orders_order_count',
+                        ),
+                    ],
+                    [],
+                    ['orders_total_revenue', 'orders_order_count'],
+                    null,
+                ),
+            ).not.toThrow();
+        });
+
+        it('should not throw for cohort rebasing with FIRST', () => {
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    [
+                        formulaCalc(
+                            'rebased',
+                            'orders_total_revenue / FIRST(orders_total_revenue, PARTITION BY orders_product_category, ORDER BY orders_order_date)',
+                        ),
+                    ],
+                    ['orders_product_category', 'orders_order_date'],
+                    ['orders_total_revenue'],
+                    null,
+                ),
+            ).not.toThrow();
+        });
+
+        it('should accept a formula with a leading equals sign', () => {
+            expect(() =>
+                validateTableCalculations(
+                    mockOrdersExplore,
+                    [formulaCalc('doubled', '=orders_total_revenue * 2')],
+                    [],
+                    ['orders_total_revenue'],
+                    null,
+                ),
+            ).not.toThrow();
+        });
+    });
 });

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -52,7 +52,9 @@ import {
     UnitOfTime,
     WeekDay,
     WindowFunctionType,
+    withLeadingEquals,
 } from '@lightdash/common';
+import { extractColumnRefs, parse as parseFormula } from '@lightdash/formula';
 import { z } from 'zod';
 import Logger from '../../../../logging/logger';
 import { populateCustomMetricsSQL } from './populateCustomMetricsSQL';
@@ -1075,6 +1077,18 @@ const NUMERIC_CALCULATION_TYPES: TableCalcSchema['type'][] = [
     'running_total',
 ];
 
+function parseFormulaRefs(
+    formula: string,
+): { refs: string[] } | { error: string } {
+    try {
+        return {
+            refs: extractColumnRefs(parseFormula(withLeadingEquals(formula))),
+        };
+    } catch (e) {
+        return { error: getErrorMessage(e) };
+    }
+}
+
 function buildTableCalcSchemaDependencyGraph(
     tableCalcs: TableCalcsSchema,
 ): DependencyNode[] {
@@ -1082,6 +1096,14 @@ function buildTableCalcSchemaDependencyGraph(
 
     return tableCalcs.map((tc) => {
         const deps: string[] = [];
+
+        if (tc.type === 'formula') {
+            // Parse errors are reported by validateTableCalculations
+            const parsed = parseFormulaRefs(tc.formula);
+            if ('refs' in parsed) {
+                deps.push(...parsed.refs);
+            }
+        }
 
         // Add fieldId dependency if it exists
         if ('fieldId' in tc && tc.fieldId !== null) {
@@ -1224,6 +1246,29 @@ export function validateTableCalculations(
 
     tableCalcs.forEach((tableCalc) => {
         const { type, name } = tableCalc;
+
+        if (type === 'formula') {
+            const parsed = parseFormulaRefs(tableCalc.formula);
+            if ('error' in parsed) {
+                errors.push(
+                    `Table calculation "${name}" has an invalid formula: ${parsed.error}`,
+                );
+                return;
+            }
+
+            parsed.refs.forEach((ref) => {
+                if (!allSelectedFieldIds.includes(ref)) {
+                    errors.push(
+                        `Table calculation "${name}" references "${ref}" which is not selected in the query. ` +
+                            'Formulas can only reference selected dimensions, metrics, custom metrics, or other table calculations. ' +
+                            `Selected fields: ${allSelectedFieldIds.join(
+                                ', ',
+                            )}.`,
+                    );
+                }
+            });
+            return;
+        }
 
         if (type === 'window_function') {
             const needsFieldId = !nullaryWindowFunctions.includes(

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -34,6 +34,7 @@ export * from './filters';
 export * from './McpSchemaCompatLayer';
 export * from './outputMetadata';
 export * from './sortField';
+export * from './tableCalcs/tableCalcFormula';
 export * from './tableCalcs/tableCalcs';
 export * from './tools';
 export * from './visualizations';

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcFormula.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcFormula.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+import { baseTableCalcSchema } from './tableCalcBaseSchemas';
+
+// Names must exist in @lightdash/formula's catalog; common cannot depend on
+// that (private) package, so a backend test guards this list against drift.
+export const FORMULA_SCHEMA_FUNCTION_NAMES = {
+    general: ['IF', 'COALESCE', 'ROUND', 'ABS', 'CONCAT'],
+    date: ['YEAR', 'DATE_TRUNC', 'DATE_DIFF', 'DATE_ADD'],
+    aggregate: ['SUM', 'AVG', 'MIN', 'MAX', 'COUNT', 'SUMIF'],
+    window: [
+        'RUNNING_TOTAL',
+        'MOVING_SUM',
+        'MOVING_AVG',
+        'LAG',
+        'LEAD',
+        'RANK',
+        'DENSE_RANK',
+        'ROW_NUMBER',
+        'FIRST',
+        'LAST',
+    ],
+} as const;
+
+const formulaDescription = [
+    'Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).',
+    'Reference fields by their field id directly, e.g. `orders_total_revenue / orders_order_count`. No prefix, no braces, no leading `=`.',
+    'Any selected dimension, metric, custom metric (`<table>_<name>`), or another table calculation name can be referenced.',
+    'Operators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.',
+    `Functions include ${FORMULA_SCHEMA_FUNCTION_NAMES.general.join(
+        ', ',
+    )}, date functions (${FORMULA_SCHEMA_FUNCTION_NAMES.date.join(
+        ', ',
+    )}), aggregates over the whole result (${FORMULA_SCHEMA_FUNCTION_NAMES.aggregate.join(
+        ', ',
+    )}), and window functions (${FORMULA_SCHEMA_FUNCTION_NAMES.window.join(
+        ', ',
+    )}).`,
+    'Window functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. `LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)`.',
+    'MOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is `MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)`.',
+    'All branches of an IF must return the same type.',
+].join('\n');
+
+// The formula grammar requires a leading '='; the agent writes formulas without it
+export function withLeadingEquals(formula: string): string {
+    const trimmed = formula.trim();
+    return trimmed.startsWith('=') ? trimmed : `=${trimmed}`;
+}
+
+export const tableCalcFormulaSchema = baseTableCalcSchema.extend({
+    type: z.literal('formula'),
+    formula: z.string().describe(formulaDescription),
+    format: z
+        .enum(['number', 'percent'])
+        .nullable()
+        .describe(
+            'Display format. Use "percent" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to "number".',
+        ),
+    resultType: z
+        .enum(['number', 'string', 'date', 'timestamp', 'boolean'])
+        .nullable()
+        .describe(
+            'Data type the formula evaluates to. null defaults to "number".',
+        ),
+});
+
+export type TableCalcFormulaSchema = z.infer<typeof tableCalcFormulaSchema>;

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import {
+    CustomFormatType,
+    TableCalculationType,
+} from '../../../../types/field';
+import {
+    convertAiTableCalcsSchemaToTableCalcs,
+    formulaTableCalcsSchema,
+    tableCalcsSchema,
+} from './tableCalcs';
+
+describe('tableCalcsSchema (wide, persisted args)', () => {
+    it('parses legacy template entries', () => {
+        const result = tableCalcsSchema.safeParse([
+            {
+                type: 'running_total',
+                name: 'running_revenue',
+                displayName: 'Running Revenue',
+                fieldId: 'orders_revenue',
+            },
+        ]);
+        expect(result.success).toBe(true);
+    });
+
+    it('parses formula entries', () => {
+        const result = tableCalcsSchema.safeParse([
+            {
+                type: 'formula',
+                name: 'aov',
+                displayName: 'AOV',
+                formula: 'orders_revenue / orders_count',
+                format: null,
+                resultType: null,
+            },
+        ]);
+        expect(result.success).toBe(true);
+    });
+});
+
+describe('formulaTableCalcsSchema (advertised agent contract)', () => {
+    it('accepts formula entries', () => {
+        const result = formulaTableCalcsSchema.safeParse([
+            {
+                type: 'formula',
+                name: 'aov',
+                displayName: 'AOV',
+                formula: 'orders_revenue / orders_count',
+                format: 'number',
+                resultType: 'number',
+            },
+        ]);
+        expect(result.success).toBe(true);
+    });
+
+    it('rejects legacy template entries', () => {
+        const result = formulaTableCalcsSchema.safeParse([
+            {
+                type: 'running_total',
+                name: 'running_revenue',
+                displayName: 'Running Revenue',
+                fieldId: 'orders_revenue',
+            },
+        ]);
+        expect(result.success).toBe(false);
+    });
+});
+
+describe('convertAiTableCalcsSchemaToTableCalcs', () => {
+    it('converts a formula calc, adding the leading equals sign', () => {
+        const [calc] = convertAiTableCalcsSchemaToTableCalcs([
+            {
+                type: 'formula',
+                name: 'aov',
+                displayName: 'AOV',
+                formula: 'orders_revenue / orders_count',
+                format: null,
+                resultType: null,
+            },
+        ]);
+        expect(calc).toEqual({
+            name: 'aov',
+            displayName: 'AOV',
+            type: TableCalculationType.NUMBER,
+            formula: '=orders_revenue / orders_count',
+            format: {
+                type: CustomFormatType.NUMBER,
+                separator: 'default',
+            },
+        });
+    });
+
+    it('keeps an existing leading equals sign', () => {
+        const [calc] = convertAiTableCalcsSchemaToTableCalcs([
+            {
+                type: 'formula',
+                name: 'doubled',
+                displayName: 'Doubled',
+                formula: '=orders_revenue * 2',
+                format: null,
+                resultType: null,
+            },
+        ]);
+        expect(calc).toMatchObject({ formula: '=orders_revenue * 2' });
+    });
+
+    it('maps percent format and non-number result types', () => {
+        const [percentCalc, boolCalc] = convertAiTableCalcsSchemaToTableCalcs([
+            {
+                type: 'formula',
+                name: 'share',
+                displayName: 'Share',
+                formula: 'orders_revenue / SUM(orders_revenue)',
+                format: 'percent',
+                resultType: null,
+            },
+            {
+                type: 'formula',
+                name: 'is_late',
+                displayName: 'Is late',
+                formula: 'orders_shipped_date > orders_due_date',
+                format: null,
+                resultType: 'boolean',
+            },
+        ]);
+        expect(percentCalc).toMatchObject({
+            format: { type: CustomFormatType.PERCENT },
+            type: TableCalculationType.NUMBER,
+        });
+        expect(boolCalc).toMatchObject({
+            type: TableCalculationType.BOOLEAN,
+        });
+        expect(boolCalc).not.toHaveProperty('format');
+    });
+
+    it('still converts legacy template calcs to template table calculations', () => {
+        const [calc] = convertAiTableCalcsSchemaToTableCalcs([
+            {
+                type: 'running_total',
+                name: 'running_revenue',
+                displayName: 'Running Revenue',
+                fieldId: 'orders_revenue',
+            },
+        ]);
+        expect(calc).toMatchObject({
+            name: 'running_revenue',
+            template: {
+                type: 'running_total',
+                fieldId: 'orders_revenue',
+            },
+        });
+        expect(calc).not.toHaveProperty('formula');
+    });
+});

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.ts
@@ -9,6 +9,11 @@ import {
     type TableCalculation,
 } from '../../../../types/field';
 import assertUnreachable from '../../../../utils/assertUnreachable';
+import {
+    tableCalcFormulaSchema,
+    withLeadingEquals,
+    type TableCalcFormulaSchema,
+} from './tableCalcFormula';
 import { tableCalcPercentChangeFromPreviousSchema } from './tableCalcPercentChangeFromPrevious';
 import { tableCalcPercentOfColumnTotalSchema } from './tableCalcPercentOfColumnTotal';
 import { tableCalcPercentOfPreviousValueSchema } from './tableCalcPercentOfPreviousValue';
@@ -16,7 +21,11 @@ import { tableCalcRankInColumnSchema } from './tableCalcRankInColumn';
 import { tableCalcRunningTotalSchema } from './tableCalcRunningTotal';
 import { tableCalcWindowFunctionSchema } from './tableCalcWindowFunction';
 
+// Wide union: `formula` plus the legacy template types. Kept for parsing
+// persisted tool args from old threads; new agent contracts advertise
+// formulaTableCalcsSchema only.
 const tableCalcSchema = z.discriminatedUnion('type', [
+    tableCalcFormulaSchema,
     tableCalcPercentChangeFromPreviousSchema,
     tableCalcPercentOfPreviousValueSchema,
     tableCalcPercentOfColumnTotalSchema,
@@ -29,9 +38,7 @@ export type TableCalcSchema = z.infer<typeof tableCalcSchema>;
 export const tableCalcsSchema = z.array(tableCalcSchema).nullable().describe(`
 Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
 
-**Available Types:**
-- Simple calculations: percent_change_from_previous, percent_of_previous_value, percent_of_column_total, rank_in_column, running_total
-- Advanced window_function: Supports row_number, percent_rank, sum, avg, count, min, max with optional partitioning, ordering, and frame clauses
+**Prefer type "formula"** — it expresses arithmetic across fields, ratios, comparisons, conditionals, and partitioned window calculations. The other types are legacy single-field templates kept for backwards compatibility.
 
 **Technical Requirements:**
 - Appear as additional columns in query results
@@ -41,6 +48,24 @@ Table calculations perform row-by-row calculations on query results without coll
 `);
 
 export type TableCalcsSchema = z.infer<typeof tableCalcsSchema>;
+
+// Formula-only contract advertised to the agent. The wide tableCalcsSchema
+// above still parses everything this produces.
+export const formulaTableCalcsSchema = z
+    .array(tableCalcFormulaSchema)
+    .nullable().describe(`
+Table calculations perform row-by-row calculations on query results without collapsing rows, using spreadsheet-like formulas.
+
+Use them whenever the question needs math the metric query alone can't express: arithmetic across metrics (\`metric_a + metric_b\`), ratios, percent of total, period-over-period change, running totals, moving averages, ranking, row-level comparisons, or aggregating already-aggregated metrics.
+
+**Technical Requirements:**
+- Appear as additional columns in query results
+- Can be used in sorts and filters alongside dimensions/metrics
+- Multiple calculations can be combined in a single query; a formula can reference another table calculation by name
+- All fields referenced must be selected in the query (dimensions, metrics, custom metrics, or other table calculations)
+`);
+
+export type FormulaTableCalcsSchema = z.infer<typeof formulaTableCalcsSchema>;
 
 function frameBoundaryStringToEnum(
     boundaryType:
@@ -66,6 +91,40 @@ function frameBoundaryStringToEnum(
     }
 }
 
+function formulaFormatToCustomFormatType(
+    format: TableCalcFormulaSchema['format'],
+): CustomFormatType {
+    switch (format) {
+        case 'percent':
+            return CustomFormatType.PERCENT;
+        case 'number':
+        case null:
+            return CustomFormatType.NUMBER;
+        default:
+            return assertUnreachable(format, 'Unknown formula format');
+    }
+}
+
+function formulaResultTypeToTableCalculationType(
+    resultType: TableCalcFormulaSchema['resultType'],
+): TableCalculationType {
+    switch (resultType) {
+        case 'string':
+            return TableCalculationType.STRING;
+        case 'date':
+            return TableCalculationType.DATE;
+        case 'timestamp':
+            return TableCalculationType.TIMESTAMP;
+        case 'boolean':
+            return TableCalculationType.BOOLEAN;
+        case 'number':
+        case null:
+            return TableCalculationType.NUMBER;
+        default:
+            return assertUnreachable(resultType, 'Unknown formula result type');
+    }
+}
+
 function convertTableCalcSchemaToTableCalc(
     tableCalc: TableCalcSchema,
 ): TableCalculation {
@@ -79,6 +138,28 @@ function convertTableCalcSchemaToTableCalc(
     };
 
     switch (type) {
+        case 'formula': {
+            const resultType = formulaResultTypeToTableCalculationType(
+                tableCalc.resultType,
+            );
+            return {
+                ...baseCalc,
+                type: resultType,
+                // Persisted formulas carry the leading '=' the grammar requires
+                formula: withLeadingEquals(tableCalc.formula),
+                // Numeric display formats don't apply to non-numeric results
+                ...(resultType === TableCalculationType.NUMBER
+                    ? {
+                          format: {
+                              type: formulaFormatToCustomFormatType(
+                                  tableCalc.format,
+                              ),
+                              separator: NumberSeparator.DEFAULT,
+                          },
+                      }
+                    : {}),
+            };
+        }
         case 'percent_change_from_previous':
             return {
                 ...baseCalc,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardV2Args.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardV2Args.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+    toolDashboardV2ArgsSchema,
+    toolDashboardV2ArgsSchemaPersisted,
+    toolDashboardV2ArgsSchemaTransformed,
+} from './toolDashboardV2Args';
+
+const visualization = (tableCalculations: unknown) => ({
+    title: 'Revenue',
+    description: 'Revenue',
+    queryConfig: {
+        exploreName: 'orders',
+        dimensions: ['orders_created_month'],
+        metrics: ['orders_revenue'],
+        sorts: [],
+        limit: 500,
+        customMetrics: null,
+        tableCalculations,
+        filters: null,
+    },
+    chartConfig: null,
+});
+
+const templateCalc = {
+    type: 'running_total',
+    name: 'running_revenue',
+    displayName: 'Running Revenue',
+    fieldId: 'orders_revenue',
+};
+
+// Persisted dashboard artifacts predate the formula-only V4 contract; the V3
+// parse path must keep accepting template table calcs.
+describe('toolDashboardV2Args persisted parsing', () => {
+    const persistedDashboard = {
+        title: 'Revenue dashboard',
+        description: 'Revenue dashboard',
+        visualizations: [visualization([templateCalc]), visualization(null)],
+    };
+
+    it('V3 schema parses persisted dashboards with template table calcs', () => {
+        expect(
+            toolDashboardV2ArgsSchemaPersisted.safeParse(persistedDashboard)
+                .success,
+        ).toBe(true);
+        expect(
+            toolDashboardV2ArgsSchemaTransformed.safeParse(persistedDashboard)
+                .success,
+        ).toBe(true);
+    });
+
+    it('advertised schema only accepts formula table calcs', () => {
+        expect(
+            toolDashboardV2ArgsSchema.safeParse(persistedDashboard).success,
+        ).toBe(false);
+        expect(
+            toolDashboardV2ArgsSchema.safeParse({
+                ...persistedDashboard,
+                visualizations: [
+                    visualization([
+                        {
+                            type: 'formula',
+                            name: 'aov',
+                            displayName: 'AOV',
+                            formula: 'orders_revenue / 2',
+                            format: null,
+                            resultType: null,
+                        },
+                    ]),
+                    visualization(null),
+                ],
+            }).success,
+        ).toBe(true);
+    });
+});

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardV2Args.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDashboardV2Args.ts
@@ -3,6 +3,7 @@ import { baseOutputMetadataSchema } from '../outputMetadata';
 import { createToolSchema } from '../toolSchemaBuilder';
 import {
     toolRunQueryArgsSchema,
+    toolRunQueryArgsSchemaPersisted,
     toolRunQueryArgsSchemaTransformed,
 } from './toolRunQueryArgs';
 
@@ -28,32 +29,54 @@ Recommended Dashboard Structure:
 // Dashboard visualization schema - use generateVisualization format for each visualization
 const dashboardV2VisualizationSchema = toolRunQueryArgsSchema;
 
+// Persisted artifacts may carry legacy template table calcs the advertised
+// (formula-only) viz schema no longer accepts; type as the wide persisted shape.
 export type DashboardV2Visualization = z.infer<
-    typeof dashboardV2VisualizationSchema
+    typeof toolRunQueryArgsSchemaPersisted
 >;
 
+const dashboardV2Fields = {
+    title: z.string().describe('A descriptive title for the dashboard'),
+    description: z
+        .string()
+        .describe('A descriptive summary or explanation for the dashboard.'),
+} as const;
+
+const visualizationsDescription =
+    'Array of visualization configurations to generate for this dashboard. Each should contribute to the overall theme and leverage the available chart types (table, bar, horizontal, line, scatter, pie, funnel).';
+
+// Advertised agent contract: formula-only table calcs per visualization.
 export const toolDashboardV2ArgsSchema = createToolSchema()
     .extend({
-        title: z.string().describe('A descriptive title for the dashboard'),
-        description: z
-            .string()
-            .describe(
-                'A descriptive summary or explanation for the dashboard.',
-            ),
+        ...dashboardV2Fields,
         visualizations: z
             .array(dashboardV2VisualizationSchema)
             .min(2)
             .max(15)
-            .describe(
-                'Array of visualization configurations to generate for this dashboard. Each should contribute to the overall theme and leverage the available chart types (table, bar, horizontal, line, scatter, pie, funnel).',
-            ),
+            .describe(visualizationsDescription),
     })
     .build();
 
-export type ToolDashboardV2Args = z.infer<typeof toolDashboardV2ArgsSchema>;
+// Wide variant for parsing persisted artifacts and incoming tool calls; it
+// accepts everything the advertised schema produces plus legacy template
+// table calcs. Tracks toolRunQueryArgsSchemaPersisted (see its invariant).
+export const toolDashboardV2ArgsSchemaPersisted = createToolSchema()
+    .extend({
+        ...dashboardV2Fields,
+        visualizations: z
+            .array(toolRunQueryArgsSchemaPersisted)
+            .min(2)
+            .max(15)
+            .describe(visualizationsDescription),
+    })
+    .build();
+
+export type ToolDashboardV2Args = z.infer<
+    typeof toolDashboardV2ArgsSchemaPersisted
+>;
 
 export const toolDashboardV2ArgsSchemaTransformed =
-    toolDashboardV2ArgsSchema.transform((data) => ({
+    toolDashboardV2ArgsSchemaPersisted.transform((data) => ({
         ...data,
         visualizations: data.visualizations.map((viz) =>
             toolRunQueryArgsSchemaTransformed.parse(viz),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -8,7 +8,10 @@ import { getFieldIdSchema } from '../fieldId';
 import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import sortFieldSchema from '../sortField';
-import { tableCalcsSchema } from '../tableCalcs/tableCalcs';
+import {
+    formulaTableCalcsSchema,
+    tableCalcsSchema,
+} from '../tableCalcs/tableCalcs';
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
 import {
@@ -74,6 +77,12 @@ const queryConfigSchemaV2 = queryConfigBaseSchema.extend({
     customMetrics: customMetricsSchema,
     tableCalculations: tableCalcsSchema,
     filters: filtersSchemaV2.nullable(),
+});
+
+// V4 narrows the advertised tableCalculations contract to formula-only.
+// V1–V3 keep the wide union (templates + formula) for parsing persisted args.
+const queryConfigSchemaV4 = queryConfigSchemaV2.extend({
+    tableCalculations: formulaTableCalcsSchema,
 });
 
 const mergeSourceQueryConfigSchema = queryConfigSchemaV2
@@ -267,9 +276,36 @@ export const toolRunQueryArgsSchemaV3 = createToolSchema()
     })
     .build();
 
-// V3 is the current agent contract. MCP runQuery continues to advertise V2.
-// Historical schemas remain available solely for persisted chats/artifacts.
-export const toolRunQueryArgsSchema = toolRunQueryArgsSchemaV3;
+export const toolRunQueryArgsSchemaV4 = createToolSchema()
+    .extend({
+        ...visualizationMetadataSchema.shape,
+        queryConfig: queryConfigSchemaV4,
+        chartConfig: chartConfigSchema,
+        mergeConfig: mergeConfigSchema.default(null),
+    })
+    .build();
+
+// V4 is the current agent contract (formula-only table calcs). MCP runQuery
+// continues to advertise V2. Historical schemas remain available solely for
+// persisted chats/artifacts — parse those with V1–V3, never with V4.
+export const toolRunQueryArgsSchema = toolRunQueryArgsSchemaV4;
+
+// Wide contract for parsing persisted args and incoming tool calls — call
+// sites use this alias, never a versioned schema. Invariant: it accepts the
+// output of every advertised version ever shipped (the wide table-calc union
+// covers templates and formulas).
+//
+// Evolving the contract:
+// - Additive field: no version bump. Add `.nullish().default(null)` to the
+//   CURRENT schema (providers accept optional keys now) — old payloads and
+//   models that omit it both parse, and this alias needs no change as long
+//   as it carries the field too (add it here if the bases diverge; Zod
+//   silently strips unknown keys).
+// - Restructure or narrowing (fields moved, union members dropped from the
+//   advertised contract): add V(N), point toolRunQueryArgsSchema at it, and
+//   keep this alias wide enough to parse everything ever persisted. Never
+//   narrow it — old threads must keep parsing.
+export const toolRunQueryArgsSchemaPersisted = toolRunQueryArgsSchemaV3;
 
 // V2 for runtimes where merge queries are disabled: a merge-shaped payload
 // must fail validation, not have Zod strip mergeConfig and run only the
@@ -298,6 +334,9 @@ export const toolRunQueryArgsSchemaV2RejectingMerge = z.preprocess(
 export type ToolRunQueryArgsV1 = z.infer<typeof toolRunQueryArgsSchemaV1>;
 export type ToolRunQueryArgsV2 = z.infer<typeof toolRunQueryArgsSchemaV2>;
 export type ToolRunQueryArgsV3 = z.infer<typeof toolRunQueryArgsSchemaV3>;
+export type ToolRunQueryArgsV4 = z.infer<typeof toolRunQueryArgsSchemaV4>;
+// Deliberately wide (no V4): handlers receive V3-parsed data, which can carry
+// legacy template table calcs the advertised V4 contract no longer accepts.
 export type ToolRunQueryArgs = ToolRunQueryArgsV2 | ToolRunQueryArgsV3;
 
 // Converts the raw V2 args into the internal domain shape: customMetrics and

--- a/packages/common/src/ee/AiAgent/utils.test.ts
+++ b/packages/common/src/ee/AiAgent/utils.test.ts
@@ -188,6 +188,68 @@ describe('parseVizConfig with legacy persisted configs', () => {
     });
 });
 
+describe('parseVizConfig table calculations', () => {
+    const runQueryArgs = (tableCalculations: unknown) => ({
+        title: 'Revenue',
+        description: 'Revenue',
+        queryConfig: {
+            exploreName: 'orders',
+            dimensions: ['orders_created_month'],
+            metrics: ['orders_revenue', 'orders_count'],
+            sorts: [],
+            limit: 500,
+            customMetrics: null,
+            tableCalculations,
+            filters: null,
+        },
+        chartConfig: null,
+    });
+
+    it('parses persisted args with legacy template table calcs', () => {
+        const parsed = parseVizConfig(
+            runQueryArgs([
+                {
+                    type: 'running_total',
+                    name: 'running_revenue',
+                    displayName: 'Running Revenue',
+                    fieldId: 'orders_revenue',
+                },
+            ]),
+        );
+
+        expect(parsed?.type).toBe(AiResultType.QUERY_RESULT);
+        expect(parsed?.metricQuery.tableCalculations).toEqual([
+            expect.objectContaining({
+                name: 'running_revenue',
+                template: expect.objectContaining({ type: 'running_total' }),
+            }),
+        ]);
+    });
+
+    it('parses args with formula table calcs', () => {
+        const parsed = parseVizConfig(
+            runQueryArgs([
+                {
+                    type: 'formula',
+                    name: 'aov',
+                    displayName: 'AOV',
+                    formula: 'orders_revenue / orders_count',
+                    format: null,
+                    resultType: null,
+                },
+            ]),
+        );
+
+        expect(parsed?.type).toBe(AiResultType.QUERY_RESULT);
+        expect(parsed?.metricQuery.tableCalculations).toEqual([
+            expect.objectContaining({
+                name: 'aov',
+                formula: '=orders_revenue / orders_count',
+            }),
+        ]);
+    });
+});
+
 describe('parseVizConfig parameters', () => {
     const runQueryConfig = {
         title: 'Add to cart events',

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -10,7 +10,7 @@ import {
     metricQueryTimeSeriesViz,
     metricQueryVerticalBarViz,
     parsePersistedRunQueryArgs,
-    toolRunQueryArgsSchemaV3,
+    toolRunQueryArgsSchemaPersisted,
     toolTableVizArgsSchemaTransformed,
     toolTimeSeriesArgsSchemaTransformed,
     toolVerticalBarArgsSchemaTransformed,
@@ -158,7 +158,7 @@ export const parseAiArtifactChartConfig = (
         config.schemaVersion === 1 &&
         'config' in config
     ) {
-        const parsed = toolRunQueryArgsSchemaV3.safeParse(config.config);
+        const parsed = toolRunQueryArgsSchemaPersisted.safeParse(config.config);
         if (parsed.success && parsed.data.mergeConfig) {
             return {
                 source: 'merge',

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -5257,9 +5257,56 @@
                                 "type": "array"
                             },
                             "tableCalculations": {
-                                "description": "\nTable calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.\n\n**Available Types:**\n- Simple calculations: percent_change_from_previous, percent_of_previous_value, percent_of_column_total, rank_in_column, running_total\n- Advanced window_function: Supports row_number, percent_rank, sum, avg, count, min, max with optional partitioning, ordering, and frame clauses\n\n**Technical Requirements:**\n- Appear as additional columns in query results\n- Can be used in sorts and filters alongside dimensions/metrics\n- Multiple calculations can be combined in a single query\n- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)\n, ",
+                                "description": "\nTable calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.\n\n**Prefer type \"formula\"** — it expresses arithmetic across fields, ratios, comparisons, conditionals, and partitioned window calculations. The other types are legacy single-field templates kept for backwards compatibility.\n\n**Technical Requirements:**\n- Appear as additional columns in query results\n- Can be used in sorts and filters alongside dimensions/metrics\n- Multiple calculations can be combined in a single query\n- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)\n, ",
                                 "items": {
                                     "anyOf": [
+                                        {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "displayName": {
+                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
+                                                    "type": "string"
+                                                },
+                                                "format": {
+                                                    "description": "Display format. Use \"percent\" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to \"number\"., ",
+                                                    "enum": [
+                                                        "number",
+                                                        "percent"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "formula": {
+                                                    "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).\nReference fields by their field id directly, e.g. `orders_total_revenue / orders_order_count`. No prefix, no braces, no leading `=`.\nAny selected dimension, metric, custom metric (`<table>_<name>`), or another table calculation name can be referenced.\nOperators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.\nFunctions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).\nWindow functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. `LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)`.\nMOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is `MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)`.\nAll branches of an IF must return the same type.",
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
+                                                    "type": "string"
+                                                },
+                                                "resultType": {
+                                                    "description": "Data type the formula evaluates to. null defaults to \"number\"., ",
+                                                    "enum": [
+                                                        "number",
+                                                        "string",
+                                                        "date",
+                                                        "timestamp",
+                                                        "boolean"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "const": "formula",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name",
+                                                "displayName",
+                                                "type",
+                                                "formula"
+                                            ],
+                                            "type": "object"
+                                        },
                                         {
                                             "additionalProperties": false,
                                             "properties": {

--- a/packages/formula/src/functions.ts
+++ b/packages/formula/src/functions.ts
@@ -165,8 +165,8 @@ export const FUNCTION_DEFINITIONS = [
     { name: 'NTILE', description: 'Distribute rows into buckets', minArgs: 1, maxArgs: 1, category: 'window' },
     { name: 'FIRST', description: 'First value in window', minArgs: 1, maxArgs: 1, category: 'window' },
     { name: 'LAST', description: 'Last value in window', minArgs: 1, maxArgs: 1, category: 'window' },
-    { name: 'MOVING_SUM', description: 'Moving sum over preceding rows', minArgs: 2, maxArgs: 2, category: 'window' },
-    { name: 'MOVING_AVG', description: 'Moving average over preceding rows', minArgs: 2, maxArgs: 2, category: 'window' },
+    { name: 'MOVING_SUM', description: 'Moving sum; second argument counts preceding rows, current row always included (pass 2 for a trailing 3-row window)', minArgs: 2, maxArgs: 2, category: 'window' },
+    { name: 'MOVING_AVG', description: 'Moving average; second argument counts preceding rows, current row always included (pass 2 for a trailing 3-row window)', minArgs: 2, maxArgs: 2, category: 'window' },
 ] as const satisfies readonly FunctionDefinition[];
 
 export type FunctionDefinitionEntry = (typeof FUNCTION_DEFINITIONS)[number];

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
@@ -1,6 +1,8 @@
 import {
     agentToolDefinitionsByName,
     isAiAgentMcpToolName,
+    toolDashboardV2ArgsSchemaPersisted,
+    toolRunQueryArgsSchemaPersisted,
     type ToolDefinition,
     type ToolName,
 } from '@lightdash/common';
@@ -9,9 +11,19 @@ import { type z } from 'zod';
 type ParsedToolName = ToolName;
 type McpStreamToolName = `mcp_${string}`;
 
-type ToolArgs<TName extends ToolName> = z.infer<
-    (typeof agentToolDefinitionsByName)[TName]['inputSchema']
->;
+// Streamed args can be wider than the advertised (formula-only) contract:
+// merge-disabled runtimes advertise the wide V2 query contract and models
+// resuming old threads may echo legacy template table calcs the backend still
+// executes. Parse those tools with the wide persisted schemas so they render.
+const wideInputSchemaOverrides = {
+    generateVisualization: toolRunQueryArgsSchemaPersisted,
+    generateDashboard: toolDashboardV2ArgsSchemaPersisted,
+} as const;
+
+type ToolArgs<TName extends ToolName> =
+    TName extends keyof typeof wideInputSchemaOverrides
+        ? z.infer<(typeof wideInputSchemaOverrides)[TName]>
+        : z.infer<(typeof agentToolDefinitionsByName)[TName]['inputSchema']>;
 type ToolOutputSchema<TName extends ToolName> =
     (typeof agentToolDefinitionsByName)[TName] extends ToolDefinition<
         string,
@@ -87,8 +99,16 @@ const parseMcpToolArgs = (toolArgs: unknown): object =>
         ? toolArgs
         : {};
 
+const hasWideInputSchema = (
+    toolName: ParsedToolName,
+): toolName is keyof typeof wideInputSchemaOverrides =>
+    toolName in wideInputSchemaOverrides;
+
 const parseToolArgs = (toolName: ParsedToolName, toolArgs: unknown) =>
-    agentToolDefinitionsByName[toolName].inputSchema.safeParse(toolArgs);
+    (hasWideInputSchema(toolName)
+        ? wideInputSchemaOverrides[toolName]
+        : agentToolDefinitionsByName[toolName].inputSchema
+    ).safeParse(toolArgs);
 
 const parseToolOutput = (toolName: ParsedToolName, toolOutput: unknown) => {
     const outputSchema =


### PR DESCRIPTION
## Summary

Agent-authored table calculations are now spreadsheet-like formulas instead of fixed single-field templates. The agent can express arithmetic across metrics (`metric_a + metric_b`), ratios, row-level comparisons, cohort rebasing (`FIRST`), `LAG`, and everything the old templates covered.

### Contract changes

- New `formula` table-calc schema (`tableCalcFormula.ts`): `formula` (no leading `=`), optional `format` (`number`/`percent`) and `resultType`.
- **Advertised contracts narrowed to formula-only**: `generateVisualization` moves to a new V4 args schema; `generateDashboard` viz entries follow. The six template schemas leave the advertised contract entirely.
- **Parsing stays wide**: V1–V3 schemas gain the `formula` union member and keep the templates, so persisted threads, artifacts, dashboard artifacts, and deep-research configs all keep parsing. `parseVizConfig`/`parsePersistedRunQueryArgs` untouched. Frontend stream parsing uses the wide V3 schemas (merge-disabled runtimes still advertise the wide V2 contract).
- MCP `run_metric_query` keeps its wide V2 contract and gains `formula` as an option.

### Validation

`validateTableCalculations` parses formulas (via `@lightdash/formula`) and checks every column ref against selected dimensions/metrics/custom metrics/sibling calcs, so bad formulas come back as tool errors instead of blank columns. Formula refs participate in circular-dependency detection.

### Conversion & compile

`convertAiTableCalcsSchemaToTableCalcs` emits `FormulaTableCalculation` (adds the leading `=` the grammar requires); compilation reuses the existing formula branch in `queryCompiler.ts`. Non-numeric `resultType`s skip numeric format metadata.

### Prompts

System prompt table-calc section rewritten formula-first with the `FUNCTION_CATALOG` from `@lightdash/formula` injected; MCP analyst prompt updated to match.

## Testing

- Unit: schema round-trips, converter (incl. `=` normalization, format/resultType mapping, template back-compat), validator (ratios, sums, LAG, FIRST cohort rebase, unknown refs, parse errors, circular refs), persisted-args replay via `parseVizConfig`, dashboard V3 persisted parsing.
- Contract snapshots updated (formula-only advertised, wide MCP).
- Browser e2e against local dev: agent authored `orders_total_completed_order_amount / orders_completed_order_count` as a formula calc on the first attempt; table rendered with correct values, persisted args contain `"type": "formula"`, replay after full reload identical. Legacy template charts still compile and render.

Closes: ZAP-900
Closes: #27708
