### PR TITLE
fix: explain missing project branch on dbt write-back instead of "Something went wrong"

### DIFF
--- a/packages/backend/src/clients/github/Github.test.ts
+++ b/packages/backend/src/clients/github/Github.test.ts
@@ -1,16 +1,24 @@
+import { NotFoundError, UnexpectedGitError } from '@lightdash/common';
 import { Octokit } from '@octokit/rest';
-import { getRepoTree, isGithubRateLimitError, searchRepoCode } from './Github';
+import {
+    getLastCommit,
+    getRepoTree,
+    isGithubRateLimitError,
+    searchRepoCode,
+} from './Github';
 
 vi.mock('@octokit/rest');
 
 const mockGetTree = vi.fn();
 const mockSearchCode = vi.fn();
+const mockListCommits = vi.fn();
 (Octokit as unknown as import('vitest').Mock).mockImplementation(
     // eslint-disable-next-line prefer-arrow-callback
     function MockOctokit() {
         return {
             rest: {
                 git: { getTree: mockGetTree },
+                repos: { listCommits: mockListCommits },
                 search: { code: mockSearchCode },
             },
             hook: { after: vi.fn(), error: vi.fn() },
@@ -178,5 +186,61 @@ describe('searchRepoCode', () => {
                 fragments: ['match in models/orders.sql'],
             },
         ]);
+    });
+});
+
+describe('getLastCommit', () => {
+    beforeEach(() => {
+        mockListCommits.mockReset();
+    });
+
+    const args = {
+        owner: 'acme',
+        repo: 'jaffle',
+        branch: 'feature/old-branch',
+        token: 't',
+    };
+
+    it('returns the head commit of the branch', async () => {
+        mockListCommits.mockResolvedValue({ data: [{ sha: 'abc123' }] });
+
+        await expect(getLastCommit(args)).resolves.toEqual({ sha: 'abc123' });
+        expect(mockListCommits).toHaveBeenCalledWith(
+            expect.objectContaining({
+                owner: 'acme',
+                repo: 'jaffle',
+                sha: 'feature/old-branch',
+            }),
+        );
+    });
+
+    it('maps a GitHub 404 to a NotFoundError that names the branch and repo', async () => {
+        mockListCommits.mockRejectedValue(
+            octokitError(
+                404,
+                {},
+                'Not Found - https://docs.github.com/rest/commits/commits#list-commits',
+            ),
+        );
+
+        const promise = getLastCommit(args);
+        await expect(promise).rejects.toBeInstanceOf(NotFoundError);
+        await expect(promise).rejects.toThrow(
+            'Branch "feature/old-branch" not found in acme/jaffle',
+        );
+    });
+
+    it('reports a branch with no commits as NotFoundError', async () => {
+        mockListCommits.mockResolvedValue({ data: [] });
+
+        await expect(getLastCommit(args)).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('wraps other GitHub failures in UnexpectedGitError', async () => {
+        mockListCommits.mockRejectedValue(octokitError(502, {}, 'Bad gateway'));
+
+        const promise = getLastCommit(args);
+        await expect(promise).rejects.toBeInstanceOf(UnexpectedGitError);
+        await expect(promise).rejects.toThrow('Bad gateway');
     });
 });

--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -249,32 +249,6 @@ export const getOrRefreshToken = async (
     };
 };
 
-export const getLastCommit = async ({
-    owner,
-    repo,
-    branch,
-    installationId,
-    token,
-}: {
-    owner: string;
-    repo: string;
-    branch: string;
-    installationId?: string;
-    token?: string;
-}) => {
-    const { octokit, headers } = getOctokit(installationId, token);
-    // GitHub API uses `sha` param to filter by branch
-    // @see https://docs.github.com/en/rest/commits/commits#list-commits
-    const response = await octokit.rest.repos.listCommits({
-        owner,
-        repo,
-        sha: branch,
-        headers,
-    });
-
-    return response.data[0];
-};
-
 /**
  * True when a thrown octokit error is a rate-limit response. GitHub signals it
  * two ways: a primary limit (403 with `x-ratelimit-remaining: 0`) and a
@@ -322,6 +296,54 @@ const logGithubRateLimit = (error: unknown, context: string): void => {
             reset: responseHeaders['x-ratelimit-reset'],
         },
     );
+};
+
+export const getLastCommit = async ({
+    owner,
+    repo,
+    branch,
+    installationId,
+    token,
+}: {
+    owner: string;
+    repo: string;
+    branch: string;
+    installationId?: string;
+    token?: string;
+}) => {
+    const { octokit, headers } = getOctokit(installationId, token);
+    try {
+        // GitHub API uses `sha` param to filter by branch
+        // @see https://docs.github.com/en/rest/commits/commits#list-commits
+        const response = await octokit.rest.repos.listCommits({
+            owner,
+            repo,
+            sha: branch,
+            headers,
+        });
+        const [lastCommit] = response.data;
+        if (!lastCommit) {
+            throw new NotFoundError(
+                `No commits found on branch "${branch}" in ${owner}/${repo}`,
+            );
+        }
+        return lastCommit;
+    } catch (error) {
+        if (error instanceof LightdashError) {
+            throw error;
+        }
+        if (
+            error instanceof Error &&
+            `status` in error &&
+            error.status === 404
+        ) {
+            throw new NotFoundError(
+                `Branch "${branch}" not found in ${owner}/${repo}. It may have been deleted or renamed, or the GitHub integration may not have access to this repository.`,
+            );
+        }
+        logGithubRateLimit(error, `listCommits ${owner}/${repo}@${branch}`);
+        throw new UnexpectedGitError(getErrorMessage(error));
+    }
 };
 
 export const getFileContent = async ({

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
@@ -1,9 +1,14 @@
-import { DbtProjectType, SupportedDbtVersions } from '@lightdash/common';
+import {
+    DbtProjectType,
+    NotFoundError,
+    SupportedDbtVersions,
+} from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import {
     createBranch,
     createPullRequest,
     getFileContent,
+    getLastCommit,
     updateFile,
 } from '../../clients/github/Github';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
@@ -220,6 +225,32 @@ describe('GitIntegrationService', () => {
                 }),
             ).rejects.toThrow(
                 'Explore write-back cannot determine which dbt source owns this model on a project with multiple git-backed dbt sources: "Project dbt connection", "Additional source"',
+            );
+
+            expect(createBranch).not.toHaveBeenCalled();
+            expect(getFileContent).not.toHaveBeenCalled();
+            expect(updateFile).not.toHaveBeenCalled();
+            expect(createPullRequest).not.toHaveBeenCalled();
+        });
+
+        it('explains a missing project branch instead of a generic server error', async () => {
+            vi.mocked(getLastCommit).mockRejectedValueOnce(
+                new NotFoundError('Branch "main" not found in owner/repo'),
+            );
+
+            const promise = service.createPullRequest(
+                writebackUser,
+                'projectUuid',
+                "'",
+                { type: 'customMetrics', fields: [CUSTOM_METRIC] },
+            );
+
+            await expect(promise).rejects.toBeInstanceOf(NotFoundError);
+            await expect(promise).rejects.toThrow(
+                'Branch "main" not found in owner/repo',
+            );
+            await expect(promise).rejects.toThrow(
+                "Check the branch configured in the project's dbt connection settings.",
             );
 
             expect(createBranch).not.toHaveBeenCalled();

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -17,6 +17,7 @@ import {
     GitFileOrDirectory,
     GitIntegrationConfiguration,
     isUserWithOrg,
+    NotFoundError,
     ParameterError,
     ParseError,
     ProjectType,
@@ -204,14 +205,28 @@ export class GitIntegrationService extends BaseService {
             type === DbtProjectType.GITHUB
                 ? GithubClient.getLastCommit
                 : GitlabClient.getLastCommit;
-        const { sha: commitSha } = await getLastCommit({
-            owner,
-            repo,
-            branch: mainBranch,
-            installationId,
-            token,
-            hostDomain,
-        });
+        let commitSha: string;
+        try {
+            ({ sha: commitSha } = await getLastCommit({
+                owner,
+                repo,
+                branch: mainBranch,
+                installationId,
+                token,
+                hostDomain,
+            }));
+        } catch (error) {
+            // `mainBranch` is the branch from the project's dbt connection
+            // settings. Both Git clients report a missing (or invisible)
+            // branch as NotFoundError; say where it comes from so the user can
+            // fix it instead of seeing a generic server error.
+            if (error instanceof NotFoundError) {
+                throw new NotFoundError(
+                    `Branch "${mainBranch}" not found in ${owner}/${repo}. It may have been deleted or renamed, or the Git integration may not have access to this repository. Check the branch configured in the project's dbt connection settings.`,
+                );
+            }
+            throw error;
+        }
 
         Logger.debug(
             `Creating branch ${branch} from ${mainBranch} (commit: ${commitSha}) in ${owner}/${repo}`,


### PR DESCRIPTION
Closes: n/a (reported via support)

### Description:

Write-back to dbt (custom metrics / custom dimensions → "Open Pull Request") starts with `GitIntegrationService.createBranch`, which asks GitHub for the head commit of the project's configured branch (`GET /repos/{owner}/{repo}/commits?sha=<branch>`). If that branch no longer exists — e.g. a feature branch that was merged and deleted after the project was configured — or the integration can't see the repository, GitHub answers `404`. `GithubClient.getLastCommit` let the raw octokit `RequestError` escape; it isn't a `LightdashError`, so `errorHandler` collapsed it into `UnexpectedServerError: "Something went wrong."` and the user got a "Notify support" toast with nothing actionable. (The same 404 is returned for a missing branch and for a repo the app can't access, so the message names both.)

**Repro:** calling the real `getLastCommit` against a nonexistent branch throws `RequestError { name: 'HttpError', status: 404 }` with no `statusCode` — exactly what production logs showed. The new unit tests were red before the change.

**Changes**
- `GithubClient.getLastCommit`: map a 404 to `NotFoundError('Branch "X" not found in owner/repo. It may have been deleted or renamed, or the GitHub integration may not have access to this repository.')`, report an empty branch as `NotFoundError`, wrap other failures in `UnexpectedGitError` — the same pattern `getFileContent` / `getRepoTree` already use. Benefits every caller (write-back, branch-from-source, project-context write-back).
- `GitIntegrationService.createBranch`: when the source-branch lookup yields `NotFoundError` (GitHub or GitLab), rethrow with the project context: `… Check the branch configured in the project's dbt connection settings.` This is what the write-back toast now shows, as a 404 instead of a 500.

**Before:** `Failed to write back custom metric — Something went wrong.`
**After:** `Failed to write back custom metric — Branch "feature/old-branch" not found in acme/jaffle. It may have been deleted or renamed, or the Git integration may not have access to this repository. Check the branch configured in the project's dbt connection settings.`

No frontend change: the toast already renders `apiError.message`.

### Risk assessment:

- [ ] This is a high-risk change

Error path only; the happy path returns the same commit object. `getLastCommit` now throws `LightdashError` subclasses instead of raw octokit errors — existing callers treat errors as opaque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
