### PR TITLE
feat: per-project results cache TTL setting and API

### DIFF
--- a/packages/api-tests/tests/resultsCacheSettings.test.ts
+++ b/packages/api-tests/tests/resultsCacheSettings.test.ts
@@ -1,0 +1,86 @@
+import {
+    FeatureFlags,
+    MAX_RESULTS_CACHE_TTL_SECONDS,
+    MIN_RESULTS_CACHE_TTL_SECONDS,
+    SEED_PROJECT,
+    type ResultsCacheProjectSettings,
+} from '@lightdash/common';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ApiClient, type Body } from '../helpers/api-client';
+import { login, loginAsViewer } from '../helpers/auth';
+
+const settingsUrl = `/api/v1/projects/${SEED_PROJECT.project_uuid}/results-cache-config`;
+const flagOverrideUrl = `/api/v2/feature-flag/${FeatureFlags.ResultsCacheEnabled}`;
+
+describe('Project results cache settings', () => {
+    let admin: ApiClient;
+    let viewer: ApiClient;
+
+    beforeAll(async () => {
+        admin = await login();
+        viewer = await loginAsViewer();
+        // PATCH is gated on results caching; enable it for the org
+        await admin.post(flagOverrideUrl, { enabled: true });
+    });
+
+    afterAll(async () => {
+        await admin.patch(settingsUrl, { cacheTtlSeconds: null });
+        await admin.delete(flagOverrideUrl);
+    });
+
+    it('defaults to the instance TTL', async () => {
+        const resp =
+            await admin.get<Body<ResultsCacheProjectSettings>>(settingsUrl);
+        expect(resp.status).toBe(200);
+        expect(resp.body.results).toEqual({
+            projectUuid: SEED_PROJECT.project_uuid,
+            cacheTtlSeconds: null,
+            instanceDefaultTtlSeconds: expect.any(Number),
+        });
+        expect(resp.body.results.instanceDefaultTtlSeconds).toBeGreaterThan(0);
+    });
+
+    it('persists a project TTL and clears it back to the default', async () => {
+        const updated = await admin.patch<Body<ResultsCacheProjectSettings>>(
+            settingsUrl,
+            { cacheTtlSeconds: 1800 },
+        );
+        expect(updated.status).toBe(200);
+        expect(updated.body.results.cacheTtlSeconds).toBe(1800);
+
+        const persisted =
+            await admin.get<Body<ResultsCacheProjectSettings>>(settingsUrl);
+        expect(persisted.body.results.cacheTtlSeconds).toBe(1800);
+
+        const cleared = await admin.patch<Body<ResultsCacheProjectSettings>>(
+            settingsUrl,
+            { cacheTtlSeconds: null },
+        );
+        expect(cleared.body.results.cacheTtlSeconds).toBeNull();
+    });
+
+    it.each([
+        ['below the minimum', MIN_RESULTS_CACHE_TTL_SECONDS - 1],
+        ['above the maximum', MAX_RESULTS_CACHE_TTL_SECONDS + 1],
+        ['not a whole number', 90.5],
+    ])('rejects a TTL %s', async (_label, cacheTtlSeconds) => {
+        const resp = await admin.patch(
+            settingsUrl,
+            { cacheTtlSeconds },
+            { failOnStatusCode: false },
+        );
+        expect(resp.status).toBe(400);
+    });
+
+    it('is not readable or writable by a viewer', async () => {
+        const read = await viewer.get(settingsUrl, { failOnStatusCode: false });
+        expect(read.status).toBe(403);
+
+        const write = await viewer.patch(
+            settingsUrl,
+            { cacheTtlSeconds: 1800 },
+            { failOnStatusCode: false },
+        );
+        expect(write.status).toBe(403);
+    });
+});

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -22,6 +22,7 @@ import {
     ApiProjectAccessListResponse,
     ApiProjectColorPaletteResponse,
     ApiProjectResponse,
+    ApiResultsCacheProjectSettingsResponse,
     ApiScheduledDeliveryAsCodeListResponse,
     ApiScheduledDeliveryAsCodeUpsertResponse,
     ApiSpaceSummaryListResponse,
@@ -91,6 +92,7 @@ import {
     type UpdatePreviewExpirationProjectSettings,
     type UpdatePreviewExpiresAt,
     type UpdateQueryTimezoneSettings,
+    type UpdateResultsCacheProjectSettings,
     type UpdateSchedulerSettings,
     type UUID,
 } from '@lightdash/common';
@@ -1294,6 +1296,64 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
         const settings = await this.services
             .getProjectService()
             .updateProjectPreviewExpirationSettings(
+                toSessionUser(req.account),
+                projectUuid,
+                body,
+            );
+        return {
+            status: 'ok',
+            results: settings,
+        };
+    }
+
+    /**
+     * Get the results cache TTL for a project. A null TTL means the
+     * instance-wide default applies.
+     * @summary Get results cache settings
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('{projectUuid}/results-cache-config')
+    @OperationId('getProjectResultsCacheSettings')
+    async getProjectResultsCacheSettings(
+        @Path() projectUuid: UUID,
+        @Request() req: express.Request,
+    ): Promise<ApiResultsCacheProjectSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        const settings = await this.services
+            .getProjectService()
+            .getProjectResultsCacheSettings(
+                toSessionUser(req.account),
+                projectUuid,
+            );
+        return {
+            status: 'ok',
+            results: settings,
+        };
+    }
+
+    /**
+     * Update the results cache TTL for a project. Pass null to fall back to
+     * the instance-wide default.
+     * @summary Update results cache settings
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Updated')
+    @Patch('{projectUuid}/results-cache-config')
+    @OperationId('updateProjectResultsCacheSettings')
+    async updateProjectResultsCacheSettings(
+        @Path() projectUuid: UUID,
+        @Body() body: UpdateResultsCacheProjectSettings,
+        @Request() req: express.Request,
+    ): Promise<ApiResultsCacheProjectSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        const settings = await this.services
+            .getProjectService()
+            .updateProjectResultsCacheSettings(
                 toSessionUser(req.account),
                 projectUuid,
                 body,

--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -43,6 +43,7 @@ export type DbProject = {
     expires_at: Date | null;
     default_preview_expiration_hours: number;
     max_preview_expiration_hours: number;
+    results_cache_ttl_seconds: number | null;
     provisioning_source: string | null;
     agent_sql_scope: AgentSqlScope | null;
 };
@@ -89,6 +90,7 @@ type UpdateDbProject = Partial<
         | 'expires_at'
         | 'default_preview_expiration_hours'
         | 'max_preview_expiration_hours'
+        | 'results_cache_ttl_seconds'
         | 'provisioning_source'
         | 'agent_sql_scope'
     >

--- a/packages/backend/src/database/migrations/20260820145644_add_results_cache_ttl_to_projects.ts
+++ b/packages/backend/src/database/migrations/20260820145644_add_results_cache_ttl_to_projects.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex';
+
+const ProjectTableName = 'projects';
+const ColumnName = 'results_cache_ttl_seconds';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(ProjectTableName, (table) => {
+        // null means the instance-wide CACHE_STALE_TIME_SECONDS applies
+        table.integer(ColumnName).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(ProjectTableName, (table) => {
+        table.dropColumn(ColumnName);
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1093,10 +1093,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                             .getAppGenerateService<AppGenerateService>()
                             .getCustomSqlProvenance(args),
                 }),
-            cacheService: ({ models, context, clients }) =>
+            cacheService: ({ models, clients }) =>
                 new CommercialCacheService({
                     queryHistoryModel: models.getQueryHistoryModel(),
-                    lightdashConfig: context.lightdashConfig,
+                    projectModel: models.getProjectModel(),
                     storageClient: clients.getResultsFileStorageClient(),
                     featureFlagModel: models.getFeatureFlagModel(),
                 }),

--- a/packages/backend/src/ee/services/CommercialCacheService.test.ts
+++ b/packages/backend/src/ee/services/CommercialCacheService.test.ts
@@ -1,8 +1,13 @@
-import { type LightdashConfig } from '../../config/parseConfig';
 import { CommercialCacheService } from './CommercialCacheService';
 
-const makeService = (resultsUpdatedAt: Date) =>
-    new CommercialCacheService({
+const makeService = (
+    resultsUpdatedAt: Date,
+    effectiveTtlSeconds: number = 24 * 60 * 60,
+) => {
+    const getEffectiveResultsCacheTtlSeconds = vi
+        .fn()
+        .mockResolvedValue(effectiveTtlSeconds);
+    const service = new CommercialCacheService({
         queryHistoryModel: {
             findMostRecentByCacheKey: vi.fn().mockResolvedValue({
                 cacheKey: 'cache-key',
@@ -17,14 +22,14 @@ const makeService = (resultsUpdatedAt: Date) =>
                 pivotTotalColumnCount: null,
             }),
         } as never,
-        lightdashConfig: {
-            results: { cacheStateTimeSeconds: 24 * 60 * 60 },
-        } as LightdashConfig,
+        projectModel: { getEffectiveResultsCacheTtlSeconds } as never,
         storageClient: {} as never,
         featureFlagModel: {
             get: vi.fn().mockResolvedValue({ enabled: true }),
         } as never,
     });
+    return { service, getEffectiveResultsCacheTtlSeconds };
+};
 
 describe('CommercialCacheService', () => {
     beforeEach(() => {
@@ -37,7 +42,7 @@ describe('CommercialCacheService', () => {
     });
 
     it('does not treat retained results as fresh after the cache window', async () => {
-        const service = makeService(new Date('2026-07-30T11:00:00.000Z'));
+        const { service } = makeService(new Date('2026-07-30T11:00:00.000Z'));
 
         await expect(
             service.findCachedResultsFile('project-uuid', 'cache-key', {
@@ -47,7 +52,7 @@ describe('CommercialCacheService', () => {
     });
 
     it('returns the logical cache expiry for fresh retained results', async () => {
-        const service = makeService(new Date('2026-07-31T11:00:00.000Z'));
+        const { service } = makeService(new Date('2026-07-31T11:00:00.000Z'));
 
         await expect(
             service.findCachedResultsFile('project-uuid', 'cache-key', {
@@ -56,6 +61,51 @@ describe('CommercialCacheService', () => {
         ).resolves.toMatchObject({
             cacheHit: true,
             expiresAt: new Date('2026-08-01T11:00:00.000Z'),
+        });
+    });
+
+    it('resolves the TTL for the requested project', async () => {
+        const { service, getEffectiveResultsCacheTtlSeconds } = makeService(
+            new Date('2026-07-31T11:00:00.000Z'),
+        );
+
+        await service.findCachedResultsFile('project-uuid', 'cache-key', {
+            userUuid: 'user-uuid',
+        });
+
+        expect(getEffectiveResultsCacheTtlSeconds).toHaveBeenCalledWith(
+            'project-uuid',
+        );
+    });
+
+    it('uses a shorter project TTL to expire results the instance default would keep', async () => {
+        const thirtyMinutes = 30 * 60;
+        const { service } = makeService(
+            new Date('2026-07-31T11:00:00.000Z'),
+            thirtyMinutes,
+        );
+
+        await expect(
+            service.findCachedResultsFile('project-uuid', 'cache-key', {
+                userUuid: 'user-uuid',
+            }),
+        ).resolves.toBeNull();
+    });
+
+    it('computes the expiry from a project TTL for fresh results', async () => {
+        const twoHours = 2 * 60 * 60;
+        const { service } = makeService(
+            new Date('2026-07-31T11:00:00.000Z'),
+            twoHours,
+        );
+
+        await expect(
+            service.findCachedResultsFile('project-uuid', 'cache-key', {
+                userUuid: 'user-uuid',
+            }),
+        ).resolves.toMatchObject({
+            cacheHit: true,
+            expiresAt: new Date('2026-07-31T13:00:00.000Z'),
         });
     });
 });

--- a/packages/backend/src/ee/services/CommercialCacheService.ts
+++ b/packages/backend/src/ee/services/CommercialCacheService.ts
@@ -1,7 +1,7 @@
 import { FeatureFlags } from '@lightdash/common';
 import { type S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
-import type { LightdashConfig } from '../../config/parseConfig';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
 import type {
     CacheServiceUser,
@@ -11,7 +11,7 @@ import { type CacheHitCacheResult } from '../../services/CacheService/types';
 
 type CacheServiceDependencies = {
     queryHistoryModel: QueryHistoryModel;
-    lightdashConfig: LightdashConfig;
+    projectModel: ProjectModel;
     storageClient: S3ResultsFileStorageClient;
     featureFlagModel: FeatureFlagModel;
 };
@@ -23,7 +23,7 @@ const DEFAULT_CACHE_EXPIRY_BUFFER_MS = 10 * 60 * 1000; // 10 minutes in millisec
 export class CommercialCacheService implements ICacheService {
     private readonly queryHistoryModel: QueryHistoryModel;
 
-    private readonly lightdashConfig: LightdashConfig;
+    private readonly projectModel: ProjectModel;
 
     private readonly featureFlagModel: FeatureFlagModel;
 
@@ -31,12 +31,12 @@ export class CommercialCacheService implements ICacheService {
 
     constructor({
         queryHistoryModel,
-        lightdashConfig,
+        projectModel,
         storageClient,
         featureFlagModel,
     }: CacheServiceDependencies) {
         this.queryHistoryModel = queryHistoryModel;
-        this.lightdashConfig = lightdashConfig;
+        this.projectModel = projectModel;
         this.storageClient = storageClient;
         this.featureFlagModel = featureFlagModel;
     }
@@ -64,14 +64,15 @@ export class CommercialCacheService implements ICacheService {
         }
 
         // Find recent query with matching cache key
-        const latestMatchingQuery =
-            await this.queryHistoryModel.findMostRecentByCacheKey(
+        const [latestMatchingQuery, staleTimeSeconds] = await Promise.all([
+            this.queryHistoryModel.findMostRecentByCacheKey(
                 cacheKey,
                 projectUuid,
-            );
+            ),
+            this.projectModel.getEffectiveResultsCacheTtlSeconds(projectUuid),
+        ]);
 
-        const staleTimeMilliseconds =
-            this.lightdashConfig.results.cacheStateTimeSeconds * 1000;
+        const staleTimeMilliseconds = staleTimeSeconds * 1000;
 
         // If stale time is greater than quadruple default buffer, use default buffer
         // Otherwise, use quarter of stale time

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -803,6 +803,48 @@ export class ProjectModel {
             });
     }
 
+    async getResultsCacheSettings(
+        projectUuid: string,
+    ): Promise<{ cacheTtlSeconds: number | null }> {
+        const row = await this.database(ProjectTableName)
+            .where('project_uuid', projectUuid)
+            .select('results_cache_ttl_seconds')
+            .first();
+
+        if (!row) {
+            throw new NotFoundError(
+                `Cannot find project with id: ${projectUuid}`,
+            );
+        }
+
+        return { cacheTtlSeconds: row.results_cache_ttl_seconds };
+    }
+
+    async updateResultsCacheSettings(
+        projectUuid: string,
+        settings: { cacheTtlSeconds: number | null },
+    ): Promise<void> {
+        const affectedRows = await this.database(ProjectTableName)
+            .where('project_uuid', projectUuid)
+            .update({ results_cache_ttl_seconds: settings.cacheTtlSeconds });
+        if (affectedRows === 0) {
+            throw new NotFoundError(
+                `Cannot find project with id: ${projectUuid}`,
+            );
+        }
+    }
+
+    async getEffectiveResultsCacheTtlSeconds(
+        projectUuid: string,
+    ): Promise<number> {
+        const { cacheTtlSeconds } =
+            await this.getResultsCacheSettings(projectUuid);
+        return (
+            cacheTtlSeconds ??
+            this.lightdashConfig.results.cacheStateTimeSeconds
+        );
+    }
+
     async updateExpiresAt(projectUuid: string, expiresAt: Date): Promise<void> {
         await this.database(ProjectTableName)
             .where('project_uuid', projectUuid)

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -207,6 +207,7 @@ const projectModel = {
     getWithSensitiveFields: vi.fn(async () => projectWithSensitiveFields),
     get: vi.fn(async () => projectWithSensitiveFields),
     getSummary: vi.fn(async () => projectSummary),
+    getEffectiveResultsCacheTtlSeconds: vi.fn(async () => 86400),
     getTablesConfiguration: vi.fn(async () => tablesConfiguration),
     updateTablesConfiguration: vi.fn(),
     getQueryTimezone: vi.fn(async () => 'UTC'),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -956,11 +956,15 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
-    public getCacheExpiresAt(baseDate: Date) {
-        return new Date(
-            baseDate.getTime() +
-                this.lightdashConfig.results.cacheStateTimeSeconds * 1000,
-        );
+    public async getCacheExpiresAt(
+        projectUuid: string,
+        baseDate: Date,
+    ): Promise<Date> {
+        const ttlSeconds =
+            await this.projectModel.getEffectiveResultsCacheTtlSeconds(
+                projectUuid,
+            );
+        return new Date(baseDate.getTime() + ttlSeconds * 1000);
     }
 
     async findResultsCache(
@@ -3345,7 +3349,10 @@ export class AsyncQueryService extends ProjectService {
             const s3StreamCreatedMs = Date.now() - t0;
 
             const createdAt = new Date();
-            const newExpiresAt = this.getCacheExpiresAt(createdAt);
+            const newExpiresAt = await this.getCacheExpiresAt(
+                projectUuid,
+                createdAt,
+            );
             this.analytics.track({
                 ...analyticsIdentity,
                 event: 'results_cache.create',
@@ -5496,6 +5503,10 @@ export class AsyncQueryService extends ProjectService {
                 await this.queryHistoryModel.updateStatusToExecuting(queryUuid);
             }
             const createdAt = new Date();
+            const resultsExpiresAt = await this.getCacheExpiresAt(
+                projectUuid,
+                createdAt,
+            );
             const staticColumns: ResultColumns = {
                 [fieldId]: { reference: fieldId, type: field.type },
             };
@@ -5510,7 +5521,7 @@ export class AsyncQueryService extends ProjectService {
                     results_file_name: fileName,
                     results_created_at: createdAt,
                     results_updated_at: createdAt,
-                    results_expires_at: this.getCacheExpiresAt(createdAt),
+                    results_expires_at: resultsExpiresAt,
                 },
                 account,
             );

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -224,6 +224,11 @@ const projectModel = {
     ),
     update: vi.fn(async () => undefined),
     delete: vi.fn(async () => undefined),
+    getResultsCacheSettings: vi.fn<ProjectModel['getResultsCacheSettings']>(
+        async () => ({ cacheTtlSeconds: null }),
+    ),
+    updateResultsCacheSettings: vi.fn(async () => undefined),
+    getEffectiveResultsCacheTtlSeconds: vi.fn(async () => 86400),
 };
 const organizationWarehouseCredentialsModel = {
     getByUuidWithSensitiveData:
@@ -630,6 +635,111 @@ describe('ProjectService', () => {
             expect(result.dbtConnection).toHaveProperty('environment', [
                 { key: 'DBT_ENV_SECRET_PASSWORD', value: 'super-secret' },
             ]);
+        });
+    });
+
+    describe('updateProjectResultsCacheSettings', () => {
+        const cachingService = getMockedProjectService({
+            ...lightdashConfigMock,
+            results: { ...lightdashConfigMock.results, cacheEnabled: true },
+        });
+
+        beforeEach(() => {
+            projectModel.updateResultsCacheSettings.mockClear();
+        });
+
+        test('rejects updates while results caching is disabled', async () => {
+            await expect(
+                service.updateProjectResultsCacheSettings(user, projectUuid, {
+                    cacheTtlSeconds: 1800,
+                }),
+            ).rejects.toThrow(ForbiddenError);
+            expect(
+                projectModel.updateResultsCacheSettings,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('rejects a TTL below one minute', async () => {
+            await expect(
+                cachingService.updateProjectResultsCacheSettings(
+                    user,
+                    projectUuid,
+                    {
+                        cacheTtlSeconds: 59,
+                    },
+                ),
+            ).rejects.toThrow(ParameterError);
+            expect(
+                projectModel.updateResultsCacheSettings,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('rejects a TTL above thirty days', async () => {
+            await expect(
+                cachingService.updateProjectResultsCacheSettings(
+                    user,
+                    projectUuid,
+                    {
+                        cacheTtlSeconds: 30 * 24 * 60 * 60 + 1,
+                    },
+                ),
+            ).rejects.toThrow(ParameterError);
+            expect(
+                projectModel.updateResultsCacheSettings,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('rejects a non-integer TTL', async () => {
+            await expect(
+                cachingService.updateProjectResultsCacheSettings(
+                    user,
+                    projectUuid,
+                    {
+                        cacheTtlSeconds: 90.5,
+                    },
+                ),
+            ).rejects.toThrow(ParameterError);
+            expect(
+                projectModel.updateResultsCacheSettings,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('persists a TTL within bounds', async () => {
+            const result =
+                await cachingService.updateProjectResultsCacheSettings(
+                    user,
+                    projectUuid,
+                    { cacheTtlSeconds: 1800 },
+                );
+
+            expect(
+                projectModel.updateResultsCacheSettings,
+            ).toHaveBeenCalledWith(projectUuid, { cacheTtlSeconds: 1800 });
+            expect(result).toEqual({
+                projectUuid,
+                cacheTtlSeconds: 1800,
+                instanceDefaultTtlSeconds:
+                    lightdashConfigMock.results.cacheStateTimeSeconds,
+            });
+        });
+
+        test('persists null to fall back to the instance default', async () => {
+            const result =
+                await cachingService.updateProjectResultsCacheSettings(
+                    user,
+                    projectUuid,
+                    { cacheTtlSeconds: null },
+                );
+
+            expect(
+                projectModel.updateResultsCacheSettings,
+            ).toHaveBeenCalledWith(projectUuid, { cacheTtlSeconds: null });
+            expect(result).toEqual({
+                projectUuid,
+                cacheTtlSeconds: null,
+                instanceDefaultTtlSeconds:
+                    lightdashConfigMock.results.cacheStateTimeSeconds,
+            });
         });
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -139,6 +139,7 @@ import {
     LightdashUser,
     ManifestCollision,
     ManifestSource,
+    MAX_RESULTS_CACHE_TTL_SECONDS,
     maybeOverrideDbtConnection,
     maybeOverrideWarehouseConnection,
     maybeReplaceFieldsInChartVersion,
@@ -154,6 +155,7 @@ import {
     mergeWarehouseCredentials,
     MetricQuery,
     MetricType,
+    MIN_RESULTS_CACHE_TTL_SECONDS,
     MissingWarehouseCredentialsError,
     MostPopularAndRecentlyUpdated,
     normalizeIndexColumns,
@@ -191,6 +193,7 @@ import {
     ResolvedProjectColorPalette,
     resolveQueryTimezone,
     ResultRow,
+    ResultsCacheProjectSettings,
     SavedChartDAO,
     SavedChartsInfoForDashboardAvailableFilters,
     SessionUser,
@@ -214,6 +217,7 @@ import {
     UpdateProjectDetails,
     UpdateProjectMember,
     UpdateQueryTimezoneSettings,
+    UpdateResultsCacheProjectSettings,
     UpdateSchedulerSettings,
     UpdateVirtualViewPayload,
     UserAccessControls,
@@ -6895,14 +6899,20 @@ export class ProjectService extends BaseService {
                     const cacheEntryMetadata = await this.s3CacheClient
                         .getResultsMetadata(queryHash)
                         .catch((e) => undefined); // ignore since error is tracked in fileStorageClient
+                    const isCacheEntryFresh = async () => {
+                        if (!cacheEntryMetadata?.LastModified) return false;
+                        const cacheTtlSeconds =
+                            await this.projectModel.getEffectiveResultsCacheTtlSeconds(
+                                projectUuid,
+                            );
+                        return (
+                            Date.now() -
+                                cacheEntryMetadata.LastModified.getTime() <
+                            cacheTtlSeconds * 1000
+                        );
+                    };
 
-                    if (
-                        cacheEntryMetadata?.LastModified &&
-                        new Date().getTime() -
-                            cacheEntryMetadata.LastModified.getTime() <
-                            this.lightdashConfig.results.cacheStateTimeSeconds *
-                                1000
-                    ) {
+                    if (await isCacheEntryFresh()) {
                         this.logger.debug(
                             `Getting data from cache, key: ${queryHash}`,
                         );
@@ -9357,6 +9367,82 @@ export class ProjectService extends BaseService {
         const persisted =
             await this.projectModel.getPreviewExpirationSettings(projectUuid);
         return { projectUuid, ...persisted };
+    }
+
+    async getProjectResultsCacheSettings(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ResultsCacheProjectSettings> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'update',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        const settings =
+            await this.projectModel.getResultsCacheSettings(projectUuid);
+        return {
+            projectUuid,
+            ...settings,
+            instanceDefaultTtlSeconds:
+                this.lightdashConfig.results.cacheStateTimeSeconds,
+        };
+    }
+
+    async updateProjectResultsCacheSettings(
+        user: SessionUser,
+        projectUuid: string,
+        settings: UpdateResultsCacheProjectSettings,
+    ): Promise<ResultsCacheProjectSettings> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'update',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        const { enabled: resultsCacheEnabled } =
+            await this.featureFlagModel.get({
+                user,
+                featureFlagId: FeatureFlags.ResultsCacheEnabled,
+            });
+        if (!resultsCacheEnabled) {
+            throw new ForbiddenError('Results caching is not enabled');
+        }
+        const { cacheTtlSeconds } = settings;
+        if (cacheTtlSeconds !== null) {
+            if (!Number.isInteger(cacheTtlSeconds)) {
+                throw new ParameterError(
+                    'Cache duration must be a whole number of seconds',
+                );
+            }
+            if (
+                cacheTtlSeconds < MIN_RESULTS_CACHE_TTL_SECONDS ||
+                cacheTtlSeconds > MAX_RESULTS_CACHE_TTL_SECONDS
+            ) {
+                throw new ParameterError(
+                    `Cache duration must be between ${MIN_RESULTS_CACHE_TTL_SECONDS} and ${MAX_RESULTS_CACHE_TTL_SECONDS} seconds (30 days)`,
+                );
+            }
+        }
+        await this.projectModel.updateResultsCacheSettings(projectUuid, {
+            cacheTtlSeconds,
+        });
+        return {
+            projectUuid,
+            cacheTtlSeconds,
+            instanceDefaultTtlSeconds:
+                this.lightdashConfig.results.cacheStateTimeSeconds,
+        };
     }
 
     async updatePreviewExpiresAt(

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -136,6 +136,7 @@ export * from './types/dataRetention';
 export * from './types/featureFlags';
 export * from './types/impersonationOrganizationSettings';
 export * from './types/previewExpirationProjectSettings';
+export * from './types/resultsCacheProjectSettings';
 export * from './types/upstreamDiff';
 export * from './types/field';
 export * from './types/ci';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -303,6 +303,7 @@ import {
 import { type ApiRenameFieldsResponse, type ApiRenameResponse } from './rename';
 import { type MostPopularAndRecentlyUpdated } from './resourceViewItem';
 import { type ResultColumns, type ResultRow } from './results';
+import { type ApiResultsCacheProjectSettingsResponse } from './resultsCacheProjectSettings';
 import { type ApiRoadmapResponse } from './roadmap';
 import {
     type ApiCustomRoleAsCodeListResponse,
@@ -1435,6 +1436,7 @@ type ApiResults =
     | ApiPreAggregateCheckResponse['results']
     | ApiImpersonationOrganizationSettingsResponse['results']
     | ApiPreviewExpirationProjectSettingsResponse['results']
+    | ApiResultsCacheProjectSettingsResponse['results']
     | ApiPreviewExpiresAtResponse['results']
     | ApiContentVerificationResponse['results']
     | ApiContentVerificationDeleteResponse['results']

--- a/packages/common/src/types/resultsCacheProjectSettings.ts
+++ b/packages/common/src/types/resultsCacheProjectSettings.ts
@@ -1,0 +1,17 @@
+import { type ApiSuccess } from './api/success';
+
+export const MIN_RESULTS_CACHE_TTL_SECONDS = 60;
+export const MAX_RESULTS_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+export type ResultsCacheProjectSettings = {
+    projectUuid: string;
+    cacheTtlSeconds: number | null;
+    instanceDefaultTtlSeconds: number;
+};
+
+export type UpdateResultsCacheProjectSettings = {
+    cacheTtlSeconds: number | null;
+};
+
+export type ApiResultsCacheProjectSettingsResponse =
+    ApiSuccess<ResultsCacheProjectSettings>;


### PR DESCRIPTION
## Summary

Part 1 of 2 (stack #27777). The results cache TTL was a single instance-wide value, `CACHE_STALE_TIME_SECONDS` (default 24 hours), shared by every project on an instance. This adds a per-project override and the API to manage it, so organisations on shared instances can choose how long cached results are served. The settings UI follows in #27776.

- New nullable column `projects.results_cache_ttl_seconds`; null means "use the instance default".
- `GET` / `PATCH /api/v1/projects/{projectUuid}/results-cache-config`, body `{ cacheTtlSeconds: number | null }`, bounded to 60 seconds to 30 days. Same `update` permission on the project as the preview-expiration settings. Both responses also carry `instanceDefaultTtlSeconds` so the UI can show the fallback without a separate call.
- `ProjectModel.getEffectiveResultsCacheTtlSeconds(projectUuid)` is the single fallback point. It is used on the write path (`results_expires_at` stamping), on the read path in `CommercialCacheService.findCachedResultsFile` (existing pagination buffer unchanged), and on the legacy sync cache path in `ProjectService`.

Enabling results caching itself is unchanged and stays behind the existing `results-cache-enabled` feature flag. `PATCH` returns 403 while the flag is off (same pattern as the impersonation toggle); `GET` stays open, and a previously stored TTL is simply inert until caching is enabled again.

## Testing

- CommercialCacheService: project TTL used when set, instance default when null, a shorter project TTL expires results the default would still serve.
- ProjectService: bounds validation (below 60s, above 30 days, non-integer rejected; in-bounds and null persisted); 403 while results caching is disabled.
- `api-tests/resultsCacheSettings.test.ts`: round trip, bounds, viewer 403.
- AsyncQueryService expiry tests updated for the project-aware `getCacheExpiresAt`.
- `common`/`backend`/`frontend` typecheck and `backend` lint pass on this slice alone.

## Notes for review

- Migration is an additive nullable column, so no release-safety declaration.
- Freshness on the read path checks both `results_updated_at + current TTL` and the `results_expires_at` stamped at write time. Lowering a project's TTL therefore applies to existing results immediately; raising it only affects results produced after the change.
- On the legacy sync path the project TTL is only looked up once the S3 metadata says a cache entry exists, so a miss does not pay the extra query.
- The autocomplete cache still reads the instance TTL; it is handled separately under PROD-10411.

Closes: [PROD-10410](https://linear.app/lightdash/issue/PROD-10410/add-project-setting-for-results-cache-ttl-that-overrides-cache-stale)
