### PR TITLE
feat: support CSV attachments in AI agent chat

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -439,6 +439,7 @@ export type AiPromptContextEntityType =
     | 'thread'
     | 'file'
     | 'repository'
+    | 'external_source'
     | 'pull_request'
     | 'proposed_change'
     | 'review_finding'

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -20,6 +20,8 @@ import { DeployService } from '../services/DeployService';
 import { InstanceConfigurationService } from '../services/InstanceConfigurationService/InstanceConfigurationService';
 import { OrganizationService } from '../services/OrganizationService/OrganizationService';
 import { ProjectService } from '../services/ProjectService/ProjectService';
+import { QuerySourceRegistry } from '../services/QuerySourceService/QuerySourceRegistry';
+import { QuerySourceService } from '../services/QuerySourceService/QuerySourceService';
 import { RolesService } from '../services/RolesService/RolesService';
 import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
 import { failInFlightAiAgentStreams } from './aiAgentShutdown';
@@ -87,6 +89,7 @@ import { EmbedService } from './services/EmbedService/EmbedService';
 import { ExternalConnectionCoderService } from './services/ExternalConnectionCoderService/ExternalConnectionCoderService';
 import { ExternalConnectionService } from './services/ExternalConnectionService/ExternalConnectionService';
 import { GoogleServiceAccountTokenProvider } from './services/ExternalConnectionService/GoogleServiceAccountTokenProvider';
+import { ExternalQuerySource } from './services/ExternalSourceService/ExternalQuerySource';
 import { ExternalSourceService } from './services/ExternalSourceService/ExternalSourceService';
 import { HomepageRecommendedActionSkipsService } from './services/HomepageRecommendedActionSkipsService';
 import { EnterpriseLicenseService } from './services/LicenseService/LicenseService';
@@ -366,6 +369,26 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     googleDriveClient: clients.getGoogleDriveClient(),
                     userOAuthGrantsModel: models.getUserOAuthGrantsModel(),
                 }),
+            querySourceService: ({ models, repository }) => {
+                const registry = QuerySourceRegistry.withBuiltInSources({
+                    asyncQueryService: repository.getAsyncQueryService(),
+                    projectService: repository.getProjectService(),
+                });
+                registry.register(
+                    new ExternalQuerySource({
+                        asyncQueryService: repository.getAsyncQueryService(),
+                        projectService: repository.getProjectService(),
+                        externalSourceModel:
+                            models.getExternalSourceModel<ExternalSourceModel>(),
+                    }),
+                );
+                return new QuerySourceService({
+                    projectModel: models.getProjectModel(),
+                    queryHistoryModel: models.getQueryHistoryModel(),
+                    featureFlagModel: models.getFeatureFlagModel(),
+                    registry,
+                });
+            },
             appGenerateService: ({ context, models, clients, repository }) =>
                 new AppGenerateService({
                     lightdashConfig: context.lightdashConfig,
@@ -1013,10 +1036,16 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getPersistentDownloadFileService(),
                     organizationAccessService:
                         repository.getOrganizationAccessService(),
-                    externalSourceTableResolver: (projectUuid, tableUuid) =>
+                    externalSourceTableResolver: (
+                        projectUuid,
+                        tableUuidOrName,
+                    ) =>
                         models
                             .getExternalSourceModel<ExternalSourceModel>()
-                            .findTableForQuery(projectUuid, tableUuid),
+                            .findTableByUuidOrName(
+                                projectUuid,
+                                tableUuidOrName,
+                            ),
                     preAggregateStrategy: new PreAggregateStrategy({
                         preAggregationDuckDbClient:
                             new PreAggregationDuckDbClient({

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -6363,6 +6363,15 @@ export class AiAgentModel {
                         entity_ref: ctx.fullName,
                         display_name: ctx.fullName,
                     };
+                case 'external_source':
+                    return {
+                        ai_prompt_uuid: promptUuid,
+                        entity_type:
+                            'external_source' as AiPromptContextEntityType,
+                        entity_uuid: null,
+                        entity_ref: ctx.tableName,
+                        display_name: ctx.tableName,
+                    };
                 // Review-remediation references store their natural key
                 // (PR url / finding fingerprint) in entity_ref and resolve the
                 // live data at read time. preview_environment keys off a real
@@ -6667,6 +6676,11 @@ export class AiAgentModel {
                 return { type: 'file', path: row.entity_ref ?? '' };
             case 'repository':
                 return { type: 'repository', fullName: row.entity_ref ?? '' };
+            case 'external_source':
+                return {
+                    type: 'external_source',
+                    tableName: row.entity_ref ?? '',
+                };
             case 'pull_request': {
                 const prUrl = row.entity_ref ?? '';
                 return {

--- a/packages/backend/src/ee/models/ExternalSourceModel.ts
+++ b/packages/backend/src/ee/models/ExternalSourceModel.ts
@@ -10,6 +10,7 @@ import {
 } from '@lightdash/common';
 import { randomUUID } from 'crypto';
 import { Knex } from 'knex';
+import { validate as validateUuid } from 'uuid';
 import {
     ExternalSourceCredentialsTableName,
     ExternalSourceIngestAttemptsTableName,
@@ -863,7 +864,14 @@ export class ExternalSourceModel {
             .first();
     }
 
-    async findTableForQuery(projectUuid: string, tableUuid: string) {
+    /**
+     * Table names cannot contain hyphens, so a uuid-shaped reference is
+     * always a uuid and the two lookups never shadow each other.
+     */
+    async findTableByUuidOrName(
+        projectUuid: string,
+        tableUuidOrName: string,
+    ) {
         const row = await this.database(ExternalSourceTablesTableName)
             .innerJoin(
                 ExternalSourcesTableName,
@@ -877,14 +885,26 @@ export class ExternalSourceModel {
             .where(`${ExternalSourceTablesTableName}.project_uuid`, projectUuid)
             .andWhere(`${ExternalSourcesTableName}.project_uuid`, projectUuid)
             .andWhere(
-                `${ExternalSourceTablesTableName}.external_source_table_uuid`,
-                tableUuid,
+                validateUuid(tableUuidOrName)
+                    ? `${ExternalSourceTablesTableName}.external_source_table_uuid`
+                    : `${ExternalSourceTablesTableName}.name`,
+                tableUuidOrName,
             )
             .first();
         return row as
             | (DbExternalSourceTable & {
                   external_source_status: ExternalSourceStatus;
               })
-            | undefined;
+              | undefined;
+    }
+
+    async listReadyTables(
+        projectUuid: string,
+    ): Promise<DbExternalSourceTable[]> {
+        return this.database(ExternalSourceTablesTableName)
+            .where('project_uuid', projectUuid)
+            .whereNotNull('locator')
+            .whereNotNull('columns')
+            .orderBy('name');
     }
 }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -980,6 +980,9 @@ export class AiAgentService extends BaseService {
                 case 'repository':
                     key = `repository:${item.fullName}`;
                     break;
+                case 'external_source':
+                    key = `external_source:${item.tableName}`;
+                    break;
                 case 'pull_request':
                     key = `pull_request:${item.prUrl}`;
                     break;
@@ -1070,6 +1073,13 @@ export class AiAgentService extends BaseService {
                             'You do not have permission to view this project source code',
                         );
                     }
+                    return;
+                }
+
+                // The external query source applies project/explore access
+                // when it scans and executes this table. The context item is
+                // only a durable hint naming which table the user attached.
+                if (item.type === 'external_source') {
                     return;
                 }
 
@@ -8104,6 +8114,8 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     return `- File \`/dbt/${item.path}\` — a source file in this project's dbt repository. Read it with the exploreRepo tool.`;
                 case 'repository':
                     return `- Repository \`${item.fullName}\` (mounted at \`/${item.fullName}\`) — explore it with the exploreRepo tool.`;
+                case 'external_source':
+                    return `- External source table \`${item.tableName}\` — inspect the external query-source schema, then query it with an "external" node in runComposerQueries. Use \`tables: ["${item.tableName}"]\` (or an alias map) and DuckDB SQL. Join its result to other query results with a downstream "duckdb" node when needed.`;
                 case 'pull_request': {
                     const number = item.prNumber ? ` #${item.prNumber}` : '';
                     const title = item.title ? ` "${item.title}"` : '';

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.test.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.test.ts
@@ -1,0 +1,177 @@
+import {
+    DimensionType,
+    ParameterError,
+    QueryExecutionContext,
+    QuerySourceType,
+    type Account,
+} from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
+import type { ProjectService } from '../../../services/ProjectService/ProjectService';
+import type { ExternalSourceModel } from '../../models/ExternalSourceModel';
+import { ExternalQuerySource } from './ExternalQuerySource';
+
+const account = { user: { id: 'user-1' } } as unknown as Account;
+
+const submitArgs = {
+    account,
+    projectUuid: 'project-1',
+    context: QueryExecutionContext.API,
+    resolvedReferences: {},
+};
+
+describe('ExternalQuerySource', () => {
+    const executeAsyncExternalSqlQuery = vi
+        .fn()
+        .mockResolvedValue({ queryUuid: 'query-1' });
+    const getAllExploresSummary = vi.fn();
+    const listReadyTables = vi.fn();
+
+    const source = new ExternalQuerySource({
+        asyncQueryService: {
+            executeAsyncExternalSqlQuery,
+        } as unknown as AsyncQueryService,
+        projectService: {
+            getAllExploresSummary,
+        } as unknown as ProjectService,
+        externalSourceModel: {
+            listReadyTables,
+        } as unknown as ExternalSourceModel,
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        executeAsyncExternalSqlQuery.mockResolvedValue({
+            queryUuid: 'query-1',
+        });
+    });
+
+    it('rejects queries of another source type', async () => {
+        await expect(
+            source.submitQuery({
+                ...submitArgs,
+                query: { sourceType: QuerySourceType.SQL, sql: 'SELECT 1' },
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('has no DAG edges: external tables are durable files', () => {
+        expect(
+            source.getQueryReferences({
+                sourceType: QuerySourceType.EXTERNAL,
+                sql: 'SELECT 1',
+                tables: ['monthly_targets'],
+            }),
+        ).toEqual([]);
+    });
+
+    it('normalizes the array shorthand to a name-keyed map', async () => {
+        const result = await source.submitQuery({
+            ...submitArgs,
+            query: {
+                sourceType: QuerySourceType.EXTERNAL,
+                sql: 'SELECT * FROM monthly_targets',
+                tables: ['monthly_targets', 'other_table'],
+            },
+        });
+
+        expect(result).toEqual({ queryUuid: 'query-1' });
+        expect(executeAsyncExternalSqlQuery).toHaveBeenCalledWith({
+            account,
+            projectUuid: 'project-1',
+            context: QueryExecutionContext.API,
+            sql: 'SELECT * FROM monthly_targets',
+            limit: undefined,
+            tables: {
+                monthly_targets: 'monthly_targets',
+                other_table: 'other_table',
+            },
+        });
+    });
+
+    it('passes the map form through unchanged', async () => {
+        await source.submitQuery({
+            ...submitArgs,
+            query: {
+                sourceType: QuerySourceType.EXTERNAL,
+                sql: 'SELECT * FROM t',
+                limit: 10,
+                tables: { t: '7b8ac342-0000-4000-8000-000000000001' },
+            },
+        });
+
+        expect(executeAsyncExternalSqlQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                limit: 10,
+                tables: { t: '7b8ac342-0000-4000-8000-000000000001' },
+            }),
+        );
+    });
+
+    it('scans only tables whose explore the caller can see, with raw columns', async () => {
+        getAllExploresSummary.mockResolvedValue([
+            {
+                name: 'monthly_targets',
+                externalSource: {
+                    sourceUuid: 'source-1',
+                    tableUuid: 'table-1',
+                    sourceType: 'csv',
+                },
+            },
+            { name: 'orders' },
+            { name: 'broken', errors: [{ type: 'x', message: 'boom' }] },
+        ]);
+        listReadyTables.mockResolvedValue([
+            {
+                external_source_table_uuid: 'table-1',
+                name: 'monthly_targets',
+                label: 'Monthly targets',
+                columns: {
+                    _month: { reference: '_month', type: DimensionType.DATE },
+                    _target: {
+                        reference: '_target',
+                        type: DimensionType.NUMBER,
+                    },
+                },
+            },
+            {
+                external_source_table_uuid: 'table-hidden',
+                name: 'hidden_table',
+                label: 'Hidden',
+                columns: {
+                    a: { reference: 'a', type: DimensionType.STRING },
+                },
+            },
+        ]);
+
+        const schema = await source.scanSchema({
+            account,
+            projectUuid: 'project-1',
+        });
+
+        expect(schema).toEqual({
+            sourceType: QuerySourceType.EXTERNAL,
+            tables: [
+                {
+                    reference: 'monthly_targets',
+                    label: 'Monthly targets',
+                    description: null,
+                    columns: [
+                        {
+                            reference: '_month',
+                            type: DimensionType.DATE,
+                            label: null,
+                            description: null,
+                        },
+                        {
+                            reference: '_target',
+                            type: DimensionType.NUMBER,
+                            label: null,
+                            description: null,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.ts
+++ b/packages/backend/src/ee/services/ExternalSourceService/ExternalQuerySource.ts
@@ -1,0 +1,153 @@
+import {
+    isSummaryExploreError,
+    ParameterError,
+    QuerySourceType,
+    type ExternalSourceQuery,
+    type QuerySourceDefinition,
+    type QuerySourceSchema,
+    type QuerySourceSchemaTable,
+    type SourceQuery,
+} from '@lightdash/common';
+import type { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
+import type { ProjectService } from '../../../services/ProjectService/ProjectService';
+import type {
+    QuerySourceClient,
+    ScanSchemaArgs,
+    SubmitSourceQueryArgs,
+} from '../../../services/QuerySourceService/types';
+import type { ExternalSourceModel } from '../../models/ExternalSourceModel';
+
+type ExternalQuerySourceArguments = {
+    asyncQueryService: AsyncQueryService;
+    projectService: ProjectService;
+    externalSourceModel: ExternalSourceModel;
+};
+
+/**
+ * A project's external source tables (uploaded CSVs, connected Google
+ * Sheets) as a query source. Unlike the duckdb source, its tables are
+ * durable ingested files rather than query results, so external queries
+ * have no upstream dependencies; joining with other results happens in a
+ * referencing duckdb query.
+ */
+export class ExternalQuerySource implements QuerySourceClient {
+    readonly definition: QuerySourceDefinition = {
+        sourceType: QuerySourceType.EXTERNAL,
+        label: 'External sources',
+        description:
+            'DuckDB SQL over external source tables (uploaded CSVs, connected Google Sheets). Tables expose ingested files as named tables: an array of table names, or a {tableName: tableNameOrUuid} map for aliasing. Column names are the ingested columns from scanSchema, not explore field ids. Join the result with warehouse data in a referencing duckdb query.',
+    };
+
+    private readonly asyncQueryService: AsyncQueryService;
+
+    private readonly projectService: ProjectService;
+
+    private readonly externalSourceModel: ExternalSourceModel;
+
+    constructor(args: ExternalQuerySourceArguments) {
+        this.asyncQueryService = args.asyncQueryService;
+        this.projectService = args.projectService;
+        this.externalSourceModel = args.externalSourceModel;
+    }
+
+    private static assertSourceQuery(query: SourceQuery): ExternalSourceQuery {
+        if (query.sourceType !== QuerySourceType.EXTERNAL) {
+            throw new ParameterError(
+                `Expected a ${QuerySourceType.EXTERNAL} query, got "${query.sourceType}"`,
+            );
+        }
+        return query;
+    }
+
+    /** The array shorthand exposes each table under its own name. */
+    private static normalizeTables(
+        tables: ExternalSourceQuery['tables'],
+    ): Record<string, string> {
+        if (Array.isArray(tables)) {
+            return Object.fromEntries(tables.map((name) => [name, name]));
+        }
+        return tables;
+    }
+
+    /**
+     * External tables the caller can see, with their ingested (raw) columns.
+     * Visibility rides the explore layer: getAllExploresSummary applies
+     * view-project authorization and user-attribute filtering, and every
+     * external table is an explore carrying its source back-reference.
+     */
+    async scanSchema({
+        account,
+        projectUuid,
+    }: ScanSchemaArgs): Promise<QuerySourceSchema> {
+        const summaries = await this.projectService.getAllExploresSummary(
+            account,
+            projectUuid,
+            true,
+            false,
+        );
+        const visibleTableUuids = new Set(
+            summaries.flatMap((summary) =>
+                !isSummaryExploreError(summary) && summary.externalSource
+                    ? [summary.externalSource.tableUuid]
+                    : [],
+            ),
+        );
+
+        const tableRows =
+            await this.externalSourceModel.listReadyTables(projectUuid);
+        const tables: QuerySourceSchemaTable[] = tableRows.flatMap((row) => {
+            if (
+                !visibleTableUuids.has(row.external_source_table_uuid) ||
+                row.columns === null
+            ) {
+                return [];
+            }
+            return [
+                {
+                    reference: row.name,
+                    label: row.label,
+                    description: null,
+                    columns: Object.values(row.columns).map((column) => ({
+                        reference: column.reference,
+                        type: column.type,
+                        label: null,
+                        description: null,
+                    })),
+                },
+            ];
+        });
+
+        return {
+            sourceType: QuerySourceType.EXTERNAL,
+            tables,
+        };
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    getQueryReferences(_query: SourceQuery): string[] {
+        // External tables are durable files, not results of other queries in
+        // the submission, so an external query never has DAG edges.
+        return [];
+    }
+
+    async submitQuery({
+        account,
+        projectUuid,
+        context,
+        query,
+    }: SubmitSourceQueryArgs): Promise<{ queryUuid: string }> {
+        const sourceQuery = ExternalQuerySource.assertSourceQuery(query);
+
+        const results =
+            await this.asyncQueryService.executeAsyncExternalSqlQuery({
+                account,
+                projectUuid,
+                sql: sourceQuery.sql,
+                limit: sourceQuery.limit,
+                tables: ExternalQuerySource.normalizeTables(sourceQuery.tables),
+                context,
+            });
+
+        return { queryUuid: results.queryUuid };
+    }
+}

--- a/packages/backend/src/ee/services/ai/compaction.ts
+++ b/packages/backend/src/ee/services/ai/compaction.ts
@@ -209,6 +209,8 @@ export class Compaction {
                 return `file /dbt/${item.path} (a source file in the dbt project; read it with exploreRepo)`;
             case 'repository':
                 return `repository ${item.fullName} (mounted at /${item.fullName}; explore it with exploreRepo)`;
+            case 'external_source':
+                return `external source table ${item.tableName} (query with an external node in runComposerQueries)`;
             case 'pull_request': {
                 const number = item.prNumber ? ` #${item.prNumber}` : '';
                 return `pull request${number} (${item.status ?? 'open'})${

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -6670,6 +6670,7 @@ How to build a pipeline:
 - Every query is a node. Name each node with "nodeId" (letters, digits, underscores; starting with a letter or underscore).
 - "semanticLayer" nodes run a metric query against an explore. Result columns are named by field id — exactly the dimensions and metrics requested (e.g. metric "payments_total_revenue" yields column "payments_total_revenue").
 - "sql" nodes run raw SQL against the project's data warehouse, in the warehouse's SQL dialect. Result columns are the SELECT output names. SQL execution may require the user to approve the SQL first.
+- "external" nodes run DuckDB SQL directly over uploaded CSV or connected Google Sheets source tables. Map each SQL table alias to its source table name with "tables". These nodes do not require warehouse SQL approval.
 - "duckdb" nodes run DuckDB SQL over other queries' results. Declare which results the SQL reads via "references": the shorthand array form lists node ids from this submission, each exposed as a table named by its node id (["orders", "revenue"] lets the SQL run SELECT * FROM orders JOIN revenue ...); the map form aliases tables or references stored results by queryUuid ({"o": "orders", "prev": "<queryUuid>"}). A referenced table's columns are the upstream result's columns.
 - The "terminal" node is the one whose results the artifact shows and whose rows are returned to you. By default it is the unique sink (the one node no other node references); pass "terminalNodeId" explicitly when the pipeline has multiple sinks.
 
@@ -6819,6 +6820,55 @@ Returns the terminal node's result columns and a CSV preview of its rows, plus p
                   "sourceType",
                   "nodeId",
                   "sql",
+                ],
+                "type": "object",
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "limit": {
+                    "default": 500,
+                    "description": "Maximum number of rows this node returns. Defaults to 500, max 500.",
+                    "exclusiveMinimum": 0,
+                    "maximum": 500,
+                    "type": "integer",
+                  },
+                  "nodeId": {
+                    "description": "Names this query so other queries in the same submission can reference its results. Also the DuckDB table name its results are exposed as.",
+                    "pattern": "^[a-zA-Z_][a-zA-Z0-9_]{0,62}$",
+                    "type": "string",
+                  },
+                  "sourceType": {
+                    "const": "external",
+                    "type": "string",
+                  },
+                  "sql": {
+                    "description": "DuckDB SQL over uploaded CSV or connected Google Sheets source tables.",
+                    "type": "string",
+                  },
+                  "tables": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": "string",
+                        },
+                        "type": "object",
+                      },
+                    ],
+                    "description": "External source tables read by the SQL. An array exposes every source table under its own name; a map aliases SQL table names to source table names.",
+                  },
+                },
+                "required": [
+                  "sourceType",
+                  "nodeId",
+                  "sql",
+                  "tables",
                 ],
                 "type": "object",
               },

--- a/packages/backend/src/ee/services/ai/tools/runComposerQueries.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runComposerQueries.test.ts
@@ -55,6 +55,14 @@ const duckdbNode: ComposerNode = {
     limit: 500,
 };
 
+const externalNode: ComposerNode = {
+    sourceType: QuerySourceType.EXTERNAL,
+    nodeId: 'targets',
+    sql: 'SELECT region, target FROM quarterly_targets',
+    tables: ['quarterly_targets'],
+    limit: 500,
+};
+
 const makeArgs = (
     overrides: Partial<ToolComposerQueriesArgs> = {},
 ): ToolComposerQueriesArgs => ({
@@ -242,6 +250,37 @@ describe('getRunComposerQueries', () => {
 
         expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
         expect(dependencies.recordSqlApproval).not.toHaveBeenCalled();
+        expect(output.metadata?.status).toBe('success');
+    });
+
+    it('passes external source nodes through without warehouse SQL approval', async () => {
+        const { tool, dependencies } = makeTool();
+
+        const output = await executeTool(
+            tool,
+            makeArgs({
+                queries: [
+                    semanticNode,
+                    externalNode,
+                    {
+                        ...duckdbNode,
+                        references: ['revenue', 'targets'],
+                    },
+                ],
+            }),
+        );
+
+        expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
+        expect(dependencies.runComposerQueries).toHaveBeenCalledWith(
+            expect.objectContaining({
+                queries: expect.arrayContaining([
+                    expect.objectContaining({
+                        sourceType: QuerySourceType.EXTERNAL,
+                        tables: ['quarterly_targets'],
+                    }),
+                ]),
+            }),
+        );
         expect(output.metadata?.status).toBe('success');
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -79,6 +79,7 @@ import {
     MissingConfigError,
     normalizeIndexColumns,
     NotFoundError,
+    NotImplementedError,
     NotSupportedError,
     OrganizationAccessStatus,
     ParameterError,
@@ -121,6 +122,7 @@ import {
     type ExecuteAsyncComposeMergeQueryRequestParams,
     type ExecuteAsyncComposeSqlQueryRequestParams,
     type ExecuteAsyncDashboardChartRequestParams,
+    type ExecuteAsyncExternalSqlQueryRequestParams,
     type ExecuteAsyncFieldValueSearchRequestParams,
     type ExecuteAsyncMergeQueryRequestParams,
     type ExecuteAsyncMetricQueryRequestParams,
@@ -257,6 +259,7 @@ import {
     type ExecuteAsyncComposeSqlQueryArgs,
     type ExecuteAsyncDashboardChartQueryArgs,
     type ExecuteAsyncDashboardSqlChartArgs,
+    type ExecuteAsyncExternalSqlQueryArgs,
     type ExecuteAsyncFieldValueSearchArgs,
     type ExecuteAsyncMergeQueryArgs,
     type ExecuteAsyncMetricQueryArgs,
@@ -392,13 +395,13 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     organizationAccessService: OrganizationAccessService;
     preAggregateStrategy?: PreAggregateStrategy;
     /**
-     * Resolves an external source table (locator, columns, version) for
-     * explores of type EXTERNAL_SOURCE. Injected by the enterprise edition;
-     * absent on OSS, where external source queries are refused.
+     * Resolves an external source table (locator, columns, version) by uuid
+     * or sql name. Injected by the enterprise edition; absent on OSS, where
+     * external source queries are refused.
      */
     externalSourceTableResolver?: (
         projectUuid: string,
-        tableUuid: string,
+        tableUuidOrName: string,
     ) => Promise<
         | (DbExternalSourceTable & {
               external_source_status: ExternalSourceStatus;
@@ -7160,6 +7163,216 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
+    /**
+     * Execute raw DuckDB SQL over a project's external source tables. Each
+     * entry in `tables` exposes an ingested table (referenced by name or
+     * uuid) as a CTE over its parquet file; the stored compiled_sql keeps the
+     * plain user SQL, so file URIs never leave the backend. Tables are
+     * durable, so resolution happens in the foreground and the cache key
+     * carries every table's ingest version.
+     */
+    async executeAsyncExternalSqlQuery({
+        account,
+        projectUuid,
+        sql,
+        context,
+        limit,
+        tables,
+    }: ExecuteAsyncExternalSqlQueryArgs): Promise<ApiExecuteAsyncSqlQueryResults> {
+        assertIsAccountWithOrg(account);
+
+        const { enabled: isEndpointEnabled } = await this.featureFlagModel.get({
+            user: {
+                userUuid: account.user.id,
+                organizationUuid: account.organization.organizationUuid,
+            },
+            featureFlagId: FeatureFlags.ExternalSources,
+        });
+        if (!isEndpointEnabled) {
+            throw new ForbiddenError('External sources are not enabled');
+        }
+
+        const projectSummary = await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = projectSummary;
+
+        // Same ability that gates compose SQL queries: interactive viewers
+        // and up, but not plain viewers.
+        const auditedAbility = this.createAuditedAbility(account);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Explore', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        try {
+            DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
+        } catch (e) {
+            throw new ParameterError(getErrorMessage(e));
+        }
+
+        const tableEntries = Object.entries(tables);
+        if (tableEntries.length === 0) {
+            throw new ParameterError(
+                'External SQL queries must name at least one external source table',
+            );
+        }
+        const resolver = this.externalSourceTableResolver;
+        if (!resolver) {
+            throw new NotImplementedError(
+                'External source queries need the enterprise DuckDB engine',
+            );
+        }
+
+        const resolvedTables = await Promise.all(
+            tableEntries.map(async ([tableName, reference]) => {
+                const table = await resolver(projectUuid, reference);
+                if (!table) {
+                    throw new ParameterError(
+                        `Unknown external source table "${reference}"`,
+                    );
+                }
+                if (!table.locator || !table.columns) {
+                    throw new ParameterError(
+                        `External source table "${reference}" has no ingested data yet. Refresh the source and try again`,
+                    );
+                }
+                return {
+                    tableName,
+                    tableUuid: table.external_source_table_uuid,
+                    version: table.version,
+                    locator: table.locator,
+                    columns: table.columns,
+                };
+            }),
+        );
+
+        const referenceCtes = resolvedTables.map(
+            ({ tableName, locator, columns }) =>
+                `${quoteDuckdbIdentifier(
+                    tableName,
+                )} AS (SELECT * FROM ${getDuckdbPreAggregateSqlTable(
+                    locator,
+                    columns,
+                )})`,
+        );
+
+        // Refreshes bump table versions without the SQL text changing, so
+        // every referenced table's version salts the key.
+        const externalSourceSalt = resolvedTables
+            .map(({ tableUuid, version }) => `esv:${tableUuid}:${version}`)
+            .sort()
+            .join('|');
+        const cacheKey = QueryHistoryModel.getCacheKey(projectUuid, {
+            sql: JSON.stringify({
+                sql,
+                tables: [...tableEntries].sort(([a], [b]) =>
+                    a.localeCompare(b),
+                ),
+            }),
+            userUuid: null,
+            externalSourceSalt,
+        });
+
+        // Throws NotImplementedError when the engine is unavailable
+        const warehouseClient =
+            this.preAggregateStrategy.createExecutionWarehouseClient();
+
+        const queryTags: RunQueryTags = {
+            ...this.getUserQueryTags(account),
+            ...AsyncQueryService.getSchedulerQueryTags(),
+            organization_uuid: organizationUuid,
+            project_uuid: projectUuid,
+            query_context: context,
+        };
+
+        const placeholderComposer = new SqlQueryComposer({
+            userSql: sql,
+            columns: [],
+            warehouseClient,
+            pivotConfiguration: undefined,
+            limit,
+            parameters: undefined,
+            dashboardFilters: undefined,
+            tileUuid: undefined,
+            dashboardSorts: undefined,
+        });
+
+        const requestParameters: ExecuteAsyncExternalSqlQueryRequestParams = {
+            sql,
+            limit,
+            context,
+            tables,
+        };
+
+        const queryCreatedAt = new Date();
+        const { queryUuid } = await this.queryHistoryModel.create(account, {
+            projectUuid,
+            organizationUuid,
+            context,
+            fields: {},
+            compiledSql: sql,
+            requestParameters,
+            metricQuery: placeholderComposer.getMetricQuery(),
+            cacheKey,
+            pivotConfiguration: null,
+            originalColumns: {},
+        });
+        this.prometheusMetrics?.trackQueryStateTransition(
+            'new',
+            QueryHistoryStatus.PENDING,
+            context,
+        );
+
+        const onboardingFlow = await this.getOnboardingFlow({
+            userUuid: account.user.id,
+            organizationUuid,
+        });
+
+        void this.runDuckdbSqlQuery({
+            account,
+            projectUuid,
+            organizationUuid,
+            isPreviewProject:
+                projectSummary.type === ProjectType.PREVIEW ||
+                projectSummary.provisioningSource === 'playground',
+            onboardingFlow,
+            queryUuid,
+            resolvedSql: AsyncQueryService.wrapSqlWithReferenceCtes(
+                sql,
+                referenceCtes,
+            ),
+            // The resolved SQL carries file URIs; only the plain user SQL is
+            // ever persisted or shown.
+            storedCompiledSql: sql,
+            limit,
+            warehouseClient,
+            queryTags,
+            queryCreatedAt,
+            cacheKey,
+            context,
+        }).catch((e) => {
+            this.logger.error(
+                `Async external SQL query ${queryUuid} failed: ${getErrorMessage(
+                    e,
+                )}`,
+            );
+        });
+
+        return {
+            queryUuid,
+            cacheMetadata: { cacheHit: false },
+            parameterReferences: [],
+            usedParametersValues: {},
+            resolvedTimezone: null,
+        };
+    }
+
     /** How long a compose query waits for a referenced query's results. */
     private static readonly REFERENCE_WAIT_TIMEOUT_MS = 15 * 60 * 1000;
 
@@ -7222,11 +7435,82 @@ export class AsyncQueryService extends ProjectService {
                   })
                 : [];
 
-            const resolvedSql = AsyncQueryService.wrapSqlWithReferenceCtes(
-                sql,
-                referenceCtes,
+            await this.runDuckdbSqlQuery({
+                account,
+                projectUuid,
+                organizationUuid,
+                isPreviewProject,
+                onboardingFlow,
+                queryUuid,
+                resolvedSql: AsyncQueryService.wrapSqlWithReferenceCtes(
+                    sql,
+                    referenceCtes,
+                ),
+                limit,
+                warehouseClient,
+                queryTags,
+                queryCreatedAt,
+                cacheKey,
+                context,
+            });
+        } catch (e) {
+            await this.queryHistoryModel.update(
+                queryUuid,
+                projectUuid,
+                {
+                    status: QueryHistoryStatus.ERROR,
+                    error: getErrorMessage(e),
+                    errored_at: new Date(),
+                },
+                account,
             );
+        }
+    }
 
+    /**
+     * Shared execution tail for DuckDB engine SQL whose table CTEs are
+     * already attached: discover columns, compile through SqlQueryComposer,
+     * persist compiled sql and fields, then execute in-process on the engine.
+     * Failures mark the query history row errored so pollers see them
+     * through the standard status lifecycle.
+     */
+    private async runDuckdbSqlQuery({
+        account,
+        projectUuid,
+        organizationUuid,
+        isPreviewProject,
+        onboardingFlow,
+        queryUuid,
+        resolvedSql,
+        storedCompiledSql,
+        limit,
+        warehouseClient,
+        queryTags,
+        queryCreatedAt,
+        cacheKey,
+        context,
+    }: {
+        account: Account;
+        projectUuid: string;
+        organizationUuid: string;
+        isPreviewProject: boolean;
+        onboardingFlow: OnboardingFlow;
+        queryUuid: string;
+        resolvedSql: string;
+        /**
+         * What to persist as compiled_sql instead of the resolved SQL, for
+         * paths whose reference CTEs carry file URIs that must stay
+         * backend-only (external source tables).
+         */
+        storedCompiledSql?: string;
+        limit: number | undefined;
+        warehouseClient: WarehouseClient;
+        queryTags: RunQueryTags;
+        queryCreatedAt: Date;
+        cacheKey: string;
+        context: QueryExecutionContext;
+    }): Promise<void> {
+        try {
             // Column discovery (LIMIT 1) also validates the SQL
             const columns: { name: string; type: DimensionType }[] = [];
             const columnDiscoverySql = applyLimitToSqlQuery({
@@ -7292,7 +7576,7 @@ export class AsyncQueryService extends ProjectService {
                 queryUuid,
                 projectUuid,
                 {
-                    compiled_sql: query,
+                    compiled_sql: storedCompiledSql ?? query,
                     fields: fieldsMap,
                     original_columns: originalColumns,
                 },

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -7242,6 +7242,13 @@ export class AsyncQueryService extends ProjectService {
                         `External source table "${reference}" has no ingested data yet. Refresh the source and try again`,
                     );
                 }
+                if (
+                    table.external_source_status !== ExternalSourceStatus.READY
+                ) {
+                    throw new ParameterError(
+                        `External source table "${reference}" is not ready. Wait for its ingest to finish and try again`,
+                    );
+                }
                 return {
                     tableName,
                     tableUuid: table.external_source_table_uuid,

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -181,6 +181,13 @@ export type ExecuteAsyncComposeSqlQueryArgs = CommonAsyncQueryArgs & {
     references?: Record<string, UUID>;
 };
 
+export type ExecuteAsyncExternalSqlQueryArgs = CommonAsyncQueryArgs & {
+    sql: string;
+    limit?: number;
+    /** Table name -> external source table (name or uuid) to expose as that table. */
+    tables: Record<string, string>;
+};
+
 export type ExecuteAsyncMergeQueryArgs = CommonAsyncQueryArgs & {
     mergeQuery: MergeQuery;
     mode: MergeQueryExecutionMode;

--- a/packages/backend/src/services/QuerySourceService/QuerySourceRegistry.ts
+++ b/packages/backend/src/services/QuerySourceService/QuerySourceRegistry.ts
@@ -4,6 +4,11 @@ import {
     type QuerySourceDefinition,
     type QuerySourceType,
 } from '@lightdash/common';
+import type { AsyncQueryService } from '../AsyncQueryService/AsyncQueryService';
+import type { ProjectService } from '../ProjectService/ProjectService';
+import { DuckdbQuerySource } from './sources/DuckdbQuerySource';
+import { SemanticLayerQuerySource } from './sources/SemanticLayerQuerySource';
+import { SqlQuerySource } from './sources/SqlQuerySource';
 import type { QuerySourceClient } from './types';
 
 /**
@@ -14,6 +19,34 @@ import type { QuerySourceClient } from './types';
 export class QuerySourceRegistry {
     private readonly sources: Map<QuerySourceType, QuerySourceClient> =
         new Map();
+
+    /**
+     * A registry with the built-in sources registered. Extension points
+     * (enterprise edition) call this and register their sources on top.
+     */
+    static withBuiltInSources({
+        asyncQueryService,
+        projectService,
+    }: {
+        asyncQueryService: AsyncQueryService;
+        projectService: ProjectService;
+    }): QuerySourceRegistry {
+        const registry = new QuerySourceRegistry();
+        registry.register(
+            new SemanticLayerQuerySource({
+                asyncQueryService,
+                projectService,
+            }),
+        );
+        registry.register(
+            new SqlQuerySource({
+                asyncQueryService,
+                projectService,
+            }),
+        );
+        registry.register(new DuckdbQuerySource({ asyncQueryService }));
+        return registry;
+    }
 
     register(source: QuerySourceClient): void {
         const { sourceType } = source.definition;

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -67,9 +67,6 @@ import { PromptService } from './PromptService/PromptService';
 import { PullRequestsService } from './PullRequestsService/PullRequestsService';
 import { QuerySourceRegistry } from './QuerySourceService/QuerySourceRegistry';
 import { QuerySourceService } from './QuerySourceService/QuerySourceService';
-import { DuckdbQuerySource } from './QuerySourceService/sources/DuckdbQuerySource';
-import { SemanticLayerQuerySource } from './QuerySourceService/sources/SemanticLayerQuerySource';
-import { SqlQuerySource } from './QuerySourceService/sources/SqlQuerySource';
 import type { ReadinessService } from './ReadinessService/ReadinessService';
 import { RenameService } from './RenameService/RenameService';
 import { RolesService } from './RolesService/RolesService';
@@ -985,22 +982,10 @@ export class ServiceRepository
 
     public getQuerySourceService(): QuerySourceService {
         return this.getService('querySourceService', () => {
-            const asyncQueryService = this.getAsyncQueryService();
-            const projectService = this.getProjectService();
-            const registry = new QuerySourceRegistry();
-            registry.register(
-                new SemanticLayerQuerySource({
-                    asyncQueryService,
-                    projectService,
-                }),
-            );
-            registry.register(
-                new SqlQuerySource({
-                    asyncQueryService,
-                    projectService,
-                }),
-            );
-            registry.register(new DuckdbQuerySource({ asyncQueryService }));
+            const registry = QuerySourceRegistry.withBuiltInSources({
+                asyncQueryService: this.getAsyncQueryService(),
+                projectService: this.getProjectService(),
+            });
 
             return new QuerySourceService({
                 projectModel: this.models.getProjectModel(),

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -209,6 +209,11 @@ export type AiPromptContextItemInput =
           fullName: string;
       }
     | {
+          // A durable table created from an uploaded CSV or connected sheet.
+          type: 'external_source';
+          tableName: string;
+      }
+    | {
           // The review-remediation pull request applying the proposed change.
           type: 'pull_request';
           prUrl: string;
@@ -271,6 +276,10 @@ export type AiPromptContextItem =
           // Resolved repository reference — a passthrough of the input.
           type: 'repository';
           fullName: string;
+      }
+    | {
+          type: 'external_source';
+          tableName: string;
       }
     | {
           type: 'pull_request';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolComposerQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolComposerQueryArgs.ts
@@ -6,6 +6,7 @@ import {
 import {
     QuerySourceType,
     type DuckdbSourceQuery,
+    type ExternalSourceQuery,
     type SemanticLayerSourceQuery,
     type SqlSourceQuery,
 } from '../../../../types/querySources';
@@ -23,6 +24,7 @@ How to build a pipeline:
 - Every query is a node. Name each node with "nodeId" (letters, digits, underscores; starting with a letter or underscore).
 - "semanticLayer" nodes run a metric query against an explore. Result columns are named by field id — exactly the dimensions and metrics requested (e.g. metric "payments_total_revenue" yields column "payments_total_revenue").
 - "sql" nodes run raw SQL against the project's data warehouse, in the warehouse's SQL dialect. Result columns are the SELECT output names. SQL execution may require the user to approve the SQL first.
+- "external" nodes run DuckDB SQL directly over uploaded CSV or connected Google Sheets source tables. Map each SQL table alias to its source table name with "tables". These nodes do not require warehouse SQL approval.
 - "duckdb" nodes run DuckDB SQL over other queries' results. Declare which results the SQL reads via "references": the shorthand array form lists node ids from this submission, each exposed as a table named by its node id (["orders", "revenue"] lets the SQL run SELECT * FROM orders JOIN revenue ...); the map form aliases tables or references stored results by queryUuid ({"o": "orders", "prev": "<queryUuid>"}). A referenced table's columns are the upstream result's columns.
 - The "terminal" node is the one whose results the artifact shows and whose rows are returned to you. By default it is the unique sink (the one node no other node references); pass "terminalNodeId" explicitly when the pipeline has multiple sinks.
 
@@ -133,9 +135,26 @@ export const createToolComposerQueriesArgsSchema = ({
         limit: limitSchema,
     });
 
+    const externalNodeSchema = z.object({
+        sourceType: z.literal(QuerySourceType.EXTERNAL),
+        nodeId: nodeIdSchema,
+        sql: z
+            .string()
+            .describe(
+                'DuckDB SQL over uploaded CSV or connected Google Sheets source tables.',
+            ),
+        tables: z
+            .union([z.array(z.string()), z.record(z.string(), z.string())])
+            .describe(
+                'External source tables read by the SQL. An array exposes every source table under its own name; a map aliases SQL table names to source table names.',
+            ),
+        limit: limitSchema,
+    });
+
     const sourceQueryNodeSchema = z.discriminatedUnion('sourceType', [
         semanticLayerNodeSchema,
         sqlNodeSchema,
+        externalNodeSchema,
         duckdbNodeSchema,
     ]);
 
@@ -181,7 +200,11 @@ export type ToolComposerQueryNode = z.infer<
  */
 export const toolComposerQueryNodeToSourceQuery = (
     node: ToolComposerQueryNode,
-): SemanticLayerSourceQuery | SqlSourceQuery | DuckdbSourceQuery => {
+):
+    | SemanticLayerSourceQuery
+    | SqlSourceQuery
+    | ExternalSourceQuery
+    | DuckdbSourceQuery => {
     switch (node.sourceType) {
         case QuerySourceType.SEMANTIC_LAYER: {
             const filters: MetricQueryRequest['filters'] | undefined =
@@ -203,6 +226,14 @@ export const toolComposerQueryNodeToSourceQuery = (
                 sourceType: node.sourceType,
                 nodeId: node.nodeId,
                 sql: node.sql,
+                limit: node.limit,
+            };
+        case QuerySourceType.EXTERNAL:
+            return {
+                sourceType: node.sourceType,
+                nodeId: node.nodeId,
+                sql: node.sql,
+                tables: node.tables,
                 limit: node.limit,
             };
         case QuerySourceType.DUCKDB:

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -2498,7 +2498,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "Execute a composer query: a pipeline of one or more queries submitted together, where DuckDB queries can join and transform the results of the other queries. Results are stored as a chart artifact that renders the terminal node's results table in the thread.\n\nUse this tool when a single source cannot answer the question — e.g. joining a semantic layer metric query with raw warehouse SQL, or post-processing prior results with SQL. A pipeline may also be a single node: a lone \"sql\" node is how raw warehouse SQL runs when no standalone runSql tool is available.\n\nHow to build a pipeline:\n- Every query is a node. Name each node with \"nodeId\" (letters, digits, underscores; starting with a letter or underscore).\n- \"semanticLayer\" nodes run a metric query against an explore. Result columns are named by field id — exactly the dimensions and metrics requested (e.g. metric \"payments_total_revenue\" yields column \"payments_total_revenue\").\n- \"sql\" nodes run raw SQL against the project's data warehouse, in the warehouse's SQL dialect. Result columns are the SELECT output names. SQL execution may require the user to approve the SQL first.\n- \"duckdb\" nodes run DuckDB SQL over other queries' results. Declare which results the SQL reads via \"references\": the shorthand array form lists node ids from this submission, each exposed as a table named by its node id ([\"orders\", \"revenue\"] lets the SQL run SELECT * FROM orders JOIN revenue ...); the map form aliases tables or references stored results by queryUuid ({\"o\": \"orders\", \"prev\": \"<queryUuid>\"}). A referenced table's columns are the upstream result's columns.\n- The \"terminal\" node is the one whose results the artifact shows and whose rows are returned to you. By default it is the unique sink (the one node no other node references); pass \"terminalNodeId\" explicitly when the pipeline has multiple sinks.\n\nResults are reusable across calls:\n- Every call returns a queryUuid per node. Any of them — not just the terminal one — can be referenced by a later call via the map form of \"references\".\n- Referencing a queryUuid reads the stored result; the query behind it is NOT re-run. A duckdb-only submission over stored results touches no source and needs no SQL approval, however many times you iterate.\n- This supports step-by-step work: run a source query once, then explore its result with as many follow-up duckdb submissions over the same queryUuid as you need.\n- The artifact shown in the thread always renders your LATEST call's terminal result, so finish with the submission that produces the table the user should see — referencing earlier queryUuids keeps that final pipeline small.\n\nReturns the terminal node's result columns and a CSV preview of its rows, plus per-node queryUuids.",
+            "description": "Execute a composer query: a pipeline of one or more queries submitted together, where DuckDB queries can join and transform the results of the other queries. Results are stored as a chart artifact that renders the terminal node's results table in the thread.\n\nUse this tool when a single source cannot answer the question — e.g. joining a semantic layer metric query with raw warehouse SQL, or post-processing prior results with SQL. A pipeline may also be a single node: a lone \"sql\" node is how raw warehouse SQL runs when no standalone runSql tool is available.\n\nHow to build a pipeline:\n- Every query is a node. Name each node with \"nodeId\" (letters, digits, underscores; starting with a letter or underscore).\n- \"semanticLayer\" nodes run a metric query against an explore. Result columns are named by field id — exactly the dimensions and metrics requested (e.g. metric \"payments_total_revenue\" yields column \"payments_total_revenue\").\n- \"sql\" nodes run raw SQL against the project's data warehouse, in the warehouse's SQL dialect. Result columns are the SELECT output names. SQL execution may require the user to approve the SQL first.\n- \"external\" nodes run DuckDB SQL directly over uploaded CSV or connected Google Sheets source tables. Map each SQL table alias to its source table name with \"tables\". These nodes do not require warehouse SQL approval.\n- \"duckdb\" nodes run DuckDB SQL over other queries' results. Declare which results the SQL reads via \"references\": the shorthand array form lists node ids from this submission, each exposed as a table named by its node id ([\"orders\", \"revenue\"] lets the SQL run SELECT * FROM orders JOIN revenue ...); the map form aliases tables or references stored results by queryUuid ({\"o\": \"orders\", \"prev\": \"<queryUuid>\"}). A referenced table's columns are the upstream result's columns.\n- The \"terminal\" node is the one whose results the artifact shows and whose rows are returned to you. By default it is the unique sink (the one node no other node references); pass \"terminalNodeId\" explicitly when the pipeline has multiple sinks.\n\nResults are reusable across calls:\n- Every call returns a queryUuid per node. Any of them — not just the terminal one — can be referenced by a later call via the map form of \"references\".\n- Referencing a queryUuid reads the stored result; the query behind it is NOT re-run. A duckdb-only submission over stored results touches no source and needs no SQL approval, however many times you iterate.\n- This supports step-by-step work: run a source query once, then explore its result with as many follow-up duckdb submissions over the same queryUuid as you need.\n- The artifact shown in the thread always renders your LATEST call's terminal result, so finish with the submission that produces the table the user should see — referencing earlier queryUuids keeps that final pipeline small.\n\nReturns the terminal node's result columns and a CSV preview of its rows, plus per-node queryUuids.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -2613,6 +2613,53 @@
                                         }
                                     },
                                     "required": ["sourceType", "nodeId", "sql"],
+                                    "type": "object"
+                                },
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "limit": {
+                                            "$ref": "#/properties/queries/items/anyOf/0/properties/limit",
+                                            "default": 500,
+                                            "description": "Maximum number of rows this node returns. Defaults to 500, max 5000."
+                                        },
+                                        "nodeId": {
+                                            "description": "Names this query so other queries in the same submission can reference its results. Also the DuckDB table name its results are exposed as.",
+                                            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]{0,62}$",
+                                            "type": "string"
+                                        },
+                                        "sourceType": {
+                                            "const": "external",
+                                            "type": "string"
+                                        },
+                                        "sql": {
+                                            "description": "DuckDB SQL over uploaded CSV or connected Google Sheets source tables.",
+                                            "type": "string"
+                                        },
+                                        "tables": {
+                                            "anyOf": [
+                                                {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            ],
+                                            "description": "External source tables read by the SQL. An array exposes every source table under its own name; a map aliases SQL table names to source table names."
+                                        }
+                                    },
+                                    "required": [
+                                        "sourceType",
+                                        "nodeId",
+                                        "sql",
+                                        "tables"
+                                    ],
                                     "type": "object"
                                 },
                                 {

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -6,6 +6,10 @@ import type { AndFilterGroup, DashboardFilters, Filters } from '../filter';
 import { type MergeQuery, type MetricSourcedMergeQuery } from '../mergeQuery';
 import type { MetricQueryRequest, SortField } from '../metricQuery';
 import type { PivotConfig } from '../pivot';
+import type {
+    ExternalSourceTableReference,
+    QuerySourceTableName,
+} from '../querySources';
 import type { DateGranularity } from '../timeFrames';
 import type { UUID } from './uuid';
 
@@ -102,6 +106,20 @@ export type ExecuteAsyncComposeSqlQueryRequestParams =
          * additionalProperties intact (and validates the uuid format).
          */
         references?: Record<string, UUID>;
+    };
+
+export type ExecuteAsyncExternalSqlQueryRequestParams =
+    CommonExecuteQueryRequestParams & {
+        sql: string;
+        limit?: number;
+        /**
+         * External source tables exposed to the SQL, keyed by table name:
+         * {"monthly_targets": "monthly_targets"} lets the SQL run
+         * SELECT * FROM monthly_targets. Values are table names or
+         * external_source_table_uuids. Ref-aliased value type for the same
+         * TSOA record-compilation reason as compose references above.
+         */
+        tables: Record<QuerySourceTableName, ExternalSourceTableReference>;
     };
 
 export type ExecuteAsyncUnderlyingDataRequestParams =

--- a/packages/common/src/types/querySources.ts
+++ b/packages/common/src/types/querySources.ts
@@ -34,6 +34,13 @@ export enum QuerySourceType {
      * step of a multi-source pipeline.
      */
     DUCKDB = 'duckdb',
+    /**
+     * DuckDB SQL over a project's external source tables (uploaded CSVs,
+     * connected Google Sheets). Tables are durable ingested files, not query
+     * results, so external queries have no upstream dependencies; join them
+     * with other results via a duckdb query. Enterprise only.
+     */
+    EXTERNAL = 'external',
 }
 
 /**
@@ -139,6 +146,33 @@ export type DuckdbSourceQuery = {
 };
 
 /**
+ * A reference to an external source table: the table's sql name or its
+ * external_source_table_uuid. Names never look like uuids (they cannot
+ * contain hyphens), so the two forms are unambiguous.
+ * @pattern ^[a-zA-Z0-9_][a-zA-Z0-9_-]{0,63}$
+ */
+export type ExternalSourceTableReference = string;
+
+/**
+ * A DuckDB SQL query over a project's external source tables. Tables expose
+ * ingested files as named tables the SQL can select from; a table's column
+ * names are its ingested columns (normalized CSV headers), not explore field
+ * ids. Shorthand array: table names, each exposed as a table of the same
+ * name — ["monthly_targets"] lets the SQL run SELECT * FROM monthly_targets.
+ * Map form for aliasing or uuid references: {tableName: tableNameOrUuid}.
+ */
+export type ExternalSourceQuery = {
+    sourceType: QuerySourceType.EXTERNAL;
+    /** Names this query so other queries in the same submission can reference its results. */
+    nodeId?: QueryNodeId;
+    sql: string;
+    limit?: number;
+    tables:
+        | ExternalSourceTableReference[]
+        | Record<QuerySourceTableName, ExternalSourceTableReference>;
+};
+
+/**
  * The tagged union every submit endpoint takes: one shape per source,
  * discriminated by sourceType. New sources add a member here — this union is
  * the extension point, not new WarehouseTypes values.
@@ -146,7 +180,8 @@ export type DuckdbSourceQuery = {
 export type SourceQuery =
     | SemanticLayerSourceQuery
     | SqlSourceQuery
-    | DuckdbSourceQuery;
+    | DuckdbSourceQuery
+    | ExternalSourceQuery;
 
 /** A column in a source schema, aligned with ResultColumns' {reference, type}. */
 export type QuerySourceSchemaColumn = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -3,12 +3,16 @@ import {
     type AiPromptContextInput,
     type AiPromptContextItem,
     type AiModelOption,
+    FeatureFlags,
 } from '@lightdash/common';
 import { ActionIcon, Box, Group, Paper, Text, Tooltip } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import {
     IconArrowUp,
+    IconPaperclip,
     IconPlayerStop,
     IconTerminal2,
+    IconX,
 } from '@tabler/icons-react';
 import Mention from '@tiptap/extension-mention';
 import { type AnyExtension, type Editor } from '@tiptap/react';
@@ -20,7 +24,9 @@ import {
     ComposerSubmitButton,
     PromptComposer,
 } from '../../../../../components/common/PromptComposer';
+import { AddDataModal } from '../../../../../features/externalSources/components/AddDataModal';
 import useUser from '../../../../../hooks/user/useUser';
+import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import { subscribeToDeepResearchComposerPrompt } from '../../deepResearch/deepResearchRegistry';
@@ -55,6 +61,7 @@ import {
     isContentMentionSuggestionActive,
     type ContentMentionSuggestionItem,
 } from './contentMentions';
+import { ContentReferenceLink } from './ContentReferenceLink';
 import { getAgentSuggestionModes } from './suggestionModes';
 
 const SUGGESTION_CHIP_MENTION_NAME = 'suggestionChip';
@@ -170,6 +177,14 @@ export const AgentChatInput = ({
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const [value, setValueState] = useState(defaultValue ?? '');
+    const [attachedSourceTables, setAttachedSourceTables] = useState<string[]>(
+        [],
+    );
+    const [isUploadOpen, { open: openUpload, close: closeUpload }] =
+        useDisclosure(false);
+    const { data: externalSourcesFlag } = useServerFeatureFlag(
+        FeatureFlags.ExternalSources,
+    );
     const [hasClickedInput, setHasClickedInput] = useState(
         !revealControlsOnFocus,
     );
@@ -511,14 +526,26 @@ export const AgentChatInput = ({
             dismissDeepResearchNudgeForSession();
             setNudgeState('done');
         }
+        const mentionContext = extractContentMentionContext(ed);
+        const sourceContext = attachedSourceTables.map((tableName) => ({
+            type: 'external_source' as const,
+            tableName,
+        }));
+        const context = [...(mentionContext.context ?? []), ...sourceContext];
+        const optimisticContext = [
+            ...(mentionContext.optimisticContext ?? []),
+            ...sourceContext,
+        ];
         onSubmitRef.current({
             message: text,
             toolHints: extractToolHints(ed),
-            ...extractContentMentionContext(ed),
+            ...(context.length > 0 ? { context } : {}),
+            ...(optimisticContext.length > 0 ? { optimisticContext } : {}),
         });
         if (clearOnSubmitRef.current) {
             ed.commands.clearContent();
             setValueState('');
+            setAttachedSourceTables([]);
         }
     };
 
@@ -772,57 +799,125 @@ export const AgentChatInput = ({
         onValueChange: handleComposerValueChange,
         shouldBlockSubmit,
         onSubmit: handleSubmit,
+        attachments:
+            attachedSourceTables.length > 0 ? (
+                <Group gap="xs" wrap="wrap">
+                    {attachedSourceTables.map((tableName) => (
+                        <ContentReferenceLink
+                            key={tableName}
+                            kind="external_source"
+                            showArrow={false}
+                        >
+                            <Group gap={4} wrap="nowrap">
+                                <span>{tableName}</span>
+                                <ActionIcon
+                                    size="xs"
+                                    variant="transparent"
+                                    color="gray"
+                                    aria-label={`Remove ${tableName}`}
+                                    onClick={() =>
+                                        setAttachedSourceTables((tables) =>
+                                            tables.filter(
+                                                (table) => table !== tableName,
+                                            ),
+                                        )
+                                    }
+                                >
+                                    <MantineIcon icon={IconX} size={11} />
+                                </ActionIcon>
+                            </Group>
+                        </ContentReferenceLink>
+                    ))}
+                </Group>
+            ) : undefined,
     };
+
+    const canUploadCsv =
+        !!projectUuid &&
+        externalSourcesFlag?.enabled === true &&
+        !disabled &&
+        !isEmbedAiAgentRoute();
+    const uploadAction = canUploadCsv ? (
+        <Tooltip label="Upload CSV" withArrow>
+            <ActionIcon
+                variant="subtle"
+                color="gray"
+                size="sm"
+                aria-label="Upload CSV"
+                onClick={openUpload}
+            >
+                <MantineIcon icon={IconPaperclip} size={15} />
+            </ActionIcon>
+        </Tooltip>
+    ) : null;
+    const uploadModal = projectUuid ? (
+        <AddDataModal
+            projectUuid={projectUuid}
+            opened={isUploadOpen}
+            onClose={closeUpload}
+            onCreated={(tableName) => {
+                setAttachedSourceTables((tables) =>
+                    tables.includes(tableName)
+                        ? tables
+                        : [...tables, tableName],
+                );
+            }}
+        />
+    ) : null;
 
     if (isMinimalMode) {
         return (
-            <Box
-                className={`${styles.minimalContainer} ${
-                    fullWidth ? styles.minimalContainerFullWidth : ''
-                }`}
-                ref={rootRef}
-            >
-                {isThreadInput && renderChipRow(styles.threadChipFlow)}
+            <>
+                <Box
+                    className={`${styles.minimalContainer} ${
+                        fullWidth ? styles.minimalContainerFullWidth : ''
+                    }`}
+                    ref={rootRef}
+                >
+                    {isThreadInput && renderChipRow(styles.threadChipFlow)}
 
-                <Box className={styles.threadInputStack}>
-                    <PromptComposer
-                        {...composerCommonProps}
-                        variant="inline"
-                        toolbarRight={
-                            <Group gap={4} align="center" wrap="nowrap">
-                                {deepResearchControl}
-                                {renderComposerAction('sm')}
-                            </Group>
-                        }
-                    />
-                </Box>
+                    <Box className={styles.threadInputStack}>
+                        <PromptComposer
+                            {...composerCommonProps}
+                            variant="inline"
+                            toolbarRight={
+                                <Group gap={4} align="center" wrap="nowrap">
+                                    {uploadAction}
+                                    {deepResearchControl}
+                                    {renderComposerAction('sm')}
+                                </Group>
+                            }
+                        />
+                    </Box>
 
-                {shouldShowDeepResearchBelowComposer
-                    ? renderExternalModeControls({
-                          actionSize: 'sm',
-                          iconSize: 14,
-                      })
-                    : showSqlModeControl && (
-                          <Box className={styles.belowComposerControls}>
-                              {renderSqlModeControl({
-                                  actionSize: 'sm',
-                                  iconSize: 14,
-                              })}
-                          </Box>
-                      )}
+                    {shouldShowDeepResearchBelowComposer
+                        ? renderExternalModeControls({
+                              actionSize: 'sm',
+                              iconSize: 14,
+                          })
+                        : showSqlModeControl && (
+                              <Box className={styles.belowComposerControls}>
+                                  {renderSqlModeControl({
+                                      actionSize: 'sm',
+                                      iconSize: 14,
+                                  })}
+                              </Box>
+                          )}
 
-                {!isThreadInput &&
-                    renderChipRow(
-                        styles.chipTray,
-                        shouldReserveEmptyStateSuggestions,
+                    {!isThreadInput &&
+                        renderChipRow(
+                            styles.chipTray,
+                            shouldReserveEmptyStateSuggestions,
+                        )}
+
+                    {showDisabledBanner && (
+                        <Text size="xs" c="dimmed" ta="right" mt="xs" px="sm">
+                            {disabledReason}
+                        </Text>
                     )}
-
-                {showDisabledBanner && (
-                    <Text size="xs" c="dimmed" ta="right" mt="xs" px="sm">
-                        {disabledReason}
-                    </Text>
-                )}
-            </Box>
+                </Box>
+                {uploadModal}
+            </>
         );
     }
 
@@ -843,11 +938,14 @@ export const AgentChatInput = ({
                 className={styles.agentComposer}
                 onMouseDown={handleInputCardMouseDown}
                 toolbarLeft={
-                    !shouldShowDeepResearchBelowComposer &&
-                    renderSqlModeControl({
-                        actionSize: 30,
-                        iconSize: 15,
-                    })
+                    <Group gap={4} wrap="nowrap">
+                        {uploadAction}
+                        {!shouldShowDeepResearchBelowComposer &&
+                            renderSqlModeControl({
+                                actionSize: 30,
+                                iconSize: 15,
+                            })}
+                    </Group>
                 }
                 toolbarRight={
                     <Group gap="xs" align="center" wrap="nowrap">
@@ -913,6 +1011,7 @@ export const AgentChatInput = ({
                     </Text>
                 </Paper>
             )}
+            {uploadModal}
         </Box>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
@@ -9,6 +9,7 @@ import {
     IconGitPullRequest,
     IconLayoutDashboard,
     IconMessages,
+    IconTable,
     IconPencil,
     IconSearch,
     IconSend,
@@ -27,6 +28,7 @@ type ContentReferenceKind =
     | 'thread'
     | 'file'
     | 'repository'
+    | 'external_source'
     | 'pull_request'
     | 'proposed_change'
     | 'review_finding'
@@ -85,6 +87,12 @@ const getIconMeta = ({
                 color: 'ldGray.7',
                 fill: 'ldGray.4',
                 icon: IconBrandGithub,
+            };
+        case 'external_source':
+            return {
+                color: 'teal.7',
+                fill: 'teal.4',
+                icon: IconTable,
             };
         case 'pull_request':
             return {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -273,6 +273,8 @@ const getContextKey = (item: AiPromptContextInput[number]) => {
             return `file:${item.path}`;
         case 'repository':
             return `repository:${item.fullName}`;
+        case 'external_source':
+            return `external_source:${item.tableName}`;
         case 'pull_request':
             return `pull_request:${item.prUrl}`;
         case 'proposed_change':

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
@@ -24,6 +24,8 @@ export const getPromptContextItemKey = (item: AiPromptContextItem) => {
             return `file:${item.path}`;
         case 'repository':
             return `repository:${item.fullName}`;
+        case 'external_source':
+            return `external_source:${item.tableName}`;
         case 'pull_request':
             return `pull_request:${item.prUrl}`;
         case 'proposed_change':
@@ -56,6 +58,8 @@ const getPromptContextItemLabel = (item: AiPromptContextItem) => {
             return item.path;
         case 'repository':
             return item.fullName;
+        case 'external_source':
+            return item.tableName;
         case 'pull_request':
             return item.title ?? `PR #${item.prNumber ?? ''}`.trim();
         case 'proposed_change':
@@ -86,6 +90,7 @@ export const getPromptContextItemHref = (
         // an in-app route, so there is no link to offer.
         case 'file':
         case 'repository':
+        case 'external_source':
             return null;
         case 'pull_request':
             return item.prUrl;

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -9,7 +9,13 @@ type Props = {
 };
 
 type ItemMeta = {
-    kind: 'chart' | 'dashboard' | 'thread' | 'file' | 'repository';
+    kind:
+        | 'chart'
+        | 'dashboard'
+        | 'thread'
+        | 'file'
+        | 'repository'
+        | 'external_source';
     label: string;
     href: string | null;
 };
@@ -17,7 +23,15 @@ type ItemMeta = {
 const getItemMeta = (
     item: Extract<
         AiPromptContextItem,
-        { type: 'chart' | 'dashboard' | 'thread' | 'file' | 'repository' }
+        {
+            type:
+                | 'chart'
+                | 'dashboard'
+                | 'thread'
+                | 'file'
+                | 'repository'
+                | 'external_source';
+        }
     >,
     projectUuid: string,
 ): ItemMeta => {
@@ -46,6 +60,12 @@ const getItemMeta = (
             return { kind: 'file', label: item.path, href: null };
         case 'repository':
             return { kind: 'repository', label: item.fullName, href: null };
+        case 'external_source':
+            return {
+                kind: 'external_source',
+                label: item.tableName,
+                href: `/projects/${projectUuid}/tables/${item.tableName}`,
+            };
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
@@ -57,7 +77,8 @@ export const PinnedContextCard: FC<Props> = ({ item, projectUuid }) => {
         case 'dashboard':
         case 'thread':
         case 'file':
-        case 'repository': {
+        case 'repository':
+        case 'external_source': {
             const meta = getItemMeta(item, projectUuid);
             return (
                 <ContentReferenceLink

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -682,6 +682,8 @@ const toOptimisticContextItem = (
             return { type: 'file', path: item.path };
         case 'repository':
             return { type: 'repository', fullName: item.fullName };
+        case 'external_source':
+            return { type: 'external_source', tableName: item.tableName };
         case 'pull_request':
             return {
                 type: 'pull_request',


### PR DESCRIPTION
## Summary

- add CSV uploads directly to the AI agent chat composer
- attach uploaded external sources as persisted agent context
- let `runComposerQueries` query external source nodes and use them in downstream compositions
- render uploaded source references consistently across chat context and pinned context
- preserve external source readiness metadata during query execution

## Demo

Verified end to end by uploading a regional targets CSV, attaching it to an agent prompt, and asking for totals by region. The agent inspected the external source through the composition query tool and returned the correct total of `$483,000`.

## Tests

- `pnpm -F backend exec vitest run --config vitest.config.ts src/ee/services/ai/tools/runComposerQueries.test.ts src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts`
- `pnpm -F frontend exec vitest run src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx`
- `pnpm -F common typecheck`
- `pnpm -F frontend typecheck`
- `pnpm -F common lint`
- `pnpm -F frontend lint`
- `NODE_OPTIONS='--max-old-space-size=8192' pnpm -F backend lint`

## Dependency

Depends on #27793, which registers external tables as query sources. Its query-source commit is included here so this branch remains testable against `main`; it can be dropped once #27793 merges.
