### PR TITLE
fix: set the viewport on the OAuth consent pages

### DIFF
--- a/packages/common/src/utils/oauth.test.ts
+++ b/packages/common/src/utils/oauth.test.ts
@@ -1,0 +1,46 @@
+import {
+    generateOAuthAuthorizePage,
+    generateOAuthSuccessResponse,
+    parseScopeString,
+} from './oauth';
+
+const VIEWPORT_META =
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />';
+
+const authorizePage = () =>
+    generateOAuthAuthorizePage({
+        action: '/api/v1/oauth/authorize',
+        client_id: 'test-client',
+        client_name: 'Test Client',
+        scope: 'read',
+        scopes: parseScopeString('read'),
+        user: {
+            firstName: 'Jane',
+            lastName: 'Doe',
+            email: 'jane@example.com',
+            organizationName: 'Example',
+        },
+        loginUrl: '/login',
+        hiddenInputs: [],
+    });
+
+describe('OAuth page templates', () => {
+    it('declares the viewport on the authorize page so it renders at 1:1 on mobile', () => {
+        expect(authorizePage()).toContain(VIEWPORT_META);
+    });
+
+    it('declares the viewport on the response page', () => {
+        expect(generateOAuthSuccessResponse('Authorized', ['Done'])).toContain(
+            VIEWPORT_META,
+        );
+    });
+
+    it('sizes the card with border-box so it cannot overflow a narrow screen', () => {
+        const containerRule = authorizePage().match(
+            /\.container \{([^}]*)\}/,
+        )?.[1];
+        expect(containerRule).toBeDefined();
+        expect(containerRule).toContain('box-sizing: border-box;');
+        expect(containerRule).toContain('width: 100%;');
+    });
+});

--- a/packages/common/src/utils/oauth.ts
+++ b/packages/common/src/utils/oauth.ts
@@ -5,7 +5,8 @@ export const oauthPageStyles = `
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Open Sans', 'Helvetica Neue', sans-serif;
         background-color: #f8fafc;
         margin: 0;
-        padding: 0;
+        padding: 20px;
+        box-sizing: border-box;
         min-height: 100vh;
         display: flex;
         align-items: center;
@@ -19,8 +20,10 @@ export const oauthPageStyles = `
         border: 1px solid #e9ecef;
         box-shadow: 0px 1px 2px 0px rgba(10, 13, 18, 0.05);
         padding: 24px;
-        max-width: 400px;
-        width: 90%;
+        margin: 0;
+        box-sizing: border-box;
+        max-width: 450px;
+        width: 100%;
         text-align: center;
     }
     .logo {
@@ -82,6 +85,7 @@ const LIGHTDASH_LOGO_SVG = `
 const OAUTH_RESPONSE_TEMPLATE = `
 <html>
     <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <style>{{{styles}}}</style>
     </head>
     <body>
@@ -105,6 +109,7 @@ const OAUTH_RESPONSE_TEMPLATE = `
 const OAUTH_AUTHORIZE_TEMPLATE = `
 <html>
     <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Authorize Application</title>
         <style>
             {{{styles}}}


### PR DESCRIPTION
Signing in to Lightdash from a phone shows the "Authorize Application" screen shrunk to roughly 40% of the screen. The text is too small to read and the buttons are hard to hit.

## Cause

The consent screen is not part of the SPA. The backend renders it from a Handlebars template in `packages/common/src/utils/oauth.ts`, so it never gets the `<head>` from `packages/frontend/index.html`. Neither OAuth template declared a viewport, and a mobile browser that finds no viewport meta assumes a 980px layout and scales the page down to fit the screen. On a 393px screen that is a scale factor of 0.40.

## Change

- Add `<meta name="viewport" content="width=device-width, initial-scale=1" />` to both OAuth page templates.
- Size the card with `box-sizing: border-box`. The card used `width: 90%` with 24px of padding outside that width, which overflowed a narrow screen by 10.7px once the viewport was correct. The `.stack` wrapper shrink-wraps the card, so a percentage width also fed back on itself. `width: 100%` with `max-width: 450px` gives the same rendered width without either problem.
- Clear the default browser margin on the card. The authorize card is a `<form>`, which picks up `margin-block-end: 1em` from the user agent stylesheet. At the page's 14px font size that is 14px, and it pushed the card 14px above centre.

## Verification

Both pages were rendered through the exported helpers and measured in Chrome under iPhone emulation (393x852, `isMobile`) and at 1440x900.

| | before | after |
|---|---|---|
| Layout viewport on a 393px screen | 980px | 393px |
| Page scale | 0.40 | 1.00 |
| Horizontal overflow | 10.7px | 0px |
| Card offset from centre | 14px high | 0px |
| Card width on desktop | 450px | 450px |

The desktop card keeps its width exactly. The only other change is the success/response card, which is 222px wide instead of 250px on desktop. Its height is unchanged, so no text re-wraps.

Added `oauth.test.ts`, which asserts both templates carry the viewport meta and that the card rule keeps `border-box`. Both assertions were checked by mutation: removing the meta fails two tests, and removing `box-sizing` from the card rule alone fails one.

Typecheck, lint, format and tests pass.

## Follow-up, not in this PR

The action buttons are 34px tall and "Switch account" is 17px, below the 44px minimum for touch targets. Worth a separate change.

Linear: SPK-1220
