### PR TITLE
feat(db): index analytics_chart_views by user and timestamp

### DIFF
--- a/packages/backend/src/database/migrations/20260820153000_index_analytics_chart_views_user_uuid_timestamp.ts
+++ b/packages/backend/src/database/migrations/20260820153000_index_analytics_chart_views_user_uuid_timestamp.ts
@@ -1,0 +1,39 @@
+import { Knex } from 'knex';
+
+export const config = { transaction: false };
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Builds a secondary index on analytics_chart_views concurrently; no lock that blocks reads or writes, no table rewrite, and older app versions keep working.',
+};
+
+const TableName = 'analytics_chart_views';
+const IndexName = 'analytics_chart_views_user_uuid_timestamp_index';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        const invalidIndex = await knex.raw<{ rowCount: number }>(
+            `SELECT 1
+             FROM pg_class
+             JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+             WHERE pg_class.relname = ?
+               AND pg_index.indrelid = ?::regclass
+               AND NOT pg_index.indisvalid`,
+            [IndexName, TableName],
+        );
+        if ((invalidIndex.rowCount ?? 0) > 0) {
+            await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${IndexName}`);
+        }
+        await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${IndexName}
+             ON ${TableName} (user_uuid, timestamp)`,
+        );
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${IndexName}`);
+}


### PR DESCRIPTION
Fix for the "Recently viewed" CPU alert.

Adds `analytics_chart_views (user_uuid, timestamp)` with the same concurrent, idempotent migration pattern as #27765.

On its own this is neutral: the planner keeps driving the query from project → charts → `chart_uuid` index, which reads every user's views on the project's charts and filters by viewer (measured 2.76s vs 2.8–3.7s at 100k viewer rows inside 3.1M project-wide rows). #27768 reshapes the query so this index is what it reads.

Relates: PROD-10289
