### PR TITLE
fix(bigquery): restore partition pruning for non-UTC timezone date filters

### DIFF
--- a/docs/timezones/timestamp-domains-design.md
+++ b/docs/timezones/timestamp-domains-design.md
@@ -79,6 +79,11 @@ additional dimensions stay unknown (the expression may change the domain), and
 an additional dimension's interval children inherit its own resolved domain,
 never the parent column's annotation.
 
+This matters for BigQuery partition pruning: the prunable `DATE(col, tz)` form
+for non-UTC day-or-coarser filters is only emitted for known-aware columns, so a
+`sql:`-backed or additional dimension over a partitioned TIMESTAMP needs an
+explicit `timestamp_domain: aware` to prune.
+
 A modeler can always override the catalog in YAML:
 
 ```yaml

--- a/examples/full-jaffle-shop-demo/dbt/models/timezone_test.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/timezone_test.sql
@@ -1,3 +1,15 @@
+{% if target.type == 'bigquery' %}
+    {{
+        config(
+            partition_by={
+                "field": "event_timestamp",
+                "data_type": "timestamp",
+                "granularity": "day"
+            }
+        )
+    }}
+{% endif %}
+
 select
     event_id,
     event_timestamp,

--- a/packages/api-tests/tests/queryTimezone.test.ts
+++ b/packages/api-tests/tests/queryTimezone.test.ts
@@ -50,6 +50,7 @@ const HOUR_DIMENSION_KEY = 'timezone_test_event_timestamp_hour';
 const METRIC_KEY = 'timezone_test_count';
 const DIMENSIONS = [DIMENSION_KEY];
 const METRICS = [METRIC_KEY];
+const EXISTING_BIGQUERY_PROJECT_UUID = process.env.BIGQUERY_TEST_PROJECT_UUID;
 
 const HOUR_EQUALS_FILTER = (instant: string) => ({
     dimensions: {
@@ -446,21 +447,25 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
     });
 });
 
-// Warehouse-parity check: the fractional-offset DATE_TRUNC has to be emitted in
-// each dialect's SQL, so re-run the discriminating sub-day assertions against a
+// Warehouse-parity check: execute the discriminating timezone filters against a
 // real BigQuery project. The staging dataset holds the same timezone_test rows
 // as the Postgres seed, so the expected counts are identical.
-describe.skipIf(!hasBigqueryCredentials())(
-    'Query timezone — BigQuery fractional offsets',
+describe.skipIf(!EXISTING_BIGQUERY_PROJECT_UUID && !hasBigqueryCredentials())(
+    'Query timezone — BigQuery filters',
     () => {
         const projectName = 'bigQuery timezone fractional test';
         // Cold BigQuery queries can exceed the default 15s poll window.
         const BIGQUERY_MAX_ATTEMPTS = 120;
         let bqAdmin: ApiClient;
         let bigqueryProjectUuid: string;
+        let ownsBigqueryProject = false;
 
         beforeAll(async () => {
             bqAdmin = await login();
+            if (EXISTING_BIGQUERY_PROJECT_UUID) {
+                bigqueryProjectUuid = EXISTING_BIGQUERY_PROJECT_UUID;
+                return;
+            }
             // Clean up any project leaked by a previously interrupted run
             // before creating a fresh one (names are not unique).
             await deleteProjectsByName(bqAdmin, [projectName]);
@@ -469,13 +474,45 @@ describe.skipIf(!hasBigqueryCredentials())(
                 projectName,
                 bigqueryWarehouseConfig(),
             );
+            ownsBigqueryProject = true;
         }, 420_000);
 
         afterAll(async () => {
-            if (bqAdmin) {
+            if (bqAdmin && ownsBigqueryProject) {
                 await deleteProjectsByName(bqAdmin, [projectName]);
             }
         });
+
+        it.each([
+            {
+                expectedCount: 5,
+                filter: EQUALS_FILTER('2024-01-15'),
+                name: 'equals',
+            },
+            {
+                expectedCount: 9,
+                filter: IN_BETWEEN_FILTER('2024-01-15', '2024-01-16'),
+                name: 'inBetween',
+            },
+            {
+                expectedCount: 5,
+                filter: GREATER_THAN_FILTER('2024-01-15'),
+                name: 'greaterThan',
+            },
+        ])(
+            'Asia/Tokyo day $name preserves local-calendar filter semantics',
+            async ({ expectedCount, filter }) => {
+                const rows = await runTimezoneTestQuery(bqAdmin, {
+                    dimensions: DIMENSIONS,
+                    metrics: METRICS,
+                    timezone: 'Asia/Tokyo',
+                    filters: filter,
+                    projectUuid: bigqueryProjectUuid,
+                    maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+                });
+                expect(getTotalCount(rows, METRIC_KEY)).toBe(expectedCount);
+            },
+        );
 
         it('Asia/Kathmandu (+05:45): groups into 10 hourly buckets', async () => {
             const rows = await runTimezoneTestQuery(bqAdmin, {

--- a/packages/api-tests/tests/queryTimezone.test.ts
+++ b/packages/api-tests/tests/queryTimezone.test.ts
@@ -1,3 +1,4 @@
+import { WeekDay } from '@lightdash/common';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ApiClient } from '../helpers/api-client';
 import { login } from '../helpers/auth';
@@ -50,7 +51,6 @@ const HOUR_DIMENSION_KEY = 'timezone_test_event_timestamp_hour';
 const METRIC_KEY = 'timezone_test_count';
 const DIMENSIONS = [DIMENSION_KEY];
 const METRICS = [METRIC_KEY];
-const EXISTING_BIGQUERY_PROJECT_UUID = process.env.BIGQUERY_TEST_PROJECT_UUID;
 
 const HOUR_EQUALS_FILTER = (instant: string) => ({
     dimensions: {
@@ -89,6 +89,20 @@ const IN_BETWEEN_FILTER = (from: string, to: string) => ({
                 target: { fieldId: 'timezone_test_event_timestamp_day' },
                 operator: 'inBetween',
                 values: [from, to],
+            },
+        ],
+    },
+});
+
+const GRAIN_EQUALS_FILTER = (grain: string, value: string) => ({
+    dimensions: {
+        id: 'tz-test',
+        and: [
+            {
+                id: 'tz-grain-eq',
+                target: { fieldId: `timezone_test_event_timestamp_${grain}` },
+                operator: 'equals',
+                values: [value],
             },
         ],
     },
@@ -450,7 +464,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
 // Warehouse-parity check: execute the discriminating timezone filters against a
 // real BigQuery project. The staging dataset holds the same timezone_test rows
 // as the Postgres seed, so the expected counts are identical.
-describe.skipIf(!EXISTING_BIGQUERY_PROJECT_UUID && !hasBigqueryCredentials())(
+describe.skipIf(!hasBigqueryCredentials())(
     'Query timezone — BigQuery filters',
     () => {
         const projectName = 'bigQuery timezone fractional test';
@@ -458,27 +472,23 @@ describe.skipIf(!EXISTING_BIGQUERY_PROJECT_UUID && !hasBigqueryCredentials())(
         const BIGQUERY_MAX_ATTEMPTS = 120;
         let bqAdmin: ApiClient;
         let bigqueryProjectUuid: string;
-        let ownsBigqueryProject = false;
 
         beforeAll(async () => {
             bqAdmin = await login();
-            if (EXISTING_BIGQUERY_PROJECT_UUID) {
-                bigqueryProjectUuid = EXISTING_BIGQUERY_PROJECT_UUID;
-                return;
-            }
             // Clean up any project leaked by a previously interrupted run
             // before creating a fresh one (names are not unique).
             await deleteProjectsByName(bqAdmin, [projectName]);
             bigqueryProjectUuid = await createAndRefreshProject(
                 bqAdmin,
                 projectName,
-                bigqueryWarehouseConfig(),
+                // Monday start makes row #11 (Sun 14 Jan 15:00 UTC) cross a
+                // week boundary in Asia/Tokyo.
+                { ...bigqueryWarehouseConfig(), startOfWeek: WeekDay.MONDAY },
             );
-            ownsBigqueryProject = true;
         }, 420_000);
 
         afterAll(async () => {
-            if (bqAdmin && ownsBigqueryProject) {
+            if (bqAdmin) {
                 await deleteProjectsByName(bqAdmin, [projectName]);
             }
         });
@@ -507,6 +517,57 @@ describe.skipIf(!EXISTING_BIGQUERY_PROJECT_UUID && !hasBigqueryCredentials())(
                     metrics: METRICS,
                     timezone: 'Asia/Tokyo',
                     filters: filter,
+                    projectUuid: bigqueryProjectUuid,
+                    maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+                });
+                expect(getTotalCount(rows, METRIC_KEY)).toBe(expectedCount);
+            },
+        );
+
+        // Coarser grains use boundary rows that land in a different
+        // week / month / quarter / year once shifted out of UTC; the UTC
+        // answer is one lower in every case.
+        it.each([
+            {
+                grain: 'week',
+                timezone: 'Asia/Tokyo',
+                value: '2024-01-15',
+                // #11 is Mon 15 Jan 00:00 Tokyo (Sun 14 Jan UTC); #1 is Mon 15 Jan in both.
+                eventIds: [11, 1],
+                expectedCount: 2,
+            },
+            {
+                grain: 'month',
+                timezone: 'Asia/Tokyo',
+                value: '2024-02-01',
+                // #18 is 1 Feb 00:00 Tokyo (31 Jan UTC); #20 is 16 Feb in both.
+                eventIds: [18, 20],
+                expectedCount: 2,
+            },
+            {
+                grain: 'quarter',
+                timezone: 'Pacific/Pago_Pago',
+                value: '2023-10-01',
+                // #17 is 31 Dec 2023 13:00 Pago Pago (1 Jan 2024 UTC); #1 is Q1 2024 in both.
+                eventIds: [17, 1],
+                expectedCount: 1,
+            },
+            {
+                grain: 'year',
+                timezone: 'Pacific/Pago_Pago',
+                value: '2023-01-01',
+                eventIds: [17, 1],
+                expectedCount: 1,
+            },
+        ])(
+            '$timezone $grain equals preserves local-calendar filter semantics',
+            async ({ grain, timezone, value, eventIds, expectedCount }) => {
+                const rows = await runTimezoneTestQuery(bqAdmin, {
+                    dimensions: DIMENSIONS,
+                    metrics: METRICS,
+                    timezone,
+                    filters: GRAIN_EQUALS_FILTER(grain, value),
+                    eventIds,
                     projectUuid: bigqueryProjectUuid,
                     maxAttempts: BIGQUERY_MAX_ATTEMPTS,
                 });

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -8273,6 +8273,42 @@ describe('Session-independent explicit path (per-column, no session pin)', () =>
         );
     });
 
+    test('BigQuery known-aware day grain emits the prunable DATE(col, tz) in SELECT and filter LHS', () => {
+        const explore = buildNaiveExplore(
+            SupportedDbtAdapter.BIGQUERY,
+            'aware',
+        );
+        const args = gateArgs(
+            SupportedDbtAdapter.BIGQUERY,
+            bigqueryClientMock,
+            explore,
+        );
+        const { query } = buildQuery({
+            ...args,
+            compiledMetricQuery: {
+                ...args.compiledMetricQuery,
+                filters: filterOn('events_occurred_at_day'),
+            },
+        });
+        const prunable = `DATE("events".occurred_at, 'Asia/Tokyo')`;
+        // Selected dim and filter LHS both carry the direct prunable form.
+        expect(query.split(prunable).length - 1).toBeGreaterThanOrEqual(2);
+        expect(query).not.toContain('DATETIME_TRUNC');
+    });
+
+    test('BigQuery unknown-domain day grain keeps the DATETIME round-trip', () => {
+        const { query } = buildQuery(
+            gateArgs(
+                SupportedDbtAdapter.BIGQUERY,
+                bigqueryClientMock,
+                buildNaiveExplore(SupportedDbtAdapter.BIGQUERY),
+            ),
+        );
+        expect(query).toContain(
+            `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP("events".occurred_at), 'Asia/Tokyo'), DAY) AS DATE)`,
+        );
+    });
+
     test('unknown domains stay byte-identical to a no-domain compile (Trino)', () => {
         const explore = buildNaiveExplore(SupportedDbtAdapter.TRINO);
         const { query } = buildQuery(

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -19,6 +19,7 @@ import {
     UnitOfTime,
     VizAggregationOptions,
     VizIndexType,
+    WeekDay,
     type CompiledDimension,
     type CompiledMetric,
     type MetricFilterRule,
@@ -8307,6 +8308,445 @@ describe('Session-independent explicit path (per-column, no session pin)', () =>
         expect(query).toContain(
             `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP("events".occurred_at), 'Asia/Tokyo'), DAY) AS DATE)`,
         );
+    });
+
+    describe('BigQuery prunable DATE-domain swap (known-aware, non-UTC)', () => {
+        const TZ = 'Asia/Tokyo';
+        const DAY = `DATE("events".occurred_at, '${TZ}')`;
+        const WEEK = `DATE_TRUNC(${DAY}, WEEK(MONDAY))`;
+        const MONTH = `DATE_TRUNC(${DAY}, MONTH)`;
+        const LEGACY_DAY = `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP("events".occurred_at), '${TZ}'), DAY) AS DATE)`;
+
+        const dateDim = (
+            name: string,
+            timeInterval: TimeFrames,
+        ): CompiledDimension => ({
+            type: DimensionType.DATE,
+            name,
+            label: name,
+            table: 'events',
+            tableLabel: 'events',
+            fieldType: FieldType.DIMENSION,
+            sql: `DATE_TRUNC(\${TABLE}.occurred_at, ${timeInterval})`,
+            compiledSql: `DATE_TRUNC("events".occurred_at, ${timeInterval})`,
+            tablesReferences: ['events'],
+            hidden: false,
+            timeInterval,
+            timeIntervalBaseDimensionName: 'occurred_at',
+            timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+        });
+
+        const awareExplore = (): Explore =>
+            withExtraDimension(
+                withExtraDimension(
+                    buildNaiveExplore(SupportedDbtAdapter.BIGQUERY, 'aware'),
+                    dateDim('occurred_at_week', TimeFrames.WEEK),
+                ),
+                dateDim('occurred_at_month', TimeFrames.MONTH),
+            );
+
+        const bqClient = {
+            ...bigqueryClientMock,
+            getStartOfWeek: () => WeekDay.MONDAY,
+        };
+
+        const rule = (
+            fieldId: string,
+            operator: FilterOperator,
+            values: unknown[],
+            settings?: { unitOfTime: UnitOfTime; completed: boolean },
+        ): CompiledMetricQuery['filters'] => ({
+            dimensions: {
+                id: 'root',
+                and: [
+                    {
+                        id: 'rule-1',
+                        target: { fieldId },
+                        operator,
+                        values,
+                        ...(settings ? { settings } : {}),
+                    },
+                ],
+            },
+        });
+
+        const compile = (
+            filters: CompiledMetricQuery['filters'],
+            explore: Explore = awareExplore(),
+            overrides: Partial<Parameters<typeof buildQuery>[0]> = {},
+            dimensions: string[] = ['events_occurred_at_day'],
+        ) => {
+            const args = gateArgs(
+                SupportedDbtAdapter.BIGQUERY,
+                bqClient,
+                explore,
+                overrides,
+            );
+            return buildQuery({
+                ...args,
+                compiledMetricQuery: {
+                    ...args.compiledMetricQuery,
+                    dimensions,
+                    filters,
+                },
+            }).query;
+        };
+
+        const whereClause = (query: string): string =>
+            query.slice(query.indexOf('WHERE'));
+
+        test.each([
+            [
+                FilterOperator.EQUALS,
+                ['2024-09-08'],
+                `(${DAY}) = ('2024-09-08')`,
+            ],
+            [
+                FilterOperator.NOT_EQUALS,
+                ['2024-09-08'],
+                `(${DAY}) != ('2024-09-08')`,
+            ],
+            [
+                FilterOperator.LESS_THAN,
+                ['2024-09-08'],
+                `(${DAY}) < ('2024-09-08')`,
+            ],
+            [
+                FilterOperator.LESS_THAN_OR_EQUAL,
+                ['2024-09-08'],
+                `(${DAY}) <= ('2024-09-08')`,
+            ],
+            [
+                FilterOperator.GREATER_THAN,
+                ['2024-09-08'],
+                `(${DAY}) > ('2024-09-08')`,
+            ],
+            [
+                FilterOperator.GREATER_THAN_OR_EQUAL,
+                ['2024-09-08'],
+                `(${DAY}) >= ('2024-09-08')`,
+            ],
+            [
+                FilterOperator.IN_BETWEEN,
+                ['2024-09-01', '2024-09-08'],
+                `(${DAY}) >= ('2024-09-01') AND (${DAY}) <= ('2024-09-08')`,
+            ],
+        ])(
+            'absolute %s on day grain uses DATE(col, tz)',
+            (operator, values, expected) => {
+                const query = compile(
+                    rule('events_occurred_at_day', operator, values),
+                );
+                expect(whereClause(query)).toContain(expected);
+                expect(query).not.toContain('DATETIME_TRUNC');
+            },
+        );
+
+        test('multi-value equals renders an IN over DATE(col, tz)', () => {
+            const query = compile(
+                rule('events_occurred_at_day', FilterOperator.EQUALS, [
+                    '2024-09-08',
+                    '2024-09-10',
+                ]),
+            );
+            expect(whereClause(query)).toContain(
+                `(${DAY}) IN (('2024-09-08'),('2024-09-10'))`,
+            );
+        });
+
+        test('week grain keeps the configured start of week inside DATE_TRUNC', () => {
+            const query = compile(
+                rule('events_occurred_at_week', FilterOperator.EQUALS, [
+                    '2024-09-02',
+                ]),
+                awareExplore(),
+                {},
+                ['events_occurred_at_week'],
+            );
+            expect(whereClause(query)).toContain(`(${WEEK}) = ('2024-09-02')`);
+            expect(query).toContain(`${WEEK} AS \`events_occurred_at_week\``);
+        });
+
+        test('unconfigured start of week emits bare WEEK', () => {
+            const query = compile(
+                rule('events_occurred_at_week', FilterOperator.EQUALS, [
+                    '2024-09-02',
+                ]),
+                awareExplore(),
+                {
+                    warehouseSqlBuilder: {
+                        ...bigqueryClientMock,
+                        getStartOfWeek: () => undefined,
+                    },
+                },
+            );
+            expect(whereClause(query)).toContain(
+                `(DATE_TRUNC(${DAY}, WEEK)) = ('2024-09-02')`,
+            );
+        });
+
+        test('month grain uses DATE_TRUNC(DATE(col, tz), MONTH) in SELECT, GROUP BY and WHERE', () => {
+            const query = compile(
+                rule('events_occurred_at_month', FilterOperator.EQUALS, [
+                    '2024-09-01',
+                ]),
+                awareExplore(),
+                {},
+                ['events_occurred_at_month'],
+            );
+            expect(query).toContain(`${MONTH} AS \`events_occurred_at_month\``);
+            expect(whereClause(query)).toContain(`(${MONTH}) = ('2024-09-01')`);
+            expect(query).not.toContain('DATETIME_TRUNC');
+        });
+
+        describe('relative windows reuse the DATE renderer on the prunable LHS', () => {
+            beforeEach(() => {
+                vi.useFakeTimers();
+                vi.setSystemTime(new Date('2024-09-10T03:00:00Z'));
+            });
+            afterEach(() => {
+                vi.useRealTimers();
+            });
+
+            test('inThePast 7 days', () => {
+                const query = compile(
+                    rule(
+                        'events_occurred_at_day',
+                        FilterOperator.IN_THE_PAST,
+                        [7],
+                        {
+                            unitOfTime: UnitOfTime.days,
+                            completed: false,
+                        },
+                    ),
+                );
+                expect(whereClause(query)).toContain(
+                    `(${DAY}) >= ('2024-09-03')`,
+                );
+                expect(whereClause(query)).toContain(
+                    `(${DAY}) <= ('2024-09-10')`,
+                );
+            });
+
+            test('inThePast 1 completed month', () => {
+                const query = compile(
+                    rule(
+                        'events_occurred_at_day',
+                        FilterOperator.IN_THE_PAST,
+                        [1],
+                        {
+                            unitOfTime: UnitOfTime.months,
+                            completed: true,
+                        },
+                    ),
+                );
+                expect(whereClause(query)).toContain(
+                    `(${DAY}) >= ('2024-08-01')`,
+                );
+                expect(whereClause(query)).toContain(
+                    `(${DAY}) < ('2024-09-01')`,
+                );
+            });
+
+            test('inTheNext 3 days', () => {
+                const query = compile(
+                    rule(
+                        'events_occurred_at_day',
+                        FilterOperator.IN_THE_NEXT,
+                        [3],
+                        {
+                            unitOfTime: UnitOfTime.days,
+                            completed: false,
+                        },
+                    ),
+                );
+                expect(whereClause(query)).toContain(
+                    `(${DAY}) >= ('2024-09-10')`,
+                );
+                expect(whereClause(query)).toContain(
+                    `(${DAY}) <= ('2024-09-13')`,
+                );
+            });
+
+            test('inTheCurrent week', () => {
+                const query = compile(
+                    rule(
+                        'events_occurred_at_day',
+                        FilterOperator.IN_THE_CURRENT,
+                        [1],
+                        {
+                            unitOfTime: UnitOfTime.weeks,
+                            completed: false,
+                        },
+                    ),
+                );
+                expect(whereClause(query)).toContain(
+                    `(${DAY}) >= ('2024-09-09')`,
+                );
+                expect(whereClause(query)).toContain(
+                    `(${DAY}) <= ('2024-09-15')`,
+                );
+            });
+        });
+
+        test('null checks keep the prunable LHS', () => {
+            const query = compile(
+                rule('events_occurred_at_day', FilterOperator.NULL, []),
+            );
+            expect(whereClause(query)).toContain(`(${DAY}) IS NULL`);
+        });
+
+        test('metric-embedded day filter is re-rendered with DATE(col, tz)', () => {
+            const BAKED = `(DATE_TRUNC('DAY', "events".occurred_at)) = ('2024-09-08')`;
+            const base = awareExplore();
+            const explore: Explore = {
+                ...base,
+                tables: {
+                    ...base.tables,
+                    events: {
+                        ...base.tables.events,
+                        metrics: {
+                            ...base.tables.events.metrics,
+                            recent_count: {
+                                ...base.tables.events.metrics.event_count,
+                                name: 'recent_count',
+                                label: 'recent_count',
+                                compiledSql: `COUNT(CASE WHEN (${BAKED}) THEN "events".id ELSE NULL END)`,
+                                compiledTimestampFilters: [
+                                    {
+                                        id: 'mf-1',
+                                        fieldId: 'events_occurred_at_day',
+                                        compiledSql: BAKED,
+                                    },
+                                ],
+                                filters: [
+                                    {
+                                        id: 'mf-1',
+                                        target: { fieldRef: 'occurred_at_day' },
+                                        operator: FilterOperator.EQUALS,
+                                        values: ['2024-09-08'],
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            };
+            const args = gateArgs(
+                SupportedDbtAdapter.BIGQUERY,
+                bqClient,
+                explore,
+            );
+            const { query } = buildQuery({
+                ...args,
+                compiledMetricQuery: {
+                    ...args.compiledMetricQuery,
+                    metrics: ['events_recent_count'],
+                },
+            });
+            expect(query).toContain(`CASE WHEN ((${DAY}) = ('2024-09-08'))`);
+            expect(query).not.toContain('DATETIME_TRUNC');
+        });
+
+        describe("fallbacks keep today's SQL", () => {
+            test('raw grain keeps the bare column on the filter LHS', () => {
+                const query = compile(
+                    rule(
+                        'events_occurred_at_raw',
+                        FilterOperator.GREATER_THAN,
+                        ['2024-09-08T00:00:00Z'],
+                    ),
+                );
+                expect(whereClause(query)).toContain(
+                    `("events".occurred_at) >`,
+                );
+                expect(whereClause(query)).not.toContain('DATE(');
+            });
+
+            test('hour grain keeps the DATETIME round-trip', () => {
+                const query = compile(
+                    rule(
+                        'events_occurred_at_hour',
+                        FilterOperator.NOT_NULL,
+                        [],
+                    ),
+                );
+                expect(query).toContain(
+                    `TIMESTAMP(DATETIME_TRUNC(DATETIME(TIMESTAMP("events".occurred_at), '${TZ}'), HOUR), '${TZ}')`,
+                );
+            });
+
+            test('convert_timezone: false keeps the bare truncation in SELECT; the filter LHS (which always wraps) becomes prunable', () => {
+                const query = compile(
+                    rule('events_occurred_at_day', FilterOperator.NOT_NULL, []),
+                    buildNaiveExplore(
+                        SupportedDbtAdapter.BIGQUERY,
+                        'aware',
+                        true,
+                    ),
+                );
+                expect(query).toContain(
+                    `DATE_TRUNC('DAY', "events".occurred_at) AS \`events_occurred_at_day\``,
+                );
+                expect(whereClause(query)).toContain(`(${DAY}) IS NOT NULL`);
+            });
+
+            test('UTC project timezone keeps the existing UTC path', () => {
+                const query = compile(
+                    rule('events_occurred_at_day', FilterOperator.NOT_NULL, []),
+                    awareExplore(),
+                    { timezone: 'UTC', columnTimezone: 'UTC' },
+                );
+                expect(query).toContain(`DATE("events".occurred_at)`);
+                expect(query).not.toContain(DAY);
+            });
+
+            test('naive DATETIME base keeps the rebased round-trip', () => {
+                const query = compile(
+                    rule('events_occurred_at_day', FilterOperator.NOT_NULL, []),
+                    buildNaiveExplore(SupportedDbtAdapter.BIGQUERY, 'naive'),
+                );
+                expect(query).toContain(
+                    `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP("events".occurred_at, '${TZ}'), '${TZ}'), DAY) AS DATE)`,
+                );
+                expect(query).not.toContain(DAY);
+            });
+
+            test('unknown domain keeps the legacy round-trip', () => {
+                const query = compile(
+                    rule('events_occurred_at_day', FilterOperator.EQUALS, [
+                        '2024-09-08',
+                    ]),
+                    buildNaiveExplore(SupportedDbtAdapter.BIGQUERY),
+                );
+                expect(whereClause(query)).toContain(
+                    `(${LEGACY_DAY}) = ('2024-09-08')`,
+                );
+            });
+        });
+
+        test('non-BigQuery adapters are unchanged (Postgres aware day)', () => {
+            const args = gateArgs(
+                SupportedDbtAdapter.POSTGRES,
+                warehouseClientMock,
+                buildNaiveExplore(SupportedDbtAdapter.POSTGRES, 'aware'),
+            );
+            const { query } = buildQuery({
+                ...args,
+                compiledMetricQuery: {
+                    ...args.compiledMetricQuery,
+                    filters: rule(
+                        'events_occurred_at_day',
+                        FilterOperator.EQUALS,
+                        ['2024-09-08'],
+                    ),
+                },
+            });
+            expect(query).toContain(
+                `CAST(DATE_TRUNC('DAY', ("events".occurred_at)::timestamptz AT TIME ZONE '${TZ}') AS DATE)`,
+            );
+            expect(query).not.toContain(`DATE("events".occurred_at, '${TZ}')`);
+        });
     });
 
     test('unknown domains stay byte-identical to a no-domain compile (Trino)', () => {

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -908,7 +908,7 @@ describe('TimeFrames', () => {
                 );
             });
 
-            test('tz-wrapped path is unchanged (never pruned, stays as-is)', () => {
+            test('tz-wrapped path with unknown domain keeps the DATETIME round-trip', () => {
                 expect(
                     getSqlForTruncatedDate(
                         SupportedDbtAdapter.BIGQUERY,
@@ -940,6 +940,93 @@ describe('TimeFrames', () => {
                         true,
                     ),
                 ).toEqual(`CAST(DATE_TRUNC('DAY', ${col}) AS DATE)`);
+            });
+        });
+
+        // Wrapped aware path: DATE(ts, tz) is by definition the calendar date
+        // of the instant in tz — same value as the DATETIME round-trip, but
+        // the partition pruner can see through it.
+        describe('BigQuery prunable tz-wrapped trunc for known-aware columns', () => {
+            const bqAwareTrunc = (
+                timeFrame: TimeFrames,
+                startOfWeek: WeekDay | null = null,
+            ) =>
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.BIGQUERY,
+                    timeFrame,
+                    col,
+                    DimensionType.TIMESTAMP,
+                    startOfWeek,
+                    tz,
+                    undefined,
+                    'aware',
+                    true, // castDayOrCoarserToDate
+                );
+
+            test('day grain emits DATE(col, tz)', () => {
+                expect(bqAwareTrunc(TimeFrames.DAY)).toEqual(
+                    `DATE(${col}, '${tz}')`,
+                );
+            });
+
+            test('month/quarter/year grains emit DATE_TRUNC(DATE(col, tz), part)', () => {
+                expect(bqAwareTrunc(TimeFrames.MONTH)).toEqual(
+                    `DATE_TRUNC(DATE(${col}, '${tz}'), MONTH)`,
+                );
+                expect(bqAwareTrunc(TimeFrames.QUARTER)).toEqual(
+                    `DATE_TRUNC(DATE(${col}, '${tz}'), QUARTER)`,
+                );
+                expect(bqAwareTrunc(TimeFrames.YEAR)).toEqual(
+                    `DATE_TRUNC(DATE(${col}, '${tz}'), YEAR)`,
+                );
+            });
+
+            test('week grain keeps the custom start of week', () => {
+                expect(bqAwareTrunc(TimeFrames.WEEK, WeekDay.TUESDAY)).toEqual(
+                    `DATE_TRUNC(DATE(${col}, '${tz}'), WEEK(TUESDAY))`,
+                );
+            });
+
+            test('sub-day grain keeps the DATETIME round-trip', () => {
+                expect(bqAwareTrunc(TimeFrames.HOUR)).toEqual(
+                    `TIMESTAMP(DATETIME_TRUNC(DATETIME(TIMESTAMP(${col}), '${tz}'), HOUR), '${tz}')`,
+                );
+            });
+
+            test('naive domain keeps the rebased round-trip', () => {
+                expect(
+                    getSqlForTruncatedDate(
+                        SupportedDbtAdapter.BIGQUERY,
+                        TimeFrames.DAY,
+                        col,
+                        DimensionType.TIMESTAMP,
+                        null,
+                        tz,
+                        'Asia/Tokyo',
+                        'naive',
+                        true,
+                    ),
+                ).toEqual(
+                    `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP(${col}, 'Asia/Tokyo'), '${tz}'), DAY) AS DATE)`,
+                );
+            });
+
+            test('non-BigQuery adapters keep the generic wrapped cast', () => {
+                expect(
+                    getSqlForTruncatedDate(
+                        SupportedDbtAdapter.POSTGRES,
+                        TimeFrames.DAY,
+                        col,
+                        DimensionType.TIMESTAMP,
+                        null,
+                        tz,
+                        undefined,
+                        'aware',
+                        true,
+                    ),
+                ).toEqual(
+                    `CAST(DATE_TRUNC('DAY', (${col})::timestamptz AT TIME ZONE '${tz}') AS DATE)`,
+                );
             });
         });
 

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -943,9 +943,8 @@ describe('TimeFrames', () => {
             });
         });
 
-        // Wrapped aware path: DATE(ts, tz) is by definition the calendar date
-        // of the instant in tz — same value as the DATETIME round-trip, but
-        // the partition pruner can see through it.
+        // Wrapped aware path: DATE(ts, tz) replaces the DATETIME round-trip
+        // with the same value in a form the partition pruner can see through.
         describe('BigQuery prunable tz-wrapped trunc for known-aware columns', () => {
             const bqAwareTrunc = (
                 timeFrame: TimeFrames,

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -76,16 +76,17 @@ type WarehouseConfig = {
         type: DimensionType,
         startOfWeek?: WeekDay | null,
     ) => string;
-    // Timezone-wrapped variant of the above for known-aware columns: returns a
-    // DATE in `timezone` directly, skipping the conversion round-trip that
-    // defeats partition pruning (BigQuery only).
-    getSqlForTruncatedDateAsDateInTimezone?: (
-        timeFrame: TimeFrames,
-        originalSql: string,
-        type: DimensionType,
-        startOfWeek: WeekDay | null | undefined,
-        timezone: string,
-    ) => string;
+    // Known-aware variant: a DATE in `timezone` without the conversion
+    // round-trip that defeats partition pruning. Null where not prunable.
+    getSqlForTruncatedDateAsDateInTimezone:
+        | ((
+              timeFrame: TimeFrames,
+              originalSql: string,
+              type: DimensionType,
+              startOfWeek: WeekDay | null | undefined,
+              timezone: string,
+          ) => string)
+        | null;
     getSqlForDatePart: (
         timeFrame: TimeFrames,
         originalSql: string,
@@ -526,9 +527,8 @@ const bigqueryConfig: WarehouseConfig = {
         }
         return `DATE_TRUNC(${originalSql}, ${datePart})`;
     },
-    // DATE(ts, tz) is by definition the calendar date of the instant in tz —
-    // same value as CAST(DATETIME_TRUNC(DATETIME(ts, tz), ...) AS DATE), but
-    // the pruner can see through it.
+    // DATE(ts, tz) is the calendar date of the instant in tz: same value as
+    // the DATETIME round-trip, but the partition pruner can see through it.
     getSqlForTruncatedDateAsDateInTimezone: (
         timeFrame,
         originalSql,
@@ -616,6 +616,7 @@ const bigqueryConfig: WarehouseConfig = {
 
 // Snowflake handles start of week by setting a session variable (WEEK_START)
 const snowflakeConfig: WarehouseConfig = {
+    getSqlForTruncatedDateAsDateInTimezone: null,
     getSqlForTruncatedDate: (timeFrame, originalSql) =>
         `DATE_TRUNC('${timeFrame}', ${originalSql})`,
     getSqlForDatePart: (timeFrame: TimeFrames, originalSql: string) => {
@@ -667,6 +668,7 @@ const snowflakeConfig: WarehouseConfig = {
 };
 
 const postgresConfig: WarehouseConfig = {
+    getSqlForTruncatedDateAsDateInTimezone: null,
     getSqlForTruncatedDate: (timeFrame, originalSql, _, startOfWeek) => {
         if (timeFrame === TimeFrames.WEEK && isWeekDay(startOfWeek)) {
             const intervalDiff = `${startOfWeek} days`;
@@ -737,6 +739,7 @@ const postgresConfig: WarehouseConfig = {
 };
 
 const databricksConfig: WarehouseConfig = {
+    getSqlForTruncatedDateAsDateInTimezone: null,
     getSqlForTruncatedDate: (timeFrame, originalSql, _, startOfWeek) => {
         if (timeFrame === TimeFrames.WEEK && isWeekDay(startOfWeek)) {
             const intervalDiff = `${startOfWeek}`;
@@ -807,6 +810,7 @@ const databricksConfig: WarehouseConfig = {
 };
 
 const trinoConfig: WarehouseConfig = {
+    getSqlForTruncatedDateAsDateInTimezone: null,
     // Trino rejects sub-day DATE_TRUNC on DATE columns ('SECOND' is not a
     // valid DATE field). Cast to TIMESTAMP for sub-day grains; no-op when the
     // input is already a TIMESTAMP.
@@ -885,6 +889,7 @@ const trinoConfig: WarehouseConfig = {
 };
 
 const clickhouseConfig: WarehouseConfig = {
+    getSqlForTruncatedDateAsDateInTimezone: null,
     getSqlForTruncatedDate: (timeFrame, originalSql, _, startOfWeek) => {
         if (timeFrame === TimeFrames.WEEK && isWeekDay(startOfWeek)) {
             const intervalDiff = startOfWeek;

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -76,6 +76,16 @@ type WarehouseConfig = {
         type: DimensionType,
         startOfWeek?: WeekDay | null,
     ) => string;
+    // Timezone-wrapped variant of the above for known-aware columns: returns a
+    // DATE in `timezone` directly, skipping the conversion round-trip that
+    // defeats partition pruning (BigQuery only).
+    getSqlForTruncatedDateAsDateInTimezone?: (
+        timeFrame: TimeFrames,
+        originalSql: string,
+        type: DimensionType,
+        startOfWeek: WeekDay | null | undefined,
+        timezone: string,
+    ) => string;
     getSqlForDatePart: (
         timeFrame: TimeFrames,
         originalSql: string,
@@ -515,6 +525,21 @@ const bigqueryConfig: WarehouseConfig = {
                 : `DATE_TRUNC(DATE(${originalSql}), ${datePart})`;
         }
         return `DATE_TRUNC(${originalSql}, ${datePart})`;
+    },
+    // DATE(ts, tz) is by definition the calendar date of the instant in tz —
+    // same value as CAST(DATETIME_TRUNC(DATETIME(ts, tz), ...) AS DATE), but
+    // the pruner can see through it.
+    getSqlForTruncatedDateAsDateInTimezone: (
+        timeFrame,
+        originalSql,
+        _type,
+        startOfWeek,
+        timezone,
+    ) => {
+        const datePart = bigqueryDatePart(timeFrame, startOfWeek);
+        return timeFrame === TimeFrames.DAY
+            ? `DATE(${originalSql}, '${timezone}')`
+            : `DATE_TRUNC(DATE(${originalSql}, '${timezone}'), ${datePart})`;
     },
     getSqlForDatePart: (
         timeFrame: TimeFrames,
@@ -1096,6 +1121,24 @@ export const getSqlForTruncatedDate = (
             originalSql,
             type,
             startOfWeek,
+        );
+    }
+
+    // Known-aware columns can truncate to a DATE in the target tz directly
+    // where the adapter defines a prunable form (BigQuery).
+    const truncatedDateAsDateInTimezone =
+        warehouseConfigs[adapterType].getSqlForTruncatedDateAsDateInTimezone;
+    if (
+        castToDate &&
+        wrap.timestampDomain === 'aware' &&
+        truncatedDateAsDateInTimezone
+    ) {
+        return truncatedDateAsDateInTimezone(
+            timeFrame,
+            originalSql,
+            type,
+            startOfWeek,
+            wrap.timezone,
         );
     }
 


### PR DESCRIPTION
## Problem

With timezone support enabled and a non-UTC project timezone, day/week/month/quarter/year filters on BigQuery `TIMESTAMP` columns compile to

```sql
CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP(col), 'Asia/Tokyo'), DAY) AS DATE) = '2024-01-15'
```

BigQuery's partition pruner can't see through that, so the whole table is scanned, and tables with `require_partition_filter=TRUE` reject the query outright.

## Fix

For known-aware `TIMESTAMP` columns on BigQuery, day-or-coarser grains now render in the DATE domain, which BigQuery prunes on:

```sql
DATE(col, 'Asia/Tokyo')                          -- day
DATE_TRUNC(DATE(col, 'Asia/Tokyo'), MONTH)       -- week / month / quarter / year
```

Same value as before (the civil date of the instant in the project timezone), so filter semantics and the documented DST behaviour are unchanged. Everything else keeps today's SQL: UTC, naive/unknown columns, sub-day grains, DATE columns, other warehouses. A `convert_timezone: false` column keeps its bare SELECT; its filter LHS was already timezone-wrapped on `main` and now takes the same prunable form (same value).

Only known-aware columns qualify, so a `sql:`-backed or additional dimension over a partitioned TIMESTAMP needs an explicit `timestamp_domain: aware` to get the prunable form (the catalog cannot classify an expression).

## Tests

* Unit: `timeFrames` and `MetricQueryBuilder` cover every grain, operator (=, !=, <, <=, >, >=, inBetween, IN), custom and default week start, inThePast/inTheNext/inTheCurrent, null, metric-embedded filters, each fallback, and non-BigQuery parity.
* The dbt `timezone_test` example is now day-partitioned on BigQuery; the API suite runs day (equals, inBetween, greaterThan), week, month, quarter and year filters against it, using boundary rows that change bucket once shifted out of UTC.
* Verified live: generated queries run on a `require_partition_filter` table and match the previous predicate row-for-row across New York and Santiago DST transitions.

Closes: lightdash/lightdash#27306<br>Closes: lightdash/lightdash#27306

## Local verification (2026-08-20)

Run against a local stack with timezone support enabled and a project pointing at the deployed, day-partitioned staging `timezone_test` table. Semantics were checked on both the Postgres seed (untouched by this PR, used as the oracle) and BigQuery.

### Partition pruning

Each compiled statement was run once through the SQL runner endpoint (`POST /api/v2/projects/{p}/query/sql`), then the same statement with the previous predicate (`CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP(col), tz), G) AS DATE)`) substituted back in. Bytes processed per job from `INFORMATION_SCHEMA.JOBS_BY_USER`. The table is 33 rows; 264 bytes is a full scan of one column.

<!-- linear:table-colwidths:266,266,266 -->
| case | this PR | before |
| -- | -- | -- |
| day equals, Asia/Tokyo | 72 | 264 |
| day equals, America/Chicago | 96 | 264 |
| day equals (multi-value IN), Asia/Tokyo | 104 | 264 |
| day inBetween, Asia/Tokyo | 72 | 264 |
| day lessThan / lessThanOrEqual, Asia/Tokyo | 16 / 80 | 264 |
| day greaterThan / greaterThanOrEqual, Asia/Tokyo | 248 / 256 | 264 |
| day inThePast 7 days, Asia/Tokyo | 0 | 264 |
| week / month / quarter / year equals, America/New_York | 0 / 120 / 168 / 256 | 264 |
| day notEquals, Asia/Tokyo | 264 | 264 |
| `convert_timezone: false` column, day equals | 528 | 528 |

Every previous statement scans the whole table; every new one is pruned to the touched partitions (a non-UTC local day spans two UTC day partitions, e.g. Tokyo Jan 15 = 9 rows = 72 bytes). The two unchanged rows are expected: `!=` cannot prune, and the opt-out column is not the partition column.

### Semantics and DST

* 55/55 in a parity suite run on both warehouses: 5 zones (UTC, New_York, Chicago, Tokyo, Pago_Pago) × 6 operators on the interior rows; week / month / quarter / year boundary rows; America/New_York spring-forward (rows [#13](<https://github.com/lightdash/lightdash/issues/13>), [#14](<https://github.com/lightdash/lightdash/issues/14>), [#32](<https://github.com/lightdash/lightdash/issues/32>), [#33](<https://github.com/lightdash/lightdash/issues/33>) all filter into `2024-03-10` only) and fall-back ([#15](<https://github.com/lightdash/lightdash/issues/15>), [#16](<https://github.com/lightdash/lightdash/issues/16>) into `2024-11-03`, nothing strictly after); GROUP BY day agrees with the filter on both transition days; month filters across both transitions; the 13-row monthly series stays one per month; America/Santiago either side of its offset flip.
* Existing `queryTimezone` (including the BigQuery block in this PR), `queryTimezoneBoundary`, `dataTimezone`, `userTimezone`, `embedTimezone`: 120 passed.
* `common` and `MetricQueryBuilder` unit tests green.

Compiled SQL shape confirmed for every fallback: UTC, hour grain and naive `event_timestamp_ntz` keep today's SQL; the `convert_timezone: false` filter LHS takes the prunable form with the same value.