### PR TITLE
fix(ci): fetch blobless in the release-safety preview checkouts

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -217,10 +217,19 @@ jobs:
               core.warning(`Could not verify the describes-stamp: ${error.message}`);
             }
 
+      # SPK-1218: blobless, like the release job's checkout (SPK-997). `fetch-depth: 0`
+      # makes actions/checkout fetch every branch and every tag with full history —
+      # 1,900 branches and 7,500 tags here, 571 MiB — and `fetch-tags: false` does not
+      # stop it, because checkout hardcodes `+refs/tags/*:refs/tags/*` into the refspec
+      # whenever the depth is 0. When a stack submit starts ~10 of these runs at once,
+      # server-side pack generation stalls and the fetch sends nothing until the job's
+      # 10-minute timeout kills it. Filtered, the same fetch moves 95 MiB. Only the
+      # commit graph is needed here: `git merge-base` reads no file contents.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.watched.outputs.watched == 'true'
         with:
           fetch-depth: 0
+          filter: blob:none
 
       # Resolved once, here, and reused by every job: the spec pair, the migration
       # diff and the comment's base label all have to describe the same comparison.
@@ -422,9 +431,13 @@ jobs:
         with:
           egress-policy: audit
 
+      # SPK-1218: blobless, for the reason spelled out on the `changes` checkout.
+      # The gates only diff against `base_sha`, so the blobs they touch are lazily
+      # fetched on demand instead of every ref's full contents arriving up front.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          filter: blob:none
 
       # SPK-1021: pnpm is set up BEFORE setup-node so that `cache: 'pnpm'` can
       # resolve the store path — setup-node shells out to pnpm to find it, and


### PR DESCRIPTION
## Problem

The `Resolve base and changed surfaces` job sometimes runs its full 10-minute budget and dies as `cancelled`. Two engineers hit it today. The whole 10 minutes is a single `git fetch` inside `actions/checkout` that never produces a byte of progress ([example run](https://github.com/lightdash/lightdash/actions/runs/32403906476/job/96538337740) — 588s of a 606s job).

`fetch-depth: 0` makes `actions/checkout` fetch **every branch and every tag with complete history**:

```
git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules origin \
  +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +<sha>:refs/remotes/pull/<n>/merge
```

`fetch-tags: false` is already set and does not prevent this. `actions/checkout` hardcodes `+refs/tags/*:refs/tags/*` into the refspec whenever the depth is 0, and an explicit refspec overrides `--no-tags`. This repository has **1,903 branches and 7,506 tags**. When several runs start at the same moment — a stack submit fires about ten — server-side pack generation stalls and the fetch sends nothing until the job timeout kills it.

## Fix

Add `filter: blob:none` to both full-history checkouts. The release job already fetches this way.

The commit graph stays complete, which is all these jobs read from history:

- the `changes` job runs `git merge-base` and reads no file contents;
- the gates diff against `base_sha`, so the blobs they touch are fetched lazily instead of every ref's full contents arriving up front.

## Measured

Same fetch, replicated against the real remote:

| variant | transferred | wall |
| --- | --- | --- |
| unfiltered (current) | 571 MiB | 31s |
| `--filter=blob:none` | 95 MiB | 6s |
| `blob:none` + worktree materialised | 134 MiB | 12s |

Workflow wall clock, successful runs only:

| day | runs | median | p90 | max | runs >= 10 min |
| --- | --- | --- | --- | --- | --- |
| 2026-07-30 | 117 | 293s | 466s | 753s | 5 |
| 2026-08-13 | 97 | 535s | 769s | 980s | 40 |
| 2026-08-19 | 209 | 314s | 483s | 875s | 36 |
| 2026-08-20 | 194 | 324s | 441s | 1214s | 30 |

In a median 335s run, the two `fetch-depth: 0` checkouts take 159s. That is 47% of the runtime, and they cause every timeout.

## Not in this change

Two things I found while measuring, both filed on SPK-1218 as follow-ups:

- `Mark the verdict as pending for this commit` sits below the checkout, so a stalled fetch kills the job before the gate marks itself pending. That is the silent-gate state SPK-1013 exists to prevent.
- `release-safety-tests.yml` runs `release-safety-workflow-shape.test.ts`, which guards `release-safety-pr.yml`, but its `paths:` filter does not list that file. A change to the guarded file does not run its guard.

## Verification

`scripts/release-safety-workflow-shape.test.ts` passes locally.

Linear: SPK-1218
