### PR TITLE
feat(external-sources): upload flow and sidebar section in the Explorer

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -177,6 +177,10 @@ import {
     type ExploreError,
     type SummaryExplore,
 } from './explore';
+import {
+    type ExternalSource,
+    type StagedExternalSourceUpload,
+} from './externalSources';
 import { type ApiFavoriteItems, type ApiToggleFavorite } from './favorites';
 import {
     type DimensionType,
@@ -1475,7 +1479,10 @@ type ApiResults =
     | ExternalConnectionSample[]
     | AppExternalConnectionLink
     | AppExternalConnectionLink[]
-    | ExternalFetchResponse;
+    | ExternalFetchResponse
+    | ExternalSource
+    | ExternalSource[]
+    | StagedExternalSourceUpload;
 // Note: EE API types removed from ApiResults to avoid circular imports
 // They can still be used with ApiResponse<T> by importing from '@lightdash/common'
 

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -1,20 +1,27 @@
 import { subject } from '@casl/ability';
-import { ExploreType, type SummaryExplore } from '@lightdash/common';
-import { TextInput, Stack, ActionIcon } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import {
+    ExploreType,
+    FeatureFlags,
+    type SummaryExplore,
+} from '@lightdash/common';
+import { TextInput, Stack, ActionIcon, Button, Group } from '@mantine/core';
+import { useDebouncedValue, useDisclosure } from '@mantine/hooks';
 import {
     IconAlertCircle,
     IconAlertTriangle,
+    IconPlus,
     IconSearch,
     IconX,
 } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useCallback, useMemo, useState, useTransition } from 'react';
 import { useLocation, useNavigate } from 'react-router';
+import { AddDataModal } from '../../../features/externalSources/components/AddDataModal';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useExplores } from '../../../hooks/useExplores';
 import { useProjectTableGroups } from '../../../hooks/useProjectTableGroups';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../../providers/Ability';
 import MantineIcon from '../../common/MantineIcon';
 import PageBreadcrumbs from '../../common/PageBreadcrumbs';
@@ -48,6 +55,20 @@ const BasePanel = ({ onExploreClick }: Props) => {
     const exploresResult = useExplores(projectUuid, true, true);
     const tableGroupsResult = useProjectTableGroups(projectUuid);
     const { data: org } = useOrganization();
+    const { data: externalSourcesFlag } = useServerFeatureFlag(
+        FeatureFlags.ExternalSources,
+    );
+    const [
+        isAddDataModalOpen,
+        { open: openAddDataModal, close: closeAddDataModal },
+    ] = useDisclosure(false);
+    // The modal navigates into the created table; inside embeds and the merge
+    // picker (onExploreClick overridden) that navigation would break the
+    // host flow, so the affordance is hidden there.
+    const canShowAddData =
+        externalSourcesFlag?.enabled === true &&
+        !onExploreClick &&
+        !!projectUuid;
 
     const filteredExplores = useMemo(() => {
         const validSearch = debouncedSearch
@@ -92,10 +113,12 @@ const BasePanel = ({ onExploreClick }: Props) => {
         defaultUngroupedExplores,
         customUngroupedExplores,
         sortedPreAggregateExplores,
+        sortedExternalSourceExplores,
     ] = useMemo(() => {
         if (!filteredExplores) {
             return [
                 [],
+                [] as SummaryExplore[],
                 [] as SummaryExplore[],
                 [] as SummaryExplore[],
                 [] as SummaryExplore[],
@@ -105,10 +128,13 @@ const BasePanel = ({ onExploreClick }: Props) => {
         const defaultExplores: SummaryExplore[] = [];
         const customExplores: SummaryExplore[] = [];
         const preAggregateExplores: SummaryExplore[] = [];
+        const externalSourceExplores: SummaryExplore[] = [];
 
         for (const explore of filteredExplores) {
             if (explore.type === ExploreType.PRE_AGGREGATE) {
                 preAggregateExplores.push(explore);
+            } else if (explore.type === ExploreType.EXTERNAL_SOURCE) {
+                externalSourceExplores.push(explore);
             } else if (exploreHasGroups(explore)) {
                 groupedExplores.push(explore);
             } else if (explore.type === ExploreType.VIRTUAL) {
@@ -124,13 +150,20 @@ const BasePanel = ({ onExploreClick }: Props) => {
 
         defaultExplores.sort((a, b) => a.label.localeCompare(b.label));
         customExplores.sort((a, b) => a.label.localeCompare(b.label));
+        externalSourceExplores.sort((a, b) => a.label.localeCompare(b.label));
         preAggregateExplores.sort((a, b) =>
             (getPreAggregateName(a) ?? '').localeCompare(
                 getPreAggregateName(b) ?? '',
             ),
         );
 
-        return [tree, defaultExplores, customExplores, preAggregateExplores];
+        return [
+            tree,
+            defaultExplores,
+            customExplores,
+            preAggregateExplores,
+            externalSourceExplores,
+        ];
     }, [filteredExplores, tableGroupDetails]);
 
     const handleExploreClick = useCallback(
@@ -180,10 +213,36 @@ const BasePanel = ({ onExploreClick }: Props) => {
                                 projectUuid,
                             })}
                         >
-                            <PageBreadcrumbs
-                                size="md"
-                                items={[{ title: 'Tables', active: true }]}
-                            />
+                            <Group justify="space-between" wrap="nowrap">
+                                <PageBreadcrumbs
+                                    size="md"
+                                    items={[{ title: 'Tables', active: true }]}
+                                />
+                                {canShowAddData && (
+                                    <Can
+                                        I="manage"
+                                        this={subject('ExternalSource', {
+                                            organizationUuid:
+                                                org?.organizationUuid,
+                                            projectUuid,
+                                        })}
+                                    >
+                                        <Button
+                                            variant="default"
+                                            size="compact-xs"
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconPlus}
+                                                    size="sm"
+                                                />
+                                            }
+                                            onClick={openAddDataModal}
+                                        >
+                                            Add data
+                                        </Button>
+                                    </Can>
+                                )}
+                            </Group>
                         </Can>
 
                         <TextInput
@@ -215,11 +274,21 @@ const BasePanel = ({ onExploreClick }: Props) => {
                             defaultUngroupedExplores={defaultUngroupedExplores}
                             customUngroupedExplores={customUngroupedExplores}
                             preAggregateExplores={sortedPreAggregateExplores}
+                            externalSourceExplores={
+                                sortedExternalSourceExplores
+                            }
                             searchQuery={debouncedSearch}
                             onExploreClick={handleExploreClick}
                         />
                     </Stack>
                 </ItemDetailProvider>
+                {canShowAddData && projectUuid && (
+                    <AddDataModal
+                        projectUuid={projectUuid}
+                        opened={isAddDataModalOpen}
+                        onClose={closeAddDataModal}
+                    />
+                )}
             </>
         );
     }

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -14,12 +14,9 @@ import {
     Stack,
 } from '@mantine/core';
 import { useToggle } from '@mantine/hooks';
-import {
-    IconAlertTriangle,
-    IconInfoCircle,
-    IconTable,
-} from '@tabler/icons-react';
+import { IconAlertTriangle, IconInfoCircle } from '@tabler/icons-react';
 import React from 'react';
+import { getExploreIcon } from '../../../features/externalSources/utils/exploreIcons';
 import MantineIcon from '../../common/MantineIcon';
 import { TableItemDetailPreview } from '../ExploreTree/TableTree/ItemDetailPreview';
 import WarningsHoverCardContent from '../WarningsHoverCardContent';
@@ -103,7 +100,7 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
                     withBorder={false}
                 >
                     <MantineIcon
-                        icon={IconTable}
+                        icon={getExploreIcon(explore)}
                         size="md"
                         color="ldGray.7"
                         stroke={1.5}

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/VirtualizedExploreList.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/VirtualizedExploreList.tsx
@@ -40,6 +40,7 @@ interface VirtualizedExploreListProps {
     defaultUngroupedExplores: SummaryExplore[];
     customUngroupedExplores: SummaryExplore[];
     preAggregateExplores: SummaryExplore[];
+    externalSourceExplores: SummaryExplore[];
     searchQuery: string;
     onExploreClick: (explore: SummaryExplore) => void;
 }
@@ -68,6 +69,7 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
     defaultUngroupedExplores,
     customUngroupedExplores,
     preAggregateExplores,
+    externalSourceExplores,
     searchQuery,
     onExploreClick,
 }) => {
@@ -159,6 +161,30 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
             });
         }
 
+        if (externalSourceExplores.length > 0) {
+            // Auto-expand while searching so matches inside the section are
+            // visible without a manual toggle.
+            const isExternalSourcesExpanded =
+                expandedSections.has('External sources') || !!searchQuery;
+            items.push({ type: 'divider', id: `divider-${itemId++}` });
+            items.push({
+                type: 'section-header',
+                id: `section-${itemId++}`,
+                label: 'External sources',
+                isExpanded: isExternalSourcesExpanded,
+            });
+            if (isExternalSourcesExpanded) {
+                for (const explore of externalSourceExplores) {
+                    items.push({
+                        type: 'explore',
+                        id: `external-source-${itemId++}`,
+                        explore,
+                        depth: 0,
+                    });
+                }
+            }
+        }
+
         if (customUngroupedExplores.length > 0) {
             const isVirtualViewsExpanded =
                 expandedSections.has('Virtual Views');
@@ -209,6 +235,7 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
         defaultUngroupedExplores,
         customUngroupedExplores,
         preAggregateExplores,
+        externalSourceExplores,
         expandedGroupPaths,
         expandedSections,
         searchQuery,

--- a/packages/frontend/src/features/externalSources/assets/google-sheets.svg
+++ b/packages/frontend/src/features/externalSources/assets/google-sheets.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" fill="none" viewBox="0 0 192 192">
+  <path fill="#009954" d="M183.96 117.4c0 8.94 0 13.41-1.4 16.96a20 20 0 0 1-11.23 11.24c-3.55 1.4-8.02 1.4-16.97 1.4h-60.8c-8.94 0-13.41 0-16.96-1.4a20 20 0 0 1-11.23-11.24c-1.4-3.55-1.4-8.02-1.4-16.96V74.6c0-8.94 0-13.42 1.4-16.96A20 20 0 0 1 76.6 46.4C80.15 45 84.62 45 93.56 45h60.8c8.95 0 13.42 0 16.97 1.4a20 20 0 0 1 11.23 11.24c1.4 3.54 1.4 8.02 1.4 16.96z"/>
+  <mask id="a" width="161" height="128" x="7" y="32" maskUnits="userSpaceOnUse" style="mask-type:alpha">
+    <path fill="#0ebc5f" d="M167.96 130.4c0 8.94 0 13.41-1.4 16.96a20 20 0 0 1-11.23 11.24c-3.55 1.4-8.02 1.4-16.97 1.4H37.56c-8.94 0-13.41 0-16.96-1.4a20 20 0 0 1-11.23-11.24c-1.4-3.55-1.4-8.02-1.4-16.96V61.6c0-8.94 0-13.42 1.4-16.96A20 20 0 0 1 20.6 33.4C24.15 32 28.62 32h100.8c8.95 0 13.42 0 16.97 1.4a20 20 0 0 1 11.23 11.24c1.4 3.54 1.4 8.02 1.4 16.96z"/>
+  </mask>
+  <g mask="url(#a)">
+    <path fill="#0ebc5f" d="M167.96 160h-160V32h160z"/>
+    <g filter="url(#b)">
+      <path fill="url(#c)" d="M183.96 65a20 20 0 0 0-20-20h-104a20 20 0 0 0-20 20v62a20 20 0 0 0 20 20h104a20 20 0 0 0 20-20z"/>
+    </g>
+  </g>
+  <path fill="#fff" d="M47.96 122a6 6 0 0 1-6-6V77h-14a6 6 0 0 1 0-12h14V52a6 6 0 0 1 12 0v13h58a6 6 0 1 1 0 12h-58v39a6 6 0 0 1-6 6"/>
+  <defs>
+    <linearGradient id="c" x1="61.73" x2="163.21" y1="88.31" y2="88.31" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0ebc5f"/>
+      <stop offset=".95" stop-color="#78c9ff"/>
+    </linearGradient>
+    <filter id="b" width="168" height="126" x="27.96" y="33" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feGaussianBlur result="effect1_foregroundBlur_2015_872" stdDeviation="6"/>
+    </filter>
+  </defs>
+</svg>

--- a/packages/frontend/src/features/externalSources/components/AddDataModal.tsx
+++ b/packages/frontend/src/features/externalSources/components/AddDataModal.tsx
@@ -1,0 +1,275 @@
+import {
+    ExternalSourceStatus,
+    snakeCaseName,
+    type StagedExternalSourceUpload,
+} from '@lightdash/common';
+import {
+    Badge,
+    Button,
+    Group,
+    Loader,
+    Stack,
+    Table,
+    Text,
+    TextInput,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { IconFileSpreadsheet } from '@tabler/icons-react';
+import { useEffect, useRef, useState, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import Callout from '../../../components/common/Callout';
+import MantineModal from '../../../components/common/MantineModal';
+import useToaster from '../../../hooks/toaster/useToaster';
+import {
+    useCommitCsvUpload,
+    useExternalSource,
+    useInvalidateTables,
+    useUploadCsv,
+} from '../hooks/useExternalSources';
+import { CsvDropzone } from './CsvDropzone';
+
+type SchemaPreviewStepProps = {
+    projectUuid: string;
+    stage: StagedExternalSourceUpload;
+    onBack: () => void;
+    onCommitted: (sourceUuid: string) => void;
+};
+
+const SchemaPreviewStep: FC<SchemaPreviewStepProps> = ({
+    projectUuid,
+    stage,
+    onBack,
+    onCommitted,
+}) => {
+    const commitMutation = useCommitCsvUpload(projectUuid);
+    const form = useForm({
+        initialValues: { tableName: '' },
+        validate: {
+            tableName: (value) =>
+                value.trim().length === 0 ? 'Give the table a name' : null,
+        },
+    });
+    const columns = Object.values(stage.inferredColumns);
+    const slug = snakeCaseName(form.values.tableName || '');
+
+    const handleSubmit = form.onSubmit((values) => {
+        commitMutation.mutate(
+            {
+                sourceUuid: stage.sourceUuid,
+                payload: { tableName: values.tableName.trim() },
+            },
+            {
+                onSuccess: (source) => onCommitted(source.sourceUuid),
+            },
+        );
+    });
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <Stack gap="md">
+                <TextInput
+                    label="Table name"
+                    placeholder="quarterly_targets"
+                    description={
+                        slug
+                            ? `Will appear as ${slug}`
+                            : 'How this table will appear in the sidebar'
+                    }
+                    data-autofocus
+                    {...form.getInputProps('tableName')}
+                    error={
+                        form.errors.tableName ??
+                        (commitMutation.isError
+                            ? commitMutation.error.error.message
+                            : undefined)
+                    }
+                />
+                <Stack gap="xs">
+                    <Text fz="sm" fw={500}>
+                        Columns · {columns.length}
+                    </Text>
+                    <Table verticalSpacing={6} horizontalSpacing="sm">
+                        <Table.Tbody>
+                            {columns.map((column) => (
+                                <Table.Tr key={column.reference}>
+                                    <Table.Td>
+                                        <Text fz="xs" fw={500}>
+                                            {column.reference}
+                                        </Text>
+                                    </Table.Td>
+                                    <Table.Td w={110}>
+                                        <Text fz="xs" c="dimmed">
+                                            {column.type}
+                                        </Text>
+                                    </Table.Td>
+                                </Table.Tr>
+                            ))}
+                        </Table.Tbody>
+                    </Table>
+                    <Text fz="xs" c="dimmed">
+                        Row count, plus sum and average metrics for numeric
+                        columns, are added automatically.
+                    </Text>
+                </Stack>
+                <Group justify="space-between">
+                    <Button
+                        variant="default"
+                        onClick={onBack}
+                        disabled={commitMutation.isLoading}
+                    >
+                        Back
+                    </Button>
+                    <Button type="submit" loading={commitMutation.isLoading}>
+                        Create table
+                    </Button>
+                </Group>
+            </Stack>
+        </form>
+    );
+};
+
+type PreparingStepProps = {
+    projectUuid: string;
+    sourceUuid: string;
+    onReady: (exploreName: string) => void;
+    onRetry: () => void;
+};
+
+const PreparingStep: FC<PreparingStepProps> = ({
+    projectUuid,
+    sourceUuid,
+    onReady,
+    onRetry,
+}) => {
+    const { data: source } = useExternalSource(projectUuid, sourceUuid, {
+        poll: true,
+    });
+    const settledRef = useRef(false);
+
+    // Reacting to a server-state transition (ingest finished) with a
+    // navigation side effect — a legitimate external-system sync.
+    useEffect(() => {
+        if (settledRef.current) return;
+        if (source?.status === ExternalSourceStatus.READY && source.tables[0]) {
+            settledRef.current = true;
+            onReady(source.tables[0].name);
+        }
+    }, [source, onReady]);
+
+    if (source?.status === ExternalSourceStatus.ERROR) {
+        return (
+            <Stack gap="md">
+                <Callout variant="danger" title="We couldn't import this file">
+                    {source.errorMessage ??
+                        'Something went wrong while preparing the table.'}
+                </Callout>
+                <Group justify="flex-end">
+                    <Button variant="default" onClick={onRetry}>
+                        Try another file
+                    </Button>
+                </Group>
+            </Stack>
+        );
+    }
+
+    return (
+        <Stack gap="xs" align="center" py="lg">
+            <Loader size="sm" />
+            <Text fz="sm" fw={500}>
+                Preparing your table…
+            </Text>
+            <Text fz="xs" c="dimmed">
+                You'll land in the new table as soon as it's ready.
+            </Text>
+        </Stack>
+    );
+};
+
+type AddDataModalProps = {
+    projectUuid: string;
+    opened: boolean;
+    onClose: () => void;
+};
+
+export const AddDataModal: FC<AddDataModalProps> = ({
+    projectUuid,
+    opened,
+    onClose,
+}) => {
+    const navigate = useNavigate();
+    const { showToastSuccess } = useToaster();
+    const uploadMutation = useUploadCsv(projectUuid);
+    const [committedSourceUuid, setCommittedSourceUuid] = useState<string>();
+    const invalidateTables = useInvalidateTables();
+
+    const handleClose = () => {
+        uploadMutation.reset();
+        setCommittedSourceUuid(undefined);
+        onClose();
+    };
+
+    const stage = uploadMutation.data;
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={handleClose}
+            title="Upload a CSV"
+            icon={IconFileSpreadsheet}
+            size="lg"
+        >
+            <Stack gap="md">
+                {!stage && !committedSourceUuid && (
+                    <>
+                        <CsvDropzone
+                            isUploading={uploadMutation.isLoading}
+                            onFile={(file) => uploadMutation.mutate(file)}
+                        />
+                        <Group gap="xs" justify="center">
+                            <Badge variant="light" color="gray" size="xs">
+                                Coming soon
+                            </Badge>
+                            <Text fz="xs" c="dimmed">
+                                Google Sheets and other sources
+                            </Text>
+                        </Group>
+                    </>
+                )}
+                {stage && !committedSourceUuid && (
+                    <SchemaPreviewStep
+                        key={stage.sourceUuid}
+                        projectUuid={projectUuid}
+                        stage={stage}
+                        onBack={() => uploadMutation.reset()}
+                        onCommitted={(sourceUuid) => {
+                            setCommittedSourceUuid(sourceUuid);
+                            uploadMutation.reset();
+                        }}
+                    />
+                )}
+                {committedSourceUuid && (
+                    <PreparingStep
+                        projectUuid={projectUuid}
+                        sourceUuid={committedSourceUuid}
+                        onReady={(exploreName) => {
+                            void invalidateTables(projectUuid);
+                            showToastSuccess({
+                                title: 'Table created',
+                                subtitle:
+                                    'Pick fields to build your first chart.',
+                            });
+                            handleClose();
+                            void navigate(
+                                `/projects/${projectUuid}/tables/${exploreName}`,
+                            );
+                        }}
+                        onRetry={() => {
+                            setCommittedSourceUuid(undefined);
+                            uploadMutation.reset();
+                        }}
+                    />
+                )}
+            </Stack>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/features/externalSources/components/CsvDropzone.module.css
+++ b/packages/frontend/src/features/externalSources/components/CsvDropzone.module.css
@@ -1,0 +1,28 @@
+.dropzone {
+    border: 1px dashed var(--mantine-color-gray-4);
+    border-radius: var(--mantine-radius-md);
+    padding: var(--mantine-spacing-xl);
+    cursor: pointer;
+    transition:
+        border-color 120ms ease,
+        background-color 120ms ease;
+}
+
+.dropzoneActive {
+    border-color: var(--mantine-color-blue-5);
+    background-color: var(--mantine-color-blue-0);
+}
+
+.browseButton {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-decoration: underline;
+    color: inherit;
+    font: inherit;
+}
+
+.browseButton:hover {
+    text-decoration: none;
+}

--- a/packages/frontend/src/features/externalSources/components/CsvDropzone.tsx
+++ b/packages/frontend/src/features/externalSources/components/CsvDropzone.tsx
@@ -1,0 +1,118 @@
+import { MAX_EXTERNAL_SOURCE_FILE_BYTES } from '@lightdash/common';
+import { Box, FileButton, Loader, Stack, Text } from '@mantine/core';
+import { IconCloudUpload } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import useToaster from '../../../hooks/toaster/useToaster';
+import classes from './CsvDropzone.module.css';
+
+const ACCEPT = '.csv,.tsv';
+
+const formatMb = (bytes: number): string =>
+    `${Math.round(bytes / (1024 * 1024))} MB`;
+
+type Props = {
+    isUploading: boolean;
+    onFile: (file: File) => void;
+};
+
+/**
+ * Hand-rolled dropzone (drag events + FileButton) — @mantine/dropzone is not
+ * a dependency. Rejects doomed uploads client-side so a too-big file never
+ * hits the wire.
+ */
+export const CsvDropzone: FC<Props> = ({ isUploading, onFile }) => {
+    const { showToastError } = useToaster();
+    const [isDragging, setIsDragging] = useState(false);
+
+    const handleFile = (file: File) => {
+        const lower = file.name.toLowerCase();
+        if (!lower.endsWith('.csv') && !lower.endsWith('.tsv')) {
+            showToastError({
+                title: `Unsupported file: ${file.name}`,
+                subtitle: 'Upload a .csv or .tsv file.',
+            });
+            return;
+        }
+        if (file.size > MAX_EXTERNAL_SOURCE_FILE_BYTES) {
+            showToastError({
+                title: `${file.name} is too large`,
+                subtitle: `Files must be under ${formatMb(
+                    MAX_EXTERNAL_SOURCE_FILE_BYTES,
+                )}.`,
+            });
+            return;
+        }
+        if (file.size === 0) {
+            showToastError({
+                title: `${file.name} is empty`,
+                subtitle: 'Upload a file with at least a header row.',
+            });
+            return;
+        }
+        onFile(file);
+    };
+
+    return (
+        <FileButton
+            onChange={(file) => {
+                if (file && !isUploading) handleFile(file);
+            }}
+            accept={ACCEPT}
+            inputProps={{ 'aria-label': 'Upload a CSV file' }}
+        >
+            {({ onClick }) => (
+                <Box
+                    className={`${classes.dropzone} ${
+                        isDragging ? classes.dropzoneActive : ''
+                    }`}
+                    onClick={isUploading ? undefined : onClick}
+                    onDragEnter={(e) => {
+                        e.preventDefault();
+                        setIsDragging(true);
+                    }}
+                    onDragOver={(e) => {
+                        e.preventDefault();
+                    }}
+                    onDragLeave={(e) => {
+                        if (
+                            !e.currentTarget.contains(
+                                e.relatedTarget as Node | null,
+                            )
+                        ) {
+                            setIsDragging(false);
+                        }
+                    }}
+                    onDrop={(e) => {
+                        e.preventDefault();
+                        setIsDragging(false);
+                        if (isUploading) return;
+                        const file = e.dataTransfer.files[0];
+                        if (file) handleFile(file);
+                    }}
+                >
+                    <Stack gap="xs" align="center">
+                        {isUploading ? (
+                            <Loader size="sm" />
+                        ) : (
+                            <MantineIcon
+                                icon={IconCloudUpload}
+                                size="lg"
+                                color="ldGray.7"
+                            />
+                        )}
+                        <Text fz="sm" fw={500} ta="center">
+                            {isUploading
+                                ? 'Uploading and analyzing…'
+                                : 'Drop a CSV here or click to browse'}
+                        </Text>
+                        <Text fz="xs" c="dimmed" ta="center">
+                            .csv or .tsv, up to{' '}
+                            {formatMb(MAX_EXTERNAL_SOURCE_FILE_BYTES)}
+                        </Text>
+                    </Stack>
+                </Box>
+            )}
+        </FileButton>
+    );
+};

--- a/packages/frontend/src/features/externalSources/hooks/useExternalSources.ts
+++ b/packages/frontend/src/features/externalSources/hooks/useExternalSources.ts
@@ -1,0 +1,111 @@
+import {
+    ExternalSourceStatus,
+    type ApiError,
+    type CreateExternalSourceTablePayload,
+    type ExternalSource,
+    type StagedExternalSourceUpload,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+const EXTERNAL_SOURCES_BASE = (projectUuid: string) =>
+    `/ee/projects/${projectUuid}/external-sources`;
+
+const getExternalSourceApi = async (projectUuid: string, sourceUuid: string) =>
+    lightdashApi<ExternalSource>({
+        url: `${EXTERNAL_SOURCES_BASE(projectUuid)}/${sourceUuid}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+// Raw body + filename in query params (matches the backend controller —
+// mirrors the design-file upload precedent, NOT multipart/form-data).
+const uploadCsvApi = async (args: { projectUuid: string; file: File }) => {
+    const search = new URLSearchParams({ filename: args.file.name });
+    return lightdashApi<StagedExternalSourceUpload>({
+        url: `${EXTERNAL_SOURCES_BASE(
+            args.projectUuid,
+        )}/upload?${search.toString()}`,
+        method: 'POST',
+        body: args.file,
+        headers: {
+            'Content-Type': args.file.type || 'text/csv',
+        },
+    });
+};
+
+const commitUploadApi = async (args: {
+    projectUuid: string;
+    sourceUuid: string;
+    payload: CreateExternalSourceTablePayload;
+}) =>
+    lightdashApi<ExternalSource>({
+        url: `${EXTERNAL_SOURCES_BASE(args.projectUuid)}/${
+            args.sourceUuid
+        }/commit`,
+        method: 'POST',
+        body: JSON.stringify(args.payload),
+    });
+
+/**
+ * Polls while the source is syncing; when it settles, the caller reacts to
+ * the status change (e.g. invalidates the tables list and navigates).
+ */
+export const useExternalSource = (
+    projectUuid: string | undefined,
+    sourceUuid: string | undefined,
+    options?: { poll?: boolean },
+) =>
+    useQuery<ExternalSource, ApiError>({
+        queryKey: ['external-sources', projectUuid, sourceUuid],
+        queryFn: () => getExternalSourceApi(projectUuid!, sourceUuid!),
+        enabled: !!projectUuid && !!sourceUuid,
+        refetchInterval: options?.poll
+            ? (data) =>
+                  data?.status === ExternalSourceStatus.SYNCING ? 2000 : false
+            : false,
+    });
+
+export const useUploadCsv = (projectUuid: string | undefined) => {
+    const { showToastApiError } = useToaster();
+    return useMutation<StagedExternalSourceUpload, ApiError, File>({
+        mutationFn: (file) => uploadCsvApi({ projectUuid: projectUuid!, file }),
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Could not upload the file',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useCommitCsvUpload = (projectUuid: string | undefined) => {
+    const queryClient = useQueryClient();
+    return useMutation<
+        ExternalSource,
+        ApiError,
+        { sourceUuid: string; payload: CreateExternalSourceTablePayload }
+    >({
+        mutationFn: ({ sourceUuid, payload }) =>
+            commitUploadApi({
+                projectUuid: projectUuid!,
+                sourceUuid,
+                payload,
+            }),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: ['external-sources', projectUuid],
+            });
+        },
+    });
+};
+
+/** Invalidate the explore lists after an ingest completes. */
+export const useInvalidateTables = () => {
+    const queryClient = useQueryClient();
+    return (projectUuid: string) =>
+        queryClient.invalidateQueries({
+            queryKey: ['tables', projectUuid],
+        });
+};

--- a/packages/frontend/src/features/externalSources/utils/exploreIcons.ts
+++ b/packages/frontend/src/features/externalSources/utils/exploreIcons.ts
@@ -1,0 +1,26 @@
+import {
+    ExternalSourceType,
+    assertUnreachable,
+    type SummaryExplore,
+} from '@lightdash/common';
+import { IconFileSpreadsheet, IconTable } from '@tabler/icons-react';
+
+const getExternalSourceRef = (explore: SummaryExplore) =>
+    'externalSource' in explore ? explore.externalSource : undefined;
+
+/** Sidebar icon for an explore row; external tables show their source type. */
+export const getExploreIcon = (explore: SummaryExplore) => {
+    const ref = getExternalSourceRef(explore);
+    if (!ref) return IconTable;
+    switch (ref.sourceType) {
+        case ExternalSourceType.CSV:
+            return IconFileSpreadsheet;
+        case ExternalSourceType.GOOGLE_SHEETS:
+            return IconFileSpreadsheet;
+        default:
+            return assertUnreachable(
+                ref.sourceType,
+                'Unknown external source type',
+            );
+    }
+};


### PR DESCRIPTION
Third slice of external data sources: the Explorer upload flow. A user drops a CSV in the Tables sidebar, reviews the inferred schema, names the table, and lands in the new explore ready to chart.

## What this adds

- New feature module `features/externalSources`: `useExternalSources` hooks (raw-body `File` upload, commit, source polling at 2s while syncing, cache invalidation of the tables list) and the `AddDataModal` (dropzone, schema preview step with inferred columns and a table-name form, preparing step that polls until the ingest settles, inline error states with retry).
- Sidebar: external-source explores render in their own 'External sources' section (fifth bucket in `BasePanel`) above Virtual Views, with per-type icons from the `externalSource` ref on `SummaryExplore`; auto-expands on search.
- 'Add data' entry point in the tables panel, gated by the feature flag and `create ExternalSource` ability.

## Regression analysis

- All new UI is behind the flag and ability checks; users without either see an unchanged Explorer.
- The new sidebar bucket only matches `ExploreType.EXTERNAL_SOURCE`, so existing grouping of dbt and virtual-view explores is unchanged.
- No changes to query execution paths; this PR is frontend plus one common type reused from the stack below.

## Testing

- Verified live in the app: upload, schema preview, create, land in explore, build a chart on the auto-metrics (screenshots in the stack thread).
- `pnpm -F frontend typecheck`, lint, and the `unused-exports` gate green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6KsLFbzm9A1kViYX5pM3k
