### PR TITLE
fix(frontend): gate SQL chart Google Sheets Sync by delivery permissions

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.test.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.test.tsx
@@ -174,14 +174,15 @@ describe('HeaderView — Google Sheets Sync entry point', () => {
         expect(screen.queryByText('Edit chart')).not.toBeInTheDocument();
     });
 
-    it('renders no menu when the user has neither edit nor delivery permissions', async () => {
+    it('renders no menu when the user has neither edit nor delivery permissions', () => {
         renderWithProviders(<HeaderView />, {
             health: withGoogleDriveConfigured(),
             user: { abilityRules: [] },
         });
 
-        // findBy* polls until it times out, so this asserts the menu target
-        // never appears — not merely that it hasn't rendered yet.
-        await expect(screen.findByRole('button')).rejects.toThrow();
+        // Synchronous on purpose: dropping the gate would render the target on
+        // the first pass, so this catches it without polling. The tests above
+        // are what prove the menu appears once permissions are granted.
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.test.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.test.tsx
@@ -1,0 +1,187 @@
+import { type HealthState } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defaultAbility } from '../../../../providers/Ability/constants';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import { HeaderView } from './HeaderView';
+
+vi.mock('react-router', () => ({
+    useNavigate: () => vi.fn(),
+    useLocation: () => ({ search: '', pathname: '/' }),
+}));
+
+// Redux-connected via the sqlRunner slice — the selectors are the only part
+// of the store this component reads.
+const mockState = {
+    sqlRunner: {
+        projectUuid: 'project-1',
+        savedSqlChart: {
+            savedSqlUuid: 'sql-chart-1',
+            name: 'My SQL chart',
+            slug: 'my-sql-chart',
+            description: null,
+            views: 0,
+            firstViewedAt: null,
+            lastUpdatedAt: new Date('2026-01-01T00:00:00.000Z'),
+            lastUpdatedBy: null,
+            space: { uuid: 'space-1', name: 'My space', userAccess: undefined },
+        },
+        modals: {
+            addToDashboard: { isOpen: false },
+            deleteChartModal: { isOpen: false },
+        },
+    },
+};
+
+vi.mock('../../store/hooks', () => ({
+    useAppDispatch: () => vi.fn(),
+    useAppSelector: (selector: (state: typeof mockState) => unknown) =>
+        selector(mockState),
+}));
+
+vi.mock('../../../../hooks/useProject', () => ({
+    useProject: vi.fn(() => ({ data: { upstreamProjectUuid: undefined } })),
+}));
+
+vi.mock('../../hooks/useSavedSqlCharts', () => ({
+    usePromoteSqlChartMutation: vi.fn(() => ({ mutate: vi.fn() })),
+    usePromoteSqlChartDiffMutation: vi.fn(() => ({
+        mutate: vi.fn(),
+        data: undefined,
+        reset: vi.fn(),
+        isLoading: false,
+    })),
+}));
+
+// None of these open during these tests — stubbed so their dependency trees
+// never mount.
+vi.mock(
+    '../../../../components/SavedDashboards/AddTilesToDashboardModal',
+    () => ({
+        default: () => null,
+    }),
+);
+vi.mock('../DeleteSqlChartModal', () => ({ DeleteSqlChartModal: () => null }));
+vi.mock('../../../sync/components/SqlChartSyncModal', () => ({
+    SqlChartSyncModal: () => null,
+}));
+vi.mock('../../../promotion/components/PromotionConfirmDialog', () => ({
+    PromotionConfirmDialog: () => null,
+}));
+vi.mock(
+    '../../../../components/Explorer/SavedChartsHeader/TitleBreadcrumbs',
+    () => ({ TitleBreadCrumbs: () => null }),
+);
+vi.mock(
+    '../../../../components/common/ResourceInfoPopup/ResourceInfoPopup',
+    () => ({ ResourceInfoPopup: () => null }),
+);
+vi.mock('../../../../components/common/PageHeader/UpdatedInfo', () => ({
+    UpdatedInfo: () => null,
+}));
+
+// Matches AppProviderMock's default user fixture (mockUserResponse).
+const DEFAULT_ORG_UUID = '172a2270-000f-42be-9c68-c4752c23ae51';
+
+const withGoogleDriveConfigured = (): Partial<HealthState> => ({
+    auth: {
+        google: {
+            oauth2ClientId: 'client-id',
+            googleDriveApiKey: 'api-key',
+        },
+    } as HealthState['auth'],
+});
+
+// `Can` reads the module-level `defaultAbility` singleton, not the mocked
+// `user.data` — the real app calls `ability.update(user.abilityRules)` on this
+// same instance from PrivateRoute.
+const grantGoogleSheetsAbility = () => {
+    defaultAbility.update([
+        {
+            action: 'manage',
+            subject: 'GoogleSheets',
+            conditions: { organizationUuid: DEFAULT_ORG_UUID },
+        },
+    ]);
+};
+
+/** Delivery permissions only — no `manage` on SavedChart or SqlRunner. */
+const viewOnlyWithDeliveryPermissions = () => ({
+    abilityRules: [
+        {
+            action: 'create' as const,
+            subject: 'ScheduledDeliveries' as const,
+            conditions: {
+                organizationUuid: DEFAULT_ORG_UUID,
+                projectUuid: 'project-1',
+            },
+        },
+        {
+            action: 'manage' as const,
+            subject: 'GoogleSheets' as const,
+            conditions: {
+                organizationUuid: DEFAULT_ORG_UUID,
+                projectUuid: 'project-1',
+            },
+        },
+    ],
+});
+
+// The menu target itself is gated on an async health query, so wait for it
+// rather than racing the first render.
+const openMenu = async () => {
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button'));
+};
+
+describe('HeaderView — Google Sheets Sync entry point', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        defaultAbility.update([]);
+    });
+
+    afterEach(() => {
+        defaultAbility.update([]);
+    });
+
+    it('shows Google Sheets Sync without chart edit access', async () => {
+        grantGoogleSheetsAbility();
+        renderWithProviders(<HeaderView />, {
+            health: withGoogleDriveConfigured(),
+            user: viewOnlyWithDeliveryPermissions(),
+        });
+
+        await openMenu();
+
+        expect(
+            await screen.findByText('Google Sheets Sync'),
+        ).toBeInTheDocument();
+    });
+
+    it('hides manage-only actions from a user without chart edit access', async () => {
+        grantGoogleSheetsAbility();
+        renderWithProviders(<HeaderView />, {
+            health: withGoogleDriveConfigured(),
+            user: viewOnlyWithDeliveryPermissions(),
+        });
+
+        await openMenu();
+        await screen.findByText('Google Sheets Sync');
+
+        expect(screen.queryByText('Add to dashboard')).not.toBeInTheDocument();
+        expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+        expect(screen.queryByText('Edit chart')).not.toBeInTheDocument();
+    });
+
+    it('renders no menu when the user has neither edit nor delivery permissions', async () => {
+        renderWithProviders(<HeaderView />, {
+            health: withGoogleDriveConfigured(),
+            user: { abilityRules: [] },
+        });
+
+        // findBy* polls until it times out, so this asserts the menu target
+        // never appears — not merely that it hasn't rendered yet.
+        await expect(screen.findByRole('button')).rejects.toThrow();
+    });
+});

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -26,7 +26,6 @@ import { ResourceInfoPopup } from '../../../../components/common/ResourceInfoPop
 import { TitleBreadCrumbs } from '../../../../components/Explorer/SavedChartsHeader/TitleBreadcrumbs';
 import AddTilesToDashboardModal from '../../../../components/SavedDashboards/AddTilesToDashboardModal';
 import { useProject } from '../../../../hooks/useProject';
-import { Can } from '../../../../providers/Ability';
 import useApp from '../../../../providers/App/useApp';
 import { PromotionConfirmDialog } from '../../../promotion/components/PromotionConfirmDialog';
 import {
@@ -137,6 +136,19 @@ export const HeaderView: FC = () => {
         health.data?.auth.google.oauth2ClientId !== undefined &&
         health.data?.auth.google.googleDriveApiKey !== undefined;
 
+    // Creating a sync needs delivery + Drive permissions, not chart edit
+    // rights — the same gate the saved chart and data app headers use.
+    const canSyncWithGoogleSheets =
+        hasGoogleDriveEnabled &&
+        canCreateScheduledDeliveries === true &&
+        user.data?.ability?.can(
+            'manage',
+            subject('GoogleSheets', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        ) === true;
+
     const { mutate: promoteSqlChart } = usePromoteSqlChartMutation(projectUuid);
     const {
         mutate: getPromoteSqlChartDiff,
@@ -207,7 +219,7 @@ export const HeaderView: FC = () => {
                             </Button>
                         )}
 
-                        {canManageChart && (
+                        {(canManageChart || canSyncWithGoogleSheets) && (
                             <Menu
                                 position="bottom"
                                 withArrow
@@ -221,49 +233,40 @@ export const HeaderView: FC = () => {
                                     </ActionIcon>
                                 </Menu.Target>
                                 <Menu.Dropdown>
-                                    <Menu.Label>Manage</Menu.Label>
-                                    <Menu.Item
-                                        leftSection={
-                                            <MantineIcon
-                                                icon={IconLayoutGridAdd}
-                                            />
-                                        }
-                                        onClick={() =>
-                                            dispatch(
-                                                toggleModal('addToDashboard'),
-                                            )
-                                        }
-                                    >
-                                        Add to dashboard
-                                    </Menu.Item>
-                                    {hasGoogleDriveEnabled &&
-                                        canCreateScheduledDeliveries && (
-                                            <Can
-                                                I="manage"
-                                                this={subject('GoogleSheets', {
-                                                    organizationUuid:
-                                                        user.data
-                                                            ?.organizationUuid,
-                                                    projectUuid,
-                                                })}
+                                    {canManageChart && (
+                                        <>
+                                            <Menu.Label>Manage</Menu.Label>
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconLayoutGridAdd}
+                                                    />
+                                                }
+                                                onClick={() =>
+                                                    dispatch(
+                                                        toggleModal(
+                                                            'addToDashboard',
+                                                        ),
+                                                    )
+                                                }
                                             >
-                                                <Menu.Item
-                                                    leftSection={
-                                                        <MantineIcon
-                                                            icon={
-                                                                IconCirclesRelation
-                                                            }
-                                                        />
-                                                    }
-                                                    onClick={
-                                                        syncModalHandlers.open
-                                                    }
-                                                >
-                                                    Google Sheets Sync
-                                                </Menu.Item>
-                                            </Can>
-                                        )}
-                                    {canPromoteChart && (
+                                                Add to dashboard
+                                            </Menu.Item>
+                                        </>
+                                    )}
+                                    {canSyncWithGoogleSheets && (
+                                        <Menu.Item
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconCirclesRelation}
+                                                />
+                                            }
+                                            onClick={syncModalHandlers.open}
+                                        >
+                                            Google Sheets Sync
+                                        </Menu.Item>
+                                    )}
+                                    {canManageChart && canPromoteChart && (
                                         <Tooltip
                                             label="You must enable first an upstream project in settings > Data ops"
                                             disabled={
@@ -296,23 +299,27 @@ export const HeaderView: FC = () => {
                                             </div>
                                         </Tooltip>
                                     )}
-                                    <Menu.Item
-                                        leftSection={
-                                            <MantineIcon
-                                                icon={IconTrash}
-                                                color="red"
-                                            />
-                                        }
-                                        color="red"
-                                        disabled={!canManageSqlRunner}
-                                        onClick={() =>
-                                            dispatch(
-                                                toggleModal('deleteChartModal'),
-                                            )
-                                        }
-                                    >
-                                        Delete
-                                    </Menu.Item>
+                                    {canManageChart && (
+                                        <Menu.Item
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconTrash}
+                                                    color="red"
+                                                />
+                                            }
+                                            color="red"
+                                            disabled={!canManageSqlRunner}
+                                            onClick={() =>
+                                                dispatch(
+                                                    toggleModal(
+                                                        'deleteChartModal',
+                                                    ),
+                                                )
+                                            }
+                                        >
+                                            Delete
+                                        </Menu.Item>
+                                    )}
                                 </Menu.Dropdown>
                             </Menu>
                         )}


### PR DESCRIPTION
## What changed

The SQL Runner chart header's overflow menu is no longer gated wholesale on `canManageChart`. It now renders when the user can reach at least one item, and each manage-only item — "Add to dashboard", "Promote chart", "Delete" — carries its own `canManageChart` check. The Google Sheets Sync entry is gated on Drive being configured + `create:ScheduledDeliveries` + `manage:GoogleSheets`.

## Why

lightdash/lightdash#27723 fixed this class of bug for saved charts and data apps. SQL Runner charts have it too and weren't covered.

The sync item already checked the right permissions — it was just unreachable, because the menu it lives in required manage rights on the chart. `SavedSqlService.checkCreateScheduledDeliveryAccess` requires only `create:ScheduledDeliveries` plus **view** access to the chart's space, and `manage:GoogleSheets` for the gsheets format. Same contract as `SavedChartService` and the data app path.

Nothing else becomes visible: every item that previously required manage rights still requires them. The "Manage" section label is now scoped to the manage-only items, so a view-only user sees a menu containing just the sync entry.

The item's inline `<Can>` wrapper was replaced with an ability check on `user.data.ability`, matching how every other permission in this file is computed and letting the same boolean decide whether the menu renders at all. Both read the same rules at runtime — `PrivateRoute` updates the `Can` singleton from `user.abilityRules`.

## Testing

New `HeaderView.test.tsx` (the component had no test file):

* a user with delivery + Google Sheets permissions but no chart edit access sees "Google Sheets Sync"
* that same user does not see "Add to dashboard", "Delete", or "Edit chart"
* a user with neither edit nor delivery permissions gets no menu at all

The first two were confirmed to fail against the unfixed component before the fix was written. `pnpm -F frontend test` on this file: 3 passed. `pnpm -F frontend lint`: 0 warnings, 0 errors. `pnpm -F frontend typecheck`: clean.

Not covered here: SQL Runner has no "Scheduled deliveries" entry at all, only the gsheets sync. Whether it should gain one is a separate question.

## References

Closes: lightdash/lightdash#27730<br>Closes: lightdash/lightdash#27730<br>Relates: lightdash/lightdash#27715