### PR TITLE
feat(ai-agents): restrict MCP table calculations to formula-only schema

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -5368,35 +5368,33 @@ Example B — "Revenue by month with year-over-year comparison"
               },
               "tableCalculations": {
                 "description": "
-Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
+Table calculations perform row-by-row calculations on query results without collapsing rows, using spreadsheet-like formulas.
 
-**Prefer type "formula"** — it expresses arithmetic across fields, ratios, comparisons, conditionals, and partitioned window calculations. The other types are legacy single-field templates kept for backwards compatibility.
+Use them whenever the question needs math the metric query alone can't express: arithmetic across metrics (\`metric_a + metric_b\`), ratios, percent of total, period-over-period change, running totals, moving averages, ranking, row-level comparisons, or aggregating already-aggregated metrics.
 
 **Technical Requirements:**
 - Appear as additional columns in query results
 - Can be used in sorts and filters alongside dimensions/metrics
-- Multiple calculations can be combined in a single query
-- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)
+- Multiple calculations can be combined in a single query; a formula can reference another table calculation by name
+- All fields referenced must be selected in the query (dimensions, metrics, custom metrics, or other table calculations)
 , ",
                 "items": {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "properties": {
-                        "displayName": {
-                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                          "type": "string",
-                        },
-                        "format": {
-                          "description": "Display format. Use "percent" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to "number"., ",
-                          "enum": [
-                            "number",
-                            "percent",
-                          ],
-                          "type": "string",
-                        },
-                        "formula": {
-                          "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "format": {
+                      "description": "Display format. Use "percent" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to "number"., ",
+                      "enum": [
+                        "number",
+                        "percent",
+                      ],
+                      "type": "string",
+                    },
+                    "formula": {
+                      "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).
 Reference fields by their field id directly, e.g. \`orders_total_revenue / orders_order_count\`. No prefix, no braces, no leading \`=\`.
 Any selected dimension, metric, custom metric (\`<table>_<name>\`), or another table calculation name can be referenced.
 Operators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.
@@ -5404,439 +5402,35 @@ Functions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_T
 Window functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. \`LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)\`.
 MOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is \`MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)\`.
 All branches of an IF must return the same type.",
-                          "type": "string",
-                        },
-                        "name": {
-                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                          "type": "string",
-                        },
-                        "resultType": {
-                          "description": "Data type the formula evaluates to. null defaults to "number"., ",
-                          "enum": [
-                            "number",
-                            "string",
-                            "date",
-                            "timestamp",
-                            "boolean",
-                          ],
-                          "type": "string",
-                        },
-                        "type": {
-                          "const": "formula",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "name",
-                        "displayName",
-                        "type",
-                        "formula",
-                      ],
-                      "type": "object",
+                      "type": "string",
                     },
-                    {
-                      "additionalProperties": false,
-                      "properties": {
-                        "displayName": {
-                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                          "type": "string",
-                        },
-                        "fieldId": {
-                          "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                          "type": "string",
-                        },
-                        "name": {
-                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                          "type": "string",
-                        },
-                        "orderBy": {
-                          "description": "Specifies the order in which rows are processed by the table calculation.
-For time-series: typically order by date/time ascending.
-For rankings: order by the metric you want to rank, descending for highest-first.",
-                          "items": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "fieldId": {
-                                "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                "type": "string",
-                              },
-                              "order": {
-                                "description": ", ",
-                                "enum": [
-                                  "asc",
-                                  "desc",
-                                ],
-                                "type": "string",
-                              },
-                            },
-                            "required": [
-                              "fieldId",
-                            ],
-                            "type": "object",
-                          },
-                          "minItems": 1,
-                          "type": "array",
-                        },
-                        "partitionBy": {
-                          "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows)., ",
-                          "items": {
-                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "type": "array",
-                        },
-                        "type": {
-                          "const": "percent_change_from_previous",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "name",
-                        "displayName",
-                        "type",
-                        "fieldId",
-                        "orderBy",
-                      ],
-                      "type": "object",
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
                     },
-                    {
-                      "additionalProperties": false,
-                      "properties": {
-                        "displayName": {
-                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                          "type": "string",
-                        },
-                        "fieldId": {
-                          "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                          "type": "string",
-                        },
-                        "name": {
-                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                          "type": "string",
-                        },
-                        "orderBy": {
-                          "description": "Specifies the order in which rows are processed by the table calculation.
-For time-series: typically order by date/time ascending.
-For rankings: order by the metric you want to rank, descending for highest-first.",
-                          "items": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "fieldId": {
-                                "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                "type": "string",
-                              },
-                              "order": {
-                                "description": ", ",
-                                "enum": [
-                                  "asc",
-                                  "desc",
-                                ],
-                                "type": "string",
-                              },
-                            },
-                            "required": [
-                              "fieldId",
-                            ],
-                            "type": "object",
-                          },
-                          "minItems": 1,
-                          "type": "array",
-                        },
-                        "partitionBy": {
-                          "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows)., ",
-                          "items": {
-                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "type": "array",
-                        },
-                        "type": {
-                          "const": "percent_of_previous_value",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "name",
-                        "displayName",
-                        "type",
-                        "fieldId",
-                        "orderBy",
+                    "resultType": {
+                      "description": "Data type the formula evaluates to. null defaults to "number"., ",
+                      "enum": [
+                        "number",
+                        "string",
+                        "date",
+                        "timestamp",
+                        "boolean",
                       ],
-                      "type": "object",
+                      "type": "string",
                     },
-                    {
-                      "additionalProperties": false,
-                      "properties": {
-                        "displayName": {
-                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                          "type": "string",
-                        },
-                        "fieldId": {
-                          "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                          "type": "string",
-                        },
-                        "name": {
-                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                          "type": "string",
-                        },
-                        "partitionBy": {
-                          "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows)., ",
-                          "items": {
-                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "type": "array",
-                        },
-                        "type": {
-                          "const": "percent_of_column_total",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "name",
-                        "displayName",
-                        "type",
-                        "fieldId",
-                      ],
-                      "type": "object",
+                    "type": {
+                      "const": "formula",
+                      "type": "string",
                     },
-                    {
-                      "additionalProperties": false,
-                      "properties": {
-                        "displayName": {
-                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                          "type": "string",
-                        },
-                        "fieldId": {
-                          "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                          "type": "string",
-                        },
-                        "name": {
-                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                          "type": "string",
-                        },
-                        "type": {
-                          "const": "rank_in_column",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "name",
-                        "displayName",
-                        "type",
-                        "fieldId",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "properties": {
-                        "displayName": {
-                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                          "type": "string",
-                        },
-                        "fieldId": {
-                          "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                          "type": "string",
-                        },
-                        "name": {
-                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                          "type": "string",
-                        },
-                        "type": {
-                          "const": "running_total",
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "name",
-                        "displayName",
-                        "type",
-                        "fieldId",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "properties": {
-                        "displayName": {
-                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                          "type": "string",
-                        },
-                        "fieldId": {
-                          "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error, Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                          "type": "string",
-                        },
-                        "frame": {
-                          "additionalProperties": false,
-                          "description": "Defines which rows to include in calculation. Null uses database defaults.
-
-**Common patterns:**
-- Moving average (N periods): {frameType: "rows", start: {type: "preceding", offset: N-1}, end: {type: "current_row"}}
-- Running total: {frameType: "rows", start: {type: "unbounded_preceding"}, end: {type: "current_row"}}
-- Centered window: {frameType: "rows", start: {type: "preceding", offset: 1}, end: {type: "following", offset: 1}}
-
-**Default when null:**
-- Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)
-- Aggregates WITHOUT ORDER BY: Entire partition (all rows)
-- Ranking functions: Always use entire partition (frame clause has no effect), ",
-                          "properties": {
-                            "end": {
-                              "additionalProperties": false,
-                              "description": "End boundary (required)",
-                              "properties": {
-                                "offset": {
-                                  "description": "Number of rows for PRECEDING/FOLLOWING, ",
-                                  "exclusiveMinimum": 0,
-                                  "type": "integer",
-                                },
-                                "type": {
-                                  "enum": [
-                                    "unbounded_preceding",
-                                    "preceding",
-                                    "current_row",
-                                    "following",
-                                    "unbounded_following",
-                                  ],
-                                  "type": "string",
-                                },
-                              },
-                              "required": [
-                                "type",
-                              ],
-                              "type": "object",
-                            },
-                            "frameType": {
-                              "description": "Frame type:
-- rows: Physical row count
-- range: Logical value-based (includes peer rows with same ORDER BY value)",
-                              "enum": [
-                                "rows",
-                                "range",
-                              ],
-                              "type": "string",
-                            },
-                            "start": {
-                              "additionalProperties": false,
-                              "description": "Start boundary. Null for single-boundary syntax., ",
-                              "properties": {
-                                "offset": {
-                                  "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING"), ",
-                                  "exclusiveMinimum": 0,
-                                  "type": "integer",
-                                },
-                                "type": {
-                                  "enum": [
-                                    "unbounded_preceding",
-                                    "preceding",
-                                    "current_row",
-                                    "following",
-                                    "unbounded_following",
-                                  ],
-                                  "type": "string",
-                                },
-                              },
-                              "required": [
-                                "type",
-                              ],
-                              "type": "object",
-                            },
-                          },
-                          "required": [
-                            "frameType",
-                            "end",
-                          ],
-                          "type": "object",
-                        },
-                        "name": {
-                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                          "type": "string",
-                        },
-                        "orderBy": {
-                          "description": "Specifies the order in which rows are processed by the table calculation.
-For time-series: typically order by date/time ascending.
-For rankings: order by the metric you want to rank, descending for highest-first., ",
-                          "items": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "fieldId": {
-                                "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                "type": "string",
-                              },
-                              "order": {
-                                "description": ", ",
-                                "enum": [
-                                  "asc",
-                                  "desc",
-                                ],
-                                "type": "string",
-                              },
-                            },
-                            "required": [
-                              "fieldId",
-                            ],
-                            "type": "object",
-                          },
-                          "type": "array",
-                        },
-                        "partitionBy": {
-                          "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows)., ",
-                          "items": {
-                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "type": "array",
-                        },
-                        "type": {
-                          "const": "window_function",
-                          "type": "string",
-                        },
-                        "windowFunction": {
-                          "description": "Type of window function to apply.
-
-**Ranking functions** (fieldId optional, ignored if provided):
-- row_number: Sequential numbering (1, 2, 3...)
-- percent_rank: Relative rank as percentage (0.0-1.0)
-- cume_dist: Cumulative distribution as percentage (0.0-1.0)
-- rank: Positional rank (1, 2, 3...) with ties
-
-**Aggregate functions** (fieldId required):
-- sum: Sum values within frame
-- avg: Average values within frame
-- count: Count values within frame
-- min: Minimum value within frame
-- max: Maximum value within frame",
-                          "enum": [
-                            "row_number",
-                            "percent_rank",
-                            "cume_dist",
-                            "rank",
-                            "sum",
-                            "avg",
-                            "count",
-                            "min",
-                            "max",
-                          ],
-                          "type": "string",
-                        },
-                      },
-                      "required": [
-                        "name",
-                        "displayName",
-                        "type",
-                        "windowFunction",
-                      ],
-                      "type": "object",
-                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "formula",
                   ],
+                  "type": "object",
                 },
                 "type": "array",
               },

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -266,7 +266,7 @@ import {
     toolRunQueryArgsSchemaV2RejectingMerge,
     toolRunQueryArgsSchemaV2Transformed,
     toolRunQueryOutputSchema,
-    type toolRunQueryArgsSchemaV2,
+    type toolRunQueryArgsSchemaV2FormulaOnly,
 } from './toolRunQueryArgs';
 import {
     TOOL_RUN_SAVED_CHART_DESCRIPTION,
@@ -537,8 +537,10 @@ export const runQueryToolDefinition: ToolDefinitionWithMcpOutput<
     title: 'Run query',
     description: TOOL_RUN_QUERY_DESCRIPTION,
     availability: ['agent', 'mcp'],
-    // Custom chart types are agent-only for the PoC — MCP keeps the
-    // builtin-only chart config contract.
+    // MCP contract: formula-only table calcs (template calls fail at the
+    // boundary with an error the model can correct) and builtin-only chart
+    // config (custom chart types are agent-only for the PoC). The
+    // transformed parse stays wide for persisted-args replay.
     inputSchema: toolRunQueryArgsSchemaV2Mcp,
     inputSchemaTransformed: toolRunQueryArgsSchemaV2Transformed,
     agent: { outputSchema: toolRunQueryOutputSchema },
@@ -554,7 +556,7 @@ export const runQueryToolDefinition: ToolDefinitionWithMcpOutput<
 // stripped to the primary query by Zod. Lazy, like `.for('agent')`.
 export const getRunQueryAgentViewRejectingMerge = (): AgentToolView<
     'runQuery',
-    typeof toolRunQueryArgsSchemaV2,
+    typeof toolRunQueryArgsSchemaV2FormulaOnly,
     typeof toolRunQueryOutputSchema
 > => ({
     ...runQueryToolDefinition.for('agent'),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -258,7 +258,7 @@ import {
     toolRenderChartArgsSchemaTransformed,
     toolRunQueryArgsSchema,
     toolRunQueryArgsSchemaTransformed,
-    toolRunQueryArgsSchemaV2,
+    toolRunQueryArgsSchemaV2FormulaOnly,
     toolRunQueryArgsSchemaV2RejectingMerge,
     toolRunQueryArgsSchemaV2Transformed,
     toolRunQueryOutputSchema,
@@ -527,7 +527,7 @@ export const generateVisualizationToolDefinition: ToolDefinitionWithoutMcpOutput
 
 export const runQueryToolDefinition: ToolDefinitionWithMcpOutput<
     'runQuery',
-    typeof toolRunQueryArgsSchemaV2,
+    typeof toolRunQueryArgsSchemaV2FormulaOnly,
     typeof toolRunQueryArgsSchemaV2Transformed,
     typeof toolRunQueryOutputSchema,
     typeof mcpRunMetricQueryStructuredOutputSchema
@@ -536,7 +536,10 @@ export const runQueryToolDefinition: ToolDefinitionWithMcpOutput<
     title: 'Run query',
     description: TOOL_RUN_QUERY_DESCRIPTION,
     availability: ['agent', 'mcp'],
-    inputSchema: toolRunQueryArgsSchemaV2,
+    // Formula-only advertised contract; incoming template calls fail
+    // validation at the boundary with an error the model can correct. The
+    // transformed parse stays wide for persisted-args replay.
+    inputSchema: toolRunQueryArgsSchemaV2FormulaOnly,
     inputSchemaTransformed: toolRunQueryArgsSchemaV2Transformed,
     agent: { outputSchema: toolRunQueryOutputSchema },
     mcp: {
@@ -551,7 +554,7 @@ export const runQueryToolDefinition: ToolDefinitionWithMcpOutput<
 // stripped to the primary query by Zod. Lazy, like `.for('agent')`.
 export const getRunQueryAgentViewRejectingMerge = (): AgentToolView<
     'runQuery',
-    typeof toolRunQueryArgsSchemaV2,
+    typeof toolRunQueryArgsSchemaV2FormulaOnly,
     typeof toolRunQueryOutputSchema
 > => ({
     ...runQueryToolDefinition.for('agent'),

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.test.ts
@@ -12,7 +12,9 @@ import {
     toolRunQueryArgsSchemaTransformed,
     toolRunQueryArgsSchemaV1,
     toolRunQueryArgsSchemaV2,
+    toolRunQueryArgsSchemaV2FormulaOnly,
     toolRunQueryArgsSchemaV2RejectingMerge,
+    toolRunQueryArgsSchemaV2Transformed,
     toolRunQueryArgsSchemaV3,
 } from './toolRunQueryArgs';
 
@@ -259,5 +261,57 @@ describe('isRunQueryArgsV1', () => {
 
         expect(isRunQueryArgsV1(v1)).toBe(true);
         expect(isRunQueryArgsV1(v2)).toBe(false);
+    });
+});
+
+const templateCalc = {
+    type: 'running_total',
+    name: 'running_revenue',
+    displayName: 'Running Revenue',
+    fieldId: 'orders_revenue',
+};
+
+const formulaCalc = {
+    type: 'formula',
+    name: 'aov',
+    displayName: 'AOV',
+    formula: 'orders_revenue / orders_count',
+    format: null,
+    resultType: null,
+};
+
+// MCP run_metric_query and merge-disabled agent runtimes advertise this;
+// templates must fail at the boundary while the execution parse stays wide.
+describe('toolRunQueryArgsSchemaV2FormulaOnly', () => {
+    it('accepts formula table calcs', () => {
+        expect(
+            toolRunQueryArgsSchemaV2FormulaOnly.safeParse(
+                buildV2Args({ tableCalculations: [formulaCalc] }),
+            ).success,
+        ).toBe(true);
+    });
+
+    it('rejects legacy template table calcs', () => {
+        expect(
+            toolRunQueryArgsSchemaV2FormulaOnly.safeParse(
+                buildV2Args({ tableCalculations: [templateCalc] }),
+            ).success,
+        ).toBe(false);
+    });
+
+    it('rejects template calcs through the merge-rejecting variant too', () => {
+        expect(
+            toolRunQueryArgsSchemaV2RejectingMerge.safeParse(
+                buildV2Args({ tableCalculations: [templateCalc] }),
+            ).success,
+        ).toBe(false);
+    });
+
+    it('wide transformed parse still accepts persisted template payloads', () => {
+        expect(
+            toolRunQueryArgsSchemaV2Transformed.safeParse(
+                buildV2Args({ tableCalculations: [templateCalc] }),
+            ).success,
+        ).toBe(true);
     });
 });

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.test.ts
@@ -14,8 +14,10 @@ import {
     toolRunQueryArgsSchemaTransformed,
     toolRunQueryArgsSchemaV1,
     toolRunQueryArgsSchemaV2,
+    toolRunQueryArgsSchemaV2FormulaOnly,
     toolRunQueryArgsSchemaV2Mcp,
     toolRunQueryArgsSchemaV2RejectingMerge,
+    toolRunQueryArgsSchemaV2Transformed,
     toolRunQueryArgsSchemaV3,
 } from './toolRunQueryArgs';
 
@@ -392,5 +394,65 @@ describe('isRunQueryArgsV1', () => {
 
         expect(isRunQueryArgsV1(v1)).toBe(true);
         expect(isRunQueryArgsV1(v2)).toBe(false);
+    });
+});
+
+const templateCalc = {
+    type: 'running_total',
+    name: 'running_revenue',
+    displayName: 'Running Revenue',
+    fieldId: 'orders_revenue',
+};
+
+const formulaCalc = {
+    type: 'formula',
+    name: 'aov',
+    displayName: 'AOV',
+    formula: 'orders_revenue / orders_count',
+    format: null,
+    resultType: null,
+};
+
+// MCP run_metric_query and merge-disabled agent runtimes advertise this;
+// templates must fail at the boundary while the execution parse stays wide.
+describe('toolRunQueryArgsSchemaV2FormulaOnly', () => {
+    it('accepts formula table calcs', () => {
+        expect(
+            toolRunQueryArgsSchemaV2FormulaOnly.safeParse(
+                buildV2Args({ tableCalculations: [formulaCalc] }),
+            ).success,
+        ).toBe(true);
+    });
+
+    it('rejects legacy template table calcs', () => {
+        expect(
+            toolRunQueryArgsSchemaV2FormulaOnly.safeParse(
+                buildV2Args({ tableCalculations: [templateCalc] }),
+            ).success,
+        ).toBe(false);
+    });
+
+    it('rejects template calcs through the MCP view too', () => {
+        expect(
+            toolRunQueryArgsSchemaV2Mcp.safeParse(
+                buildV2Args({ tableCalculations: [templateCalc] }),
+            ).success,
+        ).toBe(false);
+    });
+
+    it('rejects template calcs through the merge-rejecting variant too', () => {
+        expect(
+            toolRunQueryArgsSchemaV2RejectingMerge.safeParse(
+                buildV2Args({ tableCalculations: [templateCalc] }),
+            ).success,
+        ).toBe(false);
+    });
+
+    it('wide transformed parse still accepts persisted template payloads', () => {
+        expect(
+            toolRunQueryArgsSchemaV2Transformed.safeParse(
+                buildV2Args({ tableCalculations: [templateCalc] }),
+            ).success,
+        ).toBe(true);
     });
 });

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -267,6 +267,18 @@ export const toolRunQueryArgsSchemaV2 = createToolSchema()
     })
     .build();
 
+// Merge-less advertised contract with formula-only table calcs: MCP
+// run_metric_query and merge-disabled agent runtimes. Template-shaped
+// payloads fail validation at the boundary with an actionable Zod error the
+// model can correct; persisted args still parse via the wide schemas.
+export const toolRunQueryArgsSchemaV2FormulaOnly = createToolSchema()
+    .extend({
+        ...visualizationMetadataSchema.shape,
+        queryConfig: queryConfigSchemaV4,
+        chartConfig: chartConfigSchema,
+    })
+    .build();
+
 export const toolRunQueryArgsSchemaV3 = createToolSchema()
     .extend({
         ...visualizationMetadataSchema.shape,
@@ -307,7 +319,7 @@ export const toolRunQueryArgsSchema = toolRunQueryArgsSchemaV4;
 //   narrow it — old threads must keep parsing.
 export const toolRunQueryArgsSchemaPersisted = toolRunQueryArgsSchemaV3;
 
-// V2 for runtimes where merge queries are disabled: a merge-shaped payload
+// For runtimes where merge queries are disabled: a merge-shaped payload
 // must fail validation, not have Zod strip mergeConfig and run only the
 // primary query. The preprocess leaves the emitted JSON schema unchanged.
 export const toolRunQueryArgsSchemaV2RejectingMerge = z.preprocess(
@@ -328,7 +340,7 @@ export const toolRunQueryArgsSchemaV2RejectingMerge = z.preprocess(
         }
         return raw;
     },
-    toolRunQueryArgsSchemaV2,
+    toolRunQueryArgsSchemaV2FormulaOnly,
 );
 
 export type ToolRunQueryArgsV1 = z.infer<typeof toolRunQueryArgsSchemaV1>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -315,6 +315,18 @@ export const toolRunQueryArgsSchemaV2 = createToolSchema()
     })
     .build();
 
+// Merge-less advertised contract with formula-only table calcs: MCP
+// run_metric_query and merge-disabled agent runtimes. Template-shaped
+// payloads fail validation at the boundary with an actionable Zod error the
+// model can correct; persisted args still parse via the wide schemas.
+export const toolRunQueryArgsSchemaV2FormulaOnly = createToolSchema()
+    .extend({
+        ...visualizationMetadataSchema.shape,
+        queryConfig: queryConfigSchemaV4,
+        chartConfig: chartConfigSchema,
+    })
+    .build();
+
 export const toolRunQueryArgsSchemaV3 = createToolSchema()
     .extend({
         ...visualizationMetadataSchema.shape,
@@ -333,11 +345,12 @@ export const toolRunQueryArgsSchemaV4 = createToolSchema()
     })
     .build();
 
-// MCP run_metric_query view: custom chart types are agent-only for the PoC,
-// so MCP keeps advertising (and accepting) only the builtin chart config.
-export const toolRunQueryArgsSchemaV2Mcp = toolRunQueryArgsSchemaV2.extend({
-    chartConfig: chartConfigBuiltinOnlySchema,
-});
+// MCP run_metric_query view: formula-only table calcs, and custom chart
+// types are agent-only for the PoC so MCP keeps the builtin chart config.
+export const toolRunQueryArgsSchemaV2Mcp =
+    toolRunQueryArgsSchemaV2FormulaOnly.extend({
+        chartConfig: chartConfigBuiltinOnlySchema,
+    });
 
 // V4 is the current agent contract (formula-only table calcs). MCP runQuery
 // continues to advertise V2. Historical schemas remain available solely for
@@ -361,7 +374,7 @@ export const toolRunQueryArgsSchema = toolRunQueryArgsSchemaV4;
 //   narrow it — old threads must keep parsing.
 export const toolRunQueryArgsSchemaPersisted = toolRunQueryArgsSchemaV3;
 
-// V2 for runtimes where merge queries are disabled: a merge-shaped payload
+// For runtimes where merge queries are disabled: a merge-shaped payload
 // must fail validation, not have Zod strip mergeConfig and run only the
 // primary query. The preprocess leaves the emitted JSON schema unchanged.
 export const toolRunQueryArgsSchemaV2RejectingMerge = z.preprocess(
@@ -382,7 +395,7 @@ export const toolRunQueryArgsSchemaV2RejectingMerge = z.preprocess(
         }
         return raw;
     },
-    toolRunQueryArgsSchemaV2,
+    toolRunQueryArgsSchemaV2FormulaOnly,
 );
 
 export type ToolRunQueryArgsV1 = z.infer<typeof toolRunQueryArgsSchemaV1>;

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -5257,414 +5257,50 @@
                                 "type": "array"
                             },
                             "tableCalculations": {
-                                "description": "\nTable calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.\n\n**Prefer type \"formula\"** — it expresses arithmetic across fields, ratios, comparisons, conditionals, and partitioned window calculations. The other types are legacy single-field templates kept for backwards compatibility.\n\n**Technical Requirements:**\n- Appear as additional columns in query results\n- Can be used in sorts and filters alongside dimensions/metrics\n- Multiple calculations can be combined in a single query\n- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)\n, ",
+                                "description": "\nTable calculations perform row-by-row calculations on query results without collapsing rows, using spreadsheet-like formulas.\n\nUse them whenever the question needs math the metric query alone can't express: arithmetic across metrics (`metric_a + metric_b`), ratios, percent of total, period-over-period change, running totals, moving averages, ranking, row-level comparisons, or aggregating already-aggregated metrics.\n\n**Technical Requirements:**\n- Appear as additional columns in query results\n- Can be used in sorts and filters alongside dimensions/metrics\n- Multiple calculations can be combined in a single query; a formula can reference another table calculation by name\n- All fields referenced must be selected in the query (dimensions, metrics, custom metrics, or other table calculations)\n, ",
                                 "items": {
-                                    "anyOf": [
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "format": {
-                                                    "description": "Display format. Use \"percent\" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to \"number\"., ",
-                                                    "enum": [
-                                                        "number",
-                                                        "percent"
-                                                    ],
-                                                    "type": "string"
-                                                },
-                                                "formula": {
-                                                    "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).\nReference fields by their field id directly, e.g. `orders_total_revenue / orders_order_count`. No prefix, no braces, no leading `=`.\nAny selected dimension, metric, custom metric (`<table>_<name>`), or another table calculation name can be referenced.\nOperators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.\nFunctions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).\nWindow functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. `LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)`.\nMOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is `MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)`.\nAll branches of an IF must return the same type.",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "resultType": {
-                                                    "description": "Data type the formula evaluates to. null defaults to \"number\"., ",
-                                                    "enum": [
-                                                        "number",
-                                                        "string",
-                                                        "date",
-                                                        "timestamp",
-                                                        "boolean"
-                                                    ],
-                                                    "type": "string"
-                                                },
-                                                "type": {
-                                                    "const": "formula",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "formula"
-                                            ],
-                                            "type": "object"
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "displayName": {
+                                            "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
+                                            "type": "string"
                                         },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field whose values you want to compare \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "orderBy": {
-                                                    "description": "Specifies the order in which rows are processed by the table calculation.\nFor time-series: typically order by date/time ascending.\nFor rankings: order by the metric you want to rank, descending for highest-first.",
-                                                    "items": {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "fieldId": {
-                                                                "description": "Field to order by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                "type": "string"
-                                                            },
-                                                            "order": {
-                                                                "description": ", ",
-                                                                "enum": [
-                                                                    "asc",
-                                                                    "desc"
-                                                                ],
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": ["fieldId"],
-                                                        "type": "object"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "percent_change_from_previous",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId",
-                                                "orderBy"
-                                            ],
-                                            "type": "object"
+                                        "format": {
+                                            "description": "Display format. Use \"percent\" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to \"number\"., ",
+                                            "enum": ["number", "percent"],
+                                            "type": "string"
                                         },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field whose values you want to compare \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "orderBy": {
-                                                    "description": "Specifies the order in which rows are processed by the table calculation.\nFor time-series: typically order by date/time ascending.\nFor rankings: order by the metric you want to rank, descending for highest-first.",
-                                                    "items": {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "fieldId": {
-                                                                "description": "Field to order by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                "type": "string"
-                                                            },
-                                                            "order": {
-                                                                "description": ", ",
-                                                                "enum": [
-                                                                    "asc",
-                                                                    "desc"
-                                                                ],
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": ["fieldId"],
-                                                        "type": "object"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "percent_of_previous_value",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId",
-                                                "orderBy"
-                                            ],
-                                            "type": "object"
+                                        "formula": {
+                                            "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).\nReference fields by their field id directly, e.g. `orders_total_revenue / orders_order_count`. No prefix, no braces, no leading `=`.\nAny selected dimension, metric, custom metric (`<table>_<name>`), or another table calculation name can be referenced.\nOperators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.\nFunctions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).\nWindow functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. `LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)`.\nMOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is `MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)`.\nAll branches of an IF must return the same type.",
+                                            "type": "string"
                                         },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to calculate percentage of column total \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "percent_of_column_total",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId"
-                                            ],
-                                            "type": "object"
+                                        "name": {
+                                            "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
+                                            "type": "string"
                                         },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to rank by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "type": {
-                                                    "const": "rank_in_column",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId"
+                                        "resultType": {
+                                            "description": "Data type the formula evaluates to. null defaults to \"number\"., ",
+                                            "enum": [
+                                                "number",
+                                                "string",
+                                                "date",
+                                                "timestamp",
+                                                "boolean"
                                             ],
-                                            "type": "object"
+                                            "type": "string"
                                         },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to calculate running total of \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "type": {
-                                                    "const": "running_total",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error, Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "frame": {
-                                                    "additionalProperties": false,
-                                                    "description": "Defines which rows to include in calculation. Null uses database defaults.\n\n**Common patterns:**\n- Moving average (N periods): {frameType: \"rows\", start: {type: \"preceding\", offset: N-1}, end: {type: \"current_row\"}}\n- Running total: {frameType: \"rows\", start: {type: \"unbounded_preceding\"}, end: {type: \"current_row\"}}\n- Centered window: {frameType: \"rows\", start: {type: \"preceding\", offset: 1}, end: {type: \"following\", offset: 1}}\n\n**Default when null:**\n- Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)\n- Aggregates WITHOUT ORDER BY: Entire partition (all rows)\n- Ranking functions: Always use entire partition (frame clause has no effect), ",
-                                                    "properties": {
-                                                        "end": {
-                                                            "additionalProperties": false,
-                                                            "description": "End boundary (required)",
-                                                            "properties": {
-                                                                "offset": {
-                                                                    "description": "Number of rows for PRECEDING/FOLLOWING, ",
-                                                                    "exclusiveMinimum": 0,
-                                                                    "type": "integer"
-                                                                },
-                                                                "type": {
-                                                                    "enum": [
-                                                                        "unbounded_preceding",
-                                                                        "preceding",
-                                                                        "current_row",
-                                                                        "following",
-                                                                        "unbounded_following"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "type"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "frameType": {
-                                                            "description": "Frame type:\n- rows: Physical row count\n- range: Logical value-based (includes peer rows with same ORDER BY value)",
-                                                            "enum": [
-                                                                "rows",
-                                                                "range"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        "start": {
-                                                            "additionalProperties": false,
-                                                            "description": "Start boundary. Null for single-boundary syntax., ",
-                                                            "properties": {
-                                                                "offset": {
-                                                                    "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for \"6 PRECEDING\"), ",
-                                                                    "exclusiveMinimum": 0,
-                                                                    "type": "integer"
-                                                                },
-                                                                "type": {
-                                                                    "enum": [
-                                                                        "unbounded_preceding",
-                                                                        "preceding",
-                                                                        "current_row",
-                                                                        "following",
-                                                                        "unbounded_following"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "type"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "frameType",
-                                                        "end"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "orderBy": {
-                                                    "description": "Specifies the order in which rows are processed by the table calculation.\nFor time-series: typically order by date/time ascending.\nFor rankings: order by the metric you want to rank, descending for highest-first., ",
-                                                    "items": {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "fieldId": {
-                                                                "description": "Field to order by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                "type": "string"
-                                                            },
-                                                            "order": {
-                                                                "description": ", ",
-                                                                "enum": [
-                                                                    "asc",
-                                                                    "desc"
-                                                                ],
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": ["fieldId"],
-                                                        "type": "object"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "window_function",
-                                                    "type": "string"
-                                                },
-                                                "windowFunction": {
-                                                    "description": "Type of window function to apply.\n\n**Ranking functions** (fieldId optional, ignored if provided):\n- row_number: Sequential numbering (1, 2, 3...)\n- percent_rank: Relative rank as percentage (0.0-1.0)\n- cume_dist: Cumulative distribution as percentage (0.0-1.0)\n- rank: Positional rank (1, 2, 3...) with ties\n\n**Aggregate functions** (fieldId required):\n- sum: Sum values within frame\n- avg: Average values within frame\n- count: Count values within frame\n- min: Minimum value within frame\n- max: Maximum value within frame",
-                                                    "enum": [
-                                                        "row_number",
-                                                        "percent_rank",
-                                                        "cume_dist",
-                                                        "rank",
-                                                        "sum",
-                                                        "avg",
-                                                        "count",
-                                                        "min",
-                                                        "max"
-                                                    ],
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "windowFunction"
-                                            ],
-                                            "type": "object"
+                                        "type": {
+                                            "const": "formula",
+                                            "type": "string"
                                         }
-                                    ]
+                                    },
+                                    "required": [
+                                        "name",
+                                        "displayName",
+                                        "type",
+                                        "formula"
+                                    ],
+                                    "type": "object"
                                 },
                                 "type": "array"
                             }

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -5496,414 +5496,50 @@
                                 "type": "array"
                             },
                             "tableCalculations": {
-                                "description": "\nTable calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.\n\n**Prefer type \"formula\"** — it expresses arithmetic across fields, ratios, comparisons, conditionals, and partitioned window calculations. The other types are legacy single-field templates kept for backwards compatibility.\n\n**Technical Requirements:**\n- Appear as additional columns in query results\n- Can be used in sorts and filters alongside dimensions/metrics\n- Multiple calculations can be combined in a single query\n- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)\n, ",
+                                "description": "\nTable calculations perform row-by-row calculations on query results without collapsing rows, using spreadsheet-like formulas.\n\nUse them whenever the question needs math the metric query alone can't express: arithmetic across metrics (`metric_a + metric_b`), ratios, percent of total, period-over-period change, running totals, moving averages, ranking, row-level comparisons, or aggregating already-aggregated metrics.\n\n**Technical Requirements:**\n- Appear as additional columns in query results\n- Can be used in sorts and filters alongside dimensions/metrics\n- Multiple calculations can be combined in a single query; a formula can reference another table calculation by name\n- All fields referenced must be selected in the query (dimensions, metrics, custom metrics, or other table calculations)\n, ",
                                 "items": {
-                                    "anyOf": [
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "format": {
-                                                    "description": "Display format. Use \"percent\" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to \"number\"., ",
-                                                    "enum": [
-                                                        "number",
-                                                        "percent"
-                                                    ],
-                                                    "type": "string"
-                                                },
-                                                "formula": {
-                                                    "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).\nReference fields by their field id directly, e.g. `orders_total_revenue / orders_order_count`. No prefix, no braces, no leading `=`.\nAny selected dimension, metric, custom metric (`<table>_<name>`), or another table calculation name can be referenced.\nOperators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.\nFunctions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).\nWindow functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. `LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)`.\nMOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is `MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)`.\nAll branches of an IF must return the same type.",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "resultType": {
-                                                    "description": "Data type the formula evaluates to. null defaults to \"number\"., ",
-                                                    "enum": [
-                                                        "number",
-                                                        "string",
-                                                        "date",
-                                                        "timestamp",
-                                                        "boolean"
-                                                    ],
-                                                    "type": "string"
-                                                },
-                                                "type": {
-                                                    "const": "formula",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "formula"
-                                            ],
-                                            "type": "object"
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "displayName": {
+                                            "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
+                                            "type": "string"
                                         },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field whose values you want to compare \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "orderBy": {
-                                                    "description": "Specifies the order in which rows are processed by the table calculation.\nFor time-series: typically order by date/time ascending.\nFor rankings: order by the metric you want to rank, descending for highest-first.",
-                                                    "items": {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "fieldId": {
-                                                                "description": "Field to order by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                "type": "string"
-                                                            },
-                                                            "order": {
-                                                                "description": ", ",
-                                                                "enum": [
-                                                                    "asc",
-                                                                    "desc"
-                                                                ],
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": ["fieldId"],
-                                                        "type": "object"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "percent_change_from_previous",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId",
-                                                "orderBy"
-                                            ],
-                                            "type": "object"
+                                        "format": {
+                                            "description": "Display format. Use \"percent\" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to \"number\"., ",
+                                            "enum": ["number", "percent"],
+                                            "type": "string"
                                         },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field whose values you want to compare \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "orderBy": {
-                                                    "description": "Specifies the order in which rows are processed by the table calculation.\nFor time-series: typically order by date/time ascending.\nFor rankings: order by the metric you want to rank, descending for highest-first.",
-                                                    "items": {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "fieldId": {
-                                                                "description": "Field to order by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                "type": "string"
-                                                            },
-                                                            "order": {
-                                                                "description": ", ",
-                                                                "enum": [
-                                                                    "asc",
-                                                                    "desc"
-                                                                ],
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": ["fieldId"],
-                                                        "type": "object"
-                                                    },
-                                                    "minItems": 1,
-                                                    "type": "array"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "percent_of_previous_value",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId",
-                                                "orderBy"
-                                            ],
-                                            "type": "object"
+                                        "formula": {
+                                            "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).\nReference fields by their field id directly, e.g. `orders_total_revenue / orders_order_count`. No prefix, no braces, no leading `=`.\nAny selected dimension, metric, custom metric (`<table>_<name>`), or another table calculation name can be referenced.\nOperators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.\nFunctions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).\nWindow functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. `LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)`.\nMOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is `MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)`.\nAll branches of an IF must return the same type.",
+                                            "type": "string"
                                         },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to calculate percentage of column total \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "percent_of_column_total",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId"
-                                            ],
-                                            "type": "object"
+                                        "name": {
+                                            "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
+                                            "type": "string"
                                         },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to rank by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "type": {
-                                                    "const": "rank_in_column",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId"
+                                        "resultType": {
+                                            "description": "Data type the formula evaluates to. null defaults to \"number\"., ",
+                                            "enum": [
+                                                "number",
+                                                "string",
+                                                "date",
+                                                "timestamp",
+                                                "boolean"
                                             ],
-                                            "type": "object"
+                                            "type": "string"
                                         },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to calculate running total of \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "type": {
-                                                    "const": "running_total",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "fieldId"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "displayName": {
-                                                    "description": "Display name for the table calculation, e.g. \"MoM revenue change\"",
-                                                    "type": "string"
-                                                },
-                                                "fieldId": {
-                                                    "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error, Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string"
-                                                },
-                                                "frame": {
-                                                    "additionalProperties": false,
-                                                    "description": "Defines which rows to include in calculation. Null uses database defaults.\n\n**Common patterns:**\n- Moving average (N periods): {frameType: \"rows\", start: {type: \"preceding\", offset: N-1}, end: {type: \"current_row\"}}\n- Running total: {frameType: \"rows\", start: {type: \"unbounded_preceding\"}, end: {type: \"current_row\"}}\n- Centered window: {frameType: \"rows\", start: {type: \"preceding\", offset: 1}, end: {type: \"following\", offset: 1}}\n\n**Default when null:**\n- Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)\n- Aggregates WITHOUT ORDER BY: Entire partition (all rows)\n- Ranking functions: Always use entire partition (frame clause has no effect), ",
-                                                    "properties": {
-                                                        "end": {
-                                                            "additionalProperties": false,
-                                                            "description": "End boundary (required)",
-                                                            "properties": {
-                                                                "offset": {
-                                                                    "description": "Number of rows for PRECEDING/FOLLOWING, ",
-                                                                    "exclusiveMinimum": 0,
-                                                                    "type": "integer"
-                                                                },
-                                                                "type": {
-                                                                    "enum": [
-                                                                        "unbounded_preceding",
-                                                                        "preceding",
-                                                                        "current_row",
-                                                                        "following",
-                                                                        "unbounded_following"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "type"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "frameType": {
-                                                            "description": "Frame type:\n- rows: Physical row count\n- range: Logical value-based (includes peer rows with same ORDER BY value)",
-                                                            "enum": [
-                                                                "rows",
-                                                                "range"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        "start": {
-                                                            "additionalProperties": false,
-                                                            "description": "Start boundary. Null for single-boundary syntax., ",
-                                                            "properties": {
-                                                                "offset": {
-                                                                    "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for \"6 PRECEDING\"), ",
-                                                                    "exclusiveMinimum": 0,
-                                                                    "type": "integer"
-                                                                },
-                                                                "type": {
-                                                                    "enum": [
-                                                                        "unbounded_preceding",
-                                                                        "preceding",
-                                                                        "current_row",
-                                                                        "following",
-                                                                        "unbounded_following"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "type"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "frameType",
-                                                        "end"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                "name": {
-                                                    "description": "Unique name for the table calculation, e.g. \"percent_change_from_previous\"",
-                                                    "type": "string"
-                                                },
-                                                "orderBy": {
-                                                    "description": "Specifies the order in which rows are processed by the table calculation.\nFor time-series: typically order by date/time ascending.\nFor rankings: order by the metric you want to rank, descending for highest-first., ",
-                                                    "items": {
-                                                        "additionalProperties": false,
-                                                        "properties": {
-                                                            "fieldId": {
-                                                                "description": "Field to order by \"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                                "type": "string"
-                                                            },
-                                                            "order": {
-                                                                "description": ", ",
-                                                                "enum": [
-                                                                    "asc",
-                                                                    "desc"
-                                                                ],
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": ["fieldId"],
-                                                        "type": "object"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "partitionBy": {
-                                                    "description": "Fields to PARTITION BY - divides result set into independent groups.\nEach partition calculates independently (rankings restart, percentages sum to 100% per partition).\nEmpty array or null: single partition (calculations across all rows)., ",
-                                                    "items": {
-                                                        "description": "\"fieldId\" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                },
-                                                "type": {
-                                                    "const": "window_function",
-                                                    "type": "string"
-                                                },
-                                                "windowFunction": {
-                                                    "description": "Type of window function to apply.\n\n**Ranking functions** (fieldId optional, ignored if provided):\n- row_number: Sequential numbering (1, 2, 3...)\n- percent_rank: Relative rank as percentage (0.0-1.0)\n- cume_dist: Cumulative distribution as percentage (0.0-1.0)\n- rank: Positional rank (1, 2, 3...) with ties\n\n**Aggregate functions** (fieldId required):\n- sum: Sum values within frame\n- avg: Average values within frame\n- count: Count values within frame\n- min: Minimum value within frame\n- max: Maximum value within frame",
-                                                    "enum": [
-                                                        "row_number",
-                                                        "percent_rank",
-                                                        "cume_dist",
-                                                        "rank",
-                                                        "sum",
-                                                        "avg",
-                                                        "count",
-                                                        "min",
-                                                        "max"
-                                                    ],
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "name",
-                                                "displayName",
-                                                "type",
-                                                "windowFunction"
-                                            ],
-                                            "type": "object"
+                                        "type": {
+                                            "const": "formula",
+                                            "type": "string"
                                         }
-                                    ]
+                                    },
+                                    "required": [
+                                        "name",
+                                        "displayName",
+                                        "type",
+                                        "formula"
+                                    ],
+                                    "type": "object"
                                 },
                                 "type": "array"
                             }

--- a/release-safety.declarations.json
+++ b/release-safety.declarations.json
@@ -4,6 +4,10 @@
         "ai-agent-legacy-viz-tool-names-removed": {
             "reason": "The retired AI agent tool names generateBarVizConfig, generateTableVizConfig and generateTimeSeriesVizConfig are removed from the AgentToolName API enum. No agent has emitted them since November 2025, so this only affects AI threads created before then: their legacy chart tool calls stop rendering. Threads still load and every other message is unaffected.",
             "requiredStop": false
+        },
+        "mcp-run-metric-query-formula-only-table-calcs": {
+            "reason": "The MCP run_metric_query tool no longer accepts template table calculations (running_total, percent_of_previous_value, etc.) in queryConfig.tableCalculations; only formula table calculations are accepted. MCP clients that send template-shaped payloads (scripted callers or agents replaying stored arguments) get an input validation error after upgrading and must switch to equivalent formulas. Agent-generated payloads self-correct because clients re-read the advertised schema.",
+            "requiredStop": false
         }
     }
 }


### PR DESCRIPTION
## Summary

Stacked on #27728. Narrows the **advertised** `run_metric_query` MCP contract (and the merge-disabled agent runtime contract) to formula-only table calculations — templates are no longer offered going forward.

- New `toolRunQueryArgsSchemaV2FormulaOnly` (V2 shape + formula-only calcs) advertised by `runQueryToolDefinition` and the merge-rejecting agent view.
- **Boundary behavior**: template-shaped calls fail validation with an actionable Zod error the calling model can correct in one retry.
- **Back-compat**: execution/persisted parses stay wide (`V2Transformed`, persisted aliases), so existing threads, artifacts, and replays with template calcs are unchanged.
- `mcp-tools-1.0.json` + contract snapshots regenerated (templates drop out of the MCP schema, −849 lines).
- Contract tests pin all four edges: formula accepted, template rejected, rejected through the merge-rejecting variant, persisted template payloads still parse.

Note for reviewers: this is a deliberate breaking change to the MCP tool contract for clients that send legacy template calcs; LLM clients self-correct from the validation error.

Relates: ZAP-900

🤖 Generated with [Claude Code](https://claude.com/claude-code)