### PR TITLE
fix: keep the role-set picker single-line and fit three small pills

### DIFF
--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -311,7 +311,8 @@ const UsersTable: FC = () => {
                 accessorKey: 'role',
                 header: 'Role',
                 enableSorting: false,
-                size: 200,
+                // Wide enough for a set of three small role pills on one line
+                size: 260,
                 Cell: ({ row }) => {
                     const user = row.original;
                     if (multipleRolesEnabled) {

--- a/packages/frontend/src/features/roleSets/components/OrganizationRoleSetCell.tsx
+++ b/packages/frontend/src/features/roleSets/components/OrganizationRoleSetCell.tsx
@@ -77,7 +77,7 @@ export const OrganizationRoleSetCell: FC<Props> = ({
             onChange={onChange}
             disabled={disabled || isPending}
             ariaLabel={`Roles for ${user.email}`}
-            w={280}
+            w={260}
         />
     );
 };

--- a/packages/frontend/src/features/roleSets/components/RoleSetMultiSelect.module.css
+++ b/packages/frontend/src/features/roleSets/components/RoleSetMultiSelect.module.css
@@ -1,0 +1,7 @@
+/* Mantine gives the inline search field min-width: 100px, which wraps it to a
+   second line (doubling the field height) as soon as pills fill the row. A
+   caret-sized minimum keeps the field single-line; it can still wrap once the
+   user actually types. */
+.inputField {
+    min-width: 24px;
+}

--- a/packages/frontend/src/features/roleSets/components/RoleSetMultiSelect.tsx
+++ b/packages/frontend/src/features/roleSets/components/RoleSetMultiSelect.tsx
@@ -1,5 +1,6 @@
 import { MultiSelect, Tooltip } from '@mantine/core';
 import { useCallback, useMemo } from 'react';
+import classes from './RoleSetMultiSelect.module.css';
 
 export type RoleOption = { value: string; label: string };
 
@@ -113,6 +114,7 @@ export function RoleSetMultiSelect<TSystemRole extends string>({
                 placeholder={
                     toValues(value).length === 0 ? placeholder : undefined
                 }
+                classNames={{ inputField: classes.inputField }}
                 searchable
                 hidePickedOptions
                 comboboxProps={{ withinPortal: true }}


### PR DESCRIPTION
Follow-up to the role-set UI (PROD-10217 / #27569).

Two related layout issues with the role-set multi-select:

1. **The box was two lines tall even when the pills fit.** Mantine's inline search field ships with `min-width: 100px`; once pills filled the row, the *empty* field wrapped to a second line and doubled the input height (`Admin × Reviewer ×` at 200px column width). A CSS-module override caps it at caret width — it still grows normally when the user types.
2. **The org users Role column was too narrow.** It clamped the picker to 200px, so even two pills wrapped. Column and picker are now **260px** — measured in-browser to fit three small role pills (`Viewer × Rev × Reviewer ×`) on one line with margin, without letting the Role column dominate. The project access tables keep their existing 300px.

Verified live: one-, two- and three-pill rows all render as a single 30px-tall line; typing/filtering in the picker still works. Frontend tests, typecheck, lint green. Flag-off legacy Selects untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)