### PR TITLE
fix(release-safety): warn when migration metadata is incomplete

### DIFF
--- a/scripts/release-safety-migrations.test.ts
+++ b/scripts/release-safety-migrations.test.ts
@@ -80,6 +80,7 @@ test('analyzer reads core tables and forward heaviness only', () => {
             },
         },
         complete: true,
+        incompleteReasons: [],
     });
 });
 
@@ -117,6 +118,39 @@ test('dynamic raw SQL degrades unknown dimensions and completeness', () => {
         scansTable: 'unknown',
     });
     assert.strictEqual(result.complete, false);
+    assert.deepStrictEqual(result.incompleteReasons, ['parse-failure']);
+});
+
+test('column alter reports that rewrite safety needs a declaration', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000017_alter.ts',
+        `
+            export async function up(knex) {
+                await knex.schema.alterTable('users', (table) => {
+                    table.string('name', 100).alter();
+                });
+            }
+        `,
+    );
+    assert.strictEqual(result.complete, false);
+    assert.deepStrictEqual(result.incompleteReasons, ['column-alter']);
+});
+
+test('dynamic table arguments report an unresolved table name', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260810000018_table.ts',
+        `
+            export async function up(knex) {
+                await knex.schema.createTable(getTableName(), (table) => {
+                    table.uuid('user_uuid');
+                });
+            }
+        `,
+    );
+    assert.strictEqual(result.complete, false);
+    assert.deepStrictEqual(result.incompleteReasons, [
+        'unresolved-table-name',
+    ]);
 });
 
 test('raw SQL built from a local constant reads as fully as a literal', () => {

--- a/scripts/release-safety-migrations.test.ts
+++ b/scripts/release-safety-migrations.test.ts
@@ -1,6 +1,12 @@
 import * as assert from 'node:assert';
 import { execFileSync } from 'node:child_process';
-import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+    copyFileSync,
+    mkdirSync,
+    mkdtempSync,
+    rmSync,
+    writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -400,12 +406,71 @@ test('IO reads the requested ref and represents unreadable paths honestly', () =
     assert.ok(logs.some((message) => message.includes('could not read HEAD:')));
 });
 
+test('IO accepts safe and breaking classifications for incomplete metadata', () => {
+    for (const kind of ['safe', 'breaking'] as const) {
+        const directory = mkdtempSync(
+            join(tmpdir(), 'release-safety-classified-'),
+        );
+        const migration = `${core}/20260810000019_classified_${kind}.ts`;
+        try {
+            mkdirSync(join(directory, core), { recursive: true });
+            writeFileSync(
+                join(directory, migration),
+                `
+                    export const classification = { kind: '${kind}', reason: 'The author classified the type widening.' };
+                    export async function up(knex) {
+                        await knex.schema.alterTable('users', (table) => {
+                            table.string('name', 100).alter();
+                        });
+                    }
+                `,
+            );
+            execFileSync('git', ['init'], { cwd: directory });
+            execFileSync('git', ['add', migration], { cwd: directory });
+            execFileSync(
+                'git',
+                [
+                    '-c',
+                    'user.name=Release Safety Test',
+                    '-c',
+                    'user.email=release-safety@example.com',
+                    'commit',
+                    '-m',
+                    'test fixture',
+                ],
+                { cwd: directory },
+            );
+            const previousDirectory = process.cwd();
+            process.chdir(directory);
+            try {
+                const result = readMigrationMetadata({
+                    paths: [migration],
+                    ref: 'HEAD',
+                });
+                assert.strictEqual(result.complete, true);
+                assert.strictEqual(
+                    result.migrations[0].heaviness.rewritesTable,
+                    'unknown',
+                );
+            } finally {
+                process.chdir(previousDirectory);
+            }
+        } finally {
+            rmSync(directory, { force: true, recursive: true });
+        }
+    }
+});
+
 test('loads and runs without repository dependency resolution', () => {
     const directory = mkdtempSync(join(tmpdir(), 'release-safety-migration-'));
     try {
         copyFileSync(
             join(process.cwd(), 'scripts/release-safety-migrations.ts'),
             join(directory, 'analyzer.ts'),
+        );
+        copyFileSync(
+            join(process.cwd(), 'scripts/breaking-change-declarations.ts'),
+            join(directory, 'breaking-change-declarations.ts'),
         );
         writeFileSync(
             join(directory, 'run.ts'),

--- a/scripts/release-safety-migrations.ts
+++ b/scripts/release-safety-migrations.ts
@@ -48,7 +48,13 @@ export interface MigrationDetail {
 export interface MigrationSourceAnalysis {
     migration: MigrationDetail;
     complete: boolean;
+    incompleteReasons: MigrationIncompleteReason[];
 }
+
+export type MigrationIncompleteReason =
+    | 'parse-failure'
+    | 'column-alter'
+    | 'unresolved-table-name';
 
 export interface ReadMigrationMetadataOptions {
     paths: string[];
@@ -618,20 +624,27 @@ export function analyzeMigrationSource(
         scansTable: false,
     };
     let complete = tokenized.valid && body !== null;
+    const incompleteReasons = new Set<MigrationIncompleteReason>();
+    if (!complete) incompleteReasons.add('parse-failure');
 
     const mark = (...keys: HeavinessKey[]): void => {
         for (const key of keys) heaviness[key] = true;
     };
-    const markUnknown = (...keys: HeavinessKey[]): void => {
+    const markUnknown = (
+        reason: MigrationIncompleteReason,
+        ...keys: HeavinessKey[]
+    ): void => {
         for (const key of keys) {
             if (heaviness[key] !== true) heaviness[key] = 'unknown';
         }
         complete = false;
+        incompleteReasons.add(reason);
     };
     const addTable = (token: Token | undefined): void => {
         const table = resolveTable(token, constants);
         if (table === null) {
             complete = false;
+            incompleteReasons.add('unresolved-table-name');
         } else {
             tables.add(table.split('.').at(-1) ?? table);
         }
@@ -727,7 +740,9 @@ export function analyzeMigrationSource(
             ) {
                 mark('locksTable');
             }
-            if (token.value === 'alter') markUnknown('rewritesTable');
+            if (token.value === 'alter') {
+                markUnknown('column-alter', 'rewritesTable');
+            }
 
             if (token.value === 'raw') {
                 // The argument is only the whole argument when the call ends
@@ -739,7 +754,12 @@ export function analyzeMigrationSource(
                     ? resolveSqlArgument(argument, sqlConstants)
                     : null;
                 if (sql === null) {
-                    markUnknown('locksTable', 'rewritesTable', 'scansTable');
+                    markUnknown(
+                        'parse-failure',
+                        'locksTable',
+                        'rewritesTable',
+                        'scansTable',
+                    );
                     continue;
                 }
                 for (const table of rawSqlTables(sql)) tables.add(table);
@@ -777,6 +797,7 @@ export function analyzeMigrationSource(
 
     if (!tokenized.valid) {
         complete = false;
+        incompleteReasons.add('parse-failure');
         for (const key of Object.keys(heaviness) as HeavinessKey[]) {
             if (heaviness[key] !== true) heaviness[key] = 'unknown';
         }
@@ -790,6 +811,7 @@ export function analyzeMigrationSource(
             heaviness,
         },
         complete,
+        incompleteReasons: [...incompleteReasons],
     };
 }
 

--- a/scripts/release-safety-migrations.ts
+++ b/scripts/release-safety-migrations.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { parseChangeDeclarations } from './breaking-change-declarations';
 
 /** Knex migration files are timestamped: YYYYMMDDHHMMSS_description.ts */
 const MIGRATION_FILENAME_RE = /^\d{14}_.+\.(ts|js)$/;
@@ -851,7 +852,11 @@ export function readMigrationMetadata(
 
         const analysis = analyzeMigrationSource(migrationPath, source);
         migrations.push(analysis.migration);
-        if (!analysis.complete) {
+        const classification = parseChangeDeclarations(
+            source,
+            migrationPath,
+        ).classification;
+        if (!analysis.complete && classification === null) {
             log(`metadata extraction incomplete for ${options.ref}:${migrationPath}`);
             complete = false;
         }

--- a/scripts/release-safety-pr-gate.test.ts
+++ b/scripts/release-safety-pr-gate.test.ts
@@ -8,6 +8,7 @@ import {
     detectLegacyInlineBreakingDeclarations,
     evaluateReleaseSafetyGate,
     ReleaseSafetyGateMarker,
+    validateGitSha,
 } from './release-safety-pr-gate';
 
 let passed = 0;
@@ -68,6 +69,14 @@ function evaluate(
 
 const migrationPath =
     'packages/backend/src/database/migrations/20260820120000_example.ts';
+
+test('git ref validation rejects option-like input', () => {
+    assert.throws(
+        () => validateGitSha('--not-a-ref'),
+        /full 40-character lowercase hex SHA/,
+    );
+    assert.strictEqual(validateGitSha('a'.repeat(40)), 'a'.repeat(40));
+});
 
 test('dynamic SQL reports the parse failure remedy', () => {
     const diagnostics = detectIncompleteMigrationMetadata([

--- a/scripts/release-safety-pr-gate.test.ts
+++ b/scripts/release-safety-pr-gate.test.ts
@@ -4,6 +4,7 @@ import type {
     BreakingChangeDeclarationDiff,
 } from './release-safety-declarations';
 import {
+    detectIncompleteMigrationMetadata,
     detectLegacyInlineBreakingDeclarations,
     evaluateReleaseSafetyGate,
     ReleaseSafetyGateMarker,
@@ -52,14 +53,110 @@ function evaluate(
     inlineDeclarationDiagnostics: ReturnType<
         typeof detectLegacyInlineBreakingDeclarations
     > = [],
+    migrationDiagnostics: ReturnType<
+        typeof detectIncompleteMigrationMetadata
+    > = [],
 ) {
     return evaluateReleaseSafetyGate({
         marker: releaseMarker,
         markerPath,
         declarationChanges,
         inlineDeclarationDiagnostics,
+        migrationDiagnostics,
     });
 }
+
+const migrationPath =
+    'packages/backend/src/database/migrations/20260820120000_example.ts';
+
+test('dynamic SQL reports the parse failure remedy', () => {
+    const diagnostics = detectIncompleteMigrationMetadata([
+        {
+            file: migrationPath,
+            source: `export async function up(knex) { await knex.raw(buildSql()); }`,
+        },
+    ]);
+    assert.ok(
+        diagnostics.some(({ message }) =>
+            message.includes('write the name inline, or use a module constant'),
+        ),
+    );
+    assert.deepStrictEqual(
+        evaluate(marker(false, false), changes(), [], diagnostics),
+        diagnostics,
+    );
+});
+
+test('column alter reports the rewrite declaration remedy', () => {
+    const diagnostics = detectIncompleteMigrationMetadata([
+        {
+            file: migrationPath,
+            source: `export async function up(knex) {
+                await knex.schema.alterTable('users', (table) => {
+                    table.string('name', 100).alter();
+                });
+            }`,
+        },
+    ]);
+    assert.ok(
+        diagnostics.some(({ message }) =>
+            message.includes('declare whether this rewrites the table'),
+        ),
+    );
+    assert.ok(
+        diagnostics.every(
+            ({ message }) => !message.includes('write the name inline'),
+        ),
+    );
+});
+
+test('dynamic table argument reports the table-name remedy', () => {
+    const diagnostics = detectIncompleteMigrationMetadata([
+        {
+            file: migrationPath,
+            source: `export async function up(knex) {
+                await knex.schema.createTable(getTableName(), () => undefined);
+            }`,
+        },
+    ]);
+    assert.ok(
+        diagnostics.some(({ message }) =>
+            message.includes(
+                'name the table with a literal or a module constant',
+            ),
+        ),
+    );
+});
+
+test('an explicit migration classification satisfies incomplete metadata', () => {
+    const diagnostics = detectIncompleteMigrationMetadata([
+        {
+            file: migrationPath,
+            source: `
+                export const classification = { kind: 'safe', reason: 'The type widening does not rewrite existing rows.' };
+                export async function up(knex) {
+                    await knex.schema.alterTable('users', (table) => {
+                        table.string('name', 100).alter();
+                    });
+                }
+            `,
+        },
+    ]);
+    assert.deepStrictEqual(diagnostics, []);
+});
+
+test('a matching migration declaration satisfies incomplete metadata', () => {
+    const diagnostics = detectIncompleteMigrationMetadata(
+        [
+            {
+                file: migrationPath,
+                source: `export async function up(knex) { await knex.raw(buildSql()); }`,
+            },
+        ],
+        [{ ...declaration, migration: migrationPath }],
+    );
+    assert.deepStrictEqual(diagnostics, []);
+});
 
 test('breaking REST without a new declaration fails', () => {
     const diagnostics = evaluate(marker(true, false));

--- a/scripts/release-safety-pr-gate.ts
+++ b/scripts/release-safety-pr-gate.ts
@@ -10,8 +10,15 @@ import {
     collectBreakingChangeDeclarationsBetweenRefs,
     DEFAULT_DECLARATIONS_PATH,
 } from './release-safety-declarations';
-import type { BreakingChangeDeclarationDiff } from './release-safety-declarations';
-import { isMigrationPath } from './release-safety-migrations';
+import type {
+    BreakingChangeDeclaration,
+    BreakingChangeDeclarationDiff,
+} from './release-safety-declarations';
+import {
+    analyzeMigrationSource,
+    isMigrationPath,
+} from './release-safety-migrations';
+import type { MigrationIncompleteReason } from './release-safety-migrations';
 
 interface ApiSurface {
     checked: boolean;
@@ -38,6 +45,7 @@ export interface EvaluateReleaseSafetyGateInput {
     markerPath: string;
     declarationChanges: BreakingChangeDeclarationDiff;
     inlineDeclarationDiagnostics?: readonly GateDiagnostic[];
+    migrationDiagnostics?: readonly GateDiagnostic[];
 }
 
 export interface ChangedSourceFile {
@@ -82,6 +90,51 @@ export function detectLegacyInlineBreakingDeclarations(
     return diagnostics;
 }
 
+const INCOMPLETE_MIGRATION_MESSAGES: Record<
+    MigrationIncompleteReason,
+    string
+> = {
+    'parse-failure':
+        'release-safety cannot read this migration; write the name inline, or use a module constant',
+    'column-alter':
+        'release-safety cannot judge a column .alter(); declare whether this rewrites the table with export const classification with kind and reason',
+    'unresolved-table-name':
+        'release-safety cannot resolve the table name; name the table with a literal or a module constant',
+};
+
+export function detectIncompleteMigrationMetadata(
+    sources: readonly ChangedSourceFile[],
+    migrationDeclarations: readonly BreakingChangeDeclaration[] = [],
+): GateDiagnostic[] {
+    const declaredMigrations = new Set(
+        migrationDeclarations.flatMap((declaration) =>
+            declaration.migration === undefined ? [] : [declaration.migration],
+        ),
+    );
+    const diagnostics: GateDiagnostic[] = [];
+    for (const source of sources) {
+        if (!isMigrationPath(source.file)) continue;
+        const analysis = analyzeMigrationSource(source.file, source.source);
+        if (analysis.complete) continue;
+        const classification = parseChangeDeclarations(
+            source.source,
+            source.file,
+        ).classification;
+        if (classification !== null || declaredMigrations.has(source.file)) {
+            continue;
+        }
+        for (const reason of analysis.incompleteReasons) {
+            diagnostics.push({
+                level: 'error',
+                file: source.file,
+                line: 1,
+                message: INCOMPLETE_MIGRATION_MESSAGES[reason],
+            });
+        }
+    }
+    return diagnostics;
+}
+
 export function evaluateReleaseSafetyGate(
     input: EvaluateReleaseSafetyGateInput,
 ): GateDiagnostic[] {
@@ -93,6 +146,7 @@ export function evaluateReleaseSafetyGate(
             message: diagnostic.message,
         }));
     diagnostics.push(...(input.inlineDeclarationDiagnostics ?? []));
+    diagnostics.push(...(input.migrationDiagnostics ?? []));
     const breakingSurfaces = [
         input.marker.api.rest.checked && input.marker.api.rest.breaking === true
             ? 'REST'
@@ -195,6 +249,32 @@ function changedSourceFiles(baseSha: string): ChangedSourceFile[] {
     }));
 }
 
+function changedMigrationFiles(baseSha: string): ChangedSourceFile[] {
+    const paths = execFileSync(
+        'git',
+        [
+            'diff',
+            '--name-only',
+            '--diff-filter=ACMR',
+            '-z',
+            baseSha,
+            'HEAD',
+            '--',
+            'packages/backend/src/database/migrations',
+            'packages/backend/src/ee/database/migrations',
+        ],
+        { encoding: 'utf8' },
+    )
+        .split('\0')
+        .filter(Boolean)
+        .filter(isMigrationPath)
+        .filter((file) => fs.existsSync(file));
+    return paths.map((file) => ({
+        file,
+        source: fs.readFileSync(file, 'utf8'),
+    }));
+}
+
 function main(): void {
     const baseSha = argument('base-sha');
     const markerPath = argument('marker');
@@ -203,15 +283,20 @@ function main(): void {
     const marker = JSON.parse(
         fs.readFileSync(markerPath, 'utf8'),
     ) as ReleaseSafetyGateMarker;
+    const declarationChanges = collectBreakingChangeDeclarationsBetweenRefs(
+        baseSha,
+        'HEAD',
+    );
     const diagnostics = evaluateReleaseSafetyGate({
         marker,
         markerPath,
-        declarationChanges: collectBreakingChangeDeclarationsBetweenRefs(
-            baseSha,
-            'HEAD',
-        ),
+        declarationChanges,
         inlineDeclarationDiagnostics: detectLegacyInlineBreakingDeclarations(
             changedSourceFiles(baseSha),
+        ),
+        migrationDiagnostics: detectIncompleteMigrationMetadata(
+            changedMigrationFiles(baseSha),
+            declarationChanges.added,
         ),
     });
     diagnostics.forEach(emit);

--- a/scripts/release-safety-pr-gate.ts
+++ b/scripts/release-safety-pr-gate.ts
@@ -205,6 +205,13 @@ function argument(name: string): string | undefined {
     return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
+export function validateGitSha(ref: string): string {
+    if (!/^[0-9a-f]{40}$/.test(ref)) {
+        throw new Error('git ref must be a full 40-character lowercase hex SHA');
+    }
+    return ref;
+}
+
 function escapeCommandData(value: string): string {
     return value
         .replaceAll('%', '%25')
@@ -276,10 +283,11 @@ function changedMigrationFiles(baseSha: string): ChangedSourceFile[] {
 }
 
 function main(): void {
-    const baseSha = argument('base-sha');
+    const baseShaArgument = argument('base-sha');
     const markerPath = argument('marker');
-    if (!baseSha) throw new Error('--base-sha is required');
+    if (!baseShaArgument) throw new Error('--base-sha is required');
     if (!markerPath) throw new Error('--marker is required');
+    const baseSha = validateGitSha(baseShaArgument);
     const marker = JSON.parse(
         fs.readFileSync(markerPath, 'utf8'),
     ) as ReleaseSafetyGateMarker;


### PR DESCRIPTION
## What breaks

The pull request check does not tell migration authors when release safety cannot judge a migration. An unreadable migration can make a later release verdict unknown and hold upgrades.

## What changed

- Check only migrations that the pull request adds or changes.
- Report specific steps for unreadable SQL, column `.alter()`, and unresolved table names.
- Reuse inline classifications and matching migration declarations.
- Keep the release generator decision code unchanged.

## Behaviour change

A valid migration `classification` now makes otherwise incomplete migration metadata count as complete. This affects release verdicts and therefore what can auto-merge: a downstream safe verdict can now allow an upgrade instead of incomplete metadata forcing `unknown`.

The migration author self-declaration is now load-bearing for upgrades to production instances. A `breaking` classification also cures incompleteness, but the pull request gate requires a matching registry declaration. That declaration forces `rollingUpdateSafe: false`, so the upgrade does not auto-merge as rolling-safe.

## Tests

- `npm run test:release-safety`
- Confirmed the new cases fail on `origin/main`.
- Confirmed both `safe` and `breaking` classifications cure incomplete metadata.

Linear: SPK-1227