### PR TITLE
feat(explorer): minimal flagged chart gallery sidebar

### DIFF
--- a/packages/common/src/featureFlags/previewFeatureFlags.ts
+++ b/packages/common/src/featureFlags/previewFeatureFlags.ts
@@ -26,6 +26,10 @@ const PREVIEW_EXCLUDED_FEATURE_FLAGS: ReadonlySet<string> = new Set<string>([
     FeatureFlags.AiReviewReplayCapture,
     // Security hardening: previews must not accept long-lived GitHub PATs.
     FeatureFlags.AiMcpGithubPat,
+    // The Explorer E2E specs drive the legacy chart type picker, which the
+    // gallery replaces; keep previews on the shipped path until it has its
+    // own coverage. QA can still turn it on with a feature_flag_overrides row.
+    FeatureFlags.ExplorerChartGallery,
     // Derived from instance configuration: left to their config handler so a
     // preview never advertises a feature whose backend isn't configured.
     CommercialFeatureFlags.AiCopilot,

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -108,6 +108,12 @@ export enum FeatureFlags {
     EnableDataApps = 'enable-data-apps',
 
     /**
+     * Keep Explorer fields mounted on the left while chart selection and
+     * configuration render in a right sidebar.
+     */
+    ExplorerChartGallery = 'explorer-chart-gallery',
+
+    /**
      * Let embedded dashboard builders create and edit charts in place ("New
      * chart" in the add-tile menu and "Edit chart" on tiles). Resolved with
      * the embed write actor and organization, surfaced via embedWriteContext.

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
@@ -1,0 +1,58 @@
+.root {
+    height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.scrollArea {
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.scrollContent {
+    min-width: 0;
+}
+
+.row {
+    width: 100%;
+    padding: var(--mantine-spacing-sm);
+    border: 1px solid transparent;
+    border-radius: var(--mantine-radius-md);
+    text-align: left;
+}
+
+.row:hover:not(:disabled) {
+    background: var(--mantine-color-ldGray-0);
+}
+
+.row[data-selected='true'] {
+    border-color: var(--mantine-color-blue-5);
+    background: light-dark(
+        var(--mantine-color-blue-0),
+        color-mix(in srgb, var(--mantine-color-blue-9) 26%, transparent)
+    );
+}
+
+.thumbnail {
+    display: grid;
+    width: 86px;
+    height: 54px;
+    flex: 0 0 86px;
+    place-items: center;
+    overflow: hidden;
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-dark-5));
+    border-radius: var(--mantine-radius-sm);
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+}
+
+.icon {
+    flex: 0 0 auto;
+}
+
+.icon[data-rotated='true'] {
+    rotate: 90deg;
+}

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
@@ -1,0 +1,207 @@
+import { ChartType, type DataAppViz, type ItemsMap } from '@lightdash/common';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type * as ReactRouter from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDataAppVisualizations } from '../../../features/chartTypes/hooks/useDataAppVisualizations';
+import { renderWithProviders } from '../../../testing/testUtils';
+import ExplorerChartTypeGallery from './ChartTypeGallery';
+
+const { mocks } = vi.hoisted(() => ({
+    mocks: {
+        setChartType: vi.fn(),
+        setCartesianType: vi.fn(),
+        setStacking: vi.fn(),
+        selectProjectChartType: vi.fn(),
+        refetch: vi.fn(),
+        fetchNextPage: vi.fn(),
+        navigate: vi.fn(),
+        canCreateDataApp: vi.fn(() => true),
+    },
+}));
+
+const projectChartType = {
+    dataAppVizUuid: 'project-chart-type',
+    name: 'Event pulse',
+    description: 'Reusable ranked bars',
+    projectUuid: 'project-uuid',
+    spaceUuid: null,
+    createdAt: new Date('2026-08-20T00:00:00Z'),
+    createdByUserUuid: 'user-uuid',
+    schema: { fields: [], configOptions: [], colorPalette: null },
+} satisfies DataAppViz;
+
+const itemsMap = { orders_status: { name: 'status' } } as unknown as ItemsMap;
+
+vi.mock('../../../features/chartTypes/hooks/useDataAppVisualizations');
+vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({ data: { enabled: true } }),
+}));
+vi.mock('../../LightdashVisualization/useVisualizationContext', () => ({
+    useVisualizationContext: () => ({
+        visualizationConfig: {
+            chartType: ChartType.TABLE,
+            chartConfig: {},
+        },
+        setChartType: mocks.setChartType,
+        setCartesianType: mocks.setCartesianType,
+        setStacking: mocks.setStacking,
+        isLoading: false,
+        resultsData: { rows: [{}] },
+        pivotDimensions: undefined,
+        itemsMap,
+    }),
+}));
+vi.mock(
+    '../../VisualizationConfigs/CustomChartType/useSelectProjectChartType',
+    () => ({
+        useSelectProjectChartType: () => mocks.selectProjectChartType,
+    }),
+);
+vi.mock('../../../features/apps/hooks/useCanCreateDataApp', () => ({
+    useCanCreateDataApp: () => mocks.canCreateDataApp(),
+}));
+vi.mock('react-router', async (importOriginal) => ({
+    ...(await importOriginal<typeof ReactRouter>()),
+    useParams: () => ({ projectUuid: 'project-uuid' }),
+    useLocation: () => ({ search: '?tableName=orders' }),
+    useNavigate: () => mocks.navigate,
+}));
+
+const mockedUseDataAppVisualizations = vi.mocked(useDataAppVisualizations);
+
+const setProjectQuery = (error: Error | null = null) => {
+    mockedUseDataAppVisualizations.mockReturnValue({
+        data: error
+            ? undefined
+            : {
+                  pages: [
+                      {
+                          data: [projectChartType],
+                          pagination: {
+                              page: 1,
+                              pageSize: 25,
+                              totalPageCount: 1,
+                              totalResults: 1,
+                          },
+                      },
+                  ],
+                  pageParams: [1],
+              },
+        isInitialLoading: false,
+        error,
+        refetch: mocks.refetch,
+        hasNextPage: false,
+        fetchNextPage: mocks.fetchNextPage,
+        isFetchingNextPage: false,
+    } as unknown as ReturnType<typeof useDataAppVisualizations>);
+};
+
+const renderGallery = () => {
+    const onSelected = vi.fn();
+    renderWithProviders(<ExplorerChartTypeGallery onSelected={onSelected} />);
+    return onSelected;
+};
+
+describe('ExplorerChartTypeGallery', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.canCreateDataApp.mockReturnValue(true);
+        setProjectQuery();
+    });
+
+    it('uses the shared built-in selection command and opens Configure', async () => {
+        const onSelected = renderGallery();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: /Pie chart/ }),
+        );
+
+        expect(mocks.setStacking).toHaveBeenCalledWith(undefined);
+        expect(mocks.setCartesianType).toHaveBeenCalledWith(undefined);
+        expect(mocks.setChartType).toHaveBeenCalledWith(ChartType.PIE);
+        expect(onSelected).toHaveBeenCalledTimes(1);
+    });
+
+    it('filters built-in choices using the gallery search', async () => {
+        renderGallery();
+
+        await userEvent.type(
+            screen.getByRole('textbox', { name: 'Search chart types' }),
+            'pie',
+        );
+
+        await waitFor(() =>
+            expect(
+                screen.queryByRole('button', { name: /Bar chart/ }),
+            ).not.toBeInTheDocument(),
+        );
+        expect(
+            screen.getByRole('button', { name: /Pie chart/ }),
+        ).toBeInTheDocument();
+    });
+
+    it('selects the existing Vega configuration path', async () => {
+        const onSelected = renderGallery();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: /Vega \(JSON editor\)/ }),
+        );
+
+        expect(mocks.setChartType).toHaveBeenCalledWith(ChartType.CUSTOM);
+        expect(onSelected).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the existing project chart-type selection handler', async () => {
+        const onSelected = renderGallery();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: /Event pulse/ }),
+        );
+
+        expect(mocks.selectProjectChartType).toHaveBeenCalledWith(
+            projectChartType,
+            itemsMap,
+        );
+        expect(onSelected).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens the chart type builder from the project section', async () => {
+        renderGallery();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: /Create new chart type/ }),
+        );
+
+        expect(mocks.navigate).toHaveBeenCalledWith({
+            pathname: '/projects/project-uuid/chart-types/new',
+            search: '?tableName=orders',
+        });
+    });
+
+    it('hides the create action without permission to author chart types', () => {
+        mocks.canCreateDataApp.mockReturnValue(false);
+        renderGallery();
+
+        expect(
+            screen.queryByRole('button', { name: /Create new chart type/ }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /Event pulse/ }),
+        ).toBeInTheDocument();
+    });
+
+    it('keeps built-in choices usable when project types fail to load', async () => {
+        setProjectQuery(new Error('unavailable'));
+        renderGallery();
+
+        expect(
+            screen.getByText('Failed to load project chart types'),
+        ).toBeInTheDocument();
+        await userEvent.click(
+            screen.getByRole('button', { name: /Vega \(JSON editor\)/ }),
+        );
+
+        expect(mocks.setChartType).toHaveBeenCalledWith(ChartType.CUSTOM);
+    });
+});

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -1,0 +1,330 @@
+import {
+    FeatureFlags,
+    getAppDisplayName,
+    type DataAppViz,
+} from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Group,
+    Loader,
+    ScrollArea,
+    Stack,
+    Text,
+    TextInput,
+    UnstyledButton,
+} from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import {
+    IconChevronRight,
+    IconPlus,
+    IconPuzzle,
+    IconSearch,
+} from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
+import { useDataAppVisualizations } from '../../../features/chartTypes/hooks/useDataAppVisualizations';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import MantineIcon from '../../common/MantineIcon';
+import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import { useSelectProjectChartType } from '../../VisualizationConfigs/CustomChartType/useSelectProjectChartType';
+import {
+    useChartTypeOptions,
+    type ChartTypeOption,
+} from '../VisualizationCardOptions/useChartTypeOptions';
+import classes from './ChartTypeGallery.module.css';
+
+export type ChartTypeGalleryItem = Omit<ChartTypeOption, 'id'> & {
+    key: string;
+    disabled: boolean;
+};
+
+type ThumbnailProps = Pick<ChartTypeOption, 'icon' | 'rotatedIcon'>;
+
+export const ChartTypeThumbnail: FC<ThumbnailProps> = ({
+    icon,
+    rotatedIcon,
+}) => (
+    <Box className={classes.thumbnail}>
+        <MantineIcon
+            className={classes.icon}
+            data-rotated={rotatedIcon}
+            icon={icon}
+            size="xl"
+            color="blue"
+        />
+    </Box>
+);
+
+export type ChartTypeGallerySection = {
+    label: string;
+    items: ChartTypeGalleryItem[];
+    loading: boolean;
+    errorMessage: string | null;
+    emptyMessage: string;
+    onRetry: (() => void) | null;
+    onLoadMore: (() => void) | null;
+    loadingMore: boolean;
+    /** Opens the chart type builder; null hides the create action. */
+    onCreateNew: (() => void) | null;
+};
+
+type GalleryProps = {
+    search: string;
+    onSearchChange: (search: string) => void;
+    sections: ChartTypeGallerySection[];
+};
+
+const ChartTypeGallery: FC<GalleryProps> = ({
+    search,
+    onSearchChange,
+    sections,
+}) => (
+    <Stack className={classes.root} gap="md">
+        <TextInput
+            size="xs"
+            value={search}
+            onChange={(event) => onSearchChange(event.currentTarget.value)}
+            placeholder="Search the gallery"
+            leftSection={<MantineIcon icon={IconSearch} />}
+            aria-label="Search chart types"
+        />
+
+        <ScrollArea
+            className={classes.scrollArea}
+            offsetScrollbars
+            scrollbars="y"
+            type="hover"
+            scrollbarSize={8}
+            classNames={{ content: classes.scrollContent }}
+        >
+            <Stack gap="lg" pb="xs">
+                {sections.map((section) => (
+                    <Stack key={section.label} gap="xs">
+                        <Text fz="xs" fw={600} c="dimmed">
+                            {section.label}
+                        </Text>
+
+                        {section.loading ? (
+                            <Group gap="xs">
+                                <Loader size="xs" />
+                                <Text fz="xs" c="dimmed">
+                                    Loading chart types…
+                                </Text>
+                            </Group>
+                        ) : section.errorMessage !== null ? (
+                            <Group justify="space-between" wrap="nowrap">
+                                <Text fz="xs" c="red">
+                                    {section.errorMessage}
+                                </Text>
+                                {section.onRetry !== null ? (
+                                    <Button
+                                        variant="subtle"
+                                        size="compact-xs"
+                                        onClick={section.onRetry}
+                                    >
+                                        Retry
+                                    </Button>
+                                ) : null}
+                            </Group>
+                        ) : section.items.length === 0 ? (
+                            <Text fz="xs" c="dimmed">
+                                {section.emptyMessage}
+                            </Text>
+                        ) : (
+                            section.items.map((item) => (
+                                <UnstyledButton
+                                    key={item.key}
+                                    className={classes.row}
+                                    data-selected={item.selected}
+                                    disabled={item.disabled}
+                                    onClick={item.select}
+                                >
+                                    <Group wrap="nowrap" gap="sm">
+                                        <ChartTypeThumbnail
+                                            icon={item.icon}
+                                            rotatedIcon={item.rotatedIcon}
+                                        />
+                                        <Stack gap={2} flex={1}>
+                                            <Text size="sm" fw={500}>
+                                                {item.label}
+                                            </Text>
+                                            <Text
+                                                fz="xs"
+                                                c="dimmed"
+                                                lineClamp={2}
+                                            >
+                                                {item.description}
+                                            </Text>
+                                        </Stack>
+                                        <MantineIcon
+                                            icon={IconChevronRight}
+                                            color="ldGray"
+                                            size="sm"
+                                        />
+                                    </Group>
+                                </UnstyledButton>
+                            ))
+                        )}
+
+                        {section.onLoadMore !== null ? (
+                            <Button
+                                variant="subtle"
+                                size="xs"
+                                loading={section.loadingMore}
+                                onClick={section.onLoadMore}
+                            >
+                                Load more
+                            </Button>
+                        ) : null}
+
+                        {/* An action, not a chart type; wanted even when the
+                            section is empty. */}
+                        {section.onCreateNew !== null ? (
+                            <Button
+                                variant="subtle"
+                                size="xs"
+                                px="xs"
+                                leftSection={<MantineIcon icon={IconPlus} />}
+                                onClick={section.onCreateNew}
+                                justify="flex-start"
+                            >
+                                Create new chart type
+                            </Button>
+                        ) : null}
+                    </Stack>
+                ))}
+            </Stack>
+        </ScrollArea>
+    </Stack>
+);
+
+type ExplorerChartTypeGalleryProps = {
+    onSelected: () => void;
+};
+
+const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
+    onSelected,
+}) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const location = useLocation();
+    const navigate = useNavigate();
+    const [search, setSearch] = useState('');
+    const [debouncedSearch] = useDebouncedValue(search, 300);
+    const dataAppsEnabled =
+        useServerFeatureFlag(FeatureFlags.EnableDataApps).data?.enabled ===
+        true;
+    const {
+        data,
+        isInitialLoading,
+        error,
+        refetch,
+        hasNextPage,
+        fetchNextPage,
+        isFetchingNextPage,
+    } = useDataAppVisualizations(
+        dataAppsEnabled ? projectUuid : undefined,
+        debouncedSearch,
+    );
+    const canCreateChartType = useCanCreateDataApp(projectUuid);
+    const { visualizationConfig, itemsMap } = useVisualizationContext();
+    const selectProjectChartType = useSelectProjectChartType();
+    const { disabled, options, vegaOption } = useChartTypeOptions();
+
+    const projectTypes = useMemo(
+        () => data?.pages.flatMap((page) => page.data) ?? [],
+        [data?.pages],
+    );
+    const selectedProjectUuid = isDataAppVizVisualizationConfig(
+        visualizationConfig,
+    )
+        ? visualizationConfig.chartConfig.dataAppVizUuid
+        : null;
+    const matchesBuiltInSearch = (option: ChartTypeOption) =>
+        option.label.toLowerCase().includes(debouncedSearch.toLowerCase());
+
+    const builtInItems: ChartTypeGalleryItem[] = [...options, vegaOption]
+        .filter(matchesBuiltInSearch)
+        .map(({ id, ...option }) => ({
+            ...option,
+            key: id,
+            disabled,
+            select: () => {
+                option.select();
+                onSelected();
+            },
+        }));
+    const projectItems = projectTypes.map(
+        (dataAppViz: DataAppViz): ChartTypeGalleryItem => ({
+            key: dataAppViz.dataAppVizUuid,
+            label: getAppDisplayName(
+                dataAppViz.name,
+                dataAppViz.dataAppVizUuid,
+            ),
+            description:
+                dataAppViz.description ||
+                `${dataAppViz.schema?.fields.length ?? 0} fields`,
+            icon: IconPuzzle,
+            rotatedIcon: false,
+            selected: selectedProjectUuid === dataAppViz.dataAppVizUuid,
+            disabled,
+            select: () => {
+                selectProjectChartType(dataAppViz, itemsMap ?? {});
+                onSelected();
+            },
+        }),
+    );
+
+    const sections: ChartTypeGallerySection[] = [
+        ...(dataAppsEnabled
+            ? [
+                  {
+                      label: 'Project',
+                      items: projectItems,
+                      loading: isInitialLoading,
+                      errorMessage: error
+                          ? 'Failed to load project chart types'
+                          : null,
+                      emptyMessage: debouncedSearch
+                          ? 'No project chart types match your search'
+                          : 'No project chart types yet',
+                      onRetry: error ? () => void refetch() : null,
+                      onLoadMore: hasNextPage
+                          ? () => void fetchNextPage()
+                          : null,
+                      loadingMore: isFetchingNextPage,
+                      onCreateNew: canCreateChartType
+                          ? () =>
+                                void navigate({
+                                    pathname: `/projects/${projectUuid}/chart-types/new`,
+                                    search: location.search,
+                                })
+                          : null,
+                  },
+              ]
+            : []),
+        {
+            label: 'Built in',
+            items: builtInItems,
+            loading: false,
+            errorMessage: null,
+            emptyMessage: 'No built-in chart types match your search',
+            onRetry: null,
+            onLoadMore: null,
+            loadingMore: false,
+            onCreateNew: null,
+        },
+    ];
+
+    return (
+        <ChartTypeGallery
+            search={search}
+            onSearchChange={setSearch}
+            sections={sections}
+        />
+    );
+};
+
+export default ExplorerChartTypeGallery;

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.module.css
@@ -1,0 +1,30 @@
+.root {
+    height: 100%;
+    min-height: 0;
+    padding: var(--mantine-spacing-md);
+    padding-bottom: 0;
+}
+
+.header {
+    flex: 0 0 auto;
+    padding-bottom: var(--mantine-spacing-md);
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-dark-5));
+}
+
+.body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+    padding-top: var(--mantine-spacing-md);
+}
+
+.configure {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.selectedChart {
+    flex: 0 0 auto;
+}

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
@@ -1,0 +1,105 @@
+import { ChartKind, ChartType } from '@lightdash/common';
+import { IconCode, IconTable } from '@tabler/icons-react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import ExplorerChartSidebar from './ExplorerChartSidebar';
+
+vi.mock('../VisualizationCard/VisualizationConfig', () => ({
+    default: () => <div>Configure controls</div>,
+}));
+vi.mock('./ChartTypeGallery', () => ({
+    default: ({ onSelected }: { onSelected: () => void }) => (
+        <button onClick={onSelected}>Select chart</button>
+    ),
+    ChartTypeThumbnail: () => <span>Table thumbnail</span>,
+}));
+vi.mock('../../../features/chartTypes/hooks/useDataAppVisualization', () => ({
+    useDataAppVisualization: () => ({ data: undefined }),
+}));
+vi.mock('../../LightdashVisualization/useVisualizationContext', () => ({
+    useVisualizationContext: () => ({
+        visualizationConfig: {
+            chartType: ChartType.TABLE,
+            chartConfig: {},
+        },
+    }),
+}));
+vi.mock('../VisualizationCardOptions/useChartTypeOptions', () => ({
+    useChartTypeOptions: () => ({
+        selectedChartType: {
+            id: ChartKind.TABLE,
+            label: 'Table',
+            icon: IconTable,
+            rotatedIcon: false,
+        },
+        vegaOption: {
+            id: ChartKind.CUSTOM,
+            label: 'Vega (JSON editor)',
+            icon: IconCode,
+            rotatedIcon: false,
+        },
+    }),
+}));
+
+const ReopenHarness = () => {
+    const [open, setOpen] = useState(true);
+    return (
+        <>
+            {open ? (
+                <ExplorerChartSidebar
+                    chartType={ChartType.TABLE}
+                    onClose={() => setOpen(false)}
+                />
+            ) : (
+                <button onClick={() => setOpen(true)}>Reopen</button>
+            )}
+        </>
+    );
+};
+
+describe('ExplorerChartSidebar', () => {
+    it('moves from Configure to Choose and back after selection', async () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <ExplorerChartSidebar
+                    chartType={ChartType.TABLE}
+                    onClose={vi.fn()}
+                />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('Configure controls')).toBeInTheDocument();
+        expect(screen.getByText('Table')).toBeInTheDocument();
+        await userEvent.click(screen.getByText('Choose type'));
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Select chart' }),
+        );
+
+        expect(screen.getByText('Configure controls')).toBeInTheDocument();
+    });
+
+    it('reopens in Configure after closing from Choose', async () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <ReopenHarness />
+            </MemoryRouter>,
+        );
+
+        await userEvent.click(screen.getByText('Choose type'));
+        await userEvent.click(
+            screen.getByRole('button', {
+                name: 'Close visualization config',
+            }),
+        );
+        await userEvent.click(screen.getByRole('button', { name: 'Reopen' }));
+
+        expect(screen.getByText('Configure controls')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Select chart' }),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -1,0 +1,194 @@
+import { ChartKind, ChartType, getAppDisplayName } from '@lightdash/common';
+import {
+    ActionIcon,
+    Anchor,
+    Button,
+    Group,
+    Paper,
+    SegmentedControl,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import {
+    IconArrowLeft,
+    IconPuzzle,
+    IconSettings,
+    IconX,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Link, useLocation, useParams } from 'react-router';
+import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
+import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
+import { ChartGalleryContext } from '../../common/ChartGallery/ChartGalleryContext';
+import MantineIcon from '../../common/MantineIcon';
+import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import VisualizationConfig from '../VisualizationCard/VisualizationConfig';
+import {
+    useChartTypeOptions,
+    type SelectedChartType,
+} from '../VisualizationCardOptions/useChartTypeOptions';
+import ExplorerChartTypeGallery, {
+    ChartTypeThumbnail,
+} from './ChartTypeGallery';
+import classes from './ExplorerChartSidebar.module.css';
+
+type Props = {
+    chartType: ChartType;
+    onClose: () => void;
+};
+
+type Mode = 'choose' | 'configure';
+
+const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
+    const [mode, setMode] = useState<Mode>('configure');
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const location = useLocation();
+    const { visualizationConfig } = useVisualizationContext();
+    const { selectedChartType, vegaOption } = useChartTypeOptions();
+    const dataAppVizUuid = isDataAppVizVisualizationConfig(visualizationConfig)
+        ? visualizationConfig.chartConfig.dataAppVizUuid
+        : undefined;
+    const { data: selectedProjectType } = useDataAppVisualization(
+        projectUuid,
+        dataAppVizUuid,
+        null,
+    );
+
+    const canEditSelectedType = useCanEditDataApp(projectUuid, {
+        spaceUuid: selectedProjectType?.spaceUuid ?? null,
+        createdByUserUuid: selectedProjectType?.createdByUserUuid ?? null,
+    });
+
+    const isProjectType = chartType === ChartType.DATA_APP_VIZ;
+    const selectedItem: SelectedChartType = isProjectType
+        ? {
+              id: ChartKind.DATA_APP_VIZ,
+              label: selectedProjectType
+                  ? getAppDisplayName(
+                        selectedProjectType.name,
+                        selectedProjectType.dataAppVizUuid,
+                    )
+                  : 'Project chart type',
+              icon: IconPuzzle,
+              rotatedIcon: false,
+          }
+        : chartType === ChartType.CUSTOM
+          ? vegaOption
+          : selectedChartType;
+
+    return (
+        <ChartGalleryContext.Provider value={true}>
+            <Stack className={classes.root} gap={0}>
+                <Group
+                    className={classes.header}
+                    justify="space-between"
+                    wrap="nowrap"
+                >
+                    <Group gap="xs" wrap="nowrap">
+                        <MantineIcon icon={IconSettings} />
+                        <Text fw={600}>Configure chart</Text>
+                    </Group>
+                    <Tooltip
+                        label="Close visualization config"
+                        position="right"
+                    >
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            size="sm"
+                            aria-label="Close visualization config"
+                            onClick={onClose}
+                        >
+                            <MantineIcon icon={IconX} />
+                        </ActionIcon>
+                    </Tooltip>
+                </Group>
+
+                <Stack className={classes.body} gap="md">
+                    <SegmentedControl
+                        fullWidth
+                        value={mode}
+                        onChange={(value) => setMode(value as Mode)}
+                        data={[
+                            { value: 'choose', label: 'Choose type' },
+                            { value: 'configure', label: 'Configure' },
+                        ]}
+                    />
+
+                    {mode === 'choose' ? (
+                        <ExplorerChartTypeGallery
+                            onSelected={() => setMode('configure')}
+                        />
+                    ) : (
+                        <Stack className={classes.configure} gap="md">
+                            <Button
+                                variant="subtle"
+                                size="xs"
+                                px={0}
+                                leftSection={
+                                    <MantineIcon icon={IconArrowLeft} />
+                                }
+                                onClick={() => setMode('choose')}
+                            >
+                                Change chart type
+                            </Button>
+
+                            <Paper
+                                className={classes.selectedChart}
+                                withBorder
+                                radius="md"
+                                p="sm"
+                            >
+                                <Group wrap="nowrap">
+                                    <ChartTypeThumbnail
+                                        icon={selectedItem.icon}
+                                        rotatedIcon={selectedItem.rotatedIcon}
+                                    />
+                                    <Stack gap={3}>
+                                        <Text fw={600}>
+                                            {selectedItem.label}
+                                        </Text>
+                                        <Group gap="xs">
+                                            {isProjectType &&
+                                            selectedProjectType &&
+                                            canEditSelectedType ? (
+                                                <Anchor
+                                                    component={Link}
+                                                    to={{
+                                                        pathname: `/projects/${projectUuid}/chart-types/${selectedProjectType.dataAppVizUuid}`,
+                                                        search: location.search,
+                                                    }}
+                                                    fz="xs"
+                                                    fw={500}
+                                                >
+                                                    Edit ↗
+                                                </Anchor>
+                                            ) : null}
+                                        </Group>
+                                    </Stack>
+                                </Group>
+                                {isProjectType &&
+                                selectedProjectType?.description ? (
+                                    <Text fz="xs" c="dimmed" lh={1.5} mt="xs">
+                                        {selectedProjectType.description}
+                                    </Text>
+                                ) : null}
+                            </Paper>
+
+                            <VisualizationConfig
+                                chartType={chartType}
+                                onClose={onClose}
+                                withHeader={false}
+                                withChartTypePicker={false}
+                            />
+                        </Stack>
+                    )}
+                </Stack>
+            </Stack>
+        </ChartGalleryContext.Provider>
+    );
+};
+
+export default ExplorerChartSidebar;

--- a/packages/frontend/src/components/Explorer/ChartGallery/useChartGalleryRightSidebar.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/useChartGalleryRightSidebar.test.tsx
@@ -1,0 +1,82 @@
+import { renderHook } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { Provider } from 'react-redux';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    createExplorerStore,
+    explorerActions,
+} from '../../../features/explorer/store';
+import { useChartGalleryRightSidebar } from './useChartGalleryRightSidebar';
+
+const testState = vi.hoisted(() => ({
+    isChartGalleryEnabled: false,
+}));
+
+vi.mock('./useIsChartGalleryEnabled', () => ({
+    useIsChartGalleryEnabled: () => testState.isChartGalleryEnabled,
+}));
+
+vi.mock('../VisualizationCard/VisualizationConfigPortal', () => ({
+    default: () => <div data-testid="visualization-config-portal" />,
+}));
+
+const renderWithStore = <Result,>(
+    ui: () => Result,
+    { openVisualizationConfig = false } = {},
+) => {
+    const store = createExplorerStore();
+    if (openVisualizationConfig) {
+        store.dispatch(explorerActions.openVisualizationConfig());
+    }
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+        <Provider store={store}>{children}</Provider>
+    );
+
+    return renderHook(ui, { wrapper });
+};
+
+describe('useChartGalleryRightSidebar', () => {
+    beforeEach(() => {
+        testState.isChartGalleryEnabled = false;
+    });
+
+    it('returns falsy/null right-sidebar props when the flag is off', () => {
+        const { result } = renderWithStore(() =>
+            useChartGalleryRightSidebar({ enabled: true }),
+        );
+
+        expect(result.current.rightSidebar).toBeNull();
+        expect(result.current.isRightSidebarOpen).toBe(false);
+        expect(result.current.keepRightSidebarMounted).toBe(false);
+        expect(result.current.noRightSidebarPadding).toBe(false);
+    });
+
+    it('returns the portal and follows the selector when the flag is on and enabled', () => {
+        testState.isChartGalleryEnabled = true;
+
+        const { result } = renderWithStore(
+            () => useChartGalleryRightSidebar({ enabled: true }),
+            { openVisualizationConfig: true },
+        );
+
+        expect(result.current.rightSidebar).not.toBeNull();
+        expect(result.current.isRightSidebarOpen).toBe(true);
+        expect(result.current.keepRightSidebarMounted).toBe(true);
+        expect(result.current.noRightSidebarPadding).toBe(true);
+    });
+
+    it('hides the sidebar when the flag is on but the caller has not enabled it', () => {
+        testState.isChartGalleryEnabled = true;
+
+        const { result } = renderWithStore(
+            () => useChartGalleryRightSidebar({ enabled: false }),
+            { openVisualizationConfig: true },
+        );
+
+        expect(result.current.rightSidebar).toBeNull();
+        expect(result.current.isRightSidebarOpen).toBe(false);
+        expect(result.current.keepRightSidebarMounted).toBe(true);
+        expect(result.current.noRightSidebarPadding).toBe(true);
+    });
+});

--- a/packages/frontend/src/components/Explorer/ChartGallery/useChartGalleryRightSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/useChartGalleryRightSidebar.tsx
@@ -1,0 +1,38 @@
+import { type ComponentProps } from 'react';
+import {
+    selectIsVisualizationConfigOpen,
+    useExplorerSelector,
+} from '../../../features/explorer/store';
+import type Page from '../../common/Page/Page';
+import VisualizationConfigPortal from '../VisualizationCard/VisualizationConfigPortal';
+import { useIsChartGalleryEnabled } from './useIsChartGalleryEnabled';
+
+type RightSidebarProps = Pick<
+    ComponentProps<typeof Page>,
+    | 'rightSidebar'
+    | 'isRightSidebarOpen'
+    | 'keepRightSidebarMounted'
+    | 'noRightSidebarPadding'
+>;
+
+export const useChartGalleryRightSidebar = ({
+    enabled,
+}: {
+    enabled: boolean;
+}): RightSidebarProps => {
+    const isVisualizationConfigOpen = useExplorerSelector(
+        selectIsVisualizationConfigOpen,
+    );
+    const isChartGalleryEnabled = useIsChartGalleryEnabled();
+
+    return {
+        rightSidebar:
+            isChartGalleryEnabled && enabled ? (
+                <VisualizationConfigPortal />
+            ) : null,
+        isRightSidebarOpen:
+            isChartGalleryEnabled && enabled && isVisualizationConfigOpen,
+        keepRightSidebarMounted: isChartGalleryEnabled,
+        noRightSidebarPadding: isChartGalleryEnabled,
+    };
+};

--- a/packages/frontend/src/components/Explorer/ChartGallery/useIsChartGalleryEnabled.ts
+++ b/packages/frontend/src/components/Explorer/ChartGallery/useIsChartGalleryEnabled.ts
@@ -1,0 +1,6 @@
+import { FeatureFlags } from '@lightdash/common';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+
+export const useIsChartGalleryEnabled = () =>
+    useServerFeatureFlag(FeatureFlags.ExplorerChartGallery).data?.enabled ===
+    true;

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.test.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.test.tsx
@@ -161,13 +161,24 @@ describe('ExplorePanel chart configuration placement', () => {
         testState.enabledFlags.clear();
     });
 
-    it('swaps the fields for the config portal while configuring', () => {
+    it('keeps the legacy portal and hides fields when the gallery flag is off', () => {
         renderPanel(undefined, true);
 
         expect(
             document.getElementById('visualization-config-portal'),
         ).not.toBeNull();
         expect(screen.getByTestId('explore-tree')).not.toBeVisible();
+    });
+
+    it('keeps fields mounted and leaves the portal to the right rail when enabled', () => {
+        testState.enabledFlags.add(FeatureFlags.ExplorerChartGallery);
+
+        renderPanel(undefined, true);
+
+        expect(
+            document.getElementById('visualization-config-portal'),
+        ).toBeNull();
+        expect(screen.getByTestId('explore-tree')).toBeVisible();
     });
 });
 

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -57,6 +57,7 @@ import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
 import PageBreadcrumbs from '../../common/PageBreadcrumbs';
+import { useIsChartGalleryEnabled } from '../ChartGallery/useIsChartGalleryEnabled';
 import ExploreTree from '../ExploreTree';
 import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailProvider';
@@ -85,6 +86,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
         FeatureFlags.EditYamlInUi,
     );
     const { data: mergeFlag } = useServerFeatureFlag(FeatureFlags.MergeQueries);
+    const isChartGalleryEnabled = useIsChartGalleryEnabled();
     const merge = useMergeSafe();
     const additionalSource = merge?.additionalSources[0];
     const [isChoosingMergeExplore, setIsChoosingMergeExplore] = useState(
@@ -260,13 +262,18 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
 
     return (
         <>
-            <VisualizationConfigPortal active={isVisualizationConfigOpen} />
+            {!isChartGalleryEnabled && (
+                <VisualizationConfigPortal active={isVisualizationConfigOpen} />
+            )}
 
             <Stack
                 h="100%"
                 style={{
                     flexGrow: 1,
-                    display: isVisualizationConfigOpen ? 'none' : 'flex',
+                    display:
+                        !isChartGalleryEnabled && isVisualizationConfigOpen
+                            ? 'none'
+                            : 'flex',
                 }}
             >
                 {merge?.isMerging && merge.readOnly && <MergeJoinBar />}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -61,6 +61,8 @@ import LightdashVisualization from '../../LightdashVisualization';
 import VisualizationProvider from '../../LightdashVisualization/VisualizationProvider';
 import { type EchartsSeriesClickEvent } from '../../SimpleChart';
 import SortButton from '../../SortButton';
+import ExplorerChartSidebar from '../ChartGallery/ExplorerChartSidebar';
+import { useIsChartGalleryEnabled } from '../ChartGallery/useIsChartGalleryEnabled';
 import { DevCopyChartDebugData } from '../ExplorerHeader/DevCopyChartDebugData';
 import VisualizationConfig from '../VisualizationCard/VisualizationConfig';
 import { SeriesContextMenu } from './SeriesContextMenu';
@@ -92,6 +94,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
     const dispatch = useExplorerDispatch();
     // In fullscreen the chart card header is hidden so the chart owns the viewport
     const { isFullscreen } = useFullscreen();
+    const isChartGalleryEnabled = useIsChartGalleryEnabled();
 
     // Get savedChart from Redux
     const savedChart = useExplorerSelector(selectSavedChart);
@@ -289,6 +292,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
 
     const portalTarget = useVisualizationConfigPortalTarget(
         isVisualizationConfigOpen,
+        { followHost: isChartGalleryEnabled },
     );
 
     const {
@@ -513,13 +517,27 @@ const VisualizationCard: FC<Props> = memo((props) => {
                                  */}
                                 {portalTarget &&
                                     createPortal(
-                                        <VisualizationConfig
-                                            chartType={
-                                                unsavedChartVersion.chartConfig
-                                                    .type
-                                            }
-                                            onClose={closeVisualizationConfig}
-                                        />,
+                                        isChartGalleryEnabled ? (
+                                            <ExplorerChartSidebar
+                                                chartType={
+                                                    unsavedChartVersion
+                                                        .chartConfig.type
+                                                }
+                                                onClose={
+                                                    closeVisualizationConfig
+                                                }
+                                            />
+                                        ) : (
+                                            <VisualizationConfig
+                                                chartType={
+                                                    unsavedChartVersion
+                                                        .chartConfig.type
+                                                }
+                                                onClose={
+                                                    closeVisualizationConfig
+                                                }
+                                            />
+                                        ),
                                         portalTarget,
                                     )}
 

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.test.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { createPortal } from 'react-dom';
 import { describe, expect, it } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
@@ -7,8 +7,14 @@ import { VisualizationConfigPortalId } from '../ExplorePanel/constants';
 import useVisualizationConfigPortalTarget from './useVisualizationConfigPortalTarget';
 import VisualizationConfigPortal from './VisualizationConfigPortal';
 
-const PortalProducer = ({ isOpen }: { isOpen: boolean }) => {
-    const target = useVisualizationConfigPortalTarget(isOpen);
+const PortalProducer = ({
+    isOpen,
+    followHost = false,
+}: {
+    isOpen: boolean;
+    followHost?: boolean;
+}) => {
+    const target = useVisualizationConfigPortalTarget(isOpen, { followHost });
 
     return target ? createPortal(<div>Configure content</div>, target) : null;
 };
@@ -49,5 +55,58 @@ describe('VisualizationConfigPortal', () => {
         expect(
             await screen.findByText('Configure content'),
         ).toBeInTheDocument();
+    });
+
+    it('retargets content when the portal host is replaced', async () => {
+        renderWithProviders(
+            <Page
+                withNavbar={false}
+                rightSidebar={<VisualizationConfigPortal />}
+                isRightSidebarOpen
+                keepRightSidebarMounted
+            >
+                <PortalProducer isOpen followHost />
+            </Page>,
+        );
+        const originalTarget = document.getElementById(
+            VisualizationConfigPortalId,
+        );
+        const replacementTarget = document.createElement('div');
+        replacementTarget.id = VisualizationConfigPortalId;
+
+        originalTarget?.replaceWith(replacementTarget);
+
+        expect(
+            await screen.findByText('Configure content'),
+        ).toBeInTheDocument();
+        expect(replacementTarget).toContainElement(
+            screen.getByText('Configure content'),
+        );
+    });
+
+    it('keeps the original target when not following the host', async () => {
+        renderWithProviders(
+            <Page
+                withNavbar={false}
+                rightSidebar={<VisualizationConfigPortal />}
+                isRightSidebarOpen
+                keepRightSidebarMounted
+            >
+                <PortalProducer isOpen />
+            </Page>,
+        );
+        const originalTarget = document.getElementById(
+            VisualizationConfigPortalId,
+        );
+        const replacementTarget = document.createElement('div');
+        replacementTarget.id = VisualizationConfigPortalId;
+
+        originalTarget?.replaceWith(replacementTarget);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(replacementTarget).toBeEmptyDOMElement();
+        expect(
+            within(originalTarget!).queryByText('Configure content'),
+        ).not.toBeNull();
     });
 });

--- a/packages/frontend/src/components/Explorer/VisualizationCard/useVisualizationConfigPortalTarget.ts
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/useVisualizationConfigPortalTarget.ts
@@ -1,16 +1,43 @@
 import { useLayoutEffect, useState } from 'react';
 import { VisualizationConfigPortalId } from '../ExplorePanel/constants';
 
-const useVisualizationConfigPortalTarget = (isOpen: boolean) => {
+type Options = {
+    // The gallery sidebar host can be replaced while open; follow it across remounts.
+    followHost: boolean;
+};
+
+const useVisualizationConfigPortalTarget = (
+    isOpen: boolean,
+    { followHost }: Options,
+) => {
     const [target, setTarget] = useState<HTMLElement | null>(null);
 
     useLayoutEffect(() => {
-        setTarget(
-            isOpen
-                ? document.getElementById(VisualizationConfigPortalId)
-                : null,
-        );
-    }, [isOpen]);
+        if (!isOpen) {
+            setTarget(null);
+            return;
+        }
+
+        const updateTarget = () => {
+            setTarget((currentTarget) => {
+                const nextTarget = document.getElementById(
+                    VisualizationConfigPortalId,
+                );
+                return currentTarget === nextTarget
+                    ? currentTarget
+                    : nextTarget;
+            });
+        };
+
+        updateTarget();
+
+        if (!followHost) return;
+
+        const observer = new MutationObserver(updateTarget);
+        observer.observe(document.body, { childList: true, subtree: true });
+
+        return () => observer.disconnect();
+    }, [isOpen, followHost]);
 
     return target;
 };

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
@@ -1,5 +1,6 @@
 import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
+import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
 import { Comparison } from './BigNumberComparison';
 import { BigNumberConditionalFormatting } from './BigNumberConditionalFormatting';
 import { Layout } from './BigNumberLayout';
@@ -7,7 +8,7 @@ import { Layout } from './BigNumberLayout';
 export const ConfigTabs: FC = memo(() => {
     return (
         <Tabs defaultValue="layout" keepMounted={false}>
-            <Tabs.List mb="sm">
+            <ConfigTabsList mb="sm">
                 <Tabs.Tab px="sm" value="layout">
                     Layout
                 </Tabs.Tab>
@@ -17,7 +18,7 @@ export const ConfigTabs: FC = memo(() => {
                 <Tabs.Tab px="sm" value="conditionalFormatting">
                     Conditional formatting
                 </Tabs.Tab>
-            </Tabs.List>
+            </ConfigTabsList>
 
             <Tabs.Panel value="layout">
                 <Layout />

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ConfigTabs/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ConfigTabs/index.tsx
@@ -1,5 +1,6 @@
 import { Tabs } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
+import ConfigTabsList from '../../../common/ChartGallery/ConfigTabsList';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { Axes } from '../Axes';
 import { Grid } from '../Grid';
@@ -14,7 +15,7 @@ export const ConfigTabs: FC = memo(() => {
 
     return (
         <Tabs defaultValue="layout" keepMounted={false}>
-            <Tabs.List mb="sm">
+            <ConfigTabsList mb="sm">
                 <Tabs.Tab px="sm" value="layout">
                     Layout
                 </Tabs.Tab>
@@ -30,7 +31,7 @@ export const ConfigTabs: FC = memo(() => {
                 <Tabs.Tab px="sm" value="grid">
                     Margins
                 </Tabs.Tab>
-            </Tabs.List>
+            </ConfigTabsList>
             <Tabs.Panel value="layout">
                 <Layout items={items} />
             </Tabs.Panel>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.test.tsx
@@ -1,8 +1,9 @@
 import { ChartType } from '@lightdash/common';
-import { act, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import type * as ReactRouter from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../testing/testUtils';
+import { ChartGalleryContext } from '../../../common/ChartGallery/ChartGalleryContext';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { ConfigTabs } from './CustomVisConfig';
 
@@ -10,11 +11,14 @@ type CustomChartTypeSectionProps = {
     onCreateNew: (() => void) | null;
 };
 
-const { locationSearch, navigate, sectionProps } = vi.hoisted(() => ({
-    locationSearch: { current: '' },
-    navigate: vi.fn(),
-    sectionProps: [] as CustomChartTypeSectionProps[],
-}));
+const { locationSearch, navigate, sectionProps, enabledFlags } = vi.hoisted(
+    () => ({
+        locationSearch: { current: '' },
+        navigate: vi.fn(),
+        sectionProps: [] as CustomChartTypeSectionProps[],
+        enabledFlags: new Set<string>(['enable-data-apps']),
+    }),
+);
 
 vi.mock('react-router', async (importOriginal) => ({
     ...(await importOriginal<typeof ReactRouter>()),
@@ -27,7 +31,7 @@ vi.mock('../../../../features/apps/hooks/useCanCreateDataApp', () => ({
 }));
 vi.mock('../../../../hooks/useServerOrClientFeatureFlag', () => ({
     useServerFeatureFlag: (featureFlag: string) => ({
-        data: { enabled: featureFlag === 'enable-data-apps' },
+        data: { enabled: enabledFlags.has(featureFlag) },
     }),
 }));
 vi.mock('../../../LightdashVisualization/useVisualizationContext', () => ({
@@ -55,6 +59,8 @@ describe('CustomVisConfig', () => {
         locationSearch.current = '';
         navigate.mockClear();
         sectionProps.length = 0;
+        enabledFlags.clear();
+        enabledFlags.add('enable-data-apps');
         vi.mocked(useVisualizationContext).mockReturnValue({
             itemsMap: {},
             visualizationConfig: {
@@ -83,5 +89,24 @@ describe('CustomVisConfig', () => {
             pathname: '/projects/project-1/chart-types/new',
             search: locationSearch.current,
         });
+    });
+
+    it('hides the chart type section inside the chart gallery', async () => {
+        renderWithProviders(
+            <ChartGalleryContext.Provider value={true}>
+                <ConfigTabs />
+            </ChartGalleryContext.Provider>,
+        );
+
+        await waitFor(() =>
+            expect(screen.queryByText('Vega-Lite JSON')).toBeInTheDocument(),
+        );
+        expect(sectionProps).toHaveLength(0);
+    });
+
+    it('shows the chart type section outside the gallery when data apps are enabled', async () => {
+        renderWithProviders(<ConfigTabs />);
+
+        await waitFor(() => expect(sectionProps.length).toBeGreaterThan(0));
     });
 });

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -14,6 +14,7 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 import { useDeepCompareEffect } from 'react-use';
 import { useCanCreateDataApp } from '../../../../features/apps/hooks/useCanCreateDataApp';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+import { useIsInsideChartGallery } from '../../../common/ChartGallery/ChartGalleryContext';
 import DocumentationHelpButton from '../../../DocumentationHelpButton';
 import { isCustomVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
@@ -212,6 +213,8 @@ export const ConfigTabs: React.FC = memo(() => {
     const dataAppsEnabled =
         useServerFeatureFlag(FeatureFlags.EnableDataApps).data?.enabled ===
         true;
+    // With the chart gallery, the user already picked a chart type there.
+    const isInsideChartGallery = useIsInsideChartGallery();
     const canCreateApp = useCanCreateDataApp(projectUuid);
     const selectProjectChartType = useSelectProjectChartType();
     const createProjectChartType = useCreateProjectChartType();
@@ -250,7 +253,7 @@ export const ConfigTabs: React.FC = memo(() => {
     return (
         <>
             <Stack>
-                {dataAppsEnabled && (
+                {dataAppsEnabled && !isInsideChartGallery && (
                     <CustomChartTypeSection
                         projectUuid={projectUuid ?? ''}
                         selected={{ kind: 'builtInVega' }}

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -24,6 +24,7 @@ import type * as ReactRouter from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { defaultAbility } from '../../../providers/Ability/constants';
 import { renderWithProviders } from '../../../testing/testUtils';
+import { ChartGalleryContext } from '../../common/ChartGallery/ChartGalleryContext';
 import { ConfigTabs } from './DataAppVizConfigTabs';
 
 type PickerProps = {
@@ -391,6 +392,17 @@ describe('DataAppVizConfigTabs', () => {
         expect(
             screen.getByText('Run your query to pick a custom chart type.'),
         ).toBeInTheDocument();
+    });
+
+    it('hides the picker inside the chart gallery', () => {
+        renderWithProviders(
+            <ChartGalleryContext.Provider value={true}>
+                <ConfigTabs />
+            </ChartGalleryContext.Provider>,
+        );
+
+        expect(pickerProps).toHaveLength(0);
+        expect(screen.queryByText('Custom chart type')).not.toBeInTheDocument();
     });
 
     it('points builders at the dedicated builder when nothing is selected', async () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -16,6 +16,7 @@ import {
     reconcileDataAppVizFieldMapping,
 } from '../../../features/chartTypes/utils/autoMapDataAppVizFields';
 import { getDataAppVizFieldItems } from '../../../features/chartTypes/utils/getDataAppVizFieldItems';
+import { useIsInsideChartGallery } from '../../common/ChartGallery/ChartGalleryContext';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { ColorPaletteSection } from '../common/ColorPaletteSection';
@@ -59,6 +60,9 @@ export const ConfigTabs: FC = memo(() => {
     );
 
     const canCreateApp = useCanCreateDataApp(projectUuid);
+    // The gallery sidebar already shows the picked type, so the picker and
+    // the type card are redundant there.
+    const isInsideChartGallery = useIsInsideChartGallery();
     const canEditSelectedType = useCanEditDataApp(projectUuid, {
         spaceUuid: dataAppViz?.spaceUuid ?? null,
         createdByUserUuid: dataAppViz?.createdByUserUuid ?? null,
@@ -125,7 +129,7 @@ export const ConfigTabs: FC = memo(() => {
                 fieldMapping={effectiveMapping}
                 onFieldChange={handleFieldChange}
             />
-            {dataAppViz && (
+            {dataAppViz && !isInsideChartGallery && (
                 <Box className={classes.typeCard}>
                     <Text fz="xs" fw={500}>
                         {getAppDisplayName(
@@ -159,38 +163,46 @@ export const ConfigTabs: FC = memo(() => {
     return (
         <Box className={classes.panel}>
             <Stack>
-                <CustomChartTypeSection
-                    projectUuid={projectUuid ?? ''}
-                    selected={selectedOption}
-                    selectedDataAppViz={dataAppViz ?? null}
-                    hasColumns={hasColumns}
-                    onSelectVega={() => setChartType(ChartType.CUSTOM)}
-                    onSelectProjectType={(picked) => {
-                        const pickedFields = picked.schema?.fields ?? [];
-                        const pickedMapping = autoMapDataAppVizFields(
-                            pickedFields,
-                            itemsMap ?? NO_COLUMNS,
-                        );
-                        setDataAppVizUuid(picked.dataAppVizUuid, pickedMapping);
-                        setMappingPivotDimensions(pickedFields, pickedMapping);
-                    }}
-                    onClear={() => {
-                        setDataAppVizUuid('', {});
-                        setPivotDimensions(undefined);
-                    }}
-                    onCreateNew={
-                        canCreateApp
-                            ? () =>
-                                  void navigate({
-                                      pathname: `/projects/${projectUuid}/chart-types/new`,
-                                      search: location.search,
-                                  })
-                            : null
-                    }
-                    onBrowseGallery={() =>
-                        void navigate(`/projects/${projectUuid}/gallery`)
-                    }
-                />
+                {!isInsideChartGallery && (
+                    <CustomChartTypeSection
+                        projectUuid={projectUuid ?? ''}
+                        selected={selectedOption}
+                        selectedDataAppViz={dataAppViz ?? null}
+                        hasColumns={hasColumns}
+                        onSelectVega={() => setChartType(ChartType.CUSTOM)}
+                        onSelectProjectType={(picked) => {
+                            const pickedFields = picked.schema?.fields ?? [];
+                            const pickedMapping = autoMapDataAppVizFields(
+                                pickedFields,
+                                itemsMap ?? NO_COLUMNS,
+                            );
+                            setDataAppVizUuid(
+                                picked.dataAppVizUuid,
+                                pickedMapping,
+                            );
+                            setMappingPivotDimensions(
+                                pickedFields,
+                                pickedMapping,
+                            );
+                        }}
+                        onClear={() => {
+                            setDataAppVizUuid('', {});
+                            setPivotDimensions(undefined);
+                        }}
+                        onCreateNew={
+                            canCreateApp
+                                ? () =>
+                                      void navigate({
+                                          pathname: `/projects/${projectUuid}/chart-types/new`,
+                                          search: location.search,
+                                      })
+                                : null
+                        }
+                        onBrowseGallery={() =>
+                            void navigate(`/projects/${projectUuid}/gallery`)
+                        }
+                    />
+                )}
 
                 {/* With nothing selected the tabs would only be an empty row. */}
                 {dataAppVizUuid ? (

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
@@ -21,6 +21,7 @@ import {
     Tooltip,
 } from '@mantine/core';
 import { memo, type FC } from 'react';
+import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
 import FieldSelect from '../../common/FieldSelect';
 import { isFunnelVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -61,7 +62,7 @@ export const ConfigTabs: FC = memo(() => {
 
     return (
         <Tabs defaultValue="general" keepMounted={false}>
-            <Tabs.List mb="sm">
+            <ConfigTabsList mb="sm">
                 <Tabs.Tab px="sm" value="general">
                     General
                 </Tabs.Tab>
@@ -71,7 +72,7 @@ export const ConfigTabs: FC = memo(() => {
                 <Tabs.Tab px="sm" value="display">
                     Display
                 </Tabs.Tab>
-            </Tabs.List>
+            </ConfigTabsList>
 
             <Tabs.Panel value="general">
                 <Stack>

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeConfigTabs.tsx
@@ -1,19 +1,20 @@
 import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
+import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
 import { GaugeDisplayConfig } from './GaugeDisplayConfig';
 import { GaugeFieldsConfig } from './GaugeFieldsConfig';
 
 export const ConfigTabs: FC = memo(() => {
     return (
         <Tabs defaultValue="fields" keepMounted={false}>
-            <Tabs.List mb="sm">
+            <ConfigTabsList mb="sm">
                 <Tabs.Tab px="sm" value="fields">
                     Layout
                 </Tabs.Tab>
                 <Tabs.Tab px="sm" value="display">
                     Display
                 </Tabs.Tab>
-            </Tabs.List>
+            </ConfigTabsList>
 
             <Tabs.Panel value="fields">
                 <GaugeFieldsConfig />

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapConfigTabs.tsx
@@ -1,19 +1,20 @@
 import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
+import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
 import { Display } from './MapDisplayConfig';
 import { Layout } from './MapLayoutConfig';
 
 export const ConfigTabs: FC = memo(() => {
     return (
         <Tabs defaultValue="general" keepMounted={false}>
-            <Tabs.List mb="sm">
+            <ConfigTabsList mb="sm">
                 <Tabs.Tab px="sm" value="general">
                     General
                 </Tabs.Tab>
                 <Tabs.Tab px="sm" value="display">
                     Map display
                 </Tabs.Tab>
-            </Tabs.List>
+            </ConfigTabsList>
 
             <Tabs.Panel value="general">
                 <Layout />

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartConfigTabs.tsx
@@ -1,5 +1,6 @@
 import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
+import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
 import { Display } from './PieChartDisplayConfig';
 import { Layout } from './PieChartLayoutConfig';
 import { Series } from './PieChartSeriesConfig';
@@ -7,7 +8,7 @@ import { Series } from './PieChartSeriesConfig';
 export const ConfigTabs: FC = memo(() => {
     return (
         <Tabs defaultValue="layout" keepMounted={false}>
-            <Tabs.List mb="sm">
+            <ConfigTabsList mb="sm">
                 <Tabs.Tab px="sm" value="layout">
                     Layout
                 </Tabs.Tab>
@@ -17,7 +18,7 @@ export const ConfigTabs: FC = memo(() => {
                 <Tabs.Tab px="sm" value="display">
                     Display
                 </Tabs.Tab>
-            </Tabs.List>
+            </ConfigTabsList>
 
             <Tabs.Panel value="layout">
                 <Layout />

--- a/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
@@ -11,6 +11,7 @@ import {
 } from '@lightdash/common';
 import { Stack, Tabs, Text, SegmentedControl } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
+import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
 import FieldSelect from '../../common/FieldSelect';
 import { isSankeyVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -89,14 +90,14 @@ export const ConfigTabs: FC = memo(() => {
 
     return (
         <Tabs defaultValue="general" keepMounted={false}>
-            <Tabs.List mb="sm">
+            <ConfigTabsList mb="sm">
                 <Tabs.Tab px="sm" value="general">
                     General
                 </Tabs.Tab>
                 <Tabs.Tab px="sm" value="display">
                     Display
                 </Tabs.Tab>
-            </Tabs.List>
+            </ConfigTabsList>
 
             <Tabs.Panel value="general">
                 <Stack>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
@@ -1,5 +1,6 @@
 import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
+import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
 import { ColumnCellDisplay } from './ColumnCellDisplay';
 import ConditionalFormattingList from './ConditionalFormattingList';
 import GeneralSettings from './GeneralSettings';
@@ -7,7 +8,7 @@ import GeneralSettings from './GeneralSettings';
 export const ConfigTabs: FC = memo(() => {
     return (
         <Tabs defaultValue="general" keepMounted={false}>
-            <Tabs.List mb="sm">
+            <ConfigTabsList mb="sm">
                 <Tabs.Tab px="sm" value="general">
                     General
                 </Tabs.Tab>
@@ -17,7 +18,7 @@ export const ConfigTabs: FC = memo(() => {
                 <Tabs.Tab px="sm" value="cell-display">
                     Cell display
                 </Tabs.Tab>
-            </Tabs.List>
+            </ConfigTabsList>
 
             <Tabs.Panel value="general">
                 <GeneralSettings />

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapConfigTabs.tsx
@@ -1,19 +1,20 @@
 import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
+import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
 import { Display } from './TreemapDisplayConfig';
 import { Layout } from './TreemapLayoutConfig';
 
 export const ConfigTabs: FC = memo(() => {
     return (
         <Tabs defaultValue="layout" keepMounted={false}>
-            <Tabs.List mb="sm">
+            <ConfigTabsList mb="sm">
                 <Tabs.Tab px="sm" value="layout">
                     Layout
                 </Tabs.Tab>
                 <Tabs.Tab px="sm" value="display">
                     Display
                 </Tabs.Tab>
-            </Tabs.List>
+            </ConfigTabsList>
 
             <Tabs.Panel value="layout">
                 <Layout />

--- a/packages/frontend/src/components/common/ChartGallery/ChartGalleryContext.ts
+++ b/packages/frontend/src/components/common/ChartGallery/ChartGalleryContext.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+/** True inside the gallery sidebar, which has already picked the chart type,
+ *  so a config panel's own picker is redundant there. */
+export const ChartGalleryContext = createContext(false);
+
+export const useIsInsideChartGallery = () => useContext(ChartGalleryContext);

--- a/packages/frontend/src/components/common/ChartGallery/ConfigTabsList.tsx
+++ b/packages/frontend/src/components/common/ChartGallery/ConfigTabsList.tsx
@@ -1,0 +1,17 @@
+import { Tabs, type TabsListProps } from '@mantine/core';
+import { type FC } from 'react';
+import OverflowTabsList from '../OverflowTabsList/OverflowTabsList';
+import { useIsInsideChartGallery } from './ChartGalleryContext';
+
+// The gallery sidebar is narrow, so its tab strips scroll instead of wrapping.
+const ConfigTabsList: FC<TabsListProps> = ({ children, ...props }) => {
+    const isInsideChartGallery = useIsInsideChartGallery();
+
+    return isInsideChartGallery ? (
+        <OverflowTabsList {...props}>{children}</OverflowTabsList>
+    ) : (
+        <Tabs.List {...props}>{children}</Tabs.List>
+    );
+};
+
+export default ConfigTabsList;

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
@@ -197,6 +197,56 @@ describe('useDataAppVizVisualizationConfig', () => {
         });
     });
 
+    it('adopts a viz switched from outside without echoing it back', () => {
+        const onConfigChange = vi.fn();
+        const { result, rerender } = renderHook(
+            ({ config }) =>
+                useDataAppVizVisualizationConfig(config, onConfigChange),
+            { initialProps: { config: initialConfig } },
+        );
+
+        act(() => result.current.setOption('viz-1', 'barColor', '#ff0000'));
+        onConfigChange.mockClear();
+
+        rerender({
+            config: {
+                dataAppVizUuid: 'viz-2',
+                fieldMapping: { value: 'orders_total' },
+                optionValues: {},
+            },
+        });
+
+        expect(result.current.dataAppVizUuid).toBe('viz-2');
+        expect(result.current.fieldMapping).toEqual({ value: 'orders_total' });
+        expect(result.current.optionValues).toEqual({});
+        expect(onConfigChange).not.toHaveBeenCalled();
+
+        act(() => result.current.setOption('viz-2', 'barColor', '#00ff00'));
+
+        expect(onConfigChange).toHaveBeenCalledWith({
+            dataAppVizUuid: 'viz-2',
+            fieldMapping: { value: 'orders_total' },
+            optionValues: { barColor: '#00ff00' },
+        });
+    });
+
+    it('keeps local edits when the same viz is echoed back', () => {
+        const onConfigChange = vi.fn();
+        const { result, rerender } = renderHook(
+            ({ config }) =>
+                useDataAppVizVisualizationConfig(config, onConfigChange),
+            { initialProps: { config: initialConfig } },
+        );
+
+        act(() => result.current.setOption('viz-1', 'barColor', '#ff0000'));
+        rerender({ config: { ...initialConfig } });
+
+        expect(result.current.optionValues).toEqual({
+            showLegend: false,
+            barColor: '#ff0000',
+        });
+    });
+
     it('round-trips the emitted config back into a fresh hook', () => {
         const onConfigChange = vi.fn();
         const { result } = renderHook(() =>

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
@@ -62,6 +62,20 @@ const useDataAppVizVisualizationConfig = (
         };
     }, []);
 
+    // A viz switched from outside this hook (the chart gallery goes through
+    // the store) arrives as a new initial config while the hook stays mounted.
+    const externalDataAppVizUuid = initialChartConfig?.dataAppVizUuid ?? '';
+    useLayoutEffect(() => {
+        if (externalDataAppVizUuid === configRef.current.dataAppVizUuid) return;
+        const next = {
+            dataAppVizUuid: externalDataAppVizUuid,
+            fieldMapping: initialChartConfig?.fieldMapping ?? {},
+            optionValues: initialChartConfig?.optionValues ?? {},
+        };
+        configRef.current = next;
+        setConfigState(next);
+    }, [externalDataAppVizUuid, initialChartConfig]);
+
     const commit = useCallback((next: Required<DataAppVizChart>) => {
         configRef.current = next;
         setConfigState(next);

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 import { useNavigate, useParams } from 'react-router';
 import Page from '../components/common/Page/Page';
 import Explorer from '../components/Explorer';
+import { useChartGalleryRightSidebar } from '../components/Explorer/ChartGallery/useChartGalleryRightSidebar';
 import ExploreSideBar from '../components/Explorer/ExploreSideBar/index';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import {
@@ -34,6 +35,7 @@ const ExplorerContent = memo(() => {
     useExplorerQueryEffects();
 
     const dispatch = useExplorerDispatch();
+    const rightSidebarProps = useChartGalleryRightSidebar({ enabled: true });
     const navigate = useNavigate();
     const merge = useMergeSafe();
 
@@ -61,6 +63,7 @@ const ExplorerContent = memo(() => {
         <Page
             title={data ? data?.label : 'Tables'}
             sidebar={<ExploreSideBar />}
+            {...rightSidebarProps}
             withFullHeight
             withPaddedContent
         >

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -5,6 +5,7 @@ import ErrorState from '../components/common/ErrorState';
 import Page from '../components/common/Page/Page';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import Explorer from '../components/Explorer';
+import { useChartGalleryRightSidebar } from '../components/Explorer/ChartGallery/useChartGalleryRightSidebar';
 import LoadingSkeleton from '../components/Explorer/ExploreTree/LoadingSkeleton';
 import SavedChartsHeader from '../components/Explorer/SavedChartsHeader';
 import {
@@ -26,6 +27,9 @@ const LazyExplorePanel = lazy(
 const SavedExplorerContent = memo(() => {
     const { mode } = useParams<{ mode?: string }>();
     const isEditMode = mode === 'edit';
+    const rightSidebarProps = useChartGalleryRightSidebar({
+        enabled: isEditMode,
+    });
 
     // Run the query effects hook - orchestrates all query effects
     useExplorerQueryEffects();
@@ -40,6 +44,7 @@ const SavedExplorerContent = memo(() => {
                 </Suspense>
             }
             isSidebarOpen={isEditMode}
+            {...rightSidebarProps}
             withFullHeight
             withPaddedContent
         >


### PR DESCRIPTION
## Summary

Behind the `ExplorerChartGallery` feature flag, the Explorer keeps the fields panel mounted on the left and moves chart type selection and configuration into a right sidebar:

- **Choose type**: a searchable gallery of project chart types (when data apps are enabled, with a "Create new chart type" action for users who can author them) and built-in chart types, including the Vega JSON editor.
- **Configure**: the existing config panel for the chosen type, under a card showing the selected type (with description and an Edit link for project types) and a "Change chart type" action.

Everything Explorer-specific lives in `components/Explorer/ChartGallery/`. The two pieces the generic config panels depend on, `ChartGalleryContext` and `ConfigTabsList`, live in `components/common/ChartGallery/`. Config panels rendered inside the sidebar read `ChartGalleryContext` (not the flag) to hide their own chart type picker and to scroll their tab strips via `ConfigTabsList` instead of wrapping.

The flag is read in three places: `useChartGalleryRightSidebar` (wires the `Page` right sidebar for `Explorer` and `SavedExplorer`), `ExplorePanel`, and `VisualizationCard`.

With the flag off, the Explorer is unchanged, including at runtime: the portal-target hook only installs its host-following `MutationObserver` when the flag is on, so flag-off keeps the previous lookup-once behaviour.

The flag is listed in `PREVIEW_EXCLUDED_FEATURE_FLAGS`, so preview environments and the Cypress E2E suite (which runs against the preview) exercise the legacy, flag-off path. Turn it on in a preview with a `feature_flag_overrides` row.

<img width="1600" height="1000" alt="1-configure" src="https://github.com/user-attachments/assets/a0a93fdf-2db1-4234-8696-d7fcd0634e3e" />
<img width="1600" height="1000" alt="2-choose-type" src="https://github.com/user-attachments/assets/131b02e6-9929-4e16-9390-d2641fee2136" />
<img width="1600" height="1000" alt="3-project-type" src="https://github.com/user-attachments/assets/6e9b2d25-e6df-4dd4-b850-a53a84cd38f3" />


## Testing

- Unit tests for the sidebar, gallery (including create-new visibility and navigation), context-gated panels, the right-sidebar hook, the portal target hook (flag-on retargeting and flag-off no-follow), and `ExplorePanel` placement (vitest).
- Manually verified with the flag on: built-in, Vega, and project chart types; tab overflow; padding parity with the left panel. With the flag off: layout, config panel, chart type menu, and project-type picker match `main`.

Closes: GLITCH-674
