### PR TITLE
fix(homepage): cap the recently-viewed query with a statement timeout

### DIFF
--- a/packages/backend/src/database/errors.ts
+++ b/packages/backend/src/database/errors.ts
@@ -2,3 +2,6 @@ import { DatabaseError } from 'pg';
 
 export const isUniqueConstraintViolation = (error: unknown): boolean =>
     error instanceof DatabaseError && error.code === '23505';
+
+export const isStatementTimeout = (error: unknown): boolean =>
+    error instanceof DatabaseError && error.code === '57014';

--- a/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { DatabaseError } from 'pg';
 import {
     AnnouncementsTableName,
     HomepagesTableName,
@@ -229,6 +230,36 @@ describe('ProjectHomepageModel', () => {
             await expect(
                 model.publishProjectDraftAnnouncements(PROJECT_UUID),
             ).resolves.toEqual([]);
+        });
+    });
+
+    describe('getRecentlyViewed', () => {
+        const USER_UUID = '00000000-0000-0000-0000-000000000020';
+
+        it('returns no items when the query hits the statement timeout', async () => {
+            const timeout = new DatabaseError(
+                'canceling statement due to statement timeout',
+                0,
+                'error',
+            );
+            timeout.code = '57014';
+            tracker.on.any(/statement_timeout/).responseOnce([]);
+            tracker.on.any(/analytics_chart_views/).simulateErrorOnce(timeout);
+
+            await expect(
+                model.getRecentlyViewed(PROJECT_UUID, USER_UUID),
+            ).resolves.toEqual([]);
+        });
+
+        it('rethrows other database errors', async () => {
+            tracker.on.any(/statement_timeout/).responseOnce([]);
+            tracker.on
+                .any(/analytics_chart_views/)
+                .simulateErrorOnce(new Error('connection reset'));
+
+            await expect(
+                model.getRecentlyViewed(PROJECT_UUID, USER_UUID),
+            ).rejects.toThrow('connection reset');
         });
     });
 

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -22,6 +22,8 @@ import {
     type UpdateOrganizationHomepageSettings,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
+import { isStatementTimeout } from '../../database/errors';
+import Logger from '../../logging/logger';
 import { OrganizationHomepageSettingsTableName } from '../database/entities/organizationHomepageSettings';
 import {
     AnnouncementsTableName,
@@ -30,6 +32,8 @@ import {
     type DbAnnouncement,
     type DbProjectHomepage,
 } from '../database/entities/projectHomepages';
+
+const RECENTLY_VIEWED_STATEMENT_TIMEOUT_MS = 10_000;
 
 export class ProjectHomepageModel {
     private readonly database: Knex;
@@ -318,14 +322,19 @@ export class ProjectHomepageModel {
         userUuid: string,
         limit: number = 8,
     ): Promise<HomepageRecentlyViewedItem[]> {
-        const { rows } = await this.database.raw<{
-            rows: Array<{
-                content_type: 'chart' | 'dashboard';
-                content_uuid: string;
-                viewed_at: Date;
-            }>;
-        }>(
-            `
+        try {
+            return await this.database.transaction(async (trx) => {
+                await trx.raw(
+                    `SET LOCAL statement_timeout = ${RECENTLY_VIEWED_STATEMENT_TIMEOUT_MS}`,
+                );
+                const { rows } = await trx.raw<{
+                    rows: Array<{
+                        content_type: 'chart' | 'dashboard';
+                        content_uuid: string;
+                        viewed_at: Date;
+                    }>;
+                }>(
+                    `
             SELECT content_type, content_uuid, max(viewed_at) AS viewed_at
             FROM (
                 SELECT 'chart' AS content_type,
@@ -371,13 +380,21 @@ export class ProjectHomepageModel {
             ORDER BY viewed_at DESC
             LIMIT :limit
             `,
-            { userUuid, projectUuid, limit },
-        );
-        return rows.map((row) => ({
-            contentType: row.content_type,
-            uuid: row.content_uuid,
-            viewedAt: row.viewed_at,
-        }));
+                    { userUuid, projectUuid, limit },
+                );
+                return rows.map((row) => ({
+                    contentType: row.content_type,
+                    uuid: row.content_uuid,
+                    viewedAt: row.viewed_at,
+                }));
+            });
+        } catch (error) {
+            if (!isStatementTimeout(error)) throw error;
+            Logger.warn(
+                `Recently viewed query exceeded ${RECENTLY_VIEWED_STATEMENT_TIMEOUT_MS}ms in project ${projectUuid}; returning no items`,
+            );
+            return [];
+        }
     }
 
     // Publishing to "everyone" promotes the homepage to the project default


### PR DESCRIPTION
Fix for the "Recently viewed" CPU alert.

Runs the recently-viewed query under `SET LOCAL statement_timeout = 10000` inside a transaction and returns an empty list (with a warning log) when Postgres cancels it. This bounds the blast radius: a user with a pathological history now gets an empty block instead of a query that keeps burning DB CPU for 30 minutes after the HTTP request has long timed out — and client retries can no longer stack copies of it.

Adds `isStatementTimeout` next to `isUniqueConstraintViolation` in `database/errors.ts`, plus unit tests for the timeout and rethrow branches.

Measured locally (200k/10k rows, before the index lands): single call → `200 []` in 10.1s, no lingering backend, DB CPU back to baseline immediately; 4 concurrent calls all end at 10.1s (previously pinned both cores for ~100s).

Relates: PROD-10289
