### PR TITLE
fix(dashboards): make filter auto-apply tab-aware when adding tiles

### DIFF
--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -1,3 +1,4 @@
+import { DashboardTileTypes } from '../types/dashboard';
 import { DimensionType, FieldType } from '../types/field';
 import {
     FilterGroupOperator,
@@ -20,6 +21,7 @@ import {
     applyDashboardFiltersForTile,
     createFilterRuleFromField,
     createFilterRuleFromModelRequiredFilterRule,
+    excludeTilesFromTabScopedFilters,
     getDashboardFilterRulesForTileAndReferences,
     getFilterExpression,
     getFilterRuleFromFieldWithDefaultValue,
@@ -2418,4 +2420,147 @@ describe('createFilterRuleFromField — quick filter operator per field type', (
             });
         },
     );
+});
+
+describe('excludeTilesFromTabScopedFilters', () => {
+    const TAB_1 = 'tab-1';
+    const TAB_2 = 'tab-2';
+    const chartTile = (uuid: string, tabUuid?: string) => ({
+        uuid,
+        type: DashboardTileTypes.SAVED_CHART,
+        tabUuid,
+    });
+    const markdownTile = (uuid: string, tabUuid: string) => ({
+        uuid,
+        type: DashboardTileTypes.MARKDOWN,
+        tabUuid,
+    });
+    const rule = (
+        id: string,
+        tileTargets?: DashboardFilterRule['tileTargets'],
+    ): DashboardFilterRule => ({
+        id,
+        label: undefined,
+        target: { fieldId: 'orders_status', tableName: 'orders' },
+        operator: FilterOperator.EQUALS,
+        values: ['completed'],
+        ...(tileTargets ? { tileTargets } : {}),
+    });
+    const filters = (
+        dimensions: DashboardFilterRule[],
+        metrics: DashboardFilterRule[] = [],
+    ): DashboardFilters => ({ dimensions, metrics, tableCalculations: [] });
+
+    it('excludes a new tile from a filter that excludes every chart tile on its tab', () => {
+        const existing = [chartTile('t1', TAB_1), chartTile('t2', TAB_2)];
+        const scopedToTab2 = rule('f1', { t1: false });
+        const result = excludeTilesFromTabScopedFilters(
+            filters([scopedToTab2]),
+            [chartTile('new-tile', TAB_1)],
+            existing,
+        );
+        expect(result.dimensions[0].tileTargets).toEqual({
+            t1: false,
+            'new-tile': false,
+        });
+    });
+
+    it('keeps auto-apply for a filter that targets at least one chart tile on the tab', () => {
+        const existing = [
+            chartTile('t1', TAB_1),
+            chartTile('t2', TAB_1),
+            chartTile('t3', TAB_2),
+        ];
+        const partiallyApplied = rule('f1', { t1: false });
+        const input = filters([partiallyApplied]);
+        const result = excludeTilesFromTabScopedFilters(
+            input,
+            [chartTile('new-tile', TAB_1)],
+            existing,
+        );
+        expect(result).toBe(input);
+    });
+
+    it('keeps auto-apply when the tab has no pre-existing chart tiles', () => {
+        const existing = [chartTile('t2', TAB_2)];
+        const scopedToTab2 = rule('f1', {});
+        const input = filters([scopedToTab2]);
+        const result = excludeTilesFromTabScopedFilters(
+            input,
+            [chartTile('new-tile', TAB_1)],
+            existing,
+        );
+        expect(result).toBe(input);
+    });
+
+    it('ignores non-chart tiles when checking whether a tab is fully excluded', () => {
+        const existing = [
+            chartTile('t1', TAB_1),
+            markdownTile('md1', TAB_1),
+            chartTile('t2', TAB_2),
+        ];
+        const scopedToTab2 = rule('f1', { t1: false });
+        const result = excludeTilesFromTabScopedFilters(
+            filters([scopedToTab2]),
+            [chartTile('new-tile', TAB_1)],
+            existing,
+        );
+        expect(result.dimensions[0].tileTargets).toEqual({
+            t1: false,
+            'new-tile': false,
+        });
+    });
+
+    it('does nothing for new tiles without a tab', () => {
+        const existing = [chartTile('t1', TAB_1)];
+        const input = filters([rule('f1', { t1: false })]);
+        const result = excludeTilesFromTabScopedFilters(
+            input,
+            [chartTile('new-tile', undefined)],
+            existing,
+        );
+        expect(result).toBe(input);
+    });
+
+    it('applies the same inference to metric filters', () => {
+        const existing = [chartTile('t1', TAB_1), chartTile('t2', TAB_2)];
+        const metricScopedToTab2 = rule('m1', { t1: false });
+        const result = excludeTilesFromTabScopedFilters(
+            filters([], [metricScopedToTab2]),
+            [chartTile('new-tile', TAB_1)],
+            existing,
+        );
+        expect(result.metrics[0].tileTargets).toEqual({
+            t1: false,
+            'new-tile': false,
+        });
+    });
+
+    it('handles each new tile against its own tab', () => {
+        const existing = [chartTile('t1', TAB_1), chartTile('t2', TAB_2)];
+        const scopedToTab1 = rule('f1', { t2: false });
+        const result = excludeTilesFromTabScopedFilters(
+            filters([scopedToTab1]),
+            [chartTile('new-1', TAB_1), chartTile('new-2', TAB_2)],
+            existing,
+        );
+        expect(result.dimensions[0].tileTargets).toEqual({
+            t2: false,
+            'new-2': false,
+        });
+    });
+
+    it('treats a mapped tile target as applied, not excluded', () => {
+        const existing = [chartTile('t1', TAB_1)];
+        const mappedOnTab1 = rule('f1', {
+            t1: { fieldId: 'orders_status', tableName: 'orders' },
+        });
+        const input = filters([mappedOnTab1]);
+        const result = excludeTilesFromTabScopedFilters(
+            input,
+            [chartTile('new-tile', TAB_1)],
+            existing,
+        );
+        expect(result).toBe(input);
+    });
 });

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -496,6 +496,72 @@ export const isTileFilterable = (tile: DashboardTile) =>
         DashboardTileTypes.DATA_APP,
     ].includes(tile.type);
 
+const isChartTile = (tile: Pick<DashboardTile, 'type'>): boolean =>
+    tile.type === DashboardTileTypes.SAVED_CHART ||
+    tile.type === DashboardTileTypes.SQL_CHART;
+
+/**
+ * Tab scoping is emulated by excluding (`tileTargets[uuid] = false`) every
+ * chart tile on the other tabs, so a newly added tile — absent from every
+ * tileTargets — auto-applies filters that were scoped away from its tab.
+ * Infer the tab scope instead: when a filter already excludes every chart
+ * tile on the new tile's tab, exclude the new tile too. Tabs with no chart
+ * tiles keep the auto-apply default (there is no configuration to infer from).
+ */
+export const excludeTilesFromTabScopedFilters = (
+    dashboardFilters: DashboardFilters,
+    newTiles: Array<Pick<DashboardTile, 'uuid' | 'type' | 'tabUuid'>>,
+    existingTiles: Array<Pick<DashboardTile, 'uuid' | 'type' | 'tabUuid'>>,
+): DashboardFilters => {
+    const newChartTiles = newTiles.filter(
+        (tile) => isChartTile(tile) && tile.tabUuid,
+    );
+    if (newChartTiles.length === 0) return dashboardFilters;
+
+    const existingChartTileUuidsByTab = existingTiles
+        .filter((tile) => isChartTile(tile) && tile.tabUuid)
+        .reduce<Record<string, string[]>>((acc, tile) => {
+            acc[tile.tabUuid!] = [...(acc[tile.tabUuid!] ?? []), tile.uuid];
+            return acc;
+        }, {});
+
+    let hasChanges = false;
+    const excludeFromRules = (rules: DashboardFilterRule[]) =>
+        rules.map((rule) => {
+            const excludedTiles = newChartTiles.filter((tile) => {
+                const tabTileUuids =
+                    existingChartTileUuidsByTab[tile.tabUuid!] ?? [];
+                return (
+                    tabTileUuids.length > 0 &&
+                    tabTileUuids.every(
+                        (uuid) => rule.tileTargets?.[uuid] === false,
+                    )
+                );
+            });
+            if (excludedTiles.length === 0) return rule;
+            hasChanges = true;
+            return {
+                ...rule,
+                tileTargets: {
+                    ...rule.tileTargets,
+                    ...Object.fromEntries(
+                        excludedTiles.map((tile) => [
+                            tile.uuid,
+                            false as const,
+                        ]),
+                    ),
+                },
+            };
+        });
+
+    const next: DashboardFilters = {
+        dimensions: excludeFromRules(dashboardFilters.dimensions),
+        metrics: excludeFromRules(dashboardFilters.metrics),
+        tableCalculations: excludeFromRules(dashboardFilters.tableCalculations),
+    };
+    return hasChanges ? next : dashboardFilters;
+};
+
 const getDefaultTileTargets = (
     field: FilterableDimension | Metric | Field,
     availableTileFilters: Record<

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     copyDateZoomTileTargets,
+    excludeTilesFromTabScopedFilters,
     getShadowedReservedNames,
     isEmptyDateZoomConfig,
     normalizeDateZoomConfig,
@@ -8,6 +9,7 @@ import {
     removeDateZoomTileTargets,
     ContentType,
     DateGranularity,
+    type DashboardFilterRule,
     type UpdateDashboard,
     type DashboardTile,
     type Dashboard as IDashboard,
@@ -472,24 +474,32 @@ const Dashboard: FC = () => {
             // original.
             if (tileUuidMapping && Object.keys(tileUuidMapping).length > 0) {
                 setDashboardFilters((prev) => {
-                    const updatedDimensions = prev.dimensions.map((filter) => {
-                        if (!filter.tileTargets) return filter;
-                        const nextTileTargets = { ...filter.tileTargets };
-                        let changed = false;
-                        for (const [newUuid, oldUuid] of Object.entries(
-                            tileUuidMapping,
-                        )) {
-                            if (oldUuid in nextTileTargets) {
-                                nextTileTargets[newUuid] =
-                                    nextTileTargets[oldUuid];
-                                changed = true;
+                    const remapRules = <T extends DashboardFilterRule>(
+                        rules: T[],
+                    ): T[] =>
+                        rules.map((filter) => {
+                            if (!filter.tileTargets) return filter;
+                            const nextTileTargets = { ...filter.tileTargets };
+                            let changed = false;
+                            for (const [newUuid, oldUuid] of Object.entries(
+                                tileUuidMapping,
+                            )) {
+                                if (oldUuid in nextTileTargets) {
+                                    nextTileTargets[newUuid] =
+                                        nextTileTargets[oldUuid];
+                                    changed = true;
+                                }
                             }
-                        }
-                        return changed
-                            ? { ...filter, tileTargets: nextTileTargets }
-                            : filter;
-                    });
-                    return { ...prev, dimensions: updatedDimensions };
+                            return changed
+                                ? { ...filter, tileTargets: nextTileTargets }
+                                : filter;
+                        });
+                    return {
+                        ...prev,
+                        dimensions: remapRules(prev.dimensions),
+                        metrics: remapRules(prev.metrics),
+                        tableCalculations: remapRules(prev.tableCalculations),
+                    };
                 });
                 setHaveFiltersChanged(true);
 
@@ -508,6 +518,19 @@ const Dashboard: FC = () => {
                 if (nextDateZoomConfig !== dateZoomConfig) {
                     setDateZoomConfig(nextDateZoomConfig);
                 }
+            } else if (dashboardTiles) {
+                // Tab-aware auto-apply: a filter that already excludes every
+                // chart tile on the target tab is scoped away from that tab,
+                // so exclude the newly added tiles from it too.
+                const scopedFilters = excludeTilesFromTabScopedFilters(
+                    dashboardFilters,
+                    newTiles,
+                    dashboardTiles,
+                );
+                if (scopedFilters !== dashboardFilters) {
+                    setDashboardFilters(() => scopedFilters);
+                    setHaveFiltersChanged(true);
+                }
             }
         },
         [
@@ -517,6 +540,8 @@ const Dashboard: FC = () => {
             setDashboardTiles,
             setHaveTilesChanged,
             setHaveTabsChanged,
+            dashboardFilters,
+            dashboardTiles,
             setDashboardFilters,
             setHaveFiltersChanged,
             dateZoomConfig,


### PR DESCRIPTION
## Problem

On a multi-tab dashboard where each tab has its own tab-scoped filter, adding a new saved-chart tile to any tab attaches **every** tab's filters to it. Tab scoping is emulated by writing `tileTargets[tileUuid] = false` for the tiles on other tabs at configuration time, so a brand-new tile — absent from every filter's `tileTargets` — falls into the auto-apply default everywhere. Where filters share a field, the new tile is queried with a stack of contradictory values; each new tile then needs a manual un-check pass across every other tab's filter.

The auto-apply default itself is correct (PROD-4835) — the gap is that it knows nothing about the tab scoping that `tileTargets` is also being used to express.

## Fix

Make the auto-apply decision tab-aware when tiles are added (the MVP from the ticket): a new helper `excludeTilesFromTabScopedFilters` infers tab scope from the existing config — if a filter already excludes **every** chart tile on the target tab, the new tile is excluded too (`tileTargets[newTileUuid] = false`); otherwise auto-apply behaves exactly as before. Tabs with no chart tiles, untabbed dashboards, and duplicate-tile flows (which have their own `tileUuidMapping` repair) are untouched. The inference can only fall back to today's behaviour, never wrongly exclude: it considers exactly the tile set the filter-config UI writes exclusions for.

Also extends the existing duplicate-tile `tileTargets` remap to metric and table-calculation filters (previously only dimensions), per the ticket's scope note.

## Verification

- 8 new unit tests for the helper in `filters.test.ts` (exclusion, partial-targeting, empty tab, untabbed, non-chart tiles, metric filters, per-tab independence, mapped targets).
- Reproduced end-to-end on a local stack first: 3-tab dashboard, one tile per tab, three same-field filters each scoped to one tab. Adding a chart to tab 3 via the UI attached all three filters (persisted: new tile absent from every `tileTargets`). After the fix, the same flow shows only tab 3's filter; persisted state has `tileTargets[newTile] = false` for the two other tabs' filters and leaves tab 3's own filter on auto — so it still applies to the new tile (no PROD-4835 regression).

Closes: PROD-10299
Closes: #27609

🤖 Generated with [Claude Code](https://claude.com/claude-code)