### PR TITLE
fix(ci): partial-clone filter for release-safety full-history checkouts

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -217,10 +217,14 @@ jobs:
               core.warning(`Could not verify the describes-stamp: ${error.message}`);
             }
 
+      # blob:none keeps the full commit graph for merge-base while skipping file
+      # contents — the unfiltered fetch (~480MiB, all heads+tags) sometimes stalls
+      # past the job's 10-minute timeout.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.watched.outputs.watched == 'true'
         with:
           fetch-depth: 0
+          filter: blob:none
 
       # Resolved once, here, and reused by every job: the spec pair, the migration
       # diff and the comment's base label all have to describe the same comparison.
@@ -422,9 +426,12 @@ jobs:
         with:
           egress-policy: audit
 
+      # blob:none: the gates only diff against base_sha, so missing blobs are
+      # lazy-fetched on demand instead of downloading every ref's full contents.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          filter: blob:none
 
       # SPK-1021: pnpm is set up BEFORE setup-node so that `cache: 'pnpm'` can
       # resolve the store path — setup-node shells out to pnpm to find it, and


### PR DESCRIPTION
## Problem

The `Resolve base and changed surfaces` job in the release-safety preview workflow sometimes runs for its full 10-minute budget and dies as `cancelled` (job `timeout-minutes: 10`). Example: [this run on #27782](https://github.com/lightdash/lightdash/actions/runs/32403906476/job/96538337740) — the entire 10 minutes was a single `git fetch` inside `actions/checkout` that never produced a byte of progress.

The root cause is `fetch-depth: 0`, which makes actions/checkout fetch **all branches and all tags with full history**: for this repo that's ~480 MiB of pack data across ~1,900 branches and ~7,500 tags. On healthy runs the fetch takes ~50s; when GitHub's server-side pack generation is slow (e.g. a stack submit firing ~10 of these runs simultaneously, each requesting a full clone), it stalls past the timeout.

## Fix

Add `filter: blob:none` to the two `fetch-depth: 0` checkouts. The full commit graph is kept — which is all these jobs actually need from history:

- **changes job**: only runs `git merge-base` (commit graph); `dorny/paths-filter` uses the GitHub API for PRs.
- **preview job**: the declaration/SQL gates diff against `base_sha`; under `blob:none` any blobs those diffs touch are lazy-fetched on demand in a single batched request, instead of downloading every ref's full contents upfront.

The working-tree materialisation at checkout still happens (one batched blob fetch for HEAD's tree), so nothing downstream changes behaviour — the fetch just stops paying for ~480 MiB of blobs it never reads.

## Regression analysis

- `git merge-base` and `git rev-parse` operate on commit objects only — unaffected by a blob filter.
- `git diff`/`git log -p` against `base_sha` in the gate scripts trigger transparent lazy blob fetches (checkout leaves the authenticated origin remote configured, `persist-credentials` default). Worst case is a small extra fetch per diff, scoped to the files actually diffed.
- If a lazy fetch ever failed (network), the gate scripts would fail loudly with a git error — same failure mode as the fetch failing today, not a silent wrong verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkRjA3NuezkNrWkgTa9YSn