### PR TITLE
fix(scim): run last-admin guard before deactivating a user

### DIFF
--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -1088,6 +1088,11 @@ describe('ScimService', () => {
                     ScimServiceArgumentsMock.groupsModel
                         .removeUserFromAllGroups,
                 ).not.toHaveBeenCalled();
+                // the guard must fire BEFORE the user row is touched — a
+                // refused deactivation may not flip is_active (partial write)
+                expect(
+                    ScimServiceArgumentsMock.userModel.updateUser,
+                ).not.toHaveBeenCalled();
             });
         });
 

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -1088,8 +1088,8 @@ describe('ScimService', () => {
                     ScimServiceArgumentsMock.groupsModel
                         .removeUserFromAllGroups,
                 ).not.toHaveBeenCalled();
-                // the guard must fire BEFORE the user row is touched — a
-                // refused deactivation may not flip is_active (partial write)
+                // guard must fire before user row is touched
+
                 expect(
                     ScimServiceArgumentsMock.userModel.updateUser,
                 ).not.toHaveBeenCalled();

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -775,6 +775,27 @@ export class ScimService extends BaseService {
                     organizationUuid,
                     userUuid,
                 );
+            // Deactivation clears the user's roles. Run the demotion (and its
+            // last-admin guard) before touching the user row so a refused
+            // deactivation leaves the account fully untouched.
+            if (user.active === false && dbUser.isActive) {
+                // The model refuses to demote the organization's last active admin.
+                await this.rolesModel.setUserOrgAndProjectRoles(
+                    organizationUuid,
+                    userUuid,
+                    OrganizationMemberRole.MEMBER,
+                    [],
+                    false,
+                );
+                this.logger.info(
+                    'SCIM: Reset organization and project roles for inactive user',
+                    {
+                        userUuid,
+                        organizationUuid,
+                    },
+                );
+            }
+
             // update user
             const updatedUser = await this.userModel.updateUser(
                 dbUser.userUuid,
@@ -838,25 +859,7 @@ export class ScimService extends BaseService {
                 });
             }
 
-            // If setting user to inactive, drop org role to MEMBER and remove project roles.
-            // Deactivating the last active admin would leave the organization unmanageable.
             if (user.active === false) {
-                // The model refuses to demote the organization's last active admin.
-                await this.rolesModel.setUserOrgAndProjectRoles(
-                    organizationUuid,
-                    userUuid,
-                    OrganizationMemberRole.MEMBER,
-                    [],
-                    false,
-                );
-                this.logger.info(
-                    'SCIM: Reset organization and project roles for inactive user',
-                    {
-                        userUuid,
-                        organizationUuid,
-                    },
-                );
-
                 // Remove user from all groups in the organization when deactivated
                 try {
                     const groupsCount =

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -472,12 +472,16 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
                                     disabled={u.hasProjectRole}
                                     multiline
                                     w={
-                                        u.isMember && !u.hasProjectRole
+                                        u.highestRole ===
+                                            OrganizationMemberRole.MEMBER &&
+                                        !u.hasProjectRole
                                             ? 280
                                             : undefined
                                     }
                                     label={
-                                        u.isMember && !u.hasProjectRole ? (
+                                        u.highestRole ===
+                                            OrganizationMemberRole.MEMBER &&
+                                        !u.hasProjectRole ? (
                                             <Text fz="xs">
                                                 <Text fw={600} fz="xs">
                                                     Members have no access to


### PR DESCRIPTION
Related to PROD-9762 (multiple roles). Found during a 50-scenario test sweep of the multiple-roles rollout.

## Bug

`ScimService.updateUser` handled `active: false` by updating the user row (`is_active = false`) **first** and only afterwards running the role demotion whose model-level guard protects the organization's last active admin. When the guard refused (sole admin), the request returned `403 "Organization must have at least one admin"` — but the user row stayed deactivated. Result: the org is left with **zero active admins** while the IdP is told the operation failed. Reproduced live via SCIM `PATCH { active: false }` against a sole admin.

`DELETE /Users/{id}` was already safe (pre-checks admins before deleting); the legacy demote endpoints and the v2 role-set endpoints are also unaffected (guard runs inside the model write).

## Fix

Move the deactivation's role reset (`setUserOrgAndProjectRoles → MEMBER`, whose model guard row-locks and refuses on last admin) **before** `userModel.updateUser`. A refused deactivation now leaves the account fully untouched; the allowed path is behaviourally identical (verified live: sole admin → 403 + `is_active=t, role=admin`; with a second admin → 200 + `f|member`).

Strengthened the existing "deactivating the last admin through SCIM is blocked" test to assert `userModel.updateUser` is never called — the exact assertion that would have caught this.

Also included (one-liner, same test sweep): the project access page tooltip for members whose access comes from a group now shows "User inherits this role from Group X" instead of "Members have no access…", matching the role cell placeholder.

## Tests
- ScimService suite: 79 pass (incl. strengthened last-admin test)
- ProjectAccess/roleSets frontend suites pass; typecheck + lint green
- Live verification on a seeded dev instance (both negative and positive deactivate paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)