### PR TITLE
fix: support modifier-click for explorer previews

### DIFF
--- a/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.tsx
@@ -47,7 +47,7 @@ type Props = {
     upgrade: (SdkUpgradeOffer & { disabled: boolean }) | null;
     onUpgradeStarted: () => void;
     onToggleHistory: () => void;
-    onPreviewInExplorer: () => void;
+    previewInExplorerLink: To | null;
 };
 
 const ChartTypeBuilderHeader: FC<Props> = ({
@@ -62,7 +62,7 @@ const ChartTypeBuilderHeader: FC<Props> = ({
     upgrade,
     onUpgradeStarted,
     onToggleHistory,
-    onPreviewInExplorer,
+    previewInExplorerLink,
 }) => {
     const [isEditingDetails, setIsEditingDetails] = useState(false);
     const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
@@ -166,8 +166,12 @@ const ChartTypeBuilderHeader: FC<Props> = ({
                         History
                     </Button>
                 )}
-                {latestReadyVersion !== null && (
-                    <Button size="xs" onClick={onPreviewInExplorer}>
+                {latestReadyVersion !== null && previewInExplorerLink && (
+                    <Button
+                        size="xs"
+                        component={Link}
+                        to={previewInExplorerLink}
+                    >
                         Preview in explorer
                     </Button>
                 )}

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -496,7 +496,15 @@ describe('ChartTypeBuilder', () => {
             `/projects/p1/chart-types/${dataAppVizUuid}${explorerSearch()}`,
         );
 
-        fireEvent.click(screen.getByText('Preview in explorer'));
+        const previewLink = screen.getByRole('link', {
+            name: 'Preview in explorer',
+        });
+        expect(previewLink).toHaveAttribute(
+            'href',
+            expect.stringContaining('/projects/p1/tables/orders?'),
+        );
+
+        fireEvent.click(previewLink);
 
         const destination = new URL(
             screen.getByTestId('location').textContent ?? '',
@@ -532,7 +540,15 @@ describe('ChartTypeBuilder', () => {
             'href',
             '/projects/p1/gallery',
         );
-        fireEvent.click(screen.getByText('Preview in explorer'));
+        const previewLink = screen.getByRole('link', {
+            name: 'Preview in explorer',
+        });
+        expect(previewLink).toHaveAttribute(
+            'href',
+            `/projects/p1/tables?dataAppVizUuid=${dataAppVizUuid}`,
+        );
+
+        fireEvent.click(previewLink);
 
         expect(screen.getByTestId('location')).toHaveTextContent(
             `/projects/p1/tables?dataAppVizUuid=${dataAppVizUuid}`,

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -333,18 +333,14 @@ const ChartTypeBuilder: FC = () => {
             false,
         );
     }, [activeVizUuid, explorerChart, projectUuid]);
-    const handlePreviewInExplorer = useCallback(() => {
-        if (!activeVizUuid) return;
+    const previewInExplorerLink = useMemo(() => {
+        if (!activeVizUuid) return null;
 
-        if (explorerDestination) {
-            void navigate(explorerDestination);
-            return;
-        }
-
-        void navigate(
-            `/projects/${projectUuid}/tables?dataAppVizUuid=${activeVizUuid}`,
+        return (
+            explorerDestination ??
+            `/projects/${projectUuid}/tables?dataAppVizUuid=${activeVizUuid}`
         );
-    }, [activeVizUuid, explorerDestination, navigate, projectUuid]);
+    }, [activeVizUuid, explorerDestination, projectUuid]);
 
     const canEdit = useCanEditDataApp(projectUuid, {
         spaceUuid: appMeta?.spaceUuid ?? null,
@@ -480,7 +476,7 @@ const ChartTypeBuilder: FC = () => {
                         ? handleCloseHistory()
                         : setIsHistoryOpen(true)
                 }
-                onPreviewInExplorer={handlePreviewInExplorer}
+                previewInExplorerLink={previewInExplorerLink}
             />
             <PanelGroup direction="horizontal" className={classes.main}>
                 <Panel id="chart-type-builder-canvas" order={1} minSize={50}>


### PR DESCRIPTION
Closes:

### Description:

Changes the visualization builder's Preview in explorer control from a programmatic button to a router link. Normal clicks retain the existing in-app navigation, while Cmd/Ctrl-click and other native link interactions can open the preview in a new tab.

Adds regression coverage for Explorer-origin and standalone visualization preview destinations.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: this preserves the existing destination and unmodified-click behavior while restoring native link semantics.

### Testing:

- pnpm -F frontend test src/pages/ChartTypeBuilder.test.tsx
- pnpm -F frontend typecheck
- pnpm -F frontend lint
- Manual Cmd-click and plain-click verification in the running visualization builder