### PR TITLE
feat: export Agent chart artifacts as images

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/ExportImageModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/ExportImageModal.tsx
@@ -1,6 +1,7 @@
 import { IconPhoto } from '@tabler/icons-react';
 import { useCallback, type FC, type RefObject } from 'react';
 import ChartDownloadOptions from '../common/ChartDownload/ChartDownloadOptions';
+import { type DownloadType } from '../common/ChartDownload/chartDownloadUtils';
 import MantineModal from '../common/MantineModal';
 import { type EChartsReact } from '../EChartsReactWrapper';
 
@@ -9,6 +10,7 @@ interface ExportImageModalProps {
     chartName?: string;
     isOpen: boolean;
     onClose: () => void;
+    unavailableOptions?: DownloadType[];
 }
 
 const ExportImageModal: FC<ExportImageModalProps> = ({
@@ -16,6 +18,7 @@ const ExportImageModal: FC<ExportImageModalProps> = ({
     chartName,
     isOpen,
     onClose,
+    unavailableOptions,
 }) => {
     const getChartInstance = useCallback(
         () => echartRef?.current?.getEchartsInstance(),
@@ -35,6 +38,7 @@ const ExportImageModal: FC<ExportImageModalProps> = ({
             <ChartDownloadOptions
                 getChartInstance={getChartInstance}
                 chartName={chartName}
+                unavailableOptions={unavailableOptions}
             />
         </MantineModal>
     );

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadOptions.test.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadOptions.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import ChartDownloadOptions from './ChartDownloadOptions';
+
+const showToastError = vi.fn();
+
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastError }),
+}));
+
+describe('ChartDownloadOptions', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('reports copy and download failures when the chart is unavailable', () => {
+        renderWithProviders(
+            <ChartDownloadOptions getChartInstance={() => undefined} />,
+        );
+
+        const [copyButton] = screen.getAllByRole('button');
+        fireEvent.click(copyButton);
+        fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+
+        expect(showToastError).toHaveBeenNthCalledWith(1, {
+            title: 'Unable to copy chart image',
+        });
+        expect(showToastError).toHaveBeenNthCalledWith(2, {
+            title: 'Unable to download chart image',
+        });
+        expect(document.querySelector('.tabler-icon-check')).toBeNull();
+    });
+
+    it('keeps the selected format when it is selected again', async () => {
+        renderWithProviders(
+            <ChartDownloadOptions getChartInstance={() => undefined} />,
+        );
+
+        const formatSelect = screen.getByRole('textbox');
+        await userEvent.click(formatSelect);
+        await userEvent.click(
+            await screen.findByRole('option', { name: 'PNG' }),
+        );
+
+        expect(formatSelect).toHaveValue('PNG');
+    });
+});

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadOptions.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadOptions.tsx
@@ -12,6 +12,7 @@ import {
 import { IconCheck, IconCopy, IconDownload } from '@tabler/icons-react';
 import { type PieSeriesOption } from 'echarts';
 import React, { useCallback, useState } from 'react';
+import useToaster from '../../../hooks/toaster/useToaster';
 import { copyImageToClipboard } from '../../../utils/copyImageToClipboard';
 import {
     type EChartsInstance,
@@ -119,13 +120,14 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
 }) => {
     const [isCopied, setIsCopied] = useState(false);
     const [type, setType] = useState<DownloadType>(DownloadType.PNG);
+    const { showToastError } = useToaster();
     const [isBackgroundTransparent, setIsBackgroundTransparent] =
         useState(false);
 
     const onDownload = useCallback(async () => {
         const chartInstance = getChartInstance();
         if (!chartInstance) {
-            console.error('Chart instance is not available');
+            showToastError({ title: 'Unable to download chart image' });
             return;
         }
         const { needsWorkaround, updatedOptions, originalOptions } =
@@ -147,6 +149,7 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
                         await base64SvgToBase64Image(svgBase64, width),
                         width,
                         height,
+                        chartName,
                     );
                     break;
                 case DownloadType.SVG:
@@ -181,19 +184,25 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
             }
         } catch (e) {
             console.error(`Unable to download ${type} from chart`, e);
+            showToastError({ title: 'Unable to download chart image' });
         } finally {
             // rollback workaround
             if (needsWorkaround) {
                 chartInstance.setOption(originalOptions);
             }
         }
-    }, [getChartInstance, chartName, type, isBackgroundTransparent]);
+    }, [
+        getChartInstance,
+        chartName,
+        type,
+        isBackgroundTransparent,
+        showToastError,
+    ]);
 
     const onCopyToClipboard = useCallback(async () => {
-        setIsCopied(true);
         const chartInstance = getChartInstance();
         if (!chartInstance) {
-            console.error('Chart instance is not available');
+            showToastError({ title: 'Unable to copy chart image' });
             return;
         }
 
@@ -208,13 +217,15 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
             );
             await copyImageToClipboard(base64Image);
 
+            setIsCopied(true);
             setTimeout(() => {
                 setIsCopied(false);
             }, 1000);
         } catch (e) {
             console.error('Unable to copy chart to clipboard:', e);
+            showToastError({ title: 'Unable to copy chart image' });
         }
-    }, [getChartInstance, isBackgroundTransparent]);
+    }, [getChartInstance, isBackgroundTransparent, showToastError]);
 
     return (
         <Stack>
@@ -224,6 +235,7 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
                 id="download-type"
                 value={type}
                 onChange={(value) => setType(value as DownloadType)}
+                allowDeselect={false}
                 comboboxProps={{ withinPortal: false }}
                 data={Object.values(DownloadType)
                     .filter(

--- a/packages/frontend/src/components/common/ChartDownload/chartDownloadUtils.ts
+++ b/packages/frontend/src/components/common/ChartDownload/chartDownloadUtils.ts
@@ -83,7 +83,12 @@ export function downloadJson(object: Object) {
     document.body.removeChild(link);
 }
 
-export function downloadPdf(base64: string, width: number, height: number) {
+export function downloadPdf(
+    base64: string,
+    width: number,
+    height: number,
+    name?: string,
+) {
     const padding: number = 20;
     let doc: JsPDF;
     if (width > height) {
@@ -98,5 +103,5 @@ export function downloadPdf(base64: string, width: number, height: number) {
         width,
         height,
     });
-    doc.save(FILE_NAME);
+    doc.save(name || FILE_NAME);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartImageExport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartImageExport.test.tsx
@@ -1,0 +1,54 @@
+import { Button, MantineProvider, Menu } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef, useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { type EChartsReact } from '../../../../../components/EChartsReactWrapper';
+import {
+    AiChartImageExportMenuItem,
+    AiChartImageExportModal,
+} from './AiChartImageExport';
+
+const TestImageExport = () => {
+    const [opened, setOpened] = useState(false);
+
+    return (
+        <>
+            <Menu>
+                <Menu.Target>
+                    <Button>Actions</Button>
+                </Menu.Target>
+                <Menu.Dropdown>
+                    <AiChartImageExportMenuItem
+                        onClick={() => setOpened(true)}
+                    />
+                </Menu.Dropdown>
+            </Menu>
+            <AiChartImageExportModal
+                chartRef={createRef<EChartsReact>()}
+                chartName="Orders by status"
+                opened={opened}
+                onClose={() => setOpened(false)}
+            />
+        </>
+    );
+};
+
+describe('AiChartImageExport', () => {
+    it('opens the existing image export controls', async () => {
+        render(
+            <MantineProvider>
+                <TestImageExport />
+            </MantineProvider>,
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: 'Actions' }));
+        await userEvent.click(
+            await screen.findByRole('menuitem', { name: 'Export image' }),
+        );
+
+        expect(screen.getByRole('dialog')).toBeVisible();
+        expect(screen.getByText('Export Image')).toBeVisible();
+        expect(screen.getByRole('textbox')).toHaveValue('PNG');
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartImageExport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartImageExport.tsx
@@ -1,0 +1,39 @@
+import { Menu } from '@mantine/core';
+import { IconPhoto } from '@tabler/icons-react';
+import { type FC, type RefObject } from 'react';
+import { DownloadType } from '../../../../../components/common/ChartDownload/chartDownloadUtils';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import ExportImageModal from '../../../../../components/DashboardTiles/ExportImageModal';
+import { type EChartsReact } from '../../../../../components/EChartsReactWrapper';
+
+type ModalProps = {
+    chartRef: RefObject<EChartsReact | null> | undefined;
+    chartName: string;
+    opened: boolean;
+    onClose: () => void;
+};
+
+export const AiChartImageExportMenuItem: FC<{ onClick: () => void }> = ({
+    onClick,
+}) => (
+    <Menu.Item leftSection={<MantineIcon icon={IconPhoto} />} onClick={onClick}>
+        Export image
+    </Menu.Item>
+);
+
+export const AiChartImageExportModal: FC<ModalProps> = ({
+    chartRef,
+    chartName,
+    opened,
+    onClose,
+}) => {
+    return (
+        <ExportImageModal
+            echartRef={chartRef}
+            chartName={chartName}
+            isOpen={opened}
+            onClose={onClose}
+            unavailableOptions={[DownloadType.JSON]}
+        />
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -25,6 +25,7 @@ import {
 } from '@tabler/icons-react';
 import { Fragment, useCallback, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router';
+import { CHART_TYPES_WITHOUT_IMAGE_EXPORT } from '../../../../../components/common/ChartDownload/chartDownloadUtils';
 import CodeBlock from '../../../../../components/common/CodeBlock/CodeBlock';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
@@ -61,6 +62,10 @@ import {
     remapFieldIdsDeep,
 } from '../../utils/canonicalizeAiMerge';
 import { AiChartDownloadModal } from './AiChartDownloadModal';
+import {
+    AiChartImageExportMenuItem,
+    AiChartImageExportModal,
+} from './AiChartImageExport';
 import { AiScheduleDeliveryModal } from './AiScheduleDeliveryModal';
 
 type Props = {
@@ -117,6 +122,10 @@ export const AiChartQuickOptions = ({
     const [sqlModalOpened, { open: openSqlModal, close: closeSqlModal }] =
         useDisclosure(false);
     const [
+        exportImageModalOpened,
+        { open: openExportImageModal, close: closeExportImageModal },
+    ] = useDisclosure(false);
+    const [
         downloadModalOpened,
         { open: openDownloadModal, close: closeDownloadModal },
     ] = useDisclosure(false);
@@ -138,22 +147,21 @@ export const AiChartQuickOptions = ({
             projectUuid,
         }),
     );
-    const canDownloadResults =
-        showDownloadResults &&
-        !isEmbed &&
-        user.data?.ability?.can(
-            'manage',
-            subject('ExportCsv', {
-                organizationUuid: user.data?.organizationUuid,
-                projectUuid,
-            }),
-        );
+    const canExportData = user.data?.ability?.can(
+        'manage',
+        subject('ExportCsv', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+    const canDownloadResults = showDownloadResults && !isEmbed && canExportData;
     const {
         visualizationConfig,
         columnOrder,
         resultsData,
         chartConfig,
         pivotDimensions,
+        chartRef,
     } = useVisualizationContext();
     const { mutate: savePromptQuery } = useSavePromptQuery(
         projectUuid,
@@ -175,6 +183,12 @@ export const AiChartQuickOptions = ({
     const isVerified = artifactData?.verifiedByUserUuid !== null;
 
     const isDisabled = !metricQuery || !type || !visualizationConfig;
+    const canExportImage =
+        artifactData?.artifactType === 'chart' &&
+        !isEmbed &&
+        !!type &&
+        !CHART_TYPES_WITHOUT_IMAGE_EXPORT.includes(type) &&
+        canExportData;
 
     // Renamed to the merge editor's conventions so the saved chart and the
     // explore link are indistinguishable from a merge built by hand.
@@ -492,7 +506,8 @@ export const AiChartQuickOptions = ({
         hasSavedChartAction ||
         hasSaveActions ||
         hasExploreAction ||
-        hasSqlActions;
+        hasSqlActions ||
+        canExportImage;
 
     return (
         <Fragment>
@@ -531,6 +546,11 @@ export const AiChartQuickOptions = ({
                     </Menu.Target>
                     <Menu.Dropdown>
                         <Menu.Label>Quick actions</Menu.Label>
+                        {canExportImage && (
+                            <AiChartImageExportMenuItem
+                                onClick={openExportImageModal}
+                            />
+                        )}
                         {canDownloadResults && (
                             <Menu.Item
                                 leftSection={
@@ -682,6 +702,12 @@ export const AiChartQuickOptions = ({
                     mergeQuery={merge?.query ?? null}
                 />
             )}
+            <AiChartImageExportModal
+                chartRef={chartRef}
+                chartName={saveChartOptions.name ?? 'Untitled chart'}
+                opened={exportImageModalOpened}
+                onClose={closeExportImageModal}
+            />
             {!!compiledSql && (
                 <MantineModal
                     opened={sqlModalOpened}


### PR DESCRIPTION
## Summary

- add Export image to eligible Agent chart artifacts
- reuse the live ECharts image controls for copy and PNG/JPEG/SVG/PDF downloads
- preserve title filenames, permissions, error feedback, and opaque PNG default
- prevent the format selector from clearing its current value

## Testing

- frontend Vitest: 363 files, 2,693 tests passed
- frontend typecheck passed
- Browser: reloaded a persisted Agent chart, verified formats/defaults, and executed PNG download without errors

Closes: ZAP-898
Closes: #27707