### PR TITLE
fix(ai): stop repeated Deep Research query errors

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
@@ -5,6 +5,7 @@ import {
     DEEP_RESEARCH_RESOURCE_RECOVERY_ATTEMPTS,
     INVALID_INPUT_CAP,
     QUERY_TOOL_NAMES,
+    REPEATED_QUERY_ERROR_CAP,
     WAREHOUSE_ERROR_CAP,
     WAREHOUSE_SLOW_CAP,
 } from './queryRetryCap';
@@ -101,6 +102,61 @@ describe('query retry cap', () => {
         const override = turn.override();
         expect(override?.activeTools).toEqual([NON_QUERY_TOOL]);
         expect(override?.nudge.toLowerCase()).toContain('do not run it again');
+    });
+
+    it('stops Deep Research after the same runtime query error repeats', () => {
+        const turn = makeTurn();
+        times(REPEATED_QUERY_ERROR_CAP, () =>
+            turn.failure(
+                'generateVisualization',
+                'Error running query. Unknown field orders_is_corrupted',
+            ),
+        );
+
+        const override = turn.override('deep_research');
+
+        expect(override?.activeTools).toEqual([NON_QUERY_TOOL]);
+        expect(override?.nudge).toContain('Unknown field orders_is_corrupted');
+        expect(override?.nudge).toContain('same query error repeated');
+    });
+
+    it('leaves standard runs on the existing aggregate retry cap', () => {
+        const turn = makeTurn();
+        times(REPEATED_QUERY_ERROR_CAP, () =>
+            turn.failure(
+                'generateVisualization',
+                'Error running query. Unknown field orders_is_corrupted',
+            ),
+        );
+
+        expect(turn.override('standard')).toBeNull();
+    });
+
+    it('resets the repeated error count after a successful query', () => {
+        const turn = makeTurn();
+        turn.failure(
+            'generateVisualization',
+            'Error running query. Unknown field orders_is_corrupted',
+        );
+        turn.success('generateVisualization');
+        turn.failure(
+            'generateVisualization',
+            'Error running query. Unknown field orders_is_corrupted',
+        );
+
+        expect(turn.override('deep_research')).toBeNull();
+    });
+
+    it('keeps Deep Research query tools for distinct repair errors', () => {
+        const turn = makeTurn();
+        times(REPEATED_QUERY_ERROR_CAP, () =>
+            turn.failure(
+                'generateVisualization',
+                `Error running query. Unknown field attempt-${crypto.randomUUID()}`,
+            ),
+        );
+
+        expect(turn.override('deep_research')).toBeNull();
     });
 
     it('trips sooner on repeated warehouse timeouts', () => {

--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
@@ -23,6 +23,7 @@ export const QUERY_TOOL_NAMES: ReadonlySet<string> = new Set([
 export const WAREHOUSE_SLOW_CAP = 2;
 /** Executed-query failures of any kind: the model is looping, not converging. */
 export const WAREHOUSE_ERROR_CAP = 3;
+export const REPEATED_QUERY_ERROR_CAP = 2;
 /** Two changed query attempts after the original resource-limit failure. */
 export const DEEP_RESEARCH_RESOURCE_RECOVERY_ATTEMPTS = 2;
 /**
@@ -88,10 +89,18 @@ type QueryRetryCapDecision =
  */
 const shouldCapQueryRetries = (
     classes: QueryResultClass[],
+    hasRepeatedRuntimeError: boolean,
 ): QueryRetryCapDecision => {
     const warehouseSlow = classes.filter((c) => c === 'warehouse-slow').length;
     const warehouseErrors = classes.filter(isWarehouseFailure).length;
     const invalidInputs = classes.filter((c) => c === 'invalid-input').length;
+    if (hasRepeatedRuntimeError) {
+        return {
+            capped: true,
+            reason: 'the same query error repeated',
+            kind: 'give-up',
+        };
+    }
     if (warehouseSlow >= WAREHOUSE_SLOW_CAP) {
         return {
             capped: true,
@@ -176,6 +185,31 @@ const cleanWarehouseError = (value: string): string =>
         .trim();
 
 const MAX_ERROR_SNIPPET_CHARS = 500;
+
+const hasRepeatedRuntimeError = (results: QueryResult[]): boolean => {
+    const latestSuccessIndex = results.findLastIndex(
+        (result) => result.class === 'ok',
+    );
+    const signatures = results
+        .slice(latestSuccessIndex + 1)
+        .filter((result) => result.class === 'other')
+        .map((result) =>
+            cleanWarehouseError(result.value)
+                .replace(/\s+/g, ' ')
+                .trim()
+                .toLowerCase(),
+        )
+        .filter(Boolean);
+    const counts = signatures.reduce<Map<string, number>>(
+        (accumulator, signature) =>
+            accumulator.set(signature, (accumulator.get(signature) ?? 0) + 1),
+        new Map(),
+    );
+
+    return [...counts.values()].some(
+        (count) => count >= REPEATED_QUERY_ERROR_CAP,
+    );
+};
 
 const countActiveResourceFailureRounds = (results: QueryResult[]): number => {
     const rounds = new Map<number, QueryResult[]>();
@@ -282,7 +316,10 @@ export const buildQueryRetryStepOverride = (
                 executionMode !== 'deep_research' ||
                 !isRecoverableResourceFailure(resultClass),
         );
-    const decision = shouldCapQueryRetries(classes);
+    const decision = shouldCapQueryRetries(
+        classes,
+        executionMode === 'deep_research' && hasRepeatedRuntimeError(results),
+    );
     if (!decision.capped) return null;
 
     switch (decision.kind) {


### PR DESCRIPTION
Closes: No linked issue

## Summary

PR 2 of 3 stops Deep Research after two identical runtime query errors, before an agent spends another warehouse call on a repair that is not changing.

Stacks on top of #27747, which adds the database schema-parity guard.

## Changes

- Normalizes runtime warehouse errors into stable signatures.
- Applies the two-error fast cap only to Deep Research.
- Resets repeated-error tracking after a successful query.
- Preserves the existing aggregate, timeout, validation, and resource-recovery limits.

```
Before: same error → same error → same error → stop
After:  same error → same error              → stop

Success between failures → reset
Standard agent mode      → unchanged
```

## Test plan

- [x] `queryRetryCap.test.ts` (20 tests)
- [x] Identical and distinct runtime errors
- [x] Standard-mode exclusion and reset-after-success
- [x] Backend lint and typecheck

