### PR TITLE
fix(homepage): read recently-viewed from the viewer's own chart views

### DIFF
--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -336,18 +336,24 @@ export class ProjectHomepageModel {
                     }>;
                 }>(
                     `
+            -- MATERIALIZED keeps the planner from flattening this back into a
+            -- scan of every view on the project's charts.
+            WITH user_chart_views AS MATERIALIZED (
+                SELECT user_uuid, chart_uuid, context, timestamp
+                FROM analytics_chart_views
+                WHERE user_uuid = :userUuid
+                  AND timestamp > now() - make_interval(days => :windowDays)
+            )
             SELECT content_type, content_uuid, max(viewed_at) AS viewed_at
             FROM (
                 SELECT 'chart' AS content_type,
                        acv.chart_uuid AS content_uuid,
                        acv.timestamp AS viewed_at
-                FROM analytics_chart_views acv
+                FROM user_chart_views acv
                 JOIN saved_queries sq ON sq.saved_query_uuid = acv.chart_uuid
                 JOIN spaces s ON s.space_id = sq.space_id
                 JOIN projects p ON p.project_id = s.project_id
-                WHERE acv.user_uuid = :userUuid
-                  AND acv.timestamp > now() - make_interval(days => :windowDays)
-                  AND p.project_uuid = :projectUuid
+                WHERE p.project_uuid = :projectUuid
                   AND sq.deleted_at IS NULL
                   AND s.deleted_at IS NULL
                   -- Opening a dashboard records a view for every tile on it,


### PR DESCRIPTION
Fix for the "Recently viewed" CPU alert.

Materializes the viewer's own 90-day chart views first (`WITH … AS MATERIALIZED`) and feeds that into the existing joins and anti-join. After #27763–#27766 the remaining cost scaled with all users' views on the project's charts, so a large project could still exhaust the 10s budget for everyone; now it scales with the viewer's own recent history, served by the index from #27767. Same result set (verified against the previous shape).

Measured locally at 100k viewer rows inside 3.1M project-wide rows: 2.76s → 0.13s (4 concurrent ≈ 0.21s each). Worst realistic case, ~1M viewer rows inside the 90-day window: 1.1s. Without #27767 this shape falls back to a seq scan of `analytics_chart_views`, so the two go together.

Closes: PROD-10289
