### PR TITLE
feat: query caching tab in project settings

### DIFF
--- a/packages/frontend/src/components/ProjectResultsCache/index.tsx
+++ b/packages/frontend/src/components/ProjectResultsCache/index.tsx
@@ -1,0 +1,172 @@
+import {
+    MAX_RESULTS_CACHE_TTL_SECONDS,
+    MIN_RESULTS_CACHE_TTL_SECONDS,
+} from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Group,
+    Loader,
+    Stack,
+    Switch,
+    Text,
+    Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { type FC } from 'react';
+import {
+    useResultsCacheSettings,
+    useUpdateResultsCacheSettings,
+} from '../../hooks/useProjectResultsCacheSettings';
+import { NumberInput } from '../common/NumberInput';
+import { SettingsGridCard } from '../common/Settings/SettingsCard';
+
+const MIN_TTL_MINUTES = MIN_RESULTS_CACHE_TTL_SECONDS / 60;
+const MAX_TTL_MINUTES = MAX_RESULTS_CACHE_TTL_SECONDS / 60;
+
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
+
+const plural = (value: number, unit: string) =>
+    `${value} ${unit}${value === 1 ? '' : 's'}`;
+
+const formatDuration = (minutes: number): string => {
+    if (minutes >= 2 * MINUTES_PER_DAY && minutes % MINUTES_PER_DAY === 0) {
+        return plural(minutes / MINUTES_PER_DAY, 'day');
+    }
+    if (minutes > MINUTES_PER_HOUR) {
+        const hours = minutes / MINUTES_PER_HOUR;
+        return plural(
+            Number.isInteger(hours) ? hours : Number(hours.toFixed(1)),
+            'hour',
+        );
+    }
+    return plural(minutes, 'minute');
+};
+
+const formatDurationHint = (minutes: number | ''): string | null =>
+    typeof minutes === 'number' && minutes > MINUTES_PER_HOUR
+        ? `= ${formatDuration(minutes)}`
+        : null;
+
+type FormValues = {
+    useInstanceDefault: boolean;
+    ttlMinutes: number | '';
+};
+
+type FormProps = {
+    projectUuid: string;
+    initialTtlSeconds: number | null;
+    instanceDefaultSeconds: number;
+};
+
+const ProjectResultsCacheForm: FC<FormProps> = ({
+    projectUuid,
+    initialTtlSeconds,
+    instanceDefaultSeconds,
+}) => {
+    const { mutate: updateSettings, isLoading: isUpdating } =
+        useUpdateResultsCacheSettings(projectUuid);
+    const instanceDefaultMinutes = Math.round(instanceDefaultSeconds / 60);
+
+    const form = useForm<FormValues>({
+        initialValues: {
+            useInstanceDefault: initialTtlSeconds === null,
+            ttlMinutes:
+                initialTtlSeconds === null
+                    ? instanceDefaultMinutes
+                    : Math.round(initialTtlSeconds / 60),
+        },
+        validate: {
+            ttlMinutes: (value, values) => {
+                if (values.useInstanceDefault) return null;
+                if (
+                    typeof value !== 'number' ||
+                    !Number.isInteger(value) ||
+                    value < MIN_TTL_MINUTES ||
+                    value > MAX_TTL_MINUTES
+                ) {
+                    return `Enter a whole number of minutes between ${MIN_TTL_MINUTES} and ${MAX_TTL_MINUTES} (30 days)`;
+                }
+                return null;
+            },
+        },
+    });
+
+    return (
+        <form
+            onSubmit={form.onSubmit(({ useInstanceDefault, ttlMinutes }) => {
+                if (useInstanceDefault) {
+                    updateSettings({ cacheTtlSeconds: null });
+                } else if (typeof ttlMinutes === 'number') {
+                    updateSettings({ cacheTtlSeconds: ttlMinutes * 60 });
+                }
+            })}
+        >
+            <Stack gap="md">
+                <Switch
+                    label="Use the default cache duration"
+                    description={`Cached results expire after ${formatDuration(
+                        instanceDefaultMinutes,
+                    )}.`}
+                    disabled={isUpdating}
+                    {...form.getInputProps('useInstanceDefault', {
+                        type: 'checkbox',
+                    })}
+                />
+
+                <NumberInput
+                    label="Cache duration (minutes)"
+                    min={MIN_TTL_MINUTES}
+                    max={MAX_TTL_MINUTES}
+                    step={1}
+                    rightSectionWidth={90}
+                    rightSection={
+                        <Text c="ldGray.6" fz="xs">
+                            {formatDurationHint(form.values.ttlMinutes)}
+                        </Text>
+                    }
+                    disabled={isUpdating || form.values.useInstanceDefault}
+                    {...form.getInputProps('ttlMinutes')}
+                />
+
+                <Group justify="flex-end">
+                    <Button type="submit" loading={isUpdating}>
+                        Save
+                    </Button>
+                </Group>
+            </Stack>
+        </form>
+    );
+};
+
+type Props = {
+    projectUuid: string;
+};
+
+const ProjectResultsCache: FC<Props> = ({ projectUuid }) => {
+    const { data: settings, isLoading } = useResultsCacheSettings(projectUuid);
+
+    return (
+        <SettingsGridCard>
+            <Box>
+                <Title order={5}>Cache duration</Title>
+                <Text c="ldGray.6" fz="xs">
+                    How long cached results are kept before Lightdash queries
+                    the warehouse again.
+                </Text>
+            </Box>
+            {isLoading || !settings ? (
+                <Loader size="sm" />
+            ) : (
+                <ProjectResultsCacheForm
+                    projectUuid={projectUuid}
+                    initialTtlSeconds={settings.cacheTtlSeconds}
+                    instanceDefaultSeconds={settings.instanceDefaultTtlSeconds}
+                />
+            )}
+        </SettingsGridCard>
+    );
+};
+
+export default ProjectResultsCache;

--- a/packages/frontend/src/components/ProjectResultsCache/index.tsx
+++ b/packages/frontend/src/components/ProjectResultsCache/index.tsx
@@ -131,7 +131,11 @@ const ProjectResultsCacheForm: FC<FormProps> = ({
                 />
 
                 <Group justify="flex-end">
-                    <Button type="submit" loading={isUpdating}>
+                    <Button
+                        type="submit"
+                        loading={isUpdating}
+                        disabled={isUpdating || !form.isValid()}
+                    >
                         Save
                     </Button>
                 </Group>

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -45,6 +45,7 @@ import ProjectAppearance from '../ProjectAppearance/ProjectAppearance';
 import { UpdateProjectConnection } from '../ProjectConnection';
 import ProjectParameters from '../ProjectParameters';
 import ProjectPreviewExpiration from '../ProjectPreviewExpiration';
+import ProjectResultsCache from '../ProjectResultsCache';
 import ProjectTablesConfiguration from '../ProjectTablesConfiguration/ProjectTablesConfiguration';
 import SettingsAgentDataScope from '../SettingsAgentDataScope';
 import SettingsQueryTimezone from '../SettingsQueryTimezone';
@@ -99,6 +100,9 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
 
     const { data: dataAppsFlag, isLoading: isDataAppsFlagLoading } =
         useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const { data: resultsCacheFlag, isLoading: isResultsCacheFlagLoading } =
+        useServerFeatureFlag(FeatureFlags.ResultsCacheEnabled);
+    const isResultsCacheEnabled = resultsCacheFlag?.enabled ?? false;
     const isDataAppsEnabled = dataAppsFlag?.enabled ?? false;
     const canManageExternalConnections =
         isDataAppsEnabled &&
@@ -366,6 +370,23 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
                       },
                   ]
                 : []),
+            ...(isResultsCacheEnabled
+                ? [
+                      {
+                          path: `/caching`,
+                          element: (
+                              <ProjectSettingsPage
+                                  title="Results caching"
+                                  description="Choose how long charts and dashboards in this project load from cached results before Lightdash queries the warehouse again."
+                              >
+                                  <ProjectResultsCache
+                                      projectUuid={projectUuid}
+                                  />
+                              </ProjectSettingsPage>
+                          ),
+                      },
+                  ]
+                : []),
             {
                 path: `/preAggregates`,
                 children: [
@@ -464,6 +485,7 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
         isSoftDeleteEnabled,
         isPgWireEnabled,
         isGitProject,
+        isResultsCacheEnabled,
         user.data?.ability,
         canManageExternalConnections,
         canManageExternalSources,
@@ -485,12 +507,19 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
             '/generalSettings/projectManagement/:projectUuid/dataAppConnections',
             location.pathname,
         );
+    const isAwaitingCachingRoute =
+        isResultsCacheFlagLoading &&
+        !!matchPath(
+            '/generalSettings/projectManagement/:projectUuid/caching',
+            location.pathname,
+        );
 
     if (
         isInitialLoading ||
         !project ||
         !projectUuid ||
-        isAwaitingDataAppConnectionsRoute
+        isAwaitingDataAppConnectionsRoute ||
+        isAwaitingCachingRoute
     ) {
         return (
             <div style={{ marginTop: '20px' }}>

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -80,6 +80,7 @@ export type SettingsContext = {
     dataAppsFlag: FeatureFlag | undefined;
     isDataAppsFlagLoading: boolean;
     externalSourcesFlag: FeatureFlag | undefined;
+    isResultsCacheEnabled: boolean;
     embeddingEnabled: FeatureFlag | undefined;
     allowPasswordAuthentication: boolean;
     hasSocialLogin: boolean | undefined;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -79,6 +79,10 @@ export const useSettingsContext = (): SettingsContext => {
     const { data: externalSourcesFlag } = useServerFeatureFlag(
         FeatureFlags.ExternalSources,
     );
+    const { data: resultsCacheFlag } = useServerFeatureFlag(
+        FeatureFlags.ResultsCacheEnabled,
+    );
+    const isResultsCacheEnabled = resultsCacheFlag?.enabled ?? false;
 
     const { data: proLimitsFlag } = useServerFeatureFlag(
         FeatureFlags.ProLimits,
@@ -201,6 +205,7 @@ export const useSettingsContext = (): SettingsContext => {
         dataAppsFlag,
         isDataAppsFlagLoading: dataAppsFlagQuery.isInitialLoading,
         externalSourcesFlag,
+        isResultsCacheEnabled,
         embeddingEnabled,
         allowPasswordAuthentication,
         hasSocialLogin,

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -89,6 +89,7 @@ export const useSettingsNavigation = (
         embeddingEnabled,
         dataAppsFlag,
         externalSourcesFlag,
+        isResultsCacheEnabled,
         isGitProject,
     } = context;
 
@@ -695,6 +696,23 @@ export const useSettingsNavigation = (
                 });
             }
 
+            if (isResultsCacheEnabled) {
+                projectItems.push({
+                    label: 'Results caching',
+                    to: `${base}/caching`,
+                    icon: IconDatabaseExport,
+                    keywords: [
+                        'cache',
+                        'results',
+                        'duration',
+                        'expire',
+                        'refresh',
+                    ],
+                    children: [],
+                    exact: true,
+                });
+            }
+
             projectItems.push({
                 label: 'Parameters',
                 to: `${base}/parameters`,
@@ -1011,6 +1029,7 @@ export const useSettingsNavigation = (
         isEmbeddingEnabled,
         isDataAppsEnabled,
         isExternalSourcesEnabled,
+        isResultsCacheEnabled,
         isGitProject,
         track,
     ]);

--- a/packages/frontend/src/hooks/useProjectResultsCacheSettings.ts
+++ b/packages/frontend/src/hooks/useProjectResultsCacheSettings.ts
@@ -1,0 +1,62 @@
+import {
+    type ApiError,
+    type ApiResultsCacheProjectSettingsResponse,
+    type UpdateResultsCacheProjectSettings,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+import useToaster from './toaster/useToaster';
+
+const queryKey = (projectUuid: string) => [
+    'results_cache_settings',
+    projectUuid,
+];
+
+const getResultsCacheSettings = async (projectUuid: string) =>
+    lightdashApi<ApiResultsCacheProjectSettingsResponse['results']>({
+        url: `/projects/${projectUuid}/results-cache-config`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useResultsCacheSettings = (projectUuid: string) =>
+    useQuery<ApiResultsCacheProjectSettingsResponse['results'], ApiError>({
+        queryKey: queryKey(projectUuid),
+        queryFn: () => getResultsCacheSettings(projectUuid),
+        enabled: !!projectUuid,
+    });
+
+const updateResultsCacheSettings = async (
+    projectUuid: string,
+    data: UpdateResultsCacheProjectSettings,
+) =>
+    lightdashApi<ApiResultsCacheProjectSettingsResponse['results']>({
+        url: `/projects/${projectUuid}/results-cache-config`,
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
+
+export const useUpdateResultsCacheSettings = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+
+    return useMutation<
+        ApiResultsCacheProjectSettingsResponse['results'],
+        ApiError,
+        UpdateResultsCacheProjectSettings
+    >((data) => updateResultsCacheSettings(projectUuid, data), {
+        mutationKey: ['results_cache_settings_update', projectUuid],
+        onSuccess: async () => {
+            showToastSuccess({
+                title: 'Cache duration updated',
+            });
+            await queryClient.invalidateQueries(queryKey(projectUuid));
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update cache duration',
+                apiError: error,
+            });
+        },
+    });
+};


### PR DESCRIPTION
## Summary

Part 2 of 2 (stack #27777), on top of #27772. Adds the "Query caching" tab to project settings so project admins can view and change the results cache TTL without using the API.

- New project settings route `/caching`, with a sidebar entry next to Pre-aggregates. Both are shown only when the organisation's `results-cache-enabled` feature flag is on.
- The input is in minutes (1 to 43200, i.e. 30 days), converted to seconds on save, with an hours hint once the value passes 60 minutes. A "Use the default cache duration" switch clears the override and shows the instance value, e.g. "Cached results expire after 24 hours." Copy follows the public docs vocabulary (results caching, cache duration, expire).
- The instance default shown next to the switch comes from `instanceDefaultTtlSeconds` in the settings response (#27772), so no health changes.
- A direct load or refresh of `/caching` waits for the flag to resolve before the nested catch-all can redirect, mirroring the existing `dataAppConnections` guard.

## Testing

- `common`/`backend`/`frontend` typecheck and `frontend`/`backend` lint pass.
- Verified in a running stack: tab visible with the flag on, saving 90 minutes persists `5400`, out-of-range values show an inline error, switching back to the default clears to `null`, values rehydrate on reload.

Relates: [PROD-10410](https://linear.app/lightdash/issue/PROD-10410/add-project-setting-for-results-cache-ttl-that-overrides-cache-stale)




