### PR TITLE
fix(homepage): bound recently-viewed to the last 90 days

### DIFF
--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -34,6 +34,7 @@ import {
 } from '../database/entities/projectHomepages';
 
 const RECENTLY_VIEWED_STATEMENT_TIMEOUT_MS = 10_000;
+const RECENTLY_VIEWED_WINDOW_DAYS = 90;
 
 export class ProjectHomepageModel {
     private readonly database: Knex;
@@ -345,6 +346,7 @@ export class ProjectHomepageModel {
                 JOIN spaces s ON s.space_id = sq.space_id
                 JOIN projects p ON p.project_id = s.project_id
                 WHERE acv.user_uuid = :userUuid
+                  AND acv.timestamp > now() - make_interval(days => :windowDays)
                   AND p.project_uuid = :projectUuid
                   AND sq.deleted_at IS NULL
                   AND s.deleted_at IS NULL
@@ -372,6 +374,7 @@ export class ProjectHomepageModel {
                 JOIN spaces s ON s.space_id = d.space_id
                 JOIN projects p ON p.project_id = s.project_id
                 WHERE adv.user_uuid = :userUuid
+                  AND adv.timestamp > now() - make_interval(days => :windowDays)
                   AND p.project_uuid = :projectUuid
                   AND d.deleted_at IS NULL
                   AND s.deleted_at IS NULL
@@ -380,7 +383,12 @@ export class ProjectHomepageModel {
             ORDER BY viewed_at DESC
             LIMIT :limit
             `,
-                    { userUuid, projectUuid, limit },
+                    {
+                        userUuid,
+                        projectUuid,
+                        limit,
+                        windowDays: RECENTLY_VIEWED_WINDOW_DAYS,
+                    },
                 );
                 return rows.map((row) => ({
                     contentType: row.content_type,


### PR DESCRIPTION
Fix for the "Recently viewed" CPU alert.

Only scans the viewer's last 90 days of chart and dashboard views, so the cost stays flat no matter how much history a user accumulates. The block shows the 8 most recent items; anything older than 90 days is not meaningful there.

Measured locally (200k/10k rows, on top of #27763–#27765): 0.27s → 0.20s; at 1M/30k rows, with #27763–#27766 combined, 0.8s.

Relates: PROD-10289
