### PR TITLE
feat(external-sources): register external tables as a query source

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -20,6 +20,8 @@ import { DeployService } from '../services/DeployService';
 import { InstanceConfigurationService } from '../services/InstanceConfigurationService/InstanceConfigurationService';
 import { OrganizationService } from '../services/OrganizationService/OrganizationService';
 import { ProjectService } from '../services/ProjectService/ProjectService';
+import { QuerySourceRegistry } from '../services/QuerySourceService/QuerySourceRegistry';
+import { QuerySourceService } from '../services/QuerySourceService/QuerySourceService';
 import { RolesService } from '../services/RolesService/RolesService';
 import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
 import { failInFlightAiAgentStreams } from './aiAgentShutdown';
@@ -87,6 +89,7 @@ import { EmbedService } from './services/EmbedService/EmbedService';
 import { ExternalConnectionCoderService } from './services/ExternalConnectionCoderService/ExternalConnectionCoderService';
 import { ExternalConnectionService } from './services/ExternalConnectionService/ExternalConnectionService';
 import { GoogleServiceAccountTokenProvider } from './services/ExternalConnectionService/GoogleServiceAccountTokenProvider';
+import { ExternalQuerySource } from './services/ExternalSourceService/ExternalQuerySource';
 import { ExternalSourceService } from './services/ExternalSourceService/ExternalSourceService';
 import { HomepageRecommendedActionSkipsService } from './services/HomepageRecommendedActionSkipsService';
 import { EnterpriseLicenseService } from './services/LicenseService/LicenseService';
@@ -366,6 +369,26 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     googleDriveClient: clients.getGoogleDriveClient(),
                     userOAuthGrantsModel: models.getUserOAuthGrantsModel(),
                 }),
+            querySourceService: ({ models, repository }) => {
+                const registry = QuerySourceRegistry.withBuiltInSources({
+                    asyncQueryService: repository.getAsyncQueryService(),
+                    projectService: repository.getProjectService(),
+                });
+                registry.register(
+                    new ExternalQuerySource({
+                        asyncQueryService: repository.getAsyncQueryService(),
+                        projectService: repository.getProjectService(),
+                        externalSourceModel:
+                            models.getExternalSourceModel<ExternalSourceModel>(),
+                    }),
+                );
+                return new QuerySourceService({
+                    projectModel: models.getProjectModel(),
+                    queryHistoryModel: models.getQueryHistoryModel(),
+                    featureFlagModel: models.getFeatureFlagModel(),
+                    registry,
+                });
+            },
             appGenerateService: ({ context, models, clients, repository }) =>
                 new AppGenerateService({
                     lightdashConfig: context.lightdashConfig,
@@ -1013,10 +1036,16 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getPersistentDownloadFileService(),
                     organizationAccessService:
                         repository.getOrganizationAccessService(),
-                    externalSourceTableResolver: (projectUuid, tableUuid) =>
+                    externalSourceTableResolver: (
+                        projectUuid,
+                        tableUuidOrName,
+                    ) =>
                         models
                             .getExternalSourceModel<ExternalSourceModel>()
-                            .findTableForQuery(projectUuid, tableUuid),
+                            .findTableByUuidOrName(
+                                projectUuid,
+                                tableUuidOrName,
+                            ),
                     preAggregateStrategy: new PreAggregateStrategy({
                         preAggregationDuckDbClient:
                             new PreAggregationDuckDbClient({

--- a/packages/backend/src/ee/models/ExternalSourceModel.ts
+++ b/packages/backend/src/ee/models/ExternalSourceModel.ts
@@ -5,11 +5,13 @@ import {
     type ExternalSource,
     type ExternalSourceConnection,
     type ExternalSourceTable,
+    type ExternalSourceTableReference,
     type ExternalSourceType,
     type ResultColumns,
 } from '@lightdash/common';
 import { randomUUID } from 'crypto';
 import { Knex } from 'knex';
+import { validate as validateUuid } from 'uuid';
 import {
     ExternalSourceCredentialsTableName,
     ExternalSourceIngestAttemptsTableName,
@@ -29,6 +31,8 @@ type ExternalSourceModelArguments = {
     database: Knex;
     encryptionUtil: Pick<EncryptionUtil, 'encrypt' | 'decrypt'>;
 };
+
+const EXTERNAL_SOURCE_TABLE_NAME_PATTERN = /^[a-z][a-z0-9_]{0,254}$/;
 
 export class ExternalSourceModel {
     private readonly database: Knex;
@@ -863,7 +867,18 @@ export class ExternalSourceModel {
             .first();
     }
 
-    async findTableForQuery(projectUuid: string, tableUuid: string) {
+    /** UUIDs contain hyphens; SQL table names do not, so lookups are unambiguous. */
+    async findTableByUuidOrName(
+        projectUuid: string,
+        tableUuidOrName: ExternalSourceTableReference,
+    ) {
+        const isTableUuid = validateUuid(tableUuidOrName);
+        if (
+            !isTableUuid &&
+            !EXTERNAL_SOURCE_TABLE_NAME_PATTERN.test(tableUuidOrName)
+        ) {
+            return undefined;
+        }
         const row = await this.database(ExternalSourceTablesTableName)
             .innerJoin(
                 ExternalSourcesTableName,
@@ -876,15 +891,34 @@ export class ExternalSourceModel {
             )
             .where(`${ExternalSourceTablesTableName}.project_uuid`, projectUuid)
             .andWhere(`${ExternalSourcesTableName}.project_uuid`, projectUuid)
-            .andWhere(
-                `${ExternalSourceTablesTableName}.external_source_table_uuid`,
-                tableUuid,
-            )
+            .andWhere((queryBuilder) => {
+                if (isTableUuid) {
+                    queryBuilder.where(
+                        `${ExternalSourceTablesTableName}.external_source_table_uuid`,
+                        tableUuidOrName,
+                    );
+                } else {
+                    queryBuilder.where(
+                        `${ExternalSourceTablesTableName}.name`,
+                        tableUuidOrName,
+                    );
+                }
+            })
             .first();
         return row as
             | (DbExternalSourceTable & {
                   external_source_status: ExternalSourceStatus;
               })
             | undefined;
+    }
+
+    async listReadyTables(
+        projectUuid: string,
+    ): Promise<DbExternalSourceTable[]> {
+        return this.database(ExternalSourceTablesTableName)
+            .where('project_uuid', projectUuid)
+            .whereNotNull('locator')
+            .whereNotNull('columns')
+            .orderBy('name');
     }
 }

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.test.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.test.ts
@@ -1,0 +1,177 @@
+import {
+    DimensionType,
+    ParameterError,
+    QueryExecutionContext,
+    QuerySourceType,
+    type Account,
+} from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
+import type { ProjectService } from '../../../services/ProjectService/ProjectService';
+import type { ExternalSourceModel } from '../../models/ExternalSourceModel';
+import { ExternalQuerySource } from './ExternalQuerySource';
+
+const account = { user: { id: 'user-1' } } as unknown as Account;
+
+const submitArgs = {
+    account,
+    projectUuid: 'project-1',
+    context: QueryExecutionContext.API,
+    resolvedReferences: {},
+};
+
+describe('ExternalQuerySource', () => {
+    const executeAsyncExternalSqlQuery = vi
+        .fn()
+        .mockResolvedValue({ queryUuid: 'query-1' });
+    const getAllExploresSummary = vi.fn();
+    const listReadyTables = vi.fn();
+
+    const source = new ExternalQuerySource({
+        asyncQueryService: {
+            executeAsyncExternalSqlQuery,
+        } as unknown as AsyncQueryService,
+        projectService: {
+            getAllExploresSummary,
+        } as unknown as ProjectService,
+        externalSourceModel: {
+            listReadyTables,
+        } as unknown as ExternalSourceModel,
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        executeAsyncExternalSqlQuery.mockResolvedValue({
+            queryUuid: 'query-1',
+        });
+    });
+
+    it('rejects queries of another source type', async () => {
+        await expect(
+            source.submitQuery({
+                ...submitArgs,
+                query: { sourceType: QuerySourceType.SQL, sql: 'SELECT 1' },
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('has no DAG edges: external tables are durable files', () => {
+        expect(
+            source.getQueryReferences({
+                sourceType: QuerySourceType.EXTERNAL,
+                sql: 'SELECT 1',
+                tables: ['monthly_targets'],
+            }),
+        ).toEqual([]);
+    });
+
+    it('normalizes the array shorthand to a name-keyed map', async () => {
+        const result = await source.submitQuery({
+            ...submitArgs,
+            query: {
+                sourceType: QuerySourceType.EXTERNAL,
+                sql: 'SELECT * FROM monthly_targets',
+                tables: ['monthly_targets', 'other_table'],
+            },
+        });
+
+        expect(result).toEqual({ queryUuid: 'query-1' });
+        expect(executeAsyncExternalSqlQuery).toHaveBeenCalledWith({
+            account,
+            projectUuid: 'project-1',
+            context: QueryExecutionContext.API,
+            sql: 'SELECT * FROM monthly_targets',
+            limit: undefined,
+            tables: {
+                monthly_targets: 'monthly_targets',
+                other_table: 'other_table',
+            },
+        });
+    });
+
+    it('passes the map form through unchanged', async () => {
+        await source.submitQuery({
+            ...submitArgs,
+            query: {
+                sourceType: QuerySourceType.EXTERNAL,
+                sql: 'SELECT * FROM t',
+                limit: 10,
+                tables: { t: '7b8ac342-0000-4000-8000-000000000001' },
+            },
+        });
+
+        expect(executeAsyncExternalSqlQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                limit: 10,
+                tables: { t: '7b8ac342-0000-4000-8000-000000000001' },
+            }),
+        );
+    });
+
+    it('scans only tables whose explore the caller can see, with raw columns', async () => {
+        getAllExploresSummary.mockResolvedValue([
+            {
+                name: 'monthly_targets',
+                externalSource: {
+                    sourceUuid: 'source-1',
+                    tableUuid: 'table-1',
+                    sourceType: 'csv',
+                },
+            },
+            { name: 'orders' },
+            { name: 'broken', errors: [{ type: 'x', message: 'boom' }] },
+        ]);
+        listReadyTables.mockResolvedValue([
+            {
+                external_source_table_uuid: 'table-1',
+                name: 'monthly_targets',
+                label: 'Monthly targets',
+                columns: {
+                    _month: { reference: '_month', type: DimensionType.DATE },
+                    _target: {
+                        reference: '_target',
+                        type: DimensionType.NUMBER,
+                    },
+                },
+            },
+            {
+                external_source_table_uuid: 'table-hidden',
+                name: 'hidden_table',
+                label: 'Hidden',
+                columns: {
+                    a: { reference: 'a', type: DimensionType.STRING },
+                },
+            },
+        ]);
+
+        const schema = await source.scanSchema({
+            account,
+            projectUuid: 'project-1',
+        });
+
+        expect(schema).toEqual({
+            sourceType: QuerySourceType.EXTERNAL,
+            tables: [
+                {
+                    reference: 'monthly_targets',
+                    label: 'Monthly targets',
+                    description: null,
+                    columns: [
+                        {
+                            reference: '_month',
+                            type: DimensionType.DATE,
+                            label: null,
+                            description: null,
+                        },
+                        {
+                            reference: '_target',
+                            type: DimensionType.NUMBER,
+                            label: null,
+                            description: null,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.ts
@@ -1,0 +1,143 @@
+import {
+    isSummaryExploreError,
+    ParameterError,
+    QuerySourceType,
+    type ExternalSourceQuery,
+    type ExternalSourceTableReference,
+    type QuerySourceDefinition,
+    type QuerySourceSchema,
+    type QuerySourceSchemaTable,
+    type QuerySourceTableName,
+    type SourceQuery,
+} from '@lightdash/common';
+import type { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
+import type { ProjectService } from '../../../services/ProjectService/ProjectService';
+import type {
+    QuerySourceClient,
+    ScanSchemaArgs,
+    SubmitSourceQueryArgs,
+} from '../../../services/QuerySourceService/types';
+import type { ExternalSourceModel } from '../../models/ExternalSourceModel';
+
+type ExternalQuerySourceArguments = {
+    asyncQueryService: AsyncQueryService;
+    projectService: ProjectService;
+    externalSourceModel: ExternalSourceModel;
+};
+
+/** Durable external tables exposed as a DuckDB query source. */
+export class ExternalQuerySource implements QuerySourceClient {
+    readonly definition: QuerySourceDefinition = {
+        sourceType: QuerySourceType.EXTERNAL,
+        label: 'External sources',
+        description:
+            'DuckDB SQL over external source tables (uploaded CSVs, connected Google Sheets). Tables expose ingested files as named tables: an array of table names, or a {tableName: tableNameOrUuid} map for aliasing. Column names are the ingested columns from scanSchema, not explore field ids. Join the result with warehouse data in a referencing duckdb query.',
+    };
+
+    private readonly asyncQueryService: AsyncQueryService;
+
+    private readonly projectService: ProjectService;
+
+    private readonly externalSourceModel: ExternalSourceModel;
+
+    constructor(args: ExternalQuerySourceArguments) {
+        this.asyncQueryService = args.asyncQueryService;
+        this.projectService = args.projectService;
+        this.externalSourceModel = args.externalSourceModel;
+    }
+
+    private static assertSourceQuery(query: SourceQuery): ExternalSourceQuery {
+        if (query.sourceType !== QuerySourceType.EXTERNAL) {
+            throw new ParameterError(
+                `Expected a ${QuerySourceType.EXTERNAL} query, got "${query.sourceType}"`,
+            );
+        }
+        return query;
+    }
+
+    /** The array shorthand exposes each table under its own name. */
+    private static normalizeTables(
+        tables: ExternalSourceQuery['tables'],
+    ): Record<QuerySourceTableName, ExternalSourceTableReference> {
+        if (Array.isArray(tables)) {
+            return Object.fromEntries(tables.map((name) => [name, name]));
+        }
+        return tables;
+    }
+
+    /** Returns ingested columns for external explores visible to the caller. */
+    async scanSchema({
+        account,
+        projectUuid,
+    }: ScanSchemaArgs): Promise<QuerySourceSchema> {
+        const summaries = await this.projectService.getAllExploresSummary(
+            account,
+            projectUuid,
+            true,
+            false,
+        );
+        const visibleTableUuids = new Set(
+            summaries.flatMap((summary) =>
+                !isSummaryExploreError(summary) && summary.externalSource
+                    ? [summary.externalSource.tableUuid]
+                    : [],
+            ),
+        );
+
+        const tableRows =
+            await this.externalSourceModel.listReadyTables(projectUuid);
+        const tables: QuerySourceSchemaTable[] = tableRows.flatMap((row) => {
+            if (
+                !visibleTableUuids.has(row.external_source_table_uuid) ||
+                row.columns === null
+            ) {
+                return [];
+            }
+            return [
+                {
+                    reference: row.name,
+                    label: row.label,
+                    description: null,
+                    columns: Object.values(row.columns).map((column) => ({
+                        reference: column.reference,
+                        type: column.type,
+                        label: null,
+                        description: null,
+                    })),
+                },
+            ];
+        });
+
+        return {
+            sourceType: QuerySourceType.EXTERNAL,
+            tables,
+        };
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    getQueryReferences(_query: SourceQuery): string[] {
+        // Durable external tables create no dependency edges.
+        return [];
+    }
+
+    async submitQuery({
+        account,
+        projectUuid,
+        context,
+        query,
+    }: SubmitSourceQueryArgs): Promise<{ queryUuid: string }> {
+        const sourceQuery = ExternalQuerySource.assertSourceQuery(query);
+
+        const results =
+            await this.asyncQueryService.executeAsyncExternalSqlQuery({
+                account,
+                projectUuid,
+                sql: sourceQuery.sql,
+                limit: sourceQuery.limit,
+                tables: ExternalQuerySource.normalizeTables(sourceQuery.tables),
+                context,
+            });
+
+        return { queryUuid: results.queryUuid };
+    }
+}

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -79,6 +79,7 @@ import {
     MissingConfigError,
     normalizeIndexColumns,
     NotFoundError,
+    NotImplementedError,
     NotSupportedError,
     OrganizationAccessStatus,
     ParameterError,
@@ -121,12 +122,14 @@ import {
     type ExecuteAsyncComposeMergeQueryRequestParams,
     type ExecuteAsyncComposeSqlQueryRequestParams,
     type ExecuteAsyncDashboardChartRequestParams,
+    type ExecuteAsyncExternalSqlQueryRequestParams,
     type ExecuteAsyncFieldValueSearchRequestParams,
     type ExecuteAsyncMergeQueryRequestParams,
     type ExecuteAsyncMetricQueryRequestParams,
     type ExecuteAsyncQueryRequestParams,
     type ExecuteAsyncSavedChartRequestParams,
     type ExecuteAsyncUnderlyingDataRequestParams,
+    type ExternalSourceTableReference,
     type MergeQueryChart,
     type Organization,
     type ParameterDefinitions,
@@ -257,6 +260,7 @@ import {
     type ExecuteAsyncComposeSqlQueryArgs,
     type ExecuteAsyncDashboardChartQueryArgs,
     type ExecuteAsyncDashboardSqlChartArgs,
+    type ExecuteAsyncExternalSqlQueryArgs,
     type ExecuteAsyncFieldValueSearchArgs,
     type ExecuteAsyncMergeQueryArgs,
     type ExecuteAsyncMetricQueryArgs,
@@ -391,14 +395,10 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     persistentDownloadFileService: PersistentDownloadFileService;
     organizationAccessService: OrganizationAccessService;
     preAggregateStrategy?: PreAggregateStrategy;
-    /**
-     * Resolves an external source table (locator, columns, version) for
-     * explores of type EXTERNAL_SOURCE. Injected by the enterprise edition;
-     * absent on OSS, where external source queries are refused.
-     */
+    /** EE resolver for external tables; absent in OSS. */
     externalSourceTableResolver?: (
         projectUuid: string,
-        tableUuid: string,
+        tableUuidOrName: ExternalSourceTableReference,
     ) => Promise<
         | (DbExternalSourceTable & {
               external_source_status: ExternalSourceStatus;
@@ -7160,6 +7160,206 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
+    /** Executes DuckDB SQL over versioned external tables without persisting file URIs. */
+    async executeAsyncExternalSqlQuery({
+        account,
+        projectUuid,
+        sql,
+        context,
+        limit,
+        tables,
+    }: ExecuteAsyncExternalSqlQueryArgs): Promise<ApiExecuteAsyncSqlQueryResults> {
+        assertIsAccountWithOrg(account);
+
+        const { enabled: isEndpointEnabled } = await this.featureFlagModel.get({
+            user: {
+                userUuid: account.user.id,
+                organizationUuid: account.organization.organizationUuid,
+            },
+            featureFlagId: FeatureFlags.ExternalSources,
+        });
+        if (!isEndpointEnabled) {
+            throw new ForbiddenError('External sources are not enabled');
+        }
+
+        const projectSummary = await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = projectSummary;
+
+        // External SQL uses the same ability as compose SQL.
+        const auditedAbility = this.createAuditedAbility(account);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Explore', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        try {
+            DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
+        } catch (e) {
+            throw new ParameterError(getErrorMessage(e));
+        }
+
+        const tableEntries = Object.entries(tables);
+        if (tableEntries.length === 0) {
+            throw new ParameterError(
+                'External SQL queries must name at least one external source table',
+            );
+        }
+        const resolver = this.externalSourceTableResolver;
+        if (!resolver) {
+            throw new NotImplementedError(
+                'External source queries need the enterprise DuckDB engine',
+            );
+        }
+
+        const resolvedTables = await Promise.all(
+            tableEntries.map(async ([tableName, reference]) => {
+                const table = await resolver(projectUuid, reference);
+                if (!table) {
+                    throw new ParameterError(
+                        `Unknown external source table "${reference}"`,
+                    );
+                }
+                if (!table.locator || !table.columns) {
+                    throw new ParameterError(
+                        `External source table "${reference}" has no ingested data yet. Refresh the source and try again`,
+                    );
+                }
+                return {
+                    tableName,
+                    tableUuid: table.external_source_table_uuid,
+                    version: table.version,
+                    locator: table.locator,
+                    columns: table.columns,
+                };
+            }),
+        );
+
+        const referenceCtes = resolvedTables.map(
+            ({ tableName, locator, columns }) =>
+                `${quoteDuckdbIdentifier(
+                    tableName,
+                )} AS (SELECT * FROM ${getDuckdbPreAggregateSqlTable(
+                    locator,
+                    columns,
+                )})`,
+        );
+
+        // Table versions invalidate cached SQL results after refresh.
+        const externalSourceSalt = resolvedTables
+            .map(({ tableUuid, version }) => `esv:${tableUuid}:${version}`)
+            .sort()
+            .join('|');
+        const cacheKey = QueryHistoryModel.getCacheKey(projectUuid, {
+            sql: JSON.stringify({
+                sql,
+                tables: [...tableEntries].sort(([a], [b]) =>
+                    a.localeCompare(b),
+                ),
+            }),
+            userUuid: null,
+            externalSourceSalt,
+        });
+
+        // Throws NotImplementedError when the engine is unavailable
+        const warehouseClient =
+            this.preAggregateStrategy.createExecutionWarehouseClient();
+
+        const queryTags: RunQueryTags = {
+            ...this.getUserQueryTags(account),
+            ...AsyncQueryService.getSchedulerQueryTags(),
+            organization_uuid: organizationUuid,
+            project_uuid: projectUuid,
+            query_context: context,
+        };
+
+        const placeholderComposer = new SqlQueryComposer({
+            userSql: sql,
+            columns: [],
+            warehouseClient,
+            pivotConfiguration: undefined,
+            limit,
+            parameters: undefined,
+            dashboardFilters: undefined,
+            tileUuid: undefined,
+            dashboardSorts: undefined,
+        });
+
+        const requestParameters: ExecuteAsyncExternalSqlQueryRequestParams = {
+            sql,
+            limit,
+            context,
+            tables,
+        };
+
+        const queryCreatedAt = new Date();
+        const { queryUuid } = await this.queryHistoryModel.create(account, {
+            projectUuid,
+            organizationUuid,
+            context,
+            fields: {},
+            compiledSql: sql,
+            requestParameters,
+            metricQuery: placeholderComposer.getMetricQuery(),
+            cacheKey,
+            pivotConfiguration: null,
+            originalColumns: {},
+        });
+        this.prometheusMetrics?.trackQueryStateTransition(
+            'new',
+            QueryHistoryStatus.PENDING,
+            context,
+        );
+
+        const onboardingFlow = await this.getOnboardingFlow({
+            userUuid: account.user.id,
+            organizationUuid,
+        });
+
+        void this.runDuckdbSqlQuery({
+            account,
+            projectUuid,
+            organizationUuid,
+            isPreviewProject:
+                projectSummary.type === ProjectType.PREVIEW ||
+                projectSummary.provisioningSource === 'playground',
+            onboardingFlow,
+            queryUuid,
+            resolvedSql: AsyncQueryService.wrapSqlWithReferenceCtes(
+                sql,
+                referenceCtes,
+            ),
+            // Only persist the user SQL; resolved SQL contains private URIs.
+            storedCompiledSql: sql,
+            limit,
+            warehouseClient,
+            queryTags,
+            queryCreatedAt,
+            cacheKey,
+            context,
+        }).catch((e) => {
+            this.logger.error(
+                `Async external SQL query ${queryUuid} failed: ${getErrorMessage(
+                    e,
+                )}`,
+            );
+        });
+
+        return {
+            queryUuid,
+            cacheMetadata: { cacheHit: false },
+            parameterReferences: [],
+            usedParametersValues: {},
+            resolvedTimezone: null,
+        };
+    }
+
     /** How long a compose query waits for a referenced query's results. */
     private static readonly REFERENCE_WAIT_TIMEOUT_MS = 15 * 60 * 1000;
 
@@ -7222,11 +7422,72 @@ export class AsyncQueryService extends ProjectService {
                   })
                 : [];
 
-            const resolvedSql = AsyncQueryService.wrapSqlWithReferenceCtes(
-                sql,
-                referenceCtes,
+            await this.runDuckdbSqlQuery({
+                account,
+                projectUuid,
+                organizationUuid,
+                isPreviewProject,
+                onboardingFlow,
+                queryUuid,
+                resolvedSql: AsyncQueryService.wrapSqlWithReferenceCtes(
+                    sql,
+                    referenceCtes,
+                ),
+                limit,
+                warehouseClient,
+                queryTags,
+                queryCreatedAt,
+                cacheKey,
+                context,
+            });
+        } catch (e) {
+            await this.queryHistoryModel.update(
+                queryUuid,
+                projectUuid,
+                {
+                    status: QueryHistoryStatus.ERROR,
+                    error: getErrorMessage(e),
+                    errored_at: new Date(),
+                },
+                account,
             );
+        }
+    }
 
+    /** Executes resolved DuckDB SQL through the standard query lifecycle. */
+    private async runDuckdbSqlQuery({
+        account,
+        projectUuid,
+        organizationUuid,
+        isPreviewProject,
+        onboardingFlow,
+        queryUuid,
+        resolvedSql,
+        storedCompiledSql,
+        limit,
+        warehouseClient,
+        queryTags,
+        queryCreatedAt,
+        cacheKey,
+        context,
+    }: {
+        account: Account;
+        projectUuid: string;
+        organizationUuid: string;
+        isPreviewProject: boolean;
+        onboardingFlow: OnboardingFlow;
+        queryUuid: string;
+        resolvedSql: string;
+        /** Safe SQL persisted instead of resolved SQL containing private URIs. */
+        storedCompiledSql?: string;
+        limit: number | undefined;
+        warehouseClient: WarehouseClient;
+        queryTags: RunQueryTags;
+        queryCreatedAt: Date;
+        cacheKey: string;
+        context: QueryExecutionContext;
+    }): Promise<void> {
+        try {
             // Column discovery (LIMIT 1) also validates the SQL
             const columns: { name: string; type: DimensionType }[] = [];
             const columnDiscoverySql = applyLimitToSqlQuery({
@@ -7292,7 +7553,7 @@ export class AsyncQueryService extends ProjectService {
                 queryUuid,
                 projectUuid,
                 {
-                    compiled_sql: query,
+                    compiled_sql: storedCompiledSql ?? query,
                     fields: fieldsMap,
                     original_columns: originalColumns,
                 },

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -15,11 +15,13 @@ import {
     type DashboardFilters,
     type DateZoom,
     type DownloadAsyncQueryResultsPayload,
+    type ExternalSourceTableReference,
     type Filters,
     type ItemsMap,
     type ParametersValuesMap,
     type PreAggregateExecutionEngine,
     type QueryExecutionContext,
+    type QuerySourceTableName,
     type ResultColumns,
     type ResultsPaginationArgs,
     type RunQueryTags,
@@ -179,6 +181,13 @@ export type ExecuteAsyncComposeSqlQueryArgs = CommonAsyncQueryArgs & {
     limit?: number;
     /** Table name -> queryUuid of a previous async query to expose as that table. */
     references?: Record<string, UUID>;
+};
+
+export type ExecuteAsyncExternalSqlQueryArgs = CommonAsyncQueryArgs & {
+    sql: string;
+    limit?: number;
+    /** Table name -> external source table (name or uuid) to expose as that table. */
+    tables: Record<QuerySourceTableName, ExternalSourceTableReference>;
 };
 
 export type ExecuteAsyncMergeQueryArgs = CommonAsyncQueryArgs & {

--- a/packages/backend/src/services/QuerySourceService/QuerySourceRegistry.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceRegistry.ts
@@ -4,6 +4,11 @@ import {
     type QuerySourceDefinition,
     type QuerySourceType,
 } from '@lightdash/common';
+import type { AsyncQueryService } from '../AsyncQueryService/AsyncQueryService';
+import type { ProjectService } from '../ProjectService/ProjectService';
+import { DuckdbQuerySource } from './sources/DuckdbQuerySource';
+import { SemanticLayerQuerySource } from './sources/SemanticLayerQuerySource';
+import { SqlQuerySource } from './sources/SqlQuerySource';
 import type { QuerySourceClient } from './types';
 
 /**
@@ -14,6 +19,31 @@ import type { QuerySourceClient } from './types';
 export class QuerySourceRegistry {
     private readonly sources: Map<QuerySourceType, QuerySourceClient> =
         new Map();
+
+    /** Creates the built-in registry for extension by enterprise sources. */
+    static withBuiltInSources({
+        asyncQueryService,
+        projectService,
+    }: {
+        asyncQueryService: AsyncQueryService;
+        projectService: ProjectService;
+    }): QuerySourceRegistry {
+        const registry = new QuerySourceRegistry();
+        registry.register(
+            new SemanticLayerQuerySource({
+                asyncQueryService,
+                projectService,
+            }),
+        );
+        registry.register(
+            new SqlQuerySource({
+                asyncQueryService,
+                projectService,
+            }),
+        );
+        registry.register(new DuckdbQuerySource({ asyncQueryService }));
+        return registry;
+    }
 
     register(source: QuerySourceClient): void {
         const { sourceType } = source.definition;

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -67,9 +67,6 @@ import { PromptService } from './PromptService/PromptService';
 import { PullRequestsService } from './PullRequestsService/PullRequestsService';
 import { QuerySourceRegistry } from './QuerySourceService/QuerySourceRegistry';
 import { QuerySourceService } from './QuerySourceService/QuerySourceService';
-import { DuckdbQuerySource } from './QuerySourceService/sources/DuckdbQuerySource';
-import { SemanticLayerQuerySource } from './QuerySourceService/sources/SemanticLayerQuerySource';
-import { SqlQuerySource } from './QuerySourceService/sources/SqlQuerySource';
 import type { ReadinessService } from './ReadinessService/ReadinessService';
 import { RenameService } from './RenameService/RenameService';
 import { RolesService } from './RolesService/RolesService';
@@ -985,22 +982,10 @@ export class ServiceRepository
 
     public getQuerySourceService(): QuerySourceService {
         return this.getService('querySourceService', () => {
-            const asyncQueryService = this.getAsyncQueryService();
-            const projectService = this.getProjectService();
-            const registry = new QuerySourceRegistry();
-            registry.register(
-                new SemanticLayerQuerySource({
-                    asyncQueryService,
-                    projectService,
-                }),
-            );
-            registry.register(
-                new SqlQuerySource({
-                    asyncQueryService,
-                    projectService,
-                }),
-            );
-            registry.register(new DuckdbQuerySource({ asyncQueryService }));
+            const registry = QuerySourceRegistry.withBuiltInSources({
+                asyncQueryService: this.getAsyncQueryService(),
+                projectService: this.getProjectService(),
+            });
 
             return new QuerySourceService({
                 projectModel: this.models.getProjectModel(),

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -6,6 +6,10 @@ import type { AndFilterGroup, DashboardFilters, Filters } from '../filter';
 import { type MergeQuery, type MetricSourcedMergeQuery } from '../mergeQuery';
 import type { MetricQueryRequest, SortField } from '../metricQuery';
 import type { PivotConfig } from '../pivot';
+import type {
+    ExternalSourceTableReference,
+    QuerySourceTableName,
+} from '../querySources';
 import type { DateGranularity } from '../timeFrames';
 import type { UUID } from './uuid';
 
@@ -102,6 +106,14 @@ export type ExecuteAsyncComposeSqlQueryRequestParams =
          * additionalProperties intact (and validates the uuid format).
          */
         references?: Record<string, UUID>;
+    };
+
+export type ExecuteAsyncExternalSqlQueryRequestParams =
+    CommonExecuteQueryRequestParams & {
+        sql: string;
+        limit?: number;
+        /** Table alias to external table SQL name or UUID. */
+        tables: Record<QuerySourceTableName, ExternalSourceTableReference>;
     };
 
 export type ExecuteAsyncUnderlyingDataRequestParams =

--- a/packages/common/src/types/querySources.ts
+++ b/packages/common/src/types/querySources.ts
@@ -34,6 +34,8 @@ export enum QuerySourceType {
      * step of a multi-source pipeline.
      */
     DUCKDB = 'duckdb',
+    /** Durable external tables queried with DuckDB; enterprise only. */
+    EXTERNAL = 'external',
 }
 
 /**
@@ -139,6 +141,24 @@ export type DuckdbSourceQuery = {
 };
 
 /**
+ * External table SQL name or UUID.
+ * @pattern ^[a-zA-Z0-9_][a-zA-Z0-9_-]{0,63}$
+ */
+export type ExternalSourceTableReference = string;
+
+/** DuckDB SQL over named durable external tables. */
+export type ExternalSourceQuery = {
+    sourceType: QuerySourceType.EXTERNAL;
+    /** Names this query so other queries in the same submission can reference its results. */
+    nodeId?: QueryNodeId;
+    sql: string;
+    limit?: number;
+    tables:
+        | ExternalSourceTableReference[]
+        | Record<QuerySourceTableName, ExternalSourceTableReference>;
+};
+
+/**
  * The tagged union every submit endpoint takes: one shape per source,
  * discriminated by sourceType. New sources add a member here — this union is
  * the extension point, not new WarehouseTypes values.
@@ -146,7 +166,8 @@ export type DuckdbSourceQuery = {
 export type SourceQuery =
     | SemanticLayerSourceQuery
     | SqlSourceQuery
-    | DuckdbSourceQuery;
+    | DuckdbSourceQuery
+    | ExternalSourceQuery;
 
 /** A column in a source schema, aligned with ResultColumns' {reference, type}. */
 export type QuerySourceSchemaColumn = {


### PR DESCRIPTION
Seventh slice of external data sources: external tables join the multi-source query platform as a live `QuerySourceClient`. `QuerySourceType.EXTERNAL` takes raw DuckDB SQL over a project's ingested tables, which unlocks two things the stack below didn't have: arbitrary SQL over CSVs and Sheets (previously metric-query-only), and agent-visible schema discovery through the standard source catalog surface.

## What this adds

- **Common**: `QuerySourceType.EXTERNAL` and `ExternalSourceQuery` in the `SourceQuery` union: `{sql, tables}` where `tables` is an array of table names (each exposed under its own name) or a `{tableName: tableNameOrUuid}` map for aliasing, mirroring the duckdb source's reference ergonomics. Ref-aliased record value types keep TSOA's record compilation intact.
- **`AsyncQueryService.executeAsyncExternalSqlQuery`**: resolves every referenced table in the foreground (they are durable files, not running queries), builds server-side `read_parquet` CTEs, and runs on the engine through a shared execution tail extracted from the compose path (`runDuckdbSqlQuery`: column discovery, `SqlQueryComposer` compile, `query_history` update, in-process execution). User SQL passes `validateUserSqlFileAccess` before any CTE is attached; stored `compiled_sql` keeps the plain user SQL so file URIs never leave the backend.
- **Cache correctness**: the cache key carries `esv:{tableUuid}:{version}` for every referenced table (sorted), so a Sheets refresh or CSV replace invalidates results whose SQL text did not change. Table entries are sorted before hashing so key order doesn't fragment the cache.
- **EE adapter** (`ExternalQuerySource`): `scanSchema` returns the raw ingested columns (normalized CSV headers, what the SQL actually selects) for exactly the tables whose explores the caller can see, delegating authorization and user-attribute filtering to `getAllExploresSummary`. `getQueryReferences` is empty: external tables are durable, so external queries have no DAG edges; joining with warehouse results happens in a referencing `duckdb` query.
- **Registration**: `QuerySourceRegistry.withBuiltInSources()` factory (the registry's documented enterprise extension point); the EE overrides the `querySourceService` provider and registers the adapter on top. The injected `externalSourceTableResolver` widens from uuid-only to uuid-or-name (table names cannot contain hyphens, so the forms never shadow).

One thing the live test surfaced, fixed here because this PR introduced it: the shared execution tail persisted the resolved SQL into `compiled_sql`, which for external tables carries the parquet S3 URI (fine for compose, whose references are the caller's own result files). The tail now takes a `storedCompiledSql` override and the external path persists the plain user SQL, keeping the stack's URI-never-leaves-the-backend invariant (verified in `query_history` on the live instance). A second, pre-existing bug the live test found (`externalSource` missing from explore summaries) is split into #27794 below, which this PR's `scanSchema` depends on.

## Regression analysis

- OSS behavior is unchanged: the built-in three sources construct through the new factory with identical arguments, and `QuerySourceType.EXTERNAL` is simply unregistered (a clear "unknown query source" error). The provider override only exists under an enterprise license.
- The compose path is a pure extraction: `runComposeSqlQuery` delegates to `runDuckdbSqlQuery` with the same values in the same order; the full backend suite passed unchanged.
- Gating is double-layered: the query-sources API keeps its `MultiSourceQuery` flag, and the new method additionally requires `ExternalSources` plus the same `manage Explore` ability compose SQL uses.
- The resolver widening is backward compatible: existing callers pass uuids, which resolve exactly as before.

## Testing

- Full backend suite green (478 files) including new adapter tests: source-type assertion, array-shorthand normalization, empty DAG edges, and schema scan visibility filtering with raw column mapping.
- `pnpm generate-api` compiles the new union member (validated locally; generated files not committed per convention).
- **Live-verified end to end** on an isolated instance: `GET /query-sources` lists the source, `GET /query-sources/external/schema` returns the three ingested tables with raw typed columns, and one submission with an external node (SQL over the CSV), a semanticLayer node (orders revenue), and a duckdb node FULL OUTER JOINing them returned correct matched rows. The external leg's `query_history` row carries the plain user SQL and the version-salted cache key.

## Naming note for review

The plan doc reserved a `csv` source slot; this lands as `external` because the adapter covers Sheets (and future raw-slot sources) too, wrapping the durable `external_source_tables` registry rather than growing a parallel store. Happy to rename before merge if `csv` (or something else) is preferred for the public contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6KsLFbzm9A1kViYX5pM3k
