### PR TITLE
fix(tests): cover the Explore externalSource field for virtual views

### DIFF
--- a/packages/backend/src/contentAsCode/fieldCoverage/virtual_view.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/virtual_view.test.ts
@@ -9,6 +9,7 @@ describeContentAsCodeSchemaContract({
         'baseTable',
         'caseSensitive',
         'databricksCompute',
+        'externalSource',
         'granularityLabels',
         'groupLabel',
         'groups',


### PR DESCRIPTION
Build & Test fails on every PR based on current main. One test throws:

```
FAIL backend-unit-tests src/contentAsCode/fieldCoverage/virtual_view.test.ts
  > virtual_view content-as-code schema contract > classifies every model and document field
Error: [content-as-code:virtual_view] Explore has new fields not covered by VirtualViewAsCode:
  - externalSource
```

Confirmed on two unrelated PRs, so this is a main-side break rather than any one change.

## Cause

The external sources work added `externalSource?: ExternalSourceRef` to `Explore`. `virtual_view.test.ts` is a coverage contract: every field on `Explore` must either appear in `VirtualViewAsCode` or be listed in `skippedModelFields`. The new field is in neither.

It did not fail on the change that added the field because tests are selected per PR. A change that does not touch `contentAsCode` paths never runs this test, so the break only surfaces on later, unrelated PRs.

## Why skip rather than cover

`ExternalSourceRef` is `{ sourceUuid, tableUuid, sourceType }`, so it holds instance-scoped uuids recording where an explore came from. Code documents are promoted between projects and instances, and those uuids do not travel. `VirtualViewAsCode` is deliberately small, holding slug, name, sql, columns and parameters, and every other server-derived field on `Explore` is already skipped.

## Verification

Locally, on this branch: the previously failing test passes, and all 14 tests in `src/contentAsCode/` pass. Removing the one added line reproduces the original failure, so the line is what fixes it. Format and lint pass on the changed file.

## Follow-up, separate

Worth deciding whether a virtual view backed by an external source should be exported at all, or reported in the `skipped` array the export already returns for malformed views. That is a product decision and not needed to unblock CI. Captured on the ticket.

Linear: SPK-1229
