### PR TITLE
feat(release-safety): prove compatible migration operations safe

### DIFF
--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -230,6 +230,23 @@ test('unsupported and mixed migration operations stay unknown', () => {
     }
 });
 
+test('a newly added operation cannot silently become safe at runtime', () => {
+    const input = {
+        ...base,
+        migrations: migration,
+        migrationDetails,
+        migrationOperations: ['future-operation' as MigrationOperation],
+        migrationMetadataComplete: true,
+        declarationMetadataComplete: true,
+        ...checkedSurfaces,
+    };
+    assert.strictEqual(isDeterministicallyRollingUpdateSafe(input), false);
+    assert.strictEqual(
+        buildMarker(input).compatibility.rollingUpdateSafe,
+        'unknown',
+    );
+});
+
 test('incomplete migration metadata blocks deterministic safety', () => {
     const input = {
         ...base,

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -3,10 +3,13 @@ import {
     buildMarker,
     detectMigrations,
     GitChange,
+    isAiReviewEligible,
+    isDeterministicallyRollingUpdateSafe,
     MARKER_SCHEMA_VERSION,
     ownExpandContractFloor,
     parseArgs,
 } from './gen-release-safety';
+import type { MigrationOperation } from './release-safety-migrations';
 
 let passed = 0;
 const failures: string[] = [];
@@ -77,6 +80,13 @@ const migrationDetails = [
             scansTable: false,
         },
     },
+];
+const compatibleOperations: MigrationOperation[] = [
+    'create-index-concurrently',
+    'drop-index-concurrently-if-exists',
+    'set-statement-timeout',
+    'reset-statement-timeout',
+    'select-invalid-index',
 ];
 
 test('parses an explicit generated MCP snapshot pair', () => {
@@ -177,6 +187,163 @@ test('migration release stays unknown without a definitive review', () => {
     assert.deepStrictEqual(marker.migrations.files, migrationDetails);
     assert.strictEqual(marker.migrations.coreCount, 1);
     assert.strictEqual(marker.migrations.eeCount, 0);
+});
+
+test('provably compatible migration operations are deterministically safe', () => {
+    const input = {
+        ...base,
+        migrations: migration,
+        migrationDetails,
+        migrationOperations: compatibleOperations,
+        migrationMetadataComplete: true,
+        declarationMetadataComplete: true,
+        ...checkedSurfaces,
+    };
+    assert.strictEqual(isDeterministicallyRollingUpdateSafe(input), true);
+    assert.strictEqual(
+        buildMarker(input).compatibility.rollingUpdateSafe,
+        true,
+    );
+});
+
+test('unsupported and mixed migration operations stay unknown', () => {
+    for (const migrationOperations of [
+        ['create-unique-index-concurrently'] as MigrationOperation[],
+        ['create-index-concurrently', 'unknown'] as MigrationOperation[],
+        [] as MigrationOperation[],
+    ]) {
+        const input = {
+            ...base,
+            migrations: migration,
+            migrationDetails,
+            migrationOperations,
+            ...checkedSurfaces,
+        };
+        assert.strictEqual(
+            isDeterministicallyRollingUpdateSafe(input),
+            false,
+        );
+        assert.strictEqual(
+            buildMarker(input).compatibility.rollingUpdateSafe,
+            'unknown',
+        );
+    }
+});
+
+test('incomplete migration metadata blocks deterministic safety', () => {
+    const input = {
+        ...base,
+        migrations: migration,
+        migrationDetails,
+        migrationOperations: compatibleOperations,
+        migrationMetadataComplete: false,
+        ...checkedSurfaces,
+    };
+    assert.strictEqual(isDeterministicallyRollingUpdateSafe(input), false);
+    assert.strictEqual(
+        buildMarker(input).compatibility.rollingUpdateSafe,
+        'unknown',
+    );
+});
+
+test('existing deterministic false verdicts cannot be loosened', () => {
+    const inputs = [
+        {
+            sqlLint: {
+                ran: true,
+                breaking: true,
+                findings: ['unsupported SQL'],
+            },
+        },
+        {
+            config: {
+                checked: true,
+                breaking: true as const,
+                changes: [],
+            },
+        },
+        {
+            declaredBreaks: [
+                {
+                    id: 'old-code-breaks',
+                    reason: 'Old code cannot use the new schema.',
+                    requiredStop: false,
+                },
+            ],
+        },
+    ];
+    for (const override of inputs) {
+        const input = {
+            ...base,
+            migrations: migration,
+            migrationDetails,
+            migrationOperations: compatibleOperations,
+            migrationMetadataComplete: true,
+            declarationMetadataComplete: true,
+            ...checkedSurfaces,
+            ...override,
+        };
+        assert.strictEqual(isDeterministicallyRollingUpdateSafe(input), false);
+        assert.strictEqual(
+            buildMarker(input).compatibility.rollingUpdateSafe,
+            false,
+        );
+    }
+});
+
+test('a definitive AI false overrides deterministic migration safety', () => {
+    const marker = buildMarker({
+        ...base,
+        migrations: migration,
+        migrationDetails,
+        migrationOperations: compatibleOperations,
+        migrationMetadataComplete: true,
+        declarationMetadataComplete: true,
+        ...checkedSurfaces,
+        aiReview: {
+            rollingUpdateSafe: false,
+            recommendedStrategy: 'Recreate',
+            summary: 'unsafe',
+        },
+    });
+    assert.strictEqual(marker.compatibility.rollingUpdateSafe, false);
+});
+
+test('AI eligibility skips only a proven-safe migration-only review', () => {
+    const safeMigrationInput = {
+        migrations: migration,
+        migrationOperations: compatibleOperations,
+        migrationMetadataComplete: true,
+        declarationMetadataComplete: true,
+        ...checkedSurfaces,
+    };
+    assert.strictEqual(isAiReviewEligible(safeMigrationInput), false);
+    assert.strictEqual(
+        isAiReviewEligible({
+            ...safeMigrationInput,
+            restApi: {
+                ...checkedSurfaces.restApi,
+                breaking: true,
+                changes: ['removed endpoint'],
+                breakingCount: 1,
+            },
+        }),
+        true,
+    );
+    assert.strictEqual(
+        isAiReviewEligible({
+            ...safeMigrationInput,
+            migrationOperations: ['unknown'],
+        }),
+        true,
+    );
+    assert.strictEqual(
+        isAiReviewEligible({
+            ...safeMigrationInput,
+            migrations: noMigrations,
+        }),
+        false,
+    );
 });
 
 test('definitive AI review can prove a migration safe', () => {
@@ -301,6 +468,11 @@ test('schema v2 omits capabilities, notes, and per-migration transaction data', 
             (marker.migrations.files[0] as unknown as Record<string, unknown>),
         false,
     );
+    assert.strictEqual(
+        'operations' in
+            (marker.migrations as unknown as Record<string, unknown>),
+        false,
+    );
 });
 
 test('carried floor keeps the highest minimum previous version', () => {
@@ -341,6 +513,7 @@ test('ownExpandContractFloor matches the marker floor', () => {
     const marker = buildMarker(input);
     assert.strictEqual(ownExpandContractFloor(input), '1.100.0');
     assert.strictEqual(marker.upgrade.minPreviousVersion, '1.100.0');
+    assert.strictEqual(marker.compatibility.rollingUpdateSafe, true);
 });
 
 if (failures.length > 0) {

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -210,16 +210,17 @@ export interface DeterministicSafetyInput {
     sqlLint?: SqlLintSummary | null;
 }
 
-const DETERMINISTICALLY_SAFE_OPERATIONS: ReadonlySet<MigrationOperation> =
-    new Set([
-        'create-index-concurrently',
-        'drop-index-concurrently-if-exists',
-        'set-statement-timeout',
-        'reset-statement-timeout',
-        'set-lock-timeout',
-        'reset-lock-timeout',
-        'select-invalid-index',
-    ]);
+const DETERMINISTIC_OPERATION_SAFETY = {
+    'create-index-concurrently': true,
+    'create-unique-index-concurrently': false,
+    'drop-index-concurrently-if-exists': true,
+    'set-statement-timeout': true,
+    'reset-statement-timeout': true,
+    'set-lock-timeout': true,
+    'reset-lock-timeout': true,
+    'select-invalid-index': true,
+    unknown: false,
+} satisfies Record<MigrationOperation, boolean>;
 
 export function isDeterministicallyRollingUpdateSafe(
     input: DeterministicSafetyInput,
@@ -238,8 +239,9 @@ export function isDeterministicallyRollingUpdateSafe(
         (input.declaredBreaks?.length ?? 0) === 0 &&
         !(input.sqlLint?.ran && input.sqlLint.breaking) &&
         operations.length > 0 &&
-        operations.every((operation) =>
-            DETERMINISTICALLY_SAFE_OPERATIONS.has(operation),
+        operations.every(
+            (operation) =>
+                DETERMINISTIC_OPERATION_SAFETY[operation] === true,
         )
     );
 }

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -33,7 +33,10 @@ import {
     loadReleaseSafetyIndex,
     writeReleaseSafetyIndex,
 } from './release-safety-index';
-import type { MigrationDetail } from './release-safety-migrations';
+import type {
+    MigrationDetail,
+    MigrationOperation,
+} from './release-safety-migrations';
 import {
     isMigrationPath,
     readMigrationMetadata,
@@ -124,6 +127,7 @@ export interface BuildMarkerInput {
     /** null when migrations could not be determined (e.g. first release / no prev tag) */
     migrations: MigrationsResult | null;
     migrationDetails?: MigrationDetail[];
+    migrationOperations?: MigrationOperation[];
     migrationMetadataComplete?: boolean;
     declarationMetadataComplete?: boolean;
     declaredBreaks?: BreakingChangeDeclaration[];
@@ -192,6 +196,62 @@ export interface SqlLintSummary {
     breaking: boolean;
     /** Pre-rendered finding strings for the marker note. */
     findings: string[];
+}
+
+export interface DeterministicSafetyInput {
+    migrations: MigrationsResult | null;
+    migrationOperations?: readonly MigrationOperation[];
+    migrationMetadataComplete?: boolean;
+    declarationMetadataComplete?: boolean;
+    declaredBreaks?: readonly BreakingChangeDeclaration[];
+    config?: ConfigSurface | null;
+    restApi?: ApiSurface | null;
+    mcpApi?: ApiSurface | null;
+    sqlLint?: SqlLintSummary | null;
+}
+
+const DETERMINISTICALLY_SAFE_OPERATIONS: ReadonlySet<MigrationOperation> =
+    new Set([
+        'create-index-concurrently',
+        'drop-index-concurrently-if-exists',
+        'set-statement-timeout',
+        'reset-statement-timeout',
+        'set-lock-timeout',
+        'reset-lock-timeout',
+        'select-invalid-index',
+    ]);
+
+export function isDeterministicallyRollingUpdateSafe(
+    input: DeterministicSafetyInput,
+): boolean {
+    const operations = input.migrationOperations ?? [];
+    return (
+        input.migrations?.present === true &&
+        input.migrationMetadataComplete === true &&
+        input.declarationMetadataComplete === true &&
+        input.restApi?.checked === true &&
+        input.restApi.breaking === false &&
+        input.mcpApi?.checked === true &&
+        input.mcpApi.breaking === false &&
+        input.config?.checked === true &&
+        input.config.breaking === false &&
+        (input.declaredBreaks?.length ?? 0) === 0 &&
+        !(input.sqlLint?.ran && input.sqlLint.breaking) &&
+        operations.length > 0 &&
+        operations.every((operation) =>
+            DETERMINISTICALLY_SAFE_OPERATIONS.has(operation),
+        )
+    );
+}
+
+export function isAiReviewEligible(input: DeterministicSafetyInput): boolean {
+    const apiBreak =
+        input.restApi?.breaking === true || input.mcpApi?.breaking === true;
+    return (
+        apiBreak ||
+        (input.migrations?.present === true &&
+            !isDeterministicallyRollingUpdateSafe(input))
+    );
 }
 
 /**
@@ -263,9 +323,16 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     );
     const fullyChecked =
         rest.checked && mcp.checked && config.checked && metadataComplete;
+    const deterministicallySafe = isDeterministicallyRollingUpdateSafe(input);
 
     let rollingUpdateSafe: TriState = 'unknown';
-    if (present === false && fullyChecked && !apiBreak && !deterministicBreak) {
+    if (
+        (present === false &&
+            fullyChecked &&
+            !apiBreak &&
+            !deterministicBreak) ||
+        deterministicallySafe
+    ) {
         rollingUpdateSafe = true;
     }
     if (linterFlagged || deterministicBreak) {
@@ -645,20 +712,27 @@ export async function generateReleaseSafety(
 
     // P6: gated AI rolling-update review — the VALIDATION layer over the
     // deterministic detectors. Runs when a key is present AND something was flagged
-    // worth validating: a migration is present (even a linter-clean one — it can
-    // recognise an expand/contract the linter can't), OR a REST/MCP break was
-    // flagged (it decides whether an in-flight frontend/client actually breaks). It
-    // is fed the deterministic breaking lists so it validates exactly what the
-    // detectors found. Any degrade leaves the verdict at the linter floor /
+    // worth validating: a migration is not deterministically proven safe, OR a
+    // REST/MCP break was flagged (it decides whether an in-flight frontend/client
+    // actually breaks). It is fed the deterministic breaking lists so it validates
+    // exactly what the detectors found. Any degrade leaves the verdict at the linter
+    // floor /
     // cautious default and never fails the release.
     const restBreakingChanges =
         restApi?.checked && restApi.breaking === true ? restApi.changes : [];
     const mcpBreakingChanges =
         mcpApi?.checked && mcpApi.breaking === true ? mcpApi.changes : [];
-    const reviewable =
-        migrations?.present === true ||
-        restBreakingChanges.length > 0 ||
-        mcpBreakingChanges.length > 0;
+    const reviewable = isAiReviewEligible({
+        migrations,
+        migrationOperations: migrationMetadata.operations,
+        migrationMetadataComplete: migrationMetadata.complete,
+        declarationMetadataComplete: declarations.diagnostics.length === 0,
+        declaredBreaks: declarations.added,
+        config,
+        restApi,
+        mcpApi,
+        sqlLint,
+    });
     let aiReview: AiReviewSummary | null = null;
     if (wantAiReview && markerEnabled && reviewable && args.lastTag) {
         const apiKey = process.env.ANTHROPIC_API_KEY;
@@ -761,6 +835,7 @@ export async function generateReleaseSafety(
                 : new Date().toISOString()),
         migrations,
         migrationDetails: migrationMetadata.migrations,
+        migrationOperations: migrationMetadata.operations,
         migrationMetadataComplete: migrationMetadata.complete,
         declarationMetadataComplete: declarations.diagnostics.length === 0,
         declaredBreaks: declarations.added,

--- a/scripts/release-safety-migrations.test.ts
+++ b/scripts/release-safety-migrations.test.ts
@@ -85,6 +85,7 @@ test('analyzer reads core tables and forward heaviness only', () => {
                 scansTable: true,
             },
         },
+        operations: ['unknown'],
         complete: true,
         incompleteReasons: [],
     });
@@ -167,7 +168,7 @@ test('raw SQL built from a local constant reads as fully as a literal', () => {
             const IndexName = 'analytics_chart_views_user_uuid_timestamp_idx';
             export async function up(knex) {
                 await knex.raw(\`DROP INDEX CONCURRENTLY IF EXISTS \${IndexName}\`);
-                await knex.raw(
+                await knex.raw<{ rowCount: number }>(
                     \`CREATE INDEX CONCURRENTLY \${IndexName} ON \${TableName} (user_uuid, timestamp)\`,
                 );
             }
@@ -179,7 +180,103 @@ test('raw SQL built from a local constant reads as fully as a literal', () => {
         rewritesTable: false,
         scansTable: true,
     });
+    assert.deepStrictEqual(result.operations, [
+        'create-index-concurrently',
+        'drop-index-concurrently-if-exists',
+    ]);
     assert.strictEqual(result.complete, true);
+});
+
+test('analyzer extracts the compatible index migration ancillary operations', () => {
+    const coreResult = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260820153000_index.ts',
+        `
+            const TableName = 'analytics_chart_views';
+            const IndexName = 'analytics_chart_views_user_uuid_timestamp_index';
+            export async function up(knex) {
+                await knex.raw('SET statement_timeout = 0');
+                await knex.raw(
+                    \`SELECT 1
+                     FROM pg_class
+                     JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+                     WHERE pg_class.relname = ?
+                       AND pg_index.indrelid = ?::regclass
+                       AND NOT pg_index.indisvalid\`,
+                    [IndexName, TableName],
+                );
+                await knex.raw(\`DROP INDEX CONCURRENTLY IF EXISTS \${IndexName}\`);
+                await knex.raw(
+                    \`CREATE INDEX CONCURRENTLY IF NOT EXISTS \${IndexName} ON \${TableName} (user_uuid, timestamp)\`,
+                );
+                await knex.raw('RESET statement_timeout');
+            }
+        `,
+    );
+    assert.deepStrictEqual(coreResult.operations, [
+        'create-index-concurrently',
+        'drop-index-concurrently-if-exists',
+        'reset-statement-timeout',
+        'select-invalid-index',
+        'set-statement-timeout',
+    ]);
+
+    const eeResult = analyzeMigrationSource(
+        'packages/backend/src/ee/database/migrations/20260820150000_index.ts',
+        `
+            const IndexName = 'ai_thread_organization_uuid_index';
+            export async function up(knex) {
+                await knex.raw(\`SET lock_timeout = '10s'\`);
+                await knex.raw(
+                    \`SELECT 1 FROM pg_index i
+                     JOIN pg_class c ON c.oid = i.indexrelid
+                     WHERE c.relname = '\${IndexName}' AND NOT i.indisvalid\`,
+                );
+                await knex.raw('RESET lock_timeout');
+            }
+        `,
+    );
+    assert.deepStrictEqual(eeResult.operations, [
+        'reset-lock-timeout',
+        'select-invalid-index',
+        'set-lock-timeout',
+    ]);
+});
+
+test('unique concurrent indexes remain a distinct unsupported operation', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260820160000_unique.ts',
+        `
+            export async function up(knex) {
+                await knex.raw('CREATE UNIQUE INDEX CONCURRENTLY users_email_idx ON users (email)');
+            }
+        `,
+    );
+    assert.deepStrictEqual(result.operations, [
+        'create-unique-index-concurrently',
+    ]);
+    assert.deepStrictEqual(result.migration.heaviness, {
+        locksTable: false,
+        rewritesTable: false,
+        scansTable: true,
+    });
+    assert.strictEqual(result.complete, true);
+});
+
+test('mixed and unsupported database work cannot produce an empty operation set', () => {
+    const result = analyzeMigrationSource(
+        'packages/backend/src/database/migrations/20260820170000_mixed.ts',
+        `
+            export async function up(knex) {
+                await knex.raw('CREATE INDEX CONCURRENTLY users_name_idx ON users (name)');
+                await knex.raw('ALTER TABLE users ADD COLUMN nickname text');
+                await knex.schema.createTable('settings', () => undefined);
+            }
+        `,
+    );
+    assert.deepStrictEqual(result.operations, [
+        'create-index-concurrently',
+        'unknown',
+    ]);
 });
 
 test('numeric constants substitute as readily as string ones', () => {
@@ -459,6 +556,23 @@ test('IO accepts safe and breaking classifications for incomplete metadata', () 
             rmSync(directory, { force: true, recursive: true });
         }
     }
+});
+
+test('IO exposes the operation set from the real compatible index migration', () => {
+    const result = readMigrationMetadata({
+        paths: [
+            'packages/backend/src/database/migrations/20260820153000_index_analytics_chart_views_user_uuid_timestamp.ts',
+        ],
+        ref: 'HEAD',
+    });
+    assert.deepStrictEqual(result.operations, [
+        'create-index-concurrently',
+        'drop-index-concurrently-if-exists',
+        'reset-statement-timeout',
+        'select-invalid-index',
+        'set-statement-timeout',
+    ]);
+    assert.strictEqual(result.complete, true);
 });
 
 test('loads and runs without repository dependency resolution', () => {

--- a/scripts/release-safety-migrations.ts
+++ b/scripts/release-safety-migrations.ts
@@ -46,8 +46,20 @@ export interface MigrationDetail {
     heaviness: MigrationHeaviness;
 }
 
+export type MigrationOperation =
+    | 'create-index-concurrently'
+    | 'create-unique-index-concurrently'
+    | 'drop-index-concurrently-if-exists'
+    | 'set-statement-timeout'
+    | 'reset-statement-timeout'
+    | 'set-lock-timeout'
+    | 'reset-lock-timeout'
+    | 'select-invalid-index'
+    | 'unknown';
+
 export interface MigrationSourceAnalysis {
     migration: MigrationDetail;
+    operations: MigrationOperation[];
     complete: boolean;
     incompleteReasons: MigrationIncompleteReason[];
 }
@@ -65,6 +77,7 @@ export interface ReadMigrationMetadataOptions {
 
 export interface MigrationMetadata {
     migrations: MigrationDetail[];
+    operations: MigrationOperation[];
     complete: boolean;
 }
 
@@ -598,7 +611,59 @@ const rawSqlTables = (sql: string): string[] => {
 const SQL_COMMENTS = /--[^\n]*|\/\*[\s\S]*?\*\//g;
 
 const sqlStatements = (sql: string): string[] =>
-    sql.replace(SQL_COMMENTS, ' ').split(';');
+    sql
+        .replace(SQL_COMMENTS, ' ')
+        .split(';')
+        .map((statement) => statement.trim())
+        .filter(Boolean);
+
+const classifySqlStatement = (statement: string): MigrationOperation => {
+    const normalized = statement.replace(/\s+/g, ' ').trim();
+    if (
+        /^create index concurrently(?: if not exists)?\s+(?:\?\?|(?:["`]?[a-z_][\w$]*["`]?\.)?["`]?[a-z_][\w$]*["`]?)\s+on\s+(?:\?\?|(?:["`]?[a-z_][\w$]*["`]?\.)?["`]?[a-z_][\w$]*["`]?)\s*\(.+\)(?:\s+where\s+.+)?$/i.test(
+            normalized,
+        )
+    ) {
+        return 'create-index-concurrently';
+    }
+    if (/^create unique index concurrently\b/i.test(normalized)) {
+        return 'create-unique-index-concurrently';
+    }
+    if (
+        /^drop index concurrently if exists\s+(?:\?\?|(?:["`]?[a-z_][\w$]*["`]?\.)?["`]?[a-z_][\w$]*["`]?)$/i.test(
+            normalized,
+        )
+    ) {
+        return 'drop-index-concurrently-if-exists';
+    }
+    const setTimeout = normalized.match(
+        /^set(?: local| session)? (statement_timeout|lock_timeout)\s*(?:=|to)\s*(?:default|0|\d+(?:\.\d+)?|['"][^'"]+['"])$/i,
+    );
+    if (setTimeout) {
+        return setTimeout[1].toLowerCase() === 'statement_timeout'
+            ? 'set-statement-timeout'
+            : 'set-lock-timeout';
+    }
+    const resetTimeout = normalized.match(
+        /^reset (statement_timeout|lock_timeout)$/i,
+    );
+    if (resetTimeout) {
+        return resetTimeout[1].toLowerCase() === 'statement_timeout'
+            ? 'reset-statement-timeout'
+            : 'reset-lock-timeout';
+    }
+    if (
+        /^select 1 from pg_class join pg_index on pg_index\.indexrelid = pg_class\.oid where pg_class\.relname = \? and pg_index\.indrelid = \?::regclass and not pg_index\.indisvalid$/i.test(
+            normalized,
+        ) ||
+        /^select 1 from pg_index i join pg_class c on c\.oid = i\.indexrelid where c\.relname = (?:\?|['"][^'"]+['"]) and not i\.indisvalid$/i.test(
+            normalized,
+        )
+    ) {
+        return 'select-invalid-index';
+    }
+    return 'unknown';
+};
 
 const addsValidatedConstraint = (statement: string): boolean =>
     /\badd\s+constraint\b/i.test(statement) &&
@@ -619,6 +684,7 @@ export function analyzeMigrationSource(
         'number',
     ]);
     const tables = new Set<string>();
+    const operations = new Set<MigrationOperation>();
     const heaviness: MigrationHeaviness = {
         locksTable: false,
         rewritesTable: false,
@@ -653,17 +719,52 @@ export function analyzeMigrationSource(
 
     if (body === null) {
         Object.assign(heaviness, UNKNOWN_HEAVINESS);
+        operations.add('unknown');
     } else {
         for (let index = 0; index < body.length; index += 1) {
             const token = body[index];
             const previous = body[index - 1];
             const next = body[index + 1];
-            const argument = body[index + 2];
+            const rawCallBoundaryIndex =
+                token.kind === 'identifier' &&
+                token.value === 'raw' &&
+                previous?.kind === 'punctuation' &&
+                previous.value === '.' &&
+                ((next?.kind === 'punctuation' && next.value === '(') ||
+                    (next?.kind === 'operator' && next.value === '<'))
+                    ? body.findIndex(
+                          (candidate, candidateIndex) =>
+                              candidateIndex > index &&
+                              candidate.depth === token.depth &&
+                              candidate.kind === 'punctuation' &&
+                              ['(', ';', ','].includes(candidate.value),
+                      )
+                    : -1;
+            const rawCallOpeningIndex =
+                rawCallBoundaryIndex >= 0 &&
+                body[rawCallBoundaryIndex].value === '('
+                    ? rawCallBoundaryIndex
+                    : -1;
             const isMethod =
                 previous?.kind === 'punctuation' &&
                 previous.value === '.' &&
-                next?.kind === 'punctuation' &&
-                next.value === '(';
+                ((next?.kind === 'punctuation' && next.value === '(') ||
+                    rawCallOpeningIndex >= 0);
+            const argumentIndex =
+                token.kind === 'identifier' && token.value === 'raw'
+                    ? rawCallOpeningIndex + 1
+                    : index + 2;
+            const argument = body[argumentIndex];
+
+            if (
+                token.kind === 'identifier' &&
+                token.value === 'raw' &&
+                previous?.kind === 'punctuation' &&
+                previous.value === '.' &&
+                rawCallOpeningIndex < 0
+            ) {
+                operations.add('unknown');
+            }
 
             if (
                 token.kind === 'identifier' &&
@@ -672,6 +773,18 @@ export function analyzeMigrationSource(
                 next.value === '('
             ) {
                 addTable(argument);
+                operations.add('unknown');
+            } else if (
+                token.kind === 'identifier' &&
+                ['knex', 'trx'].includes(token.value) &&
+                !(
+                    next?.kind === 'punctuation' &&
+                    next.value === '.' &&
+                    body[index + 2]?.kind === 'identifier' &&
+                    body[index + 2]?.value === 'raw'
+                )
+            ) {
+                operations.add('unknown');
             }
 
             if (!isMethod || token.kind !== 'identifier') continue;
@@ -749,12 +862,13 @@ export function analyzeMigrationSource(
                 // The argument is only the whole argument when the call ends
                 // or a second one follows; anything else builds it at runtime.
                 const argumentEnds = [')', ','].includes(
-                    body[index + 3]?.value ?? '',
+                    body[argumentIndex + 1]?.value ?? '',
                 );
                 const sql = argumentEnds
                     ? resolveSqlArgument(argument, sqlConstants)
                     : null;
                 if (sql === null) {
+                    operations.add('unknown');
                     markUnknown(
                         'parse-failure',
                         'locksTable',
@@ -762,6 +876,11 @@ export function analyzeMigrationSource(
                         'scansTable',
                     );
                     continue;
+                }
+                const statements = sqlStatements(sql);
+                if (statements.length === 0) operations.add('unknown');
+                for (const statement of statements) {
+                    operations.add(classifySqlStatement(statement));
                 }
                 for (const table of rawSqlTables(sql)) tables.add(table);
                 if (/\b(?:alter|drop|rename|truncate)\s+table\b/i.test(sql)) {
@@ -799,6 +918,7 @@ export function analyzeMigrationSource(
     if (!tokenized.valid) {
         complete = false;
         incompleteReasons.add('parse-failure');
+        operations.add('unknown');
         for (const key of Object.keys(heaviness) as HeavinessKey[]) {
             if (heaviness[key] !== true) heaviness[key] = 'unknown';
         }
@@ -811,6 +931,7 @@ export function analyzeMigrationSource(
             tables: [...tables].sort(),
             heaviness,
         },
+        operations: [...operations].sort(),
         complete,
         incompleteReasons: [...incompleteReasons],
     };
@@ -828,6 +949,7 @@ export function readMigrationMetadata(
 ): MigrationMetadata {
     const log = options.log ?? (() => undefined);
     const migrations: MigrationDetail[] = [];
+    const operations = new Set<MigrationOperation>();
     let complete = true;
 
     for (const migrationPath of [...options.paths].sort()) {
@@ -846,12 +968,14 @@ export function readMigrationMetadata(
             const message = error instanceof Error ? error.message : String(error);
             log(`could not read ${options.ref}:${migrationPath}: ${message}`);
             migrations.push(unreadableMigration(migrationPath));
+            operations.add('unknown');
             complete = false;
             continue;
         }
 
         const analysis = analyzeMigrationSource(migrationPath, source);
         migrations.push(analysis.migration);
+        for (const operation of analysis.operations) operations.add(operation);
         const classification = parseChangeDeclarations(
             source,
             migrationPath,
@@ -862,5 +986,5 @@ export function readMigrationMetadata(
         }
     }
 
-    return { migrations, complete };
+    return { migrations, operations: [...operations].sort(), complete };
 }


### PR DESCRIPTION
## What breaks

Safe index-only migrations stay unknown unless a person or the AI review confirms them. This holds automatic upgrades even when the migration form proves that old code still works.

## What changed

- Read exact operation kinds from migration SQL without changing the public marker schema.
- Mark a fully checked migration release safe when every operation is on the conservative compatibility list.
- Skip the AI review for that deterministic result.
- Keep unique concurrent indexes, incomplete metadata, linter findings, and other unknown operations on the existing safe side of the gate.

## Tests

- npm run test:release-safety
- Applied the new tests to origin/main and confirmed that both changed suites fail before the implementation.

Linear: SPK-1228