### PR TITLE
enforce: conventional commits locally via husky commit-msg hook

### DIFF
--- a/.claude/skills/creating-pull-requests/SKILL.md
+++ b/.claude/skills/creating-pull-requests/SKILL.md
@@ -12,6 +12,7 @@ Conventions for every PR body in this repo. Applies regardless of whether the PR
 
 ## Rules
 
+0. **PR titles must be conventional commits** — `<type>[optional scope]: <description>`, with a type from build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test (e.g. `fix(dashboards): remove infinite loop during login`). The `Validate PR Title` check blocks merging otherwise, and the title becomes the squash-merge commit that drives semantic-release — use `feat`/`fix` only for user-facing value.
 1. **Never mention client/customer names or their data examples** anywhere in the PR title, description, or commit messages. Redact to generic terms ("a customer", "an org", "example values") even when a Linear ticket or issue references the customer by name.
 2. **Never quote, summarize, or attribute Slack messages or other internal-communication content** anywhere in the PR title, description, or commit messages — even when Slack/internal chatter was used as an investigation or evidence source. Cite only that the signal was checked and what it showed, in generic terms (no channel names, no quoted text, no who-said-what).
 3. **Always close or reference a Linear ticket.** Every PR links to a Linear ticket — `Closes: PROD-XXXX` to close it, or `Relates: PROD-XXXX` if it shouldn't auto-close. **If no ticket is provided, do not fabricate one and do not silently omit it** — flag it to the developer and ask for the ticket. Only open the PR without a ticket once they explicitly confirm there isn't one.
@@ -36,6 +37,7 @@ Relates: #22801
 
 ## Checklist Before Opening
 
+- [ ] The PR title is a valid conventional commit (`type(scope): description`)
 - [ ] No client/customer name or their data anywhere in the title, body, or commits
 - [ ] No quoted/summarized Slack or internal-communication content anywhere in the title, body, or commits
 - [ ] A `Closes:`/`Relates:` line for a Linear ticket is present, OR the developer explicitly confirmed there's no ticket

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -164,6 +164,11 @@ other part of the system, please use the appropriate tag to avoid the extra over
 You can see all
 the [supported types here](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json).
 
+This format is enforced in two places:
+
+-   Locally, the `commit-msg` hook (`.husky/commit-msg`) rejects non-conventional commit messages at commit time.
+-   On GitHub, the `Validate PR Title` check validates the PR title (and, for single-commit PRs, the commit message) as soon as the PR is opened or the title is edited. The PR title matters because we squash & merge: it becomes the commit on `main` that semantic-release reads.
+
 #### Merge Strategy
 
 We use `squash & merge` to keep the main branch history clean.

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Enforce conventional commit messages locally, mirroring the "Validate PR
+# Title" CI check (.github/workflows/validate-pr-title.yml). Catching this at
+# commit time avoids PRs that are green except for the semantic title check:
+# GitHub pre-fills the PR title from the commit message, and single-commit PRs
+# have their commit message validated directly (validateSingleCommit: true).
+
+MSG_FILE="$1"
+HEADER="$(head -n 1 "$MSG_FILE")"
+
+# Skip messages git generates or that never reach main (we squash & merge)
+case "$HEADER" in
+  "Merge "*|"Revert \""*|"fixup! "*|"squash! "*|"amend! "*) exit 0 ;;
+esac
+
+# Same types as the CI check (conventional-commit-types defaults)
+TYPES="build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test"
+
+if printf '%s' "$HEADER" | grep -Eq "^($TYPES)(\([^)]*\))?!?: .+$"; then
+  exit 0
+fi
+
+echo "\033[1;31mInvalid commit message:\033[0m $HEADER"
+echo ""
+echo "Commit messages must follow the conventional commit format:"
+echo ""
+echo "    <type>[optional scope][!]: <description>"
+echo ""
+echo "    e.g. feat: add table calculations"
+echo "         fix(dashboards): remove infinite loop during login"
+echo ""
+echo "Valid types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test"
+echo ""
+echo "This mirrors the 'Validate PR Title' check on PRs. See"
+echo ".github/CONTRIBUTING.md (Commit & Pull Request Naming Conventions)."
+exit 1


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR adds a local `commit-msg` hook (via Husky) that enforces conventional commit format at commit time, mirroring the existing "Validate PR Title" CI check. This catches formatting issues early and prevents PRs that are green except for the semantic title validation.

**Changes:**

- **`.husky/commit-msg`** (new): Git hook that validates commit messages against the conventional commit format (`<type>[optional scope][!]: <description>`). Supports all standard types (build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test) and skips validation for auto-generated messages (merge, revert, fixup, squash, amend).

- **`.github/CONTRIBUTING.md`**: Added documentation explaining that conventional commit format is enforced in two places:
  - Locally via the `commit-msg` hook at commit time
  - On GitHub via the `Validate PR Title` check (which matters because we squash & merge)

- **`.claude/skills/creating-pull-requests/SKILL.md`**: Updated PR creation guidelines to include conventional commit format as rule #0, with examples and a checklist item to verify PR titles before opening.

### Risk assessment:

- [ ] This is a high-risk change

This is a low-risk change. It adds a local validation hook that provides developer feedback without blocking any workflows — developers can still commit with `--no-verify` if needed, and the CI check remains the authoritative gate for merging.

https://claude.ai/code/session_01CpVq57gZKuJ5GiSK8s2eDo