### PR TITLE
feat(db): index analytics_dashboard_views by user and timestamp

### DIFF
--- a/packages/backend/src/database/migrations/20260820151000_index_analytics_dashboard_views_user_uuid_timestamp.ts
+++ b/packages/backend/src/database/migrations/20260820151000_index_analytics_dashboard_views_user_uuid_timestamp.ts
@@ -1,0 +1,39 @@
+import { Knex } from 'knex';
+
+export const config = { transaction: false };
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Builds a secondary index on analytics_dashboard_views concurrently; no lock that blocks reads or writes, no table rewrite, and older app versions keep working.',
+};
+
+const TableName = 'analytics_dashboard_views';
+const IndexName = 'analytics_dashboard_views_user_uuid_timestamp_index';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        const invalidIndex = await knex.raw<{ rowCount: number }>(
+            `SELECT 1
+             FROM pg_class
+             JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+             WHERE pg_class.relname = ?
+               AND pg_index.indrelid = ?::regclass
+               AND NOT pg_index.indisvalid`,
+            [IndexName, TableName],
+        );
+        if ((invalidIndex.rowCount ?? 0) > 0) {
+            await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${IndexName}`);
+        }
+        await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${IndexName}
+             ON ${TableName} (user_uuid, timestamp)`,
+        );
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${IndexName}`);
+}


### PR DESCRIPTION
Fix for the "Recently viewed" CPU alert — the one that removes the spike.

Adds `analytics_dashboard_views (user_uuid, timestamp)` with `CREATE INDEX CONCURRENTLY` (no read/write blocking), `transaction: false`, `statement_timeout = 0`, invalid-index recovery and a stable literal index name, following `20260428153355_add_primary_keys_to_analytics_and_scheduler_log.ts`. No `lock_timeout` on purpose: for a concurrent build a finite lock timeout would make the migration fail behind a long transaction instead of waiting, which is worse for a deploy.

With the predicate rewrite from #27763 the `NOT EXISTS` becomes an index range probe per chart view instead of a filter over all of the user's dashboard views.

Measured locally (200k/10k rows): 64s → 0.27s; 4 concurrent calls ~0.5s each. The index alone without #27763 does nothing (65s), so merge order matters.

Relates: PROD-10289
