### PR TITLE
fix(homepage): make the recently-viewed anti-join index-friendly

### DIFF
--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -344,13 +344,15 @@ export class ProjectHomepageModel {
                   -- Tiles are tagged where we can, but several code paths
                   -- write untagged rows, so also drop chart views that land
                   -- in the moments around one of this user's dashboard views.
+                  -- Keep the range on tile_dv.timestamp: that is what lets a
+                  -- (user_uuid, timestamp) index serve this lookup.
                   AND (acv.context ->> 'source') IS DISTINCT FROM 'dashboard'
                   AND NOT EXISTS (
                       SELECT 1
                       FROM analytics_dashboard_views tile_dv
                       WHERE tile_dv.user_uuid = acv.user_uuid
-                        AND acv.timestamp BETWEEN tile_dv.timestamp - interval '2 seconds'
-                                              AND tile_dv.timestamp + interval '15 seconds'
+                        AND tile_dv.timestamp BETWEEN acv.timestamp - interval '15 seconds'
+                                                  AND acv.timestamp + interval '2 seconds'
                   )
                 UNION ALL
                 SELECT 'dashboard' AS content_type,


### PR DESCRIPTION
Fix for the Cloud SQL CPU alert (PROD-10289) caused by the homepage "Recently viewed" query (`ProjectHomepageModel.getRecentlyViewed`). One user with a very large view history made each call run for 12–30 minutes; timed-out clients retried while Postgres kept running the old executions, and the overlapping copies pegged the instance.

This PR only rewrites the anti-join window so the range is expressed on `tile_dv.timestamp` instead of `acv.timestamp`. Algebraically identical (same result set, verified on a seeded DB), but it is what lets Postgres use a `(user_uuid, timestamp)` index on `analytics_dashboard_views` as an index condition instead of a join filter.

Measured locally with 200k chart views / 10k dashboard views for one user: 64s before → 66s after (neutral on its own; the index in #27765 brings it to 0.27s).

Relates: PROD-10289
