### PR TITLE
fix(bigquery): use prunable timezone date expressions

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -8273,6 +8273,42 @@ describe('Session-independent explicit path (per-column, no session pin)', () =>
         );
     });
 
+    test('BigQuery known-aware day grain emits the prunable DATE(col, tz) in SELECT and filter LHS', () => {
+        const explore = buildNaiveExplore(
+            SupportedDbtAdapter.BIGQUERY,
+            'aware',
+        );
+        const args = gateArgs(
+            SupportedDbtAdapter.BIGQUERY,
+            bigqueryClientMock,
+            explore,
+        );
+        const { query } = buildQuery({
+            ...args,
+            compiledMetricQuery: {
+                ...args.compiledMetricQuery,
+                filters: filterOn('events_occurred_at_day'),
+            },
+        });
+        const prunable = `DATE("events".occurred_at, 'Asia/Tokyo')`;
+        // Selected dim and filter LHS both carry the direct prunable form.
+        expect(query.split(prunable).length - 1).toBeGreaterThanOrEqual(2);
+        expect(query).not.toContain('DATETIME_TRUNC');
+    });
+
+    test('BigQuery unknown-domain day grain keeps the DATETIME round-trip', () => {
+        const { query } = buildQuery(
+            gateArgs(
+                SupportedDbtAdapter.BIGQUERY,
+                bigqueryClientMock,
+                buildNaiveExplore(SupportedDbtAdapter.BIGQUERY),
+            ),
+        );
+        expect(query).toContain(
+            `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP("events".occurred_at), 'Asia/Tokyo'), DAY) AS DATE)`,
+        );
+    });
+
     test('unknown domains stay byte-identical to a no-domain compile (Trino)', () => {
         const explore = buildNaiveExplore(SupportedDbtAdapter.TRINO);
         const { query } = buildQuery(

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -908,7 +908,7 @@ describe('TimeFrames', () => {
                 );
             });
 
-            test('tz-wrapped path is unchanged (never pruned, stays as-is)', () => {
+            test('tz-wrapped path with unknown domain keeps the DATETIME round-trip', () => {
                 expect(
                     getSqlForTruncatedDate(
                         SupportedDbtAdapter.BIGQUERY,
@@ -940,6 +940,93 @@ describe('TimeFrames', () => {
                         true,
                     ),
                 ).toEqual(`CAST(DATE_TRUNC('DAY', ${col}) AS DATE)`);
+            });
+        });
+
+        // Wrapped aware path: DATE(ts, tz) is by definition the calendar date
+        // of the instant in tz — same value as the DATETIME round-trip, but
+        // the partition pruner can see through it.
+        describe('BigQuery prunable tz-wrapped trunc for known-aware columns', () => {
+            const bqAwareTrunc = (
+                timeFrame: TimeFrames,
+                startOfWeek: WeekDay | null = null,
+            ) =>
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.BIGQUERY,
+                    timeFrame,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    startOfWeek,
+                    tz,
+                    undefined,
+                    'aware',
+                    true, // castDayOrCoarserToDate
+                );
+
+            test('day grain emits DATE(col, tz)', () => {
+                expect(bqAwareTrunc(TimeFrames.DAY)).toEqual(
+                    `DATE(${col}, '${tz}')`,
+                );
+            });
+
+            test('month/quarter/year grains emit DATE_TRUNC(DATE(col, tz), part)', () => {
+                expect(bqAwareTrunc(TimeFrames.MONTH)).toEqual(
+                    `DATE_TRUNC(DATE(${col}, '${tz}'), MONTH)`,
+                );
+                expect(bqAwareTrunc(TimeFrames.QUARTER)).toEqual(
+                    `DATE_TRUNC(DATE(${col}, '${tz}'), QUARTER)`,
+                );
+                expect(bqAwareTrunc(TimeFrames.YEAR)).toEqual(
+                    `DATE_TRUNC(DATE(${col}, '${tz}'), YEAR)`,
+                );
+            });
+
+            test('week grain keeps the custom start of week', () => {
+                expect(bqAwareTrunc(TimeFrames.WEEK, WeekDay.TUESDAY)).toEqual(
+                    `DATE_TRUNC(DATE(${col}, '${tz}'), WEEK(TUESDAY))`,
+                );
+            });
+
+            test('sub-day grain keeps the DATETIME round-trip', () => {
+                expect(bqAwareTrunc(TimeFrames.HOUR)).toEqual(
+                    `TIMESTAMP(DATETIME_TRUNC(DATETIME(TIMESTAMP(${col}), '${tz}'), HOUR), '${tz}')`,
+                );
+            });
+
+            test('naive domain keeps the rebased round-trip', () => {
+                expect(
+                    getSqlForTruncatedDate(
+                        SupportedDbtAdapter.BIGQUERY,
+                        TimeFrames.DAY,
+                        col,
+                        DimensionType.TIMESTAMP,
+                        null,
+                        tz,
+                        'Asia/Tokyo',
+                        'naive',
+                        true,
+                    ),
+                ).toEqual(
+                    `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP(${col}, 'Asia/Tokyo'), '${tz}'), DAY) AS DATE)`,
+                );
+            });
+
+            test('non-BigQuery adapters keep the generic wrapped cast', () => {
+                expect(
+                    getSqlForTruncatedDate(
+                        SupportedDbtAdapter.POSTGRES,
+                        TimeFrames.DAY,
+                        col,
+                        DimensionType.TIMESTAMP,
+                        null,
+                        tz,
+                        undefined,
+                        'aware',
+                        true,
+                    ),
+                ).toEqual(
+                    `CAST(DATE_TRUNC('DAY', (${col})::timestamptz AT TIME ZONE '${tz}') AS DATE)`,
+                );
             });
         });
 

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -76,6 +76,16 @@ type WarehouseConfig = {
         type: DimensionType,
         startOfWeek?: WeekDay | null,
     ) => string;
+    // Timezone-wrapped variant of the above for known-aware columns: returns a
+    // DATE in `timezone` directly, skipping the conversion round-trip that
+    // defeats partition pruning (BigQuery only).
+    getSqlForTruncatedDateAsDateInTimezone?: (
+        timeFrame: TimeFrames,
+        originalSql: string,
+        type: DimensionType,
+        startOfWeek: WeekDay | null | undefined,
+        timezone: string,
+    ) => string;
     getSqlForDatePart: (
         timeFrame: TimeFrames,
         originalSql: string,
@@ -515,6 +525,21 @@ const bigqueryConfig: WarehouseConfig = {
                 : `DATE_TRUNC(DATE(${originalSql}), ${datePart})`;
         }
         return `DATE_TRUNC(${originalSql}, ${datePart})`;
+    },
+    // DATE(ts, tz) is by definition the calendar date of the instant in tz —
+    // same value as CAST(DATETIME_TRUNC(DATETIME(ts, tz), ...) AS DATE), but
+    // the pruner can see through it.
+    getSqlForTruncatedDateAsDateInTimezone: (
+        timeFrame,
+        originalSql,
+        _type,
+        startOfWeek,
+        timezone,
+    ) => {
+        const datePart = bigqueryDatePart(timeFrame, startOfWeek);
+        return timeFrame === TimeFrames.DAY
+            ? `DATE(${originalSql}, '${timezone}')`
+            : `DATE_TRUNC(DATE(${originalSql}, '${timezone}'), ${datePart})`;
     },
     getSqlForDatePart: (
         timeFrame: TimeFrames,
@@ -1096,6 +1121,24 @@ export const getSqlForTruncatedDate = (
             originalSql,
             type,
             startOfWeek,
+        );
+    }
+
+    // Known-aware columns can truncate to a DATE in the target tz directly
+    // where the adapter defines a prunable form (BigQuery, GLITCH-628).
+    const truncatedDateAsDateInTimezone =
+        warehouseConfigs[adapterType].getSqlForTruncatedDateAsDateInTimezone;
+    if (
+        castToDate &&
+        wrap.timestampDomain === 'aware' &&
+        truncatedDateAsDateInTimezone
+    ) {
+        return truncatedDateAsDateInTimezone(
+            timeFrame,
+            originalSql,
+            type,
+            startOfWeek,
+            wrap.timezone,
         );
     }
 


### PR DESCRIPTION
### Status

**Draft research candidate B — not selected for merge.** This PR tests a direct BigQuery expression swap as an alternative to the redundant filter mirror in #27678.

### Description

- Add a warehouse-specific time-frame hook for timezone-aware, known-`TIMESTAMP`, day-or-coarser dimensions.
- Render the local calendar value directly as:
  - day: `DATE(column, timezone)`
  - week/month/quarter/year: `DATE_TRUNC(DATE(column, timezone), grain)`
- Keep the existing `DATETIME` round-trip for sub-day grains and naive or unknown timestamp domains.
- Keep every non-BigQuery adapter unchanged.

This produces the same local calendar date as the existing timezone round-trip for aware instants, but gives BigQuery an expression that pruned the physical timestamp partition and passed `require_partition_filter` in the live verification matrix.

### Important trade-offs

- This is a single-predicate design: there is no duplicate condition that can drift from the semantic predicate.
- The seam is shared time-frame rendering, so the new expression also affects SELECT/GROUP BY and eligible relative-date filters rather than only one filter path.
- That broader leverage is also the main risk: an equivalence mistake would change rendered dimension semantics, not only pruning.
- `DATE(column, timezone)` and nested `DATE_TRUNC(DATE(...), grain)` pruned in live tests, but the exact nested forms are not all stated as guaranteed partition-pruning forms in BigQuery's documentation.
- Function-wrapped expressions are not the documented shape for clustered-table block pruning.
- The branch contains focused common-package SQL-shape tests. The deployable fixture and API harness currently live in #27678 and would need to be rebased or extracted before this candidate could ship independently.

### Verification completed on this candidate

- 3,621 common tests and 7,499 backend tests passed on the prototype before its rebase onto current `main`; no existing SQL expectation changed.
- Focused tests cover day/week/month/quarter/year, custom week starts, sub-day fallback, naive-domain fallback, and non-BigQuery fallback.
- Live BigQuery verification on the shared day-partitioned fixtures showed semantic parity and the same bytes as candidate A:
  - day: 144 bytes
  - week: 208 bytes
  - month: 240 bytes
  - quarter: 336 bytes
  - year: 512 bytes
- The expressions passed `require_partition_filter = TRUE` and matched the existing semantic predicate through New York and Santiago DST transitions, including a skipped local midnight.

### Comparison candidate

- #27678 retains the current predicate and adds a filter-side `TIMESTAMP_TRUNC` mirror, plus the deployable fixture and API regression harness.
- The current research preference is a third shape: keep this PR's DATE-domain expression but apply it only at the filter-rendering seam. That preserves the single-predicate design and relative-window coverage without changing SELECT/GROUP BY SQL.

### Risk assessment

- [ ] This is a high-risk change

The code is narrowly adapter-, grain-, and timestamp-domain-gated and falls back to the existing renderer elsewhere. It remains an experimental candidate until we decide whether optimizer behavior that is live-verified but not fully documented is an acceptable production contract.
