### PR TITLE
fix(ai): prevent Deep Research event schema drift

### DIFF
--- a/packages/backend/src/ee/database/migrations/20260713150100_add_ai_deep_research_events.ts
+++ b/packages/backend/src/ee/database/migrations/20260713150100_add_ai_deep_research_events.ts
@@ -1,8 +1,19 @@
-import { AI_DEEP_RESEARCH_EVENT_TYPES } from '@lightdash/common';
-import { Knex } from 'knex';
+import type { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Creates a new event table and its initial constraints.',
+} as const;
 
 const AiDeepResearchRunsTableName = 'ai_deep_research_runs';
 const AiDeepResearchEventsTableName = 'ai_deep_research_events';
+// Keep historical migrations immutable. Later event types must expand the
+// constraint in a new migration so fresh and already-deployed schemas match.
+const eventTypesAtCreation = [
+    'status_changed',
+    'cancellation_requested',
+    'progress',
+] as const;
 
 export async function up(knex: Knex): Promise<void> {
     await knex.schema.createTable(AiDeepResearchEventsTableName, (table) => {
@@ -19,7 +30,7 @@ export async function up(knex: Knex): Promise<void> {
         table
             .text('event_type')
             .notNullable()
-            .checkIn([...AI_DEEP_RESEARCH_EVENT_TYPES]);
+            .checkIn([...eventTypesAtCreation]);
         table.jsonb('payload').notNullable();
         table
             .timestamp('created_at', { useTz: false })

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -1,4 +1,5 @@
 import {
+    AI_DEEP_RESEARCH_EVENT_TYPES,
     AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
     SEED_ORG_1,
     SEED_ORG_1_ADMIN,
@@ -246,6 +247,23 @@ describe('AiDeepResearchRunModel integration', () => {
                 : eventType,
         );
     };
+
+    it('accepts every canonical Deep Research event type', async () => {
+        const run = await createRun();
+
+        await expect(
+            database(AiDeepResearchEventsTableName)
+                .insert(
+                    AI_DEEP_RESEARCH_EVENT_TYPES.map((eventType) => ({
+                        ai_deep_research_run_uuid:
+                            run.ai_deep_research_run_uuid,
+                        event_type: eventType,
+                        payload: {},
+                    })),
+                )
+                .returning('event_type'),
+        ).resolves.toHaveLength(AI_DEEP_RESEARCH_EVENT_TYPES.length);
+    });
 
     it('rejects research after standard execution claims the prompt', async () => {
         const standardPromptUuid = await createAdditionalPrompt();


### PR DESCRIPTION
Closes: No linked issue

## Summary

PR 1 of 3 prevents Deep Research event-type drift between application code and deployed databases. It freezes the historical event constraint and adds an integration contract that fails when a canonical event type lacks a schema migration.

## Changes

- Replaces the live application constant in the original events migration with its historical three-value schema snapshot.
- Inserts every canonical event type against a fully migrated integration database.
- Keeps later event additions, including `report_adjusted`, dependent on explicit constraint migrations.

```
canonical event types
        ↓
integration insert ──→ migrated CHECK constraint
        ↓                         ↓
       pass              drift fails before release
```

## Test plan

- [x] Fresh database migration sequence
- [x] `AiDeepResearchRunModel.integration.test.ts` (28 tests)
- [x] Backend lint and typecheck

