### PR TITLE
fix: harden OAuth authorize redirect handling

### DIFF
--- a/packages/api-tests/tests/oauthLogin.test.ts
+++ b/packages/api-tests/tests/oauthLogin.test.ts
@@ -42,13 +42,16 @@ const PKCE_TEST_VALUES = {
     codeChallenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
 };
 
-// Helper to extract redirect URL from HTML response
-const extractRedirectUrlFromHtml = (html: string): string => {
-    const match = /window\.location\.href = "([^"]+)"/.exec(html);
-    if (!match) {
-        throw new Error('No redirect URL found in HTML response');
+const getRedirectLocation = (response: {
+    status: number;
+    headers: Headers;
+}): string => {
+    expect(response.status).toBe(302);
+    const location = response.headers.get('location');
+    if (!location) {
+        throw new Error('Missing OAuth redirect location');
     }
-    return match[1];
+    return location;
 };
 
 /**
@@ -160,12 +163,12 @@ async function postFormEncoded<T = unknown>(
     ) => Promise<{ status: number; body: unknown; headers: Headers }>,
     path: string,
     body: Record<string, string>,
-): Promise<{ status: number; body: T }> {
+): Promise<{ status: number; body: T; headers: Headers }> {
     return fetchWithAuth(path, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams(body).toString(),
-    }) as Promise<{ status: number; body: T }>;
+    }) as Promise<{ status: number; body: T; headers: Headers }>;
 }
 
 describe('OAuth API Integration Tests', () => {
@@ -280,11 +283,7 @@ describe('OAuth API Integration Tests', () => {
                 `${apiUrl}/authorize`,
                 formData,
             );
-            expect(postResponse.status).toBe(200);
-
-            const location = extractRedirectUrlFromHtml(
-                postResponse.body as string,
-            );
+            const location = getRedirectLocation(postResponse);
             const redirectUrl = new URL(location);
             const code = redirectUrl.searchParams.get('code') || '';
 
@@ -314,10 +313,7 @@ describe('OAuth API Integration Tests', () => {
                 `${apiUrl}/authorize`,
                 formData,
             );
-            expect(postResponse.status).toBe(200);
-            const location = extractRedirectUrlFromHtml(
-                postResponse.body as string,
-            );
+            const location = getRedirectLocation(postResponse);
             const redirectUrl = new URL(location);
             const code = redirectUrl.searchParams.get('code') || '';
             expect(code).not.toBe('');
@@ -369,10 +365,7 @@ describe('OAuth API Integration Tests', () => {
                 `${apiUrl}/authorize`,
                 formData,
             );
-            expect(postResponse.status).toBe(200);
-            const location = extractRedirectUrlFromHtml(
-                postResponse.body as string,
-            );
+            const location = getRedirectLocation(postResponse);
             const redirectUrl = new URL(location);
             const code = redirectUrl.searchParams.get('code') || '';
             expect(code).not.toBe('');
@@ -483,10 +476,7 @@ describe('OAuth API Integration Tests', () => {
                 `${apiUrl}/authorize`,
                 formData,
             );
-            expect(postResponse.status).toBe(200);
-            const location = extractRedirectUrlFromHtml(
-                postResponse.body as string,
-            );
+            const location = getRedirectLocation(postResponse);
             const redirectUrl = new URL(location);
             const code = redirectUrl.searchParams.get('code') || '';
             expect(code).not.toBe('');
@@ -624,10 +614,7 @@ describe('OAuth API Integration Tests', () => {
                 `${apiUrl}/authorize`,
                 formData,
             );
-            expect(postResponse.status).toBe(200);
-            const location = extractRedirectUrlFromHtml(
-                postResponse.body as string,
-            );
+            const location = getRedirectLocation(postResponse);
             const redirectUrl = new URL(location);
             const code = redirectUrl.searchParams.get('code') || '';
             expect(code).not.toBe('');
@@ -695,10 +682,7 @@ describe('OAuth API Integration Tests', () => {
                 `${apiUrl}/authorize`,
                 formData,
             );
-            expect(postResponse.status).toBe(200);
-            const location = extractRedirectUrlFromHtml(
-                postResponse.body as string,
-            );
+            const location = getRedirectLocation(postResponse);
             const code = new URL(location).searchParams.get('code') || '';
             expect(code).not.toBe('');
 
@@ -760,10 +744,7 @@ describe('OAuth API Integration Tests', () => {
                 `${apiUrl}/authorize`,
                 formData,
             );
-            expect(postResponse.status).toBe(200);
-            const location = extractRedirectUrlFromHtml(
-                postResponse.body as string,
-            );
+            const location = getRedirectLocation(postResponse);
             const code = new URL(location).searchParams.get('code') || '';
 
             const tokenResponse = await postFormEncoded<OAuthTokenResponse>(
@@ -908,10 +889,7 @@ describe('OAuth API Integration Tests', () => {
                 `${apiUrl}/authorize`,
                 formData,
             );
-            expect(postResponse.status).toBe(200);
-            const location = extractRedirectUrlFromHtml(
-                postResponse.body as string,
-            );
+            const location = getRedirectLocation(postResponse);
             const redirectUrl = new URL(location);
             const code = redirectUrl.searchParams.get('code') || '';
             expect(code).not.toBe('');

--- a/packages/backend/src/routers/oauthRouter.test.ts
+++ b/packages/backend/src/routers/oauthRouter.test.ts
@@ -1,0 +1,236 @@
+import OAuth2Server from '@node-oauth/oauth2-server';
+import express from 'express';
+import { once } from 'node:events';
+import { request as httpRequest, type IncomingHttpHeaders } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { OAuthService } from '../services/OAuthService/OAuthService';
+import oauthRouter from './oauthRouter';
+
+vi.mock('../logging/logger', () => ({
+    default: {
+        error: vi.fn(),
+    },
+}));
+
+type OAuthServiceStub = Pick<OAuthService, 'authorize' | 'validateRedirectUri'>;
+
+const createOAuthService = () => ({
+    authorize: vi.fn<OAuthServiceStub['authorize']>(),
+    validateRedirectUri: vi.fn<OAuthServiceStub['validateRedirectUri']>(),
+});
+
+const authenticatedUser = {
+    userId: 1,
+    organizationUuid: 'organization-uuid',
+} as Express.User;
+
+const requestAuthorize = async ({
+    body,
+    oauthService,
+    user = authenticatedUser,
+}: {
+    body: Record<string, string>;
+    oauthService: ReturnType<typeof createOAuthService>;
+    user?: Express.User | null;
+}): Promise<{
+    body: string;
+    headers: IncomingHttpHeaders;
+    status: number;
+}> => {
+    const app = express();
+    app.use(express.json());
+    app.use((request, _response, next) => {
+        request.user = user ?? undefined;
+        request.services = {
+            getOauthService: () => oauthService as unknown as OAuthService,
+        } as Express.Request['services'];
+        next();
+    });
+    app.use('/api/v1/oauth', oauthRouter);
+
+    const server = app.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+
+    try {
+        return await new Promise((resolve, reject) => {
+            const request = httpRequest(
+                {
+                    headers: { 'content-type': 'application/json' },
+                    hostname: '127.0.0.1',
+                    method: 'POST',
+                    path: '/api/v1/oauth/authorize',
+                    port: (server.address() as AddressInfo).port,
+                },
+                (response) => {
+                    const chunks: Buffer[] = [];
+                    response.on('data', (chunk: Buffer) => chunks.push(chunk));
+                    response.on('end', () =>
+                        resolve({
+                            body: Buffer.concat(chunks).toString('utf8'),
+                            headers: response.headers,
+                            status: response.statusCode ?? 0,
+                        }),
+                    );
+                },
+            );
+            request.on('error', reject);
+            request.end(JSON.stringify(body));
+        });
+    } finally {
+        await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+        });
+    }
+};
+
+describe('OAuth authorize redirects', () => {
+    it.each([
+        'https://unregistered.example/callback',
+        'urn:example:unregistered-callback',
+    ])(
+        'rejects the unregistered redirect URI %s without reflection',
+        async (redirectUri) => {
+            const oauthService = createOAuthService();
+            oauthService.validateRedirectUri.mockResolvedValue(false);
+
+            const response = await requestAuthorize({
+                body: {
+                    approve: 'false',
+                    client_id: 'client-id',
+                    redirect_uri: redirectUri,
+                    state: 'request-state',
+                },
+                oauthService,
+            });
+
+            expect(response.status).toBe(400);
+            expect(response.headers.location).toBeUndefined();
+            expect(response.headers['content-type']).toContain(
+                'application/json',
+            );
+            expect(response.body).toBe(
+                '{"error":"invalid_request","error_description":"Invalid client_id or redirect_uri"}',
+            );
+            expect(response.body).not.toContain(redirectUri);
+            expect(oauthService.validateRedirectUri).toHaveBeenCalledWith(
+                'client-id',
+                redirectUri,
+            );
+        },
+    );
+
+    it('redirects a denied request to its registered URI', async () => {
+        const oauthService = createOAuthService();
+        oauthService.validateRedirectUri.mockResolvedValue(true);
+
+        const response = await requestAuthorize({
+            body: {
+                approve: 'false',
+                client_id: 'client-id',
+                redirect_uri: 'https://registered.example/callback?existing=1',
+                state: 'request-state',
+            },
+            oauthService,
+        });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe(
+            'https://registered.example/callback?existing=1&error=access_denied&state=request-state',
+        );
+        expect(oauthService.authorize).not.toHaveBeenCalled();
+    });
+
+    it('redirects a successful request with its authorization code', async () => {
+        const oauthService = createOAuthService();
+        oauthService.validateRedirectUri.mockResolvedValue(true);
+        oauthService.authorize.mockResolvedValue({
+            authorizationCode: 'authorization-code',
+        } as OAuth2Server.AuthorizationCode);
+
+        const response = await requestAuthorize({
+            body: {
+                approve: 'true',
+                client_id: 'client-id',
+                redirect_uri: 'https://registered.example/callback',
+                state: 'request-state',
+            },
+            oauthService,
+        });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe(
+            'https://registered.example/callback?code=authorization-code&state=request-state',
+        );
+    });
+
+    it('redirects an authorization error only after URI validation', async () => {
+        const oauthService = createOAuthService();
+        oauthService.validateRedirectUri.mockResolvedValue(true);
+        oauthService.authorize.mockRejectedValue(new Error('authorize failed'));
+
+        const response = await requestAuthorize({
+            body: {
+                approve: 'true',
+                client_id: 'client-id',
+                redirect_uri: 'https://registered.example/callback',
+                state: 'request-state',
+            },
+            oauthService,
+        });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe(
+            'https://registered.example/callback?error=server_error&state=request-state',
+        );
+    });
+
+    it('does not include an authorization code in an error redirect', async () => {
+        const oauthService = createOAuthService();
+        oauthService.validateRedirectUri.mockResolvedValue(true);
+        oauthService.authorize.mockResolvedValue({
+            authorizationCode: 'authorization-code',
+        } as OAuth2Server.AuthorizationCode);
+        const redirectSpy = vi
+            .spyOn(express.response, 'redirect')
+            .mockImplementationOnce(() => {
+                throw new Error('redirect failed');
+            });
+
+        try {
+            const response = await requestAuthorize({
+                body: {
+                    approve: 'true',
+                    client_id: 'client-id',
+                    redirect_uri: 'https://registered.example/callback',
+                    state: 'request-state',
+                },
+                oauthService,
+            });
+
+            expect(response.status).toBe(302);
+            const location = new URL(response.headers.location ?? '');
+            expect(location.searchParams.get('error')).toBe('server_error');
+            expect(location.searchParams.has('code')).toBe(false);
+            expect(location.searchParams.get('state')).toBe('request-state');
+        } finally {
+            redirectSpy.mockRestore();
+        }
+    });
+
+    it('checks authentication before handling a denial', async () => {
+        const oauthService = createOAuthService();
+
+        const response = await requestAuthorize({
+            body: {
+                approve: 'false',
+                client_id: 'client-id',
+                redirect_uri: 'https://registered.example/callback',
+            },
+            oauthService,
+            user: null,
+        });
+
+        expect(response.status).toBe(401);
+        expect(oauthService.validateRedirectUri).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/routers/oauthRouter.ts
+++ b/packages/backend/src/routers/oauthRouter.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {
     generateOAuthAuthorizePage,
-    generateOAuthRedirectPage,
     getErrorMessage,
     OAuthIntrospectResponse,
     parseScopeString,
@@ -27,6 +26,36 @@ const oauthRouter: Router = express.Router({ mergeParams: true });
 function getOAuthService(req: express.Request): OAuthService {
     return req.services.getOauthService();
 }
+
+const getValidatedRedirectUrl = async (
+    req: express.Request,
+): Promise<URL | null> => {
+    const clientId = req.body.client_id;
+    const redirectUri = req.body.redirect_uri;
+    if (typeof clientId !== 'string' || typeof redirectUri !== 'string') {
+        return null;
+    }
+
+    const isRegistered = await getOAuthService(req).validateRedirectUri(
+        clientId,
+        redirectUri,
+    );
+    if (!isRegistered) {
+        return null;
+    }
+
+    try {
+        return new URL(redirectUri);
+    } catch {
+        return null;
+    }
+};
+
+const sendInvalidRedirectResponse = (res: express.Response) =>
+    res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'Invalid client_id or redirect_uri',
+    });
 
 // Get authorization - use OAuth2Server
 oauthRouter.get('/authorize', async (req, res, next) => {
@@ -105,34 +134,24 @@ oauthRouter.get('/authorize', async (req, res, next) => {
 });
 
 oauthRouter.post('/authorize', async (req, res) => {
-    if (req.body.approve === 'false') {
-        // Denied
-        res.set('Content-Type', 'text/html');
-        const redirectUri = req.body.redirect_uri;
-        if (!redirectUri) {
-            return res.status(400).json({
-                error: 'invalid_request',
-                error_description: 'Missing redirect_uri',
-            });
-        }
-        const url = new URL(redirectUri);
-        url.searchParams.set('error', 'access_denied');
-        if (req.body.state) {
-            url.searchParams.set('state', req.body.state);
-        }
-        return res.send(
-            generateOAuthRedirectPage({
-                redirectUrl: url.toString(),
-                message:
-                    'Access denied. Redirecting you back to your application...',
-            }),
-        );
-    }
     if (!req.user) {
         return res.status(401).send('Unauthorized');
     }
     if (!req.user.userId || !req.user.organizationUuid) {
         return res.status(400).send('Missing userUuid or organizationUuid');
+    }
+
+    const redirectUrl = await getValidatedRedirectUrl(req);
+    if (!redirectUrl) {
+        return sendInvalidRedirectResponse(res);
+    }
+
+    if (req.body.approve === 'false') {
+        redirectUrl.searchParams.set('error', 'access_denied');
+        if (req.body.state) {
+            redirectUrl.searchParams.set('state', req.body.state);
+        }
+        return res.redirect(302, redirectUrl.toString());
     }
 
     // Normalize scope parameter directly on the request object
@@ -155,40 +174,23 @@ oauthRouter.post('/authorize', async (req, res) => {
                 organizationUuid: req.user.organizationUuid,
             },
         );
-        const redirectUri = req.body.redirect_uri;
-        if (!redirectUri) {
-            return res.status(400).json({
-                error: 'invalid_request',
-                error_description: 'Missing redirect_uri',
-            });
-        }
-        const url = new URL(redirectUri);
-        url.searchParams.set('code', authorizationCode.authorizationCode);
+        redirectUrl.searchParams.set(
+            'code',
+            authorizationCode.authorizationCode,
+        );
         if (req.body.state) {
-            url.searchParams.set('state', req.body.state);
+            redirectUrl.searchParams.set('state', req.body.state);
         }
 
-        res.set('Content-Type', 'text/html');
-        return res.send(
-            generateOAuthRedirectPage({
-                redirectUrl: url.toString(),
-                message: 'Redirecting you back to your application...',
-            }),
-        );
+        return res.redirect(302, redirectUrl.toString());
     } catch (error) {
         Logger.error(`Authorization error: ${error}`);
-        const redirectUrl = new URL(req.body.redirect_uri);
-        redirectUrl.searchParams.set('error', 'server_error');
-        if (req.body.state)
-            redirectUrl.searchParams.set('state', req.body.state);
-        res.set('Content-Type', 'text/html');
-        return res.send(
-            generateOAuthRedirectPage({
-                redirectUrl: redirectUrl.toString(),
-                message:
-                    'An error occurred. Redirecting you back to your application...',
-            }),
-        );
+        const errorUrl = new URL(req.body.redirect_uri);
+        errorUrl.searchParams.set('error', 'server_error');
+        if (req.body.state) {
+            errorUrl.searchParams.set('state', req.body.state);
+        }
+        return res.redirect(302, errorUrl.toString());
     }
 });
 

--- a/packages/backend/src/services/OAuthService/OAuthService.test.ts
+++ b/packages/backend/src/services/OAuthService/OAuthService.test.ts
@@ -25,8 +25,10 @@ describe('OAuthService edge cases', () => {
         } as AnyType;
         mockOAuthModel = {
             getAccessToken: vi.fn(),
+            getClient: vi.fn(),
             revokeToken: vi.fn(),
             revokeRefreshToken: vi.fn(),
+            validateRedirectUri: vi.fn(),
         } as AnyType;
         mockLightdashConfig = {
             siteUrl: 'https://lightdash.com',
@@ -117,5 +119,43 @@ describe('OAuthService edge cases', () => {
                 organization_uuid: 'o',
             } as AnyType),
         ).rejects.toThrow('Invalid redirect_uri');
+    });
+
+    describe('validateRedirectUri', () => {
+        const client: OAuth2Server.Client = {
+            id: 'client-id',
+            redirectUris: ['https://example.com/callback'],
+            grants: ['authorization_code'],
+        };
+
+        it('returns false when the client cannot be resolved', async () => {
+            vi.mocked(mockOAuthModel.getClient).mockResolvedValue(false);
+
+            await expect(
+                oauthService.validateRedirectUri(
+                    'unknown-client',
+                    'https://example.com/callback',
+                ),
+            ).resolves.toBe(false);
+            expect(mockOAuthModel.validateRedirectUri).not.toHaveBeenCalled();
+        });
+
+        it('delegates redirect matching to the OAuth model', async () => {
+            vi.mocked(mockOAuthModel.getClient).mockResolvedValue(client);
+            vi.mocked(mockOAuthModel.validateRedirectUri).mockResolvedValue(
+                true,
+            );
+
+            await expect(
+                oauthService.validateRedirectUri(
+                    'client-id',
+                    'https://example.com/callback',
+                ),
+            ).resolves.toBe(true);
+            expect(mockOAuthModel.validateRedirectUri).toHaveBeenCalledWith(
+                'https://example.com/callback',
+                client,
+            );
+        });
     });
 });

--- a/packages/backend/src/services/OAuthService/OAuthService.ts
+++ b/packages/backend/src/services/OAuthService/OAuthService.ts
@@ -80,6 +80,17 @@ export class OAuthService extends BaseService {
         });
     }
 
+    public async validateRedirectUri(
+        clientId: string,
+        redirectUri: string,
+    ): Promise<boolean> {
+        const client = await this.oauthModel.getClient(clientId);
+        return (
+            client !== false &&
+            this.oauthModel.validateRedirectUri(redirectUri, client)
+        );
+    }
+
     public async token(
         request: OAuth2Server.Request,
         response: OAuth2Server.Response,

--- a/packages/common/src/utils/oauth.ts
+++ b/packages/common/src/utils/oauth.ts
@@ -375,59 +375,9 @@ const OAUTH_ICONS = {
         '<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/><path d="M12 6v6l4 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>',
 } as const;
 
-// OAuth redirect page template
-const OAUTH_REDIRECT_TEMPLATE = `
-<html>
-    <head>
-        <title>Redirecting...</title>
-        <style>
-            {{{styles}}}
-            .spinner {
-                width: 32px;
-                height: 32px;
-                margin: 0 auto 16px auto;
-                border: 3px solid #e9ecef;
-                border-top: 3px solid #111418;
-                border-radius: 50%;
-                animation: spin 1s linear infinite;
-            }
-            @keyframes spin {
-                0% { transform: rotate(0deg); }
-                100% { transform: rotate(360deg); }
-            }
-            .redirect-link {
-                color: #111418;
-                text-decoration: none;
-                font-weight: 500;
-            }
-            .redirect-link:hover {
-                text-decoration: underline;
-            }
-        </style>
-        <script>
-            setTimeout(function() {
-                window.location.href = "{{{redirectUrl}}}";
-            }, 2000);
-        </script>
-    </head>
-    <body>
-        <div class="stack">
-            <div class="container">
-                {{{logo}}}
-                <div class="spinner"></div>
-                <h1>Redirecting...</h1>
-                <p>{{message}}</p>
-                <p>If you are not redirected automatically, <a href="{{{redirectUrl}}}" class="redirect-link">click here</a>.</p>
-            </div>
-        </div>
-    </body>
-</html>
-`;
-
 // Compile the templates once with proper type safety
 const compiledResponseTemplate = compile(OAUTH_RESPONSE_TEMPLATE);
 const compiledAuthorizeTemplate = compile(OAUTH_AUTHORIZE_TEMPLATE);
-const compiledRedirectTemplate = compile(OAUTH_REDIRECT_TEMPLATE);
 
 export type OAuthResponseStatus = 'success' | 'error';
 export type OAuthIconType = keyof typeof OAUTH_ICONS;
@@ -460,11 +410,6 @@ export interface OAuthAuthorizeParams {
     /** Where "Switch account" sends the user after logging out */
     loginUrl: string;
     hiddenInputs: OAuthHiddenInput[];
-}
-
-export interface OAuthRedirectParams {
-    redirectUrl: string;
-    message: string;
 }
 
 // Scope descriptions mapping
@@ -581,17 +526,4 @@ export const generateOAuthAuthorizePage = (
             ...params.user,
             initials: getUserInitials(params.user),
         },
-    });
-
-/**
- * Generates an OAuth redirect page HTML using JavaScript redirect
- * This prevents CSP errors by using JavaScript-based redirection instead of HTTP redirects
- */
-export const generateOAuthRedirectPage = (
-    params: OAuthRedirectParams,
-): string =>
-    compiledRedirectTemplate({
-        styles: oauthPageStyles,
-        logo: LIGHTDASH_LOGO_SVG,
-        ...params,
     });


### PR DESCRIPTION
## Summary

- Require an authenticated user before OAuth authorization decisions.
- Validate the redirect URI for the resolved client before every authorization response.
- Send validated callbacks with HTTP 302 responses and remove the unused redirect page.

## Verification

- Backend and common typechecks
- OAuth router and service tests
- Touched-path lint for backend and common

Linear: SPK-1201