### PR TITLE
refactor(explorer): extract chart type options and the config portal

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.test.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.test.tsx
@@ -4,7 +4,10 @@ import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createExplorerStore } from '../../../features/explorer/store';
+import {
+    createExplorerStore,
+    explorerActions,
+} from '../../../features/explorer/store';
 import { useExplore } from '../../../hooks/useExplore';
 import { renderWithProviders } from '../../../testing/testUtils';
 import ExplorePanel from './index';
@@ -88,15 +91,24 @@ const exploreQuery = (overrides: Partial<ExploreQuery>): ExploreQuery =>
         ...overrides,
     }) as unknown as ExploreQuery;
 
-const renderPanel = (appMocks?: Parameters<typeof renderWithProviders>[1]) =>
-    renderWithProviders(
+const renderPanel = (
+    appMocks?: Parameters<typeof renderWithProviders>[1],
+    openVisualizationConfig = false,
+) => {
+    const store = createExplorerStore();
+    if (openVisualizationConfig) {
+        store.dispatch(explorerActions.openVisualizationConfig());
+    }
+
+    return renderWithProviders(
         <MemoryRouter>
-            <Provider store={createExplorerStore()}>
+            <Provider store={store}>
                 <ExplorePanel />
             </Provider>
         </MemoryRouter>,
         appMocks,
     );
+};
 
 describe('ExplorePanel loading state', () => {
     beforeEach(() => {
@@ -140,6 +152,22 @@ describe('ExplorePanel loading state', () => {
         renderPanel();
 
         expect(screen.queryByTestId('explore-tree')).not.toBeNull();
+    });
+});
+
+describe('ExplorePanel chart configuration placement', () => {
+    beforeEach(() => {
+        mockUseExplore.mockReturnValue(exploreQuery({ data: mockExplore }));
+        testState.enabledFlags.clear();
+    });
+
+    it('swaps the fields for the config portal while configuring', () => {
+        renderPanel(undefined, true);
+
+        expect(
+            document.getElementById('visualization-config-portal'),
+        ).not.toBeNull();
+        expect(screen.getByTestId('explore-tree')).not.toBeVisible();
     });
 });
 

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -60,9 +60,9 @@ import PageBreadcrumbs from '../../common/PageBreadcrumbs';
 import ExploreTree from '../ExploreTree';
 import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailProvider';
+import VisualizationConfigPortal from '../VisualizationCard/VisualizationConfigPortal';
 import WarningsHoverCardContent from '../WarningsHoverCardContent';
 import { useIsGitProject } from '../WriteBackModal/hooks';
-import { VisualizationConfigPortalId } from './constants';
 
 interface ExplorePanelProps {
     onBack?: () => void;
@@ -260,14 +260,7 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
 
     return (
         <>
-            <Stack
-                id={VisualizationConfigPortalId}
-                style={{
-                    flexGrow: 1,
-                    overflow: 'hidden',
-                    display: isVisualizationConfigOpen ? 'flex' : 'none',
-                }}
-            />
+            <VisualizationConfigPortal active={isVisualizationConfigOpen} />
 
             <Stack
                 h="100%"

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -61,10 +61,10 @@ import LightdashVisualization from '../../LightdashVisualization';
 import VisualizationProvider from '../../LightdashVisualization/VisualizationProvider';
 import { type EchartsSeriesClickEvent } from '../../SimpleChart';
 import SortButton from '../../SortButton';
-import { VisualizationConfigPortalId } from '../ExplorePanel/constants';
 import { DevCopyChartDebugData } from '../ExplorerHeader/DevCopyChartDebugData';
 import VisualizationConfig from '../VisualizationCard/VisualizationConfig';
 import { SeriesContextMenu } from './SeriesContextMenu';
+import useVisualizationConfigPortalTarget from './useVisualizationConfigPortalTarget';
 import VisualizationTimezone from './VisualizationTimezone';
 import VisualizationWarning from './VisualizationWarning';
 
@@ -287,22 +287,15 @@ const VisualizationCard: FC<Props> = memo((props) => {
         [dispatch],
     );
 
-    const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+    const portalTarget = useVisualizationConfigPortalTarget(
+        isVisualizationConfigOpen,
+    );
 
     const {
         ref: measureRef,
         width: containerWidth,
         height: containerHeight,
     } = useElementSize();
-
-    useLayoutEffect(() => {
-        if (isVisualizationConfigOpen) {
-            const target = document.getElementById(VisualizationConfigPortalId);
-            setPortalTarget(target);
-        } else {
-            setPortalTarget(null);
-        }
-    }, [isVisualizationConfigOpen]);
 
     useLayoutEffect(() => {
         if (!isEditMode) {

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -34,9 +34,16 @@ const CustomVisConfigTabsLazy = lazy(() =>
 type Props = {
     chartType: ChartType;
     onClose: () => void;
+    withHeader?: boolean;
+    withChartTypePicker?: boolean;
 };
 
-const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
+const VisualizationConfig: FC<Props> = ({
+    chartType,
+    onClose,
+    withHeader = true,
+    withChartTypePicker = true,
+}) => {
     const ConfigTab = useMemo(() => {
         switch (chartType) {
             case ChartType.BIG_NUMBER:
@@ -76,30 +83,38 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
 
     return (
         <>
-            <Group justify="space-between">
-                <Text fz={16} fw={600}>
-                    Configure chart
-                </Text>
+            {withHeader ? (
+                <>
+                    <Group justify="space-between">
+                        <Text fz={16} fw={600}>
+                            Configure chart
+                        </Text>
 
-                <Tooltip label="Close visualization config" position="right">
-                    <ActionIcon
-                        variant="subtle"
-                        color="gray"
-                        size="sm"
-                        onClick={onClose}
-                    >
-                        <MantineIcon icon={IconX} />
-                    </ActionIcon>
-                </Tooltip>
-            </Group>
+                        <Tooltip
+                            label="Close visualization config"
+                            position="right"
+                        >
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                size="sm"
+                                onClick={onClose}
+                            >
+                                <MantineIcon icon={IconX} />
+                            </ActionIcon>
+                        </Tooltip>
+                    </Group>
 
-            <Divider />
+                    <Divider />
+                </>
+            ) : null}
 
-            <Group>
-                <Text fw={600}>Chart type</Text>
-
-                <VisualizationCardOptions />
-            </Group>
+            {withChartTypePicker ? (
+                <Group>
+                    <Text fw={600}>Chart type</Text>
+                    <VisualizationCardOptions />
+                </Group>
+            ) : null}
 
             <ScrollArea
                 offsetScrollbars
@@ -107,7 +122,7 @@ const VisualizationConfig: FC<Props> = ({ chartType, onClose }) => {
                 classNames={{
                     content: scrollAreaClasses.verticalContent,
                 }}
-                style={{ flex: 1 }}
+                style={{ flex: 1, minHeight: 0 }}
                 type="hover"
                 scrollbarSize={8}
             >

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.module.css
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.module.css
@@ -1,0 +1,9 @@
+.portal {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.portal[data-active='false'] {
+    display: none;
+}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.test.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.test.tsx
@@ -1,0 +1,53 @@
+import { screen } from '@testing-library/react';
+import { createPortal } from 'react-dom';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import Page from '../../common/Page/Page';
+import { VisualizationConfigPortalId } from '../ExplorePanel/constants';
+import useVisualizationConfigPortalTarget from './useVisualizationConfigPortalTarget';
+import VisualizationConfigPortal from './VisualizationConfigPortal';
+
+const PortalProducer = ({ isOpen }: { isOpen: boolean }) => {
+    const target = useVisualizationConfigPortalTarget(isOpen);
+
+    return target ? createPortal(<div>Configure content</div>, target) : null;
+};
+
+describe('VisualizationConfigPortal', () => {
+    it('is mounted before the transitioned right sidebar opens', () => {
+        renderWithProviders(
+            <Page
+                withNavbar={false}
+                rightSidebar={<VisualizationConfigPortal />}
+                isRightSidebarOpen={false}
+                keepRightSidebarMounted
+            >
+                <div>Chart</div>
+            </Page>,
+        );
+
+        expect(
+            document.getElementById(VisualizationConfigPortalId),
+        ).not.toBeNull();
+    });
+
+    it('keeps portal content attached when the right sidebar opens', async () => {
+        const renderPage = (isOpen: boolean) => (
+            <Page
+                withNavbar={false}
+                rightSidebar={<VisualizationConfigPortal />}
+                isRightSidebarOpen={isOpen}
+                keepRightSidebarMounted
+            >
+                <PortalProducer isOpen={isOpen} />
+            </Page>
+        );
+        const { rerender } = renderWithProviders(renderPage(false));
+
+        rerender(renderPage(true));
+
+        expect(
+            await screen.findByText('Configure content'),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfigPortal.tsx
@@ -1,0 +1,18 @@
+import { Stack } from '@mantine/core';
+import { type FC } from 'react';
+import { VisualizationConfigPortalId } from '../ExplorePanel/constants';
+import classes from './VisualizationConfigPortal.module.css';
+
+type Props = {
+    active?: boolean;
+};
+
+const VisualizationConfigPortal: FC<Props> = ({ active = true }) => (
+    <Stack
+        id={VisualizationConfigPortalId}
+        className={classes.portal}
+        data-active={active}
+    />
+);
+
+export default VisualizationConfigPortal;

--- a/packages/frontend/src/components/Explorer/VisualizationCard/useVisualizationConfigPortalTarget.ts
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/useVisualizationConfigPortalTarget.ts
@@ -1,0 +1,18 @@
+import { useLayoutEffect, useState } from 'react';
+import { VisualizationConfigPortalId } from '../ExplorePanel/constants';
+
+const useVisualizationConfigPortalTarget = (isOpen: boolean) => {
+    const [target, setTarget] = useState<HTMLElement | null>(null);
+
+    useLayoutEffect(() => {
+        setTarget(
+            isOpen
+                ? document.getElementById(VisualizationConfigPortalId)
+                : null,
+        );
+    }, [isOpen]);
+
+    return target;
+};
+
+export default useVisualizationConfigPortalTarget;

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.module.css
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.module.css
@@ -1,0 +1,3 @@
+.rotatedIcon {
+    rotate: 90deg;
+}

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -1,60 +1,25 @@
-import {
-    assertUnreachable,
-    CartesianSeriesType,
-    ChartType,
-    FeatureFlags,
-    isSeriesWithMixedChartTypes,
-} from '@lightdash/common';
+import { ChartType, FeatureFlags } from '@lightdash/common';
 import { Button, Menu } from '@mantine/core';
-import {
-    IconChartArea,
-    IconChartAreaLine,
-    IconChartBar,
-    IconChartDots,
-    IconChartLine,
-    IconChartPie,
-    IconChartTreemap,
-    IconChevronDown,
-    IconCode,
-    IconFilter,
-    IconGauge,
-    IconGitMerge,
-    IconMap,
-    IconSquareNumber1,
-    IconTable,
-} from '@tabler/icons-react';
-import { memo, useMemo, type FC, type ReactNode } from 'react';
+import { IconChevronDown, IconCode } from '@tabler/icons-react';
+import { memo, type FC } from 'react';
 import { useParams } from 'react-router';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
-import {
-    isBigNumberVisualizationConfig,
-    isCartesianVisualizationConfig,
-    isCustomVisualizationConfig,
-    isDataAppVizVisualizationConfig,
-    isFunnelVisualizationConfig,
-    isGaugeVisualizationConfig,
-    isMapVisualizationConfig,
-    isPieVisualizationConfig,
-    isSankeyVisualizationConfig,
-    isTableVisualizationConfig,
-    isTreemapVisualizationConfig,
-} from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { useCreateProjectChartType } from '../../VisualizationConfigs/CustomChartType/useSelectProjectChartType';
+import classes from './index.module.css';
+import { useChartTypeOptions } from './useChartTypeOptions';
 
 const VisualizationCardOptions: FC = memo(() => {
+    const { setChartType } = useVisualizationContext();
     const {
-        visualizationConfig,
-        setChartType,
-        setCartesianType,
-        setStacking,
-        isLoading,
-        resultsData,
-        pivotDimensions,
-    } = useVisualizationContext();
-    const disabled = isLoading || !resultsData || resultsData.rows.length <= 0;
+        disabled,
+        isCustomChart,
+        options,
+        resetCartesianState,
+        selectedChartType,
+    } = useChartTypeOptions();
 
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const dataAppsEnabled =
@@ -62,173 +27,17 @@ const VisualizationCardOptions: FC = memo(() => {
         true;
     const canCreateApp = useCanCreateDataApp(projectUuid);
     const createProjectChartType = useCreateProjectChartType();
-    // Without data apps there are no project chart types to describe, and
-    // without create rights the composer would not be offered once landed.
     const canComposeCustomChartType = dataAppsEnabled && canCreateApp;
+    const handleSelectCustom = () => {
+        resetCartesianState();
+        if (isCustomChart) return;
 
-    const cartesianConfig = useMemo(() => {
-        if (isCartesianVisualizationConfig(visualizationConfig)) {
-            return visualizationConfig.chartConfig;
+        if (canComposeCustomChartType) {
+            createProjectChartType();
+            return;
         }
-        return undefined;
-    }, [visualizationConfig]);
-
-    const cartesianType = cartesianConfig?.dirtyChartType;
-
-    const cartesianFlipAxis = cartesianConfig?.dirtyLayout?.flipAxes;
-    const isChartTypeTheSameForAllSeries = cartesianConfig
-        ? !isSeriesWithMixedChartTypes(
-              cartesianConfig.dirtyEchartsConfig?.series,
-          )
-        : undefined;
-
-    const selectedChartType = useMemo<{
-        text: string;
-        icon: ReactNode;
-    }>(() => {
-        switch (visualizationConfig.chartType) {
-            case ChartType.CARTESIAN: {
-                if (!isChartTypeTheSameForAllSeries) {
-                    return {
-                        text: 'Mixed',
-                        icon: (
-                            <MantineIcon
-                                icon={IconChartAreaLine}
-                                color="ldGray"
-                            />
-                        ),
-                    };
-                }
-
-                const cartesianChartType =
-                    visualizationConfig.chartConfig.dirtyChartType;
-
-                switch (cartesianChartType) {
-                    case CartesianSeriesType.AREA:
-                        return {
-                            text: 'Area chart',
-                            icon: (
-                                <MantineIcon
-                                    icon={IconChartArea}
-                                    color="ldGray"
-                                />
-                            ),
-                        };
-                    case CartesianSeriesType.LINE:
-                        return {
-                            text: 'Line chart',
-                            icon: (
-                                <MantineIcon
-                                    icon={IconChartLine}
-                                    color="ldGray"
-                                />
-                            ),
-                        };
-
-                    case CartesianSeriesType.BAR:
-                        return cartesianFlipAxis
-                            ? {
-                                  text: 'Horizontal bar chart',
-                                  icon: (
-                                      <MantineIcon
-                                          icon={IconChartBar}
-                                          style={{ rotate: '90deg' }}
-                                          color="ldGray"
-                                      />
-                                  ),
-                              }
-                            : {
-                                  text: 'Bar chart',
-                                  icon: (
-                                      <MantineIcon
-                                          icon={IconChartBar}
-                                          color="ldGray"
-                                      />
-                                  ),
-                              };
-                    case CartesianSeriesType.SCATTER:
-                        return {
-                            text: 'Scatter chart',
-                            icon: (
-                                <MantineIcon
-                                    icon={IconChartDots}
-                                    color="ldGray"
-                                />
-                            ),
-                        };
-                    default:
-                        return assertUnreachable(
-                            cartesianChartType,
-                            `Unknown cartesian type ${cartesianChartType}`,
-                        );
-                }
-            }
-            case ChartType.TABLE:
-                return {
-                    text: 'Table',
-                    icon: <MantineIcon icon={IconTable} color="ldGray" />,
-                };
-            case ChartType.BIG_NUMBER:
-                return {
-                    text: 'Big value',
-                    icon: (
-                        <MantineIcon icon={IconSquareNumber1} color="ldGray" />
-                    ),
-                };
-            case ChartType.PIE:
-                return {
-                    text: 'Pie chart',
-                    icon: <MantineIcon icon={IconChartPie} color="ldGray" />,
-                };
-            case ChartType.FUNNEL:
-                return {
-                    text: 'Funnel chart',
-                    icon: <MantineIcon icon={IconFilter} color="ldGray" />,
-                };
-            case ChartType.TREEMAP:
-                return {
-                    text: 'Treemap',
-                    icon: (
-                        <MantineIcon icon={IconChartTreemap} color="ldGray" />
-                    ),
-                };
-            case ChartType.GAUGE:
-                return {
-                    text: 'Gauge',
-                    icon: <MantineIcon icon={IconGauge} color="ldGray" />,
-                };
-            case ChartType.MAP:
-                return {
-                    text: 'Map',
-                    icon: <MantineIcon icon={IconMap} color="ldGray" />,
-                };
-            // Vega and the project's reusable chart types are both "Custom":
-            // which one the chart is on is chosen in the secondary picker, not
-            // here. Keeping the umbrella off any single entry is what lets a
-            // future custom chart source be added without a rename.
-            case ChartType.CUSTOM:
-            case ChartType.DATA_APP_VIZ:
-                return {
-                    text: 'Custom',
-                    icon: <MantineIcon icon={IconCode} color="ldGray" />,
-                };
-            case ChartType.SANKEY:
-                return {
-                    text: 'Sankey',
-                    icon: <MantineIcon icon={IconGitMerge} color="ldGray" />,
-                };
-            default: {
-                return assertUnreachable(
-                    visualizationConfig,
-                    `Unknown visualization chart type`,
-                );
-            }
-        }
-    }, [
-        visualizationConfig,
-        isChartTypeTheSameForAllSeries,
-        cartesianFlipAxis,
-    ]);
+        setChartType(ChartType.CUSTOM);
+    };
 
     return (
         <Menu
@@ -246,299 +55,53 @@ const VisualizationCardOptions: FC = memo(() => {
                     variant="default"
                     size="xs"
                     disabled={disabled}
-                    leftSection={selectedChartType.icon}
+                    leftSection={
+                        <MantineIcon
+                            icon={selectedChartType.icon}
+                            color="ldGray"
+                            className={
+                                selectedChartType.rotatedIcon
+                                    ? classes.rotatedIcon
+                                    : undefined
+                            }
+                        />
+                    }
                     rightSection={
                         <MantineIcon icon={IconChevronDown} color="ldGray" />
                     }
                     data-testid="VisualizationCardOptions"
                 >
-                    {selectedChartType.text}
+                    {selectedChartType.label}
                 </Button>
             </Menu.Target>
 
             <Menu.Dropdown>
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isChartTypeTheSameForAllSeries &&
-                        isCartesianVisualizationConfig(visualizationConfig) &&
-                        cartesianType === CartesianSeriesType.BAR &&
-                        !cartesianFlipAxis
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconChartBar} />}
-                    onClick={() => {
-                        setCartesianType({
-                            type: CartesianSeriesType.BAR,
-                            flipAxes: false,
-                            hasAreaStyle: false,
-                        });
-                        setChartType(ChartType.CARTESIAN);
-                    }}
-                >
-                    Bar chart
-                </Menu.Item>
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isChartTypeTheSameForAllSeries &&
-                        isCartesianVisualizationConfig(visualizationConfig) &&
-                        cartesianType === CartesianSeriesType.BAR &&
-                        cartesianFlipAxis
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={
-                        <MantineIcon
-                            icon={IconChartBar}
-                            style={{ rotate: '90deg' }}
-                        />
-                    }
-                    onClick={() => {
-                        setCartesianType({
-                            type: CartesianSeriesType.BAR,
-                            flipAxes: true,
-                            hasAreaStyle: false,
-                        });
-                        if (!pivotDimensions) setStacking(false);
-                        setChartType(ChartType.CARTESIAN);
-                    }}
-                >
-                    Horizontal bar chart
-                </Menu.Item>
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isChartTypeTheSameForAllSeries &&
-                        isCartesianVisualizationConfig(visualizationConfig) &&
-                        cartesianType === CartesianSeriesType.LINE
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconChartLine} />}
-                    onClick={() => {
-                        setCartesianType({
-                            type: CartesianSeriesType.LINE,
-                            flipAxes: false,
-                            hasAreaStyle: false,
-                        });
-                        setStacking(false);
-                        setChartType(ChartType.CARTESIAN);
-                    }}
-                >
-                    Line chart
-                </Menu.Item>
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isChartTypeTheSameForAllSeries &&
-                        isCartesianVisualizationConfig(visualizationConfig) &&
-                        cartesianType === CartesianSeriesType.AREA
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconChartArea} />}
-                    onClick={() => {
-                        setCartesianType({
-                            type: CartesianSeriesType.LINE,
-                            flipAxes: false,
-                            hasAreaStyle: true,
-                        });
-                        setStacking(true);
-                        setChartType(ChartType.CARTESIAN);
-                    }}
-                >
-                    Area chart
-                </Menu.Item>
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isChartTypeTheSameForAllSeries &&
-                        isCartesianVisualizationConfig(visualizationConfig) &&
-                        cartesianType === CartesianSeriesType.SCATTER
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconChartDots} />}
-                    onClick={() => {
-                        setCartesianType({
-                            type: CartesianSeriesType.SCATTER,
-                            flipAxes: false,
-                            hasAreaStyle: false,
-                        });
-                        setStacking(false);
-                        setChartType(ChartType.CARTESIAN);
-                    }}
-                >
-                    Scatter chart
-                </Menu.Item>
+                {options.map((option) => (
+                    <Menu.Item
+                        key={option.id}
+                        disabled={disabled}
+                        color={option.selected ? 'blue' : undefined}
+                        leftSection={
+                            <MantineIcon
+                                icon={option.icon}
+                                className={
+                                    option.rotatedIcon
+                                        ? classes.rotatedIcon
+                                        : undefined
+                                }
+                            />
+                        }
+                        onClick={option.select}
+                    >
+                        {option.label}
+                    </Menu.Item>
+                ))}
 
                 <Menu.Item
                     disabled={disabled}
-                    color={
-                        isPieVisualizationConfig(visualizationConfig)
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconChartPie} />}
-                    onClick={() => {
-                        setStacking(undefined);
-                        setCartesianType(undefined);
-                        setChartType(ChartType.PIE);
-                    }}
-                >
-                    Pie chart
-                </Menu.Item>
-
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isFunnelVisualizationConfig(visualizationConfig)
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconFilter} />}
-                    onClick={() => {
-                        setStacking(undefined);
-                        setCartesianType(undefined);
-                        setChartType(ChartType.FUNNEL);
-                    }}
-                >
-                    Funnel chart
-                </Menu.Item>
-
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isTreemapVisualizationConfig(visualizationConfig)
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconChartTreemap} />}
-                    onClick={() => {
-                        setStacking(undefined);
-                        setCartesianType(undefined);
-                        setChartType(ChartType.TREEMAP);
-                    }}
-                >
-                    Treemap
-                </Menu.Item>
-
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isGaugeVisualizationConfig(visualizationConfig)
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconGauge} />}
-                    onClick={() => {
-                        setStacking(undefined);
-                        setCartesianType(undefined);
-                        setChartType(ChartType.GAUGE);
-                    }}
-                >
-                    Gauge
-                </Menu.Item>
-
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isSankeyVisualizationConfig(visualizationConfig)
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconGitMerge} />}
-                    onClick={() => {
-                        setStacking(undefined);
-                        setCartesianType(undefined);
-                        setChartType(ChartType.SANKEY);
-                    }}
-                >
-                    Sankey
-                </Menu.Item>
-
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isMapVisualizationConfig(visualizationConfig)
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconMap} />}
-                    onClick={() => {
-                        setStacking(undefined);
-                        setCartesianType(undefined);
-                        setChartType(ChartType.MAP);
-                    }}
-                >
-                    Map
-                </Menu.Item>
-
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isTableVisualizationConfig(visualizationConfig)
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconTable} />}
-                    onClick={() => {
-                        setStacking(undefined);
-                        setCartesianType(undefined);
-                        setChartType(ChartType.TABLE);
-                    }}
-                >
-                    Table
-                </Menu.Item>
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isBigNumberVisualizationConfig(visualizationConfig)
-                            ? 'blue'
-                            : undefined
-                    }
-                    leftSection={<MantineIcon icon={IconSquareNumber1} />}
-                    onClick={() => {
-                        setStacking(undefined);
-                        setCartesianType(undefined);
-                        setChartType(ChartType.BIG_NUMBER);
-                    }}
-                >
-                    Big value
-                </Menu.Item>
-
-                <Menu.Item
-                    disabled={disabled}
-                    color={
-                        isCustomVisualizationConfig(visualizationConfig) ||
-                        isDataAppVizVisualizationConfig(visualizationConfig)
-                            ? 'blue'
-                            : undefined
-                    }
+                    color={isCustomChart ? 'blue' : undefined}
                     leftSection={<MantineIcon icon={IconCode} />}
-                    onClick={() => {
-                        setStacking(undefined);
-                        setCartesianType(undefined);
-                        // Already on a custom type means this is a no-op rather
-                        // than a reset of what they picked.
-                        if (
-                            isCustomVisualizationConfig(visualizationConfig) ||
-                            isDataAppVizVisualizationConfig(visualizationConfig)
-                        ) {
-                            return;
-                        }
-                        // The composer is the default landing spot: describing
-                        // the chart you want beats hand-writing a Vega spec.
-                        // Vega is a pick away in the secondary picker, and is
-                        // the fallback wherever the composer isn't offered.
-                        if (canComposeCustomChartType) {
-                            createProjectChartType();
-                            return;
-                        }
-                        setChartType(ChartType.CUSTOM);
-                    }}
+                    onClick={handleSelectCustom}
                 >
                     Custom
                 </Menu.Item>

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/useChartTypeOptions.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/useChartTypeOptions.tsx
@@ -1,0 +1,298 @@
+import {
+    CartesianSeriesType,
+    ChartKind,
+    ChartType,
+    isSeriesWithMixedChartTypes,
+} from '@lightdash/common';
+import {
+    IconChartArea,
+    IconChartAreaLine,
+    IconChartBar,
+    IconChartDots,
+    IconChartLine,
+    IconChartPie,
+    IconChartTreemap,
+    IconCode,
+    IconFilter,
+    IconGauge,
+    IconGitMerge,
+    IconMap,
+    IconSquareNumber1,
+    IconTable,
+    type Icon as TablerIcon,
+} from '@tabler/icons-react';
+import {
+    isBigNumberVisualizationConfig,
+    isCartesianVisualizationConfig,
+    isCustomVisualizationConfig,
+    isDataAppVizVisualizationConfig,
+    isFunnelVisualizationConfig,
+    isGaugeVisualizationConfig,
+    isMapVisualizationConfig,
+    isPieVisualizationConfig,
+    isSankeyVisualizationConfig,
+    isTableVisualizationConfig,
+    isTreemapVisualizationConfig,
+} from '../../LightdashVisualization/types';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+
+export type ChartTypeOption = {
+    id: ChartKind;
+    label: string;
+    description: string;
+    icon: TablerIcon;
+    rotatedIcon: boolean;
+    selected: boolean;
+    select: () => void;
+};
+
+export type SelectedChartType = Pick<
+    ChartTypeOption,
+    'id' | 'label' | 'icon' | 'rotatedIcon'
+>;
+
+const MIXED_CHART_TYPE: SelectedChartType = {
+    id: ChartKind.MIXED,
+    label: 'Mixed',
+    icon: IconChartAreaLine,
+    rotatedIcon: false,
+};
+
+const CUSTOM_CHART_TYPE: SelectedChartType = {
+    id: ChartKind.CUSTOM,
+    label: 'Custom',
+    icon: IconCode,
+    rotatedIcon: false,
+};
+
+export const useChartTypeOptions = () => {
+    const {
+        visualizationConfig,
+        setChartType,
+        setCartesianType,
+        setStacking,
+        isLoading,
+        resultsData,
+        pivotDimensions,
+    } = useVisualizationContext();
+
+    const disabled = isLoading || !resultsData || resultsData.rows.length <= 0;
+    const cartesianConfig = isCartesianVisualizationConfig(visualizationConfig)
+        ? visualizationConfig.chartConfig
+        : undefined;
+    const cartesianType = cartesianConfig?.dirtyChartType;
+    const cartesianFlipAxis = cartesianConfig?.dirtyLayout?.flipAxes;
+    const hasSingleCartesianType = cartesianConfig
+        ? !isSeriesWithMixedChartTypes(
+              cartesianConfig.dirtyEchartsConfig?.series,
+          )
+        : undefined;
+
+    const resetCartesianState = () => {
+        setStacking(undefined);
+        setCartesianType(undefined);
+    };
+    const resetCartesian = (chartType: ChartType) => {
+        resetCartesianState();
+        setChartType(chartType);
+    };
+
+    const options: ChartTypeOption[] = [
+        {
+            id: ChartKind.VERTICAL_BAR,
+            label: 'Bar chart',
+            description: 'Compare categories',
+            icon: IconChartBar,
+            rotatedIcon: false,
+            selected:
+                hasSingleCartesianType === true &&
+                cartesianType === CartesianSeriesType.BAR &&
+                !cartesianFlipAxis,
+            select: () => {
+                setCartesianType({
+                    type: CartesianSeriesType.BAR,
+                    flipAxes: false,
+                    hasAreaStyle: false,
+                });
+                setChartType(ChartType.CARTESIAN);
+            },
+        },
+        {
+            id: ChartKind.HORIZONTAL_BAR,
+            label: 'Horizontal bar chart',
+            description: 'Compare ranked categories',
+            icon: IconChartBar,
+            rotatedIcon: true,
+            selected:
+                hasSingleCartesianType === true &&
+                cartesianType === CartesianSeriesType.BAR &&
+                cartesianFlipAxis === true,
+            select: () => {
+                setCartesianType({
+                    type: CartesianSeriesType.BAR,
+                    flipAxes: true,
+                    hasAreaStyle: false,
+                });
+                if (!pivotDimensions) setStacking(false);
+                setChartType(ChartType.CARTESIAN);
+            },
+        },
+        {
+            id: ChartKind.LINE,
+            label: 'Line chart',
+            description: 'Show a trend',
+            icon: IconChartLine,
+            rotatedIcon: false,
+            selected:
+                hasSingleCartesianType === true &&
+                cartesianType === CartesianSeriesType.LINE,
+            select: () => {
+                setCartesianType({
+                    type: CartesianSeriesType.LINE,
+                    flipAxes: false,
+                    hasAreaStyle: false,
+                });
+                setStacking(false);
+                setChartType(ChartType.CARTESIAN);
+            },
+        },
+        {
+            id: ChartKind.AREA,
+            label: 'Area chart',
+            description: 'Compare magnitude over time',
+            icon: IconChartArea,
+            rotatedIcon: false,
+            selected:
+                hasSingleCartesianType === true &&
+                cartesianType === CartesianSeriesType.AREA,
+            select: () => {
+                setCartesianType({
+                    type: CartesianSeriesType.LINE,
+                    flipAxes: false,
+                    hasAreaStyle: true,
+                });
+                setStacking(true);
+                setChartType(ChartType.CARTESIAN);
+            },
+        },
+        {
+            id: ChartKind.SCATTER,
+            label: 'Scatter chart',
+            description: 'Find relationships and outliers',
+            icon: IconChartDots,
+            rotatedIcon: false,
+            selected:
+                hasSingleCartesianType === true &&
+                cartesianType === CartesianSeriesType.SCATTER,
+            select: () => {
+                setCartesianType({
+                    type: CartesianSeriesType.SCATTER,
+                    flipAxes: false,
+                    hasAreaStyle: false,
+                });
+                setStacking(false);
+                setChartType(ChartType.CARTESIAN);
+            },
+        },
+        {
+            id: ChartKind.PIE,
+            label: 'Pie chart',
+            description: 'Show part-to-whole',
+            icon: IconChartPie,
+            rotatedIcon: false,
+            selected: isPieVisualizationConfig(visualizationConfig),
+            select: () => resetCartesian(ChartType.PIE),
+        },
+        {
+            id: ChartKind.FUNNEL,
+            label: 'Funnel chart',
+            description: 'Show stage conversion',
+            icon: IconFilter,
+            rotatedIcon: false,
+            selected: isFunnelVisualizationConfig(visualizationConfig),
+            select: () => resetCartesian(ChartType.FUNNEL),
+        },
+        {
+            id: ChartKind.TREEMAP,
+            label: 'Treemap',
+            description: 'Show hierarchical proportions',
+            icon: IconChartTreemap,
+            rotatedIcon: false,
+            selected: isTreemapVisualizationConfig(visualizationConfig),
+            select: () => resetCartesian(ChartType.TREEMAP),
+        },
+        {
+            id: ChartKind.GAUGE,
+            label: 'Gauge',
+            description: 'Track progress toward a target',
+            icon: IconGauge,
+            rotatedIcon: false,
+            selected: isGaugeVisualizationConfig(visualizationConfig),
+            select: () => resetCartesian(ChartType.GAUGE),
+        },
+        {
+            id: ChartKind.SANKEY,
+            label: 'Sankey',
+            description: 'Show flow between categories',
+            icon: IconGitMerge,
+            rotatedIcon: false,
+            selected: isSankeyVisualizationConfig(visualizationConfig),
+            select: () => resetCartesian(ChartType.SANKEY),
+        },
+        {
+            id: ChartKind.MAP,
+            label: 'Map',
+            description: 'Plot geographic values',
+            icon: IconMap,
+            rotatedIcon: false,
+            selected: isMapVisualizationConfig(visualizationConfig),
+            select: () => resetCartesian(ChartType.MAP),
+        },
+        {
+            id: ChartKind.TABLE,
+            label: 'Table',
+            description: 'Show every result row',
+            icon: IconTable,
+            rotatedIcon: false,
+            selected: isTableVisualizationConfig(visualizationConfig),
+            select: () => resetCartesian(ChartType.TABLE),
+        },
+        {
+            id: ChartKind.BIG_NUMBER,
+            label: 'Big value',
+            description: 'Highlight a single metric',
+            icon: IconSquareNumber1,
+            rotatedIcon: false,
+            selected: isBigNumberVisualizationConfig(visualizationConfig),
+            select: () => resetCartesian(ChartType.BIG_NUMBER),
+        },
+    ];
+
+    const vegaOption: ChartTypeOption = {
+        id: ChartKind.CUSTOM,
+        label: 'Vega (JSON editor)',
+        description: 'Write Vega-Lite JSON by hand',
+        icon: IconCode,
+        rotatedIcon: false,
+        selected: isCustomVisualizationConfig(visualizationConfig),
+        select: () => resetCartesian(ChartType.CUSTOM),
+    };
+
+    const isCustomChart =
+        isCustomVisualizationConfig(visualizationConfig) ||
+        isDataAppVizVisualizationConfig(visualizationConfig);
+    // Vega and project chart types share one "Custom" entry in the picker;
+    // cartesian series that do not resolve to a single entry are mixed.
+    const selectedChartType: SelectedChartType = isCustomChart
+        ? CUSTOM_CHART_TYPE
+        : (options.find((option) => option.selected) ?? MIXED_CHART_TYPE);
+
+    return {
+        disabled,
+        isCustomChart,
+        options,
+        resetCartesianState,
+        selectedChartType,
+        vegaOption,
+    };
+};

--- a/packages/frontend/src/components/common/Page/Page.tsx
+++ b/packages/frontend/src/components/common/Page/Page.tsx
@@ -52,6 +52,8 @@ type Props = {
     sidebarWidthProps?: SidebarWidthProps;
     rightSidebar?: React.ReactNode;
     isRightSidebarOpen?: boolean;
+    keepRightSidebarMounted?: boolean;
+    noRightSidebarPadding?: boolean;
     rightSidebarWidthProps?: SidebarWidthProps;
     header?: React.ReactNode;
 } & Omit<StyleProps, 'withSidebar' | 'withHeader' | 'hasBanner'>;
@@ -67,6 +69,8 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
     sidebarWidthProps,
     rightSidebar,
     isRightSidebarOpen = false,
+    keepRightSidebarMounted = false,
+    noRightSidebarPadding,
     rightSidebarWidthProps,
 
     withCenteredContent = false,
@@ -176,10 +180,13 @@ const Page: FC<React.PropsWithChildren<Props>> = ({
 
                 {rightSidebar ? (
                     <Sidebar
-                        noSidebarPadding={noSidebarPadding}
+                        noSidebarPadding={
+                            noRightSidebarPadding ?? noSidebarPadding
+                        }
                         widthProps={rightSidebarWidthProps}
                         mainWidth={mainWidth}
                         isOpen={isRightSidebarOpen}
+                        keepMounted={keepRightSidebarMounted}
                         position={SidebarPosition.RIGHT}
                         onResizeStart={startSidebarResizing}
                         onResizeEnd={stopSidebarResizing}

--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -20,6 +20,7 @@ import { SidebarPosition, type SidebarWidthProps } from './types';
 
 type Props = {
     isOpen?: boolean;
+    keepMounted?: boolean;
     isCollapsed?: boolean;
     collapsible?: boolean;
     collapsedContent?: React.ReactNode;
@@ -47,6 +48,7 @@ const ResizeHandle: FC<{
 
 const Sidebar: FC<React.PropsWithChildren<Props>> = ({
     isOpen = true,
+    keepMounted = false,
     isCollapsed = false,
     collapsible = false,
     collapsedContent,
@@ -150,6 +152,7 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
             >
                 <Transition
                     mounted={isOpen}
+                    keepMounted={keepMounted}
                     duration={SIDEBAR_ANIMATION_DURATION}
                     transition={transition}
                 >

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -83,7 +83,7 @@ export const selectIsResultsExpanded = createSelector(
 
 export const selectIsVisualizationConfigOpen = createSelector(
     [selectExplorerState],
-    (explorer) => explorer.isVisualizationConfigOpen,
+    (explorer) => explorer.isVisualizationConfigOpen === true,
 );
 
 // FiltersCard specific selectors


### PR DESCRIPTION
## Summary

Preparation for the Explorer chart gallery sidebar (stacked on top). No behaviour change.

- \`VisualizationCardOptions\`: the chart type menu's entries, selected summary, and select handlers move into \`useChartTypeOptions\` so another picker can render the same list.
- \`VisualizationConfigPortal\` + \`useVisualizationConfigPortalTarget\`: the config portal target that \`ExplorePanel\` rendered inline and \`VisualizationCard\` looked up by id become a component and a hook.
- \`VisualizationConfig\` gains \`withHeader\` / \`withChartTypePicker\` props (both default on).
- \`Page\` / \`Sidebar\` gain \`keepRightSidebarMounted\`, \`noRightSidebarPadding\`, and \`keepMounted\`; nothing passes them yet.

## Testing

- Existing Explorer and VisualizationConfigs tests pass; a portal test and an \`ExplorePanel\` placement test are added.
- Manually checked the Explorer config panel and chart type menu render as before.

Relates: GLITCH-674