### PR TITLE
fix: use thread terminology in AI thread retention copy

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ThreadRetentionCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ThreadRetentionCard.tsx
@@ -36,11 +36,11 @@ export const ThreadRetentionCard = ({
             >
                 <Box maw={620}>
                     <Title order={5} mb={4}>
-                        Conversation retention
+                        Thread retention
                     </Title>
                     <Text c="ldGray.6" fz="xs">
-                        Automatically delete agent conversations after a period
-                        of inactivity. Agents can shorten this window but not
+                        Automatically delete agent threads after a period of
+                        inactivity. Agents can shorten this window but not
                         extend it.
                     </Text>
                 </Box>
@@ -62,7 +62,7 @@ export const ThreadRetentionCard = ({
             <MantineModal
                 opened={pendingRetentionHours !== undefined}
                 onClose={() => setPendingRetentionHours(undefined)}
-                title="Reduce conversation retention?"
+                title="Reduce thread retention?"
                 icon={IconAlertTriangle}
                 role="alertdialog"
                 confirmLabel="Reduce retention"
@@ -77,7 +77,7 @@ export const ThreadRetentionCard = ({
             >
                 <Stack gap="xs">
                     <Text fz="sm">
-                        Conversations inactive for longer than{' '}
+                        Threads inactive for longer than{' '}
                         {pendingRetentionHours !== undefined
                             ? formatRetentionHours(pendingRetentionHours)
                             : ''}{' '}
@@ -89,14 +89,14 @@ export const ThreadRetentionCard = ({
                         <Group gap="xs">
                             <Loader size="xs" />
                             <Text fz="sm" c="dimmed">
-                                Counting affected conversations…
+                                Counting affected threads…
                             </Text>
                         </Group>
                     ) : previewQuery.data &&
                       previewQuery.data.threadCount > 0 ? (
                         <Callout
                             variant="danger"
-                            title={`${previewQuery.data.threadCount} conversation${
+                            title={`${previewQuery.data.threadCount} thread${
                                 previewQuery.data.threadCount === 1 ? '' : 's'
                             } across ${previewQuery.data.agentCount} agent${
                                 previewQuery.data.agentCount === 1 ? '' : 's'

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -887,8 +887,8 @@ export const AiAgentFormSetup = ({
                             <>
                                 <Divider />
                                 <AgentSettingsSubsection
-                                    title="Conversation retention"
-                                    description={`Delete this agent's conversations after a period of inactivity. Active conversations are never cut off.${
+                                    title="Thread retention"
+                                    description={`Delete this agent's threads after a period of inactivity. Active threads are never cut off.${
                                         aiOrganizationSettings?.threadRetentionHours !=
                                         null
                                             ? ' The organization retention policy caps this setting.'

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadRetentionNotice.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadRetentionNotice.tsx
@@ -36,8 +36,8 @@ export const ThreadRetentionNotice: FC<Props> = ({
         <Group gap={4} wrap="nowrap">
             <MantineIcon icon={IconHourglass} size={14} color="ldGray.6" />
             <Text size="xs" c="ldGray.6">
-                Conversations are deleted after{' '}
-                {formatRetentionHours(effectiveHours)} of inactivity
+                Threads are deleted after {formatRetentionHours(effectiveHours)}{' '}
+                of inactivity
             </Text>
         </Group>
     );


### PR DESCRIPTION
The retention settings copy said "conversations" while the rest of the AI UI (admin Threads page) and the API (`threadRetentionHours`) say "threads", so the same object had two names depending on where you looked.

Follow-up to ZAP-787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)