### PR TITLE
feat(ai-writeback): run dbt parse before opening a pull request

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -391,7 +391,10 @@ import { type AiDeepResearchSubmittedReport } from '../AiDeepResearchService/AiD
 import { isDeepResearchRawSqlMcpTool } from '../AiDeepResearchService/toolClassification';
 import { AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
 import { AiWritebackService } from '../AiWritebackService/AiWritebackService';
-import { WritebackThreadPrClosedError } from '../AiWritebackService/errors';
+import {
+    WritebackDbtParseError,
+    WritebackThreadPrClosedError,
+} from '../AiWritebackService/errors';
 import type { AiWritebackSource } from '../AiWritebackService/types';
 import { type WritebackPreviewService } from '../AiWritebackService/WritebackPreviewService';
 import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewDeploySetupService';
@@ -8659,6 +8662,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             } else if (error instanceof InsufficientGitPermissionsError) {
                 toolResult = GIT_WRITE_PERMISSION_AGENT_MESSAGE;
                 errorCode = 'git_write_permission';
+            } else if (error instanceof WritebackDbtParseError) {
+                // The host's `dbt parse` gate blocked the pull request. The
+                // error already tells the agent what broke and what to do, and
+                // it's the agent's own mistake — not a system failure.
+                toolResult = error.message;
+                errorCode = 'unknown';
             } else {
                 toolResult = toolErrorHandler(
                     error,

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -29,6 +29,7 @@ import {
     revokeInstallationToken,
 } from '../../../clients/github/Github';
 import { createSandboxManager, SandboxManager } from '../SandboxRuntime';
+import { SandboxCommandError } from '../SandboxRuntime/errors';
 import {
     AiWritebackService,
     auditReasonForError,
@@ -53,6 +54,7 @@ import {
 import { DeniedPathError } from './deniedPaths';
 import {
     RepoTooLargeError,
+    WritebackDbtParseError,
     WritebackGitNotConnectedError,
     WritebackRunAbortedError,
     WritebackThreadPrClosedError,
@@ -1426,6 +1428,149 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
         });
         expect(createPullRequest).not.toHaveBeenCalled();
         expect(fakeSandboxProvider.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    // The `dbt parse` gate: the host parses the project itself rather than
+    // trusting the agent's own compile summary, and only holds a failure against
+    // the change when the project parsed BEFORE the turn.
+    describe('dbt parse gate', () => {
+        // `dbt parse` outcomes in call order: the baseline parse (before the
+        // agent), then one per post-change check.
+        const fakeSandboxWithParse = (
+            parseOutcomes: (boolean | 'unknown')[],
+        ): AnyType => {
+            let parseCalls = 0;
+            let agentCalls = 0;
+            const sandbox = fakeSandbox(0, true);
+            sandbox.commands.run = vi.fn(
+                async (command: string, opts: AnyType) => {
+                    if (command.includes('claude')) {
+                        agentCalls += 1;
+                        opts?.onStdout?.(
+                            `${JSON.stringify({
+                                type: 'assistant',
+                                message: {
+                                    content: [
+                                        {
+                                            type: 'text',
+                                            text:
+                                                agentCalls === 1
+                                                    ? agentReply()
+                                                    : `Fixed.\n${PR_TITLE_OPEN}Add metric${PR_TITLE_CLOSE}`,
+                                        },
+                                    ],
+                                },
+                            })}\n`,
+                        );
+                        return { exitCode: 0, stdout: '' };
+                    }
+                    if (command.includes('dbt parse')) {
+                        const parsed = parseOutcomes[parseCalls] ?? true;
+                        parseCalls += 1;
+                        // Not a verdict on the project — a transport/timeout
+                        // failure, which must never read as a broken change.
+                        if (parsed === 'unknown') {
+                            throw new Error('deadline_exceeded');
+                        }
+                        if (!parsed) {
+                            throw new SandboxCommandError(
+                                1,
+                                '',
+                                'Compilation Error in model orders\n  depends on a node named "missing" which was not found',
+                            );
+                        }
+                        return { exitCode: 0, stdout: '' };
+                    }
+                    // Profiles discovery — a found profiles.yml is what lets the
+                    // host run `dbt parse` at all.
+                    if (command.includes('profiles.yml')) {
+                        return {
+                            exitCode: 0,
+                            stdout: '/home/user/repo/profiles/profiles.yml\n',
+                        };
+                    }
+                    if (command.includes('--name-status')) {
+                        return { exitCode: 0, stdout: 'A\0models/x.sql\0' };
+                    }
+                    return { exitCode: 0, stdout: '' };
+                },
+            );
+            return {
+                sandbox,
+                parseCalls: () => parseCalls,
+                agentCalls: () => agentCalls,
+            };
+        };
+
+        it('opens the PR when the changes still parse', async () => {
+            const { sandbox, parseCalls, agentCalls } = fakeSandboxWithParse([
+                true,
+                true,
+            ]);
+            fakeSandboxProvider.create.mockResolvedValue(sandbox);
+
+            const result = await runService(sandbox);
+
+            expect(result.prUrl).toBe(PR_7);
+            // Baseline + post-change, and no repair turn was needed.
+            expect(parseCalls()).toBe(2);
+            expect(agentCalls()).toBe(1);
+        });
+
+        it('gives the agent one repair turn and opens the PR once it parses', async () => {
+            const { sandbox, parseCalls, agentCalls } = fakeSandboxWithParse([
+                true,
+                false,
+                true,
+            ]);
+            fakeSandboxProvider.create.mockResolvedValue(sandbox);
+
+            const result = await runService(sandbox);
+
+            expect(result.prUrl).toBe(PR_7);
+            expect(agentCalls()).toBe(2);
+            expect(parseCalls()).toBe(3);
+            // The repair turn's reply is what the user sees.
+            expect(result.output).toContain('Fixed.');
+        });
+
+        it('opens no PR when the changes still do not parse after the repair', async () => {
+            const { sandbox } = fakeSandboxWithParse([true, false, false]);
+            fakeSandboxProvider.create.mockResolvedValue(sandbox);
+
+            await expect(runService(sandbox)).rejects.toThrow(
+                WritebackDbtParseError,
+            );
+            expect(createPullRequest).not.toHaveBeenCalled();
+        });
+
+        it('does not treat a parse that could not run as a broken change', async () => {
+            const { sandbox, agentCalls } = fakeSandboxWithParse([
+                true,
+                'unknown',
+            ]);
+            fakeSandboxProvider.create.mockResolvedValue(sandbox);
+
+            const result = await runService(sandbox);
+
+            expect(result.prUrl).toBe(PR_7);
+            expect(agentCalls()).toBe(1);
+        });
+
+        it('does not hold a pre-existing parse failure against the change', async () => {
+            // The baseline parse fails, so the project was already broken: the
+            // gate is skipped and the PR opens without a repair turn.
+            const { sandbox, agentCalls, parseCalls } = fakeSandboxWithParse([
+                false,
+            ]);
+            fakeSandboxProvider.create.mockResolvedValue(sandbox);
+
+            const result = await runService(sandbox);
+
+            expect(result.prUrl).toBe(PR_7);
+            expect(agentCalls()).toBe(1);
+            expect(parseCalls()).toBe(1);
+        });
     });
 });
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    assertUnreachable,
     DbtProjectType,
     FeatureFlags,
     ForbiddenError,
@@ -88,6 +89,7 @@ import {
     COMPILE_TIMINGS_PATH,
     COMPILE_WRAPPER_PATH,
     CWD,
+    DBT_PARSE_TIMEOUT_MS,
     GATHER_REPO_CONTEXT_SANDBOX_PATH,
     GENERAL_ALLOWED_TOOLS,
     GENERAL_DISALLOWED_TOOLS,
@@ -111,6 +113,7 @@ import {
 import { DeniedPathError } from './deniedPaths';
 import {
     RepoTooLargeError,
+    WritebackDbtParseError,
     WritebackGitNotConnectedError,
     WritebackRunAbortedError,
     WritebackThreadPrClosedError,
@@ -118,17 +121,26 @@ import {
 import { GithubProvider } from './providers/GithubProvider';
 import { GitlabProvider } from './providers/GitlabProvider';
 import type { GitProvider } from './providers/GitProvider';
-import { buildGatherRepoContextScript } from './scripts';
+import { buildDbtParseCommand, buildGatherRepoContextScript } from './scripts';
 import { loadWarehouseSkills, warehouseTypeToSkillKey } from './skills';
-import { buildGeneralSystemPrompt, buildSystemPrompt } from './templates';
+import {
+    buildDbtParseRepairPrompt,
+    buildGeneralSystemPrompt,
+    buildSystemPrompt,
+} from './templates';
 import type {
     AdoptedPullRequest,
+    AgentRunOutcome,
     AiWritebackRunArgs,
     AiWritebackSource,
     AiWritebackUsage,
     AppliedChanges,
+    ChangeVerification,
     CloneTarget,
     CodingAgentConfig,
+    CodingAgentSetup,
+    DbtParseBaseline,
+    DbtParseBaselineStatus,
     GitConnection,
     GitInstallation,
     RepoContext,
@@ -152,6 +164,8 @@ import {
     resolveSandboxDbtVersion,
     resolveSandboxTemplateRef,
     splitStreamBuffer,
+    sumAgentUsage,
+    summarizeDbtParseFailure,
     summarizeRepoListing,
     summarizeToolInput,
 } from './utils';
@@ -2295,19 +2309,14 @@ export class AiWritebackService extends BaseService {
                 afterAgentRun: () => config.afterAgentRun(sandbox!),
             });
 
-            const {
-                title: prTitle,
-                description: prDescription,
-                summary: prSummary,
-                sanitizedStdout,
-            } = extractPrMetadata(agent.stdout);
+            const prMetadata = extractPrMetadata(agent.stdout);
             this.logger.info(
                 `AiWriteback: extracted PR metadata from stdout (title=${
-                    prTitle !== null
-                }, description=${prDescription !== null})`,
+                    prMetadata.title !== null
+                }, description=${prMetadata.description !== null})`,
             );
 
-            const { hasChanges } = await sandbox.git.status(CWD);
+            let { hasChanges } = await sandbox.git.status(CWD);
 
             // The agent crashed mid-run. The working tree may be in a
             // partial/inconsistent state, so skip the push/PR side-effects
@@ -2338,6 +2347,37 @@ export class AiWritebackService extends BaseService {
                         : `The coding agent exited with code ${agent.exitCode} and no pull request was created.`,
                 );
             }
+
+            // Host-side gate before any commit/push/PR: do the changes still
+            // verify (dbt: does the project parse)? A break earns ONE repair
+            // turn; if it survives that, no pull request is opened.
+            let repair: AgentRunOutcome | null = null;
+            if (hasChanges && config.verifyChanges) {
+                const gate = await this.verifyChangesOrRepair({
+                    sandbox,
+                    turn,
+                    config,
+                    setup,
+                    source,
+                    recordStep,
+                });
+                repair = gate.repair;
+                hasChanges = gate.hasChanges;
+            }
+            // The repair turn is the agent's last word, so its PR metadata and
+            // reply win — falling back to the first turn's for anything it
+            // didn't re-emit.
+            const repairMetadata = repair
+                ? extractPrMetadata(repair.stdout)
+                : null;
+            const prTitle = repairMetadata?.title ?? prMetadata.title;
+            const prDescription =
+                repairMetadata?.description ?? prMetadata.description;
+            const prSummary = repairMetadata?.summary ?? prMetadata.summary;
+            const sanitizedStdout = repairMetadata?.sanitizedStdout.trim()
+                ? repairMetadata.sanitizedStdout
+                : prMetadata.sanitizedStdout;
+            const usage = sumAgentUsage(agent.usage, repair?.usage ?? null);
 
             // Finalize claim: atomic arbitration with tasks/cancel before any
             // external side effect (commit/push/PR all happen inside
@@ -2383,7 +2423,7 @@ export class AiWritebackService extends BaseService {
                 exitCode: agent.exitCode,
                 hasChanges,
                 prCreated: applied.prCreated,
-                usage: agent.usage,
+                usage,
                 repoContext,
             });
 
@@ -2455,17 +2495,22 @@ export class AiWritebackService extends BaseService {
                 performance.now() - runStartedAt,
                 'error',
             );
-            Sentry.captureException(error, {
-                tags: {
-                    errorType: 'AiWritebackRunFailed',
-                    failureStage,
-                },
-                extra: {
-                    projectUuid,
-                    aiThreadUuid: aiThreadUuid ?? null,
-                    sandboxId: sandbox?.sandboxId ?? null,
-                },
-            });
+            // A change the agent couldn't make parse is a modelling mistake, not
+            // a system failure: it's already logged and tracked, so keep it out
+            // of Sentry.
+            if (!(error instanceof WritebackDbtParseError)) {
+                Sentry.captureException(error, {
+                    tags: {
+                        errorType: 'AiWritebackRunFailed',
+                        failureStage,
+                    },
+                    extra: {
+                        projectUuid,
+                        aiThreadUuid: aiThreadUuid ?? null,
+                        sandboxId: sandbox?.sandboxId ?? null,
+                    },
+                });
+            }
             tracker.failed(failureStage, error, repoContext);
             await persistRunFailed(error);
             throw error;
@@ -3661,11 +3706,7 @@ export class AiWritebackService extends BaseService {
         beforeAgentRun: () => Promise<void>;
         /** Mode-specific teardown run just after the CLI (e.g. dbt compile timings). */
         afterAgentRun: () => Promise<void>;
-    }): Promise<{
-        stdout: string;
-        exitCode: number;
-        usage: AiWritebackUsage | null;
-    }> {
+    }): Promise<AgentRunOutcome> {
         await sandbox.files.write(SYSTEM_PROMPT_PATH, systemPrompt);
         await sandbox.files.write(PROMPT_PATH, prompt);
 
@@ -3987,14 +4028,215 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
-     * Install the dbt compile wrapper, push the warehouse skill files, and reset
-     * the compile-timings log — the in-sandbox prerequisites for a dbt-writeback
-     * turn. Extracted as the `beforeAgentRun` hook of {@link dbtWritebackConfig}.
+     * Verify the agent's changes host-side before any git side effect, and give
+     * the agent ONE repair turn when they don't verify. The check runs on the
+     * host — not as a prompt instruction — because the class of failure it
+     * catches is exactly the agent believing its edit was fine (a dangling
+     * `ref()`, a mistyped YAML key) and opening a pull request that breaks dbt.
+     *
+     * The repair turn continues the same CLI session, so the agent still has the
+     * context of the edits it just made. If the changes still don't verify (or
+     * the repair turn itself crashes) the run fails with dbt's own error and no
+     * pull request is opened — an obviously broken dbt project is worse than no
+     * change at all. A repair that reverts everything leaves no changes, which
+     * the caller treats as a normal "nothing to open a PR for" turn.
+     */
+    private async verifyChangesOrRepair({
+        sandbox,
+        turn,
+        config,
+        setup,
+        source,
+        recordStep,
+    }: {
+        sandbox: SandboxHandle;
+        turn: TurnContext;
+        config: CodingAgentConfig;
+        setup: CodingAgentSetup;
+        source: AiWritebackSource;
+        recordStep: (step: AiWritebackStep) => void;
+    }): Promise<{ repair: AgentRunOutcome | null; hasChanges: boolean }> {
+        const verify = config.verifyChanges;
+        if (!verify) return { repair: null, hasChanges: true };
+
+        recordStep({ kind: 'stage', label: 'Checking the project parses' });
+        const verification = await verify(sandbox, turn);
+        if (verification.status === 'skipped') {
+            this.logger.info('AI writeback change verification skipped', {
+                event: 'ai_writeback.run.verify',
+                source,
+                sandboxId: sandbox.sandboxId,
+                status: verification.status,
+                reason: verification.reason,
+            });
+            return { repair: null, hasChanges: true };
+        }
+        if (verification.status === 'passed') {
+            this.logger.info('AI writeback change verification passed', {
+                event: 'ai_writeback.run.verify',
+                source,
+                sandboxId: sandbox.sandboxId,
+                status: verification.status,
+            });
+            return { repair: null, hasChanges: true };
+        }
+
+        this.logger.warn('AI writeback change verification failed', {
+            event: 'ai_writeback.run.verify',
+            source,
+            sandboxId: sandbox.sandboxId,
+            status: verification.status,
+            failureOutput: verification.failureOutput,
+        });
+        recordStep({ kind: 'stage', label: 'Fixing the changes' });
+        const repair = await this.runAgentInSandbox({
+            sandbox,
+            systemPrompt: setup.systemPrompt,
+            prompt: buildDbtParseRepairPrompt(verification.failureOutput),
+            // Continue the session the agent just finished, whatever the
+            // original turn was — it still holds the edits it made.
+            isResume: true,
+            source,
+            recordStep,
+            allowedTools: setup.allowedTools,
+            disallowedTools: setup.disallowedTools,
+            addDirs: setup.addDirs,
+            model: setup.model,
+            warehouseType: turn.warehouseType,
+            // The sandbox prerequisites were installed for the first turn and
+            // survive it, so only the post-run diagnostics are re-run.
+            beforeAgentRun: () => Promise.resolve(),
+            afterAgentRun: () => config.afterAgentRun(sandbox),
+        });
+        const { hasChanges } = await sandbox.git.status(CWD);
+        if (repair.exitCode !== 0) {
+            throw new WritebackDbtParseError(verification.failureOutput);
+        }
+        // The repair reverted everything: nothing to open a pull request for,
+        // and the agent's reply explains why.
+        if (!hasChanges) {
+            return { repair, hasChanges };
+        }
+        const recheck = await verify(sandbox, turn);
+        if (recheck.status === 'failed') {
+            throw new WritebackDbtParseError(recheck.failureOutput);
+        }
+        this.logger.info('AI writeback change verification repaired', {
+            event: 'ai_writeback.run.verify',
+            source,
+            sandboxId: sandbox.sandboxId,
+            status: recheck.status,
+        });
+        return { repair, hasChanges };
+    }
+
+    /**
+     * Run `dbt parse` on the working tree as it stands. `commands.run` throws on
+     * a non-zero exit, so a SandboxCommandError IS dbt's verdict — but any other
+     * throw (timeout, transport) says nothing about the project, and resolves to
+     * `unknown` so it can never be mistaken for a broken change.
+     */
+    private async runDbtParse(
+        sandbox: SandboxHandle,
+        turn: TurnContext,
+    ): Promise<
+        | { outcome: 'parsed' }
+        | { outcome: 'failed'; failureOutput: string }
+        | { outcome: 'unknown'; reason: string }
+    > {
+        const command = buildDbtParseCommand({
+            dbtBin: dbtSandboxVenvBin(turn.dbtVersion),
+            projectDir: `${CWD}/${turn.gitConnection.projectSubPath}`,
+            profilesDir: TMP_PROFILES_DIR,
+        });
+        const start = performance.now();
+        try {
+            await sandbox.commands.run(command, {
+                cwd: CWD,
+                timeoutMs: DBT_PARSE_TIMEOUT_MS,
+            });
+            this.logger.info(
+                `AiWriteback: dbt parse ok (${AiWritebackService.elapsed(
+                    start,
+                )}ms, sandboxId=${sandbox.sandboxId})`,
+            );
+            return { outcome: 'parsed' };
+        } catch (error) {
+            if (!(error instanceof SandboxCommandError)) {
+                this.logger.warn(
+                    `AiWriteback: dbt parse could not be run (${AiWritebackService.elapsed(
+                        start,
+                    )}ms, sandboxId=${sandbox.sandboxId}): ${getErrorMessage(
+                        error,
+                    )}`,
+                );
+                return { outcome: 'unknown', reason: getErrorMessage(error) };
+            }
+            const failureOutput = summarizeDbtParseFailure({
+                stdout: error.stdout,
+                stderr: error.stderr,
+            });
+            this.logger.info(
+                `AiWriteback: dbt parse failed (${AiWritebackService.elapsed(
+                    start,
+                )}ms, sandboxId=${sandbox.sandboxId}): ${failureOutput}`,
+            );
+            return { outcome: 'failed', failureOutput };
+        }
+    }
+
+    /**
+     * The `verifyChanges` hook of {@link dbtWritebackConfig}: does the dbt
+     * project still parse after the agent's edits? Only a project that parsed
+     * BEFORE the turn can fail this gate — otherwise a pre-existing breakage
+     * (unresolvable packages, a profile the placeholder patch can't satisfy)
+     * would block every write-back to that repo.
+     */
+    private async verifyDbtParses(
+        sandbox: SandboxHandle,
+        turn: TurnContext,
+        baseline: DbtParseBaseline,
+    ): Promise<ChangeVerification> {
+        if (baseline.status !== 'parsed') {
+            return {
+                status: 'skipped',
+                reason:
+                    baseline.status === 'not-run'
+                        ? 'the dbt project could not be parsed before this turn, so a failure now would not be attributable to the change'
+                        : 'the dbt project already failed to parse before this turn',
+            };
+        }
+        const parse = await this.runDbtParse(sandbox, turn);
+        switch (parse.outcome) {
+            case 'parsed':
+                return { status: 'passed' };
+            case 'failed':
+                return {
+                    status: 'failed',
+                    failureOutput: parse.failureOutput,
+                };
+            case 'unknown':
+                return {
+                    status: 'skipped',
+                    reason: `dbt parse could not be run: ${parse.reason}`,
+                };
+            default:
+                return assertUnreachable(parse, 'Unknown dbt parse outcome');
+        }
+    }
+
+    /**
+     * Install the dbt compile wrapper, push the warehouse skill files, reset the
+     * compile-timings log, and record whether the project parsed BEFORE the
+     * agent edits anything — the in-sandbox prerequisites for a dbt-writeback
+     * turn. Extracted as the `beforeAgentRun` hook of {@link dbtWritebackConfig};
+     * returns the baseline the post-agent parse gate is judged against.
      */
     private async prepareDbtAgentRun(
         sandbox: SandboxHandle,
         turn: TurnContext,
-    ): Promise<void> {
+        profilesStaged: boolean,
+    ): Promise<DbtParseBaselineStatus> {
         // Install the compile wrapper. The agent runs ${COMPILE_WRAPPER_PATH}
         // (allowlisted) instead of `lightdash compile` directly, and the wrapper
         // drops secrets from the environment before exec'ing the real CLI — so a
@@ -4079,6 +4321,21 @@ export class AiWritebackService extends BaseService {
         if (skills.warehouse !== null) {
             await sandbox.files.write(WAREHOUSE_SKILL_PATH, skills.warehouse);
         }
+
+        // Baseline for the post-agent `dbt parse` gate: does the project parse
+        // BEFORE the agent edits anything? Only meaningful once `dbt deps` has
+        // run and a credential-free profiles copy is staged. A project that is
+        // already broken can't have the gate held against it, so the gate is
+        // skipped rather than blocking every write-back to that repo.
+        if (!profilesStaged) return 'not-run';
+        const parse = await this.runDbtParse(sandbox, turn);
+        if (parse.outcome === 'failed') {
+            this.logger.warn(
+                `AiWriteback: dbt parse gate disabled — the project does not parse before this turn (sandboxId=${sandbox.sandboxId}): ${parse.failureOutput}`,
+            );
+            return 'failed';
+        }
+        return parse.outcome === 'parsed' ? 'parsed' : 'not-run';
     }
 
     /**
@@ -4088,6 +4345,15 @@ export class AiWritebackService extends BaseService {
      * wrapper / timings hooks. This is the specialization {@link run} uses.
      */
     private dbtWritebackConfig(): CodingAgentConfig {
+        // Per-run state shared by the hooks below: whether a credential-free
+        // profiles copy was staged (set while building the prompt) and whether
+        // the project parsed before the agent touched it (set just before the
+        // CLI runs). Both feed the post-agent `dbt parse` gate. A config is
+        // built per run, so this never leaks across runs.
+        const parseBaseline: DbtParseBaseline = {
+            profilesStaged: false,
+            status: 'not-run',
+        };
         return {
             mode: 'dbt-writeback',
             // Provider-aware writeback template (E2B template ref on e2b, the
@@ -4108,6 +4374,7 @@ export class AiWritebackService extends BaseService {
                     sandbox,
                     turn.gitConnection.projectSubPath,
                 );
+                parseBaseline.profilesStaged = profilesStaged;
                 const skillKey = warehouseTypeToSkillKey(turn.warehouseType);
                 const systemPrompt = buildSystemPrompt(
                     turn.gitConnection.projectSubPath,
@@ -4128,9 +4395,16 @@ export class AiWritebackService extends BaseService {
                     model: CLAUDE_MODEL,
                 };
             },
-            beforeAgentRun: (sandbox, turn) =>
-                this.prepareDbtAgentRun(sandbox, turn),
+            beforeAgentRun: async (sandbox, turn) => {
+                parseBaseline.status = await this.prepareDbtAgentRun(
+                    sandbox,
+                    turn,
+                    parseBaseline.profilesStaged,
+                );
+            },
             afterAgentRun: (sandbox) => this.reportCompileTimings(sandbox),
+            verifyChanges: (sandbox, turn) =>
+                this.verifyDbtParses(sandbox, turn, parseBaseline),
         };
     }
 

--- a/packages/backend/src/ee/services/AiWritebackService/__snapshots__/templates.test.ts.snap
+++ b/packages/backend/src/ee/services/AiWritebackService/__snapshots__/templates.test.ts.snap
@@ -20,6 +20,11 @@ BEFORE editing a \`schema.yml\` \`type:\` field or modifying SQL that changes a 
 
 Before writing or modifying dbt model SQL (a \`.sql\` model, or a \`schema.yml\` \`sql:\` expression), use the \`effective-dbt-sql\` skill for how to structure it. In particular: reuse an existing dimension or metric instead of re-deriving its value, and never compute a value with a correlated subquery — join an aggregated CTE or use a window function instead. This is separate from the type-coercion rules above: that guidance governs a column's emitted type; this governs the shape of the SQL.
 
+When you finish, the host runs \`dbt parse\` on your changes itself. If they do
+not parse you get ONE chance to fix them, and if they still do not parse no pull
+request is opened — so do the compile step below rather than assuming an edit
+was fine.
+
 If you made any file changes, perform these follow-up steps before you finish:
 
 1. The dbt project directory (containing \`dbt_project.yml\`) is
@@ -95,6 +100,11 @@ exports[`buildSystemPrompt — warehouse skill guidance > matches the snapshot f
 This Lightdash project's warehouse is **postgres**. BEFORE editing a \`schema.yml\` \`type:\` field or modifying SQL that changes a column's emitted type, you MUST read /home/user/.lightdash-skills/warehouse.md and /home/user/.lightdash-skills/shared.md. They contain warehouse-specific type-coercion rules. Skipping this step has produced PRs that broke filters and silently changed query results.
 
 Before writing or modifying dbt model SQL (a \`.sql\` model, or a \`schema.yml\` \`sql:\` expression), use the \`effective-dbt-sql\` skill for how to structure it. In particular: reuse an existing dimension or metric instead of re-deriving its value, and never compute a value with a correlated subquery — join an aggregated CTE or use a window function instead. This is separate from the type-coercion rules above: that guidance governs a column's emitted type; this governs the shape of the SQL.
+
+When you finish, the host runs \`dbt parse\` on your changes itself. If they do
+not parse you get ONE chance to fix them, and if they still do not parse no pull
+request is opened — so do the compile step below rather than assuming an edit
+was fine.
 
 If you made any file changes, perform these follow-up steps before you finish:
 

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -119,6 +119,16 @@ export const COMPILE_STRIPPED_ENV_VARS = [
     'GH_TOKEN',
 ];
 
+// Ceiling on a single host-run `dbt parse`. Parsing a large project (deps
+// already installed) is tens of seconds; this bounds a pathological project
+// well under RUN_TIMEOUT_MS so the gate can never eat the whole run budget.
+export const DBT_PARSE_TIMEOUT_MS = 5 * 60 * 1000;
+
+// How much of a failed `dbt parse` output we keep. It reaches the agent's repair
+// prompt and the user-facing error, so it must carry dbt's error block (path +
+// message) without dumping the whole log.
+export const DBT_PARSE_OUTPUT_TAIL_CHARS = 2000;
+
 // Fine-grained tool permissions for the Claude Code CLI — used in place of
 // `--dangerously-skip-permissions`. Follows Claude Code's `--allowedTools`
 // syntax: `Tool(specifier)`, where `//path` denotes an absolute filesystem

--- a/packages/backend/src/ee/services/AiWritebackService/errors.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/errors.ts
@@ -77,3 +77,19 @@ export class WritebackRunAbortedError extends Error {
         this.runStatus = runStatus;
     }
 }
+
+/**
+ * Thrown when the host's `dbt parse` gate finds that the agent's changes stop
+ * the dbt project parsing, and the agent could not repair them. No pull request
+ * is opened: an obviously broken dbt project is worse than no change at all.
+ * The message carries dbt's own error output so the agent can relay it and offer
+ * the user the patch by hand.
+ */
+export class WritebackDbtParseError extends ParameterError {
+    constructor(parseOutput: string) {
+        super(
+            `The changes were made but they stop the dbt project parsing, so no pull request was opened. Tell the user what broke, using dbt's own error below, and offer to try a different approach:\n\n${parseOutput}`,
+        );
+        this.name = 'WritebackDbtParseError';
+    }
+}

--- a/packages/backend/src/ee/services/AiWritebackService/scripts.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/scripts.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { buildGatherRepoContextScript } from './scripts';
+import { buildDbtParseCommand, buildGatherRepoContextScript } from './scripts';
 
 describe('buildGatherRepoContextScript', () => {
     const temporaryDirectories: string[] = [];
@@ -37,4 +37,29 @@ describe('buildGatherRepoContextScript', () => {
             expect(output.trim()).toBe('./model.sql');
         },
     );
+});
+
+describe('buildDbtParseCommand', () => {
+    const command = buildDbtParseCommand({
+        dbtBin: '/usr/local/dbt1.9/bin',
+        projectDir: "/home/user/repo/team's dbt",
+        profilesDir: '/tmp/ld-profiles',
+    });
+
+    it('pins dbt to the project version venv and points at the staged profiles', () => {
+        expect(command).toContain(
+            'PATH="/usr/local/dbt1.9/bin:$PATH" dbt parse',
+        );
+        expect(command).toContain(
+            "--project-dir '/home/user/repo/team'\"'\"'s dbt'",
+        );
+        expect(command).toContain("--profiles-dir '/tmp/ld-profiles'");
+    });
+
+    // A parse runs dbt over customer models, so it must not carry secrets a
+    // Jinja `env_var(...)` could read — the same property the compile wrapper has.
+    it('strips secrets from the parse environment', () => {
+        expect(command).toContain('-u ANTHROPIC_API_KEY');
+        expect(command).toContain('-u GITHUB_TOKEN');
+    });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/scripts.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/scripts.ts
@@ -1,3 +1,4 @@
+import { COMPILE_STRIPPED_ENV_VARS } from './constants';
 import { quoteShellArgument } from './utils';
 
 /**
@@ -5,6 +6,34 @@ import { quoteShellArgument } from './utils';
  * is a function returning the rendered script body so call sites get
  * type-checked variable substitution and JSON-safe quoting at the boundary.
  */
+
+/**
+ * Command the host runs to check that the dbt project still parses: `dbt parse`
+ * with the project's dbt venv on PATH and secrets stripped from the child, the
+ * same hardening the agent's compile wrapper applies (a malicious model must not
+ * be able to read them via Jinja `env_var(...)` during the parse).
+ *
+ * `--profiles-dir` points at the credential-free profiles copy the host stages,
+ * so the parse needs no warehouse connection and no environment variables.
+ */
+export const buildDbtParseCommand = ({
+    dbtBin,
+    projectDir,
+    profilesDir,
+}: {
+    dbtBin: string;
+    projectDir: string;
+    profilesDir: string;
+}): string => {
+    const unsetFlags = COMPILE_STRIPPED_ENV_VARS.map(
+        (name) => `-u ${name}`,
+    ).join(' ');
+    return (
+        `env ${unsetFlags} PATH="${dbtBin}:$PATH" dbt parse ` +
+        `--project-dir ${quoteShellArgument(projectDir)} ` +
+        `--profiles-dir ${quoteShellArgument(profilesDir)}`
+    );
+};
 
 /**
  * Pre-compute a dbt project file listing for the AI writeback agent: every

--- a/packages/backend/src/ee/services/AiWritebackService/templates.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.ts
@@ -82,6 +82,31 @@ const buildStagedProfilesSteps = (dbtProjectDir: string): string => `
 
 3. End your final reply with the two structured-output blocks below.`;
 
+/**
+ * Prompt for the one repair turn the host grants when its own `dbt parse` gate
+ * fails on the agent's changes. The agent still has the session (and the
+ * files) it just edited, so this only has to hand it dbt's error and the
+ * expectation: fix it, or revert to a state that parses.
+ */
+export const buildDbtParseRepairPrompt = (parseFailure: string): string =>
+    `
+Your changes do not parse. The host ran \`dbt parse\` on the working tree after
+you finished and it failed:
+
+<dbt_parse_error>
+${parseFailure}
+</dbt_parse_error>
+
+Fix this now — no pull request is opened while the project does not parse.
+
+- Fix the file(s) you changed so the project parses. Do NOT work around the
+  error by disabling, deleting, or renaming unrelated models.
+- If your approach cannot be made to parse, revert your changes entirely and
+  say so in your reply instead.
+- Re-run the compile wrapper to confirm before you finish.
+- End your reply with the same structured-output blocks as before.
+`.trim();
+
 export const buildSystemPrompt = (
     dbtProjectDir: string,
     context: {
@@ -163,6 +188,11 @@ ${context.repoContext.listing}
 `
             : ''
     }
+When you finish, the host runs \`dbt parse\` on your changes itself. If they do
+not parse you get ONE chance to fix them, and if they still do not parse no pull
+request is opened — so do the compile step below rather than assuming an edit
+was fine.
+
 If you made any file changes, perform these follow-up steps before you finish:
 ${
     context.profilesStaged

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -189,7 +189,30 @@ export type CodingAgentConfig = {
      * depend on what the agent did (dbt: read + report the compile timings).
      */
     afterAgentRun: (sandbox: SandboxHandle) => Promise<void>;
+    /**
+     * Host-side check that the agent's changes are not obviously broken, run
+     * after the CLI exits and BEFORE any commit/push/PR (dbt: `dbt parse`).
+     * Undefined for the general agent, whose verification is the PR's own CI.
+     */
+    verifyChanges?: (
+        sandbox: SandboxHandle,
+        turn: TurnContext,
+    ) => Promise<ChangeVerification>;
 };
+
+/**
+ * Outcome of a {@link CodingAgentConfig.verifyChanges} check.
+ * - `passed`: the changes verify — carry on to the pull request.
+ * - `skipped`: the check couldn't be trusted (no staged profiles, or the project
+ *   already failed to verify before the agent touched it), so it isn't held
+ *   against the change. `reason` is logged.
+ * - `failed`: the agent broke the project. `failureOutput` is the tool's own
+ *   error, shown to the agent for one repair turn and to the user if it stands.
+ */
+export type ChangeVerification =
+    | { status: 'passed' }
+    | { status: 'skipped'; reason: string }
+    | { status: 'failed'; failureOutput: string };
 
 /**
  * The git-target half of a {@link TurnContext}, resolved per mode before the
@@ -323,6 +346,28 @@ export type AiWritebackUsage = {
     numTurns: number | null;
     /** Time (ms) spent in LLM API calls — the rest is local tool execution. */
     durationApiMs: number | null;
+};
+
+/** What one Claude Code CLI invocation produced. */
+export type AgentRunOutcome = {
+    /** The agent's final assistant message. */
+    stdout: string;
+    exitCode: number;
+    usage: AiWritebackUsage | null;
+};
+
+/**
+ * Whether the dbt project parsed BEFORE this turn's edits, which is what makes
+ * the post-agent `dbt parse` gate attributable to the agent. Mutable: filled in
+ * as the run progresses (profiles staged while building the prompt, `status`
+ * just before the CLI runs) and read by the gate afterwards.
+ */
+export type DbtParseBaselineStatus = 'not-run' | 'parsed' | 'failed';
+
+export type DbtParseBaseline = {
+    /** A credential-free profiles copy was staged, so `dbt parse` can run. */
+    profilesStaged: boolean;
+    status: DbtParseBaselineStatus;
 };
 
 /** Title/description/summary parsed out of the agent's final stdout. */

--- a/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
@@ -41,6 +41,8 @@ import {
     resolveSandboxDbtVersion,
     resolveSandboxTemplateRef,
     splitStreamBuffer,
+    sumAgentUsage,
+    summarizeDbtParseFailure,
     summarizeToolInput,
 } from './utils';
 
@@ -757,5 +759,71 @@ describe('resolveSandboxDbtVersion', () => {
         expect(resolveSandboxDbtVersion(DbtVersionOptionLatest.LATEST)).toBe(
             getLatestSupportDbtVersion(),
         );
+    });
+});
+
+describe('summarizeDbtParseFailure', () => {
+    it("keeps dbt's error block and drops its banner lines", () => {
+        const summary = summarizeDbtParseFailure({
+            stdout: [
+                '15:01:02  Running with dbt=1.9.0',
+                '15:01:02  Registered adapter: postgres=1.9.0',
+                '',
+                'Compilation Error in model orders (models/orders.sql)',
+                '  depends on a node named "missing_model" which was not found',
+            ].join('\n'),
+            stderr: '',
+        });
+
+        expect(summary).toContain('Compilation Error in model orders');
+        expect(summary).toContain('missing_model');
+        expect(summary).not.toContain('Registered adapter');
+    });
+
+    it('keeps the tail of a long output, where dbt prints the error', () => {
+        const summary = summarizeDbtParseFailure({
+            stdout: `${'noise\n'.repeat(2000)}Parsing Error: invalid yaml`,
+            stderr: '',
+        });
+
+        expect(summary.length).toBeLessThanOrEqual(2000);
+        expect(summary).toContain('Parsing Error: invalid yaml');
+    });
+
+    it('never returns an empty summary', () => {
+        expect(summarizeDbtParseFailure({ stdout: '', stderr: '' })).toBe(
+            'dbt parse failed with no output',
+        );
+    });
+});
+
+describe('sumAgentUsage', () => {
+    const usage = (costUsd: number | null, numTurns: number | null) => ({
+        costUsd,
+        inputTokens: 10,
+        outputTokens: 20,
+        cacheReadInputTokens: null,
+        cacheCreationInputTokens: null,
+        numTurns,
+        durationApiMs: 100,
+    });
+
+    it('adds both turns of a repaired run', () => {
+        expect(sumAgentUsage(usage(0.5, 3), usage(0.25, 2))).toMatchObject({
+            costUsd: 0.75,
+            inputTokens: 20,
+            numTurns: 5,
+            durationApiMs: 200,
+        });
+    });
+
+    it('keeps an unknown field unknown rather than zeroing it', () => {
+        expect(
+            sumAgentUsage(usage(null, 1), usage(null, 1))?.costUsd,
+        ).toBeNull();
+        expect(sumAgentUsage(usage(0.5, 1), null)).toMatchObject({
+            costUsd: 0.5,
+        });
+        expect(sumAgentUsage(null, null)).toBeNull();
     });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -12,6 +12,7 @@ import {
 import type { AiWritebackFailureStage } from '../../../analytics/LightdashAnalytics';
 import {
     COMPILE_WRAPPER_PATH,
+    DBT_PARSE_OUTPUT_TAIL_CHARS,
     DBT_VENV_BIN_PREFIX,
     PR_DESCRIPTION_CLOSE,
     PR_DESCRIPTION_OPEN,
@@ -23,6 +24,7 @@ import {
 import type {
     AgentStreamEvent,
     AgentToolCall,
+    AiWritebackUsage,
     CloneTarget,
     GitCommitAuthor,
     GitConnection,
@@ -643,3 +645,64 @@ export const resolveSandboxDbtVersion = (
  */
 export const dbtSandboxVenvBin = (version: SupportedDbtVersions): string =>
     `${DBT_VENV_BIN_PREFIX}${version.slice(1)}/bin`;
+
+/**
+ * Condense a failed `dbt parse` into the part worth showing: dbt writes its
+ * error block to stdout (with a copy of the summary on stderr), padded with
+ * banner/timing lines that carry no signal. Keeps the last
+ * `DBT_PARSE_OUTPUT_TAIL_CHARS` characters of the useful lines — the tail is
+ * where dbt prints the offending file and message.
+ */
+export const summarizeDbtParseFailure = ({
+    stdout,
+    stderr,
+}: {
+    stdout: string;
+    stderr: string;
+}): string => {
+    const lines = `${stdout}\n${stderr}`
+        .split('\n')
+        .map((line) => line.trimEnd())
+        .filter((line) => {
+            // dbt prefixes most lines with a timestamp; drop it before matching
+            // its log banners and progress chatter, which are never the error.
+            const body = line.trim().replace(/^\d{2}:\d{2}:\d{2}\s+/, '');
+            return (
+                body.length > 0 &&
+                !/^(Running with dbt=|Registered adapter:|Found \d)/.test(body)
+            );
+        });
+    const summary = lines.join('\n').slice(-DBT_PARSE_OUTPUT_TAIL_CHARS);
+    return summary.length > 0 ? summary : 'dbt parse failed with no output';
+};
+
+/**
+ * Add up the usage of the turns that made up one run (the agent's turn plus, if
+ * the verification gate needed one, its repair turn) so analytics report the
+ * whole run's spend. Null-preserving: two unknown values stay unknown rather
+ * than collapsing to zero.
+ */
+export const sumAgentUsage = (
+    first: AiWritebackUsage | null,
+    second: AiWritebackUsage | null,
+): AiWritebackUsage | null => {
+    if (first === null) return second;
+    if (second === null) return first;
+    const add = (a: number | null, b: number | null): number | null =>
+        a === null && b === null ? null : (a ?? 0) + (b ?? 0);
+    return {
+        costUsd: add(first.costUsd, second.costUsd),
+        inputTokens: add(first.inputTokens, second.inputTokens),
+        outputTokens: add(first.outputTokens, second.outputTokens),
+        cacheReadInputTokens: add(
+            first.cacheReadInputTokens,
+            second.cacheReadInputTokens,
+        ),
+        cacheCreationInputTokens: add(
+            first.cacheCreationInputTokens,
+            second.cacheCreationInputTokens,
+        ),
+        numTurns: add(first.numTurns, second.numTurns),
+        durationApiMs: add(first.durationApiMs, second.durationApiMs),
+    };
+};


### PR DESCRIPTION
The writeback agent was only *asked* to run `lightdash compile` — an instruction it can skip or misread — so changes that broke dbt in obvious ways (a dangling `ref()`, a mistyped YAML key) still reached a PR.

The host now runs `dbt parse` itself after the agent finishes and before any commit/push/PR:

- **Attributable only.** A baseline `dbt parse` runs before the agent edits anything (right after `dbt deps`, using the credential-free profiles copy the host already stages). Only a project that parsed *before* the turn can fail the gate, so a pre-existing breakage — unresolvable packages, a profile the placeholder patch can't satisfy — never blocks a writeback. A parse that can't be run at all (timeout/transport) is likewise skipped, never read as a broken change.
- **One repair turn.** On a failure the agent gets a single follow-up turn in the same CLI session with dbt's own error, then the changes are re-parsed. Its reply and PR metadata win over the first turn's, and both turns' token usage is reported.
- **No broken PRs.** If the changes still don't parse, the run fails with dbt's error relayed to the agent (and the user) and no PR is opened. A repair that reverts everything is just a normal "no changes" turn.

The parse runs with the project's dbt-version venv on PATH and secrets stripped from the environment — the same hardening as the existing compile wrapper. The general (`editRepo`) agent is unchanged: its verification is the PR's own CI.

Verified with `pnpm -F backend lint`, `typecheck`, and the backend AI test suites (`AiWritebackService`: 313 passing, incl. new gate tests for pass / repair-then-pass / still-failing / pre-existing failure / parse-couldn't-run; `ai` + `AiAgentService`: 1795 passing).
