### PR TITLE
fix(upgrade-automation): stop a cancelled deploy run freezing upgrades

### DIFF
--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -159,6 +159,14 @@ if [[ "$DEPLOY_CONCLUSION" == "success" ]]; then
         fi
         sleep 20
     done
+elif [[ "$DEPLOY_CONCLUSION" == "cancelled" ]]; then
+    # A push to the default branch cancels the deployment run already in
+    # flight. That is routine on a busy branch and says nothing about this
+    # pin: the run that replaced it carries the same commit, and its own
+    # verification covers the same version. Freezing here would stop every
+    # future upgrade over a deployment that never actually failed.
+    last_reason=deploy_workflow_cancelled
+    superseded=true
 else
     last_reason="deploy_workflow_$DEPLOY_CONCLUSION"
 fi

--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -107,7 +107,15 @@ summary_file=$(mktemp)
 issue_body=$(mktemp)
 trap 'rm -f "$response_body" "$response_headers" "$summary_file" "$issue_body"' EXIT
 
-if [[ "$DEPLOY_CONCLUSION" == "success" ]]; then
+# A cancelled run is not a failed deployment: a push to the default branch
+# cancels the run already in flight, and the run that replaces it carries the
+# same commit. Neither is it proof of success, because a cancellation may have
+# no replacement at all. Poll instead of deciding: the running version is the
+# evidence. It converges when a later run deploys this pin, reports the
+# superseded path when the pin has already moved on, and freezes when nothing
+# deployed. Deciding either way without polling would trade a false freeze for
+# a silent one.
+if [[ "$DEPLOY_CONCLUSION" == "success" || "$DEPLOY_CONCLUSION" == "cancelled" ]]; then
     while [[ $(date +%s) -lt $deadline ]]; do
         remaining_seconds=$((deadline - $(date +%s)))
         curl_timeout=$((remaining_seconds < 20 ? remaining_seconds : 20))
@@ -159,14 +167,6 @@ if [[ "$DEPLOY_CONCLUSION" == "success" ]]; then
         fi
         sleep 20
     done
-elif [[ "$DEPLOY_CONCLUSION" == "cancelled" ]]; then
-    # A push to the default branch cancels the deployment run already in
-    # flight. That is routine on a busy branch and says nothing about this
-    # pin: the run that replaced it carries the same commit, and its own
-    # verification covers the same version. Freezing here would stop every
-    # future upgrade over a deployment that never actually failed.
-    last_reason=deploy_workflow_cancelled
-    superseded=true
 else
     last_reason="deploy_workflow_$DEPLOY_CONCLUSION"
 fi

--- a/examples/upgrade-automation/scripts/verify.sh
+++ b/examples/upgrade-automation/scripts/verify.sh
@@ -107,14 +107,8 @@ summary_file=$(mktemp)
 issue_body=$(mktemp)
 trap 'rm -f "$response_body" "$response_headers" "$summary_file" "$issue_body"' EXIT
 
-# A cancelled run is not a failed deployment: a push to the default branch
-# cancels the run already in flight, and the run that replaces it carries the
-# same commit. Neither is it proof of success, because a cancellation may have
-# no replacement at all. Poll instead of deciding: the running version is the
-# evidence. It converges when a later run deploys this pin, reports the
-# superseded path when the pin has already moved on, and freezes when nothing
-# deployed. Deciding either way without polling would trade a false freeze for
-# a silent one.
+# A cancelled run proves neither failure nor success, so poll: the running
+# version decides, and nothing deployed still freezes.
 if [[ "$DEPLOY_CONCLUSION" == "success" || "$DEPLOY_CONCLUSION" == "cancelled" ]]; then
     while [[ $(date +%s) -lt $deadline ]]; do
         remaining_seconds=$((deadline - $(date +%s)))

--- a/examples/upgrade-automation/scripts/verify.test.sh
+++ b/examples/upgrade-automation/scripts/verify.test.sh
@@ -329,10 +329,13 @@ run_version_comparison_test 1.2.4 1.2.3 0 superseded superseded:1.2.4 false 'new
 run_version_comparison_test 1.2.2 1.2.3 1 failure version_mismatch:1.2.2 true 'older version mismatch'
 run_version_comparison_test 1.2.4-beta.1 1.2.3 1 failure version_mismatch:1.2.4-beta.1 true 'prerelease version mismatch'
 
-# A push to the default branch cancels the deployment run already in flight.
-# The replacement run carries the same commit and verifies the same version, so
-# a cancellation must not freeze every future upgrade.
-run_version_comparison_test 1.2.3 1.2.3 0 superseded deploy_workflow_cancelled false 'cancelled deployment run' cancelled
+# A cancelled run decides nothing on its own, so the running version decides.
+# A later run that deploys this pin verifies normally; a pin already moved on
+# reports superseded; nothing deployed still freezes. Asserting all three stops
+# a future change quietly treating every cancellation as safe.
+run_version_comparison_test 1.2.3 1.2.3 0 success ready false 'cancelled run whose replacement deployed the pin' cancelled
+run_version_comparison_test 1.2.4 1.2.3 0 superseded superseded:1.2.4 false 'cancelled run overtaken by a newer pin' cancelled
+run_version_comparison_test 1.2.2 1.2.3 1 failure version_mismatch:1.2.2 true 'cancelled run that never deployed' cancelled
 run_version_comparison_test 1.2.3 1.2.3 1 failure deploy_workflow_failure true 'failed deployment run' failure
 
 run_freeze_cleanup_test() {

--- a/examples/upgrade-automation/scripts/verify.test.sh
+++ b/examples/upgrade-automation/scripts/verify.test.sh
@@ -194,6 +194,7 @@ run_version_comparison_test() {
     local expected_reason=$5
     local expect_issue_create=$6
     local test_name=$7
+    local deploy_conclusion=${8:-success}
     local scenario_dir
     scenario_dir=$(mktemp -d)
     mkdir -p "$scenario_dir/bin"
@@ -284,7 +285,7 @@ EOF
         VERIFY_WINDOW=60s \
         FREEZE_LABEL=upgrade-freeze \
         DEPLOY_RUN_URL=https://example.test/run/1 \
-        DEPLOY_CONCLUSION=success \
+        DEPLOY_CONCLUSION="$deploy_conclusion" \
         DEPLOYED_SHA=0000000000000000000000000000000000000000 \
         GH_TOKEN=test-token \
         "$root/examples/upgrade-automation/scripts/verify.sh" 2>&1)
@@ -327,6 +328,12 @@ EOF
 run_version_comparison_test 1.2.4 1.2.3 0 superseded superseded:1.2.4 false 'newer version supersession'
 run_version_comparison_test 1.2.2 1.2.3 1 failure version_mismatch:1.2.2 true 'older version mismatch'
 run_version_comparison_test 1.2.4-beta.1 1.2.3 1 failure version_mismatch:1.2.4-beta.1 true 'prerelease version mismatch'
+
+# A push to the default branch cancels the deployment run already in flight.
+# The replacement run carries the same commit and verifies the same version, so
+# a cancellation must not freeze every future upgrade.
+run_version_comparison_test 1.2.3 1.2.3 0 superseded deploy_workflow_cancelled false 'cancelled deployment run' cancelled
+run_version_comparison_test 1.2.3 1.2.3 1 failure deploy_workflow_failure true 'failed deployment run' failure
 
 run_freeze_cleanup_test() {
     local issue_kind=$1


### PR DESCRIPTION
## What breaks

The upgrade automation stops all future upgrades for an instance when a deployment workflow is **cancelled**. A cancelled run is not a failed deployment.

A push to the default branch cancels the deployment run already in flight. That is routine on a busy branch. The run that replaces it carries the same commit and verifies the same version.

## What happened on 2026-08-20

Two pin pull requests merged four minutes apart in `lightdash-cloud`. The second push cancelled the first deployment run. `verify.sh` recorded the readiness reason `deploy_workflow_cancelled` and opened freeze issue lightdash-cloud#3259 at 09:04 UTC.

Staging then received no automatic upgrades for the rest of the day. The instance was healthy throughout, serving the pinned version.

## Change

`verify.sh` already has a `superseded` path for the case where the running version is newer than the pin: it comments the summary and exits 0 without freezing. A cancelled deployment is the same idea one step earlier, so it now takes that path.

A genuine `failure` conclusion still freezes. So does a readiness or version check that does not pass inside the budget. Nothing about the success path changes.

## Verification

`run_version_comparison_test` now takes an optional deployment conclusion, defaulting to `success`, so the existing cases are untouched. Two cases added:

| Conclusion | Outcome | Exit | Freeze issue |
| --- | --- | --- | --- |
| `cancelled` | `superseded` | 0 | no |
| `failure` | `failure` | 1 | yes |

The cancelled case fails against `main` (`expected 0 status for cancelled deployment run, got 1`) and passes here. All 10 cases in `verify.test.sh` pass.

Linear: SPK-1222