### PR TITLE
fix: enforce per-organisation SSO policy on password and OTP login

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -11,10 +11,12 @@ import {
     getUserAbilityBuilder,
     InviteLinkPurpose,
     LightdashUser,
+    LocalIssuerTypes,
     NotFoundError,
     OpenIdIdentityIssuerType,
     OrganizationMemberProfile,
     OrganizationMemberRole,
+    OrganizationSsoProvider,
     ParameterError,
     PasswordResetLink,
     PossibleAbilities,
@@ -179,8 +181,12 @@ const projectModel = {
 };
 
 const organizationSsoModel = {
-    findEnabledMethodsForEmailDomain: vi.fn(async () => []),
-    findGoogleMethodsForEmailDomain: vi.fn(async () => []),
+    findEnabledMethodsForEmailDomain: vi.fn<
+        OrganizationSsoModel['findEnabledMethodsForEmailDomain']
+    >(async () => []),
+    findGoogleMethodsForEmailDomain: vi.fn<
+        OrganizationSsoModel['findGoogleMethodsForEmailDomain']
+    >(async () => []),
 };
 
 const organizationSettingsModel = {
@@ -2664,6 +2670,275 @@ describe('UserService', () => {
         });
     });
 
+    describe('per-organization password policy enforcement', () => {
+        type MatchingMethod = Awaited<
+            ReturnType<OrganizationSsoModel['findEnabledMethodsForEmailDomain']>
+        >[number];
+        type UserOrganization = Awaited<
+            ReturnType<UserModel['getOrganizationsForUser']>
+        >[number];
+
+        const createMatchingMethod = (
+            organizationUuid: string,
+            allowPassword: boolean,
+        ): MatchingMethod => ({
+            organizationUuid,
+            provider: OrganizationSsoProvider.AZUREAD,
+            config: {
+                oauth2ClientId: 'client-id',
+                oauth2ClientSecret: 'client-secret',
+                oauth2TenantId: 'tenant-id',
+            },
+            enabled: true,
+            overrideEmailDomains: false,
+            emailDomains: [],
+            allowPassword,
+        });
+        const createUserOrganization = (
+            organizationUuid: string,
+        ): UserOrganization => ({
+            organizationUuid,
+            organizationName: organizationUuid,
+            organizationCreatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        });
+
+        test('refuses email and email OTP when every matching member organization requires SSO', async () => {
+            const method = createMatchingMethod('organization-1', false);
+            const organization = createUserOrganization('organization-1');
+            vi.mocked(organizationSsoModel.findEnabledMethodsForEmailDomain)
+                .mockResolvedValueOnce([method])
+                .mockResolvedValueOnce([method]);
+            vi.mocked(userModel.findUserByEmail)
+                .mockResolvedValueOnce(sessionUser)
+                .mockResolvedValueOnce(sessionUser);
+            vi.mocked(userModel.getOrganizationsForUser)
+                .mockResolvedValueOnce([organization])
+                .mockResolvedValueOnce([organization]);
+
+            await expect(
+                userService.isLoginMethodAllowed(
+                    'user@example.com',
+                    LocalIssuerTypes.EMAIL,
+                ),
+            ).resolves.toBe(false);
+            await expect(
+                userService.isLoginMethodAllowed(
+                    'user@example.com',
+                    LocalIssuerTypes.EMAIL_OTP,
+                ),
+            ).resolves.toBe(false);
+        });
+
+        test('surfaces the organization SSO message from password login', async () => {
+            const method = createMatchingMethod('organization-1', false);
+            vi.mocked(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).mockResolvedValueOnce([method]);
+            vi.mocked(userModel.findUserByEmail).mockResolvedValueOnce(
+                sessionUser,
+            );
+            vi.mocked(userModel.getOrganizationsForUser).mockResolvedValueOnce([
+                createUserOrganization('organization-1'),
+            ]);
+
+            await expect(
+                userService.loginWithPassword('user@example.com', 'password'),
+            ).rejects.toThrow(
+                new ForbiddenError('Your organisation requires SSO sign-in'),
+            );
+        });
+
+        test('surfaces the organization SSO message from email OTP login using one policy result', async () => {
+            const method = createMatchingMethod('organization-1', false);
+            vi.mocked(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).mockResolvedValueOnce([method]);
+            vi.mocked(userModel.findUserByEmail)
+                .mockResolvedValueOnce(sessionUser)
+                .mockResolvedValueOnce(sessionUser);
+            vi.mocked(userModel.getOrganizationsForUser).mockResolvedValueOnce([
+                createUserOrganization('organization-1'),
+            ]);
+
+            await expect(
+                userService.loginWithEmailOtp('user@example.com', '123456'),
+            ).rejects.toThrow(
+                new ForbiddenError('Your organisation requires SSO sign-in'),
+            );
+            expect(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).toHaveBeenCalledTimes(1);
+        });
+
+        test('surfaces the organization SSO message from password recovery', async () => {
+            const method = createMatchingMethod('organization-1', false);
+            vi.mocked(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).mockResolvedValueOnce([method]);
+            vi.mocked(userModel.findUserByEmail)
+                .mockResolvedValueOnce(sessionUser)
+                .mockResolvedValueOnce(sessionUser);
+            vi.mocked(userModel.getOrganizationsForUser).mockResolvedValueOnce([
+                createUserOrganization('organization-1'),
+            ]);
+
+            await expect(
+                userService.recoverPassword({ email: 'user@example.com' }),
+            ).rejects.toThrow(
+                new ForbiddenError('Your organisation requires SSO sign-in'),
+            );
+        });
+
+        test('keeps password recovery as a no-op when no account exists', async () => {
+            vi.mocked(userModel.findUserByEmail).mockResolvedValueOnce(
+                undefined,
+            );
+
+            await expect(
+                userService.recoverPassword({ email: 'new@example.com' }),
+            ).resolves.toBeUndefined();
+            expect(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('allows email and email OTP when the matching method allows password', async () => {
+            const method = createMatchingMethod('organization-1', true);
+            const organization = createUserOrganization('organization-1');
+            vi.mocked(organizationSsoModel.findEnabledMethodsForEmailDomain)
+                .mockResolvedValueOnce([method])
+                .mockResolvedValueOnce([method]);
+            vi.mocked(userModel.findUserByEmail)
+                .mockResolvedValueOnce(sessionUser)
+                .mockResolvedValueOnce(sessionUser);
+            vi.mocked(userModel.getOrganizationsForUser)
+                .mockResolvedValueOnce([organization])
+                .mockResolvedValueOnce([organization]);
+
+            await expect(
+                userService.isLoginMethodAllowed(
+                    'user@example.com',
+                    LocalIssuerTypes.EMAIL,
+                ),
+            ).resolves.toBe(true);
+            await expect(
+                userService.isLoginMethodAllowed(
+                    'user@example.com',
+                    LocalIssuerTypes.EMAIL_OTP,
+                ),
+            ).resolves.toBe(true);
+        });
+
+        test('allows password when one of two matching member organizations allows it', async () => {
+            const firstOrganization = createUserOrganization('organization-1');
+            const secondOrganization = createUserOrganization('organization-2');
+            vi.mocked(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).mockResolvedValueOnce([
+                createMatchingMethod('organization-1', false),
+                createMatchingMethod('organization-2', true),
+            ]);
+            vi.mocked(userModel.findUserByEmail).mockResolvedValueOnce(
+                sessionUser,
+            );
+            vi.mocked(userModel.getOrganizationsForUser).mockResolvedValueOnce([
+                firstOrganization,
+                secondOrganization,
+            ]);
+
+            await expect(
+                userService.isLoginMethodAllowed(
+                    'user@example.com',
+                    LocalIssuerTypes.EMAIL,
+                ),
+            ).resolves.toBe(true);
+        });
+
+        test('allows email when an SSO-only domain match belongs to another organization', async () => {
+            vi.mocked(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).mockResolvedValueOnce([
+                createMatchingMethod('other-organization', false),
+            ]);
+            vi.mocked(userModel.findUserByEmail).mockResolvedValueOnce(
+                sessionUser,
+            );
+            vi.mocked(userModel.getOrganizationsForUser).mockResolvedValueOnce([
+                createUserOrganization('member-organization'),
+            ]);
+
+            await expect(
+                userService.isLoginMethodAllowed(
+                    'user@example.com',
+                    LocalIssuerTypes.EMAIL,
+                ),
+            ).resolves.toBe(true);
+        });
+
+        test('keeps matching SSO signup available for a brand-new user', async () => {
+            vi.mocked(
+                organizationSsoModel.findEnabledMethodsForEmailDomain,
+            ).mockResolvedValueOnce([
+                createMatchingMethod('organization-1', false),
+            ]);
+            vi.mocked(userModel.findUserByEmail).mockResolvedValueOnce(
+                undefined,
+            );
+            vi.mocked(userModel.hasPasswordByEmail).mockResolvedValueOnce(
+                false,
+            );
+            const service = createUserService({
+                ...lightdashConfigMock,
+                auth: {
+                    ...lightdashConfigMock.auth,
+                    azuread: {
+                        ...lightdashConfigMock.auth.azuread,
+                        loginPath: '/login/azuread',
+                    },
+                },
+            });
+
+            await expect(
+                service.getLoginOptions('new@example.com'),
+            ).resolves.toEqual({
+                forceRedirect: true,
+                redirectUri:
+                    'https://test.lightdash.cloud/api/v1/login/azuread?login_hint=new%40example.com',
+                showOptions: [OpenIdIdentityIssuerType.AZUREAD],
+            });
+        });
+
+        test('keeps instance-level password disablement enforced with its generic message', async () => {
+            const service = createUserService({
+                ...lightdashConfigMock,
+                auth: {
+                    ...lightdashConfigMock.auth,
+                    disablePasswordAuthentication: true,
+                },
+            });
+
+            await expect(
+                service.loginWithPassword('user@example.com', 'password'),
+            ).rejects.toThrow(
+                new ForbiddenError('Password credentials are not allowed'),
+            );
+            vi.mocked(userModel.findUserByEmail).mockResolvedValueOnce(
+                sessionUser,
+            );
+            await expect(
+                service.recoverPassword({ email: 'user@example.com' }),
+            ).rejects.toThrow(
+                new ForbiddenError('Password credentials are not allowed'),
+            );
+            await expect(
+                service.isLoginMethodAllowed(
+                    'user@example.com',
+                    LocalIssuerTypes.EMAIL_OTP,
+                ),
+            ).resolves.toBe(false);
+        });
+    });
+
     describe('isLoginMethodAllowed Google per-org opt-out', () => {
         test('allows Google when the domain has no per-org policy', async () => {
             (
@@ -3150,11 +3425,8 @@ describe('UserService', () => {
                 personalAccessTokenModel: {} as PersonalAccessTokenModel,
                 organizationAllowedEmailDomainsModel:
                     {} as OrganizationAllowedEmailDomainsModel,
-                organizationSsoModel: {
-                    findOrganizationUuidByProviderAndEmailDomain: vi.fn(
-                        async () => undefined,
-                    ),
-                } as unknown as OrganizationSsoModel,
+                organizationSsoModel:
+                    organizationSsoModel as unknown as OrganizationSsoModel,
                 organizationSettingsModel: {
                     get: vi.fn(async () => ({
                         oidcLinkingEnabled: null,
@@ -3231,11 +3503,8 @@ describe('UserService', () => {
                 personalAccessTokenModel: {} as PersonalAccessTokenModel,
                 organizationAllowedEmailDomainsModel:
                     {} as OrganizationAllowedEmailDomainsModel,
-                organizationSsoModel: {
-                    findOrganizationUuidByProviderAndEmailDomain: vi.fn(
-                        async () => undefined,
-                    ),
-                } as unknown as OrganizationSsoModel,
+                organizationSsoModel:
+                    organizationSsoModel as unknown as OrganizationSsoModel,
                 organizationSettingsModel: {
                     get: vi.fn(async () => ({
                         oidcLinkingEnabled: null,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -136,6 +136,8 @@ import { getOrganizationSettingsInstanceDefaults } from './OrganizationSettingsS
 const AWS_SSO_DEVICE_GRANT_TYPE =
     'urn:ietf:params:oauth:grant-type:device_code';
 const MAX_INVITE_LINK_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+const ORGANIZATION_SSO_REQUIRED_MESSAGE =
+    'Your organisation requires SSO sign-in';
 
 type RedshiftAwsSsoSession = {
     clientId: string;
@@ -1607,24 +1609,16 @@ export class UserService extends BaseService {
                 context,
             });
 
-        if (
-            (await this.isLoginMethodAllowed(email, LocalIssuerTypes.EMAIL)) ===
-            false
-        ) {
-            emitFailure(
-                `User with email ${email} is not allowed to login with password`,
-            );
-            throw new ForbiddenError(
-                `User with email ${email} is not allowed to login with password`,
-            );
+        if (!(await this.isLoginMethodAllowed(email, LocalIssuerTypes.EMAIL))) {
+            const reason = this.lightdashConfig.auth
+                .disablePasswordAuthentication
+                ? 'Password credentials are not allowed'
+                : ORGANIZATION_SSO_REQUIRED_MESSAGE;
+            emitFailure(reason);
+            throw new ForbiddenError(reason);
         }
 
         try {
-            if (this.lightdashConfig.auth.disablePasswordAuthentication) {
-                throw new ForbiddenError(
-                    'Password credentials are not allowed',
-                );
-            }
             // TODO: move to authorization service layer
             // TODO we should probably remove the organization from the model
             const user = await this.userModel.getUserByPrimaryEmailAndPassword(
@@ -2011,6 +2005,18 @@ export class UserService extends BaseService {
     async recoverPassword(data: CreatePasswordResetLink): Promise<void> {
         const user = await this.userModel.findUserByEmail(data.email);
         if (user) {
+            if (
+                !(await this.isLoginMethodAllowed(
+                    data.email,
+                    LocalIssuerTypes.EMAIL,
+                ))
+            ) {
+                throw new ForbiddenError(
+                    this.lightdashConfig.auth.disablePasswordAuthentication
+                        ? 'Password credentials are not allowed'
+                        : ORGANIZATION_SSO_REQUIRED_MESSAGE,
+                );
+            }
             const code = nanoid(30);
             const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // expires in 1 day
             const link = await this.passwordResetLinkModel.create(
@@ -2270,15 +2276,12 @@ export class UserService extends BaseService {
 
     private async isStrictlyPasswordlessUser(
         user: LightdashUser,
-        email: string,
     ): Promise<boolean> {
-        const [hasPassword, hasOpenIdIdentity, isEmailLoginAllowed] =
-            await Promise.all([
-                this.userModel.hasPassword(user.userUuid),
-                this.userModel.hasOpenIdIdentity(user.userUuid),
-                this.isLoginMethodAllowed(email, LocalIssuerTypes.EMAIL_OTP),
-            ]);
-        return !hasPassword && !hasOpenIdIdentity && isEmailLoginAllowed;
+        const [hasPassword, hasOpenIdIdentity] = await Promise.all([
+            this.userModel.hasPassword(user.userUuid),
+            this.userModel.hasOpenIdIdentity(user.userUuid),
+        ]);
+        return !hasPassword && !hasOpenIdIdentity;
     }
 
     // OTP login is deliberately NOT gated on the NewOnboarding flag: accounts
@@ -2287,11 +2290,18 @@ export class UserService extends BaseService {
     async requestEmailOtpLogin(email: string): Promise<void> {
         const normalizedEmail = email.toLowerCase();
         const user = await this.userModel.findUserByEmail(normalizedEmail);
-        if (
-            !user ||
-            !user.isActive ||
-            !(await this.isStrictlyPasswordlessUser(user, normalizedEmail))
-        ) {
+        if (!user || !user.isActive) {
+            return;
+        }
+        const [isStrictlyPasswordlessUser, isEmailLoginAllowed] =
+            await Promise.all([
+                this.isStrictlyPasswordlessUser(user),
+                this.isLoginMethodAllowed(
+                    normalizedEmail,
+                    LocalIssuerTypes.EMAIL_OTP,
+                ),
+            ]);
+        if (!isStrictlyPasswordlessUser || !isEmailLoginAllowed) {
             return;
         }
         const emailStatus = await this.emailModel.getPrimaryEmailStatus(
@@ -2327,10 +2337,22 @@ export class UserService extends BaseService {
         };
 
         const user = await this.userModel.findUserByEmail(normalizedEmail);
+        if (!user || !user.isActive) {
+            throw invalidCode();
+        }
+        const isEmailLoginAllowed = await this.isLoginMethodAllowed(
+            normalizedEmail,
+            LocalIssuerTypes.EMAIL_OTP,
+        );
         if (
-            !user ||
-            !user.isActive ||
-            !(await this.isStrictlyPasswordlessUser(user, normalizedEmail))
+            !isEmailLoginAllowed &&
+            !this.lightdashConfig.auth.disablePasswordAuthentication
+        ) {
+            throw new ForbiddenError(ORGANIZATION_SSO_REQUIRED_MESSAGE);
+        }
+        if (
+            !isEmailLoginAllowed ||
+            !(await this.isStrictlyPasswordlessUser(user))
         ) {
             throw invalidCode();
         }
@@ -3175,11 +3197,53 @@ export class UserService extends BaseService {
             .some((m) => !m.enabled);
     }
 
+    private async getEnabledOrganizationSsoMethodsForEmail(email: string) {
+        const domain = email.split('@')[1]?.toLowerCase();
+        const allMatchingMethods = domain
+            ? await this.organizationSsoModel.findEnabledMethodsForEmailDomain(
+                  domain,
+              )
+            : [];
+        const existingUser = await this.userModel.findUserByEmail(email);
+        if (!existingUser) {
+            return {
+                existingUser,
+                matchingMethods: allMatchingMethods,
+                userOrganizationUuids: undefined,
+            };
+        }
+
+        const userOrganizations = await this.userModel.getOrganizationsForUser(
+            existingUser.userUuid,
+        );
+        const userOrganizationUuids = new Set(
+            userOrganizations.map(
+                (organization) => organization.organizationUuid,
+            ),
+        );
+        return {
+            existingUser,
+            matchingMethods: allMatchingMethods.filter((method) =>
+                userOrganizationUuids.has(method.organizationUuid),
+            ),
+            userOrganizationUuids,
+        };
+    }
+
     async isLoginMethodAllowed(email: string, loginMethod: LoginOptionTypes) {
         switch (loginMethod) {
             case LocalIssuerTypes.EMAIL:
-            case LocalIssuerTypes.EMAIL_OTP:
-                return !this.lightdashConfig.auth.disablePasswordAuthentication;
+            case LocalIssuerTypes.EMAIL_OTP: {
+                if (this.lightdashConfig.auth.disablePasswordAuthentication) {
+                    return false;
+                }
+                const { matchingMethods } =
+                    await this.getEnabledOrganizationSsoMethodsForEmail(email);
+                return (
+                    matchingMethods.length === 0 ||
+                    matchingMethods.some((method) => method.allowPassword)
+                );
+            }
             case OpenIdIdentityIssuerType.GOOGLE:
                 // Enabled by default, but an org can disable Google sign-in
                 // for its domains via a per-org policy.
@@ -3745,11 +3809,11 @@ export class UserService extends BaseService {
         // matches the email's domain. When any per-org method matches, it
         // takes precedence over instance-level SSO providers for this user.
         const domain = email.split('@')[1]?.toLowerCase();
-        const allMatchingMethods = domain
-            ? await this.organizationSsoModel.findEnabledMethodsForEmailDomain(
-                  domain,
-              )
-            : [];
+        const {
+            existingUser,
+            matchingMethods: matchingPerOrgMethods,
+            userOrganizationUuids,
+        } = await this.getEnabledOrganizationSsoMethodsForEmail(email);
         // Per-org Google policy rows for the domain (includes disabled rows —
         // a `google` row exists precisely to record an opt-out, which the
         // enabled-only discovery above would never surface).
@@ -3765,21 +3829,10 @@ export class UserService extends BaseService {
         // users to their own Azure tenant by claiming the domain. Brand-new
         // users (no account yet) still see all matching methods — the
         // upstream feature flag + ops vetting is the gate for that case.
-        const existingUser = await this.userModel.findUserByEmail(email);
-        let matchingPerOrgMethods = allMatchingMethods;
         let matchingGoogleMethods = allGoogleMethods;
-        if (existingUser) {
-            const userOrgs = await this.userModel.getOrganizationsForUser(
-                existingUser.userUuid,
-            );
-            const userOrgUuids = new Set(
-                userOrgs.map((o) => o.organizationUuid),
-            );
-            matchingPerOrgMethods = allMatchingMethods.filter((m) =>
-                userOrgUuids.has(m.organizationUuid),
-            );
+        if (userOrganizationUuids) {
             matchingGoogleMethods = allGoogleMethods.filter((m) =>
-                userOrgUuids.has(m.organizationUuid),
+                userOrganizationUuids.has(m.organizationUuid),
             );
         }
 


### PR DESCRIPTION
## Summary

- enforce per-organisation SSO settings for password and email OTP login
- apply the same rule before creating password recovery links
- share organisation membership filtering with login option discovery

## Tests

- `pnpm -F common typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F backend exec vitest run src/services/UserService.test.ts`
- `pnpm --filter backend run linter src/services/UserService.ts src/services/UserService.test.ts`

Linear: SPK-1202