### PR TITLE
fix(release-safety): read raw SQL that interpolates local constants

### DIFF
--- a/scripts/release-safety-migrations.test.ts
+++ b/scripts/release-safety-migrations.test.ts
@@ -164,6 +164,78 @@ test('numeric constants substitute as readily as string ones', () => {
     assert.strictEqual(result.complete, true);
 });
 
+// The four cases below are the fail-safe direction. Each one used to reach
+// `complete: false` with every heaviness value unknown, and a reader that
+// guesses instead would publish a confident wrong answer. A false `false`
+// tells the upgrade gate a migration is light when it is not.
+test('a nested template refuses rather than reading a fragment', () => {
+    // The tokenizer ends the outer token at the inner backtick, so the value
+    // is the fragment `${` and no placeholder matches. The real statement is
+    // an UPDATE, which rewrites and scans.
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000007_nested.ts',
+        'const A = `users`;\n' +
+            'export async function up(knex) { await knex.raw(`${`UPDATE ${A} SET x = 1`}`); }',
+    );
+    assert.deepStrictEqual(result.migration.heaviness, {
+        locksTable: 'unknown',
+        rewritesTable: 'unknown',
+        scansTable: 'unknown',
+    });
+    assert.strictEqual(result.complete, false);
+});
+
+test('a literal that is only part of the initializer is not a constant', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000008_partial.ts',
+        `
+            const SQL = 'ALTER TABLE users ' + buildRest();
+            export async function up(knex) { await knex.raw(\`\${SQL}\`); }
+        `,
+    );
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.migration.heaviness.locksTable, 'unknown');
+});
+
+test('a shadowed name is not resolved from the outer scope', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000009_shadowed.ts',
+        `
+            const SQL = 'SELECT 1';
+            export async function up(knex) {
+                const SQL = buildDangerousSql();
+                await knex.raw(\`\${SQL}\`);
+            }
+        `,
+    );
+    assert.strictEqual(result.complete, false);
+    assert.strictEqual(result.migration.heaviness.rewritesTable, 'unknown');
+});
+
+test('adding a constraint scans the table unless it says NOT VALID', () => {
+    const build = (suffix: string): string => `
+        const Table = 'ai_agent';
+        export async function up(knex) {
+            await knex.raw(
+                \`ALTER TABLE \${Table} ADD CONSTRAINT c CHECK (h IS NULL)${suffix}\`,
+            );
+        }
+    `;
+    const validated = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000010_check.ts',
+        build(''),
+    );
+    assert.strictEqual(validated.complete, true);
+    assert.strictEqual(validated.migration.heaviness.scansTable, true);
+
+    const deferred = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000011_check_deferred.ts',
+        build(' NOT VALID'),
+    );
+    assert.strictEqual(deferred.complete, true);
+    assert.strictEqual(deferred.migration.heaviness.scansTable, false);
+});
+
 test('an unresolvable interpolation still degrades', () => {
     for (const body of [
         'await knex.raw(`DROP INDEX ${buildName()}`);',

--- a/scripts/release-safety-migrations.test.ts
+++ b/scripts/release-safety-migrations.test.ts
@@ -119,6 +119,82 @@ test('dynamic raw SQL degrades unknown dimensions and completeness', () => {
     assert.strictEqual(result.complete, false);
 });
 
+test('raw SQL built from a local constant reads as fully as a literal', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000003_index.ts',
+        `
+            const TableName = 'analytics_chart_views';
+            const IndexName = 'analytics_chart_views_user_uuid_timestamp_idx';
+            export async function up(knex) {
+                await knex.raw(\`DROP INDEX CONCURRENTLY IF EXISTS \${IndexName}\`);
+                await knex.raw(
+                    \`CREATE INDEX CONCURRENTLY \${IndexName} ON \${TableName} (user_uuid, timestamp)\`,
+                );
+            }
+        `,
+    );
+    assert.deepStrictEqual(result.migration.tables, ['analytics_chart_views']);
+    assert.deepStrictEqual(result.migration.heaviness, {
+        locksTable: false,
+        rewritesTable: false,
+        scansTable: true,
+    });
+    assert.strictEqual(result.complete, true);
+});
+
+test('numeric constants substitute as readily as string ones', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/ee/database/migrations/20260810000004_bounds.ts',
+        `
+            const Table = 'ai_organization_settings';
+            const Column = 'thread_retention_hours';
+            const MIN_HOURS = 1;
+            const MAX_HOURS = 876000;
+            export async function up(knex) {
+                await knex.raw(
+                    \`ALTER TABLE \${Table} ADD CONSTRAINT \${Table}_\${Column}_range CHECK (\${Column} IS NULL OR (\${Column} >= \${MIN_HOURS} AND \${Column} <= \${MAX_HOURS}))\`,
+                );
+            }
+        `,
+    );
+    assert.deepStrictEqual(result.migration.tables, [
+        'ai_organization_settings',
+    ]);
+    assert.strictEqual(result.migration.heaviness.locksTable, true);
+    assert.strictEqual(result.complete, true);
+});
+
+test('an unresolvable interpolation still degrades', () => {
+    for (const body of [
+        'await knex.raw(`DROP INDEX ${buildName()}`);',
+        'await knex.raw(`DROP INDEX ${fromSomewhereElse}`);',
+    ]) {
+        const result = analyzeMigrationSource(
+            'packages/backend/src/database/migrations/20260810000005_unresolvable.ts',
+            `export async function up(knex) { ${body} }`,
+        );
+        assert.deepStrictEqual(result.migration.heaviness, {
+            locksTable: 'unknown',
+            rewritesTable: 'unknown',
+            scansTable: 'unknown',
+        });
+        assert.strictEqual(result.complete, false);
+    }
+});
+
+test('one unresolvable placeholder degrades the whole statement', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000006_mixed.ts',
+        `
+            const Table = 'events';
+            export async function up(knex) {
+                await knex.raw(\`TRUNCATE TABLE \${Table}_\${suffix}\`);
+            }
+        `,
+    );
+    assert.strictEqual(result.complete, false);
+});
+
 test('IO reads the requested ref and represents unreadable paths honestly', () => {
     const existing =
         'packages/backend/src/database/migrations/20250602185100_add_treemap_to_chart_type.ts';

--- a/scripts/release-safety-migrations.test.ts
+++ b/scripts/release-safety-migrations.test.ts
@@ -164,14 +164,10 @@ test('numeric constants substitute as readily as string ones', () => {
     assert.strictEqual(result.complete, true);
 });
 
-// The four cases below are the fail-safe direction. Each one used to reach
-// `complete: false` with every heaviness value unknown, and a reader that
-// guesses instead would publish a confident wrong answer. A false `false`
-// tells the upgrade gate a migration is light when it is not.
+// The cases below pin the fail-safe direction: a reader that guesses would
+// tell the upgrade gate a migration is light when it is not.
 test('a nested template refuses rather than reading a fragment', () => {
-    // The tokenizer ends the outer token at the inner backtick, so the value
-    // is the fragment `${` and no placeholder matches. The real statement is
-    // an UPDATE, which rewrites and scans.
+    // The outer token ends at the inner backtick, leaving the fragment `${`.
     const result = analyzeMigrationSource(
         'packages/backend/src/database/migrations/20260810000007_nested.ts',
         'const A = `users`;\n' +
@@ -265,6 +261,63 @@ test('one unresolvable placeholder degrades the whole statement', () => {
         `,
     );
     assert.strictEqual(result.complete, false);
+});
+
+test('a deferred constraint elsewhere does not vouch for a validated one', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000012_two_adds.ts',
+        `
+            const T = 'users';
+            export async function up(knex) {
+                await knex.raw(
+                    \`ALTER TABLE \${T} ADD CONSTRAINT a CHECK (x > 0); ALTER TABLE events ADD CONSTRAINT b CHECK (y > 0) NOT VALID\`,
+                );
+            }
+        `,
+    );
+    assert.strictEqual(result.migration.heaviness.scansTable, true);
+});
+
+test('a comment cannot defer a constraint', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000013_commented.ts',
+        `
+            const T = 'users';
+            export async function up(knex) {
+                await knex.raw(\`-- not valid\\nALTER TABLE \${T} ADD CONSTRAINT a CHECK (x > 0)\`);
+            }
+        `,
+    );
+    assert.strictEqual(result.migration.heaviness.scansTable, true);
+});
+
+test('a parameter or pattern shadowing a constant blocks resolution', () => {
+    const bodies = [
+        "await (async (SQL = 'UPDATE users SET x = 1') => knex.raw(\`\${SQL}\`))();",
+        'await (async (SQL) => knex.raw(\`\${SQL}\`))(buildSql());',
+        'const { SQL } = opts; await knex.raw(\`\${SQL}\`);',
+    ];
+    for (const body of bodies) {
+        const result = analyzeMigrationSource(
+            'packages/backend/src/database/migrations/20260810000014_shadow.ts',
+            `
+                const SQL = 'SELECT 1';
+                export async function up(knex) { ${body} }
+            `,
+        );
+        assert.strictEqual(result.complete, false);
+        assert.strictEqual(result.migration.heaviness.rewritesTable, 'unknown');
+    }
+});
+
+test('a line continuation inside a constant is cooked away', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000015_continued.ts',
+        "const SQL = 'UPD\\\nATE users SET x = 1';\n" +
+            'export async function up(knex) { await knex.raw(`${SQL}`); }',
+    );
+    assert.strictEqual(result.complete, true);
+    assert.strictEqual(result.migration.heaviness.rewritesTable, true);
 });
 
 test('IO reads the requested ref and represents unreadable paths honestly', () => {

--- a/scripts/release-safety-migrations.test.ts
+++ b/scripts/release-safety-migrations.test.ts
@@ -320,6 +320,20 @@ test('a line continuation inside a constant is cooked away', () => {
     assert.strictEqual(result.migration.heaviness.rewritesTable, true);
 });
 
+test('SQL concatenated inline is not read as the whole statement', () => {
+    for (const argument of [
+        "'ALTER TABLE users ' + buildRest()",
+        '`ALTER TABLE users ` + buildRest()',
+    ]) {
+        const result = analyzeMigrationSource(
+            'packages/backend/src/database/migrations/20260810000016_concat.ts',
+            `export async function up(knex) { await knex.raw(${argument}); }`,
+        );
+        assert.strictEqual(result.complete, false);
+        assert.strictEqual(result.migration.heaviness.scansTable, 'unknown');
+    }
+});
+
 test('IO reads the requested ref and represents unreadable paths honestly', () => {
     const existing =
         'packages/backend/src/database/migrations/20250602185100_add_treemap_to_chart_type.ts';

--- a/scripts/release-safety-migrations.ts
+++ b/scripts/release-safety-migrations.ts
@@ -339,19 +339,62 @@ const migrationEdition = (migrationPath: string): 'core' | 'ee' =>
         ? 'ee'
         : 'core';
 
+const DECLARATION_KEYWORDS = ['const', 'let', 'var'];
+
+/**
+ * PURE. How many times each name is declared anywhere in the file, at any
+ * depth.
+ *
+ * A name declared twice cannot be resolved by scanning alone: the binding in
+ * force at a `knex.raw()` call depends on lexical scope this tokenizer does
+ * not model. Counting lets the caller drop those names instead of resolving
+ * the wrong one.
+ */
+const countDeclarations = (tokens: Token[]): Map<string, number> => {
+    const counts = new Map<string, number>();
+    for (let index = 0; index + 1 < tokens.length; index += 1) {
+        if (
+            tokens[index].kind === 'identifier' &&
+            DECLARATION_KEYWORDS.includes(tokens[index].value) &&
+            tokens[index + 1].kind === 'identifier'
+        ) {
+            const name = tokens[index + 1].value;
+            counts.set(name, (counts.get(name) ?? 0) + 1);
+        }
+    }
+    return counts;
+};
+
+/**
+ * PURE. Module-scope constants whose value is a complete literal.
+ *
+ * Three conditions keep this honest, because callers treat a hit as fact:
+ * the declaration sits at depth 0, so no enclosing block can rebind it; the
+ * name is declared exactly once, so no inner scope shadows it; and the literal
+ * is the whole initializer, so `'ALTER TABLE ' + build()` is rejected rather
+ * than recorded as its prefix. Anything else is left out, which costs only an
+ * unknown verdict.
+ */
 const collectStringConstants = (
     tokens: Token[],
     kinds: readonly TokenKind[] = ['string', 'template'],
 ): Map<string, string> => {
     const constants = new Map<string, string>();
+    const declarationCounts = countDeclarations(tokens);
     for (let index = 0; index + 3 < tokens.length; index += 1) {
+        const terminator = tokens[index + 4];
         if (
             tokens[index].kind === 'identifier' &&
             tokens[index].value === 'const' &&
+            tokens[index].depth === 0 &&
             tokens[index + 1].kind === 'identifier' &&
+            declarationCounts.get(tokens[index + 1].value) === 1 &&
             tokens[index + 2].kind === 'operator' &&
             tokens[index + 2].value === '=' &&
-            kinds.includes(tokens[index + 3].kind)
+            kinds.includes(tokens[index + 3].kind) &&
+            (terminator === undefined ||
+                (terminator.kind === 'punctuation' &&
+                    [';', ','].includes(terminator.value)))
         ) {
             constants.set(tokens[index + 1].value, tokens[index + 3].value);
         }
@@ -457,6 +500,14 @@ const TEMPLATE_PLACEHOLDER = /\$\{([^}]*)\}/g;
  * migrations normally keep a `CREATE INDEX` and its matching `DROP INDEX` in
  * step. A placeholder naming anything else stays unreadable and returns null,
  * so the caller keeps degrading the verdict rather than guessing.
+ *
+ * The tokenizer flags a template dynamic on sight of `${` but does not track
+ * nesting, so a nested template ends the token mid-placeholder and leaves a
+ * fragment this regex cannot match. Returning that fragment would read as
+ * clean SQL and report heaviness the statement never had, so any `${` left
+ * after substitution means the argument was not understood. Refusing is the
+ * only safe answer: a wrong `false` claims a migration is light, while an
+ * unknown merely asks a person to look.
  */
 const resolveSqlArgument = (
     token: Token | undefined,
@@ -475,7 +526,8 @@ const resolveSqlArgument = (
         resolved += token.value.slice(cursor, match.index) + substitution;
         cursor = match.index + match[0].length;
     }
-    return resolved + token.value.slice(cursor);
+    resolved += token.value.slice(cursor);
+    return resolved.includes('${') ? null : resolved;
 };
 
 const rawSqlTables = (sql: string): string[] => {
@@ -646,6 +698,15 @@ export function analyzeMigrationSource(
                     /\b(?:select[\s\S]+from|set\s+not\s+null|validate\s+constraint|create\s+(?:unique\s+)?index)\b/i.test(
                         sql,
                     )
+                ) {
+                    mark('scansTable');
+                }
+                // Postgres validates a new CHECK or FOREIGN KEY constraint
+                // against every existing row unless the statement says NOT
+                // VALID, so the add is a full scan in all but that one form.
+                if (
+                    /\badd\s+constraint\b/i.test(sql) &&
+                    !/\bnot\s+valid\b/i.test(sql)
                 ) {
                     mark('scansTable');
                 }

--- a/scripts/release-safety-migrations.ts
+++ b/scripts/release-safety-migrations.ts
@@ -730,7 +730,14 @@ export function analyzeMigrationSource(
             if (token.value === 'alter') markUnknown('rewritesTable');
 
             if (token.value === 'raw') {
-                const sql = resolveSqlArgument(argument, sqlConstants);
+                // The argument is only the whole argument when the call ends
+                // or a second one follows; anything else builds it at runtime.
+                const argumentEnds = [')', ','].includes(
+                    body[index + 3]?.value ?? '',
+                );
+                const sql = argumentEnds
+                    ? resolveSqlArgument(argument, sqlConstants)
+                    : null;
                 if (sql === null) {
                     markUnknown('locksTable', 'rewritesTable', 'scansTable');
                     continue;

--- a/scripts/release-safety-migrations.ts
+++ b/scripts/release-safety-migrations.ts
@@ -113,8 +113,18 @@ const matchingOpening = (delimiter: ClosingDelimiter): OpeningDelimiter => {
 
 const decodeEscaped = (value: string): string =>
     value.replace(
-        /\\(?:u\{([\da-fA-F]+)\}|u([\da-fA-F]{4})|x([\da-fA-F]{2})|([0btnvfr'"`\\]))/g,
-        (_match, codePoint, unicode, hex, escaped: string | undefined) => {
+        /\\(?:u\{([\da-fA-F]+)\}|u([\da-fA-F]{4})|x([\da-fA-F]{2})|([0btnvfr'"`\\])|(\r\n|[\n\r\u2028\u2029]))/g,
+        (
+            _match,
+            codePoint,
+            unicode,
+            hex,
+            escaped: string | undefined,
+            lineContinuation: string | undefined,
+        ) => {
+            // A line continuation evaluates to nothing, so keeping it would
+            // hide the keyword it splits.
+            if (lineContinuation !== undefined) return '';
             if (codePoint !== undefined) {
                 return String.fromCodePoint(Number.parseInt(codePoint, 16));
             }
@@ -339,48 +349,17 @@ const migrationEdition = (migrationPath: string): 'core' | 'ee' =>
         ? 'ee'
         : 'core';
 
-const DECLARATION_KEYWORDS = ['const', 'let', 'var'];
-
 /**
- * PURE. How many times each name is declared anywhere in the file, at any
- * depth.
- *
- * A name declared twice cannot be resolved by scanning alone: the binding in
- * force at a `knex.raw()` call depends on lexical scope this tokenizer does
- * not model. Counting lets the caller drop those names instead of resolving
- * the wrong one.
- */
-const countDeclarations = (tokens: Token[]): Map<string, number> => {
-    const counts = new Map<string, number>();
-    for (let index = 0; index + 1 < tokens.length; index += 1) {
-        if (
-            tokens[index].kind === 'identifier' &&
-            DECLARATION_KEYWORDS.includes(tokens[index].value) &&
-            tokens[index + 1].kind === 'identifier'
-        ) {
-            const name = tokens[index + 1].value;
-            counts.set(name, (counts.get(name) ?? 0) + 1);
-        }
-    }
-    return counts;
-};
-
-/**
- * PURE. Module-scope constants whose value is a complete literal.
- *
- * Three conditions keep this honest, because callers treat a hit as fact:
- * the declaration sits at depth 0, so no enclosing block can rebind it; the
- * name is declared exactly once, so no inner scope shadows it; and the literal
- * is the whole initializer, so `'ALTER TABLE ' + build()` is rejected rather
- * than recorded as its prefix. Anything else is left out, which costs only an
- * unknown verdict.
+ * PURE. Module-scope constants whose value is a complete literal, bound exactly
+ * once. Callers treat a hit as fact, so anything shadowed or partly dynamic is
+ * left out; that costs only an unknown verdict.
  */
 const collectStringConstants = (
     tokens: Token[],
     kinds: readonly TokenKind[] = ['string', 'template'],
 ): Map<string, string> => {
     const constants = new Map<string, string>();
-    const declarationCounts = countDeclarations(tokens);
+    const bindingSites = collectBindingSites(tokens);
     for (let index = 0; index + 3 < tokens.length; index += 1) {
         const terminator = tokens[index + 4];
         if (
@@ -388,7 +367,7 @@ const collectStringConstants = (
             tokens[index].value === 'const' &&
             tokens[index].depth === 0 &&
             tokens[index + 1].kind === 'identifier' &&
-            declarationCounts.get(tokens[index + 1].value) === 1 &&
+            bindingSites.get(tokens[index + 1].value)?.size === 1 &&
             tokens[index + 2].kind === 'operator' &&
             tokens[index + 2].value === '=' &&
             kinds.includes(tokens[index + 3].kind) &&
@@ -425,6 +404,82 @@ const findMatching = (
         if (depth === 0) return index;
     }
     return null;
+};
+
+const BINDING_KEYWORDS = ['const', 'let', 'var', 'function', 'class', 'catch'];
+
+const CLOSING_FOR: Record<OpeningDelimiter, ClosingDelimiter> = {
+    '(': ')',
+    '[': ']',
+    '{': '}',
+};
+
+/**
+ * PURE. Every token index that binds a name, keyed by name. Indices not counts,
+ * because one declaration is reached by several of the rules below.
+ */
+const collectBindingSites = (tokens: Token[]): Map<string, Set<number>> => {
+    const sites = new Map<string, Set<number>>();
+    const bind = (name: string, index: number): void => {
+        const seen = sites.get(name) ?? new Set<number>();
+        seen.add(index);
+        sites.set(name, seen);
+    };
+    const closingIndexOf = (openerIndex: number): number | null => {
+        const opening = tokens[openerIndex]?.value as OpeningDelimiter;
+        const closing = CLOSING_FOR[opening];
+        return closing === undefined
+            ? null
+            : findMatching(tokens, openerIndex, opening, closing);
+    };
+    const bindEnclosed = (openerIndex: number): void => {
+        const end = closingIndexOf(openerIndex);
+        if (end === null) return;
+        for (let index = openerIndex + 1; index < end; index += 1) {
+            if (tokens[index].kind !== 'identifier') continue;
+            // A member name is a property, not a binding.
+            if (tokens[index - 1]?.value === '.') continue;
+            bind(tokens[index].value, index);
+        }
+    };
+
+    for (let index = 0; index < tokens.length; index += 1) {
+        const token = tokens[index];
+        const next = tokens[index + 1];
+        if (next === undefined) continue;
+
+        // An assignment target or a parameter default rebinds the name.
+        if (
+            token.kind === 'identifier' &&
+            next.kind === 'operator' &&
+            next.value === '='
+        ) {
+            bind(token.value, index);
+        }
+
+        // An arrow parameter list binds every name it lists.
+        if (token.kind === 'punctuation' && token.value === '(') {
+            const end = closingIndexOf(index);
+            if (end !== null && tokens[end + 1]?.value === '=>') {
+                bindEnclosed(index);
+            }
+        }
+
+        if (token.kind !== 'identifier') continue;
+        if (!BINDING_KEYWORDS.includes(token.value)) continue;
+
+        if (next.kind === 'identifier') {
+            bind(next.value, index + 1);
+            // A function declaration also binds its parameters.
+            if (tokens[index + 2]?.value === '(') bindEnclosed(index + 2);
+            continue;
+        }
+        // Destructuring, and a catch or parameter list.
+        if (next.kind === 'punctuation' && ['{', '[', '('].includes(next.value)) {
+            bindEnclosed(index + 1);
+        }
+    }
+    return sites;
 };
 
 const findUpBody = (tokens: Token[]): Token[] | null => {
@@ -492,22 +547,9 @@ const resolveTable = (
 const TEMPLATE_PLACEHOLDER = /\$\{([^}]*)\}/g;
 
 /**
- * PURE. The SQL a `knex.raw()` argument stands for, or null when the argument
- * cannot be read statically.
- *
- * A template holding `${...}` reaches here as a `dynamicTemplate`. Substituting
- * the local constants it names recovers the real statement, which is how
- * migrations normally keep a `CREATE INDEX` and its matching `DROP INDEX` in
- * step. A placeholder naming anything else stays unreadable and returns null,
- * so the caller keeps degrading the verdict rather than guessing.
- *
- * The tokenizer flags a template dynamic on sight of `${` but does not track
- * nesting, so a nested template ends the token mid-placeholder and leaves a
- * fragment this regex cannot match. Returning that fragment would read as
- * clean SQL and report heaviness the statement never had, so any `${` left
- * after substitution means the argument was not understood. Refusing is the
- * only safe answer: a wrong `false` claims a migration is light, while an
- * unknown merely asks a person to look.
+ * PURE. The SQL a `knex.raw()` argument stands for, or null when it cannot be
+ * read statically. Any `${` surviving substitution means the argument was not
+ * understood, so refuse rather than report heaviness the statement never had.
  */
 const resolveSqlArgument = (
     token: Token | undefined,
@@ -545,6 +587,15 @@ const rawSqlTables = (sql: string): string[] => {
     }
     return [...tables];
 };
+
+const SQL_COMMENTS = /--[^\n]*|\/\*[\s\S]*?\*\//g;
+
+const sqlStatements = (sql: string): string[] =>
+    sql.replace(SQL_COMMENTS, ' ').split(';');
+
+const addsValidatedConstraint = (statement: string): boolean =>
+    /\badd\s+constraint\b/i.test(statement) &&
+    !/\bnot\s+valid\b/i.test(statement);
 
 export function analyzeMigrationSource(
     migrationPath: string,
@@ -701,13 +752,10 @@ export function analyzeMigrationSource(
                 ) {
                     mark('scansTable');
                 }
-                // Postgres validates a new CHECK or FOREIGN KEY constraint
-                // against every existing row unless the statement says NOT
-                // VALID, so the add is a full scan in all but that one form.
-                if (
-                    /\badd\s+constraint\b/i.test(sql) &&
-                    !/\bnot\s+valid\b/i.test(sql)
-                ) {
+                // Adding a constraint validates every existing row unless
+                // the statement says NOT VALID. Checked per statement so one
+                // deferred add cannot vouch for a validated one beside it.
+                if (sqlStatements(sql).some(addsValidatedConstraint)) {
                     mark('scansTable');
                 }
                 if (

--- a/scripts/release-safety-migrations.ts
+++ b/scripts/release-safety-migrations.ts
@@ -339,7 +339,10 @@ const migrationEdition = (migrationPath: string): 'core' | 'ee' =>
         ? 'ee'
         : 'core';
 
-const collectStringConstants = (tokens: Token[]): Map<string, string> => {
+const collectStringConstants = (
+    tokens: Token[],
+    kinds: readonly TokenKind[] = ['string', 'template'],
+): Map<string, string> => {
     const constants = new Map<string, string>();
     for (let index = 0; index + 3 < tokens.length; index += 1) {
         if (
@@ -348,7 +351,7 @@ const collectStringConstants = (tokens: Token[]): Map<string, string> => {
             tokens[index + 1].kind === 'identifier' &&
             tokens[index + 2].kind === 'operator' &&
             tokens[index + 2].value === '=' &&
-            ['string', 'template'].includes(tokens[index + 3].kind)
+            kinds.includes(tokens[index + 3].kind)
         ) {
             constants.set(tokens[index + 1].value, tokens[index + 3].value);
         }
@@ -443,6 +446,38 @@ const resolveTable = (
     return null;
 };
 
+const TEMPLATE_PLACEHOLDER = /\$\{([^}]*)\}/g;
+
+/**
+ * PURE. The SQL a `knex.raw()` argument stands for, or null when the argument
+ * cannot be read statically.
+ *
+ * A template holding `${...}` reaches here as a `dynamicTemplate`. Substituting
+ * the local constants it names recovers the real statement, which is how
+ * migrations normally keep a `CREATE INDEX` and its matching `DROP INDEX` in
+ * step. A placeholder naming anything else stays unreadable and returns null,
+ * so the caller keeps degrading the verdict rather than guessing.
+ */
+const resolveSqlArgument = (
+    token: Token | undefined,
+    constants: ReadonlyMap<string, string>,
+): string | null => {
+    if (!token) return null;
+    if (token.kind === 'string' || token.kind === 'template') {
+        return token.value;
+    }
+    if (token.kind !== 'dynamicTemplate') return null;
+    let resolved = '';
+    let cursor = 0;
+    for (const match of token.value.matchAll(TEMPLATE_PLACEHOLDER)) {
+        const substitution = constants.get(match[1].trim());
+        if (substitution === undefined) return null;
+        resolved += token.value.slice(cursor, match.index) + substitution;
+        cursor = match.index + match[0].length;
+    }
+    return resolved + token.value.slice(cursor);
+};
+
 const rawSqlTables = (sql: string): string[] => {
     const tables = new Set<string>();
     const patterns = [
@@ -468,6 +503,11 @@ export function analyzeMigrationSource(
     const tokenized = tokenize(source);
     const body = findUpBody(tokenized.tokens);
     const constants = collectStringConstants(tokenized.tokens);
+    const sqlConstants = collectStringConstants(tokenized.tokens, [
+        'string',
+        'template',
+        'number',
+    ]);
     const tables = new Set<string>();
     const heaviness: MigrationHeaviness = {
         locksTable: false,
@@ -587,14 +627,11 @@ export function analyzeMigrationSource(
             if (token.value === 'alter') markUnknown('rewritesTable');
 
             if (token.value === 'raw') {
-                if (
-                    argument?.kind !== 'string' &&
-                    argument?.kind !== 'template'
-                ) {
+                const sql = resolveSqlArgument(argument, sqlConstants);
+                if (sql === null) {
                     markUnknown('locksTable', 'rewritesTable', 'scansTable');
                     continue;
                 }
-                const sql = argument.value;
                 for (const table of rawSqlTables(sql)) tables.add(table);
                 if (/\b(?:alter|drop|rename|truncate)\s+table\b/i.test(sql)) {
                     mark('locksTable');


### PR DESCRIPTION
## What breaks

A release gets the safety verdict `unknown` when one of its migrations builds SQL with a variable inside a template string. The verdict is wrong. The release is safe.

The upgrade automation merges a version bump only on a green verdict. An `unknown` verdict holds the bump, so an instance stops receiving upgrades until a person merges by hand.

## Cause

`analyzeMigrationSource` accepted a plain string or a plain template as the argument to `knex.raw()`. The tokenizer gives a template that holds `${...}` the kind `dynamicTemplate`, so the reader rejected it, marked all three heaviness values `unknown`, and reported the file incomplete.

`gen-release-safety.ts` turns one incomplete file into an incomplete release, and incomplete data overrides the AI review.

Two shapes trip it. The first is a table or index name held in a constant:

```ts
await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${IndexName}`);
```

The second is a numeric bound, which `collectStringConstants` did not collect at all:

```ts
const MIN_HOURS = 1;
await knex.raw(`... CHECK (${COLUMN} >= ${MIN_HOURS})`);
```

## Effect on 2026-08-20

Four releases got `unknown` for this reason. The AI review had returned `safe/high` in every one.

| Release | Migration |
| --- | --- |
| 1.215.0 | `20260819140000_add_ai_thread_retention_settings.ts` |
| 1.219.0 | `20260820150000_add_organization_uuid_index_to_ai_thread.ts` |
| 1.221.0 | `20260820151000_index_analytics_dashboard_views_user_uuid_timestamp.ts`, `20260820153000_index_analytics_chart_views_user_uuid_timestamp.ts` |
| 1.227.1 | `20260820190000_create_external_source_lifecycle_tables.ts` |

Each of those migrations is a careful one. They use `CREATE INDEX CONCURRENTLY`, a lock timeout and idempotent guards. The reader was the fault.

## Change

`resolveSqlArgument` substitutes the local constants a template names, then the statement reads exactly as a literal does. Numeric constants resolve too. A placeholder that names anything else returns no SQL, so the conservative path stays.

## Verification

Against the five migrations above, read from `origin/main`:

| Release | Before | After |
| --- | --- | --- |
| 1.215.0 | `complete=false` | `complete=true`, tables `ai_agent`, `ai_organization_settings` |
| 1.219.0 | `complete=false` | `complete=true` |
| 1.221.0 (x2) | `complete=false` | `complete=true` |
| 1.227.1 | `complete=false` | `complete=true` |

The two new positive tests fail against the reader on `main` and pass here. The two negative tests pass on both, which is the point: an argument that cannot be read still degrades. Full `npm run test:release-safety` passes.

Linear: SPK-1219