### PR TITLE
feat(ai): track Deep Research failure stages

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -37,6 +37,7 @@ import {
     type AiAgentReviewItemWritebackStrategy,
     type AiAgentRootCause,
     type AiDeepResearchEntryPoint,
+    type AiDeepResearchFailureStage,
     type AiDeepResearchTerminalReason,
     type AiDeepResearchTerminalStatus,
     type AiRouterDecisionConfidence,
@@ -2222,6 +2223,7 @@ export type AiDeepResearchRunCompletedEvent = BaseTrack & {
             | 'empty_failure'
             | 'cancelled';
         terminalReason: AiDeepResearchTerminalReason | null;
+        failureStage: AiDeepResearchFailureStage | null;
         durationMs: number | null;
         inputTokens: number | null;
         outputTokens: number | null;

--- a/packages/backend/src/ee/database/entities/aiDeepResearch.ts
+++ b/packages/backend/src/ee/database/entities/aiDeepResearch.ts
@@ -4,6 +4,7 @@ import {
     type AiDeepResearchEventPayload,
     type AiDeepResearchEventType,
     type AiDeepResearchExecutionContextSnapshot,
+    type AiDeepResearchFailureStage,
     type AiDeepResearchRunStatus,
     type AiDeepResearchTerminalReason,
 } from '@lightdash/common';
@@ -26,6 +27,8 @@ export type DbAiDeepResearchRun = {
     status: AiDeepResearchRunStatus;
     /** Why the run reached its terminal status; null while running or on success. */
     terminal_reason: AiDeepResearchTerminalReason | null;
+    /** Stable stage where a non-successful run stopped; null on success. */
+    failure_stage: AiDeepResearchFailureStage | null;
     entry_point: AiDeepResearchEntryPoint;
     result_markdown: string | null;
     report_expires_at: Date | null;
@@ -79,6 +82,7 @@ export type AiDeepResearchRunsTable = Knex.CompositeTableType<
             DbAiDeepResearchRun,
             | 'status'
             | 'terminal_reason'
+            | 'failure_stage'
             | 'result_markdown'
             | 'report_expires_at'
             | 'report_expired_at'

--- a/packages/backend/src/ee/database/migrations/20260820111154_add_deep_research_failure_stage.ts
+++ b/packages/backend/src/ee/database/migrations/20260820111154_add_deep_research_failure_stage.ts
@@ -1,0 +1,30 @@
+import type { Knex } from 'knex';
+
+const runsTable = 'ai_deep_research_runs';
+// This is a schema snapshot, not a live application constant. New stages must
+// expand the constraint in a later migration for existing installations too.
+const failureStagesAtCreation = [
+    'enqueue',
+    'authorization',
+    'investigation',
+    'finalization',
+    'persistence',
+    'recovery',
+] as const;
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(runsTable, (table) => {
+        table
+            .text('failure_stage')
+            .nullable()
+            .checkIn([...failureStagesAtCreation]);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(runsTable, (table) => {
+        table.dropColumn('failure_stage');
+    });
+}

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -1,5 +1,6 @@
 import {
     AI_DEEP_RESEARCH_EVENT_TYPES,
+    AI_DEEP_RESEARCH_FAILURE_STAGES,
     AI_DEEP_RESEARCH_REPORT_TOOL_NAME,
     SEED_ORG_1,
     SEED_ORG_1_ADMIN,
@@ -266,6 +267,23 @@ describe('AiDeepResearchRunModel integration', () => {
         ).resolves.toHaveLength(AI_DEEP_RESEARCH_EVENT_TYPES.length);
     });
 
+    it('accepts every canonical Deep Research failure stage', async () => {
+        const run = await createRun();
+
+        await expect(
+            Promise.all(
+                AI_DEEP_RESEARCH_FAILURE_STAGES.map((failureStage) =>
+                    database(AiDeepResearchRunsTableName)
+                        .where(
+                            'ai_deep_research_run_uuid',
+                            run.ai_deep_research_run_uuid,
+                        )
+                        .update({ failure_stage: failureStage }),
+                ),
+            ),
+        ).resolves.toEqual(AI_DEEP_RESEARCH_FAILURE_STAGES.map(() => 1));
+    });
+
     it('rejects research after standard execution claims the prompt', async () => {
         const standardPromptUuid = await createAdditionalPrompt();
         await database(AiPromptTableName)
@@ -390,6 +408,7 @@ describe('AiDeepResearchRunModel integration', () => {
             run.ai_deep_research_run_uuid,
             '# Partial report',
             'time_limit',
+            'investigation',
         );
 
         // The outbox is a delivery queue; the reason has to outlive it.
@@ -398,6 +417,7 @@ describe('AiDeepResearchRunModel integration', () => {
         ).toMatchObject({
             status: 'partially_completed',
             terminal_reason: 'time_limit',
+            failure_stage: 'investigation',
         });
     });
 
@@ -412,6 +432,27 @@ describe('AiDeepResearchRunModel integration', () => {
         ).toMatchObject({
             status: 'completed',
             terminal_reason: null,
+            failure_stage: null,
+        });
+    });
+
+    it('records the stage where a run failed', async () => {
+        const run = await createRun();
+        await model.claimQueuedRun(run.ai_deep_research_run_uuid);
+
+        await model.markFailed(
+            run.ai_deep_research_run_uuid,
+            'No report',
+            'provider_error',
+            'finalization',
+        );
+
+        await expect(
+            model.findByUuid(run.ai_deep_research_run_uuid),
+        ).resolves.toMatchObject({
+            status: 'failed',
+            terminal_reason: 'provider_error',
+            failure_stage: 'finalization',
         });
     });
 
@@ -460,7 +501,10 @@ describe('AiDeepResearchRunModel integration', () => {
         const racedRun = await model.findByUuid(run.ai_deep_research_run_uuid);
         if (racedRun?.status === 'running') {
             expect(racedRun.cancellation_requested_at).not.toBeNull();
-            await model.markCancelled(run.ai_deep_research_run_uuid);
+            await model.markCancelled(
+                run.ai_deep_research_run_uuid,
+                'investigation',
+            );
         }
 
         expect(
@@ -492,6 +536,7 @@ describe('AiDeepResearchRunModel integration', () => {
         ).resolves.toMatchObject({
             status: 'cancelled',
             terminal_reason: 'user_cancellation',
+            failure_stage: 'enqueue',
         });
     });
 
@@ -507,7 +552,10 @@ describe('AiDeepResearchRunModel integration', () => {
         const racedRun = await model.findByUuid(run.ai_deep_research_run_uuid);
         if (racedRun?.status === 'running') {
             expect(racedRun.cancellation_requested_at).not.toBeNull();
-            await model.markCancelled(run.ai_deep_research_run_uuid);
+            await model.markCancelled(
+                run.ai_deep_research_run_uuid,
+                'investigation',
+            );
         }
 
         const terminalRun = await model.findByUuid(
@@ -547,7 +595,10 @@ describe('AiDeepResearchRunModel integration', () => {
         await model.checkpointReport(run.ai_deep_research_run_uuid, report);
         await model.requestCancellation(run.ai_deep_research_run_uuid);
 
-        await model.markCancelled(run.ai_deep_research_run_uuid);
+        await model.markCancelled(
+            run.ai_deep_research_run_uuid,
+            'investigation',
+        );
 
         await expect(
             model.findByUuid(run.ai_deep_research_run_uuid),
@@ -573,6 +624,7 @@ describe('AiDeepResearchRunModel integration', () => {
                     run.ai_deep_research_run_uuid,
                     report,
                     'query_limit',
+                    'investigation',
                 );
             }
 
@@ -1040,6 +1092,7 @@ describe('AiDeepResearchRunModel integration', () => {
         expect(staleRuns[0]).toMatchObject({
             ai_deep_research_run_uuid: run.ai_deep_research_run_uuid,
             status: 'failed',
+            failure_stage: 'recovery',
         });
         expect(await getEventSequence(run.ai_deep_research_run_uuid)).toEqual([
             'status_changed:queued',
@@ -1069,6 +1122,7 @@ describe('AiDeepResearchRunModel integration', () => {
         expect(staleRuns[0]).toMatchObject({
             status: 'partially_completed',
             terminal_reason: 'internal_error',
+            failure_stage: 'recovery',
             result_markdown: report,
         });
         expect(await getEventSequence(run.ai_deep_research_run_uuid)).toEqual([
@@ -1092,6 +1146,7 @@ describe('AiDeepResearchRunModel integration', () => {
         expect(staleRuns[0]).toMatchObject({
             status: 'cancelled',
             terminal_reason: 'user_cancellation',
+            failure_stage: 'recovery',
             result_markdown: null,
         });
         expect(await getEventSequence(run.ai_deep_research_run_uuid)).toEqual([

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
@@ -398,6 +398,7 @@ describe('AiDeepResearchRunModel', () => {
                           RUN_UUID,
                           reportMarkdown,
                           'query_limit',
+                          'investigation',
                       );
 
             expect(updated).toBe(true);

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -10,6 +10,7 @@ import {
     type AiDeepResearchEventPayloadMap,
     type AiDeepResearchEventType,
     type AiDeepResearchExecutionContextSnapshot,
+    type AiDeepResearchFailureStage,
     type AiDeepResearchProgress,
     type AiDeepResearchReportAdjustment,
     type AiDeepResearchRunStatus,
@@ -732,6 +733,7 @@ export class AiDeepResearchRunModel {
         status: 'completed' | 'partially_completed',
         resultMarkdown: string,
         terminalReason: AiDeepResearchTerminalReason | null,
+        failureStage: AiDeepResearchFailureStage | null,
         adjustments?: AiDeepResearchReportAdjustment,
     ): Promise<boolean> {
         return this.database.transaction(async (transaction) => {
@@ -760,6 +762,7 @@ export class AiDeepResearchRunModel {
                 .update({
                     status,
                     terminal_reason: terminalReason,
+                    failure_stage: failureStage,
                     result_markdown: resultMarkdown,
                     report_expires_at: transaction.raw(
                         "now() + (? * interval '1 day')",
@@ -817,6 +820,7 @@ export class AiDeepResearchRunModel {
             'completed',
             resultMarkdown,
             null,
+            null,
             adjustments,
         );
     }
@@ -842,6 +846,7 @@ export class AiDeepResearchRunModel {
         aiDeepResearchRunUuid: string,
         resultMarkdown: string,
         terminalReason: AiDeepResearchTerminalReason,
+        failureStage: AiDeepResearchFailureStage,
         adjustments?: AiDeepResearchReportAdjustment,
     ): Promise<boolean> {
         return this.markWithReport(
@@ -849,6 +854,7 @@ export class AiDeepResearchRunModel {
             'partially_completed',
             resultMarkdown,
             terminalReason,
+            failureStage,
             adjustments,
         );
     }
@@ -857,6 +863,7 @@ export class AiDeepResearchRunModel {
         aiDeepResearchRunUuid: string,
         errorMessage: string,
         terminalReason: AiDeepResearchTerminalReason,
+        failureStage: AiDeepResearchFailureStage,
     ): Promise<boolean> {
         return this.database.transaction(async (transaction) => {
             const currentRun = await transaction<AiDeepResearchRunsTable>(
@@ -882,6 +889,7 @@ export class AiDeepResearchRunModel {
                 .update({
                     status: 'failed',
                     terminal_reason: terminalReason,
+                    failure_stage: failureStage,
                     ...metrics,
                     duration_ms:
                         AiDeepResearchRunModel.getDurationMs(transaction),
@@ -913,6 +921,7 @@ export class AiDeepResearchRunModel {
 
     async markCancelled(
         aiDeepResearchRunUuid: string,
+        failureStage: AiDeepResearchFailureStage,
         terminalReason: AiDeepResearchTerminalReason = 'user_cancellation',
     ): Promise<boolean> {
         return this.database.transaction(async (transaction) => {
@@ -941,6 +950,7 @@ export class AiDeepResearchRunModel {
                 .update({
                     status: 'cancelled',
                     terminal_reason: terminalReason,
+                    failure_stage: failureStage,
                     result_markdown: null,
                     ...metrics,
                     duration_ms:
@@ -984,6 +994,7 @@ export class AiDeepResearchRunModel {
                 .update({
                     status: 'cancelled',
                     terminal_reason: 'user_cancellation',
+                    failure_stage: 'enqueue',
                     cancellation_requested_at: now,
                     completed_at: now,
                     updated_at: now,
@@ -1144,6 +1155,7 @@ export class AiDeepResearchRunModel {
                     terminal_reason: transaction.raw(
                         "case when cancellation_requested_at is not null then 'user_cancellation' else 'internal_error' end",
                     ) as unknown as DbAiDeepResearchRun['terminal_reason'],
+                    failure_stage: 'recovery',
                     result_markdown: transaction.raw(
                         'case when cancellation_requested_at is not null then null else result_markdown end',
                     ) as unknown as string | null,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -11,6 +11,7 @@ import {
 import { type DbAiDeepResearchRun } from '../../database/entities/aiDeepResearch';
 import { AI_DEEP_RESEARCH_REPORT_TOOL_NAME } from './AiDeepResearchAgent';
 import { AiDeepResearchExecutor } from './AiDeepResearchExecutor';
+import { AiDeepResearchExecutorStageError } from './AiDeepResearchService';
 
 const budget = {
     maxTokens: 10_000,
@@ -119,6 +120,7 @@ const run = (
     resume_from_run_uuid: null,
     status: 'running',
     terminal_reason: null,
+    failure_stage: null,
     entry_point: 'ask_ai',
     result_markdown: null,
     report_expires_at: null,
@@ -370,6 +372,7 @@ describe('AiDeepResearchExecutor', () => {
             errorMessage:
                 'Deep Research cannot run because its creator is inactive',
             terminalReason: 'permission_revoked',
+            failureStage: 'authorization',
         });
         expect(generateAgentThreadResponse).not.toHaveBeenCalled();
     });
@@ -406,7 +409,11 @@ describe('AiDeepResearchExecutor', () => {
             executor.execute(run(), {
                 signal: new AbortController().signal,
             }),
-        ).rejects.toBe(temporaryError);
+        ).rejects.toMatchObject({
+            name: 'AiDeepResearchExecutorStageError',
+            failureStage: 'authorization',
+            cause: temporaryError,
+        } satisfies Partial<AiDeepResearchExecutorStageError>);
         expect(generateAgentThreadResponse).not.toHaveBeenCalled();
     });
 
@@ -425,6 +432,7 @@ describe('AiDeepResearchExecutor', () => {
             status: 'failed',
             errorMessage: 'Access revoked',
             terminalReason: 'permission_revoked',
+            failureStage: 'authorization',
         });
         expect(generateAgentThreadResponse).not.toHaveBeenCalled();
     });
@@ -554,6 +562,7 @@ describe('AiDeepResearchExecutor', () => {
         ).resolves.toEqual({
             status: 'cancelled',
             terminalReason: 'internal_error',
+            failureStage: 'authorization',
         });
         expect(generateAgentThreadResponse).not.toHaveBeenCalled();
     });
@@ -832,6 +841,7 @@ describe('AiDeepResearchExecutor', () => {
         await expect(pendingRun).resolves.toEqual({
             status: 'cancelled',
             terminalReason: 'internal_error',
+            failureStage: 'investigation',
         });
         expect(workerSignals.every((signal) => signal.aborted)).toBe(true);
     });
@@ -866,6 +876,7 @@ describe('AiDeepResearchExecutor', () => {
         expect(result).toMatchObject({
             status: 'partially_completed',
             terminalReason: 'tool_limit',
+            failureStage: 'investigation',
             report,
         });
     });
@@ -897,6 +908,7 @@ describe('AiDeepResearchExecutor', () => {
         expect(result).toMatchObject({
             status: 'partially_completed',
             terminalReason: 'query_limit',
+            failureStage: 'investigation',
             report,
         });
     });
@@ -941,6 +953,7 @@ describe('AiDeepResearchExecutor', () => {
         expect(result).toMatchObject({
             status: 'partially_completed',
             terminalReason: 'token_limit',
+            failureStage: 'investigation',
             report,
         });
     });
@@ -969,6 +982,7 @@ describe('AiDeepResearchExecutor', () => {
         expect(result).toMatchObject({
             status: 'partially_completed',
             terminalReason: 'time_limit',
+            failureStage: 'investigation',
             report,
         });
     });
@@ -1123,6 +1137,7 @@ describe('AiDeepResearchExecutor', () => {
         );
 
         expect(result.status).toBe('partially_completed');
+        expect(result).toMatchObject({ failureStage: 'investigation' });
         expect(
             result.status === 'partially_completed' && result.report.markdown,
         ).toContain('maxWarehouseQueries');
@@ -1162,6 +1177,7 @@ describe('AiDeepResearchExecutor', () => {
             report,
             warehouseQueryUuids: [],
             terminalReason: 'provider_error',
+            failureStage: 'investigation',
         });
     });
 
@@ -1207,6 +1223,7 @@ describe('AiDeepResearchExecutor', () => {
             errorMessage:
                 'Deep Research could not find relevant data for this question.',
             terminalReason: 'no_relevant_data',
+            failureStage: 'finalization',
         });
         // No point paying a model to write a report with nothing behind it.
         expect(generateDeepResearchReport).not.toHaveBeenCalled();
@@ -1287,6 +1304,7 @@ describe('AiDeepResearchExecutor', () => {
             status: 'failed',
             errorMessage: 'provider disconnected',
             terminalReason: 'provider_error',
+            failureStage: 'investigation',
         });
     });
 
@@ -1336,6 +1354,7 @@ describe('AiDeepResearchExecutor', () => {
         ).resolves.toMatchObject({
             status: 'partially_completed',
             terminalReason: 'provider_error',
+            failureStage: 'finalization',
         });
     });
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.ts
@@ -34,6 +34,7 @@ import {
 } from './AiDeepResearchAgent';
 import {
     AI_DEEP_RESEARCH_NO_RELEVANT_DATA_ERROR_MESSAGE,
+    AiDeepResearchExecutorStageError,
     getAiDeepResearchRunBudget,
     type AiDeepResearchEvidenceBuildResult,
     type AiDeepResearchExecutor as AiDeepResearchExecutorFn,
@@ -331,6 +332,7 @@ export class AiDeepResearchExecutor {
                 terminalReason: run.cancellation_requested_at
                     ? 'user_cancellation'
                     : 'internal_error',
+                failureStage: 'authorization',
             };
         }
 
@@ -348,6 +350,7 @@ export class AiDeepResearchExecutor {
                     errorMessage:
                         'Deep Research cannot run because its creator is inactive',
                     terminalReason: 'permission_revoked',
+                    failureStage: 'authorization',
                 };
             }
             await this.dependencies.aiAgentService.assertDeepResearchAccess(
@@ -361,12 +364,16 @@ export class AiDeepResearchExecutor {
             );
         } catch (error) {
             if (!isAuthorizationRevokedError(error)) {
-                throw error;
+                throw new AiDeepResearchExecutorStageError(
+                    'authorization',
+                    error,
+                );
             }
             return {
                 status: 'failed',
                 errorMessage: getErrorMessage(error),
                 terminalReason: 'permission_revoked',
+                failureStage: 'authorization',
             };
         }
 
@@ -759,6 +766,7 @@ export class AiDeepResearchExecutor {
                 terminalReason: cancelledByUser
                     ? 'user_cancellation'
                     : 'internal_error',
+                failureStage: 'investigation',
             };
         }
         if (authorizationRevokedReason) {
@@ -766,6 +774,7 @@ export class AiDeepResearchExecutor {
                 status: 'failed',
                 errorMessage: authorizationRevokedReason,
                 terminalReason: 'permission_revoked',
+                failureStage: 'authorization',
             };
         }
 
@@ -793,6 +802,7 @@ export class AiDeepResearchExecutor {
                     maxWarehouseQueries: 'query_limit' as const,
                     deadlineMs: 'time_limit' as const,
                 }[budgetExceeded],
+                failureStage: 'investigation',
             };
         }
         if (finalization?.outcome === 'checkpointed') {
@@ -801,6 +811,7 @@ export class AiDeepResearchExecutor {
                 report: finalization.report,
                 warehouseQueryUuids: queryUuids,
                 terminalReason: 'provider_error',
+                failureStage: 'finalization',
             };
         }
         if (executionError) {
@@ -812,12 +823,14 @@ export class AiDeepResearchExecutor {
                     report: finalizedReport,
                     warehouseQueryUuids: queryUuids,
                     terminalReason: 'provider_error',
+                    failureStage: 'investigation',
                 };
             }
             return {
                 status: 'failed',
                 errorMessage: getErrorMessage(executionError),
                 terminalReason: 'provider_error',
+                failureStage: 'investigation',
             };
         }
         if (finalization?.outcome === 'no_relevant_data') {
@@ -825,6 +838,7 @@ export class AiDeepResearchExecutor {
                 status: 'failed',
                 errorMessage: AI_DEEP_RESEARCH_NO_RELEVANT_DATA_ERROR_MESSAGE,
                 terminalReason: 'no_relevant_data',
+                failureStage: 'finalization',
             };
         }
         if (!finalizedReport) {
@@ -833,6 +847,7 @@ export class AiDeepResearchExecutor {
                 errorMessage:
                     'Deep Research finished without producing a report',
                 terminalReason: 'provider_error',
+                failureStage: 'finalization',
             };
         }
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -17,6 +17,7 @@ import {
 } from '@lightdash/common';
 import { AiDeepResearchActiveRunError } from '../../models/AiDeepResearchRunModel';
 import {
+    AiDeepResearchExecutorStageError,
     AiDeepResearchService,
     getAiDeepResearchRunBudget,
 } from './AiDeepResearchService';
@@ -205,7 +206,10 @@ const runRow = (overrides: Record<string, unknown> = {}) => ({
     prompt_uuid: 'prompt-1',
     tool_call_id: null,
     prompt: 'Investigate revenue',
+    resume_from_run_uuid: null,
     status: 'queued',
+    terminal_reason: null,
+    failure_stage: null,
     entry_point: 'ask_ai',
     result_markdown: null,
     report_expires_at: null,
@@ -888,6 +892,7 @@ describe('AiDeepResearchService', () => {
                 'run-1',
                 'Deep Research could not finish. Please try again.',
                 'internal_error',
+                'enqueue',
             );
             expect(model.deleteUnstartedFailedRun).toHaveBeenCalledWith(
                 'run-1',
@@ -1306,6 +1311,7 @@ describe('AiDeepResearchService', () => {
                 properties: expect.objectContaining({
                     status: 'completed',
                     terminalReason: null,
+                    failureStage: null,
                     inputTokens: 150,
                     outputTokens: 100,
                     cacheReadTokens: 200,
@@ -1334,33 +1340,44 @@ describe('AiDeepResearchService', () => {
             {
                 status: 'partially_completed' as const,
                 terminalReason: 'tool_limit' as const,
+                failureStage: 'investigation' as const,
                 executorResult: {
                     status: 'partially_completed' as const,
                     report,
                     warehouseQueryUuids: [],
                     terminalReason: 'tool_limit' as const,
+                    failureStage: 'investigation' as const,
                 },
             },
             {
                 status: 'failed' as const,
                 terminalReason: 'provider_error' as const,
+                failureStage: 'finalization' as const,
                 executorResult: {
                     status: 'failed' as const,
                     errorMessage: 'provider unavailable',
                     terminalReason: 'provider_error' as const,
+                    failureStage: 'finalization' as const,
                 },
             },
             {
                 status: 'cancelled' as const,
                 terminalReason: 'user_cancellation' as const,
+                failureStage: 'investigation' as const,
                 executorResult: {
                     status: 'cancelled' as const,
                     terminalReason: 'user_cancellation' as const,
+                    failureStage: 'investigation' as const,
                 },
             },
         ])(
             'emits one $status terminal event with its stable reason',
-            async ({ status, terminalReason, executorResult }) => {
+            async ({
+                status,
+                terminalReason,
+                failureStage,
+                executorResult,
+            }) => {
                 const { service, analytics } = buildService({
                     executor: vi.fn().mockResolvedValue(executorResult),
                     model: {
@@ -1377,6 +1394,7 @@ describe('AiDeepResearchService', () => {
                                     status === 'partially_completed'
                                         ? reportMarkdown
                                         : null,
+                                failure_stage: failureStage,
                                 ...persistedMetrics,
                             }),
                         ),
@@ -1417,6 +1435,7 @@ describe('AiDeepResearchService', () => {
                         properties: expect.objectContaining({
                             status,
                             terminalReason,
+                            failureStage,
                             durationMs: 5_000,
                             completionClass,
                             reportOutcome:
@@ -1543,6 +1562,25 @@ describe('AiDeepResearchService', () => {
             expect(model.markCompleted).toHaveBeenCalledWith(
                 'run-1',
                 chartReportMarkdown,
+            );
+        });
+
+        it('records persistence when preparing a verified report fails', async () => {
+            const error = new Error('provenance unavailable');
+            const { service, model } = buildService();
+            vi.spyOn(
+                service as AnyType,
+                'persistAndPrepareEvidenceReport',
+            ).mockRejectedValue(error);
+
+            await expect(
+                service.executeRun({ aiDeepResearchRunUuid: 'run-1' }),
+            ).rejects.toBe(error);
+            expect(model.markFailed).toHaveBeenCalledWith(
+                'run-1',
+                'Deep Research could not finish. Please try again.',
+                'internal_error',
+                'persistence',
             );
         });
 
@@ -1813,7 +1851,10 @@ describe('AiDeepResearchService', () => {
 
             await service.executeRun({ aiDeepResearchRunUuid: 'run-1' });
 
-            expect(model.markCancelled).toHaveBeenCalledWith('run-1');
+            expect(model.markCancelled).toHaveBeenCalledWith(
+                'run-1',
+                'persistence',
+            );
         });
 
         it('persists executor failures and keeps the job failed', async () => {
@@ -1829,6 +1870,27 @@ describe('AiDeepResearchService', () => {
                 'run-1',
                 'Deep Research could not finish. Please try again.',
                 'internal_error',
+                'investigation',
+            );
+        });
+
+        it('persists the stage attached to an executor infrastructure error', async () => {
+            const error = new AiDeepResearchExecutorStageError(
+                'authorization',
+                new Error('account lookup failed'),
+            );
+            const { service, model } = buildService({
+                executor: vi.fn().mockRejectedValue(error),
+            });
+
+            await expect(
+                service.executeRun({ aiDeepResearchRunUuid: 'run-1' }),
+            ).rejects.toBe(error);
+            expect(model.markFailed).toHaveBeenCalledWith(
+                'run-1',
+                'Deep Research could not finish. Please try again.',
+                'internal_error',
+                'authorization',
             );
         });
 
@@ -1839,6 +1901,7 @@ describe('AiDeepResearchService', () => {
                     errorMessage:
                         'Deep Research could not find relevant data for this question.',
                     terminalReason: 'no_relevant_data',
+                    failureStage: 'finalization',
                 }),
             });
 
@@ -1848,6 +1911,7 @@ describe('AiDeepResearchService', () => {
                 'run-1',
                 'Deep Research could not find relevant data for this question.',
                 'no_relevant_data',
+                'finalization',
             );
         });
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -35,6 +35,7 @@ import {
     type AiDeepResearchEvidencePack,
     type AiDeepResearchEvidenceQuery,
     type AiDeepResearchExecutionContextSnapshot,
+    type AiDeepResearchFailureStage,
     type AiDeepResearchJobPayload,
     type AiDeepResearchProgress,
     type AiDeepResearchReportAdjustment,
@@ -253,6 +254,17 @@ export type AiDeepResearchEvidenceBuildResult = {
     hasEvidenceBuildFailures: boolean;
 };
 
+export class AiDeepResearchExecutorStageError extends Error {
+    readonly name = 'AiDeepResearchExecutorStageError';
+
+    constructor(
+        readonly failureStage: AiDeepResearchFailureStage,
+        cause: unknown,
+    ) {
+        super(getErrorMessage(cause), { cause });
+    }
+}
+
 export type AiDeepResearchExecutorResult =
     | {
           status: 'completed';
@@ -265,15 +277,18 @@ export type AiDeepResearchExecutorResult =
           report: AiDeepResearchSubmittedReport;
           warehouseQueryUuids: string[];
           terminalReason: AiDeepResearchTerminalReason;
+          failureStage: AiDeepResearchFailureStage;
       }
     | {
           status: 'failed';
           errorMessage: string;
           terminalReason: AiDeepResearchTerminalReason;
+          failureStage: AiDeepResearchFailureStage;
       }
     | {
           status: 'cancelled';
           terminalReason: AiDeepResearchTerminalReason;
+          failureStage: AiDeepResearchFailureStage;
       };
 
 export type AiDeepResearchExecutor = (
@@ -625,6 +640,7 @@ export class AiDeepResearchService extends BaseService {
                     args.run.result_markdown !== null,
                 ),
                 terminalReason: args.event.terminal_reason,
+                failureStage: args.run.failure_stage,
                 durationMs: args.run.duration_ms,
                 inputTokens: args.run.input_tokens,
                 outputTokens: args.run.output_tokens,
@@ -965,6 +981,7 @@ export class AiDeepResearchService extends BaseService {
                 run.ai_deep_research_run_uuid,
                 FAILED_RUN_ERROR_MESSAGE,
                 'internal_error',
+                'enqueue',
             );
             await this.aiDeepResearchRunModel.deleteUnstartedFailedRun(
                 run.ai_deep_research_run_uuid,
@@ -1218,6 +1235,7 @@ export class AiDeepResearchService extends BaseService {
                 payload.aiDeepResearchRunUuid,
                 'Deep Research executor is not configured',
                 'internal_error',
+                'enqueue',
             );
             await this.dispatchPendingLifecycleAnalytics(
                 payload.aiDeepResearchRunUuid,
@@ -1226,8 +1244,10 @@ export class AiDeepResearchService extends BaseService {
         }
 
         let checkpointedReport: AiDeepResearchSubmittedReport | null = null;
+        let currentStage: AiDeepResearchFailureStage = 'investigation';
         try {
             const result = await this.executor(run, { signal });
+            currentStage = 'persistence';
             if (result.status === 'completed') {
                 const report = await this.persistAndPrepareEvidenceReport(
                     run,
@@ -1284,12 +1304,14 @@ export class AiDeepResearchService extends BaseService {
                                   payload.aiDeepResearchRunUuid,
                                   report.markdown,
                                   result.terminalReason,
+                                  result.failureStage,
                                   report.adjustments,
                               )
                             : this.aiDeepResearchRunModel.markPartiallyCompleted(
                                   payload.aiDeepResearchRunUuid,
                                   report.markdown,
                                   result.terminalReason,
+                                  result.failureStage,
                               ),
                     (error, attempt) => {
                         this.logger.warn(
@@ -1318,6 +1340,7 @@ export class AiDeepResearchService extends BaseService {
                         ? AI_DEEP_RESEARCH_NO_RELEVANT_DATA_ERROR_MESSAGE
                         : FAILED_RUN_ERROR_MESSAGE,
                     result.terminalReason,
+                    result.failureStage,
                 );
                 await this.dispatchPendingLifecycleAnalytics(
                     payload.aiDeepResearchRunUuid,
@@ -1327,6 +1350,7 @@ export class AiDeepResearchService extends BaseService {
 
             const cancelled = await this.aiDeepResearchRunModel.markCancelled(
                 payload.aiDeepResearchRunUuid,
+                result.failureStage,
                 result.terminalReason,
             );
             if (cancelled) {
@@ -1338,6 +1362,7 @@ export class AiDeepResearchService extends BaseService {
                     payload.aiDeepResearchRunUuid,
                     'Deep Research stopped without a cancellation request',
                     'internal_error',
+                    result.failureStage,
                 );
                 await this.dispatchPendingLifecycleAnalytics(
                     payload.aiDeepResearchRunUuid,
@@ -1352,6 +1377,9 @@ export class AiDeepResearchService extends BaseService {
                     payload.aiDeepResearchRunUuid,
                     FAILED_RUN_ERROR_MESSAGE,
                     'internal_error',
+                    error instanceof AiDeepResearchExecutorStageError
+                        ? error.failureStage
+                        : currentStage,
                 );
             }
             await this.dispatchPendingLifecycleAnalytics(
@@ -1852,6 +1880,7 @@ export class AiDeepResearchService extends BaseService {
         ) {
             const cancelled = await this.aiDeepResearchRunModel.markCancelled(
                 aiDeepResearchRunUuid,
+                'persistence',
             );
             if (cancelled) {
                 await this.dispatchPendingLifecycleAnalytics(

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -47,6 +47,18 @@ export const AI_DEEP_RESEARCH_TERMINAL_REASONS = [
 export type AiDeepResearchTerminalReason =
     (typeof AI_DEEP_RESEARCH_TERMINAL_REASONS)[number];
 
+export const AI_DEEP_RESEARCH_FAILURE_STAGES = [
+    'enqueue',
+    'authorization',
+    'investigation',
+    'finalization',
+    'persistence',
+    'recovery',
+] as const;
+
+export type AiDeepResearchFailureStage =
+    (typeof AI_DEEP_RESEARCH_FAILURE_STAGES)[number];
+
 export const isAiDeepResearchRunTerminal = (
     status: AiDeepResearchRunStatus,
 ): status is AiDeepResearchTerminalStatus =>


### PR DESCRIPTION
Closes: No linked issue

## Summary

PR 3 of 3 records the execution phase where a non-successful Deep Research run stopped and forwards that stable dimension to completion analytics without exposing raw errors.

Stacks on top of #27748, which prevents repeated identical query failures.

## Changes

- Adds nullable, check-constrained `failure_stage` storage.
- Records one of `enqueue`, `authorization`, `investigation`, `finalization`, `persistence`, or `recovery` across failed, partial, and cancelled terminal paths.
- Keeps `terminal_reason` as the independent cause dimension, including budget and cancellation reasons.
- Sends the persisted stage with `ai_deep_research.run_completed`; successful runs send `null`.
- Keeps the field internal and adds no raw exception, prompt, report, or SQL text to analytics.

```
terminal run
   ├─ terminal_reason → why it stopped
   └─ failure_stage  → where it stopped
                            ↓
                 completion analytics
```

## Test plan

- [x] Common and backend typecheck
- [x] Backend lint
- [x] Focused unit suites (159 tests)
- [x] Model integration suite on a fresh database (28 tests)
- [x] Migration rollback and re-apply

