### PR TITLE
fix(upgrade-automation): build the pin commit from the base it commits against

### DIFF
--- a/examples/upgrade-automation/scripts/plan.sh
+++ b/examples/upgrade-automation/scripts/plan.sh
@@ -93,8 +93,8 @@ gate_error=$(mktemp)
 merge_error=$(mktemp)
 body_file=$(mktemp)
 summary_file=$(mktemp)
-bump_file_before=$(mktemp)
-trap 'rm -f "$index_file" "$gate_error" "$merge_error" "$body_file" "$summary_file" "$bump_file_before"' EXIT
+fresh_file=$(mktemp ./plan-fresh.XXXXXX)
+trap 'rm -f "$index_file" "$gate_error" "$merge_error" "$body_file" "$summary_file" "$fresh_file"' EXIT
 
 curl --connect-timeout 10 --max-time 60 --fail --silent --show-error "$RELEASE_INDEX_URL" --output "$index_file"
 jq -e '.schemaVersion == "1" and (.entries | type == "array")' "$index_file" >/dev/null
@@ -262,33 +262,64 @@ fi
 default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch')
 upgrade_branch="${branch_prefix}-$(safe_branch_version "$mapped_version")"
 bump_file=${BUMP_TARGET%%#*}
-
-cp "$bump_file" "$bump_file_before"
-write_bump_value "$mapped_version"
-if cmp -s "$bump_file_before" "$bump_file"; then
-    echo "$bump_file already pins $mapped_version; nothing to commit"
-    exit 0
+bump_path=${BUMP_TARGET#*#}
+bump_filename=${bump_file##*/}
+bump_extension=${bump_filename##*.}
+if [[ "${bump_filename#.}" == *.* && -n "$bump_extension" ]]; then
+    mv "$fresh_file" "$fresh_file.$bump_extension"
+    fresh_file="$fresh_file.$bump_extension"
 fi
-
-base_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$default_branch" --jq '.object.sha')
-if gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$upgrade_branch" >/dev/null 2>&1; then
-    gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/heads/$upgrade_branch" \
-        -f sha="$base_sha" \
-        -F force=true >/dev/null
-else
-    gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
-        -f ref="refs/heads/$upgrade_branch" \
-        -f sha="$base_sha" >/dev/null
-fi
-
-file_contents=$(base64_file "$bump_file")
 commit_message="chore: upgrade Lightdash to $mapped_version"
-if ! commit_response=$(create_commit "$base_sha" "$bump_file" "$file_contents" "$commit_message"); then
-    branch_head=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$upgrade_branch" --jq '.object.sha')
-    if [[ "$branch_head" == "$base_sha" ]]; then
-        exit 1
+commit_response=
+committed=false
+
+for attempt in 1 2 3; do
+    base_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$default_branch" --jq '.object.sha')
+    gh api "repos/$GITHUB_REPOSITORY/contents/$bump_file?ref=$base_sha" --jq '.content' \
+        | tr -d '\n' \
+        | base64 --decode >"$fresh_file"
+
+    fresh_mapped=$(python3 "$ACTION_ROOT/scripts/bump-target.py" read "$fresh_file#$bump_path")
+    if [[ "$fresh_mapped" == "$mapped_version" ]]; then
+        echo "$bump_file already pins $mapped_version at $base_sha; nothing to commit"
+        exit 0
     fi
-    commit_response=$(create_commit "$branch_head" "$bump_file" "$file_contents" "$commit_message")
+    fresh_public=$(public_version "$fresh_mapped" "${TAG_SUFFIX:-}")
+    if version_gt "$fresh_public" "$selected_version"; then
+        echo "$bump_file already pins newer version $fresh_mapped at $base_sha; not lowering it to $mapped_version"
+        exit 0
+    fi
+    if [[ "$fresh_mapped" != "$current_mapped" ]]; then
+        echo "$bump_file moved from $current_mapped to $fresh_mapped at $base_sha; a replan is required"
+        exit 0
+    fi
+    if [[ "$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "$FREEZE_LABEL" --limit 1 --json number --jq 'length')" != "0" ]]; then
+        echo "an open $FREEZE_LABEL issue is disarming the planner; nothing to do"
+        exit 0
+    fi
+
+    if gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$upgrade_branch" >/dev/null 2>&1; then
+        gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/heads/$upgrade_branch" \
+            -f sha="$base_sha" \
+            -F force=true >/dev/null
+    else
+        gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/heads/$upgrade_branch" \
+            -f sha="$base_sha" >/dev/null
+    fi
+
+    python3 "$ACTION_ROOT/scripts/bump-target.py" write "$fresh_file#$bump_path" "$mapped_version"
+    file_contents=$(base64_file "$fresh_file")
+    if commit_response=$(create_commit "$base_sha" "$bump_file" "$file_contents" "$commit_message"); then
+        committed=true
+        break
+    fi
+    echo "commit attempt $attempt lost the race; retrying from the latest $default_branch" >&2
+done
+
+if [[ "$committed" != "true" ]]; then
+    echo "failed to commit $bump_file after 3 attempts" >&2
+    exit 1
 fi
 jq -e '.data.createCommitOnBranch.commit.oid | type == "string" and length > 0' <<<"$commit_response" >/dev/null
 
@@ -376,7 +407,9 @@ if [[ "$pr_created" == "true" ]]; then
 fi
 
 if [[ "$selected_green" == "true" && "${AUTO_MERGE:-false}" == "true" ]]; then
-    if ! gh pr merge "$pr_url" --auto --squash 2>"$merge_error"; then
+    if [[ "$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "$FREEZE_LABEL" --limit 1 --json number --jq 'length')" != "0" ]]; then
+        echo "an open $FREEZE_LABEL issue is disarming auto-merge; leaving $pr_url open"
+    elif ! gh pr merge "$pr_url" --auto --squash 2>"$merge_error"; then
         merge_state=$(gh pr view "$pr_url" --json mergeStateStatus --jq '.mergeStateStatus' || true)
         if [[ "$merge_state" == "CLEAN" ]]; then
             gh pr merge "$pr_url" --squash

--- a/examples/upgrade-automation/scripts/plan.test.sh
+++ b/examples/upgrade-automation/scripts/plan.test.sh
@@ -97,6 +97,11 @@ if [[ "\$*" == *'git/ref/heads/main'* ]]; then
     exit 0
 fi
 
+if [[ "\$*" == *'contents/values.yml?ref='* ]]; then
+    base64 <"$test_dir/values.yml" | tr -d '\n'
+    exit 0
+fi
+
 if [[ "\$*" == *'git/ref/heads/'* ]]; then
     exit 1
 fi
@@ -107,7 +112,7 @@ if [[ "\$*" == *'git/refs'* ]]; then
 fi
 
 if [[ "\$*" == *graphql* ]]; then
-    cat >/dev/null
+    cat >"$test_dir/graphql-input"
     printf '{"data":{"createCommitOnBranch":{"commit":{"oid":"2222222222222222222222222222222222222222","url":"https://example.test/c"}}}}\n'
     exit 0
 fi
@@ -334,6 +339,313 @@ fi
 
 printf 'plan invalid branch prefix test passed\n'
 
+run_transaction_test() {
+    local scenario=$1
+    local test_name=$2
+    local expected_status=$3
+    local scenario_dir
+    local output
+    local status
+    local committed_target
+    local committed_unrelated
+    local graphql_count
+    local bump_filename=values.yml
+    local fresh_suffix=yml
+
+    if [[ "$scenario" == "json_round_trip" ]]; then
+        bump_filename=values.json
+        fresh_suffix=json
+    fi
+
+    scenario_dir=$(mktemp -d)
+    mkdir -p "$scenario_dir/bin"
+    if [[ "$scenario" == "json_round_trip" ]]; then
+        cat >"$scenario_dir/$bump_filename" <<'EOF'
+{
+  "image": {"tag": "1.0.0"},
+  "unrelated": {"tag": "old"}
+}
+EOF
+    else
+        cat >"$scenario_dir/$bump_filename" <<'EOF'
+image:
+  tag: 1.0.0
+unrelated:
+  tag: old
+EOF
+    fi
+    cp "$scenario_dir/$bump_filename" "$scenario_dir/fresh-1.$fresh_suffix"
+    cp "$scenario_dir/$bump_filename" "$scenario_dir/fresh-2.$fresh_suffix"
+
+    case "$scenario" in
+        stale_checkout)
+            sed 's/tag: old/tag: new/' "$scenario_dir/$bump_filename" >"$scenario_dir/fresh-1.$fresh_suffix"
+            ;;
+        already_pinned)
+            sed 's/tag: 1.0.0/tag: 1.0.2/' "$scenario_dir/$bump_filename" >"$scenario_dir/fresh-1.$fresh_suffix"
+            ;;
+        never_lower)
+            sed 's/tag: 1.0.0/tag: 1.0.5/' "$scenario_dir/$bump_filename" >"$scenario_dir/fresh-1.$fresh_suffix"
+            ;;
+        key_moved)
+            sed 's/tag: 1.0.0/tag: 1.0.1/' "$scenario_dir/$bump_filename" >"$scenario_dir/fresh-1.$fresh_suffix"
+            ;;
+        retry_rederive)
+            sed 's/tag: old/tag: first/' "$scenario_dir/$bump_filename" >"$scenario_dir/fresh-1.$fresh_suffix"
+            sed 's/tag: old/tag: second/' "$scenario_dir/$bump_filename" >"$scenario_dir/fresh-2.$fresh_suffix"
+            ;;
+        json_round_trip)
+            sed 's/"old"/"new"/' "$scenario_dir/$bump_filename" >"$scenario_dir/fresh-1.$fresh_suffix"
+            ;;
+        freeze_mid_run | retry_exhaustion)
+            ;;
+        *)
+            printf 'unknown transaction test scenario: %s\n' "$scenario" >&2
+            rm -rf "$scenario_dir"
+            exit 1
+            ;;
+    esac
+
+    cat >"$scenario_dir/index.json" <<'EOF'
+{
+  "schemaVersion": "1",
+  "entries": [
+    {"version": "1.0.0"},
+    {"version": "1.0.2"}
+  ]
+}
+EOF
+    : >"$scenario_dir/gh.log"
+
+    cat >"$scenario_dir/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+out=
+prev=
+for arg in "$@"; do
+    if [[ "$prev" == "--output" ]]; then out=$arg; fi
+    prev=$arg
+done
+cp "$TEST_SCENARIO_DIR/index.json" "$out"
+EOF
+
+    cat >"$scenario_dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$TEST_SCENARIO_DIR/gh.log"
+
+next_count() {
+    local count_file=$1
+    local count=0
+    if [[ -f "$count_file" ]]; then
+        count=$(<"$count_file")
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$count_file"
+    printf '%s\n' "$count"
+}
+
+if [[ "$*" == "issue list"* ]]; then
+    issue_count=$(next_count "$TEST_SCENARIO_DIR/issue-count")
+    if [[ "$GH_SCENARIO" == "freeze_mid_run" && "$issue_count" -gt 1 ]]; then
+        printf '1\n'
+    else
+        printf '0\n'
+    fi
+    exit 0
+fi
+
+if [[ "$*" == *'repos/example/upgrade-test --jq .default_branch'* ]]; then
+    printf 'main\n'
+    exit 0
+fi
+
+if [[ "$*" == *'git/ref/heads/main'* ]]; then
+    base_count=$(next_count "$TEST_SCENARIO_DIR/base-count")
+    case "$base_count" in
+        1) printf '1111111111111111111111111111111111111111\n' ;;
+        2) printf '3333333333333333333333333333333333333333\n' ;;
+        *) printf '5555555555555555555555555555555555555555\n' ;;
+    esac
+    exit 0
+fi
+
+if [[ "$*" == *"contents/$GH_BUMP_FILE?ref="* ]]; then
+    content_count=$(next_count "$TEST_SCENARIO_DIR/content-count")
+    fresh_file="$TEST_SCENARIO_DIR/fresh-1.$GH_FRESH_SUFFIX"
+    if [[ "$GH_SCENARIO" == "retry_rederive" && "$content_count" -gt 1 ]]; then
+        fresh_file="$TEST_SCENARIO_DIR/fresh-2.$GH_FRESH_SUFFIX"
+    fi
+    base64 <"$fresh_file" | tr -d '\n'
+    exit 0
+fi
+
+if [[ "$*" == *'git/ref/heads/'* ]]; then
+    if [[ -f "$TEST_SCENARIO_DIR/branch-created" ]]; then
+        printf '{}\n'
+        exit 0
+    fi
+    exit 1
+fi
+
+if [[ "$*" == *'git/refs'* ]]; then
+    : >"$TEST_SCENARIO_DIR/branch-created"
+    printf '{}\n'
+    exit 0
+fi
+
+if [[ "$*" == *graphql* ]]; then
+    graphql_count=$(next_count "$TEST_SCENARIO_DIR/graphql-count")
+    cat >"$TEST_SCENARIO_DIR/graphql-input-$graphql_count"
+    if [[ "$GH_SCENARIO" == "retry_exhaustion" || ( "$GH_SCENARIO" == "retry_rederive" && "$graphql_count" == "1" ) ]]; then
+        exit 1
+    fi
+    printf '{"data":{"createCommitOnBranch":{"commit":{"oid":"2222222222222222222222222222222222222222","url":"https://example.test/c"}}}}\n'
+    exit 0
+fi
+
+if [[ "$*" == "pr list"* ]]; then
+    exit 0
+fi
+
+if [[ "$*" == "pr create"* ]]; then
+    printf 'https://example.test/pr/1\n'
+    exit 0
+fi
+
+if [[ "$*" == "pr view"* ]]; then
+    printf '{"number":1,"url":"https://example.test/pr/1"}\n'
+    exit 0
+fi
+
+if [[ "$*" == "pr comment"* ]]; then
+    exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+EOF
+
+    chmod +x "$scenario_dir/bin/curl" "$scenario_dir/bin/gh"
+
+    set +e
+    output=$(cd "$scenario_dir" && \
+        PATH="$scenario_dir/bin:$PATH" \
+        TEST_SCENARIO_DIR="$scenario_dir" \
+        GH_SCENARIO="$scenario" \
+        GH_BUMP_FILE="$bump_filename" \
+        GH_FRESH_SUFFIX="$fresh_suffix" \
+        GITHUB_REPOSITORY=example/upgrade-test \
+        BUMP_TARGET="$bump_filename#image.tag" \
+        SAFETY_GATE=false \
+        FREEZE_LABEL=upgrade-freeze \
+        GH_TOKEN=test-token \
+        "${BASH:-bash}" "$root/examples/upgrade-automation/scripts/plan.sh" 2>&1)
+    status=$?
+    set -e
+
+    if [[ $status -ne $expected_status ]]; then
+        printf 'expected %s to exit %s, got %s:\n%s\n' "$test_name" "$expected_status" "$status" "$output" >&2
+        printf 'gh calls were:\n%s\n' "$(cat "$scenario_dir/gh.log")" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+
+    if find "$scenario_dir" -maxdepth 1 -name 'plan-fresh.*' -print -quit | grep -q .; then
+        printf 'expected %s to clean up its temporary bump file\n' "$test_name" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+
+    case "$scenario" in
+        stale_checkout)
+            jq -r '.variables.input.fileChanges.additions[0].contents' "$scenario_dir/graphql-input-1" \
+                | base64 --decode >"$scenario_dir/committed.yml"
+            committed_target=$(cd "$scenario_dir" && python3 "$root/examples/upgrade-automation/scripts/bump-target.py" read committed.yml#image.tag)
+            committed_unrelated=$(cd "$scenario_dir" && python3 "$root/examples/upgrade-automation/scripts/bump-target.py" read committed.yml#unrelated.tag)
+            if [[ "$committed_target" != "1.0.2" || "$committed_unrelated" != "new" ]]; then
+                printf 'expected the fresh blob to preserve unrelated=new and bump image.tag=1.0.2, got:\n%s\n' "$(cat "$scenario_dir/committed.yml")" >&2
+                rm -rf "$scenario_dir"
+                exit 1
+            fi
+            ;;
+        json_round_trip)
+            jq -r '.variables.input.fileChanges.additions[0].contents' "$scenario_dir/graphql-input-1" \
+                | base64 --decode >"$scenario_dir/committed.json"
+            if ! jq -e '.image.tag == "1.0.2" and .unrelated.tag == "new"' "$scenario_dir/committed.json" >/dev/null; then
+                printf 'expected valid fresh JSON with image.tag=1.0.2 and unrelated.tag=new, got:\n%s\n' "$(cat "$scenario_dir/committed.json")" >&2
+                rm -rf "$scenario_dir"
+                exit 1
+            fi
+            ;;
+        already_pinned)
+            if grep -Eq -- '--method (POST|PATCH) repos/example/upgrade-test/git/refs|api graphql|pr create' "$scenario_dir/gh.log"; then
+                printf 'expected fresh main already-pinned handling to avoid branch, commit, and PR mutations, gh calls were:\n%s\n' "$(cat "$scenario_dir/gh.log")" >&2
+                rm -rf "$scenario_dir"
+                exit 1
+            fi
+            ;;
+        never_lower)
+            if [[ "$output" != *'not lowering it'* ]] || grep -Eq -- '--method (POST|PATCH) repos/example/upgrade-test/git/refs|api graphql' "$scenario_dir/gh.log"; then
+                printf 'expected never-lower handling without a commit, got:\n%s\ngh calls were:\n%s\n' "$output" "$(cat "$scenario_dir/gh.log")" >&2
+                rm -rf "$scenario_dir"
+                exit 1
+            fi
+            ;;
+        key_moved)
+            if [[ "$output" != *'a replan is required'* ]] || grep -Eq -- '--method (POST|PATCH) repos/example/upgrade-test/git/refs|api graphql' "$scenario_dir/gh.log"; then
+                printf 'expected a moved key to require a replan without a commit, got:\n%s\ngh calls were:\n%s\n' "$output" "$(cat "$scenario_dir/gh.log")" >&2
+                rm -rf "$scenario_dir"
+                exit 1
+            fi
+            ;;
+        retry_rederive)
+            graphql_count=$(<"$scenario_dir/graphql-count")
+            jq -r '.variables.input.fileChanges.additions[0].contents' "$scenario_dir/graphql-input-2" \
+                | base64 --decode >"$scenario_dir/committed.yml"
+            committed_target=$(cd "$scenario_dir" && python3 "$root/examples/upgrade-automation/scripts/bump-target.py" read committed.yml#image.tag)
+            committed_unrelated=$(cd "$scenario_dir" && python3 "$root/examples/upgrade-automation/scripts/bump-target.py" read committed.yml#unrelated.tag)
+            if [[ "$graphql_count" != "2" || "$committed_target" != "1.0.2" || "$committed_unrelated" != "second" ]] \
+                || ! jq -e '.variables.input.expectedHeadOid == "3333333333333333333333333333333333333333"' "$scenario_dir/graphql-input-2" >/dev/null; then
+                printf 'expected retry two to rebuild from the second base, got target=%s unrelated=%s graphql_count=%s\n' "$committed_target" "$committed_unrelated" "$graphql_count" >&2
+                rm -rf "$scenario_dir"
+                exit 1
+            fi
+            ;;
+        freeze_mid_run)
+            if grep -Eq -- '--method (POST|PATCH) repos/example/upgrade-test/git/refs|api graphql|pr create|pr merge' "$scenario_dir/gh.log"; then
+                printf 'expected a mid-run freeze to prevent branch, commit, PR, and merge mutations, gh calls were:\n%s\n' "$(cat "$scenario_dir/gh.log")" >&2
+                rm -rf "$scenario_dir"
+                exit 1
+            fi
+            ;;
+        retry_exhaustion)
+            graphql_count=$(<"$scenario_dir/graphql-count")
+            if [[ "$graphql_count" != "3" || "$output" != *'failed to commit values.yml after 3 attempts'* ]] || grep -q '^pr create' "$scenario_dir/gh.log"; then
+                printf 'expected three failed commits and no PR, got:\n%s\ngh calls were:\n%s\n' "$output" "$(cat "$scenario_dir/gh.log")" >&2
+                rm -rf "$scenario_dir"
+                exit 1
+            fi
+            ;;
+    esac
+
+    rm -rf "$scenario_dir"
+    printf '%s test passed\n' "$test_name"
+}
+
+run_transaction_test stale_checkout 'plan stale-checkout clobber' 0
+run_transaction_test json_round_trip 'plan JSON bump target round-trip' 0
+run_transaction_test already_pinned 'plan already pinned on fresh main' 0
+run_transaction_test never_lower 'plan never-lower' 0
+run_transaction_test key_moved 'plan key moved mid-plan' 0
+run_transaction_test retry_rederive 'plan retry re-derives from a fresh base' 0
+run_transaction_test freeze_mid_run 'plan freeze armed mid-run' 0
+run_transaction_test retry_exhaustion 'plan retry exhaustion' 1
+
 run_auto_merge_test() {
     local test_name=$1
     local auto_merge=$2
@@ -344,6 +656,7 @@ run_auto_merge_test() {
     local expected_state_view=$7
     local expected_plain_merge=$8
     local expected_error=$9
+    local freeze_before_merge=${10}
     local scenario_dir
     local output
     local status
@@ -388,7 +701,17 @@ set -euo pipefail
 printf '%s\n' "$*" >>"$TEST_SCENARIO_DIR/gh.log"
 
 if [[ "$*" == "issue list"* ]]; then
-    printf '0\n'
+    issue_count=0
+    if [[ -f "$TEST_SCENARIO_DIR/issue-count" ]]; then
+        issue_count=$(<"$TEST_SCENARIO_DIR/issue-count")
+    fi
+    issue_count=$((issue_count + 1))
+    printf '%s\n' "$issue_count" >"$TEST_SCENARIO_DIR/issue-count"
+    if [[ "$GH_FREEZE_BEFORE_MERGE" == "true" && "$issue_count" -gt 2 ]]; then
+        printf '1\n'
+    else
+        printf '0\n'
+    fi
     exit 0
 fi
 
@@ -402,6 +725,11 @@ if [[ "$*" == *'git/ref/heads/main'* ]]; then
     exit 0
 fi
 
+if [[ "$*" == *'contents/values.yml?ref='* ]]; then
+    base64 <"$TEST_SCENARIO_DIR/values.yml" | tr -d '\n'
+    exit 0
+fi
+
 if [[ "$*" == *'git/ref/heads/'* ]]; then
     exit 1
 fi
@@ -412,7 +740,7 @@ if [[ "$*" == *'git/refs'* ]]; then
 fi
 
 if [[ "$*" == *graphql* ]]; then
-    cat >/dev/null
+    cat >"$TEST_SCENARIO_DIR/graphql-input"
     printf '{"data":{"createCommitOnBranch":{"commit":{"oid":"2222222222222222222222222222222222222222","url":"https://example.test/c"}}}}\n'
     exit 0
 fi
@@ -468,6 +796,7 @@ EOF
         TEST_SCENARIO_DIR="$scenario_dir" \
         GH_AUTO_MERGE_RESULT="$auto_merge_result" \
         GH_MERGE_STATE="$merge_state" \
+        GH_FREEZE_BEFORE_MERGE="$freeze_before_merge" \
         "${auto_merge_env[@]}" \
         GITHUB_REPOSITORY=example/upgrade-test \
         BUMP_TARGET=values.yml#image.tag \
@@ -525,11 +854,18 @@ EOF
         exit 1
     fi
 
+    if [[ "$freeze_before_merge" == "true" && "$output" != *'disarming auto-merge'* ]]; then
+        printf 'expected %s to explain that auto-merge was disarmed, got:\n%s\n' "$test_name" "$output" >&2
+        rm -rf "$scenario_dir"
+        exit 1
+    fi
+
     rm -rf "$scenario_dir"
     printf '%s test passed\n' "$test_name"
 }
 
-run_auto_merge_test 'plan auto merge success' true success CLEAN 0 true false false false
-run_auto_merge_test 'plan clean auto merge fallback' true failure CLEAN 0 true true true false
-run_auto_merge_test 'plan non-clean auto merge failure' true failure DIRTY 1 true true false true
-run_auto_merge_test 'plan auto merge disabled' false success CLEAN 0 false false false false
+run_auto_merge_test 'plan auto merge success' true success CLEAN 0 true false false false false
+run_auto_merge_test 'plan clean auto merge fallback' true failure CLEAN 0 true true true false false
+run_auto_merge_test 'plan non-clean auto merge failure' true failure DIRTY 1 true true false true false
+run_auto_merge_test 'plan auto merge disabled' false success CLEAN 0 false false false false false
+run_auto_merge_test 'plan freeze before auto merge' true success CLEAN 0 false false false false true


### PR DESCRIPTION
The upgrade planner can move a version pin backwards without anyone asking it to. It did on 2026-08-20: a self-hosted fleet default tag went back nine minor versions, and a second pin went back one. Nothing reached an instance, because the deploy job was cancelled by hand within seconds.

## What breaks

The planner reads the version file when the job starts. It commits minutes later, against a parent it reads fresh at commit time. Anything another writer changed in between is overwritten with the old value.

The planner only ever edits one key. Every other key rides along at whatever value it had when the job started.

## Why the existing guard did not catch it

The commit goes through `createCommitOnBranch` with `expectedHeadOid`. That guards the branch ref, not the content the edit came from, and the script force-points the branch at that same sha a few lines earlier. It can never fail.

The no-op guard has the same shape. It compares the stale copy against itself, so it cannot see that the target value already landed.

The retry was worse. It read the new branch head and sent the same stale bytes again.

## The change

The commit phase is now a bounded loop. Each attempt:

1. reads the base sha
2. fetches the file at that exact sha
3. runs every guard against that content
4. edits one key and commits with `expectedHeadOid` set to the same sha

A lost race re-derives everything from a new base. It never replays a payload.

New guards:

- refuse to lower a pin
- abort and replan when the target key moves while the safety gate runs, because the verdict no longer matches the from-version
- re-check the freeze before the commit and before auto-merge. It was checked once, about 30 minutes earlier

Guards now run before any branch mutation, so a no-op no longer leaves an orphan branch.

## A detail worth flagging

The fetched copy needs a relative path, because `bump-target.py` rejects absolute ones. It also needs to keep its extension, because `bump-target.py` picks YAML or JSON by suffix. Both constraints land on the same filename and are enforced in different places. There is a test for the JSON case.

## Tests

`plan.test.sh` goes from 10 to 18 scenarios. The new ones:

- stale checkout no longer clobbers an unrelated key (reproduces this incident)
- JSON bump target round-trips
- already pinned on fresh main is a no-op, with no branch and no commit
- refuses to lower a pin
- aborts when the target key moves mid-plan
- a retry re-derives from a fresh base rather than replaying
- freeze armed mid-run stops the commit
- retry exhaustion fails without opening a PR

The suite needs bash 5. macOS system bash 3.2 has no `mapfile` and cannot run it.

Both new regression tests were mutation-tested: swapping the fresh blob for the stale one fails the clobber test, and removing the suffix handling fails the JSON test.

Linear: SPK-1182