### PR TITLE
feat: remove leave organization feature flag

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -208,6 +208,8 @@ const sessionModel = {
 };
 
 const organizationMemberProfileModel = {
+    getOrganizationMemberByUuid:
+        vi.fn<OrganizationMemberProfileModel['getOrganizationMemberByUuid']>(),
     getOrganizationAdmins: vi.fn<
         OrganizationMemberProfileModel['getOrganizationAdmins']
     >(async () => []),
@@ -716,6 +718,111 @@ describe('UserService', () => {
             await service.delete(orgAdmin, memberUser.userUuid);
 
             expect(userModel.delete).toHaveBeenCalledWith(memberUser.userUuid);
+        });
+    });
+
+    describe('leaveOrganization', () => {
+        const organizationMember = (
+            role: OrganizationMemberRole,
+            userUuid = sessionUser.userUuid,
+        ): OrganizationMemberProfile => ({
+            userUuid,
+            userCreatedAt: new Date(),
+            userUpdatedAt: new Date(),
+            firstName: 'First',
+            lastName: 'Last',
+            email: `${userUuid}@example.com`,
+            organizationUuid: organisation.organizationUuid,
+            role,
+            roleUuid: undefined,
+            isActive: true,
+            avatarUrl: null,
+            avatarGradient: null,
+        });
+        const userDetails: LightdashUser = {
+            ...userWithoutOrg,
+            userUuid: sessionUser.userUuid,
+            organizationUuid: sessionUser.organizationUuid,
+        };
+
+        test('refuses the sole admin and emits a denied audit event', async () => {
+            const admin = organizationMember(OrganizationMemberRole.ADMIN);
+            vi.mocked(
+                organizationMemberProfileModel.getOrganizationMemberByUuid,
+            ).mockResolvedValueOnce(admin);
+            vi.mocked(
+                organizationMemberProfileModel.getOrganizationAdmins,
+            ).mockResolvedValueOnce([admin]);
+            const service = createUserService(lightdashConfigMock);
+
+            await expect(
+                service.leaveOrganization(sessionUser),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(auditLogSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'leave_organization',
+                    status: 'denied',
+                    reason: 'Last admin in organization',
+                    actor: expect.objectContaining({
+                        uuid: sessionUser.userUuid,
+                    }),
+                    resource: expect.objectContaining({
+                        type: 'OrganizationMembership',
+                        organizationUuid: sessionUser.organizationUuid,
+                        metadata: { role: OrganizationMemberRole.ADMIN },
+                    }),
+                }),
+            );
+            expect(userModel.delete).not.toHaveBeenCalled();
+        });
+
+        test('allows an admin to leave when another admin remains', async () => {
+            const admin = organizationMember(OrganizationMemberRole.ADMIN);
+            const coAdmin = organizationMember(
+                OrganizationMemberRole.ADMIN,
+                'co-admin-uuid',
+            );
+            vi.mocked(
+                organizationMemberProfileModel.getOrganizationMemberByUuid,
+            ).mockResolvedValueOnce(admin);
+            vi.mocked(
+                organizationMemberProfileModel.getOrganizationAdmins,
+            ).mockResolvedValueOnce([admin, coAdmin]);
+            vi.mocked(userModel.getUserDetailsByUuid).mockResolvedValueOnce(
+                userDetails,
+            );
+            const service = createUserService(lightdashConfigMock);
+
+            await service.leaveOrganization(sessionUser);
+
+            expect(userModel.delete).toHaveBeenCalledWith(sessionUser.userUuid);
+        });
+
+        test('allows a non-admin member to leave', async () => {
+            const member = organizationMember(OrganizationMemberRole.MEMBER);
+            const admin = organizationMember(
+                OrganizationMemberRole.ADMIN,
+                'admin-uuid',
+            );
+            vi.mocked(
+                organizationMemberProfileModel.getOrganizationMemberByUuid,
+            ).mockResolvedValueOnce(member);
+            vi.mocked(
+                organizationMemberProfileModel.getOrganizationAdmins,
+            ).mockResolvedValueOnce([admin]);
+            vi.mocked(userModel.getUserDetailsByUuid).mockResolvedValueOnce(
+                userDetails,
+            );
+            const service = createUserService(lightdashConfigMock);
+            const memberUser = {
+                ...sessionUser,
+                role: OrganizationMemberRole.MEMBER,
+            };
+
+            await service.leaveOrganization(memberUser);
+
+            expect(userModel.delete).toHaveBeenCalledWith(sessionUser.userUuid);
         });
     });
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2607,29 +2607,6 @@ export class UserService extends BaseService {
         const { organizationUuid } = user;
         const actor = createActorFromUser(user);
 
-        const flag = await this.featureFlagModel.get({
-            user,
-            featureFlagId: FeatureFlags.LeaveOrganization,
-        });
-        if (!flag.enabled) {
-            this.logger.warn('Leave organization denied: feature disabled', {
-                userUuid: user.userUuid,
-                organizationUuid,
-            });
-            emitAuthAuditEvent({
-                actor,
-                action: 'leave_organization',
-                resourceType: 'OrganizationMembership',
-                status: 'denied',
-                reason: 'Feature disabled',
-                organizationUuid,
-                context,
-            });
-            throw new ForbiddenError(
-                'Leaving the organization is not enabled for this instance',
-            );
-        }
-
         const member =
             await this.organizationMemberProfileModel.getOrganizationMemberByUuid(
                 organizationUuid,

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -155,15 +155,6 @@ export enum FeatureFlags {
     SsoOrganizationSettings = 'sso-organization-settings',
 
     /**
-     * Expose the "Leave organization" action in the General settings danger
-     * zone and accept the corresponding API call. When disabled the panel is
-     * hidden and the endpoint returns a 403 — protects against accidental
-     * self-removal during early rollout and lets us disable the feature
-     * per-org if it causes operational issues.
-     */
-    LeaveOrganization = 'leave-organization',
-
-    /**
      * Enable query results caching. DB value (user/org override or flag
      * default) takes precedence; falls back to the RESULTS_CACHE_ENABLED env
      * var when no DB row is set. Lets shared-instance customers (eu1/app)

--- a/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/index.tsx
@@ -1,10 +1,9 @@
-import { FeatureFlags, OrganizationMemberRole } from '@lightdash/common';
+import { OrganizationMemberRole } from '@lightdash/common';
 import { Box, Button, Group, Tooltip } from '@mantine/core';
 import { IconLogout } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
 import { LeaveOrganizationModal } from './LeaveOrganizationModal';
@@ -14,18 +13,11 @@ export const LeaveOrganizationPanel: FC = () => {
     const { isInitialLoading: isOrganizationLoading, data: organization } =
         useOrganization();
 
-    const { data: leaveOrganizationFlag } = useServerFeatureFlag(
-        FeatureFlags.LeaveOrganization,
-    );
-    const isLeaveOrganizationEnabled = leaveOrganizationFlag?.enabled === true;
-
     const isAdmin = user.data?.role === OrganizationMemberRole.ADMIN;
 
     // Only admins can list org users — non-admins skip this query.
     const { data: orgUsers, isInitialLoading: isOrgUsersLoading } =
-        useOrganizationUsers({
-            enabled: isAdmin && isLeaveOrganizationEnabled,
-        });
+        useOrganizationUsers({ enabled: isAdmin });
 
     const [showModal, setShowModal] = useState(false);
 
@@ -39,7 +31,6 @@ export const LeaveOrganizationPanel: FC = () => {
         );
     }, [isAdmin, orgUsers, user.data?.userUuid]);
 
-    if (!isLeaveOrganizationEnabled) return null;
     if (isOrganizationLoading || !organization || !user.data) return null;
     if (isAdmin && isOrgUsersLoading) return null;
 

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -60,7 +60,6 @@ export type SettingsContext = {
     organization: Organization | undefined;
     project: Project | undefined;
     showImpersonationPanel: boolean | undefined;
-    isLeaveOrganizationEnabled: boolean;
     isCustomRolesEnabled: boolean | undefined;
     isProLimitsEnabled: boolean;
     isOrganizationRoadmapEnabled: boolean;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -58,11 +58,6 @@ export const useSettingsContext = (): SettingsContext => {
         isUserImpersonationEnabled?.enabled &&
         user?.ability?.can('update', 'Organization');
 
-    const { data: leaveOrganizationFlag } = useServerFeatureFlag(
-        FeatureFlags.LeaveOrganization,
-    );
-    const isLeaveOrganizationEnabled = leaveOrganizationFlag?.enabled === true;
-
     const { data: customRolesFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.CustomRoles,
     );
@@ -186,7 +181,6 @@ export const useSettingsContext = (): SettingsContext => {
         organization,
         project,
         showImpersonationPanel,
-        isLeaveOrganizationEnabled,
         isCustomRolesEnabled,
         isProLimitsEnabled,
         isOrganizationRoadmapEnabled,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -322,7 +322,7 @@ const Settings: FC = () => {
                         </SettingsGridCard>
 
                         <SettingsGridCard>
-                            <div>
+                            <Box>
                                 <Title order={5}>Danger zone</Title>
                                 <Text c="ldGray.6" fz="xs">
                                     {
@@ -335,7 +335,7 @@ const Settings: FC = () => {
                                         'Deleting the organization removes the whole workspace and all its content, including users. '}
                                     These actions are not reversible.
                                 </Text>
-                            </div>
+                            </Box>
                             <Stack gap="sm" align="flex-end">
                                 <LeaveOrganizationPanel />
                                 {user.ability?.can(

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -161,7 +161,6 @@ const Settings: FC = () => {
         hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading,
         showImpersonationPanel,
-        isLeaveOrganizationEnabled,
         isCustomRolesEnabled,
         isProLimitsEnabled,
         isOrganizationRoadmapEnabled,
@@ -200,20 +199,17 @@ const Settings: FC = () => {
                             <ProfilePanel />
                         </SettingsGridCard>
                         {health?.hasGithub && <GithubUserSettingsPanel />}
-                        {isLeaveOrganizationEnabled && (
-                            <SettingsGridCard>
-                                <Box>
-                                    <Title order={5}>Danger zone</Title>
-                                    <Text c="ldGray.6" fz="xs">
-                                        Leave the organization to remove
-                                        yourself from it (you cannot leave if
-                                        you are the only admin). This action is
-                                        not reversible.
-                                    </Text>
-                                </Box>
-                                <LeaveOrganizationPanel />
-                            </SettingsGridCard>
-                        )}
+                        <SettingsGridCard>
+                            <Box>
+                                <Title order={5}>Danger zone</Title>
+                                <Text c="ldGray.6" fz="xs">
+                                    Leave the organization to remove yourself
+                                    from it (you cannot leave if you are the
+                                    only admin). This action is not reversible.
+                                </Text>
+                            </Box>
+                            <LeaveOrganizationPanel />
+                        </SettingsGridCard>
                     </SettingsPage>
                 ),
             },
@@ -325,33 +321,29 @@ const Settings: FC = () => {
                             <SupportImpersonationPanel />
                         </SettingsGridCard>
 
-                        {(isLeaveOrganizationEnabled ||
-                            user.ability?.can('delete', 'Organization')) && (
-                            <SettingsGridCard>
-                                <div>
-                                    <Title order={5}>Danger zone</Title>
-                                    <Text c="ldGray.6" fz="xs">
-                                        {isLeaveOrganizationEnabled &&
-                                            'Leave the organization to remove yourself from it (you cannot leave if you are the only admin). '}
-                                        {user.ability?.can(
-                                            'delete',
-                                            'Organization',
-                                        ) &&
-                                            'Deleting the organization removes the whole workspace and all its content, including users. '}
-                                        These actions are not reversible.
-                                    </Text>
-                                </div>
-                                <Stack gap="sm" align="flex-end">
-                                    {isLeaveOrganizationEnabled && (
-                                        <LeaveOrganizationPanel />
-                                    )}
+                        <SettingsGridCard>
+                            <div>
+                                <Title order={5}>Danger zone</Title>
+                                <Text c="ldGray.6" fz="xs">
+                                    {
+                                        'Leave the organization to remove yourself from it (you cannot leave if you are the only admin). '
+                                    }
                                     {user.ability?.can(
                                         'delete',
                                         'Organization',
-                                    ) && <DeleteOrganizationPanel />}
-                                </Stack>
-                            </SettingsGridCard>
-                        )}
+                                    ) &&
+                                        'Deleting the organization removes the whole workspace and all its content, including users. '}
+                                    These actions are not reversible.
+                                </Text>
+                            </div>
+                            <Stack gap="sm" align="flex-end">
+                                <LeaveOrganizationPanel />
+                                {user.ability?.can(
+                                    'delete',
+                                    'Organization',
+                                ) && <DeleteOrganizationPanel />}
+                            </Stack>
+                        </SettingsGridCard>
                     </SettingsPage>
                 ),
             });
@@ -785,7 +777,6 @@ const Settings: FC = () => {
         isOrganizationRoadmapEnabled,
         isSsoOrganizationSettingsEnabled,
         isEmailWhitelabelEnabled,
-        isLeaveOrganizationEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
         canManageOrgAiAgent,


### PR DESCRIPTION
## Summary

- Remove the `leave-organization` feature flag.
- Show the leave action on every instance.
- Keep the last-admin safeguard and add service coverage.

The feature becomes available on instances where it was previously off.

The flag was added in #22915 and is now retired after rollout.

## Verification

- The focused UserService tests pass.
- The common, backend, and frontend typechecks pass.
- The common and frontend package tests pass.
- The touched-path lint checks pass.

One backend content-as-code contract test fails on `origin/main` independently of this change.

Linear: SPK-1224
