### PR TITLE
feat: migrate autocomplete cache flag to per-org feature flag with env fallback

### DIFF
--- a/docs/preview-feature-flags.md
+++ b/docs/preview-feature-flags.md
@@ -19,7 +19,8 @@ exclusion, with a reason, when that isn't safe. Flags are excluded when they:
   real repos),
 - are off pending a security review, or are deprecated,
 - derive their value from instance configuration (`ai-copilot`,
-  `results-cache-enabled`, `enable-timezone-support`) — these are left to their
+  `results-cache-enabled`, `autocomplete-cache-enabled`,
+  `enable-timezone-support`) — these are left to their
   config handler so a preview never advertises an unconfigured backend. To test
   AI copilot in a preview, configure a provider (`AI_COPILOT_ENABLED` plus
   credentials) rather than forcing the flag.

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -577,6 +577,71 @@ describe('FeatureFlagModel', () => {
         });
     });
 
+    describe('AutocompleteCacheEnabled env fallback', () => {
+        const autocompleteEnabledConfig = {
+            results: {
+                ...lightdashConfigMock.results,
+                autocompleteEnabled: true,
+            },
+        };
+
+        it('default_enabled:false overrides an env fallback of true', async () => {
+            const model = buildModel(
+                autocompleteEnabledConfig,
+                buildFakeDatabase({ flag: { default_enabled: false } }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.AutocompleteCacheEnabled,
+                user: dbUser,
+            });
+
+            expect(result).toEqual({
+                id: FeatureFlags.AutocompleteCacheEnabled,
+                enabled: false,
+            });
+        });
+
+        it('org override wins over an env fallback of false', async () => {
+            const model = buildModel(
+                {
+                    results: {
+                        ...lightdashConfigMock.results,
+                        autocompleteEnabled: false,
+                    },
+                },
+                buildFakeDatabase({
+                    flag: { default_enabled: false },
+                    orgOverride: { enabled: true },
+                }),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.AutocompleteCacheEnabled,
+                user: dbUser,
+            });
+
+            expect(result.enabled).toBe(true);
+        });
+
+        it('falls through to the env fallback when the DB has no row', async () => {
+            const model = buildModel(
+                autocompleteEnabledConfig,
+                buildFakeDatabase({}),
+            );
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.AutocompleteCacheEnabled,
+                user: dbUser,
+            });
+
+            expect(result).toEqual({
+                id: FeatureFlags.AutocompleteCacheEnabled,
+                enabled: true,
+            });
+        });
+    });
+
     describe('EnableTimezoneSupport defaults to on', () => {
         const withTimezoneSupport = (enableTimezoneSupport: boolean) => ({
             query: { ...lightdashConfigMock.query, enableTimezoneSupport },

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -65,6 +65,12 @@ export class FeatureFlagModel {
                     this.lightdashConfig.results.cacheEnabled,
                     options,
                 ),
+            [FeatureFlags.AutocompleteCacheEnabled]: (flagArgs, options) =>
+                this.getWithEnvFallback(
+                    flagArgs,
+                    this.lightdashConfig.results.autocompleteEnabled,
+                    options,
+                ),
         };
     }
 

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -109,7 +109,6 @@ export const BaseResponse: HealthState = {
         tracesSampleRate: 0,
         profilesSampleRate: 0,
     },
-    hasCacheAutocompleResults: false,
     appearance: {
         overrideColorPalette: undefined,
         overrideColorPaletteName: undefined,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -240,8 +240,6 @@ export class HealthService extends BaseService {
                 this.lightdashConfig.headlessBrowser?.host !== undefined,
             hasExtendedUsageAnalytics:
                 this.lightdashConfig.extendedUsageAnalytics.enabled,
-            hasCacheAutocompleResults:
-                this.lightdashConfig.results.autocompleteEnabled,
             appearance: {
                 overrideColorPalette:
                     this.lightdashConfig.appearance.overrideColorPalette,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -408,6 +408,12 @@ const getMockedProjectService = (
                         enabled: lightdashConfig.results.cacheEnabled,
                     };
                 }
+                if (featureFlagId === FeatureFlags.AutocompleteCacheEnabled) {
+                    return {
+                        id: featureFlagId,
+                        enabled: lightdashConfig.results.autocompleteEnabled,
+                    };
+                }
                 return { id: featureFlagId, enabled: false };
             }),
         } as unknown as FeatureFlagModel,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -7783,8 +7783,12 @@ export class ProjectService extends BaseService {
             },
         ).compile();
 
-        const isUserCacheEnabled =
-            this.lightdashConfig.results.autocompleteEnabled && !!user.userUuid;
+        const { enabled: autocompleteCacheEnabled } =
+            await this.featureFlagModel.get({
+                user,
+                featureFlagId: FeatureFlags.AutocompleteCacheEnabled,
+            });
+        const isUserCacheEnabled = autocompleteCacheEnabled && !!user.userUuid;
 
         const userUuid = getCacheUserUuid(warehouseCredentials, user.userUuid);
 

--- a/packages/common/src/featureFlags/previewFeatureFlags.ts
+++ b/packages/common/src/featureFlags/previewFeatureFlags.ts
@@ -30,6 +30,7 @@ const PREVIEW_EXCLUDED_FEATURE_FLAGS: ReadonlySet<string> = new Set<string>([
     // preview never advertises a feature whose backend isn't configured.
     CommercialFeatureFlags.AiCopilot,
     FeatureFlags.ResultsCacheEnabled,
+    FeatureFlags.AutocompleteCacheEnabled,
     FeatureFlags.EnableTimezoneSupport,
 ]);
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -664,7 +664,6 @@ export type HealthState = {
     hasGitlab: boolean;
     hasHeadlessBrowser: boolean;
     hasExtendedUsageAnalytics: boolean;
-    hasCacheAutocompleResults: boolean;
     appearance: {
         overrideColorPalette: string[] | undefined;
         overrideColorPaletteName: string | undefined;

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -166,6 +166,13 @@ export enum FeatureFlags {
     ResultsCacheEnabled = 'results-cache-enabled',
 
     /**
+     * Enable filter autocomplete results caching. DB value (user/org
+     * override or flag default) takes precedence; falls back to the
+     * AUTOCOMPLETE_CACHE_ENABLED env var when no DB row is set.
+     */
+    AutocompleteCacheEnabled = 'autocomplete-cache-enabled',
+
+    /**
      * Allow dashboard editors to mark individual dashboard filters as locked.
      * Locked filters are visible to viewers but cannot be edited from view
      * mode, and URL/embed filter overrides targeting a locked filter's field

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
@@ -32,10 +32,8 @@ vi.mock('../../../../hooks/useFieldValues', () => ({
     })),
 }));
 
-vi.mock('../../../../hooks/health/useHealth', () => ({
-    default: vi.fn(() => ({
-        data: { hasCacheAutocompleResults: false },
-    })),
+vi.mock('../../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(() => ({ data: { enabled: false } })),
 }));
 
 const mockField: FilterableItem = {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     isDimension,
     isFilterAutocompleteManualOnly,
     type FilterableItem,
@@ -32,11 +33,11 @@ import {
     useState,
     type FC,
 } from 'react';
-import useHealth from '../../../../hooks/health/useHealth';
 import {
     MAX_AUTOCOMPLETE_RESULTS,
     useFieldValues,
 } from '../../../../hooks/useFieldValues';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../MantineIcon';
 import { MultiSelectCombobox } from '../../MultiSelectCombobox/MultiSelectCombobox';
 import useFiltersContext from '../useFiltersContext';
@@ -144,7 +145,9 @@ const FilterStringAutoComplete: FC<Props> = ({
         throw new Error('projectUuid is required in FiltersProvider');
     }
 
-    const { data: healthData } = useHealth();
+    const { data: autocompleteCacheFlag } = useServerFeatureFlag(
+        FeatureFlags.AutocompleteCacheEnabled,
+    );
 
     const [search, setSearch] = useState('');
     const [pastePopUpOpened, setPastePopUpOpened] = useState(false);
@@ -513,7 +516,7 @@ const FilterStringAutoComplete: FC<Props> = ({
                                 ) : null
                             }
                             footer={
-                                healthData?.hasCacheAutocompleResults &&
+                                autocompleteCacheFlag?.enabled &&
                                 canRefreshAutocomplete ? (
                                     <RefreshIndicator
                                         refreshedAtRef={refreshedAtRef}

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
@@ -53,10 +53,8 @@ vi.mock('../../../hooks/useFieldValues', () => ({
     })),
 }));
 
-vi.mock('../../../hooks/health/useHealth', () => ({
-    default: vi.fn(() => ({
-        data: { hasCacheAutocompleResults: false },
-    })),
+vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(() => ({ data: { enabled: false } })),
 }));
 
 const mockField = {

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilterAutoComplete.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilterAutoComplete.tsx
@@ -1,4 +1,4 @@
-import { type CompiledDimension } from '@lightdash/common';
+import { FeatureFlags, type CompiledDimension } from '@lightdash/common';
 import {
     Group,
     Highlight,
@@ -14,11 +14,11 @@ import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import MultiValuePastePopover from '../../../../components/common/Filters/FilterInputs/MultiValuePastePopover';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { MultiSelectCombobox } from '../../../../components/common/MultiSelectCombobox/MultiSelectCombobox';
-import useHealth from '../../../../hooks/health/useHealth';
 import {
     MAX_AUTOCOMPLETE_RESULTS,
     useFieldValues,
 } from '../../../../hooks/useFieldValues';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import { useAppSelector } from '../../../sqlRunner/store/hooks';
 import styles from './MetricExploreFilterAutoComplete.module.css';
 
@@ -53,7 +53,9 @@ export const MetricExploreFilterAutoComplete: FC<Props> = ({
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
     );
-    const { data: healthData } = useHealth();
+    const { data: autocompleteCacheFlag } = useServerFeatureFlag(
+        FeatureFlags.AutocompleteCacheEnabled,
+    );
 
     const [search, setSearch] = useState('');
     const [pastePopUpOpened, setPastePopUpOpened] = useState(false);
@@ -210,7 +212,7 @@ export const MetricExploreFilterAutoComplete: FC<Props> = ({
                     ) : null
                 }
                 footer={
-                    healthData?.hasCacheAutocompleResults ? (
+                    autocompleteCacheFlag?.enabled ? (
                         <Tooltip
                             withinPortal
                             position="left"

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -105,7 +105,6 @@ export default function mockHealthResponse(
         hasExtendedUsageAnalytics: false,
         hasGithub: false,
         hasGitlab: false,
-        hasCacheAutocompleResults: false,
         hasMicrosoftTeams: false,
         appearance: {
             overrideColorPalette: undefined,


### PR DESCRIPTION
## Summary

Filter-autocomplete caching was gated only by the `AUTOCOMPLETE_CACHE_ENABLED` environment variable, so it could not be enabled for a single organisation on a shared instance. This moves it to a per-organisation feature flag, `autocomplete-cache-enabled`, following the same shape as the results cache flag (#22967).

- New `FeatureFlags.AutocompleteCacheEnabled`, resolved in `FeatureFlagModel` with the existing env-fallback logic: a DB value (user override, org override, flag default) wins; `AUTOCOMPLETE_CACHE_ENABLED` still applies when the flag has no DB opinion.
- `ProjectService.searchFieldUniqueValues` resolves the flag per user instead of reading config.
- `hasCacheAutocompleResults` is removed from `/api/v1/health` and `HealthState`, since the value is now per organisation. The two autocomplete components that used it now read the flag via `useServerFeatureFlag`. This mirrors what #22967 did for the results cache health field.
- Flag added to `PREVIEW_EXCLUDED_FEATURE_FLAGS` so preview projects do not force it on.

## Testing

- FeatureFlagModel tests: DB default beats env, org override beats env, no DB row falls through to env.
- ProjectService autocomplete-cache tests now run through the flag-gated path.
- Frontend autocomplete component tests updated.
- `common`/`backend`/`frontend` typecheck and lint pass.

Closes: PROD-10411