### PR TITLE
fix(backend): filter data app scheduler list by creator

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -1080,8 +1080,11 @@ export class SchedulerModel {
         return this.getSchedulersWithTargets(await schedulers);
     }
 
-    async getAppSchedulers(appUuid: string): Promise<SchedulerAndTargets[]> {
-        const schedulers = SchedulerModel.getBaseSchedulerQuery(this.database)
+    async getAppSchedulers(
+        appUuid: string,
+        createdByUserUuid?: string,
+    ): Promise<SchedulerAndTargets[]> {
+        let schedulers = SchedulerModel.getBaseSchedulerQuery(this.database)
             .where(`${SchedulerTableName}.app_uuid`, appUuid)
             .orderBy([
                 {
@@ -1093,6 +1096,12 @@ export class SchedulerModel {
                     order: 'asc',
                 },
             ]);
+        if (createdByUserUuid) {
+            schedulers = schedulers.where(
+                `${SchedulerTableName}.created_by`,
+                createdByUserUuid,
+            );
+        }
         return this.getSchedulersWithTargets(await schedulers);
     }
 

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -518,6 +518,105 @@ describe('SchedulerService', () => {
         });
     });
 
+    describe('getAppSchedulers', () => {
+        const listAppUuid = 'listAppUuid';
+        const listAppRow = {
+            app_uuid: listAppUuid,
+            organization_uuid: organizationUuid,
+            project_uuid: projectUuid,
+            space_uuid: null,
+            created_by_user_uuid: 'otherUserUuid',
+            name: 'Sales App',
+        };
+
+        const viewDataApp: RawRuleOf<Ability<PossibleAbilities>> = {
+            subject: 'DataApp',
+            action: ['view'],
+            conditions: { organizationUuid },
+        };
+        const createDeliveries: RawRuleOf<Ability<PossibleAbilities>> = {
+            subject: 'ScheduledDeliveries',
+            action: ['create'],
+            conditions: { organizationUuid },
+        };
+
+        const buildAppListService = () => {
+            const appListSchedulerModel = {
+                getAppSchedulers: vi.fn(async () => []),
+            };
+            const appListService = new SchedulerService({
+                lightdashConfig: lightdashConfigMock,
+                analytics: analyticsMock,
+                schedulerModel:
+                    appListSchedulerModel as unknown as SchedulerModel,
+                dashboardModel: {} as DashboardModel,
+                savedChartModel: {} as SavedChartModel,
+                savedSqlModel: {} as SavedSqlModel,
+                appModel: {
+                    findAppByUuid: vi.fn(async () => listAppRow),
+                } as unknown as AppModel,
+                projectModel: {} as ProjectModel,
+                schedulerClient: {} as SchedulerClient,
+                slackClient: {} as SlackClient,
+                emailClient: {} as EmailClient,
+                userModel: {} as UserModel,
+                googleDriveClient: {} as GoogleDriveClient,
+                userService: {} as UserService,
+                jobModel: {} as JobModel,
+                spacePermissionService:
+                    spacePermissionService as unknown as SpacePermissionService,
+            });
+            return { appListService, appListSchedulerModel };
+        };
+
+        test('returns only the requesting user’s schedulers when they cannot manage all deliveries', async () => {
+            const { appListService, appListSchedulerModel } =
+                buildAppListService();
+            const user = buildUser([viewDataApp, createDeliveries]);
+
+            await appListService.getAppSchedulers(user, listAppUuid);
+
+            expect(appListSchedulerModel.getAppSchedulers).toHaveBeenCalledWith(
+                listAppUuid,
+                user.userUuid,
+            );
+        });
+
+        test('returns every scheduler when the user can manage all deliveries', async () => {
+            const { appListService, appListSchedulerModel } =
+                buildAppListService();
+            const user = buildUser([
+                viewDataApp,
+                createDeliveries,
+                {
+                    subject: 'ScheduledDeliveries',
+                    action: ['manage'],
+                    conditions: { organizationUuid },
+                },
+            ]);
+
+            await appListService.getAppSchedulers(user, listAppUuid);
+
+            expect(appListSchedulerModel.getAppSchedulers).toHaveBeenCalledWith(
+                listAppUuid,
+                undefined,
+            );
+        });
+
+        test('throws ForbiddenError before listing when the user cannot create deliveries', async () => {
+            const { appListService, appListSchedulerModel } =
+                buildAppListService();
+            const user = buildUser([viewDataApp]);
+
+            await expect(
+                appListService.getAppSchedulers(user, listAppUuid),
+            ).rejects.toThrowError(ForbiddenError);
+            expect(
+                appListSchedulerModel.getAppSchedulers,
+            ).not.toHaveBeenCalled();
+        });
+    });
+
     describe('reassignSchedulerOwner', () => {
         const gsheetsScheduler: ChartScheduler = {
             ...chartSchedulerInPrivateSpace,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -671,8 +671,20 @@ export class SchedulerService extends BaseService {
         user: SessionUser,
         appUuid: string,
     ): Promise<SchedulerAndTargets[]> {
-        await this.checkAppScheduledDeliveryAccess(user, appUuid);
-        return this.schedulerModel.getAppSchedulers(appUuid);
+        const app = await this.checkAppScheduledDeliveryAccess(user, appUuid);
+        // Same narrowing as the chart/SQL chart lists — without `manage` you
+        // only see the deliveries you created, not other users' recipients.
+        const canManageAll = this.createAuditedAbility(user).can(
+            'manage',
+            subject('ScheduledDeliveries', {
+                organizationUuid: app.organization_uuid,
+                projectUuid: app.project_uuid,
+            }),
+        );
+        return this.schedulerModel.getAppSchedulers(
+            appUuid,
+            canManageAll ? undefined : user.userUuid,
+        );
     }
 
     async createAppScheduler(


### PR DESCRIPTION
## What changed

`SchedulerService.getAppSchedulers` now narrows the list to the caller's own schedulers unless they can `manage` all `ScheduledDeliveries` for the project — the same rule `SavedChartService.getSchedulers` and `SavedSqlService.getSchedulers` already apply. `SchedulerModel.getAppSchedulers` gains an optional `createdByUserUuid` filter, mirroring `getSqlChartSchedulers`.

## Why

Data apps were the only resource whose scheduler list came back unfiltered. Endpoint access is gated correctly (`checkAppScheduledDeliveryAccess` requires `view:DataApp` + `create:ScheduledDeliveries`), but every row came back once you were through the door — and `SchedulerList` renders recipient chips, including recipient email addresses, without a per-row permission check. So anyone who could view an app and create deliveries could read other users' delivery configuration for it. Mutations were never affected: `checkUserCanUpdateSchedulerResource` already scopes update/delete/enable to the creator.

Found while reviewing lightdash/lightdash#27723, which re-gates the app's "Schedule delivery" and "Google Sheets Sync" entries on `create:ScheduledDeliveries` instead of app edit access. That change is correct and matches what the backend enforces — it also widens who reaches this list, from app editors to anyone who can view the app. This PR is independent of lightdash/lightdash#27723 and can land in either order.

## Testing

Three tests in `SchedulerService.test.ts`, following the existing `createAppScheduler` local-service pattern:

* without `manage`, the model is called with the caller's uuid
* with `manage`, the model is called with `undefined` (unfiltered)
* a caller lacking `create:ScheduledDeliveries` gets `ForbiddenError` and the model is never reached (pins the ordering of the authorization check ahead of the list)

The first two were confirmed to fail against the unfixed service before the fix was written. `pnpm -F backend test` on this file: 50 passed. Lint and format clean on the touched paths.

No API surface change — the endpoint's response type is unchanged, so no route regeneration is needed.

## References

Closes: lightdash/lightdash#27729<br>Closes: lightdash/lightdash#27729<br>Relates: lightdash/lightdash#27715