### PR TITLE
fix(external-sources): project the externalSource ref into explore summaries

### DIFF
--- a/docs/external-sources/CONTEXT.md
+++ b/docs/external-sources/CONTEXT.md
@@ -14,7 +14,8 @@ _Avoid_: connection (collides with data-app external connections), integration, 
 **Source table**:
 One queryable table belonging to an external source, backed by an ingested
 parquet file in object storage and surfaced as an explore. A CSV source has
-one table; a Google Sheets source can have one per tab.
+one table. The first release creates one Google Sheets source for one selected
+tab; multi-tab sources are not yet part of the API contract.
 _Avoid_: dataset, file, view
 
 **Ingest**:
@@ -28,6 +29,13 @@ A user-initiated request to ingest a source's current data again — re-reading
 the connected sheet, or replacing the uploaded file. Not dashboard
 auto-refresh.
 _Avoid_: sync, re-import, rebuild
+
+**Ingest attempt**:
+A durable, generation-specific request to ingest one source table. The
+scheduler payload names the attempt, not mutable source state. A lease and
+execution token fence timed-out workers; retries resume publication or rebuild
+into a new object without letting stale work publish.
+_Avoid_: job (the scheduler job is only one delivery mechanism), run
 
 **Staged upload**:
 An uploaded file that has been stored and sniffed but not yet confirmed as a
@@ -53,8 +61,31 @@ _Avoid_: path, URL, link
 - Storage lives in the pre-aggregates S3 bucket under
   `external-sources/{projectUuid}/{sourceUuid}/…` because the shared DuckDB
   engine's S3 session is configured exclusively from that bucket's config.
-- Rows are durable (no TTL), unlike query results. Deleting a source deletes
-  its rows and explores; ingested files are currently left in object storage
-  (cleanup is a follow-up).
+- Every raw/parquet object is registered before upload. Replaced, deleted,
+  failed, and abandoned-stage objects become `pending_delete`; a five-minute
+  maintenance task retries exact-key deletion. Manifests intentionally survive
+  source deletion until collection succeeds.
+- Google refresh tokens are encrypted and owned by the source, not looked up
+  through its creator. A manager can explicitly reconnect to replace that
+  credential with their current Google grant.
+- External query DuckDB clients are isolated, resource-limited, and create an
+  S3 secret scoped to the exact published object URI. User SQL remains
+  SELECT-only and file-reading functions remain blocked.
+- Customer rollout limits are configurable with `EXTERNAL_SOURCES_*`: upload
+  bytes, organization storage bytes, rows, Sheets batch size, concurrent
+  ingests, concurrent DuckDB queries, lease duration, stage TTL, and GC batch
+  size. Defaults: 100 MB/file, 5 GB/org, 1M rows, two concurrent ingests and
+  queries per organization.
 - Preview projects copy source rows with fresh uuids; the ingested files are
   shared by URI, not duplicated.
+
+## Operational caveats
+
+- The DuckDB query concurrency budget is process-local. Deployments with many
+  API workers should size the per-worker limit accordingly; ingest concurrency
+  is database-coordinated and therefore cluster-wide.
+- DuckDB `SCOPE` limits which URI receives the configured credential. Production
+  should still use dedicated S3/IAM credentials restricted to the
+  `external-sources/` prefix for defense in depth.
+- Sheets paging bounds application memory and applies byte/row caps, but Google
+  API rate limits still apply; scheduler retries use the same durable attempt.

--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -75,6 +75,12 @@ import {
 } from '../database/entities/emailOneTimePasscodes';
 import { EmailTable, EmailTableName } from '../database/entities/emails';
 import {
+    ExternalSourceCredentialsTable,
+    ExternalSourceCredentialsTableName,
+    ExternalSourceIngestAttemptsTable,
+    ExternalSourceIngestAttemptsTableName,
+    ExternalSourceObjectsTable,
+    ExternalSourceObjectsTableName,
     ExternalSourcesTable,
     ExternalSourcesTableName,
     ExternalSourceTablesTable,
@@ -564,6 +570,9 @@ declare module 'knex/types/tables' {
         [EmailTableName]: EmailTable;
         [ExternalSourcesTableName]: ExternalSourcesTable;
         [ExternalSourceTablesTableName]: ExternalSourceTablesTable;
+        [ExternalSourceCredentialsTableName]: ExternalSourceCredentialsTable;
+        [ExternalSourceIngestAttemptsTableName]: ExternalSourceIngestAttemptsTable;
+        [ExternalSourceObjectsTableName]: ExternalSourceObjectsTable;
         [FeatureFlagsTableName]: FeatureFlagsTable;
         [FeatureFlagOverridesTableName]: FeatureFlagOverridesTable;
         [SessionTableName]: SessionTable;

--- a/packages/backend/src/clients/Google/GoogleDriveClient.test.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.test.ts
@@ -341,4 +341,71 @@ describe('GoogleDriveClient', () => {
             ).toBeUndefined();
         });
     });
+
+    describe('row batches', () => {
+        test('reads bounded A1 ranges without loading the full tab', async () => {
+            vi.mocked(google.auth.fromJSON).mockReturnValue({} as never);
+            vi.mocked(google.auth.GoogleAuth).mockImplementation(
+                function MockGoogleAuth(this: object) {
+                    return this;
+                } as never,
+            );
+            const getMetadata = vi.fn().mockResolvedValue({
+                data: {
+                    sheets: [
+                        {
+                            properties: {
+                                title: "Q1's data",
+                                gridProperties: {
+                                    rowCount: 5,
+                                    columnCount: 28,
+                                },
+                            },
+                        },
+                    ],
+                },
+            });
+            const getValues = vi
+                .fn()
+                .mockResolvedValueOnce({ data: { values: [['h'], ['a']] } })
+                .mockResolvedValueOnce({ data: { values: [['b'], ['c']] } })
+                .mockResolvedValueOnce({ data: { values: [['d']] } });
+            vi.mocked(google.sheets).mockReturnValue({
+                spreadsheets: {
+                    get: getMetadata,
+                    values: { get: getValues },
+                },
+            } as never);
+            const client = new GoogleDriveClient({
+                lightdashConfig: {
+                    auth: {
+                        google: {
+                            oauth2ClientId: 'client-id',
+                            oauth2ClientSecret: 'client-secret',
+                        },
+                    },
+                },
+            } as never);
+
+            const batches: unknown[][][] = [];
+            // eslint-disable-next-line no-restricted-syntax
+            for await (const batch of client.getSheetRowBatches(
+                'refresh-token',
+                'file-id',
+                "Q1's data",
+                2,
+            )) {
+                batches.push(batch);
+            }
+
+            expect(batches).toHaveLength(3);
+            expect(
+                getValues.mock.calls.map(([request]) => request.range),
+            ).toEqual([
+                "'Q1''s data'!A1:AB2",
+                "'Q1''s data'!A3:AB4",
+                "'Q1''s data'!A5:AB5",
+            ]);
+        });
+    });
 });

--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -34,6 +34,17 @@ const GOOGLE_SHEETS_CELL_CHAR_LIMIT = 50000;
 const TRUNCATION_SUFFIX = '... [TRUNCATED]';
 const TRUNCATE_INDEX = GOOGLE_SHEETS_CELL_CHAR_LIMIT - TRUNCATION_SUFFIX.length;
 
+const columnNumberToA1 = (columnCount: number): string => {
+    let value = columnCount;
+    let result = '';
+    while (value > 0) {
+        value -= 1;
+        result = String.fromCharCode(65 + (value % 26)) + result;
+        value = Math.floor(value / 26);
+    }
+    return result || 'A';
+};
+
 export class GoogleDriveClient {
     private readonly lightdashConfig: LightdashConfig;
 
@@ -253,6 +264,55 @@ export class GoogleDriveClient {
             }),
         );
         return response.data.values ?? [];
+    }
+
+    /**
+     * Page a sheet by row range. This bounds memory while retaining the same
+     * unformatted-value semantics as getSheetValues.
+     */
+    async *getSheetRowBatches(
+        refreshToken: string,
+        fileId: string,
+        tabName: string,
+        batchRows: number,
+    ): AsyncGenerator<unknown[][]> {
+        if (!this.isEnabled) {
+            throw new MissingConfigError('Google Drive is not enabled');
+        }
+        const auth = await this.getCredentials(refreshToken);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const metadata = await GoogleDriveClient.catchApiError(
+            sheets.spreadsheets.get({
+                spreadsheetId: fileId,
+                fields: 'sheets(properties(title,gridProperties(rowCount,columnCount)))',
+            }),
+        );
+        const properties = (metadata.data.sheets ?? []).find(
+            (sheet) => sheet.properties?.title === tabName,
+        )?.properties;
+        if (!properties) {
+            throw new NotFoundError(`Google Sheet tab not found: ${tabName}`);
+        }
+        const rowCount = properties.gridProperties?.rowCount ?? 0;
+        const columnCount = properties.gridProperties?.columnCount ?? 0;
+        if (rowCount === 0 || columnCount === 0) return;
+
+        const escapedTab = tabName.replaceAll("'", "''");
+        const lastColumn = columnNumberToA1(columnCount);
+        for (let startRow = 1; startRow <= rowCount; startRow += batchRows) {
+            const endRow = Math.min(startRow + batchRows - 1, rowCount);
+            // Sequential paging avoids Google API quota bursts.
+            // eslint-disable-next-line no-await-in-loop
+            const response = await GoogleDriveClient.catchApiError(
+                sheets.spreadsheets.values.get({
+                    spreadsheetId: fileId,
+                    range: `'${escapedTab}'!A${startRow}:${lastColumn}${endRow}`,
+                    valueRenderOption: 'UNFORMATTED_VALUE',
+                    dateTimeRenderOption: 'FORMATTED_STRING',
+                }),
+            );
+            yield response.data.values ?? [];
+        }
     }
 
     async assertFileIsGoogleSheet(refreshToken: string, fileId: string) {

--- a/packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts
+++ b/packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts
@@ -1,4 +1,8 @@
-import { GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import {
+    DeleteObjectCommand,
+    GetObjectCommand,
+    HeadObjectCommand,
+} from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import {
@@ -159,6 +163,18 @@ export class S3ResultsFileStorageClient extends S3CacheClient {
             );
             return null;
         }
+    }
+
+    async deleteFile(key: string): Promise<void> {
+        if (!this.configuration || !this.s3) {
+            throw new MissingConfigError('S3 configuration is not set');
+        }
+        await this.s3.send(
+            new DeleteObjectCommand({
+                Bucket: this.configuration.bucket,
+                Key: key,
+            }),
+        );
     }
 
     async getDownloadStream(

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -392,6 +392,14 @@ export const lightdashConfigMock: LightdashConfig = {
     },
     externalSources: {
         maxFileSizeBytes: 100 * 1024 * 1024,
+        maxRows: 1_000_000,
+        maxOrganizationBytes: 5 * 1024 * 1024 * 1024,
+        maxConcurrentIngestsPerOrganization: 2,
+        maxConcurrentDuckdbQueriesPerOrganization: 2,
+        googleSheetsBatchRows: 5_000,
+        stagedUploadTtlHours: 24,
+        ingestLeaseMs: 35 * 60 * 1000,
+        garbageCollectionBatchSize: 100,
     },
     preAggregates: {
         enabled: false,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1711,6 +1711,14 @@ export type LightdashConfig = {
     externalSources: {
         /** Upload cap for external source files (CSV). Stored in the pre-aggregates bucket. */
         maxFileSizeBytes: number;
+        maxRows: number;
+        maxOrganizationBytes: number;
+        maxConcurrentIngestsPerOrganization: number;
+        maxConcurrentDuckdbQueriesPerOrganization: number;
+        googleSheetsBatchRows: number;
+        stagedUploadTtlHours: number;
+        ingestLeaseMs: number;
+        garbageCollectionBatchSize: number;
     };
     motherduckInstanceCache: {
         enabled: boolean;
@@ -3369,6 +3377,38 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable(
                     'EXTERNAL_SOURCES_MAX_FILE_SIZE_BYTES',
                 ) ?? 100 * 1024 * 1024,
+            maxRows:
+                getIntegerFromEnvironmentVariable(
+                    'EXTERNAL_SOURCES_MAX_ROWS',
+                ) ?? 1_000_000,
+            maxOrganizationBytes:
+                getIntegerFromEnvironmentVariable(
+                    'EXTERNAL_SOURCES_MAX_ORGANIZATION_BYTES',
+                ) ?? 5 * 1024 * 1024 * 1024,
+            maxConcurrentIngestsPerOrganization:
+                getIntegerFromEnvironmentVariable(
+                    'EXTERNAL_SOURCES_MAX_CONCURRENT_INGESTS_PER_ORGANIZATION',
+                ) ?? 2,
+            maxConcurrentDuckdbQueriesPerOrganization:
+                getIntegerFromEnvironmentVariable(
+                    'EXTERNAL_SOURCES_MAX_CONCURRENT_DUCKDB_QUERIES_PER_ORGANIZATION',
+                ) ?? 2,
+            googleSheetsBatchRows:
+                getIntegerFromEnvironmentVariable(
+                    'EXTERNAL_SOURCES_GOOGLE_SHEETS_BATCH_ROWS',
+                ) ?? 5_000,
+            stagedUploadTtlHours:
+                getIntegerFromEnvironmentVariable(
+                    'EXTERNAL_SOURCES_STAGED_UPLOAD_TTL_HOURS',
+                ) ?? 24,
+            ingestLeaseMs:
+                getIntegerFromEnvironmentVariable(
+                    'EXTERNAL_SOURCES_INGEST_LEASE_MS',
+                ) ?? 35 * 60 * 1000,
+            garbageCollectionBatchSize:
+                getIntegerFromEnvironmentVariable(
+                    'EXTERNAL_SOURCES_GC_BATCH_SIZE',
+                ) ?? 100,
         },
         motherduckInstanceCache,
         usageEvents: {

--- a/packages/backend/src/contentAsCode/fieldCoverage/virtual_view.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/virtual_view.test.ts
@@ -9,9 +9,6 @@ describeContentAsCodeSchemaContract({
         'baseTable',
         'caseSensitive',
         'databricksCompute',
-        // External source explores are not content-as-code'd; virtual views
-        // never carry this ref
-        'externalSource',
         'granularityLabels',
         'groupLabel',
         'groups',

--- a/packages/backend/src/database/entities/externalSources.ts
+++ b/packages/backend/src/database/entities/externalSources.ts
@@ -9,6 +9,24 @@ import { type PreAggregateDuckdbLocator } from '../../utils/duckdb/duckdbSqlTabl
 
 export const ExternalSourcesTableName = 'external_sources';
 export const ExternalSourceTablesTableName = 'external_source_tables';
+export const ExternalSourceCredentialsTableName = 'external_source_credentials';
+export const ExternalSourceIngestAttemptsTableName =
+    'external_source_ingest_attempts';
+export const ExternalSourceObjectsTableName = 'external_source_objects';
+
+export type ExternalSourceIngestAttemptStatus =
+    | 'queued'
+    | 'running'
+    | 'publishing'
+    | 'succeeded'
+    | 'failed'
+    | 'cancelled';
+
+export type ExternalSourceObjectStatus =
+    | 'uploading'
+    | 'active'
+    | 'pending_delete'
+    | 'deleted';
 
 export type DbExternalSource = {
     external_source_uuid: string;
@@ -95,4 +113,114 @@ export type ExternalSourceTablesTable = Knex.CompositeTableType<
     DbExternalSourceTable,
     DbExternalSourceTableIn,
     DbExternalSourceTableUpdate
+>;
+
+export type DbExternalSourceCredential = {
+    external_source_uuid: string;
+    provider: string;
+    encrypted_refresh_token: Buffer;
+    connected_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type ExternalSourceCredentialsTable = Knex.CompositeTableType<
+    DbExternalSourceCredential,
+    Pick<
+        DbExternalSourceCredential,
+        | 'external_source_uuid'
+        | 'provider'
+        | 'encrypted_refresh_token'
+        | 'connected_by_user_uuid'
+    >,
+    Partial<
+        Pick<
+            DbExternalSourceCredential,
+            | 'provider'
+            | 'encrypted_refresh_token'
+            | 'connected_by_user_uuid'
+            | 'updated_at'
+        >
+    >
+>;
+
+export type DbExternalSourceIngestAttempt = {
+    external_source_ingest_attempt_uuid: string;
+    organization_uuid: string;
+    project_uuid: string;
+    external_source_uuid: string;
+    external_source_table_uuid: string;
+    requested_by_user_uuid: string | null;
+    target_version: number;
+    status: ExternalSourceIngestAttemptStatus;
+    execution_uuid: string | null;
+    lease_expires_at: Date | null;
+    run_count: number;
+    columns: ResultColumns | null;
+    locator: PreAggregateDuckdbLocator | null;
+    row_count: number | null;
+    total_bytes: number | null;
+    error_message: string | null;
+    created_at: Date;
+    updated_at: Date;
+    finished_at: Date | null;
+};
+
+type DbExternalSourceIngestAttemptIn = Pick<
+    DbExternalSourceIngestAttempt,
+    | 'organization_uuid'
+    | 'project_uuid'
+    | 'external_source_uuid'
+    | 'external_source_table_uuid'
+    | 'requested_by_user_uuid'
+    | 'target_version'
+> &
+    Partial<DbExternalSourceIngestAttempt>;
+
+type DbExternalSourceIngestAttemptUpdate = Partial<
+    Omit<DbExternalSourceIngestAttempt, 'external_source_ingest_attempt_uuid'>
+>;
+
+export type ExternalSourceIngestAttemptsTable = Knex.CompositeTableType<
+    DbExternalSourceIngestAttempt,
+    DbExternalSourceIngestAttemptIn,
+    DbExternalSourceIngestAttemptUpdate
+>;
+
+export type DbExternalSourceObject = {
+    external_source_object_uuid: string;
+    organization_uuid: string;
+    project_uuid: string;
+    external_source_uuid: string;
+    external_source_ingest_attempt_uuid: string | null;
+    object_key: string;
+    purpose: 'raw' | 'parquet';
+    status: ExternalSourceObjectStatus;
+    size_bytes: number | null;
+    delete_after: Date | null;
+    delete_attempts: number;
+    last_error: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+type DbExternalSourceObjectIn = Pick<
+    DbExternalSourceObject,
+    | 'organization_uuid'
+    | 'project_uuid'
+    | 'external_source_uuid'
+    | 'external_source_ingest_attempt_uuid'
+    | 'object_key'
+    | 'purpose'
+> &
+    Partial<DbExternalSourceObject>;
+
+type DbExternalSourceObjectUpdate = Partial<
+    Omit<DbExternalSourceObject, 'external_source_object_uuid'>
+>;
+
+export type ExternalSourceObjectsTable = Knex.CompositeTableType<
+    DbExternalSourceObject,
+    DbExternalSourceObjectIn,
+    DbExternalSourceObjectUpdate
 >;

--- a/packages/backend/src/database/migrations/20260819183000_create_external_sources_tables.ts
+++ b/packages/backend/src/database/migrations/20260819183000_create_external_sources_tables.ts
@@ -1,11 +1,19 @@
 import { Knex } from 'knex';
 
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds empty external-source tables without changing existing data or application contracts',
+} as const;
+
 const EXTERNAL_SOURCES_TABLE = 'external_sources';
 const EXTERNAL_SOURCE_TABLES_TABLE = 'external_source_tables';
 const PROJECTS_TABLE = 'projects';
 const USERS_TABLE = 'users';
+const LOCK_TIMEOUT = '5s';
 
 export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
     await knex.schema.createTable(EXTERNAL_SOURCES_TABLE, (table) => {
         table
             .uuid('external_source_uuid')
@@ -96,6 +104,8 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
     await knex.schema.dropTableIfExists(EXTERNAL_SOURCE_TABLES_TABLE);
     await knex.schema.dropTableIfExists(EXTERNAL_SOURCES_TABLE);
 }

--- a/packages/backend/src/database/migrations/20260819183000_create_external_sources_tables.ts
+++ b/packages/backend/src/database/migrations/20260819183000_create_external_sources_tables.ts
@@ -1,19 +1,11 @@
 import { Knex } from 'knex';
 
-export const classification = {
-    kind: 'safe',
-    reason: 'Adds empty external-source tables without changing existing data or application contracts',
-} as const;
-
 const EXTERNAL_SOURCES_TABLE = 'external_sources';
 const EXTERNAL_SOURCE_TABLES_TABLE = 'external_source_tables';
 const PROJECTS_TABLE = 'projects';
 const USERS_TABLE = 'users';
-const LOCK_TIMEOUT = '5s';
 
 export async function up(knex: Knex): Promise<void> {
-    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
-
     await knex.schema.createTable(EXTERNAL_SOURCES_TABLE, (table) => {
         table
             .uuid('external_source_uuid')
@@ -104,8 +96,6 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
-
     await knex.schema.dropTableIfExists(EXTERNAL_SOURCE_TABLES_TABLE);
     await knex.schema.dropTableIfExists(EXTERNAL_SOURCES_TABLE);
 }

--- a/packages/backend/src/database/migrations/20260820190000_create_external_source_lifecycle_tables.ts
+++ b/packages/backend/src/database/migrations/20260820190000_create_external_source_lifecycle_tables.ts
@@ -1,0 +1,161 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Creates empty lifecycle bookkeeping tables without rewriting existing rows',
+} as const;
+
+const EXTERNAL_SOURCES_TABLE = 'external_sources';
+const EXTERNAL_SOURCE_TABLES_TABLE = 'external_source_tables';
+const EXTERNAL_SOURCE_CREDENTIALS_TABLE = 'external_source_credentials';
+const EXTERNAL_SOURCE_INGEST_ATTEMPTS_TABLE = 'external_source_ingest_attempts';
+const EXTERNAL_SOURCE_OBJECTS_TABLE = 'external_source_objects';
+const PROJECTS_TABLE = 'projects';
+const ORGANIZATIONS_TABLE = 'organizations';
+const USERS_TABLE = 'users';
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.createTable(
+        EXTERNAL_SOURCE_CREDENTIALS_TABLE,
+        (table) => {
+            table
+                .uuid('external_source_uuid')
+                .notNullable()
+                .primary()
+                .references('external_source_uuid')
+                .inTable(EXTERNAL_SOURCES_TABLE)
+                .onDelete('CASCADE');
+            table.string('provider').notNullable();
+            table.binary('encrypted_refresh_token').notNullable();
+            table
+                .uuid('connected_by_user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable(USERS_TABLE)
+                .onDelete('SET NULL')
+                .index();
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .timestamp('updated_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+        },
+    );
+
+    await knex.schema.createTable(
+        EXTERNAL_SOURCE_INGEST_ATTEMPTS_TABLE,
+        (table) => {
+            table
+                .uuid('external_source_ingest_attempt_uuid')
+                .notNullable()
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+            table
+                .uuid('organization_uuid')
+                .notNullable()
+                .references('organization_uuid')
+                .inTable(ORGANIZATIONS_TABLE)
+                .onDelete('CASCADE')
+                .index();
+            table
+                .uuid('project_uuid')
+                .notNullable()
+                .references('project_uuid')
+                .inTable(PROJECTS_TABLE)
+                .onDelete('CASCADE')
+                .index();
+            table
+                .uuid('external_source_uuid')
+                .notNullable()
+                .references('external_source_uuid')
+                .inTable(EXTERNAL_SOURCES_TABLE)
+                .onDelete('CASCADE')
+                .index();
+            table
+                .uuid('external_source_table_uuid')
+                .notNullable()
+                .references('external_source_table_uuid')
+                .inTable(EXTERNAL_SOURCE_TABLES_TABLE)
+                .onDelete('CASCADE')
+                .index();
+            table
+                .uuid('requested_by_user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable(USERS_TABLE)
+                .onDelete('SET NULL')
+                .index();
+            table.integer('target_version').notNullable();
+            table.string('status').notNullable().defaultTo('queued');
+            table.uuid('execution_uuid').nullable();
+            table.timestamp('lease_expires_at', { useTz: false }).nullable();
+            table.integer('run_count').notNullable().defaultTo(0);
+            table.jsonb('columns').nullable();
+            table.jsonb('locator').nullable();
+            table.bigInteger('row_count').nullable();
+            table.bigInteger('total_bytes').nullable();
+            table.text('error_message').nullable();
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .timestamp('updated_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table.timestamp('finished_at', { useTz: false }).nullable();
+
+            table.unique(['external_source_table_uuid', 'target_version']);
+            table.index(['organization_uuid', 'status', 'lease_expires_at']);
+        },
+    );
+
+    await knex.schema.createTable(EXTERNAL_SOURCE_OBJECTS_TABLE, (table) => {
+        table
+            .uuid('external_source_object_uuid')
+            .notNullable()
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        // Deliberately no source/project/org FKs: manifests must survive
+        // cascaded domain deletion until the storage object is collected.
+        table.uuid('organization_uuid').notNullable().index();
+        table.uuid('project_uuid').notNullable().index();
+        table.uuid('external_source_uuid').notNullable().index();
+        table
+            .uuid('external_source_ingest_attempt_uuid')
+            .nullable()
+            .references('external_source_ingest_attempt_uuid')
+            .inTable(EXTERNAL_SOURCE_INGEST_ATTEMPTS_TABLE)
+            .onDelete('SET NULL')
+            .index();
+        table.string('object_key').notNullable().unique();
+        table.string('purpose').notNullable();
+        table.string('status').notNullable().defaultTo('uploading');
+        table.bigInteger('size_bytes').nullable();
+        table.timestamp('delete_after', { useTz: false }).nullable().index();
+        table.integer('delete_attempts').notNullable().defaultTo(0);
+        table.text('last_error').nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.dropTableIfExists(EXTERNAL_SOURCE_OBJECTS_TABLE);
+    await knex.schema.dropTableIfExists(EXTERNAL_SOURCE_INGEST_ATTEMPTS_TABLE);
+    await knex.schema.dropTableIfExists(EXTERNAL_SOURCE_CREDENTIALS_TABLE);
+}

--- a/packages/backend/src/ee/controllers/externalSourceController.ts
+++ b/packages/backend/src/ee/controllers/externalSourceController.ts
@@ -38,6 +38,22 @@ import {
 import { BaseController } from '../../controllers/baseController';
 import { ExternalSourceService } from '../services/ExternalSourceService/ExternalSourceService';
 
+const getRawUploadRequest = (req: express.Request, filename: string) => {
+    const contentType = req.headers['content-type'];
+    if (!contentType) {
+        throw new ParameterError('Content-Type header is required');
+    }
+    const contentLengthHeader = req.headers['content-length'];
+    if (!contentLengthHeader) {
+        throw new ParameterError('Content-Length header is required');
+    }
+    const contentLength = Number(contentLengthHeader);
+    if (!Number.isSafeInteger(contentLength) || contentLength <= 0) {
+        throw new ParameterError('Content-Length must be a positive integer');
+    }
+    return { filename, contentType, contentLength, body: req };
+};
+
 @Route('/api/v1/ee/projects/{projectUuid}/external-sources')
 @Hidden()
 @Response<ApiErrorPayload>('default', 'Error')
@@ -63,31 +79,13 @@ export class ExternalSourceController extends BaseController {
         @Query() filename: string,
     ): Promise<ApiStagedExternalSourceUploadResponse> {
         assertRegisteredAccount(req.account);
-        const contentType = req.headers['content-type'];
-        if (!contentType) {
-            throw new ParameterError('Content-Type header is required');
-        }
-        if (!req.headers['content-length']) {
-            throw new ParameterError('Content-Length header is required');
-        }
-        const contentLength = parseInt(req.headers['content-length'], 10);
-        if (Number.isNaN(contentLength) || contentLength <= 0) {
-            throw new ParameterError(
-                'Content-Length must be a positive integer',
-            );
-        }
         this.setStatus(201);
         return {
             status: 'ok',
             results: await this.getExternalSourceService().stageCsvUpload(
                 req.account,
                 projectUuid,
-                {
-                    filename,
-                    contentType,
-                    contentLength,
-                    body: req,
-                },
+                getRawUploadRequest(req, filename),
             ),
         };
     }
@@ -125,6 +123,7 @@ export class ExternalSourceController extends BaseController {
     }
 
     /**
+     * Return every committed external source in the project.
      * @summary List external sources
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
@@ -147,6 +146,7 @@ export class ExternalSourceController extends BaseController {
     }
 
     /**
+     * Return one external source and its source tables.
      * @summary Get an external source
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
@@ -285,19 +285,6 @@ export class ExternalSourceController extends BaseController {
         @Query() filename: string,
     ): Promise<ApiExternalSourceResponse> {
         assertRegisteredAccount(req.account);
-        const contentType = req.headers['content-type'];
-        if (!contentType) {
-            throw new ParameterError('Content-Type header is required');
-        }
-        if (!req.headers['content-length']) {
-            throw new ParameterError('Content-Length header is required');
-        }
-        const contentLength = parseInt(req.headers['content-length'], 10);
-        if (Number.isNaN(contentLength) || contentLength <= 0) {
-            throw new ParameterError(
-                'Content-Length must be a positive integer',
-            );
-        }
         this.setStatus(200);
         return {
             status: 'ok',
@@ -305,12 +292,7 @@ export class ExternalSourceController extends BaseController {
                 req.account,
                 projectUuid,
                 sourceUuid,
-                {
-                    filename,
-                    contentType,
-                    contentLength,
-                    body: req,
-                },
+                getRawUploadRequest(req, filename),
             ),
         };
     }

--- a/packages/backend/src/ee/controllers/externalSourceController.ts
+++ b/packages/backend/src/ee/controllers/externalSourceController.ts
@@ -232,6 +232,35 @@ export class ExternalSourceController extends BaseController {
     }
 
     /**
+     * Replace the project-owned Google credential with the current user's grant.
+     * @summary Reconnect a Google Sheets source
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/{sourceUuid}/reconnect')
+    @OperationId('ReconnectExternalSource')
+    async reconnectSource(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() sourceUuid: UUID,
+    ): Promise<ApiExternalSourceResponse> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results:
+                await this.getExternalSourceService().reconnectGoogleSheets(
+                    req.account,
+                    projectUuid,
+                    sourceUuid,
+                ),
+        };
+    }
+
+    /**
      * Rename an external source's table. Only the display label changes;
      * the sql name stays stable so saved charts keep working.
      * @summary Rename an external source

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1140,8 +1140,11 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 }),
         },
         modelProviders: {
-            externalSourceModel: ({ database }) =>
-                new ExternalSourceModel({ database }),
+            externalSourceModel: ({ database, utils }) =>
+                new ExternalSourceModel({
+                    database,
+                    encryptionUtil: utils.getEncryptionUtil(),
+                }),
             projectHomepageModel: ({ database }) =>
                 new ProjectHomepageModel({ database }),
             homepageRecommendedActionSkipsModel: ({ database }) =>

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1015,7 +1015,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     externalSourceTableResolver: (projectUuid, tableUuid) =>
                         models
                             .getExternalSourceModel<ExternalSourceModel>()
-                            .findTableByUuid(projectUuid, tableUuid),
+                            .findTableForQuery(projectUuid, tableUuid),
                     preAggregateStrategy: new PreAggregateStrategy({
                         preAggregationDuckDbClient:
                             new PreAggregationDuckDbClient({

--- a/packages/backend/src/ee/models/ExternalSourceModel.integration.test.ts
+++ b/packages/backend/src/ee/models/ExternalSourceModel.integration.test.ts
@@ -1,0 +1,250 @@
+import {
+    DbtProjectType,
+    DimensionType,
+    ExternalSourceStatus,
+    ExternalSourceType,
+    ProjectType,
+    SupportedDbtVersions,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import {
+    ExternalSourceIngestAttemptsTableName,
+    ExternalSourceObjectsTableName,
+    ExternalSourcesTableName,
+} from '../../database/entities/externalSources';
+import { getTestContext } from '../../vitest.setup.integration';
+import { ExternalSourceModel } from './ExternalSourceModel';
+
+describe('ExternalSourceModel lifecycle integration', () => {
+    let transaction: Knex.Transaction;
+    let model: ExternalSourceModel;
+    let organizationUuid: string;
+    let projectUuid: string;
+    let userUuid: string;
+
+    beforeEach(async () => {
+        transaction = await getTestContext().db.transaction();
+        const [organization] = await transaction('organizations')
+            .insert({ organization_name: 'External lifecycle test' })
+            .returning(['organization_id', 'organization_uuid']);
+        const [user] = await transaction('users')
+            .insert({
+                first_name: 'External',
+                last_name: 'Lifecycle',
+                is_marketing_opted_in: false,
+                is_tracking_anonymized: false,
+                is_setup_complete: true,
+                is_active: true,
+            })
+            .returning('user_uuid');
+        const [project] = await transaction('projects')
+            .insert({
+                name: 'External lifecycle test',
+                organization_id: organization.organization_id,
+                project_type: ProjectType.DEFAULT,
+                dbt_connection_type: DbtProjectType.DBT,
+                dbt_connection: null,
+                copied_from_project_uuid: null,
+                organization_warehouse_credentials_uuid: null,
+                dbt_version: SupportedDbtVersions.V1_7,
+                created_by_user_uuid: user.user_uuid,
+            })
+            .returning('project_uuid');
+        organizationUuid = organization.organization_uuid;
+        projectUuid = project.project_uuid;
+        userUuid = user.user_uuid;
+        model = new ExternalSourceModel({
+            database: transaction,
+            encryptionUtil: {
+                encrypt: (value: string) => Buffer.from(value),
+                decrypt: (value: Buffer) => value.toString(),
+            } as never,
+        });
+    });
+
+    afterEach(async () => transaction.rollback());
+
+    const createSourceAndTable = async (suffix: string) => {
+        const source = await model.createSource({
+            projectUuid,
+            type: ExternalSourceType.CSV,
+            name: `lifecycle_${suffix}`,
+            status: ExternalSourceStatus.STAGED,
+            connection: {
+                type: ExternalSourceType.CSV,
+                originalFilename: 'input.csv',
+            },
+            createdByUserUuid: userUuid,
+        });
+        const table = await model.createTable({
+            sourceUuid: source.sourceUuid,
+            projectUuid,
+            name: `lifecycle_${suffix}`,
+            label: 'Lifecycle test',
+        });
+        return { source, table };
+    };
+
+    test('retries with a new lease token and publishes one generation atomically', async () => {
+        const { source, table } = await createSourceAndTable(
+            crypto.randomUUID(),
+        );
+        const attempt = await model.requestIngest({
+            organizationUuid,
+            projectUuid,
+            sourceUuid: source.sourceUuid,
+            tableUuid: table.tableUuid,
+            requestedByUserUuid: userUuid,
+            targetVersion: 1,
+        });
+        expect(
+            (await model.getSource(projectUuid, source.sourceUuid)).status,
+        ).toBe(ExternalSourceStatus.SYNCING);
+
+        const firstLease = await model.claimIngestAttempt({
+            attemptUuid: attempt.external_source_ingest_attempt_uuid,
+            leaseMs: 60_000,
+            maxConcurrentPerOrganization: 1,
+        });
+        expect(firstLease?.execution_uuid).toBeTruthy();
+        await model.failIngestAttempt(
+            attempt.external_source_ingest_attempt_uuid,
+            'retry me',
+        );
+        const secondLease = await model.claimIngestAttempt({
+            attemptUuid: attempt.external_source_ingest_attempt_uuid,
+            leaseMs: 60_000,
+            maxConcurrentPerOrganization: 1,
+        });
+        expect(secondLease?.execution_uuid).not.toBe(
+            firstLease?.execution_uuid,
+        );
+
+        const recorded = await model.recordIngestOutput({
+            attemptUuid: attempt.external_source_ingest_attempt_uuid,
+            executionUuid: secondLease!.execution_uuid!,
+            columns: {
+                id: { reference: 'id', type: DimensionType.NUMBER },
+            },
+            locator: {
+                storage: 's3',
+                format: 'parquet',
+                uri: 's3://bucket/external-sources/test.parquet',
+            },
+            rowCount: 2,
+            totalBytes: 128,
+        });
+        expect(recorded).toBe(true);
+        expect(
+            await model.publishIngestAttempt({
+                attemptUuid: attempt.external_source_ingest_attempt_uuid,
+                executionUuid: secondLease!.execution_uuid!,
+            }),
+        ).toBe(true);
+
+        const published = await model.getSource(projectUuid, source.sourceUuid);
+        expect(published.status).toBe(ExternalSourceStatus.READY);
+        expect(published.tables[0].version).toBe(1);
+        expect(published.tables[0].rowCount).toBe(2);
+    });
+
+    test('enforces organization concurrency and retains manifests after deletion', async () => {
+        const first = await createSourceAndTable(crypto.randomUUID());
+        const second = await createSourceAndTable(crypto.randomUUID());
+        const request = (sourceUuid: string, tableUuid: string) =>
+            model.requestIngest({
+                organizationUuid,
+                projectUuid,
+                sourceUuid,
+                tableUuid,
+                requestedByUserUuid: userUuid,
+                targetVersion: 1,
+            });
+        const [firstAttempt, secondAttempt] = await Promise.all([
+            request(first.source.sourceUuid, first.table.tableUuid),
+            request(second.source.sourceUuid, second.table.tableUuid),
+        ]);
+        const firstLease = await model.claimIngestAttempt({
+            attemptUuid: firstAttempt.external_source_ingest_attempt_uuid,
+            leaseMs: 60_000,
+            maxConcurrentPerOrganization: 1,
+        });
+        expect(firstLease).not.toBeNull();
+        await model.failIngestAttempt(
+            firstAttempt.external_source_ingest_attempt_uuid,
+            'worker timed out',
+            true,
+        );
+        expect(
+            await model.claimIngestAttempt({
+                attemptUuid: firstAttempt.external_source_ingest_attempt_uuid,
+                leaseMs: 60_000,
+                maxConcurrentPerOrganization: 1,
+            }),
+        ).toBeNull();
+        expect(
+            await model.claimIngestAttempt({
+                attemptUuid: secondAttempt.external_source_ingest_attempt_uuid,
+                leaseMs: 60_000,
+                maxConcurrentPerOrganization: 1,
+            }),
+        ).toBeNull();
+
+        const object = await model.registerObject({
+            organizationUuid,
+            projectUuid,
+            sourceUuid: first.source.sourceUuid,
+            attemptUuid: firstAttempt.external_source_ingest_attempt_uuid,
+            key: `external-sources/${first.source.sourceUuid}/raw.csv`,
+            purpose: 'raw',
+            expectedBytes: 10,
+            maxOrganizationBytes: 100,
+        });
+        await model.deleteSource(projectUuid, first.source.sourceUuid);
+
+        const manifest = await transaction(ExternalSourceObjectsTableName)
+            .where(
+                'external_source_object_uuid',
+                object.external_source_object_uuid,
+            )
+            .first();
+        if (!manifest) throw new Error('Manifest was deleted');
+        expect(manifest.status).toBe('pending_delete');
+        expect(manifest.external_source_ingest_attempt_uuid).toBeNull();
+        expect(
+            await transaction(ExternalSourceIngestAttemptsTableName)
+                .where(
+                    'external_source_ingest_attempt_uuid',
+                    firstAttempt.external_source_ingest_attempt_uuid,
+                )
+                .first(),
+        ).toBeUndefined();
+
+        const orphan = await model.registerObject({
+            organizationUuid,
+            projectUuid,
+            sourceUuid: second.source.sourceUuid,
+            attemptUuid: secondAttempt.external_source_ingest_attempt_uuid,
+            key: `external-sources/${second.source.sourceUuid}/raw.csv`,
+            purpose: 'raw',
+            expectedBytes: 10,
+            maxOrganizationBytes: 100,
+        });
+        await transaction(ExternalSourcesTableName)
+            .where('external_source_uuid', second.source.sourceUuid)
+            .delete();
+        await model.prepareGarbageCollection({
+            stagedBefore: new Date(0),
+            uploadingBefore: new Date(0),
+            limit: 10,
+        });
+        expect(
+            await transaction(ExternalSourceObjectsTableName)
+                .where(
+                    'external_source_object_uuid',
+                    orphan.external_source_object_uuid,
+                )
+                .first('status'),
+        ).toEqual({ status: 'pending_delete' });
+    });
+});

--- a/packages/backend/src/ee/models/ExternalSourceModel.ts
+++ b/packages/backend/src/ee/models/ExternalSourceModel.ts
@@ -1,31 +1,46 @@
 import {
+    ExternalSourceStatus,
     NotFoundError,
+    ParameterError,
     type ExternalSource,
     type ExternalSourceConnection,
-    type ExternalSourceStatus,
     type ExternalSourceTable,
     type ExternalSourceType,
     type ResultColumns,
 } from '@lightdash/common';
+import { randomUUID } from 'crypto';
 import { Knex } from 'knex';
 import {
+    ExternalSourceCredentialsTableName,
+    ExternalSourceIngestAttemptsTableName,
+    ExternalSourceObjectsTableName,
     ExternalSourcesTableName,
     ExternalSourceTablesTableName,
     type DbExternalSource,
+    type DbExternalSourceIngestAttempt,
+    type DbExternalSourceObject,
     type DbExternalSourceTable,
     type DbExternalSourceUpdate,
 } from '../../database/entities/externalSources';
 import { type PreAggregateDuckdbLocator } from '../../utils/duckdb/duckdbSqlTables';
+import { type EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 
 type ExternalSourceModelArguments = {
     database: Knex;
+    encryptionUtil: Pick<EncryptionUtil, 'encrypt' | 'decrypt'>;
 };
 
 export class ExternalSourceModel {
     private readonly database: Knex;
 
+    private readonly encryptionUtil: Pick<
+        EncryptionUtil,
+        'encrypt' | 'decrypt'
+    >;
+
     constructor(args: ExternalSourceModelArguments) {
         this.database = args.database;
+        this.encryptionUtil = args.encryptionUtil;
     }
 
     /** API shape: the storage locator never leaves the backend. */
@@ -180,6 +195,571 @@ export class ExternalSourceModel {
         return ExternalSourceModel.mapTable(row);
     }
 
+    async upsertGoogleCredential(data: {
+        sourceUuid: string;
+        refreshToken: string;
+        connectedByUserUuid: string;
+    }): Promise<void> {
+        await this.database(ExternalSourceCredentialsTableName)
+            .insert({
+                external_source_uuid: data.sourceUuid,
+                provider: 'google',
+                encrypted_refresh_token: this.encryptionUtil.encrypt(
+                    data.refreshToken,
+                ),
+                connected_by_user_uuid: data.connectedByUserUuid,
+            })
+            .onConflict('external_source_uuid')
+            .merge({
+                encrypted_refresh_token: this.encryptionUtil.encrypt(
+                    data.refreshToken,
+                ),
+                connected_by_user_uuid: data.connectedByUserUuid,
+                updated_at: new Date(),
+            });
+    }
+
+    async getGoogleCredential(sourceUuid: string): Promise<string> {
+        const row = await this.database(ExternalSourceCredentialsTableName)
+            .where('external_source_uuid', sourceUuid)
+            .andWhere('provider', 'google')
+            .first('encrypted_refresh_token');
+        if (!row) {
+            throw new ParameterError(
+                'This Google Sheet needs to be reconnected',
+            );
+        }
+        return this.encryptionUtil.decrypt(row.encrypted_refresh_token);
+    }
+
+    /**
+     * Durable request boundary. Source state and the unique generation are
+     * committed together; enqueueing may safely happen afterwards because a
+     * sweeper can recover queued attempts.
+     */
+    async requestIngest(data: {
+        organizationUuid: string;
+        projectUuid: string;
+        sourceUuid: string;
+        tableUuid: string;
+        requestedByUserUuid: string;
+        targetVersion: number;
+        rawObjectKey?: string;
+    }): Promise<DbExternalSourceIngestAttempt> {
+        return this.database.transaction(async (trx) => {
+            const source = await trx(ExternalSourcesTableName)
+                .where('external_source_uuid', data.sourceUuid)
+                .andWhere('project_uuid', data.projectUuid)
+                .forUpdate()
+                .first();
+            if (!source) {
+                throw new NotFoundError('External source not found');
+            }
+            const table = await trx(ExternalSourceTablesTableName)
+                .where('external_source_table_uuid', data.tableUuid)
+                .andWhere('external_source_uuid', data.sourceUuid)
+                .forUpdate()
+                .first();
+            if (!table) {
+                throw new NotFoundError('External source table not found');
+            }
+            if (data.targetVersion !== table.version + 1) {
+                throw new ParameterError(
+                    `Expected ingest version ${table.version + 1}`,
+                );
+            }
+
+            const [attempt] = await trx(ExternalSourceIngestAttemptsTableName)
+                .insert({
+                    organization_uuid: data.organizationUuid,
+                    project_uuid: data.projectUuid,
+                    external_source_uuid: data.sourceUuid,
+                    external_source_table_uuid: data.tableUuid,
+                    requested_by_user_uuid: data.requestedByUserUuid,
+                    target_version: data.targetVersion,
+                    status: 'queued',
+                })
+                .onConflict(['external_source_table_uuid', 'target_version'])
+                .ignore()
+                .returning('*');
+            const durableAttempt =
+                attempt ??
+                (await trx(ExternalSourceIngestAttemptsTableName)
+                    .where({
+                        external_source_table_uuid: data.tableUuid,
+                        target_version: data.targetVersion,
+                    })
+                    .first());
+            if (!durableAttempt) {
+                throw new Error('Failed to create external source attempt');
+            }
+            if (data.rawObjectKey) {
+                await trx(ExternalSourceObjectsTableName)
+                    .where('object_key', data.rawObjectKey)
+                    .andWhere('external_source_uuid', data.sourceUuid)
+                    .update({
+                        external_source_ingest_attempt_uuid:
+                            durableAttempt.external_source_ingest_attempt_uuid,
+                        updated_at: new Date(),
+                    });
+            }
+            await trx(ExternalSourcesTableName)
+                .where('external_source_uuid', data.sourceUuid)
+                .update({
+                    status: ExternalSourceStatus.SYNCING,
+                    error_message: null,
+                    updated_at: new Date(),
+                });
+            return durableAttempt;
+        });
+    }
+
+    async claimIngestAttempt(data: {
+        attemptUuid: string;
+        leaseMs: number;
+        maxConcurrentPerOrganization: number;
+    }): Promise<DbExternalSourceIngestAttempt | null> {
+        return this.database.transaction(async (trx) => {
+            const attempt = await trx(ExternalSourceIngestAttemptsTableName)
+                .where('external_source_ingest_attempt_uuid', data.attemptUuid)
+                .forUpdate()
+                .first();
+            if (
+                !attempt ||
+                ['succeeded', 'cancelled'].includes(attempt.status)
+            ) {
+                return null;
+            }
+            if (
+                ['running', 'publishing', 'failed'].includes(attempt.status) &&
+                attempt.lease_expires_at &&
+                attempt.lease_expires_at > new Date()
+            ) {
+                return null;
+            }
+
+            await trx.raw('SELECT pg_advisory_xact_lock(hashtext(?))', [
+                `external-source:${attempt.organization_uuid}`,
+            ]);
+            const [{ count }] = await trx(ExternalSourceIngestAttemptsTableName)
+                .where('organization_uuid', attempt.organization_uuid)
+                .whereIn('status', ['running', 'publishing', 'failed'])
+                .where('lease_expires_at', '>', new Date())
+                .whereNot(
+                    'external_source_ingest_attempt_uuid',
+                    data.attemptUuid,
+                )
+                .count<{ count: string }[]>('* as count');
+            if (Number(count) >= data.maxConcurrentPerOrganization) {
+                return null;
+            }
+
+            const [claimed] = await trx(ExternalSourceIngestAttemptsTableName)
+                .where('external_source_ingest_attempt_uuid', data.attemptUuid)
+                .update({
+                    status: attempt.columns ? 'publishing' : 'running',
+                    execution_uuid: randomUUID(),
+                    lease_expires_at: new Date(Date.now() + data.leaseMs),
+                    run_count: attempt.run_count + 1,
+                    error_message: null,
+                    updated_at: new Date(),
+                })
+                .returning('*');
+            await trx(ExternalSourcesTableName)
+                .where('external_source_uuid', attempt.external_source_uuid)
+                .update({
+                    status: ExternalSourceStatus.SYNCING,
+                    error_message: null,
+                    updated_at: new Date(),
+                });
+            return claimed;
+        });
+    }
+
+    async recordIngestOutput(data: {
+        attemptUuid: string;
+        executionUuid: string;
+        columns: ResultColumns;
+        locator: PreAggregateDuckdbLocator;
+        rowCount: number;
+        totalBytes: number | null;
+    }): Promise<boolean> {
+        const updated = await this.database(
+            ExternalSourceIngestAttemptsTableName,
+        )
+            .where('external_source_ingest_attempt_uuid', data.attemptUuid)
+            .andWhere('execution_uuid', data.executionUuid)
+            .andWhere('status', 'running')
+            .update({
+                status: 'publishing',
+                columns: data.columns,
+                locator: data.locator,
+                row_count: data.rowCount,
+                total_bytes: data.totalBytes,
+                updated_at: new Date(),
+            });
+        return updated === 1;
+    }
+
+    async publishIngestAttempt(data: {
+        attemptUuid: string;
+        executionUuid: string;
+    }): Promise<boolean> {
+        return this.database.transaction(async (trx) => {
+            const attempt = await trx(ExternalSourceIngestAttemptsTableName)
+                .where('external_source_ingest_attempt_uuid', data.attemptUuid)
+                .forUpdate()
+                .first();
+            if (!attempt || attempt.status === 'succeeded') return true;
+            if (
+                attempt.status !== 'publishing' ||
+                attempt.execution_uuid !== data.executionUuid ||
+                !attempt.columns ||
+                !attempt.locator
+            ) {
+                return false;
+            }
+            const table = await trx(ExternalSourceTablesTableName)
+                .where(
+                    'external_source_table_uuid',
+                    attempt.external_source_table_uuid,
+                )
+                .forUpdate()
+                .first();
+            if (!table || table.version > attempt.target_version) {
+                return false;
+            }
+            if (table.version === attempt.target_version - 1) {
+                await trx(ExternalSourceTablesTableName)
+                    .where(
+                        'external_source_table_uuid',
+                        attempt.external_source_table_uuid,
+                    )
+                    .update({
+                        columns: attempt.columns,
+                        locator: attempt.locator,
+                        row_count: attempt.row_count,
+                        total_bytes: attempt.total_bytes,
+                        version: attempt.target_version,
+                        last_ingested_at: new Date(),
+                        updated_at: new Date(),
+                    });
+            } else if (table.version !== attempt.target_version) {
+                return false;
+            }
+            await trx(ExternalSourcesTableName)
+                .where('external_source_uuid', attempt.external_source_uuid)
+                .update({
+                    status: ExternalSourceStatus.READY,
+                    error_message: null,
+                    last_refreshed_at: new Date(),
+                    updated_at: new Date(),
+                });
+            await trx(ExternalSourceIngestAttemptsTableName)
+                .where('external_source_ingest_attempt_uuid', data.attemptUuid)
+                .update({
+                    status: 'succeeded',
+                    lease_expires_at: null,
+                    finished_at: new Date(),
+                    updated_at: new Date(),
+                });
+
+            const currentObjects = await trx(ExternalSourceObjectsTableName)
+                .where('external_source_ingest_attempt_uuid', data.attemptUuid)
+                .select('purpose');
+            const purposes = [...new Set(currentObjects.map((v) => v.purpose))];
+            if (purposes.length > 0) {
+                await trx(ExternalSourceObjectsTableName)
+                    .where('external_source_uuid', attempt.external_source_uuid)
+                    .whereIn('purpose', purposes)
+                    .whereNot(
+                        'external_source_ingest_attempt_uuid',
+                        data.attemptUuid,
+                    )
+                    .whereNot('status', 'deleted')
+                    .update({
+                        status: 'pending_delete',
+                        delete_after: new Date(),
+                        updated_at: new Date(),
+                    });
+                await trx(ExternalSourceObjectsTableName)
+                    .where(
+                        'external_source_ingest_attempt_uuid',
+                        data.attemptUuid,
+                    )
+                    .update({
+                        status: 'active',
+                        delete_after: null,
+                        updated_at: new Date(),
+                    });
+            }
+            return true;
+        });
+    }
+
+    async failIngestAttempt(
+        attemptUuid: string,
+        errorMessage: string,
+        deferRetryUntilLeaseExpires = false,
+    ): Promise<void> {
+        await this.database.transaction(async (trx) => {
+            const [attempt] = await trx(ExternalSourceIngestAttemptsTableName)
+                .where('external_source_ingest_attempt_uuid', attemptUuid)
+                .whereIn('status', ['queued', 'running', 'publishing'])
+                .update({
+                    status: 'failed',
+                    lease_expires_at: deferRetryUntilLeaseExpires
+                        ? undefined
+                        : null,
+                    error_message: errorMessage,
+                    updated_at: new Date(),
+                })
+                .returning('*');
+            if (attempt) {
+                await trx(ExternalSourcesTableName)
+                    .where('external_source_uuid', attempt.external_source_uuid)
+                    .update({
+                        status: ExternalSourceStatus.ERROR,
+                        error_message: errorMessage,
+                        updated_at: new Date(),
+                    });
+            }
+        });
+    }
+
+    async getAttempt(
+        attemptUuid: string,
+    ): Promise<DbExternalSourceIngestAttempt | undefined> {
+        return this.database(ExternalSourceIngestAttemptsTableName)
+            .where('external_source_ingest_attempt_uuid', attemptUuid)
+            .first();
+    }
+
+    async listRecoverableAttempts(limit: number) {
+        return this.database(ExternalSourceIngestAttemptsTableName)
+            .where('run_count', '<', 5)
+            .andWhere((builder) =>
+                builder
+                    .where('status', 'queued')
+                    .orWhere((failed) =>
+                        failed
+                            .where('status', 'failed')
+                            .andWhere((lease) =>
+                                lease
+                                    .whereNull('lease_expires_at')
+                                    .orWhere(
+                                        'lease_expires_at',
+                                        '<',
+                                        new Date(),
+                                    ),
+                            ),
+                    )
+                    .orWhere((expired) =>
+                        expired
+                            .whereIn('status', ['running', 'publishing'])
+                            .andWhere('lease_expires_at', '<', new Date()),
+                    ),
+            )
+            .orderBy('updated_at')
+            .limit(limit);
+    }
+
+    async registerObject(data: {
+        organizationUuid: string;
+        projectUuid: string;
+        sourceUuid: string;
+        attemptUuid?: string;
+        key: string;
+        purpose: 'raw' | 'parquet';
+        expectedBytes?: number;
+        maxOrganizationBytes: number;
+    }): Promise<DbExternalSourceObject> {
+        return this.database.transaction(async (trx) => {
+            await trx.raw('SELECT pg_advisory_xact_lock(hashtext(?))', [
+                `external-source-storage:${data.organizationUuid}`,
+            ]);
+            const [{ total }] = await trx(ExternalSourceObjectsTableName)
+                .where('organization_uuid', data.organizationUuid)
+                .whereNot('status', 'deleted')
+                .sum<{ total: string | null }[]>('size_bytes as total');
+            if (
+                Number(total ?? 0) + (data.expectedBytes ?? 0) >
+                data.maxOrganizationBytes
+            ) {
+                throw new ParameterError(
+                    'External source storage quota exceeded for this organization',
+                );
+            }
+            const [object] = await trx(ExternalSourceObjectsTableName)
+                .insert({
+                    organization_uuid: data.organizationUuid,
+                    project_uuid: data.projectUuid,
+                    external_source_uuid: data.sourceUuid,
+                    external_source_ingest_attempt_uuid:
+                        data.attemptUuid ?? null,
+                    object_key: data.key,
+                    purpose: data.purpose,
+                    status: 'uploading',
+                    size_bytes: data.expectedBytes ?? null,
+                })
+                .onConflict('object_key')
+                .merge({
+                    external_source_ingest_attempt_uuid:
+                        data.attemptUuid ?? null,
+                    status: 'uploading',
+                    size_bytes: data.expectedBytes ?? null,
+                    delete_after: null,
+                    last_error: null,
+                    updated_at: new Date(),
+                })
+                .returning('*');
+            return object;
+        });
+    }
+
+    async completeObject(
+        key: string,
+        sizeBytes: number,
+        maxOrganizationBytes: number,
+    ): Promise<void> {
+        await this.database.transaction(async (trx) => {
+            const object = await trx(ExternalSourceObjectsTableName)
+                .where('object_key', key)
+                .forUpdate()
+                .first();
+            if (!object)
+                throw new NotFoundError('External source object missing');
+            await trx.raw('SELECT pg_advisory_xact_lock(hashtext(?))', [
+                `external-source-storage:${object.organization_uuid}`,
+            ]);
+            const [{ total }] = await trx(ExternalSourceObjectsTableName)
+                .where('organization_uuid', object.organization_uuid)
+                .whereNot('status', 'deleted')
+                .whereNot(
+                    'external_source_object_uuid',
+                    object.external_source_object_uuid,
+                )
+                .sum<{ total: string | null }[]>('size_bytes as total');
+            if (Number(total ?? 0) + sizeBytes > maxOrganizationBytes) {
+                throw new ParameterError(
+                    'External source storage quota exceeded for this organization',
+                );
+            }
+            await trx(ExternalSourceObjectsTableName)
+                .where('object_key', key)
+                .update({
+                    status: 'active',
+                    size_bytes: sizeBytes,
+                    updated_at: new Date(),
+                });
+        });
+    }
+
+    async abandonObject(key: string, error?: string): Promise<void> {
+        await this.database(ExternalSourceObjectsTableName)
+            .where('object_key', key)
+            .whereNot('status', 'deleted')
+            .update({
+                status: 'pending_delete',
+                delete_after: new Date(),
+                last_error: error ?? null,
+                updated_at: new Date(),
+            });
+    }
+
+    async prepareSourceDeletion(sourceUuid: string): Promise<void> {
+        await this.database(ExternalSourceObjectsTableName)
+            .where('external_source_uuid', sourceUuid)
+            .whereNot('status', 'deleted')
+            .update({
+                status: 'pending_delete',
+                delete_after: new Date(),
+                updated_at: new Date(),
+            });
+    }
+
+    async prepareGarbageCollection(data: {
+        stagedBefore: Date;
+        uploadingBefore: Date;
+        limit: number;
+    }): Promise<DbExternalSourceObject[]> {
+        await this.database.transaction(async (trx) => {
+            await trx(ExternalSourceObjectsTableName)
+                .whereNot('status', 'deleted')
+                .whereNotExists(
+                    trx
+                        .select(trx.raw('1'))
+                        .from(ExternalSourcesTableName)
+                        .whereRaw(
+                            'external_sources.external_source_uuid = external_source_objects.external_source_uuid',
+                        ),
+                )
+                .update({
+                    status: 'pending_delete',
+                    delete_after: new Date(),
+                    updated_at: new Date(),
+                });
+            const staleSources = await trx(ExternalSourcesTableName)
+                .where('status', 'staged')
+                .andWhere('created_at', '<', data.stagedBefore)
+                .select('external_source_uuid');
+            const sourceUuids = staleSources.map(
+                (source) => source.external_source_uuid,
+            );
+            if (sourceUuids.length > 0) {
+                await trx(ExternalSourceObjectsTableName)
+                    .whereIn('external_source_uuid', sourceUuids)
+                    .whereNot('status', 'deleted')
+                    .update({
+                        status: 'pending_delete',
+                        delete_after: new Date(),
+                        updated_at: new Date(),
+                    });
+                await trx(ExternalSourcesTableName)
+                    .whereIn('external_source_uuid', sourceUuids)
+                    .delete();
+            }
+            await trx(ExternalSourceObjectsTableName)
+                .where('status', 'uploading')
+                .andWhere('updated_at', '<', data.uploadingBefore)
+                .update({
+                    status: 'pending_delete',
+                    delete_after: new Date(),
+                    updated_at: new Date(),
+                });
+        });
+        return this.database(ExternalSourceObjectsTableName)
+            .where('status', 'pending_delete')
+            .andWhere('delete_after', '<=', new Date())
+            .orderBy('delete_after')
+            .limit(data.limit);
+    }
+
+    async markObjectDeleted(objectUuid: string): Promise<void> {
+        await this.database(ExternalSourceObjectsTableName)
+            .where('external_source_object_uuid', objectUuid)
+            .update({
+                status: 'deleted',
+                size_bytes: null,
+                last_error: null,
+                updated_at: new Date(),
+            });
+    }
+
+    async markObjectDeleteFailed(
+        objectUuid: string,
+        error: string,
+    ): Promise<void> {
+        await this.database(ExternalSourceObjectsTableName)
+            .where('external_source_object_uuid', objectUuid)
+            .increment('delete_attempts', 1)
+            .update({
+                last_error: error,
+                delete_after: new Date(Date.now() + 5 * 60 * 1000),
+                updated_at: new Date(),
+            });
+    }
+
     /** Atomically swap a table to a freshly ingested file. */
     async updateTableIngest(
         tableUuid: string,
@@ -234,10 +814,34 @@ export class ExternalSourceModel {
     }
 
     async deleteSource(projectUuid: string, sourceUuid: string): Promise<void> {
-        await this.database(ExternalSourcesTableName)
-            .where('project_uuid', projectUuid)
-            .andWhere('external_source_uuid', sourceUuid)
-            .delete();
+        await this.database.transaction(async (trx) => {
+            await trx(ExternalSourceObjectsTableName)
+                .where('external_source_uuid', sourceUuid)
+                .whereNot('status', 'deleted')
+                .update({
+                    status: 'pending_delete',
+                    delete_after: new Date(),
+                    updated_at: new Date(),
+                });
+            await trx(ExternalSourceIngestAttemptsTableName)
+                .where('external_source_uuid', sourceUuid)
+                .whereIn('status', [
+                    'queued',
+                    'running',
+                    'publishing',
+                    'failed',
+                ])
+                .update({
+                    status: 'cancelled',
+                    lease_expires_at: null,
+                    finished_at: new Date(),
+                    updated_at: new Date(),
+                });
+            await trx(ExternalSourcesTableName)
+                .where('project_uuid', projectUuid)
+                .andWhere('external_source_uuid', sourceUuid)
+                .delete();
+        });
     }
 
     /**

--- a/packages/backend/src/ee/models/ExternalSourceModel.ts
+++ b/packages/backend/src/ee/models/ExternalSourceModel.ts
@@ -188,9 +188,10 @@ export class ExternalSourceModel {
             locator: PreAggregateDuckdbLocator;
             rowCount: number | null;
             totalBytes: number | null;
+            ingestVersion: number;
         },
-    ): Promise<void> {
-        await this.database.transaction(async (trx) => {
+    ): Promise<boolean> {
+        return this.database.transaction(async (trx) => {
             const row = await trx(ExternalSourceTablesTableName)
                 .where('external_source_table_uuid', tableUuid)
                 .forUpdate()
@@ -200,6 +201,17 @@ export class ExternalSourceModel {
                     `External source table ${tableUuid} not found`,
                 );
             }
+            if (row.version > data.ingestVersion) {
+                return false;
+            }
+            if (row.version === data.ingestVersion) {
+                return true;
+            }
+            if (row.version !== data.ingestVersion - 1) {
+                throw new Error(
+                    `Cannot publish external source ingest version ${data.ingestVersion} after version ${row.version}`,
+                );
+            }
             await trx(ExternalSourceTablesTableName)
                 .where('external_source_table_uuid', tableUuid)
                 .update({
@@ -207,10 +219,11 @@ export class ExternalSourceModel {
                     locator: data.locator,
                     row_count: data.rowCount,
                     total_bytes: data.totalBytes,
-                    version: row.version + 1,
+                    version: data.ingestVersion,
                     last_ingested_at: new Date(),
                     updated_at: new Date(),
                 });
+            return true;
         });
     }
 
@@ -244,5 +257,30 @@ export class ExternalSourceModel {
             .where('project_uuid', projectUuid)
             .andWhere('external_source_table_uuid', tableUuid)
             .first();
+    }
+
+    async findTableForQuery(projectUuid: string, tableUuid: string) {
+        const row = await this.database(ExternalSourceTablesTableName)
+            .innerJoin(
+                ExternalSourcesTableName,
+                `${ExternalSourcesTableName}.external_source_uuid`,
+                `${ExternalSourceTablesTableName}.external_source_uuid`,
+            )
+            .select(`${ExternalSourceTablesTableName}.*`)
+            .select(
+                `${ExternalSourcesTableName}.status as external_source_status`,
+            )
+            .where(`${ExternalSourceTablesTableName}.project_uuid`, projectUuid)
+            .andWhere(`${ExternalSourcesTableName}.project_uuid`, projectUuid)
+            .andWhere(
+                `${ExternalSourceTablesTableName}.external_source_table_uuid`,
+                tableUuid,
+            )
+            .first();
+        return row as
+            | (DbExternalSourceTable & {
+                  external_source_status: ExternalSourceStatus;
+              })
+            | undefined;
     }
 }

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -335,10 +335,6 @@ export class CommercialSchedulerClient extends SchedulerClient {
         return { jobId };
     }
 
-    /**
-     * One in-flight ingest per source: the stable jobKey replaces any queued
-     * ingest, so a refresh during a pending ingest coalesces.
-     */
     async ingestExternalSource(payload: IngestExternalSourceJobPayload) {
         const graphileClient = await this.graphileUtils;
         const { id: jobId } = await graphileClient.addJob(
@@ -346,8 +342,8 @@ export class CommercialSchedulerClient extends SchedulerClient {
             payload,
             {
                 runAt: new Date(),
-                maxAttempts: 1,
-                jobKey: `external-source-ingest:${payload.sourceUuid}`,
+                maxAttempts: 5,
+                jobKey: `external-source-ingest:${payload.attemptUuid}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -55,6 +55,7 @@ const AI_AGENT_MEMORY_CONSOLIDATE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 const AI_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000;
 const AGENT_ONBOARDING_TIMEOUT_MS = 60 * 60 * 1000;
+const EXTERNAL_SOURCE_INGEST_TIMEOUT_MS = 30 * 60 * 1000;
 
 export const cleanAiDeepResearchReports = async ({
     aiDeepResearchService,
@@ -123,7 +124,10 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
         ProjectHomepageService,
         'publishScheduledAnnouncement' | 'sweepDueAnnouncements'
     >;
-    externalSourceService: Pick<ExternalSourceService, 'runIngest'>;
+    externalSourceService: Pick<
+        ExternalSourceService,
+        'runIngest' | 'markIngestError'
+    >;
 };
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
@@ -715,8 +719,26 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     },
                 );
             },
-            [EE_SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE]: async (payload) => {
-                await this.externalSourceService.runIngest(payload);
+            [EE_SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        EE_SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        () => this.externalSourceService.runIngest(payload),
+                    ),
+                    helpers.job,
+                    EXTERNAL_SOURCE_INGEST_TIMEOUT_MS,
+                    async (_job, error) =>
+                        this.externalSourceService.markIngestError(
+                            payload.sourceUuid,
+                            error,
+                        ),
+                );
             },
             [EE_SCHEDULER_TASKS.AI_AGENT_EDIT_DBT_PROJECT_PIPELINE]: async (
                 payload,

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -126,7 +126,7 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     >;
     externalSourceService: Pick<
         ExternalSourceService,
-        'runIngest' | 'markIngestError'
+        'runIngest' | 'markIngestError' | 'maintain'
     >;
 };
 
@@ -201,6 +201,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
     protected getCronItems() {
         return [
             ...super.getCronItems(),
+            {
+                task: EE_SCHEDULER_TASKS.MAINTAIN_EXTERNAL_SOURCES,
+                pattern: '*/5 * * * *',
+                options: {
+                    backfillPeriod: 10 * 60 * 1000,
+                    maxAttempts: 3,
+                },
+            },
             {
                 task: EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS,
                 pattern: '*/2 * * * *', // Every 2 minutes
@@ -735,10 +743,13 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     EXTERNAL_SOURCE_INGEST_TIMEOUT_MS,
                     async (_job, error) =>
                         this.externalSourceService.markIngestError(
-                            payload.sourceUuid,
+                            payload.attemptUuid,
                             error,
                         ),
                 );
+            },
+            [EE_SCHEDULER_TASKS.MAINTAIN_EXTERNAL_SOURCES]: async () => {
+                await this.externalSourceService.maintain();
             },
             [EE_SCHEDULER_TASKS.AI_AGENT_EDIT_DBT_PROJECT_PIPELINE]: async (
                 payload,

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -233,8 +233,8 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
         };
     }
 
-    createExecutionWarehouseClient(): WarehouseClient {
-        return this.duckDbClient.createExecutionWarehouseClient();
+    createExecutionWarehouseClient(scope?: string): WarehouseClient {
+        return this.duckDbClient.createExecutionWarehouseClient(scope);
     }
 
     recordStats(params: {

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -49,7 +49,9 @@ type PreAggregationDuckDbClientArgs = {
     createDuckdbWarehouseClient?: (args: {
         s3Config: DuckdbS3SessionConfig;
         sharedResourceLimits?: DuckdbResourceLimits;
+        resourceLimits?: DuckdbResourceLimits;
         instanceCacheKey?: string;
+        organizationConcurrencyLimit?: number;
     }) => WarehouseClient;
 };
 
@@ -97,7 +99,9 @@ export class PreAggregationDuckDbClient {
     private readonly createDuckdbWarehouseClient: (args: {
         s3Config: DuckdbS3SessionConfig;
         sharedResourceLimits?: DuckdbResourceLimits;
+        resourceLimits?: DuckdbResourceLimits;
         instanceCacheKey?: string;
+        organizationConcurrencyLimit?: number;
     }) => WarehouseClient;
 
     private readonly prometheusMetrics?: PrometheusMetrics;
@@ -118,7 +122,10 @@ export class PreAggregationDuckDbClient {
                     {
                         sharedResourceLimits:
                             warehouseArgs.sharedResourceLimits,
+                        resourceLimits: warehouseArgs.resourceLimits,
                         instanceCacheKey: warehouseArgs.instanceCacheKey,
+                        organizationConcurrencyLimit:
+                            warehouseArgs.organizationConcurrencyLimit,
                         logger: Logger,
                         enableQueryProfiling: true,
                         onQueryProfile:
@@ -181,7 +188,29 @@ export class PreAggregationDuckDbClient {
         }
     }
 
-    createExecutionWarehouseClient(): WarehouseClient {
+    createExecutionWarehouseClient(scope?: string): WarehouseClient {
+        if (scope) {
+            const s3Config = getDuckdbRuntimeConfig(
+                this.lightdashConfig.preAggregates.s3,
+            );
+            if (!s3Config) {
+                throw new MissingConfigError(
+                    'External source DuckDB execution is unavailable',
+                );
+            }
+            // External-source credentials are isolated and URI-scoped. Never
+            // place this client in the bucket-wide pre-aggregate cache.
+            return this.createDuckdbWarehouseClient({
+                s3Config: { ...s3Config, scope },
+                resourceLimits: this.sharedResourceLimits ?? {
+                    memoryLimit: '512MB',
+                    threads: 2,
+                },
+                organizationConcurrencyLimit:
+                    this.lightdashConfig.externalSources
+                        .maxConcurrentDuckdbQueriesPerOrganization,
+            });
+        }
         return this.getOrCreateWarehouseClient();
     }
 

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalSourceService.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalSourceService.ts
@@ -15,15 +15,16 @@ import {
     parseGoogleSheetsSpreadsheetId,
     snakeCaseName,
     SupportedDbtAdapter,
-    type Account,
     type CreateExternalSourceTablePayload,
     type CreateGoogleSheetsSourcePayload,
     type ExternalSource,
     type ExternalSourceTablePreview,
     type IngestExternalSourceJobPayload,
+    type RegisteredAccount,
     type ResultColumns,
     type StagedExternalSourceUpload,
     type UpdateExternalSourcePayload,
+    type UUID,
 } from '@lightdash/common';
 import {
     DuckdbWarehouseClient,
@@ -31,7 +32,7 @@ import {
 } from '@lightdash/warehouses';
 import { stringify } from 'csv-stringify/sync';
 import { once } from 'events';
-import { type Readable } from 'stream';
+import { Readable } from 'stream';
 import { type GoogleDriveClient } from '../../../clients/Google/GoogleDriveClient';
 import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { type LightdashConfig } from '../../../config/parseConfig';
@@ -46,6 +47,7 @@ import {
 } from '../../../utils/duckdb/duckdbSqlTables';
 import { duckdbTypeToDimensionType } from '../../../utils/duckdb/duckdbTypeToDimensionType';
 import { getDuckdbRuntimeConfig } from '../../../utils/duckdb/getDuckdbRuntimeConfig';
+import { sanitizeDuckdbError } from '../../../utils/duckdb/sanitizeDuckdbError';
 import { type ExternalSourceModel } from '../../models/ExternalSourceModel';
 import { type CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 
@@ -71,6 +73,13 @@ type ExternalSourceServiceArguments = {
     storageClient: S3ResultsFileStorageClient;
     googleDriveClient: GoogleDriveClient;
     userOAuthGrantsModel: Pick<UserOAuthGrantsModel, 'getRefreshToken'>;
+};
+
+type ExternalSourceUploadInput = {
+    filename: string;
+    contentType: string;
+    contentLength: number;
+    body: Readable;
 };
 
 export class ExternalSourceService extends BaseService {
@@ -106,17 +115,17 @@ export class ExternalSourceService extends BaseService {
     }
 
     private static rawKey(
-        projectUuid: string,
-        sourceUuid: string,
+        projectUuid: UUID,
+        sourceUuid: UUID,
         version: number,
     ): string {
         return `external-sources/${projectUuid}/${sourceUuid}/raw/v${version}.csv`;
     }
 
     private static parquetKey(
-        projectUuid: string,
-        sourceUuid: string,
-        tableUuid: string,
+        projectUuid: UUID,
+        sourceUuid: UUID,
+        tableUuid: UUID,
         version: number,
     ): string {
         return `external-sources/${projectUuid}/${sourceUuid}/${tableUuid}/v${version}.parquet`;
@@ -163,9 +172,65 @@ export class ExternalSourceService extends BaseService {
         }
     }
 
+    private getMaxUploadBytes(): number {
+        return this.lightdashConfig.externalSources.maxFileSizeBytes;
+    }
+
+    private getMaxUploadMegabytes(): number {
+        return Math.floor(this.getMaxUploadBytes() / (1024 * 1024));
+    }
+
+    private assertValidUpload(input: ExternalSourceUploadInput): void {
+        const baseContentType = input.contentType.split(';')[0].trim();
+        if (!ALLOWED_UPLOAD_CONTENT_TYPES.includes(baseContentType)) {
+            throw new ParameterError(
+                'Unsupported file type. Upload a .csv or .tsv file',
+            );
+        }
+        if (input.contentLength > this.getMaxUploadBytes()) {
+            throw new ParameterError(
+                `File exceeds the ${this.getMaxUploadMegabytes()} MB upload limit`,
+            );
+        }
+    }
+
+    private async uploadRawFile(key: string, body: Readable): Promise<number> {
+        const { writeStream, close } = this.storageClient.createUploadStream(
+            key,
+            { contentType: 'text/csv' },
+        );
+        let totalBytes = 0;
+        try {
+            // eslint-disable-next-line no-restricted-syntax
+            for await (const chunk of body) {
+                const buffer = Buffer.isBuffer(chunk)
+                    ? chunk
+                    : Buffer.from(chunk);
+                totalBytes += buffer.length;
+                if (totalBytes > this.getMaxUploadBytes()) {
+                    throw new ParameterError(
+                        `File exceeds the ${this.getMaxUploadMegabytes()} MB upload limit`,
+                    );
+                }
+                if (!writeStream.write(buffer)) {
+                    await once(writeStream, 'drain');
+                }
+            }
+            if (totalBytes === 0) {
+                throw new ParameterError('Upload body is empty');
+            }
+            await close();
+            return totalBytes;
+        } catch (error) {
+            writeStream.destroy();
+            await close().catch(() => {});
+            throw error;
+        }
+    }
+
     private async assertAccess(
-        account: Account,
-        projectUuid: string,
+        account: RegisteredAccount,
+        projectUuid: UUID,
     ): Promise<{ organizationUuid: string; userUuid: string }> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
@@ -220,32 +285,13 @@ export class ExternalSourceService extends BaseService {
     }
 
     async stageCsvUpload(
-        account: Account,
-        projectUuid: string,
-        input: {
-            filename: string;
-            contentType: string;
-            contentLength: number;
-            body: Readable;
-        },
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        input: ExternalSourceUploadInput,
     ): Promise<StagedExternalSourceUpload> {
         const { userUuid } = await this.assertAccess(account, projectUuid);
         this.assertEngineAvailable();
-
-        const baseContentType = input.contentType.split(';')[0].trim();
-        if (!ALLOWED_UPLOAD_CONTENT_TYPES.includes(baseContentType)) {
-            throw new ParameterError(
-                'Unsupported file type. Upload a .csv or .tsv file',
-            );
-        }
-        const maxBytes = this.lightdashConfig.externalSources.maxFileSizeBytes;
-        if (input.contentLength > maxBytes) {
-            throw new ParameterError(
-                `File exceeds the ${Math.floor(
-                    maxBytes / (1024 * 1024),
-                )} MB upload limit`,
-            );
-        }
+        this.assertValidUpload(input);
 
         const source = await this.externalSourceModel.createSource({
             projectUuid,
@@ -266,37 +312,9 @@ export class ExternalSourceService extends BaseService {
             source.sourceUuid,
             1,
         );
-        const { writeStream, close } = this.storageClient.createUploadStream(
-            rawKey,
-            { contentType: 'text/csv' },
-        );
-
-        let totalBytes = 0;
         try {
-            // eslint-disable-next-line no-restricted-syntax
-            for await (const chunk of input.body) {
-                const buffer = Buffer.isBuffer(chunk)
-                    ? chunk
-                    : Buffer.from(chunk);
-                totalBytes += buffer.length;
-                if (totalBytes > maxBytes) {
-                    throw new ParameterError(
-                        `File exceeds the ${Math.floor(
-                            maxBytes / (1024 * 1024),
-                        )} MB upload limit`,
-                    );
-                }
-                if (!writeStream.write(buffer)) {
-                    await once(writeStream, 'drain');
-                }
-            }
-            if (totalBytes === 0) {
-                throw new ParameterError('Upload body is empty');
-            }
-            await close();
+            await this.uploadRawFile(rawKey, input.body);
         } catch (error) {
-            writeStream.destroy();
-            await close().catch(() => {});
             await this.externalSourceModel
                 .deleteSource(projectUuid, source.sourceUuid)
                 .catch(() => {});
@@ -323,13 +341,13 @@ export class ExternalSourceService extends BaseService {
                 .deleteSource(projectUuid, source.sourceUuid)
                 .catch(() => {});
             throw new ParameterError(
-                `Could not read the file as CSV: ${getErrorMessage(error)}`,
+                `Could not read the file as CSV: ${sanitizeDuckdbError(error)}`,
             );
         }
     }
 
     private async validateNewTableName(
-        projectUuid: string,
+        projectUuid: UUID,
         rawName: string,
     ): Promise<string> {
         const tableName = snakeCaseName(rawName);
@@ -372,9 +390,22 @@ export class ExternalSourceService extends BaseService {
         }
     }
 
+    private async enqueueIngest(
+        payload: IngestExternalSourceJobPayload,
+    ): Promise<void> {
+        try {
+            await this.schedulerClient.ingestExternalSource(payload);
+        } catch (error) {
+            await this.markIngestError(payload.sourceUuid, error).catch(
+                () => {},
+            );
+            throw error;
+        }
+    }
+
     async createGoogleSheetsSource(
-        account: Account,
-        projectUuid: string,
+        account: RegisteredAccount,
+        projectUuid: UUID,
         payload: CreateGoogleSheetsSourcePayload,
     ): Promise<ExternalSource> {
         const { organizationUuid, userUuid } = await this.assertAccess(
@@ -423,17 +454,18 @@ export class ExternalSourceService extends BaseService {
             },
             createdByUserUuid: userUuid,
         });
-        await this.externalSourceModel.createTable({
+        const table = await this.externalSourceModel.createTable({
             sourceUuid: source.sourceUuid,
             projectUuid,
             name: tableName,
             label,
         });
-        await this.schedulerClient.ingestExternalSource({
+        await this.enqueueIngest({
             organizationUuid,
             projectUuid,
             userUuid,
             sourceUuid: source.sourceUuid,
+            ingestVersion: table.version + 1,
         });
         return this.externalSourceModel.getSource(
             projectUuid,
@@ -443,9 +475,9 @@ export class ExternalSourceService extends BaseService {
 
     /** Re-read the connected sheet and re-ingest. Google Sheets sources only. */
     async refresh(
-        account: Account,
-        projectUuid: string,
-        sourceUuid: string,
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        sourceUuid: UUID,
     ): Promise<ExternalSource> {
         const { organizationUuid, userUuid } = await this.assertAccess(
             account,
@@ -466,23 +498,28 @@ export class ExternalSourceService extends BaseService {
                 'This source is already ingesting. Wait for it to finish and try again',
             );
         }
+        const table = source.tables[0];
+        if (!table) {
+            throw new NotFoundError('External source has no table');
+        }
         await this.externalSourceModel.updateSource(sourceUuid, {
             status: ExternalSourceStatus.SYNCING,
             error_message: null,
         });
-        await this.schedulerClient.ingestExternalSource({
+        await this.enqueueIngest({
             organizationUuid,
             projectUuid,
             userUuid,
             sourceUuid,
+            ingestVersion: table.version + 1,
         });
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
     }
 
     async createCsvTable(
-        account: Account,
-        projectUuid: string,
-        sourceUuid: string,
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        sourceUuid: UUID,
         payload: CreateExternalSourceTablePayload,
     ): Promise<ExternalSource> {
         const { organizationUuid, userUuid } = await this.assertAccess(
@@ -508,26 +545,27 @@ export class ExternalSourceService extends BaseService {
             status: ExternalSourceStatus.SYNCING,
             error_message: null,
         });
-        await this.externalSourceModel.createTable({
+        const table = await this.externalSourceModel.createTable({
             sourceUuid,
             projectUuid,
             name: tableName,
             label,
         });
 
-        await this.schedulerClient.ingestExternalSource({
+        await this.enqueueIngest({
             organizationUuid,
             projectUuid,
             userUuid,
             sourceUuid,
+            ingestVersion: table.version + 1,
         });
 
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
     }
 
     async list(
-        account: Account,
-        projectUuid: string,
+        account: RegisteredAccount,
+        projectUuid: UUID,
     ): Promise<ExternalSource[]> {
         await this.assertAccess(account, projectUuid);
         const sources = await this.externalSourceModel.listSources(projectUuid);
@@ -537,9 +575,9 @@ export class ExternalSourceService extends BaseService {
     }
 
     async get(
-        account: Account,
-        projectUuid: string,
-        sourceUuid: string,
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        sourceUuid: UUID,
     ): Promise<ExternalSource> {
         await this.assertAccess(account, projectUuid);
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
@@ -551,9 +589,9 @@ export class ExternalSourceService extends BaseService {
      * rebuilt from the stored schema — no re-ingest.
      */
     async rename(
-        account: Account,
-        projectUuid: string,
-        sourceUuid: string,
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        sourceUuid: UUID,
         payload: UpdateExternalSourcePayload,
     ): Promise<ExternalSource> {
         await this.assertAccess(account, projectUuid);
@@ -588,9 +626,8 @@ export class ExternalSourceService extends BaseService {
                     SupportedDbtAdapter.DUCKDB,
                 ),
             });
-            await this.projectModel.updateExternalSourceExplore(
+            await this.projectModel.saveExternalSourceExplore(
                 projectUuid,
-                table.name,
                 explore,
             );
         }
@@ -603,15 +640,10 @@ export class ExternalSourceService extends BaseService {
      * new file drops will fail validation.
      */
     async replaceCsv(
-        account: Account,
-        projectUuid: string,
-        sourceUuid: string,
-        input: {
-            filename: string;
-            contentType: string;
-            contentLength: number;
-            body: Readable;
-        },
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        sourceUuid: UUID,
+        input: ExternalSourceUploadInput,
     ): Promise<ExternalSource> {
         const { organizationUuid, userUuid } = await this.assertAccess(
             account,
@@ -639,58 +671,14 @@ export class ExternalSourceService extends BaseService {
             );
         }
 
-        const baseContentType = input.contentType.split(';')[0].trim();
-        if (!ALLOWED_UPLOAD_CONTENT_TYPES.includes(baseContentType)) {
-            throw new ParameterError(
-                'Unsupported file type. Upload a .csv or .tsv file',
-            );
-        }
-        const maxBytes = this.lightdashConfig.externalSources.maxFileSizeBytes;
-        if (input.contentLength > maxBytes) {
-            throw new ParameterError(
-                `File exceeds the ${Math.floor(
-                    maxBytes / (1024 * 1024),
-                )} MB upload limit`,
-            );
-        }
+        this.assertValidUpload(input);
 
         const rawKey = ExternalSourceService.rawKey(
             projectUuid,
             sourceUuid,
             table.version + 1,
         );
-        const { writeStream, close } = this.storageClient.createUploadStream(
-            rawKey,
-            { contentType: 'text/csv' },
-        );
-        let totalBytes = 0;
-        try {
-            // eslint-disable-next-line no-restricted-syntax
-            for await (const chunk of input.body) {
-                const buffer = Buffer.isBuffer(chunk)
-                    ? chunk
-                    : Buffer.from(chunk);
-                totalBytes += buffer.length;
-                if (totalBytes > maxBytes) {
-                    throw new ParameterError(
-                        `File exceeds the ${Math.floor(
-                            maxBytes / (1024 * 1024),
-                        )} MB upload limit`,
-                    );
-                }
-                if (!writeStream.write(buffer)) {
-                    await once(writeStream, 'drain');
-                }
-            }
-            if (totalBytes === 0) {
-                throw new ParameterError('Upload body is empty');
-            }
-            await close();
-        } catch (error) {
-            writeStream.destroy();
-            await close().catch(() => {});
-            throw error;
-        }
+        await this.uploadRawFile(rawKey, input.body);
 
         // Reject unreadable files before committing to a re-ingest
         const client = this.createIngestClient();
@@ -698,7 +686,7 @@ export class ExternalSourceService extends BaseService {
             await this.describeCsv(client, this.toUri(rawKey));
         } catch (error) {
             throw new ParameterError(
-                `Could not read the file as CSV: ${getErrorMessage(error)}`,
+                `Could not read the file as CSV: ${sanitizeDuckdbError(error)}`,
             );
         }
 
@@ -710,20 +698,21 @@ export class ExternalSourceService extends BaseService {
                 originalFilename: input.filename,
             },
         });
-        await this.schedulerClient.ingestExternalSource({
+        await this.enqueueIngest({
             organizationUuid,
             projectUuid,
             userUuid,
             sourceUuid,
+            ingestVersion: table.version + 1,
         });
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
     }
 
     async getTablePreview(
-        account: Account,
-        projectUuid: string,
-        sourceUuid: string,
-        tableUuid: string,
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        sourceUuid: UUID,
+        tableUuid: UUID,
     ): Promise<ExternalSourceTablePreview> {
         await this.assertAccess(account, projectUuid);
         const table = await this.externalSourceModel.findTableByUuid(
@@ -750,9 +739,9 @@ export class ExternalSourceService extends BaseService {
     }
 
     async delete(
-        account: Account,
-        projectUuid: string,
-        sourceUuid: string,
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        sourceUuid: UUID,
     ): Promise<void> {
         await this.assertAccess(account, projectUuid);
         const { source, tables } =
@@ -760,23 +749,29 @@ export class ExternalSourceService extends BaseService {
                 projectUuid,
                 sourceUuid,
             );
-        await Promise.all(
-            tables.map((table) =>
-                this.projectModel
-                    .deleteExternalSourceExplore(projectUuid, table.name)
-                    .catch((error) => {
-                        this.logger.warn(
-                            `Failed to delete explore for external source table ${
-                                table.name
-                            }: ${getErrorMessage(error)}`,
-                        );
-                    }),
-            ),
+        await this.projectModel.deleteExternalSourceExplores(
+            projectUuid,
+            tables.map((table) => table.name),
         );
         await this.externalSourceModel.deleteSource(
             projectUuid,
             source.external_source_uuid,
         );
+    }
+
+    async markIngestError(sourceUuid: UUID, error: unknown): Promise<void> {
+        const rawMessage = getErrorMessage(error);
+        const message = sanitizeDuckdbError(error).slice(
+            0,
+            ERROR_MESSAGE_MAX_LENGTH,
+        );
+        this.logger.error(
+            `External source ingest failed for ${sourceUuid}: ${rawMessage}`,
+        );
+        await this.externalSourceModel.updateSource(sourceUuid, {
+            status: ExternalSourceStatus.ERROR,
+            error_message: message,
+        });
     }
 
     /**
@@ -799,8 +794,24 @@ export class ExternalSourceService extends BaseService {
                 );
             }
 
+            const buildVersion = payload.ingestVersion;
+            if (table.version > buildVersion) {
+                return;
+            }
+            if (table.version === buildVersion) {
+                await this.externalSourceModel.updateSource(sourceUuid, {
+                    status: ExternalSourceStatus.READY,
+                    error_message: null,
+                });
+                return;
+            }
+            if (table.version !== buildVersion - 1) {
+                throw new ParameterError(
+                    `External source ingest version ${buildVersion} cannot follow version ${table.version}`,
+                );
+            }
+
             const client = this.createIngestClient();
-            const buildVersion = table.version + 1;
             const rawFileKey = ExternalSourceService.rawKey(
                 projectUuid,
                 sourceUuid,
@@ -842,12 +853,7 @@ export class ExternalSourceService extends BaseService {
                     );
                 }
                 const csv = stringify(values);
-                const { writeStream, close } =
-                    this.storageClient.createUploadStream(rawFileKey, {
-                        contentType: 'text/csv',
-                    });
-                writeStream.end(csv);
-                await close();
+                await this.uploadRawFile(rawFileKey, Readable.from([csv]));
             }
 
             const parquetKey = ExternalSourceService.parquetKey(
@@ -902,47 +908,36 @@ export class ExternalSourceService extends BaseService {
                 ),
             });
 
-            if (table.version === 0) {
-                await this.projectModel.createExternalSourceExplore(
-                    projectUuid,
-                    explore,
-                );
-            } else {
-                await this.projectModel.updateExternalSourceExplore(
-                    projectUuid,
-                    table.name,
-                    explore,
-                );
-            }
+            await this.projectModel.saveExternalSourceExplore(
+                projectUuid,
+                explore,
+            );
 
             const locator: PreAggregateDuckdbLocator =
                 getPreAggregateDuckdbLocator({
                     uri: parquetUri,
                     format: 'parquet',
                 });
-            await this.externalSourceModel.updateTableIngest(
+            const didPublish = await this.externalSourceModel.updateTableIngest(
                 table.external_source_table_uuid,
-                { columns, locator, rowCount, totalBytes },
+                {
+                    columns,
+                    locator,
+                    rowCount,
+                    totalBytes,
+                    ingestVersion: buildVersion,
+                },
             );
+            if (!didPublish) {
+                return;
+            }
             await this.externalSourceModel.updateSource(sourceUuid, {
                 status: ExternalSourceStatus.READY,
                 error_message: null,
                 last_refreshed_at: new Date(),
             });
         } catch (error) {
-            const message = getErrorMessage(error).slice(
-                0,
-                ERROR_MESSAGE_MAX_LENGTH,
-            );
-            this.logger.error(
-                `External source ingest failed for ${sourceUuid}: ${message}`,
-            );
-            await this.externalSourceModel
-                .updateSource(sourceUuid, {
-                    status: ExternalSourceStatus.ERROR,
-                    error_message: message,
-                })
-                .catch(() => {});
+            await this.markIngestError(sourceUuid, error).catch(() => {});
             throw error;
         }
     }

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalSourceService.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalSourceService.ts
@@ -15,6 +15,7 @@ import {
     parseGoogleSheetsSpreadsheetId,
     snakeCaseName,
     SupportedDbtAdapter,
+    TimeoutError,
     type CreateExternalSourceTablePayload,
     type CreateGoogleSheetsSourcePayload,
     type ExternalSource,
@@ -30,12 +31,13 @@ import {
     DuckdbWarehouseClient,
     warehouseSqlBuilderFromType,
 } from '@lightdash/warehouses';
-import { stringify } from 'csv-stringify/sync';
+import { stringify } from 'csv-stringify';
 import { once } from 'events';
-import { Readable } from 'stream';
+import { PassThrough, Readable } from 'stream';
 import { type GoogleDriveClient } from '../../../clients/Google/GoogleDriveClient';
 import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { type LightdashConfig } from '../../../config/parseConfig';
+import { type DbExternalSourceIngestAttempt } from '../../../database/entities/externalSources';
 import Logger from '../../../logging/logger';
 import { type FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
@@ -52,7 +54,6 @@ import { type ExternalSourceModel } from '../../models/ExternalSourceModel';
 import { type CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 
 const INGEST_RESOURCE_LIMITS = { memoryLimit: '512MB', threads: 2 };
-const INGEST_INSTANCE_CACHE_KEY = 'external-source-ingest';
 const ERROR_MESSAGE_MAX_LENGTH = 500;
 const TABLE_NAME_PATTERN = /^[a-z][a-z0-9_]*$/;
 
@@ -118,8 +119,10 @@ export class ExternalSourceService extends BaseService {
         projectUuid: UUID,
         sourceUuid: UUID,
         version: number,
+        executionUuid?: UUID,
     ): string {
-        return `external-sources/${projectUuid}/${sourceUuid}/raw/v${version}.csv`;
+        const executionSuffix = executionUuid ? `-${executionUuid}` : '';
+        return `external-sources/${projectUuid}/${sourceUuid}/raw/v${version}${executionSuffix}.csv`;
     }
 
     private static parquetKey(
@@ -127,8 +130,9 @@ export class ExternalSourceService extends BaseService {
         sourceUuid: UUID,
         tableUuid: UUID,
         version: number,
+        executionUuid: UUID,
     ): string {
-        return `external-sources/${projectUuid}/${sourceUuid}/${tableUuid}/v${version}.parquet`;
+        return `external-sources/${projectUuid}/${sourceUuid}/${tableUuid}/v${version}-${executionUuid}.parquet`;
     }
 
     private getBucket(): string {
@@ -158,7 +162,6 @@ export class ExternalSourceService extends BaseService {
             { type: 'duckdb_s3', s3Config },
             {
                 resourceLimits: INGEST_RESOURCE_LIMITS,
-                instanceCacheKey: INGEST_INSTANCE_CACHE_KEY,
                 logger: Logger,
             },
         );
@@ -228,6 +231,43 @@ export class ExternalSourceService extends BaseService {
         }
     }
 
+    private async uploadTrackedObject(data: {
+        organizationUuid: UUID;
+        projectUuid: UUID;
+        sourceUuid: UUID;
+        attemptUuid?: UUID;
+        key: string;
+        purpose: 'raw' | 'parquet';
+        body: Readable;
+        expectedBytes?: number;
+    }): Promise<number> {
+        await this.externalSourceModel.registerObject({
+            organizationUuid: data.organizationUuid,
+            projectUuid: data.projectUuid,
+            sourceUuid: data.sourceUuid,
+            attemptUuid: data.attemptUuid,
+            key: data.key,
+            purpose: data.purpose,
+            expectedBytes: data.expectedBytes,
+            maxOrganizationBytes:
+                this.lightdashConfig.externalSources.maxOrganizationBytes,
+        });
+        try {
+            const bytes = await this.uploadRawFile(data.key, data.body);
+            await this.externalSourceModel.completeObject(
+                data.key,
+                bytes,
+                this.lightdashConfig.externalSources.maxOrganizationBytes,
+            );
+            return bytes;
+        } catch (error) {
+            await this.externalSourceModel
+                .abandonObject(data.key, sanitizeDuckdbError(error))
+                .catch(() => {});
+            throw error;
+        }
+    }
+
     private async assertAccess(
         account: RegisteredAccount,
         projectUuid: UUID,
@@ -289,7 +329,10 @@ export class ExternalSourceService extends BaseService {
         projectUuid: UUID,
         input: ExternalSourceUploadInput,
     ): Promise<StagedExternalSourceUpload> {
-        const { userUuid } = await this.assertAccess(account, projectUuid);
+        const { organizationUuid, userUuid } = await this.assertAccess(
+            account,
+            projectUuid,
+        );
         this.assertEngineAvailable();
         this.assertValidUpload(input);
 
@@ -313,7 +356,15 @@ export class ExternalSourceService extends BaseService {
             1,
         );
         try {
-            await this.uploadRawFile(rawKey, input.body);
+            await this.uploadTrackedObject({
+                organizationUuid,
+                projectUuid,
+                sourceUuid: source.sourceUuid,
+                key: rawKey,
+                purpose: 'raw',
+                body: input.body,
+                expectedBytes: input.contentLength,
+            });
         } catch (error) {
             await this.externalSourceModel
                 .deleteSource(projectUuid, source.sourceUuid)
@@ -396,11 +447,39 @@ export class ExternalSourceService extends BaseService {
         try {
             await this.schedulerClient.ingestExternalSource(payload);
         } catch (error) {
-            await this.markIngestError(payload.sourceUuid, error).catch(
-                () => {},
+            // The durable queued attempt is recovered by maintain(); do not
+            // turn a transient scheduler outage into a broken source.
+            this.logger.warn(
+                `External source attempt ${payload.attemptUuid} was persisted but not enqueued: ${getErrorMessage(error)}`,
             );
-            throw error;
         }
+    }
+
+    private async requestIngest(data: {
+        organizationUuid: UUID;
+        projectUuid: UUID;
+        userUuid: UUID;
+        sourceUuid: UUID;
+        tableUuid: UUID;
+        targetVersion: number;
+        rawObjectKey?: string;
+    }): Promise<void> {
+        const attempt = await this.externalSourceModel.requestIngest({
+            organizationUuid: data.organizationUuid,
+            projectUuid: data.projectUuid,
+            sourceUuid: data.sourceUuid,
+            tableUuid: data.tableUuid,
+            requestedByUserUuid: data.userUuid,
+            targetVersion: data.targetVersion,
+            rawObjectKey: data.rawObjectKey,
+        });
+        await this.enqueueIngest({
+            organizationUuid: data.organizationUuid,
+            projectUuid: data.projectUuid,
+            userUuid: data.userUuid,
+            sourceUuid: data.sourceUuid,
+            attemptUuid: attempt.external_source_ingest_attempt_uuid,
+        });
     }
 
     async createGoogleSheetsSource(
@@ -446,7 +525,7 @@ export class ExternalSourceService extends BaseService {
             projectUuid,
             type: ExternalSourceType.GOOGLE_SHEETS,
             name: tableName,
-            status: ExternalSourceStatus.SYNCING,
+            status: ExternalSourceStatus.STAGED,
             connection: {
                 type: ExternalSourceType.GOOGLE_SHEETS,
                 spreadsheetId,
@@ -460,12 +539,18 @@ export class ExternalSourceService extends BaseService {
             name: tableName,
             label,
         });
-        await this.enqueueIngest({
+        await this.externalSourceModel.upsertGoogleCredential({
+            sourceUuid: source.sourceUuid,
+            refreshToken,
+            connectedByUserUuid: userUuid,
+        });
+        await this.requestIngest({
             organizationUuid,
             projectUuid,
             userUuid,
             sourceUuid: source.sourceUuid,
-            ingestVersion: table.version + 1,
+            tableUuid: table.tableUuid,
+            targetVersion: table.version + 1,
         });
         return this.externalSourceModel.getSource(
             projectUuid,
@@ -502,16 +587,59 @@ export class ExternalSourceService extends BaseService {
         if (!table) {
             throw new NotFoundError('External source has no table');
         }
-        await this.externalSourceModel.updateSource(sourceUuid, {
-            status: ExternalSourceStatus.SYNCING,
-            error_message: null,
-        });
-        await this.enqueueIngest({
+        await this.requestIngest({
             organizationUuid,
             projectUuid,
             userUuid,
             sourceUuid,
-            ingestVersion: table.version + 1,
+            tableUuid: table.tableUuid,
+            targetVersion: table.version + 1,
+        });
+        return this.externalSourceModel.getSource(projectUuid, sourceUuid);
+    }
+
+    /** Transfer the source to the current user's Google grant, then refresh. */
+    async reconnectGoogleSheets(
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        sourceUuid: UUID,
+    ): Promise<ExternalSource> {
+        const { organizationUuid, userUuid } = await this.assertAccess(
+            account,
+            projectUuid,
+        );
+        const source = await this.externalSourceModel.getSource(
+            projectUuid,
+            sourceUuid,
+        );
+        if (
+            source.type !== ExternalSourceType.GOOGLE_SHEETS ||
+            source.connection.type !== ExternalSourceType.GOOGLE_SHEETS
+        ) {
+            throw new ParameterError('Only Google Sheets can be reconnected');
+        }
+        if (source.status === ExternalSourceStatus.SYNCING) {
+            throw new ParameterError('This source is already ingesting');
+        }
+        const refreshToken = await this.getGoogleRefreshToken(userUuid);
+        await this.googleDriveClient.assertFileIsGoogleSheet(
+            refreshToken,
+            source.connection.spreadsheetId,
+        );
+        await this.externalSourceModel.upsertGoogleCredential({
+            sourceUuid,
+            refreshToken,
+            connectedByUserUuid: userUuid,
+        });
+        const table = source.tables[0];
+        if (!table) throw new NotFoundError('External source has no table');
+        await this.requestIngest({
+            organizationUuid,
+            projectUuid,
+            userUuid,
+            sourceUuid,
+            tableUuid: table.tableUuid,
+            targetVersion: table.version + 1,
         });
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
     }
@@ -542,7 +670,6 @@ export class ExternalSourceService extends BaseService {
         const label = payload.label?.trim() || friendlyName(tableName);
         await this.externalSourceModel.updateSource(sourceUuid, {
             name: tableName,
-            status: ExternalSourceStatus.SYNCING,
             error_message: null,
         });
         const table = await this.externalSourceModel.createTable({
@@ -552,12 +679,18 @@ export class ExternalSourceService extends BaseService {
             label,
         });
 
-        await this.enqueueIngest({
+        await this.requestIngest({
             organizationUuid,
             projectUuid,
             userUuid,
             sourceUuid,
-            ingestVersion: table.version + 1,
+            tableUuid: table.tableUuid,
+            targetVersion: table.version + 1,
+            rawObjectKey: ExternalSourceService.rawKey(
+                projectUuid,
+                sourceUuid,
+                table.version + 1,
+            ),
         });
 
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
@@ -678,32 +811,44 @@ export class ExternalSourceService extends BaseService {
             sourceUuid,
             table.version + 1,
         );
-        await this.uploadRawFile(rawKey, input.body);
+        await this.uploadTrackedObject({
+            organizationUuid,
+            projectUuid,
+            sourceUuid,
+            key: rawKey,
+            purpose: 'raw',
+            body: input.body,
+            expectedBytes: input.contentLength,
+        });
 
         // Reject unreadable files before committing to a re-ingest
         const client = this.createIngestClient();
         try {
             await this.describeCsv(client, this.toUri(rawKey));
         } catch (error) {
+            await this.externalSourceModel
+                .abandonObject(rawKey, sanitizeDuckdbError(error))
+                .catch(() => {});
             throw new ParameterError(
                 `Could not read the file as CSV: ${sanitizeDuckdbError(error)}`,
             );
         }
 
         await this.externalSourceModel.updateSource(sourceUuid, {
-            status: ExternalSourceStatus.SYNCING,
             error_message: null,
             connection: {
                 type: ExternalSourceType.CSV,
                 originalFilename: input.filename,
             },
         });
-        await this.enqueueIngest({
+        await this.requestIngest({
             organizationUuid,
             projectUuid,
             userUuid,
             sourceUuid,
-            ingestVersion: table.version + 1,
+            tableUuid: table.external_source_table_uuid,
+            targetVersion: table.version + 1,
+            rawObjectKey: rawKey,
         });
         return this.externalSourceModel.getSource(projectUuid, sourceUuid);
     }
@@ -759,19 +904,71 @@ export class ExternalSourceService extends BaseService {
         );
     }
 
-    async markIngestError(sourceUuid: UUID, error: unknown): Promise<void> {
+    async markIngestError(attemptUuid: UUID, error: unknown): Promise<void> {
         const rawMessage = getErrorMessage(error);
         const message = sanitizeDuckdbError(error).slice(
             0,
             ERROR_MESSAGE_MAX_LENGTH,
         );
         this.logger.error(
-            `External source ingest failed for ${sourceUuid}: ${rawMessage}`,
+            `External source ingest attempt ${attemptUuid} failed: ${rawMessage}`,
         );
-        await this.externalSourceModel.updateSource(sourceUuid, {
-            status: ExternalSourceStatus.ERROR,
-            error_message: message,
-        });
+        await this.externalSourceModel.failIngestAttempt(
+            attemptUuid,
+            message,
+            error instanceof TimeoutError,
+        );
+    }
+
+    private createSheetCsvStream(data: {
+        refreshToken: string;
+        spreadsheetId: string;
+        tabName: string;
+    }): { stream: Readable; completed: Promise<number> } {
+        const output = new PassThrough();
+        const csv = stringify();
+        csv.pipe(output);
+        const completed = (async () => {
+            let rows = 0;
+            try {
+                // eslint-disable-next-line no-restricted-syntax
+                for await (const batch of this.googleDriveClient.getSheetRowBatches(
+                    data.refreshToken,
+                    data.spreadsheetId,
+                    data.tabName,
+                    this.lightdashConfig.externalSources.googleSheetsBatchRows,
+                )) {
+                    // eslint-disable-next-line no-restricted-syntax
+                    for (const row of batch) {
+                        rows += 1;
+                        if (
+                            rows - 1 >
+                            this.lightdashConfig.externalSources.maxRows
+                        ) {
+                            throw new ParameterError(
+                                `Sheet exceeds the ${this.lightdashConfig.externalSources.maxRows} row limit`,
+                            );
+                        }
+                        // csv-stringify is one ordered stream; parallel writes
+                        // would corrupt row ordering.
+                        // eslint-disable-next-line no-await-in-loop
+                        if (!csv.write(row)) await once(csv, 'drain');
+                    }
+                }
+                if (rows < 2) {
+                    throw new ParameterError(
+                        'The sheet needs a header row and at least one data row',
+                    );
+                }
+                csv.end();
+                return rows - 1;
+            } catch (error) {
+                csv.destroy(error as Error);
+                output.destroy(error as Error);
+                throw error;
+            }
+        })();
+        return { stream: output, completed };
     }
 
     /**
@@ -780,28 +977,44 @@ export class ExternalSourceService extends BaseService {
      * source row as an error status.
      */
     async runIngest(payload: IngestExternalSourceJobPayload): Promise<void> {
-        const { projectUuid, sourceUuid } = payload;
+        const claimed = await this.externalSourceModel.claimIngestAttempt({
+            attemptUuid: payload.attemptUuid,
+            leaseMs: this.lightdashConfig.externalSources.ingestLeaseMs,
+            maxConcurrentPerOrganization:
+                this.lightdashConfig.externalSources
+                    .maxConcurrentIngestsPerOrganization,
+        });
+        if (!claimed) return;
+        const sourceUuid = claimed.external_source_uuid;
+        const projectUuid = claimed.project_uuid;
+        const executionUuid = claimed.execution_uuid;
+        if (!executionUuid) throw new Error('Ingest lease has no execution id');
+        let parquetKey: string | undefined;
         try {
             const { source, tables } =
                 await this.externalSourceModel.getSourceRowsForIngest(
                     projectUuid,
                     sourceUuid,
                 );
-            const table = tables[0];
+            const table = tables.find(
+                (candidate) =>
+                    candidate.external_source_table_uuid ===
+                    claimed.external_source_table_uuid,
+            );
             if (!table) {
                 throw new NotFoundError(
                     'External source has no table to ingest',
                 );
             }
 
-            const buildVersion = payload.ingestVersion;
+            const buildVersion = claimed.target_version;
             if (table.version > buildVersion) {
                 return;
             }
             if (table.version === buildVersion) {
-                await this.externalSourceModel.updateSource(sourceUuid, {
-                    status: ExternalSourceStatus.READY,
-                    error_message: null,
+                await this.externalSourceModel.publishIngestAttempt({
+                    attemptUuid: payload.attemptUuid,
+                    executionUuid,
                 });
                 return;
             }
@@ -811,29 +1024,53 @@ export class ExternalSourceService extends BaseService {
                 );
             }
 
+            if (claimed.columns && claimed.locator) {
+                const explore = createExternalSourceExplore({
+                    name: table.name,
+                    label: table.label,
+                    columns: claimed.columns,
+                    externalSource: {
+                        sourceUuid,
+                        tableUuid: table.external_source_table_uuid,
+                        sourceType: source.type,
+                    },
+                    warehouseSqlBuilder: warehouseSqlBuilderFromType(
+                        SupportedDbtAdapter.DUCKDB,
+                    ),
+                });
+                await this.projectModel.saveExternalSourceExplore(
+                    projectUuid,
+                    explore,
+                );
+                await this.externalSourceModel.publishIngestAttempt({
+                    attemptUuid: payload.attemptUuid,
+                    executionUuid,
+                });
+                return;
+            }
+
             const client = this.createIngestClient();
             const rawFileKey = ExternalSourceService.rawKey(
                 projectUuid,
                 sourceUuid,
                 buildVersion,
+                source.type === ExternalSourceType.GOOGLE_SHEETS
+                    ? executionUuid
+                    : undefined,
             );
             const rawUri = this.toUri(rawFileKey);
 
             // Sheets sources have no uploaded file: fetch the tab's values
-            // under the connecting user's Google credentials and store them
+            // under the source-owned Google credential and store them
             // as this version's raw CSV, then the shared pipeline takes over.
             if (
                 source.type === ExternalSourceType.GOOGLE_SHEETS &&
                 source.connection.type === ExternalSourceType.GOOGLE_SHEETS
             ) {
-                if (!source.created_by_user_uuid) {
-                    throw new ParameterError(
-                        'The user who connected this sheet no longer exists. Reconnect the source',
+                const refreshToken =
+                    await this.externalSourceModel.getGoogleCredential(
+                        sourceUuid,
                     );
-                }
-                const refreshToken = await this.getGoogleRefreshToken(
-                    source.created_by_user_uuid,
-                );
                 const tabName =
                     source.connection.tabName ??
                     (
@@ -842,31 +1079,47 @@ export class ExternalSourceService extends BaseService {
                             source.connection.spreadsheetId,
                         )
                     )[0];
-                const values = await this.googleDriveClient.getSheetValues(
+                const sheetCsv = this.createSheetCsvStream({
                     refreshToken,
-                    source.connection.spreadsheetId,
+                    spreadsheetId: source.connection.spreadsheetId,
                     tabName,
-                );
-                if (values.length < 2) {
-                    throw new ParameterError(
-                        'The sheet needs a header row and at least one data row',
-                    );
-                }
-                const csv = stringify(values);
-                await this.uploadRawFile(rawFileKey, Readable.from([csv]));
+                });
+                await Promise.all([
+                    this.uploadTrackedObject({
+                        organizationUuid: claimed.organization_uuid,
+                        projectUuid,
+                        sourceUuid,
+                        attemptUuid: payload.attemptUuid,
+                        key: rawFileKey,
+                        purpose: 'raw',
+                        body: sheetCsv.stream,
+                    }),
+                    sheetCsv.completed,
+                ]);
             }
 
-            const parquetKey = ExternalSourceService.parquetKey(
+            parquetKey = ExternalSourceService.parquetKey(
                 projectUuid,
                 sourceUuid,
                 table.external_source_table_uuid,
                 buildVersion,
+                executionUuid,
             );
             const parquetUri = this.toUri(parquetKey);
             const escapedRawUri = ExternalSourceService.escapeUri(rawUri);
             const escapedParquetUri =
                 ExternalSourceService.escapeUri(parquetUri);
 
+            await this.externalSourceModel.registerObject({
+                organizationUuid: claimed.organization_uuid,
+                projectUuid,
+                sourceUuid,
+                attemptUuid: payload.attemptUuid,
+                key: parquetKey,
+                purpose: 'parquet',
+                maxOrganizationBytes:
+                    this.lightdashConfig.externalSources.maxOrganizationBytes,
+            });
             await client.runSql(
                 `COPY (SELECT * FROM read_csv('${escapedRawUri}', normalize_names=true, sample_size=-1)) TO '${escapedParquetUri}' (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE 100000)`,
             );
@@ -889,9 +1142,22 @@ export class ExternalSourceService extends BaseService {
                 {},
             );
             const rowCount = Number(countRows[0]?.row_count ?? 0);
+            if (rowCount > this.lightdashConfig.externalSources.maxRows) {
+                throw new ParameterError(
+                    `Source exceeds the ${this.lightdashConfig.externalSources.maxRows} row limit`,
+                );
+            }
             const totalBytes = await this.storageClient.getFileSize(
                 parquetKey,
                 'parquet',
+            );
+            if (totalBytes === null) {
+                throw new Error('Could not determine ingested object size');
+            }
+            await this.externalSourceModel.completeObject(
+                parquetKey,
+                totalBytes,
+                this.lightdashConfig.externalSources.maxOrganizationBytes,
             );
 
             const explore = createExternalSourceExplore({
@@ -908,37 +1174,99 @@ export class ExternalSourceService extends BaseService {
                 ),
             });
 
-            await this.projectModel.saveExternalSourceExplore(
-                projectUuid,
-                explore,
-            );
-
             const locator: PreAggregateDuckdbLocator =
                 getPreAggregateDuckdbLocator({
                     uri: parquetUri,
                     format: 'parquet',
                 });
-            const didPublish = await this.externalSourceModel.updateTableIngest(
-                table.external_source_table_uuid,
-                {
-                    columns,
-                    locator,
-                    rowCount,
-                    totalBytes,
-                    ingestVersion: buildVersion,
-                },
+            const recorded = await this.externalSourceModel.recordIngestOutput({
+                attemptUuid: payload.attemptUuid,
+                executionUuid,
+                columns,
+                locator,
+                rowCount,
+                totalBytes,
+            });
+            if (!recorded) return;
+            await this.projectModel.saveExternalSourceExplore(
+                projectUuid,
+                explore,
             );
-            if (!didPublish) {
-                return;
-            }
-            await this.externalSourceModel.updateSource(sourceUuid, {
-                status: ExternalSourceStatus.READY,
-                error_message: null,
-                last_refreshed_at: new Date(),
+            await this.externalSourceModel.publishIngestAttempt({
+                attemptUuid: payload.attemptUuid,
+                executionUuid,
             });
         } catch (error) {
-            await this.markIngestError(sourceUuid, error).catch(() => {});
+            if (parquetKey) {
+                await this.externalSourceModel
+                    .abandonObject(parquetKey, sanitizeDuckdbError(error))
+                    .catch(() => {});
+            }
+            await this.markIngestError(payload.attemptUuid, error).catch(
+                () => {},
+            );
             throw error;
         }
+    }
+
+    /** Recover durable jobs and collect manifest-backed objects. */
+    async maintain(): Promise<void> {
+        const recoverable =
+            await this.externalSourceModel.listRecoverableAttempts(
+                this.lightdashConfig.externalSources.garbageCollectionBatchSize,
+            );
+        await Promise.allSettled(
+            recoverable.map((attempt) =>
+                this.schedulerClient.ingestExternalSource({
+                    organizationUuid: attempt.organization_uuid,
+                    projectUuid: attempt.project_uuid,
+                    userUuid: attempt.requested_by_user_uuid ?? 'system',
+                    sourceUuid: attempt.external_source_uuid,
+                    attemptUuid: attempt.external_source_ingest_attempt_uuid,
+                }),
+            ),
+        );
+
+        const now = Date.now();
+        const objects = await this.externalSourceModel.prepareGarbageCollection(
+            {
+                stagedBefore: new Date(
+                    now -
+                        this.lightdashConfig.externalSources
+                            .stagedUploadTtlHours *
+                            60 *
+                            60 *
+                            1000,
+                ),
+                uploadingBefore: new Date(
+                    now -
+                        Math.max(
+                            this.lightdashConfig.externalSources.ingestLeaseMs *
+                                2,
+                            2 * 60 * 60 * 1000,
+                        ),
+                ),
+                limit: this.lightdashConfig.externalSources
+                    .garbageCollectionBatchSize,
+            },
+        );
+        await Promise.all(
+            objects.map(async (object) => {
+                try {
+                    await this.storageClient.deleteFile(object.object_key);
+                    await this.externalSourceModel.markObjectDeleted(
+                        object.external_source_object_uuid,
+                    );
+                } catch (error) {
+                    await this.externalSourceModel.markObjectDeleteFailed(
+                        object.external_source_object_uuid,
+                        sanitizeDuckdbError(error).slice(
+                            0,
+                            ERROR_MESSAGE_MAX_LENGTH,
+                        ),
+                    );
+                }
+            }),
+        );
     }
 }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -204,6 +204,7 @@ type RawSummaryRow = {
     groups: Explore['groups'] | null;
     type: Explore['type'] | null;
     preAggregateSource: Explore['preAggregateSource'] | null;
+    externalSource: Explore['externalSource'] | null;
     errors: ExploreError['errors'] | null; // Fatal errors from ExploreError
     warnings: Explore['warnings'] | null; // Non-fatal warnings from partial compilation
     baseTable: Explore['baseTable'];
@@ -1554,6 +1555,7 @@ export class ProjectModel {
                     explore->'groups' as "groups",
                     explore->'type' as type,
                     explore->'preAggregateSource' as "preAggregateSource",
+                    explore->'externalSource' as "externalSource",
                     explore->'errors' as errors,
                     explore->'warnings' as warnings,
                     explore->'baseTable' as "baseTable",
@@ -1579,6 +1581,7 @@ export class ProjectModel {
             aiHint: row.aiHint ?? undefined,
             type: row.type ?? undefined,
             preAggregateSource: row.preAggregateSource ?? undefined,
+            externalSource: row.externalSource ?? undefined,
             baseTableRequiredAttributes:
                 row.baseTableRequiredAttributes ?? undefined,
             baseTableAnyAttributes: row.baseTableAnyAttributes ?? undefined,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -4320,35 +4320,8 @@ export class ProjectModel {
         });
     }
 
-    async createExternalSourceExplore(
+    async saveExternalSourceExplore(
         projectUuid: string,
-        explore: Explore,
-    ): Promise<void> {
-        await this.database.transaction(async (trx) => {
-            await ProjectModel.lockAndEnsureCachedExplores(trx, projectUuid);
-            const existing = await trx(CachedExploreTableName)
-                .select('name')
-                .where('project_uuid', projectUuid)
-                .andWhere('name', explore.name)
-                .first();
-            if (existing) {
-                throw new AlreadyExistsError(
-                    `Explore "${explore.name}" already exists`,
-                );
-            }
-            await trx(CachedExploreTableName).insert({
-                project_uuid: projectUuid,
-                name: explore.name,
-                table_names: Object.keys(explore.tables || {}),
-                explore,
-            });
-            await ProjectModel.rebuildCachedExplores(trx, projectUuid);
-        });
-    }
-
-    async updateExternalSourceExplore(
-        projectUuid: string,
-        exploreName: string,
         explore: Explore,
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
@@ -4356,37 +4329,54 @@ export class ProjectModel {
             const existing = await trx(CachedExploreTableName)
                 .select<{ explore: Explore | ExploreError }[]>('explore')
                 .where('project_uuid', projectUuid)
-                .andWhere('name', exploreName)
+                .andWhere('name', explore.name)
                 .first();
             if (
-                !existing ||
+                existing &&
                 existing.explore.type !== ExploreType.EXTERNAL_SOURCE
             ) {
-                throw new NotFoundError(
-                    `External source table "${exploreName}" does not exist`,
+                throw new AlreadyExistsError(
+                    `Explore "${explore.name}" already exists`,
                 );
             }
-            await trx(CachedExploreTableName)
-                .update({
+
+            const row = {
+                project_uuid: projectUuid,
+                name: explore.name,
+                table_names: Object.keys(explore.tables || {}),
+                explore,
+            };
+            if (existing) {
+                await trx(CachedExploreTableName)
+                    .where('project_uuid', projectUuid)
+                    .andWhere('name', explore.name)
+                    .update({
+                        table_names: row.table_names,
+                        explore: row.explore,
+                    });
+            } else {
+                await trx(CachedExploreTableName).insert({
+                    project_uuid: row.project_uuid,
+                    name: row.name,
                     table_names: Object.keys(explore.tables || {}),
                     explore,
-                })
-                .where('project_uuid', projectUuid)
-                .andWhere('name', exploreName);
+                });
+            }
             await ProjectModel.rebuildCachedExplores(trx, projectUuid);
         });
     }
 
-    async deleteExternalSourceExplore(
+    async deleteExternalSourceExplores(
         projectUuid: string,
-        name: string,
+        names: string[],
     ): Promise<void> {
+        if (names.length === 0) return;
         await this.database.transaction(async (trx) => {
             await ProjectModel.lockAndEnsureCachedExplores(trx, projectUuid);
             await trx(CachedExploreTableName)
                 .where('project_uuid', projectUuid)
                 .whereRaw("explore->>'type' = ?", [ExploreType.EXTERNAL_SOURCE])
-                .andWhere('name', name)
+                .whereIn('name', names)
                 .delete();
             await ProjectModel.rebuildCachedExplores(trx, projectUuid);
         });

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -320,6 +320,7 @@ const getTagsForTask: {
         'user.uuid': payload.userUuid,
         'project.uuid': payload.projectUuid,
     }),
+    [SCHEDULER_TASKS.MAINTAIN_EXTERNAL_SOURCES]: () => ({}),
 } as const;
 
 const getTagsFromPayload = <T extends SchedulerTaskName>(

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -30,6 +30,7 @@ import {
     Explore,
     ExploreCompiler,
     ExploreType,
+    ExternalSourceStatus,
     FeatureFlags,
     FieldType,
     ForbiddenError,
@@ -186,6 +187,7 @@ import {
     quoteDuckdbIdentifier,
 } from '../../utils/duckdb/duckdbSqlTables';
 import { getDuckdbRuntimeConfig } from '../../utils/duckdb/getDuckdbRuntimeConfig';
+import { sanitizeDuckdbError } from '../../utils/duckdb/sanitizeDuckdbError';
 import {
     processFieldsForExport,
     streamJsonlData,
@@ -396,7 +398,12 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     externalSourceTableResolver?: (
         projectUuid: string,
         tableUuid: string,
-    ) => Promise<DbExternalSourceTable | undefined>;
+    ) => Promise<
+        | (DbExternalSourceTable & {
+              external_source_status: ExternalSourceStatus;
+          })
+        | undefined
+    >;
 };
 
 type ResolvedWarehouseCredentials = CreateWarehouseCredentials & {
@@ -550,7 +557,18 @@ export class AsyncQueryService extends ProjectService {
     private async resolveExternalSourceReference(
         projectUuid: string,
         explore: Explore,
+        featureFlagContext: {
+            userUuid: string;
+            organizationUuid: string;
+        },
     ): Promise<{ cte: string; cacheKeySalt: string } | { error: string }> {
+        const { enabled } = await this.featureFlagModel.get({
+            user: featureFlagContext,
+            featureFlagId: FeatureFlags.ExternalSources,
+        });
+        if (!enabled) {
+            return { error: 'External sources are not enabled' };
+        }
         const ref = explore.externalSource;
         if (!ref) {
             return {
@@ -569,6 +587,11 @@ export class AsyncQueryService extends ProjectService {
         if (!table || !table.locator || !table.columns) {
             return {
                 error: 'The external source table has no ingested data yet. Refresh the source and try again',
+            };
+        }
+        if (table.external_source_status !== ExternalSourceStatus.READY) {
+            return {
+                error: 'The external source is not ready. Wait for its ingest to finish and try again',
             };
         }
         const cte = `${quoteDuckdbIdentifier(
@@ -633,7 +656,7 @@ export class AsyncQueryService extends ProjectService {
                 warehouseArgs.projectUuid,
                 {
                     status: QueryHistoryStatus.ERROR,
-                    error: getErrorMessage(e),
+                    error: sanitizeDuckdbError(e),
                     errored_at: new Date(),
                 },
                 account,
@@ -4359,6 +4382,10 @@ export class AsyncQueryService extends ProjectService {
                             ? await this.resolveExternalSourceReference(
                                   projectUuid,
                                   explore,
+                                  {
+                                      userUuid: account.user.id,
+                                      organizationUuid,
+                                  },
                               )
                             : undefined;
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -366,6 +366,7 @@ type AsyncQueryExecutionPlan =
     | {
           target: 'external_source';
           warehouseQuery: string;
+          objectScope: string;
           preAggregateResolved?: false;
           preAggregateResolveReason?: string;
       }
@@ -561,7 +562,10 @@ export class AsyncQueryService extends ProjectService {
             userUuid: string;
             organizationUuid: string;
         },
-    ): Promise<{ cte: string; cacheKeySalt: string } | { error: string }> {
+    ): Promise<
+        | { cte: string; cacheKeySalt: string; objectScope: string }
+        | { error: string }
+    > {
         const { enabled } = await this.featureFlagModel.get({
             user: featureFlagContext,
             featureFlagId: FeatureFlags.ExternalSources,
@@ -603,6 +607,7 @@ export class AsyncQueryService extends ProjectService {
         return {
             cte,
             cacheKeySalt: `esv:${ref.tableUuid}:${table.version}`,
+            objectScope: table.locator.uri,
         };
     }
 
@@ -614,7 +619,9 @@ export class AsyncQueryService extends ProjectService {
      */
     private static resolveExternalSourceExecutionPlan(
         query: string,
-        reference: { cte: string; cacheKeySalt: string } | { error: string },
+        reference:
+            | { cte: string; cacheKeySalt: string; objectScope: string }
+            | { error: string },
     ): AsyncQueryExecutionPlan {
         if ('error' in reference) {
             return { target: 'error', error: reference.error };
@@ -629,6 +636,7 @@ export class AsyncQueryService extends ProjectService {
             warehouseQuery: AsyncQueryService.wrapSqlWithReferenceCtes(query, [
                 reference.cte,
             ]),
+            objectScope: reference.objectScope,
         };
     }
 
@@ -640,10 +648,13 @@ export class AsyncQueryService extends ProjectService {
     private async runExternalSourceQuery(
         warehouseArgs: RunAsyncWarehouseQueryArgs,
         account: Account,
+        objectScope: string,
     ): Promise<void> {
         try {
             const warehouseClient =
-                this.preAggregateStrategy.createExecutionWarehouseClient();
+                this.preAggregateStrategy.createExecutionWarehouseClient(
+                    objectScope,
+                );
             await this.runAsyncWarehouseQuery({
                 ...warehouseArgs,
                 warehouseClientOverride: warehouseClient,
@@ -4865,6 +4876,7 @@ export class AsyncQueryService extends ProjectService {
                                     return this.runExternalSourceQuery(
                                         warehouseArgs,
                                         account,
+                                        executionPlan.objectScope,
                                     );
                                 case 'materialization':
                                 case 'warehouse':

--- a/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -70,7 +70,7 @@ export interface PreAggregateStrategy {
         resolveArgs: ResolveExecutionArgs;
     }): Promise<PreAggregateExecutionResolution>;
 
-    createExecutionWarehouseClient(): WarehouseClient;
+    createExecutionWarehouseClient(scope?: string): WarehouseClient;
 
     recordStats(params: {
         projectUuid: string;

--- a/packages/backend/src/utils/duckdb/sanitizeDuckdbError.test.ts
+++ b/packages/backend/src/utils/duckdb/sanitizeDuckdbError.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeDuckdbError } from './sanitizeDuckdbError';
+
+describe('sanitizeDuckdbError', () => {
+    it('redacts S3 locators while preserving useful context', () => {
+        expect(
+            sanitizeDuckdbError(
+                new Error(
+                    'Could not read s3://private-bucket/external-sources/project/source/v1.csv: file not found',
+                ),
+            ),
+        ).toBe('Could not read [external source data]: file not found');
+    });
+
+    it('preserves errors without a locator', () => {
+        expect(sanitizeDuckdbError(new Error('Invalid CSV header'))).toBe(
+            'Invalid CSV header',
+        );
+    });
+
+    it('redacts an HTTP storage URL containing the object key', () => {
+        expect(
+            sanitizeDuckdbError(
+                'HTTP 404 at https://storage.example.com/bucket/external-sources/project/source/v1.parquet: missing',
+            ),
+        ).toBe('HTTP 404 at [external source data]: missing');
+    });
+});

--- a/packages/backend/src/utils/duckdb/sanitizeDuckdbError.test.ts
+++ b/packages/backend/src/utils/duckdb/sanitizeDuckdbError.test.ts
@@ -25,4 +25,35 @@ describe('sanitizeDuckdbError', () => {
             ),
         ).toBe('HTTP 404 at [external source data]: missing');
     });
+
+    it('redacts every locator and never leaves a quoted object-key suffix', () => {
+        expect(
+            sanitizeDuckdbError(
+                'Failed [s3://bucket/private-a.parquet], then "s3://bucket/private-b.csv?token=secret"',
+            ),
+        ).toBe(
+            'Failed [[external source data]], then "[external source data]"',
+        );
+    });
+
+    it('redacts a presigned external-source URL including its credentials', () => {
+        expect(
+            sanitizeDuckdbError(
+                "GET 'https://storage.example.com/external-sources/project/file.parquet?X-Amz-Credential=secret&X-Amz-Signature=private' failed",
+            ),
+        ).toBe("GET '[external source data]' failed");
+    });
+
+    it('does not redact unrelated HTTP URLs', () => {
+        const message =
+            'Request to https://docs.example.com/external-data/help failed';
+        expect(sanitizeDuckdbError(message)).toBe(message);
+    });
+
+    it('handles long malformed input without an unbounded wildcard', () => {
+        const locator = `s3://bucket/${'a'.repeat(50_000)}`;
+        expect(sanitizeDuckdbError(`Failed ${locator}`)).toBe(
+            'Failed [external source data]',
+        );
+    });
 });

--- a/packages/backend/src/utils/duckdb/sanitizeDuckdbError.ts
+++ b/packages/backend/src/utils/duckdb/sanitizeDuckdbError.ts
@@ -1,0 +1,13 @@
+import { getErrorMessage } from '@lightdash/common';
+
+const STORAGE_URI_PATTERNS = [
+    /s3:\/\/.+?(?=:\s|[\s'"),;]|$)/gi,
+    /https?:\/\/\S*?\/external-sources\/.+?(?=:\s|[\s'"),;]|$)/gi,
+];
+
+export const sanitizeDuckdbError = (error: unknown): string =>
+    STORAGE_URI_PATTERNS.reduce(
+        (message, pattern) =>
+            message.replace(pattern, '[external source data]'),
+        getErrorMessage(error),
+    );

--- a/packages/backend/src/utils/duckdb/sanitizeDuckdbError.ts
+++ b/packages/backend/src/utils/duckdb/sanitizeDuckdbError.ts
@@ -1,13 +1,18 @@
 import { getErrorMessage } from '@lightdash/common';
 
 const STORAGE_URI_PATTERNS = [
-    /s3:\/\/.+?(?=:\s|[\s'"),;]|$)/gi,
-    /https?:\/\/\S*?\/external-sources\/.+?(?=:\s|[\s'"),;]|$)/gi,
+    /s3:\/\/[^\s'"`]+/giu,
+    /https?:\/\/[^\s'"`]*\/external-sources\/[^\s'"`]+/giu,
 ];
+const TRAILING_PUNCTUATION = /[\])}>,;:.!?]+$/u;
+
+const redactStorageUri = (uri: string): string => {
+    const punctuation = uri.match(TRAILING_PUNCTUATION)?.[0] ?? '';
+    return `[external source data]${punctuation}`;
+};
 
 export const sanitizeDuckdbError = (error: unknown): string =>
     STORAGE_URI_PATTERNS.reduce(
-        (message, pattern) =>
-            message.replace(pattern, '[external source data]'),
+        (message, pattern) => message.replace(pattern, redactStorageUri),
         getErrorMessage(error),
     );

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -630,8 +630,8 @@ export type PublishAnnouncementPayload = TraceTaskBase & {
 };
 
 export type IngestExternalSourceJobPayload = TraceTaskBase & {
+    attemptUuid: string;
     sourceUuid: string;
-    ingestVersion: number;
 };
 
 export type ManagedAgentHeartbeatTriggeredBy = 'cron' | 'manual' | 'on_enable';

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -631,6 +631,7 @@ export type PublishAnnouncementPayload = TraceTaskBase & {
 
 export type IngestExternalSourceJobPayload = TraceTaskBase & {
     sourceUuid: string;
+    ingestVersion: number;
 };
 
 export type ManagedAgentHeartbeatTriggeredBy = 'cron' | 'manual' | 'on_enable';

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -184,6 +184,7 @@ export const EE_SCHEDULER_TASKS = {
     PUBLISH_ANNOUNCEMENT: 'publishAnnouncement',
     SWEEP_DUE_ANNOUNCEMENTS: 'sweepDueAnnouncements',
     INGEST_EXTERNAL_SOURCE: 'ingestExternalSource',
+    MAINTAIN_EXTERNAL_SOURCES: 'maintainExternalSources',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -298,6 +299,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.PUBLISH_ANNOUNCEMENT]: PublishAnnouncementPayload;
     [SCHEDULER_TASKS.SWEEP_DUE_ANNOUNCEMENTS]: TraceTaskBase;
     [SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE]: IngestExternalSourceJobPayload;
+    [SCHEDULER_TASKS.MAINTAIN_EXTERNAL_SOURCES]: Record<string, never>;
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
     [SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
     [SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: AgentOnboardingPipelineJobPayload;
@@ -334,6 +336,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: AgentOnboardingPipelineJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_EDIT_DBT_PROJECT_PIPELINE]: AiAgentEditDbtProjectPipelineJobPayload;
     [EE_SCHEDULER_TASKS.INGEST_EXTERNAL_SOURCE]: IngestExternalSourceJobPayload;
+    [EE_SCHEDULER_TASKS.MAINTAIN_EXTERNAL_SOURCES]: Record<string, never>;
 }
 
 export type SchedulerTaskName =

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -139,7 +139,9 @@ const BasePanel = ({ onExploreClick, onExploreCreated }: Props) => {
             if (explore.type === ExploreType.PRE_AGGREGATE) {
                 preAggregateExplores.push(explore);
             } else if (explore.type === ExploreType.EXTERNAL_SOURCE) {
-                externalSourceExplores.push(explore);
+                if (externalSourcesFlag?.enabled === true) {
+                    externalSourceExplores.push(explore);
+                }
             } else if (exploreHasGroups(explore)) {
                 groupedExplores.push(explore);
             } else if (explore.type === ExploreType.VIRTUAL) {
@@ -169,7 +171,7 @@ const BasePanel = ({ onExploreClick, onExploreCreated }: Props) => {
             preAggregateExplores,
             externalSourceExplores,
         ];
-    }, [filteredExplores, tableGroupDetails]);
+    }, [externalSourcesFlag?.enabled, filteredExplores, tableGroupDetails]);
 
     const handleExploreClick = useCallback(
         (explore: SummaryExplore) => {
@@ -210,7 +212,7 @@ const BasePanel = ({ onExploreClick, onExploreCreated }: Props) => {
         return (
             <>
                 <ItemDetailProvider>
-                    <Stack h="100%" style={{ flexGrow: 1 }}>
+                    <Stack h="100%" flex={1}>
                         <Can
                             I="manage"
                             this={subject('Explore', {

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -73,7 +73,9 @@ const ProjectSettingsPage: FC<ProjectSettingsPageProps> = ({
     </SettingsPage>
 );
 
-const ProjectSettings: FC = () => {
+const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
+    externalSourcesEnabled,
+}) => {
     const { projectUuid } = useParams<{
         projectUuid: string;
     }>();
@@ -110,11 +112,8 @@ const ProjectSettings: FC = () => {
         ) ??
             false);
 
-    const { data: externalSourcesFlag } = useServerFeatureFlag(
-        FeatureFlags.ExternalSources,
-    );
     const canManageExternalSources =
-        (externalSourcesFlag?.enabled ?? false) &&
+        externalSourcesEnabled &&
         !!project &&
         (user.data?.ability.can(
             'manage',

--- a/packages/frontend/src/features/externalSources/components/AddDataModal.tsx
+++ b/packages/frontend/src/features/externalSources/components/AddDataModal.tsx
@@ -72,7 +72,7 @@ const SchemaPreviewStep: FC<SchemaPreviewStepProps> = ({
     });
 
     return (
-        <form onSubmit={handleSubmit}>
+        <form id="external-source-csv-schema-form" onSubmit={handleSubmit}>
             <Stack gap="md">
                 <TextInput
                     label="Table name"
@@ -120,13 +120,18 @@ const SchemaPreviewStep: FC<SchemaPreviewStepProps> = ({
                 </Stack>
                 <Group justify="space-between">
                     <Button
+                        type="button"
                         variant="default"
                         onClick={onBack}
                         disabled={commitMutation.isLoading}
                     >
                         Back
                     </Button>
-                    <Button type="submit" loading={commitMutation.isLoading}>
+                    <Button
+                        type="submit"
+                        form="external-source-csv-schema-form"
+                        loading={commitMutation.isLoading}
+                    >
                         Create table
                     </Button>
                 </Group>
@@ -175,7 +180,7 @@ const SheetsStep: FC<SheetsStepProps> = ({
     });
 
     return (
-        <form onSubmit={handleSubmit}>
+        <form id="external-source-sheets-form" onSubmit={handleSubmit}>
             <Stack gap="md">
                 <TextInput
                     label="Google Sheets URL"
@@ -203,6 +208,7 @@ const SheetsStep: FC<SheetsStepProps> = ({
                             <Text fz="sm">{errorMessage}</Text>
                             {needsGoogleAuth && (
                                 <Button
+                                    type="button"
                                     variant="default"
                                     size="compact-sm"
                                     loading={googleLogin.isLoading}
@@ -220,13 +226,18 @@ const SheetsStep: FC<SheetsStepProps> = ({
                 </Text>
                 <Group justify="space-between">
                     <Button
+                        type="button"
                         variant="default"
                         onClick={onBack}
                         disabled={createMutation.isLoading}
                     >
                         Back
                     </Button>
-                    <Button type="submit" loading={createMutation.isLoading}>
+                    <Button
+                        type="submit"
+                        form="external-source-sheets-form"
+                        loading={createMutation.isLoading}
+                    >
                         Connect sheet
                     </Button>
                 </Group>

--- a/packages/frontend/src/features/externalSources/components/AddDataModal.tsx
+++ b/packages/frontend/src/features/externalSources/components/AddDataModal.tsx
@@ -221,8 +221,9 @@ const SheetsStep: FC<SheetsStepProps> = ({
                     </Callout>
                 )}
                 <Text fz="xs" c="dimmed">
-                    Reads the sheet with your Google account. Refresh the table
-                    any time from its menu.
+                    Copies your Google authorization to this project source, so
+                    refreshes keep working if your user leaves. Reconnect from
+                    the source menu to transfer ownership.
                 </Text>
                 <Group justify="space-between">
                     <Button

--- a/packages/frontend/src/features/externalSources/components/ExternalSourceBadge.tsx
+++ b/packages/frontend/src/features/externalSources/components/ExternalSourceBadge.tsx
@@ -1,26 +1,9 @@
-import {
-    assertUnreachable,
-    ExternalSourceType,
-    type ExternalSourceRef,
-} from '@lightdash/common';
+import { type ExternalSourceRef } from '@lightdash/common';
 import { Badge } from '@mantine/core';
 import { IconFileSpreadsheet } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
-
-const getSourceTypeLabel = (sourceType: ExternalSourceType): string => {
-    switch (sourceType) {
-        case ExternalSourceType.CSV:
-            return 'CSV file';
-        case ExternalSourceType.GOOGLE_SHEETS:
-            return 'Google Sheet';
-        default:
-            return assertUnreachable(
-                sourceType,
-                'Unknown external source type',
-            );
-    }
-};
+import { getExternalSourceTypeLabel } from '../utils/sourceTypeLabel';
 
 export const ExternalSourceBadge: FC<{ sourceRef: ExternalSourceRef }> = ({
     sourceRef,
@@ -31,6 +14,6 @@ export const ExternalSourceBadge: FC<{ sourceRef: ExternalSourceRef }> = ({
         size="sm"
         leftSection={<MantineIcon icon={IconFileSpreadsheet} size="sm" />}
     >
-        {getSourceTypeLabel(sourceRef.sourceType)}
+        {getExternalSourceTypeLabel(sourceRef.sourceType)}
     </Badge>
 );

--- a/packages/frontend/src/features/externalSources/components/ExternalSourceExploreMenu.tsx
+++ b/packages/frontend/src/features/externalSources/components/ExternalSourceExploreMenu.tsx
@@ -11,6 +11,7 @@ import {
     IconGitMerge,
     IconInfoCircle,
     IconPencil,
+    IconPlugConnected,
     IconRefresh,
     IconTrash,
     IconUpload,
@@ -19,7 +20,10 @@ import { useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useApp from '../../../providers/App/useApp';
-import { useRefreshExternalSource } from '../hooks/useExternalSources';
+import {
+    useReconnectExternalSource,
+    useRefreshExternalSource,
+} from '../hooks/useExternalSources';
 import { DeleteExternalSourceModal } from './DeleteExternalSourceModal';
 import { RenameExternalSourceModal } from './RenameExternalSourceModal';
 import { ReplaceCsvFileModal } from './ReplaceCsvFileModal';
@@ -52,6 +56,7 @@ export const ExternalSourceExploreMenu: FC<Props> = ({
         ) === true;
 
     const refreshMutation = useRefreshExternalSource(projectUuid);
+    const reconnectMutation = useReconnectExternalSource(projectUuid);
     const [isRenameOpen, renameHandlers] = useDisclosure(false);
     const [isReplaceOpen, replaceHandlers] = useDisclosure(false);
     const [isDeleteOpen, deleteHandlers] = useDisclosure(false);
@@ -102,20 +107,38 @@ export const ExternalSourceExploreMenu: FC<Props> = ({
                             )}
                             {sourceRef.sourceType ===
                                 ExternalSourceType.GOOGLE_SHEETS && (
-                                <Menu.Item
-                                    leftSection={
-                                        <MantineIcon icon={IconRefresh} />
-                                    }
-                                    onClick={() =>
-                                        refreshMutation.mutate(
-                                            sourceRef.sourceUuid,
-                                        )
-                                    }
-                                >
-                                    <Text fz="xs" fw={500}>
-                                        Refresh from Google Sheets
-                                    </Text>
-                                </Menu.Item>
+                                <>
+                                    <Menu.Item
+                                        leftSection={
+                                            <MantineIcon icon={IconRefresh} />
+                                        }
+                                        onClick={() =>
+                                            refreshMutation.mutate(
+                                                sourceRef.sourceUuid,
+                                            )
+                                        }
+                                    >
+                                        <Text fz="xs" fw={500}>
+                                            Refresh from Google Sheets
+                                        </Text>
+                                    </Menu.Item>
+                                    <Menu.Item
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconPlugConnected}
+                                            />
+                                        }
+                                        onClick={() =>
+                                            reconnectMutation.mutate(
+                                                sourceRef.sourceUuid,
+                                            )
+                                        }
+                                    >
+                                        <Text fz="xs" fw={500}>
+                                            Reconnect Google account
+                                        </Text>
+                                    </Menu.Item>
+                                </>
                             )}
                             <Menu.Item
                                 leftSection={<MantineIcon icon={IconPencil} />}

--- a/packages/frontend/src/features/externalSources/components/ExternalSourcesSettingsPanel.tsx
+++ b/packages/frontend/src/features/externalSources/components/ExternalSourcesSettingsPanel.tsx
@@ -24,6 +24,7 @@ import {
     IconFileSpreadsheet,
     IconInfoCircle,
     IconPencil,
+    IconPlugConnected,
     IconPlus,
     IconRefresh,
     IconTrash,
@@ -35,6 +36,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
 import {
     useExternalSources,
+    useReconnectExternalSource,
     useRefreshExternalSource,
 } from '../hooks/useExternalSources';
 import { getExternalSourceTypeLabel } from '../utils/sourceTypeLabel';
@@ -88,6 +90,7 @@ export const ExternalSourcesSettingsPanel: FC<{ projectUuid: string }> = ({
     const navigate = useNavigate();
     const sourcesResult = useExternalSources(projectUuid);
     const refreshMutation = useRefreshExternalSource(projectUuid);
+    const reconnectMutation = useReconnectExternalSource(projectUuid);
     const [isAddOpen, addHandlers] = useDisclosure(false);
     const [renameTarget, setRenameTarget] = useState<ModalTarget>();
     const [replaceTarget, setReplaceTarget] = useState<ModalTarget>();
@@ -239,22 +242,40 @@ export const ExternalSourcesSettingsPanel: FC<{ projectUuid: string }> = ({
                                                         <Menu.Divider />
                                                         {source.type ===
                                                             ExternalSourceType.GOOGLE_SHEETS && (
-                                                            <Menu.Item
-                                                                leftSection={
-                                                                    <MantineIcon
-                                                                        icon={
-                                                                            IconRefresh
-                                                                        }
-                                                                    />
-                                                                }
-                                                                onClick={() =>
-                                                                    refreshMutation.mutate(
-                                                                        source.sourceUuid,
-                                                                    )
-                                                                }
-                                                            >
-                                                                Refresh
-                                                            </Menu.Item>
+                                                            <>
+                                                                <Menu.Item
+                                                                    leftSection={
+                                                                        <MantineIcon
+                                                                            icon={
+                                                                                IconRefresh
+                                                                            }
+                                                                        />
+                                                                    }
+                                                                    onClick={() =>
+                                                                        refreshMutation.mutate(
+                                                                            source.sourceUuid,
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    Refresh
+                                                                </Menu.Item>
+                                                                <Menu.Item
+                                                                    leftSection={
+                                                                        <MantineIcon
+                                                                            icon={
+                                                                                IconPlugConnected
+                                                                            }
+                                                                        />
+                                                                    }
+                                                                    onClick={() =>
+                                                                        reconnectMutation.mutate(
+                                                                            source.sourceUuid,
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    Reconnect
+                                                                </Menu.Item>
+                                                            </>
                                                         )}
                                                         {source.type ===
                                                             ExternalSourceType.CSV && (

--- a/packages/frontend/src/features/externalSources/components/ExternalSourcesSettingsPanel.tsx
+++ b/packages/frontend/src/features/externalSources/components/ExternalSourcesSettingsPanel.tsx
@@ -37,25 +37,12 @@ import {
     useExternalSources,
     useRefreshExternalSource,
 } from '../hooks/useExternalSources';
+import { getExternalSourceTypeLabel } from '../utils/sourceTypeLabel';
 import { AddDataModal } from './AddDataModal';
 import { DeleteExternalSourceModal } from './DeleteExternalSourceModal';
 import { RenameExternalSourceModal } from './RenameExternalSourceModal';
 import { ReplaceCsvFileModal } from './ReplaceCsvFileModal';
 import { SourceTablePreviewDrawer } from './SourceTablePreviewDrawer';
-
-const getSourceTypeLabel = (sourceType: ExternalSourceType): string => {
-    switch (sourceType) {
-        case ExternalSourceType.CSV:
-            return 'CSV file';
-        case ExternalSourceType.GOOGLE_SHEETS:
-            return 'Google Sheet';
-        default:
-            return assertUnreachable(
-                sourceType,
-                'Unknown external source type',
-            );
-    }
-};
 
 const StatusBadge: FC<{ source: ExternalSource }> = ({ source }) => {
     switch (source.status) {
@@ -177,7 +164,7 @@ export const ExternalSourcesSettingsPanel: FC<{ projectUuid: string }> = ({
                                         </Table.Td>
                                         <Table.Td>
                                             <Text fz="sm" c="dimmed">
-                                                {getSourceTypeLabel(
+                                                {getExternalSourceTypeLabel(
                                                     source.type,
                                                 )}
                                             </Text>

--- a/packages/frontend/src/features/externalSources/components/RenameExternalSourceModal.tsx
+++ b/packages/frontend/src/features/externalSources/components/RenameExternalSourceModal.tsx
@@ -48,7 +48,7 @@ export const RenameExternalSourceModal: FC<Props> = ({
             icon={IconPencil}
             size="md"
         >
-            <form onSubmit={handleSubmit}>
+            <form id="external-source-rename-form" onSubmit={handleSubmit}>
                 <Stack gap="md">
                     <TextInput
                         label="Name"
@@ -60,11 +60,16 @@ export const RenameExternalSourceModal: FC<Props> = ({
                         keep working.
                     </Text>
                     <Group justify="flex-end">
-                        <Button variant="default" onClick={onClose}>
+                        <Button
+                            type="button"
+                            variant="default"
+                            onClick={onClose}
+                        >
                             Cancel
                         </Button>
                         <Button
                             type="submit"
+                            form="external-source-rename-form"
                             loading={renameMutation.isLoading}
                         >
                             Rename

--- a/packages/frontend/src/features/externalSources/components/SourceTablePreviewDrawer.tsx
+++ b/packages/frontend/src/features/externalSources/components/SourceTablePreviewDrawer.tsx
@@ -1,10 +1,10 @@
 import { type ExternalSourceRef } from '@lightdash/common';
 import {
     Badge,
-    Box,
     Drawer,
     Group,
     Loader,
+    ScrollArea,
     Stack,
     Tabs,
     Text,
@@ -102,7 +102,7 @@ export const SourceTablePreviewDrawer: FC<Props> = ({
                                     Read only
                                 </Badge>
                             </Group>
-                            <Box style={{ overflowX: 'auto' }}>
+                            <ScrollArea type="auto">
                                 <LightTable
                                     containerRef={previewTableRef}
                                     w="100%"
@@ -159,7 +159,7 @@ export const SourceTablePreviewDrawer: FC<Props> = ({
                                         )}
                                     </LightTable.Body>
                                 </LightTable>
-                            </Box>
+                            </ScrollArea>
                         </Stack>
                     </Tabs.Panel>
                     <Tabs.Panel value="columns" pt="md">

--- a/packages/frontend/src/features/externalSources/hooks/useExternalSources.ts
+++ b/packages/frontend/src/features/externalSources/hooks/useExternalSources.ts
@@ -199,6 +199,42 @@ export const useRefreshExternalSource = (projectUuid: string | undefined) => {
     });
 };
 
+const reconnectExternalSourceApi = (args: {
+    projectUuid: string;
+    sourceUuid: string;
+}) =>
+    lightdashApi<ExternalSource>({
+        url: `${EXTERNAL_SOURCES_BASE(args.projectUuid)}/${args.sourceUuid}/reconnect`,
+        method: 'POST',
+        body: undefined,
+    });
+
+export const useReconnectExternalSource = (projectUuid: string | undefined) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<ExternalSource, ApiError, string>({
+        mutationFn: (sourceUuid) =>
+            reconnectExternalSourceApi({
+                projectUuid: projectUuid!,
+                sourceUuid,
+            }),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: ['external-sources', projectUuid],
+            });
+            showToastSuccess({
+                title: 'Google Sheet reconnected',
+                subtitle: 'The project now owns this connection.',
+            });
+        },
+        onError: ({ error }) =>
+            showToastApiError({
+                title: 'Could not reconnect the source',
+                apiError: error,
+            }),
+    });
+};
+
 const renameExternalSourceApi = async (args: {
     projectUuid: string;
     sourceUuid: string;

--- a/packages/frontend/src/features/externalSources/utils/sourceTypeLabel.ts
+++ b/packages/frontend/src/features/externalSources/utils/sourceTypeLabel.ts
@@ -1,0 +1,17 @@
+import { assertUnreachable, ExternalSourceType } from '@lightdash/common';
+
+export const getExternalSourceTypeLabel = (
+    sourceType: ExternalSourceType,
+): string => {
+    switch (sourceType) {
+        case ExternalSourceType.CSV:
+            return 'CSV file';
+        case ExternalSourceType.GOOGLE_SHEETS:
+            return 'Google Sheet';
+        default:
+            return assertUnreachable(
+                sourceType,
+                'Unknown external source type',
+            );
+    }
+};

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -153,6 +153,7 @@ const Settings: FC = () => {
         project,
         isScimTokenManagementEnabled,
         dataAppsFlag,
+        externalSourcesFlag,
         isDataAppsFlagLoading,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
@@ -477,7 +478,11 @@ const Settings: FC = () => {
                 path: '/projectManagement/:projectUuid/*',
                 element: (
                     <TrackPage name={PageName.PROJECT_SETTINGS}>
-                        <ProjectSettings />
+                        <ProjectSettings
+                            externalSourcesEnabled={
+                                externalSourcesFlag?.enabled ?? false
+                            }
+                        />
                     </TrackPage>
                 ),
             });
@@ -775,6 +780,7 @@ const Settings: FC = () => {
         health?.hasGitlab,
         health?.auth.google.enabled,
         dataAppsFlag?.enabled,
+        externalSourcesFlag?.enabled,
         isProLimitsEnabled,
         isOrganizationRoadmapEnabled,
         isSsoOrganizationSettingsEnabled,

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -887,6 +887,85 @@ describe('DuckdbWarehouseClient', () => {
         expect(secretSql).not.toContain("SECRET '");
     });
 
+    it('scopes S3 credentials to the trusted external-source object', async () => {
+        const runMock = vi.fn();
+        createInstanceMock.mockResolvedValue(
+            createMockConnection(
+                vi.fn(async () =>
+                    getMockStreamResult(
+                        [[{ val: 1 }]],
+                        [DUCKDB_TYPE_IDS.INTEGER],
+                    ),
+                ),
+                runMock,
+            ),
+        );
+        const scope =
+            's3://bucket/external-sources/project/source/table/v1.parquet';
+        const client = DuckdbWarehouseClient.createForPreAggregate({
+            type: 'duckdb_s3',
+            s3Config: {
+                endpoint: 's3.amazonaws.com',
+                forcePathStyle: false,
+                useSsl: true,
+                scope,
+            },
+        });
+
+        await client.runQuery('SELECT 1');
+
+        const secretSql = runMock.mock.calls
+            .map(([sql]) => sql as string)
+            .find((sql) =>
+                sql.includes('CREATE OR REPLACE SECRET __lightdash_s3'),
+            );
+        expect(secretSql).toContain(`SCOPE '${scope}'`);
+    });
+
+    it('caps isolated S3 queries per organization', async () => {
+        let resolveStream: (
+            result: ReturnType<typeof getMockStreamResult>,
+        ) => void = () => {};
+        const streamMock = vi.fn(
+            () =>
+                new Promise<ReturnType<typeof getMockStreamResult>>(
+                    (resolve) => {
+                        resolveStream = resolve;
+                    },
+                ),
+        );
+        createInstanceMock.mockImplementation(async () =>
+            createMockConnection(streamMock),
+        );
+        const createClient = () =>
+            DuckdbWarehouseClient.createForPreAggregate(
+                {
+                    type: 'duckdb_s3',
+                    s3Config: {
+                        endpoint: 's3.amazonaws.com',
+                        forcePathStyle: false,
+                        useSsl: true,
+                        scope: 's3://bucket/external-sources/object.parquet',
+                    },
+                },
+                {
+                    resourceLimits: { memoryLimit: '128MB', threads: 1 },
+                    organizationConcurrencyLimit: 1,
+                },
+            );
+        const tags = { organization_uuid: 'external-source-org' };
+
+        const first = createClient().runQuery('SELECT 1', tags);
+        await vi.waitFor(() => expect(streamMock).toHaveBeenCalledOnce());
+        await expect(createClient().runQuery('SELECT 2', tags)).rejects.toThrow(
+            'External source query capacity is full',
+        );
+        resolveStream(
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+        await first;
+    });
+
     it('should load bundled extensions without runtime installs', async () => {
         const accessMock = vi.spyOn(fs, 'access').mockResolvedValue();
         try {

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -104,6 +104,8 @@ export type DuckdbS3SessionConfig = {
     secretKey?: string;
     forcePathStyle: boolean;
     useSsl: boolean;
+    /** Limit this DuckDB secret to one trusted S3 URI or prefix. */
+    scope?: string;
 };
 
 export type DuckdbResourceLimits = {
@@ -152,6 +154,8 @@ export type DuckdbWarehouseClientOptions = {
     embeddedQueryTimeoutMs?: number;
     enableInstanceCache?: boolean;
     projectUuid?: string;
+    /** Process-local per-organization cap for isolated S3 query clients. */
+    organizationConcurrencyLimit?: number;
 };
 
 export const mapFieldTypeFromTypeId = (typeId: number): DimensionType => {
@@ -431,6 +435,11 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         ConcurrencyBudget
     >();
 
+    private static readonly organizationConcurrencyBudgets = new Map<
+        string,
+        ConcurrencyBudget
+    >();
+
     private static readonly sqlBuilder = new DuckdbSqlBuilder();
 
     private readonly databasePath: string;
@@ -460,6 +469,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
     private readonly enableInstanceCache: boolean;
 
     private readonly projectUuid?: string;
+
+    private readonly organizationConcurrencyLimit?: number;
 
     private allowsPreAggregateFileReads = false;
 
@@ -580,6 +591,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             options?.embeddedQueryTimeoutMs ?? EMBEDDED_QUERY_TIMEOUT_MS;
         this.enableInstanceCache = options?.enableInstanceCache ?? false;
         this.projectUuid = options?.projectUuid;
+        this.organizationConcurrencyLimit =
+            options?.organizationConcurrencyLimit;
     }
 
     private static hashDucklakeConfig(
@@ -665,6 +678,26 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             if (organizationBudget.isIdle()) {
                 DuckdbWarehouseClient.embeddedOrganizationConcurrencyBudgets.delete(
                     organizationUuid,
+                );
+            }
+        };
+    }
+
+    private static tryAcquireOrganizationConcurrency(
+        organizationUuid: string,
+        limit: number,
+    ): (() => void) | undefined {
+        const key = `${limit}:${organizationUuid}`;
+        const budget =
+            DuckdbWarehouseClient.organizationConcurrencyBudgets.get(key) ??
+            new ConcurrencyBudget(limit);
+        DuckdbWarehouseClient.organizationConcurrencyBudgets.set(key, budget);
+        if (!budget.tryAcquire()) return undefined;
+        return () => {
+            budget.release();
+            if (budget.isIdle()) {
+                DuckdbWarehouseClient.organizationConcurrencyBudgets.delete(
+                    key,
                 );
             }
         };
@@ -1209,6 +1242,9 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         const secretClause = s3Config.secretKey
             ? `SECRET '${escape(s3Config.secretKey)}',`
             : '';
+        const scopeClause = s3Config.scope
+            ? `SCOPE '${escape(s3Config.scope)}',`
+            : '';
 
         return `CREATE OR REPLACE SECRET __lightdash_s3 (
             TYPE s3,
@@ -1217,6 +1253,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             ${secretClause}
             ENDPOINT '${escape(s3Config.endpoint)}',
             ${regionClause}
+            ${scopeClause}
             URL_STYLE '${s3Config.forcePathStyle ? 'path' : 'vhost'}',
             USE_SSL ${s3Config.useSsl}
         );`;
@@ -1512,41 +1549,64 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             durationMs: number,
         ) => void,
     ): Promise<T> {
-        if (this.embeddedConfig) {
-            return this.withDirectSession(
-                callback,
-                organizationUuid,
-                onPhaseTiming,
+        const releaseOrganizationConcurrency =
+            !this.embeddedConfig &&
+            organizationUuid &&
+            this.organizationConcurrencyLimit
+                ? DuckdbWarehouseClient.tryAcquireOrganizationConcurrency(
+                      organizationUuid,
+                      this.organizationConcurrencyLimit,
+                  )
+                : undefined;
+        if (
+            !this.embeddedConfig &&
+            organizationUuid &&
+            this.organizationConcurrencyLimit &&
+            !releaseOrganizationConcurrency
+        ) {
+            throw new WarehouseQueryError(
+                'External source query capacity is full. Try again shortly.',
             );
         }
-
-        if (this.isMotherduck()) {
-            if (
-                this.enableInstanceCache &&
-                this.credentials.requireUserCredentials !== true
-            ) {
-                return this.withMotherduckCachedSession(
+        try {
+            if (this.embeddedConfig) {
+                return await this.withDirectSession(
                     callback,
-                    retryable,
+                    organizationUuid,
                     onPhaseTiming,
                 );
             }
-            return this.withDirectSession(
-                callback,
-                organizationUuid,
-                onPhaseTiming,
-            );
-        }
 
-        if (this.hasResourceLimits()) {
-            return this.withIsolatedSession(callback);
-        }
+            if (this.isMotherduck()) {
+                if (
+                    this.enableInstanceCache &&
+                    this.credentials.requireUserCredentials !== true
+                ) {
+                    return await this.withMotherduckCachedSession(
+                        callback,
+                        retryable,
+                        onPhaseTiming,
+                    );
+                }
+                return await this.withDirectSession(
+                    callback,
+                    organizationUuid,
+                    onPhaseTiming,
+                );
+            }
 
-        if (this.instanceCacheKey) {
-            return this.withSharedSession(callback);
-        }
+            if (this.hasResourceLimits()) {
+                return await this.withIsolatedSession(callback);
+            }
 
-        return this.withEphemeralQuerySession(callback);
+            if (this.instanceCacheKey) {
+                return await this.withSharedSession(callback);
+            }
+
+            return await this.withEphemeralQuerySession(callback);
+        } finally {
+            releaseOrganizationConcurrency?.();
+        }
     }
 
     private async withMotherduckCachedSession<T>(


### PR DESCRIPTION
Fixes a latent gap in the external-sources stack below: `SummaryExplore` gained an `externalSource` back-reference when the explore type landed (#27782), but `ProjectModel.getAllExploreSummaries` builds summaries from a hand-written SQL projection over the explore jsonb, so the field was never selected and every summary consumer received `undefined`. The type-level `Pick` promised the field without doing any runtime work, which is why nothing failed loudly.

## What this changes

Three lines in `getAllExploreSummaries`: select `explore->'externalSource'` in the projection, add it to `RawSummaryRow`, and map it through like `preAggregateSource`.

## Impact

- The sidebar's per-source-type icons (#27784) silently degraded to the generic external icon; invisible so far because every test source was a CSV, visible the moment a Google Sheet source exists.
- The query-source adapter above this PR (#27793) filters schema-scan visibility by the summaries' `externalSource` ref, so it hard-requires this fix, which is why it sits at this position in the stack.

## Regression analysis

- Purely additive projection: existing summary fields and their mapping are untouched, and explores without the key project SQL `NULL`, mapped to `undefined` exactly like `preAggregateSource`.
- Full backend suite green at this head (477 files); verified live that summaries now carry the ref and the sidebar and schema scan consume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6KsLFbzm9A1kViYX5pM3k
