### PR TITLE
fix: pin thread retention notice below the agent chat input

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -65,6 +65,19 @@
     }
 }
 
+.footerNotice {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: var(--mantine-spacing-xs);
+    padding: 0 var(--mantine-spacing-sm);
+}
+
+/* The notice component may render nothing (flag off, no retention window) —
+   collapse the wrapper so it leaves no stray gap below the input. */
+.footerNotice:empty {
+    display: none;
+}
+
 /* Minimal mode styles for existing threads */
 .minimalContainer {
     position: relative;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -12,7 +12,14 @@ import {
 } from '@tabler/icons-react';
 import Mention from '@tiptap/extension-mention';
 import { type AnyExtension, type Editor } from '@tiptap/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type ReactNode,
+} from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { ModelSelector } from '../../../../../components/common/ModelSelector/ModelSelector';
@@ -121,6 +128,8 @@ interface AgentChatInputProps {
     // Shrinks padding/min-heights for a more compact composer.
     dense?: boolean;
     showDeepResearchBelowComposer?: boolean;
+    // Rendered below the input, right-aligned like the disabled-reason banner.
+    footerNotice?: ReactNode;
 }
 
 const extractToolHints = (editor: Editor | null): string[] => {
@@ -167,6 +176,7 @@ export const AgentChatInput = ({
     revealControlsOnFocus = false,
     dense = false,
     showDeepResearchBelowComposer = false,
+    footerNotice,
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const [value, setValueState] = useState(defaultValue ?? '');
@@ -822,6 +832,10 @@ export const AgentChatInput = ({
                         {disabledReason}
                     </Text>
                 )}
+
+                {footerNotice && (
+                    <Box className={styles.footerNotice}>{footerNotice}</Box>
+                )}
             </Box>
         );
     }
@@ -912,6 +926,10 @@ export const AgentChatInput = ({
                         {disabledReason}
                     </Text>
                 </Paper>
+            )}
+
+            {footerNotice && (
+                <Box className={styles.footerNotice}>{footerNotice}</Box>
             )}
         </Box>
     );

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -407,14 +407,16 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                     {workstreams && workstreams.length > 0 && (
                         <ThreadWorkstreamsPanel workstreams={workstreams} />
                     )}
-                    <ThreadRetentionNotice
-                        agentThreadRetentionHours={
-                            agent.threadRetentionHours ?? null
-                        }
-                    />
                     <AgentChatInput
                         disabled={inputDisabled}
                         disabledReason={inputDisabledReason}
+                        footerNotice={
+                            <ThreadRetentionNotice
+                                agentThreadRetentionHours={
+                                    agent.threadRetentionHours ?? null
+                                }
+                            />
+                        }
                         loading={isBusy}
                         onSubmit={handleSubmit}
                         onStartDeepResearch={


### PR DESCRIPTION
On the agent thread page the retention notice was rendered as a loose sibling above the chat input, so it floated top-left with no relation to the composer. It now sits below the input, right-aligned inside the composer's container like the read-only banner.

Relates: ZAP-787