### PR TITLE
fix: restrict unverified user sessions

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -73,6 +73,7 @@ import {
 } from './logging/winston';
 import { sessionAccountMiddleware } from './middlewares/accountMiddleware';
 import { jwtAuthMiddleware } from './middlewares/jwtAuthMiddleware';
+import { createRestrictUnverifiedSessionMiddleware } from './middlewares/restrictUnverifiedSession/restrictUnverifiedSession';
 import { flush as flushFeatureFlagChecks } from './models/FeatureFlagModel/flagCheckAggregator';
 import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
 import PrometheusMetrics from './prometheus/PrometheusMetrics';
@@ -750,6 +751,11 @@ export default class App {
         // We'll also be able to add the user to Sentry for embedded users.
         expressApp.use(jwtAuthMiddleware);
         expressApp.use(sessionAccountMiddleware);
+        expressApp.use(
+            createRestrictUnverifiedSessionMiddleware({
+                hasEmailClient: Boolean(this.lightdashConfig.smtp),
+            }),
+        );
         // Must run after auth so req.user is populated. Stamps every downstream
         // log line with organization_uuid + organization_name via ExecutionContext.
         expressApp.use(requestExecutionContextMiddleware);

--- a/packages/backend/src/middlewares/restrictUnverifiedSession/restrictUnverifiedSession.integration.test.ts
+++ b/packages/backend/src/middlewares/restrictUnverifiedSession/restrictUnverifiedSession.integration.test.ts
@@ -1,0 +1,407 @@
+import { LightdashError } from '@lightdash/common';
+import express, { type ErrorRequestHandler } from 'express';
+import expressSession from 'express-session';
+import type { Server } from 'node:http';
+import passport from 'passport';
+import {
+    afterAll,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    test,
+} from 'vitest';
+import { RegisterRoutes } from '../../generated/routes';
+import { apiV1Router } from '../../routers/apiV1Router';
+import {
+    getTestContext,
+    type IntegrationTestContext,
+} from '../../vitest.setup.integration';
+import { sessionAccountMiddleware } from '../accountMiddleware';
+import { createRestrictUnverifiedSessionMiddleware } from './restrictUnverifiedSession';
+
+const listen = async (app: express.Express) =>
+    new Promise<{ origin: string; server: Server }>((resolve) => {
+        const server = app.listen(0, '127.0.0.1', () => {
+            const address = server.address();
+            if (!address || typeof address === 'string') {
+                throw new Error('Integration test server did not bind a port');
+            }
+            resolve({
+                origin: `http://127.0.0.1:${address.port}`,
+                server,
+            });
+        });
+    });
+
+const close = async (server: Server) =>
+    new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve();
+        });
+    });
+
+const startGuardServer = async ({
+    context,
+    userUuid,
+    hasEmailClient,
+}: {
+    context: IntegrationTestContext;
+    userUuid: string;
+    hasEmailClient: boolean;
+}) => {
+    const app = express();
+    app.use(express.json());
+    app.use(
+        expressSession({
+            secret: 'restricted-session-integration-test',
+            resave: false,
+            saveUninitialized: true,
+        }),
+    );
+    app.use(passport.initialize());
+    app.use(passport.session());
+    app.use((req, _res, next) => {
+        req.services = context.app.getServiceRepository();
+        const requestUserUuid = req.get('x-test-user-uuid') ?? userUuid;
+        context.app
+            .getModels()
+            .getUserModel()
+            .findSessionUserByUUID(requestUserUuid)
+            .then((sessionUser) => {
+                req.user = sessionUser;
+                next();
+            })
+            .catch(next);
+    });
+    app.use(sessionAccountMiddleware);
+    app.use(
+        createRestrictUnverifiedSessionMiddleware({
+            hasEmailClient,
+        }),
+    );
+    app.use('/api/v1', apiV1Router);
+    RegisterRoutes(app);
+    app.all('*', (_req, res) => res.status(204).end());
+    const errorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
+        const statusCode =
+            error instanceof LightdashError ? error.statusCode : 500;
+        res.status(statusCode).json({
+            name: error instanceof Error ? error.name : 'UnknownError',
+        });
+    };
+    app.use(errorHandler);
+    return listen(app);
+};
+
+type EndpointRequest = {
+    capability: string;
+    method: string;
+    path: string;
+    body?: unknown;
+    userUuid?: string;
+};
+
+const rejectedRequests: EndpointRequest[] = [
+    {
+        capability: 'password creation or change',
+        method: 'POST',
+        path: '/api/v1/user/password',
+        body: { password: '', newPassword: 'secure-password-1' },
+    },
+    {
+        capability: 'profile changes',
+        method: 'PATCH',
+        path: '/api/v1/user/me',
+        body: { firstName: 'Changed' },
+    },
+    {
+        capability: 'email changes',
+        method: 'PATCH',
+        path: '/api/v1/user/me',
+        body: { email: 'changed@example.com' },
+    },
+    {
+        capability: 'profile completion',
+        method: 'PATCH',
+        path: '/api/v1/user/me/complete',
+        body: { firstName: 'Changed', lastName: 'User' },
+    },
+    {
+        capability: 'avatar upload',
+        method: 'PUT',
+        path: '/api/v1/user/me/avatar',
+        body: { image: 'data' },
+    },
+    {
+        capability: 'avatar removal',
+        method: 'DELETE',
+        path: '/api/v1/user/me/avatar',
+    },
+    {
+        capability: 'organization creation',
+        method: 'PUT',
+        path: '/api/v1/org',
+        body: { name: 'Restricted organization' },
+    },
+    {
+        capability: 'organization join',
+        method: 'POST',
+        path: '/api/v1/user/me/joinOrganization/org-uuid',
+    },
+    {
+        capability: 'organization leave',
+        method: 'DELETE',
+        path: '/api/v1/user/me/leaveOrganization',
+    },
+    {
+        capability: 'personal access token creation',
+        method: 'POST',
+        path: '/api/v1/user/me/personal-access-tokens',
+        body: { description: 'restricted token' },
+    },
+    {
+        capability: 'Google identity linking',
+        method: 'GET',
+        path: '/api/v1/login/google',
+    },
+    {
+        capability: 'Google Drive identity linking',
+        method: 'GET',
+        path: '/api/v1/login/gdrive',
+    },
+    {
+        capability: 'BigQuery identity linking',
+        method: 'GET',
+        path: '/api/v1/login/bigquery',
+    },
+    {
+        capability: 'Slack identity linking',
+        method: 'GET',
+        path: '/api/v1/auth/slack',
+    },
+    {
+        capability: 'identity removal',
+        method: 'DELETE',
+        path: '/api/v1/user/identity',
+        body: { issuer: 'google' },
+    },
+];
+
+const allowedRequests: EndpointRequest[] = [
+    {
+        capability: 'health bootstrap',
+        method: 'GET',
+        path: '/api/v1/health?skipMigrationCheck=true',
+    },
+    {
+        capability: 'account bootstrap',
+        method: 'GET',
+        path: '/api/v1/user/account',
+    },
+    {
+        capability: 'current user bootstrap',
+        method: 'GET',
+        path: '/api/v1/user',
+    },
+    {
+        capability: 'verification layout feature flag bootstrap',
+        method: 'GET',
+        path: '/api/v2/feature-flag/new-onboarding',
+    },
+    {
+        capability: 'one-time passcode resend',
+        method: 'PUT',
+        path: '/api/v1/user/me/email/otp',
+    },
+    {
+        capability: 'email verification status',
+        method: 'GET',
+        path: '/api/v1/user/me/email/status',
+    },
+    {
+        capability: 'email verification',
+        method: 'GET',
+        path: '/api/v1/user/me/email/status?passcode=000000',
+    },
+    {
+        capability: 'logout',
+        method: 'GET',
+        path: '/api/v1/logout',
+    },
+    {
+        capability: 'account cancellation',
+        method: 'DELETE',
+        path: '/api/v1/user/me',
+    },
+];
+
+const sendRequest = (origin: string, request: EndpointRequest) =>
+    fetch(`${origin}${request.path}`, {
+        method: request.method,
+        headers: {
+            ...(request.userUuid === undefined
+                ? {}
+                : { 'x-test-user-uuid': request.userUuid }),
+            ...(request.body === undefined
+                ? {}
+                : { 'content-type': 'application/json' }),
+        },
+        ...(request.body === undefined
+            ? {}
+            : {
+                  body: JSON.stringify(request.body),
+              }),
+    });
+
+describe('restricted unverified sessions', () => {
+    let context: IntegrationTestContext;
+    let origin: string;
+    let server: Server;
+    let userUuid: string;
+    let cancellationUserUuid: string;
+    let email: string;
+    let cancellationEmail: string;
+
+    beforeAll(async () => {
+        context = getTestContext();
+        email = `restricted-session-${Date.now()}@example.com`;
+        const user = await context.app.getModels().getUserModel().createUser(
+            {
+                firstName: 'Restricted',
+                lastName: 'Session',
+                email,
+            },
+            true,
+            false,
+        );
+        userUuid = user.userUuid;
+        cancellationEmail = `restricted-cancellation-${Date.now()}@example.com`;
+        const cancellationUser = await context.app
+            .getModels()
+            .getUserModel()
+            .createUser(
+                {
+                    firstName: 'Restricted',
+                    lastName: 'Cancellation',
+                    email: cancellationEmail,
+                },
+                true,
+                false,
+            );
+        cancellationUserUuid = cancellationUser.userUuid;
+
+        ({ origin, server } = await startGuardServer({
+            context,
+            userUuid,
+            hasEmailClient: true,
+        }));
+    });
+
+    beforeEach(async () => {
+        await context
+            .db('emails')
+            .whereIn('email', [email, cancellationEmail])
+            .update({
+                is_verified: false,
+            });
+    });
+
+    afterAll(async () => {
+        await close(server);
+        await context
+            .db('users')
+            .whereIn('user_uuid', [userUuid, cancellationUserUuid])
+            .delete();
+    });
+
+    test.each(rejectedRequests)(
+        'rejects $capability at $method $path',
+        async (request) => {
+            const response = await sendRequest(origin, request);
+
+            expect(response.status).toBe(403);
+            await expect(response.json()).resolves.toEqual({
+                name: 'ForbiddenError',
+            });
+        },
+    );
+
+    test.each(allowedRequests)(
+        'allows $capability at $method $path',
+        async (request) => {
+            const response = await sendRequest(origin, {
+                ...request,
+                ...(request.capability === 'account cancellation'
+                    ? { userUuid: cancellationUserUuid }
+                    : {}),
+            });
+
+            expect(response.status).toBe(200);
+        },
+    );
+
+    test('rejects endpoints that are not explicitly allowed', async () => {
+        const response = await sendRequest(origin, {
+            capability: 'new endpoint',
+            method: 'POST',
+            path: '/api/v1/future-sensitive-endpoint',
+        });
+
+        expect(response.status).toBe(403);
+    });
+
+    test('allows the frontend verification route to load', async () => {
+        const response = await sendRequest(origin, {
+            capability: 'frontend verification route',
+            method: 'GET',
+            path: '/verify-email',
+        });
+
+        expect(response.status).toBe(204);
+    });
+
+    test('allows a verified session to use protected endpoints', async () => {
+        await context.db('emails').where({ email }).update({
+            is_verified: true,
+        });
+        await expect(
+            context.app
+                .getModels()
+                .getEmailModel()
+                .getPrimaryEmailStatus(userUuid),
+        ).resolves.toMatchObject({ isVerified: true });
+
+        const response = await sendRequest(origin, {
+            capability: 'protected endpoint',
+            method: 'POST',
+            path: '/api/v1/future-sensitive-endpoint',
+        });
+
+        expect(response.status).toBe(204);
+    });
+
+    test('allows an unverified session when no email client is configured', async () => {
+        const smtpDisabledServer = await startGuardServer({
+            context,
+            userUuid,
+            hasEmailClient: false,
+        });
+
+        try {
+            const response = await sendRequest(smtpDisabledServer.origin, {
+                capability: 'protected endpoint',
+                method: 'POST',
+                path: '/api/v1/future-sensitive-endpoint',
+            });
+
+            expect(response.status).toBe(204);
+        } finally {
+            await close(smtpDisabledServer.server);
+        }
+    });
+});

--- a/packages/backend/src/middlewares/restrictUnverifiedSession/restrictUnverifiedSession.ts
+++ b/packages/backend/src/middlewares/restrictUnverifiedSession/restrictUnverifiedSession.ts
@@ -1,0 +1,56 @@
+import {
+    ForbiddenError,
+    type Account,
+    type SessionAccount,
+} from '@lightdash/common';
+import type { RequestHandler } from 'express';
+
+type RestrictUnverifiedSessionOptions = {
+    hasEmailClient: boolean;
+};
+
+const allowedRequests = [
+    { method: 'GET', path: '/api/v1/health' },
+    { method: 'GET', path: '/api/v1/user' },
+    { method: 'GET', path: '/api/v1/user/account' },
+    { method: 'PUT', path: '/api/v1/user/me/email/otp' },
+    { method: 'GET', path: '/api/v1/user/me/email/status' },
+    { method: 'GET', path: '/api/v1/logout' },
+    { method: 'DELETE', path: '/api/v1/user/me' },
+    { method: 'GET', path: '/api/v2/feature-flag/new-onboarding' },
+] as const;
+
+const normalizePath = (path: string) =>
+    path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+
+const isAllowedRequest = (method: string, path: string) =>
+    allowedRequests.some(
+        (allowedRequest) =>
+            allowedRequest.method === method &&
+            allowedRequest.path === normalizePath(path),
+    );
+
+const isSessionAccount = (
+    account: Account | undefined,
+): account is SessionAccount => account?.authentication.type === 'session';
+
+export const createRestrictUnverifiedSessionMiddleware =
+    ({ hasEmailClient }: RestrictUnverifiedSessionOptions): RequestHandler =>
+    (req, _res, next) => {
+        const { account } = req;
+        const path = normalizePath(req.path);
+        if (
+            !hasEmailClient ||
+            !isSessionAccount(account) ||
+            !path.startsWith('/api/') ||
+            isAllowedRequest(req.method, path)
+        ) {
+            next();
+            return;
+        }
+        if (account.user.isEmailVerified === true) {
+            next();
+            return;
+        }
+        next(new ForbiddenError('User has not verified their email'));
+    };

--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -730,6 +730,7 @@ describe('UserModel', () => {
                 userUuid,
                 organizationUuid,
                 isSetupComplete: true,
+                isEmailVerified: true,
             } as SessionUser;
             const findSessionUser = vi
                 .spyOn(model, 'findSessionUserAndOrgByUuid')
@@ -757,6 +758,7 @@ describe('UserModel', () => {
                 userUuid,
                 organizationUuid,
                 isSetupComplete: false,
+                isEmailVerified: true,
             } as SessionUser;
             const sessionUser = {
                 ...incompleteUser,
@@ -791,6 +793,32 @@ describe('UserModel', () => {
                 userUuid,
                 organizationUuid,
                 isSetupComplete: false,
+                isEmailVerified: true,
+            } as SessionUser;
+            const findSessionUser = vi
+                .spyOn(model, 'findSessionUserAndOrgByUuid')
+                .mockResolvedValue(sessionUser);
+
+            await model.getSessionUserFromCacheOrDB(userUuid, organizationUuid);
+            await model.getSessionUserFromCacheOrDB(userUuid, organizationUuid);
+
+            expect(findSessionUser).toHaveBeenCalledTimes(2);
+            expect(sessionUserCache.set).not.toHaveBeenCalled();
+        });
+
+        it('does not cache an unverified user', async () => {
+            const { CachedUserModel, sessionUserCache } =
+                await loadUserModelWithSessionUserCache();
+            const model = new CachedUserModel({
+                database: vi.fn() as unknown as Knex,
+                lightdashConfig,
+                featureFlagModel,
+            });
+            const sessionUser = {
+                userUuid,
+                organizationUuid,
+                isSetupComplete: true,
+                isEmailVerified: false,
             } as SessionUser;
             const findSessionUser = vi
                 .spyOn(model, 'findSessionUserAndOrgByUuid')

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -100,6 +100,7 @@ export type DbUserDetails = {
     is_tracking_anonymized: boolean;
     is_marketing_opted_in: boolean;
     email: string | undefined;
+    is_verified?: boolean;
     organization_uuid?: string;
     organization_name?: string;
     organization_created_at?: Date;
@@ -230,7 +231,7 @@ export class UserModel {
         const cacheKey = `${userUuid}::${organizationUuid}`;
         // Try to get from cache first
         const cachedUser = sessionUserCache?.get<SessionUser>(cacheKey);
-        if (cachedUser?.isSetupComplete) {
+        if (cachedUser?.isSetupComplete && cachedUser.isEmailVerified) {
             // Return cached user
             return { sessionUser: cachedUser, cacheHit: true };
         }
@@ -240,7 +241,7 @@ export class UserModel {
             organizationUuid,
         );
         // Store in cache
-        if (sessionUser.isSetupComplete) {
+        if (sessionUser.isSetupComplete && sessionUser.isEmailVerified) {
             sessionUserCache?.set(cacheKey, sessionUser);
         }
         return { sessionUser, cacheHit: false };
@@ -1290,6 +1291,7 @@ export class UserModel {
             abilityRules: abilityBuilder.rules,
             ability: abilityBuilder.build(),
             ...lightdashUser,
+            isEmailVerified: user.is_verified === true,
         };
     }
 
@@ -1466,6 +1468,7 @@ export class UserModel {
             userId: user.user_id,
             abilityRules: abilityBuilder.rules,
             ability: abilityBuilder.build(),
+            isEmailVerified: user.is_verified === true,
         };
     }
 
@@ -1492,6 +1495,7 @@ export class UserModel {
             userId: user.user_id,
             abilityRules: abilityBuilder.rules,
             ability: abilityBuilder.build(),
+            isEmailVerified: user.is_verified === true,
         };
     }
 
@@ -1514,6 +1518,7 @@ export class UserModel {
             abilityRules: abilityBuilder.rules,
             ability: abilityBuilder.build(),
             userId: user.user_id,
+            isEmailVerified: user.is_verified === true,
         };
     }
 
@@ -1632,6 +1637,7 @@ export class UserModel {
                 abilityRules: abilityBuilder.rules,
                 ability: abilityBuilder.build(),
                 userId: row.user_id,
+                isEmailVerified: row.is_verified === true,
             },
             personalAccessToken:
                 PersonalAccessTokenModel.mapDbObjectToPersonalAccessToken(row),

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -107,6 +107,7 @@ export interface LightdashUser {
 
 export interface LightdashSessionUser extends AccountUser {
     type: 'registered';
+    isEmailVerified?: boolean;
     // The current effective primary key for users. It duplicates user.id.
     userUuid: string;
     // The old sequential primary key for users
@@ -148,6 +149,7 @@ export interface LightdashUserWithAbilityRules extends LightdashUser {
 
 export interface SessionUser extends LightdashUserWithAbilityRules {
     ability: MemberAbility;
+    isEmailVerified?: boolean;
     /**
      * Per-request metadata (IP, user agent, request id) populated by the auth
      * middleware. Used by the audit log; intentionally not persisted in the


### PR DESCRIPTION
## Summary

- Restrict unverified browser sessions until the primary email is verified.
- Refuse password, profile, email, organisation membership, access token, and identity changes.
- Keep passcode status, verification, resend, logout, and account cancellation available.
- Allow only the read-only bootstrap requests needed to reload the verification page.
- Apply the restriction only when SMTP is configured.
- Keep unverified session users out of the session-user cache so verification takes effect on the next request.

## Test evidence

- Focused integration suite: 28 passed against the real v1 and TSOA route stacks. It covers 15 refused operations, the five required allowed operations, four verification-page bootstrap requests, default-deny behaviour, the real frontend verification route, verified sessions, and deployments without SMTP.
- The allowed endpoint cases execute their real handlers, including SMTP resend, passcode status and verification, logout, and account deletion on a disposable user.
- Mutation check: changed the guard temporarily so it protected only the password endpoint. Fifteen tests failed, including every other refused capability and the default-deny case. Restoring the complete guard returned the suite to green.
- Backend suite: 474 files passed, 7,578 tests passed, one skipped.
- Common suite: 139 files passed, 3,655 tests passed, one skipped.
- Backend and common typechecks passed.
- Touched-path backend and common lint passed.

Linear: PROD-8906