### PR TITLE
fix(cli): show content copy failure reason in start-preview

### DIFF
--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -624,11 +624,16 @@ export const startPreviewHandler = async (
         const url = await projectUrl(project);
 
         if (!hasContentCopy) {
-            console.error(
-                styles.warning(
-                    `\n\nDeveloper preview deployed without any copied content!\n`,
-                ),
-            );
+            let errorMessage = `\n\nDeveloper preview deployed without any copied content!`;
+            if (results?.contentCopyError) {
+                errorMessage += `\nError: ${results.contentCopyError}`;
+            } else if (options.skipCopyContent) {
+                errorMessage += `\nReason: --skip-copy-content flag was used`;
+            } else if (!config.context?.project) {
+                errorMessage += `\nReason: No upstream project configured`;
+            }
+            errorMessage += '\n';
+            console.error(styles.warning(errorMessage));
         }
 
         console.error(`New project created on ${url}`);


### PR DESCRIPTION
## Problem

When content copying into a preview project fails, `lightdash preview` prints the underlying error, but `lightdash start-preview` prints only a generic "deployed without any copied content" warning — no reason given. CI pipelines typically use `start-preview`, so a broken preview looks like a working one (see PROD-10277 for a copy failure this hid).

The API response (`POST /api/v1/org/projects`) already carries `contentCopyError`; `startPreviewHandler`'s create path just never read it.

## Fix

Mirror the `previewHandler` warning branch in `startPreviewHandler`: print `Error: <contentCopyError>` when the API reports a copy failure, or the skip reason (`--skip-copy-content` used / no upstream project configured) when the copy was intentionally skipped.

## Verification

Ran the local CLI against a dev stack:

- With `--skip-copy-content`: warning now prints `Reason: --skip-copy-content flag was used`.
- With a simulated copy failure in `copyContentOnPreview` (temporary local throw): warning now prints `Error: TEST-10278 simulated copy failure`, where before it printed nothing beyond the generic line.

Closes: PROD-10278
Closes: #27571

🤖 Generated with [Claude Code](https://claude.com/claude-code)