### PR TITLE
feat(external-sources): join hint and upload inside the merge picker

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../../features/explorer/store';
 import { ExternalSourceBadge } from '../../../features/externalSources/components/ExternalSourceBadge';
 import { ExternalSourceExploreMenu } from '../../../features/externalSources/components/ExternalSourceExploreMenu';
+import { JoinWithWarehouseHint } from '../../../features/externalSources/components/JoinWithWarehouseHint';
 import { MergeJoinBar } from '../../../features/mergeQuery/components/MergeJoinBar';
 import { MergeQuerySidebar } from '../../../features/mergeQuery/components/MergeQuerySidebar';
 import {
@@ -455,6 +456,16 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                             </Menu>
                         )}
                 </Group>
+
+                {explore.type === ExploreType.EXTERNAL_SOURCE &&
+                    canMergeAnotherQuery &&
+                    !isGuidedMerge && (
+                        <Group>
+                            <JoinWithWarehouseHint
+                                onClick={handleAddMergeSource}
+                            />
+                        </Group>
+                    )}
 
                 {isGuidedMerge ? (
                     <MergeQuerySidebar

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -43,9 +43,13 @@ type Props = {
     // Overrides the default navigation to the project's explore page. Embeds
     // use this to keep the selected table inside the embed route.
     onExploreClick?: (explore: SummaryExplore) => void;
+    // Enables "Add data" in overridden-navigation contexts (the merge picker):
+    // a table created through the upload modal is handed here instead of
+    // navigating, so the host flow keeps its state.
+    onExploreCreated?: (exploreName: string) => void;
 };
 
-const BasePanel = ({ onExploreClick }: Props) => {
+const BasePanel = ({ onExploreClick, onExploreCreated }: Props) => {
     const navigate = useNavigate();
     const location = useLocation();
     const projectUuid = useProjectUuid();
@@ -62,12 +66,13 @@ const BasePanel = ({ onExploreClick }: Props) => {
         isAddDataModalOpen,
         { open: openAddDataModal, close: closeAddDataModal },
     ] = useDisclosure(false);
-    // The modal navigates into the created table; inside embeds and the merge
-    // picker (onExploreClick overridden) that navigation would break the
-    // host flow, so the affordance is hidden there.
+    // The modal navigates into the created table by default; inside embeds
+    // and the merge picker (onExploreClick overridden) that navigation would
+    // break the host flow, so the affordance only shows there when the host
+    // handles the created table itself via onExploreCreated.
     const canShowAddData =
         externalSourcesFlag?.enabled === true &&
-        !onExploreClick &&
+        (!onExploreClick || !!onExploreCreated) &&
         !!projectUuid;
 
     const filteredExplores = useMemo(() => {
@@ -287,6 +292,7 @@ const BasePanel = ({ onExploreClick }: Props) => {
                         projectUuid={projectUuid}
                         opened={isAddDataModalOpen}
                         onClose={closeAddDataModal}
+                        onCreated={onExploreCreated}
                     />
                 )}
             </>

--- a/packages/frontend/src/features/externalSources/components/AddDataModal.tsx
+++ b/packages/frontend/src/features/externalSources/components/AddDataModal.tsx
@@ -189,12 +189,15 @@ type AddDataModalProps = {
     projectUuid: string;
     opened: boolean;
     onClose: () => void;
+    /** Overrides the default navigate-into-the-explore behavior on create. */
+    onCreated?: (exploreName: string) => void;
 };
 
 export const AddDataModal: FC<AddDataModalProps> = ({
     projectUuid,
     opened,
     onClose,
+    onCreated,
 }) => {
     const navigate = useNavigate();
     const { showToastSuccess } = useToaster();
@@ -259,9 +262,13 @@ export const AddDataModal: FC<AddDataModalProps> = ({
                                     'Pick fields to build your first chart.',
                             });
                             handleClose();
-                            void navigate(
-                                `/projects/${projectUuid}/tables/${exploreName}`,
-                            );
+                            if (onCreated) {
+                                onCreated(exploreName);
+                            } else {
+                                void navigate(
+                                    `/projects/${projectUuid}/tables/${exploreName}`,
+                                );
+                            }
                         }}
                         onRetry={() => {
                             setCommittedSourceUuid(undefined);

--- a/packages/frontend/src/features/externalSources/components/CsvDropzone.module.css
+++ b/packages/frontend/src/features/externalSources/components/CsvDropzone.module.css
@@ -13,16 +13,10 @@
     background-color: var(--mantine-color-blue-0);
 }
 
-.browseButton {
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    text-decoration: underline;
-    color: inherit;
-    font: inherit;
+.dropzone {
+    display: block;
 }
 
-.browseButton:hover {
-    text-decoration: none;
+.hiddenInput {
+    display: none;
 }

--- a/packages/frontend/src/features/externalSources/components/CsvDropzone.tsx
+++ b/packages/frontend/src/features/externalSources/components/CsvDropzone.tsx
@@ -1,7 +1,7 @@
 import { MAX_EXTERNAL_SOURCE_FILE_BYTES } from '@lightdash/common';
-import { Box, FileButton, Loader, Stack, Text } from '@mantine/core';
+import { Box, Loader, Stack, Text } from '@mantine/core';
 import { IconCloudUpload } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { useId, useState, type ChangeEvent, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useToaster from '../../../hooks/toaster/useToaster';
 import classes from './CsvDropzone.module.css';
@@ -17,13 +17,15 @@ type Props = {
 };
 
 /**
- * Hand-rolled dropzone (drag events + FileButton) — @mantine/dropzone is not
- * a dependency. Rejects doomed uploads client-side so a too-big file never
- * hits the wire.
+ * A label-for-input dropzone: the OS file chooser opens through the native
+ * label association, with no JS in the path, so it works in every browser
+ * and inside modals. Rejects doomed uploads client-side so a too-big file
+ * never hits the wire.
  */
 export const CsvDropzone: FC<Props> = ({ isUploading, onFile }) => {
     const { showToastError } = useToaster();
     const [isDragging, setIsDragging] = useState(false);
+    const inputId = useId();
 
     const handleFile = (file: File) => {
         const lower = file.name.toLowerCase();
@@ -53,66 +55,76 @@ export const CsvDropzone: FC<Props> = ({ isUploading, onFile }) => {
         onFile(file);
     };
 
+    const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file && !isUploading) handleFile(file);
+        // Reset so choosing the same file again re-fires the change event
+        // eslint-disable-next-line no-param-reassign
+        event.target.value = '';
+    };
+
     return (
-        <FileButton
-            onChange={(file) => {
-                if (file && !isUploading) handleFile(file);
-            }}
-            accept={ACCEPT}
-            inputProps={{ 'aria-label': 'Upload a CSV file' }}
-        >
-            {({ onClick }) => (
-                <Box
-                    className={`${classes.dropzone} ${
-                        isDragging ? classes.dropzoneActive : ''
-                    }`}
-                    onClick={isUploading ? undefined : onClick}
-                    onDragEnter={(e) => {
-                        e.preventDefault();
-                        setIsDragging(true);
-                    }}
-                    onDragOver={(e) => {
-                        e.preventDefault();
-                    }}
-                    onDragLeave={(e) => {
-                        if (
-                            !e.currentTarget.contains(
-                                e.relatedTarget as Node | null,
-                            )
-                        ) {
-                            setIsDragging(false);
-                        }
-                    }}
-                    onDrop={(e) => {
-                        e.preventDefault();
+        <>
+            <Box
+                component="label"
+                htmlFor={inputId}
+                className={`${classes.dropzone} ${
+                    isDragging ? classes.dropzoneActive : ''
+                }`}
+                onDragEnter={(e) => {
+                    e.preventDefault();
+                    setIsDragging(true);
+                }}
+                onDragOver={(e) => {
+                    e.preventDefault();
+                }}
+                onDragLeave={(e) => {
+                    if (
+                        !e.currentTarget.contains(
+                            e.relatedTarget as Node | null,
+                        )
+                    ) {
                         setIsDragging(false);
-                        if (isUploading) return;
-                        const file = e.dataTransfer.files[0];
-                        if (file) handleFile(file);
-                    }}
-                >
-                    <Stack gap="xs" align="center">
-                        {isUploading ? (
-                            <Loader size="sm" />
-                        ) : (
-                            <MantineIcon
-                                icon={IconCloudUpload}
-                                size="lg"
-                                color="ldGray.7"
-                            />
-                        )}
-                        <Text fz="sm" fw={500} ta="center">
-                            {isUploading
-                                ? 'Uploading and analyzing…'
-                                : 'Drop a CSV here or click to browse'}
-                        </Text>
-                        <Text fz="xs" c="dimmed" ta="center">
-                            .csv or .tsv, up to{' '}
-                            {formatMb(MAX_EXTERNAL_SOURCE_FILE_BYTES)}
-                        </Text>
-                    </Stack>
-                </Box>
-            )}
-        </FileButton>
+                    }
+                }}
+                onDrop={(e) => {
+                    e.preventDefault();
+                    setIsDragging(false);
+                    if (isUploading) return;
+                    const file = e.dataTransfer.files[0];
+                    if (file) handleFile(file);
+                }}
+            >
+                <Stack gap="xs" align="center">
+                    {isUploading ? (
+                        <Loader size="sm" />
+                    ) : (
+                        <MantineIcon
+                            icon={IconCloudUpload}
+                            size="lg"
+                            color="ldGray.7"
+                        />
+                    )}
+                    <Text fz="sm" fw={500} ta="center">
+                        {isUploading
+                            ? 'Uploading and analyzing…'
+                            : 'Drop a CSV here or click to browse'}
+                    </Text>
+                    <Text fz="xs" c="dimmed" ta="center">
+                        .csv or .tsv, up to{' '}
+                        {formatMb(MAX_EXTERNAL_SOURCE_FILE_BYTES)}
+                    </Text>
+                </Stack>
+            </Box>
+            <input
+                id={inputId}
+                type="file"
+                accept={ACCEPT}
+                disabled={isUploading}
+                aria-label="Upload a CSV file"
+                className={classes.hiddenInput}
+                onChange={handleInputChange}
+            />
+        </>
     );
 };

--- a/packages/frontend/src/features/externalSources/components/JoinWithWarehouseHint.tsx
+++ b/packages/frontend/src/features/externalSources/components/JoinWithWarehouseHint.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@mantine/core';
+import { IconGitMerge } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+
+/**
+ * The discoverable path from an uploaded table to a cross-source join: one
+ * quiet button under the explore header that opens the merge flow with this
+ * table as the primary source.
+ */
+export const JoinWithWarehouseHint: FC<{ onClick: () => void }> = ({
+    onClick,
+}) => (
+    <Button
+        variant="light"
+        size="compact-xs"
+        leftSection={<MantineIcon icon={IconGitMerge} size="sm" />}
+        onClick={onClick}
+    >
+        Join with your warehouse data
+    </Button>
+);

--- a/packages/frontend/src/features/mergeQuery/components/MergeSourceTree.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeSourceTree.tsx
@@ -65,6 +65,10 @@ export const MergeSourceTree: FC<{
                             }
                             setIsChoosingExplore(false);
                         }}
+                        onExploreCreated={(exploreName) => {
+                            merge.setSourceExplore(source.id, exploreName);
+                            setIsChoosingExplore(false);
+                        }}
                     />
                 </Box>
             </Stack>


### PR DESCRIPTION
Fifth slice of external data sources: the join moment. External explores get a quiet hint to join with warehouse data, and the merge picker can upload a CSV inline so the new table becomes the second source without leaving the flow.

## What this adds

- `JoinWithWarehouseHint`: a single compact button under the header on external explores that opens the existing merge sidebar in choose-explore state.
- `BasePanel` gains an optional `onExploreCreated` callback; `MergeSourceTree` passes it so a table created from the merge picker's 'Add data' becomes source b directly, no navigation.
- `CsvDropzone` rewritten from Mantine `FileButton` to a native `label[for]` + hidden file input: the programmatic `click()` approach did not open the file chooser in a real browser (it worked under Playwright's synthetic events, which masked the bug). Drag-and-drop behavior is unchanged.

## Regression analysis

- `onExploreCreated` is optional and unset everywhere except the merge picker, so `BasePanel`'s default create-then-navigate behavior is unchanged (embeds and other `onExploreClick` consumers unaffected).
- The dropzone rewrite keeps the same props and client-side validation; only the chooser-opening mechanism changed, and the native label-for-input path needs no JS at all.
- The hint renders only on external explores behind the flag.

## Testing

- Verified live in a real browser (not just Playwright): click opens the chooser, drag-and-drop works, and uploading from inside the merge picker lands the table as source b (screenshots in the stack thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6KsLFbzm9A1kViYX5pM3k
