### PR TITLE
feat(ai-agents): run and render composer queries

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -10070,19 +10070,24 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 user,
                 featureFlagId: FeatureFlags.MergeQueries,
             });
-        // Composer queries (multi-source pipelines): the MultiSourceQuery flag
-        // gates the whole feature (the service re-checks it at execution);
-        // v0 surface is standard web chat only, so Slack prompts never get the
-        // tool, and neither do deep-research runs — composer supersedes the
-        // standalone runSql tool, but the deep-research worker/coordinator
-        // toolsets still rely on runSql.
-        const { enabled: multiSourceQueryEnabled } =
-            await this.featureFlagService.get({
+        // Composer is web-chat only and requires both orchestration and DuckDB
+        // compose; Slack and deep research retain their existing SQL tools.
+        const [
+            { enabled: multiSourceQueryEnabled },
+            { enabled: composeSqlRunnerEnabled },
+        ] = await Promise.all([
+            this.featureFlagService.get({
                 user,
                 featureFlagId: FeatureFlags.MultiSourceQuery,
-            });
+            }),
+            this.featureFlagService.get({
+                user,
+                featureFlagId: FeatureFlags.ComposeSqlRunner,
+            }),
+        ]);
         const enableComposerQueries =
             multiSourceQueryEnabled &&
+            composeSqlRunnerEnabled &&
             agentSettings.enableDataAccess &&
             !isSlackPrompt(prompt) &&
             responseExecution.mode !== 'deep_research';

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -6664,12 +6664,13 @@ Notes:
   {
     "description": "Execute a composer query: a pipeline of one or more queries submitted together, where DuckDB queries can join and transform the results of the other queries. Results are stored as a chart artifact that renders the terminal node's results table in the thread.
 
-Use this tool when a single source cannot answer the question — e.g. joining a semantic layer metric query with raw warehouse SQL, or post-processing prior results with SQL. A pipeline may also be a single node: a lone "sql" node is how raw warehouse SQL runs when no standalone runSql tool is available.
+Use this tool when a single source cannot answer the question — e.g. joining a semantic layer metric query with an uploaded CSV, joining with raw warehouse SQL, or post-processing prior results with SQL. A pipeline may also be a single node: a lone "sql" node is how raw warehouse SQL runs when no standalone runSql tool is available.
 
 How to build a pipeline:
 - Every query is a node. Name each node with "nodeId" (letters, digits, underscores; starting with a letter or underscore).
 - "semanticLayer" nodes run a metric query against an explore. Result columns are named by field id — exactly the dimensions and metrics requested (e.g. metric "payments_total_revenue" yields column "payments_total_revenue").
 - "sql" nodes run raw SQL against the project's data warehouse, in the warehouse's SQL dialect. Result columns are the SELECT output names. SQL execution may require the user to approve the SQL first.
+- "external" nodes run DuckDB SQL over durable external tables such as uploaded CSVs and connected Google Sheets. Declare the tables via "tables": an array of table names, or a map of {sqlAlias: tableNameOrTableUuid}. Use the exact table name or UUID supplied in the user's attached-table context. Result columns are the SELECT output names. A single external node can read multiple external tables.
 - "duckdb" nodes run DuckDB SQL over other queries' results. Declare which results the SQL reads via "references": the shorthand array form lists node ids from this submission, each exposed as a table named by its node id (["orders", "revenue"] lets the SQL run SELECT * FROM orders JOIN revenue ...); the map form aliases tables or references stored results by queryUuid ({"o": "orders", "prev": "<queryUuid>"}). A referenced table's columns are the upstream result's columns.
 - The "terminal" node is the one whose results the artifact shows and whose rows are returned to you. By default it is the unique sink (the one node no other node references); pass "terminalNodeId" explicitly when the pipeline has multiple sinks.
 
@@ -6868,6 +6869,55 @@ Returns the terminal node's result columns and a CSV preview of its rows, plus p
                   "nodeId",
                   "sql",
                   "references",
+                ],
+                "type": "object",
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "limit": {
+                    "default": 500,
+                    "description": "Maximum number of rows this node returns. Defaults to 500, max 500.",
+                    "exclusiveMinimum": 0,
+                    "maximum": 500,
+                    "type": "integer",
+                  },
+                  "nodeId": {
+                    "description": "Names this query so other queries in the same submission can reference its results. Also the DuckDB table name its results are exposed as.",
+                    "pattern": "^[a-zA-Z_][a-zA-Z0-9_]{0,62}$",
+                    "type": "string",
+                  },
+                  "sourceType": {
+                    "const": "external",
+                    "type": "string",
+                  },
+                  "sql": {
+                    "description": "DuckDB SQL over the declared external source tables. Each table is exposed under its name or map alias.",
+                    "type": "string",
+                  },
+                  "tables": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      {
+                        "additionalProperties": {
+                          "type": "string",
+                        },
+                        "type": "object",
+                      },
+                    ],
+                    "description": "External tables read by this query: an array of table names, or a map of {sqlAlias: tableNameOrTableUuid}. Prefer the table UUID from attached-table context so renames cannot break the query.",
+                  },
+                },
+                "required": [
+                  "sourceType",
+                  "nodeId",
+                  "sql",
+                  "tables",
                 ],
                 "type": "object",
               },

--- a/packages/backend/src/ee/services/ai/tools/runComposerQueries.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runComposerQueries.test.ts
@@ -55,6 +55,16 @@ const duckdbNode: ComposerNode = {
     limit: 500,
 };
 
+const externalNode: ComposerNode = {
+    sourceType: QuerySourceType.EXTERNAL,
+    nodeId: 'targets',
+    sql: 'SELECT region, target FROM targets',
+    tables: {
+        targets: '2b7cd26e-1b5a-4aaf-9955-e25c381c501f',
+    },
+    limit: 500,
+};
+
 const makeArgs = (
     overrides: Partial<ToolComposerQueriesArgs> = {},
 ): ToolComposerQueriesArgs => ({
@@ -242,6 +252,56 @@ describe('getRunComposerQueries', () => {
 
         expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
         expect(dependencies.recordSqlApproval).not.toHaveBeenCalled();
+        expect(output.metadata?.status).toBe('success');
+    });
+
+    it('passes attached external tables through without SQL approval', async () => {
+        const { tool, dependencies } = makeTool();
+
+        const output = await executeTool(
+            tool,
+            makeArgs({ queries: [externalNode] }),
+        );
+
+        expect(dependencies.runComposerQueries).toHaveBeenCalledWith({
+            queries: [
+                {
+                    ...externalNode,
+                    tables: {
+                        targets: '2b7cd26e-1b5a-4aaf-9955-e25c381c501f',
+                    },
+                },
+            ],
+            terminalNodeId: 'targets',
+        });
+        expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
+        expect(output.metadata?.status).toBe('success');
+    });
+
+    it('composes semantic layer results with an attached external table', async () => {
+        const { tool, dependencies } = makeTool();
+        const composedNode: ComposerNode = {
+            ...duckdbNode,
+            sql: 'SELECT revenue.*, targets.target FROM revenue JOIN targets USING (region)',
+            references: ['revenue', 'targets'],
+        };
+
+        const output = await executeTool(
+            tool,
+            makeArgs({
+                queries: [semanticNode, externalNode, composedNode],
+            }),
+        );
+
+        expect(dependencies.runComposerQueries).toHaveBeenCalledWith({
+            queries: [
+                { ...semanticNode, filters: undefined, sorts: undefined },
+                externalNode,
+                composedNode,
+            ],
+            terminalNodeId: 'joined',
+        });
+        expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
         expect(output.metadata?.status).toBe('success');
     });
 

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolComposerQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolComposerQueryArgs.ts
@@ -6,6 +6,7 @@ import {
 import {
     QuerySourceType,
     type DuckdbSourceQuery,
+    type ExternalSourceQuery,
     type SemanticLayerSourceQuery,
     type SqlSourceQuery,
 } from '../../../../types/querySources';
@@ -17,12 +18,13 @@ export const DEFAULT_COMPOSER_QUERY_MAX_LIMIT = 5000;
 
 export const TOOL_COMPOSER_QUERIES_DESCRIPTION = `Execute a composer query: a pipeline of one or more queries submitted together, where DuckDB queries can join and transform the results of the other queries. Results are stored as a chart artifact that renders the terminal node's results table in the thread.
 
-Use this tool when a single source cannot answer the question — e.g. joining a semantic layer metric query with raw warehouse SQL, or post-processing prior results with SQL. A pipeline may also be a single node: a lone "sql" node is how raw warehouse SQL runs when no standalone runSql tool is available.
+Use this tool when a single source cannot answer the question — e.g. joining a semantic layer metric query with an uploaded CSV, joining with raw warehouse SQL, or post-processing prior results with SQL. A pipeline may also be a single node: a lone "sql" node is how raw warehouse SQL runs when no standalone runSql tool is available.
 
 How to build a pipeline:
 - Every query is a node. Name each node with "nodeId" (letters, digits, underscores; starting with a letter or underscore).
 - "semanticLayer" nodes run a metric query against an explore. Result columns are named by field id — exactly the dimensions and metrics requested (e.g. metric "payments_total_revenue" yields column "payments_total_revenue").
 - "sql" nodes run raw SQL against the project's data warehouse, in the warehouse's SQL dialect. Result columns are the SELECT output names. SQL execution may require the user to approve the SQL first.
+- "external" nodes run DuckDB SQL over durable external tables such as uploaded CSVs and connected Google Sheets. Declare the tables via "tables": an array of table names, or a map of {sqlAlias: tableNameOrTableUuid}. Use the exact table name or UUID supplied in the user's attached-table context. Result columns are the SELECT output names. A single external node can read multiple external tables.
 - "duckdb" nodes run DuckDB SQL over other queries' results. Declare which results the SQL reads via "references": the shorthand array form lists node ids from this submission, each exposed as a table named by its node id (["orders", "revenue"] lets the SQL run SELECT * FROM orders JOIN revenue ...); the map form aliases tables or references stored results by queryUuid ({"o": "orders", "prev": "<queryUuid>"}). A referenced table's columns are the upstream result's columns.
 - The "terminal" node is the one whose results the artifact shows and whose rows are returned to you. By default it is the unique sink (the one node no other node references); pass "terminalNodeId" explicitly when the pipeline has multiple sinks.
 
@@ -133,10 +135,27 @@ export const createToolComposerQueriesArgsSchema = ({
         limit: limitSchema,
     });
 
+    const externalNodeSchema = z.object({
+        sourceType: z.literal(QuerySourceType.EXTERNAL),
+        nodeId: nodeIdSchema,
+        sql: z
+            .string()
+            .describe(
+                'DuckDB SQL over the declared external source tables. Each table is exposed under its name or map alias.',
+            ),
+        tables: z
+            .union([z.array(z.string()), z.record(z.string(), z.string())])
+            .describe(
+                'External tables read by this query: an array of table names, or a map of {sqlAlias: tableNameOrTableUuid}. Prefer the table UUID from attached-table context so renames cannot break the query.',
+            ),
+        limit: limitSchema,
+    });
+
     const sourceQueryNodeSchema = z.discriminatedUnion('sourceType', [
         semanticLayerNodeSchema,
         sqlNodeSchema,
         duckdbNodeSchema,
+        externalNodeSchema,
     ]);
 
     return createToolSchema()
@@ -181,7 +200,11 @@ export type ToolComposerQueryNode = z.infer<
  */
 export const toolComposerQueryNodeToSourceQuery = (
     node: ToolComposerQueryNode,
-): SemanticLayerSourceQuery | SqlSourceQuery | DuckdbSourceQuery => {
+):
+    | SemanticLayerSourceQuery
+    | SqlSourceQuery
+    | DuckdbSourceQuery
+    | ExternalSourceQuery => {
     switch (node.sourceType) {
         case QuerySourceType.SEMANTIC_LAYER: {
             const filters: MetricQueryRequest['filters'] | undefined =
@@ -211,6 +234,14 @@ export const toolComposerQueryNodeToSourceQuery = (
                 nodeId: node.nodeId,
                 sql: node.sql,
                 references: node.references,
+                limit: node.limit,
+            };
+        case QuerySourceType.EXTERNAL:
+            return {
+                sourceType: node.sourceType,
+                nodeId: node.nodeId,
+                sql: node.sql,
+                tables: node.tables,
                 limit: node.limit,
             };
         default:

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -2498,7 +2498,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "Execute a composer query: a pipeline of one or more queries submitted together, where DuckDB queries can join and transform the results of the other queries. Results are stored as a chart artifact that renders the terminal node's results table in the thread.\n\nUse this tool when a single source cannot answer the question — e.g. joining a semantic layer metric query with raw warehouse SQL, or post-processing prior results with SQL. A pipeline may also be a single node: a lone \"sql\" node is how raw warehouse SQL runs when no standalone runSql tool is available.\n\nHow to build a pipeline:\n- Every query is a node. Name each node with \"nodeId\" (letters, digits, underscores; starting with a letter or underscore).\n- \"semanticLayer\" nodes run a metric query against an explore. Result columns are named by field id — exactly the dimensions and metrics requested (e.g. metric \"payments_total_revenue\" yields column \"payments_total_revenue\").\n- \"sql\" nodes run raw SQL against the project's data warehouse, in the warehouse's SQL dialect. Result columns are the SELECT output names. SQL execution may require the user to approve the SQL first.\n- \"duckdb\" nodes run DuckDB SQL over other queries' results. Declare which results the SQL reads via \"references\": the shorthand array form lists node ids from this submission, each exposed as a table named by its node id ([\"orders\", \"revenue\"] lets the SQL run SELECT * FROM orders JOIN revenue ...); the map form aliases tables or references stored results by queryUuid ({\"o\": \"orders\", \"prev\": \"<queryUuid>\"}). A referenced table's columns are the upstream result's columns.\n- The \"terminal\" node is the one whose results the artifact shows and whose rows are returned to you. By default it is the unique sink (the one node no other node references); pass \"terminalNodeId\" explicitly when the pipeline has multiple sinks.\n\nResults are reusable across calls:\n- Every call returns a queryUuid per node. Any of them — not just the terminal one — can be referenced by a later call via the map form of \"references\".\n- Referencing a queryUuid reads the stored result; the query behind it is NOT re-run. A duckdb-only submission over stored results touches no source and needs no SQL approval, however many times you iterate.\n- This supports step-by-step work: run a source query once, then explore its result with as many follow-up duckdb submissions over the same queryUuid as you need.\n- The artifact shown in the thread always renders your LATEST call's terminal result, so finish with the submission that produces the table the user should see — referencing earlier queryUuids keeps that final pipeline small.\n\nReturns the terminal node's result columns and a CSV preview of its rows, plus per-node queryUuids.",
+            "description": "Execute a composer query: a pipeline of one or more queries submitted together, where DuckDB queries can join and transform the results of the other queries. Results are stored as a chart artifact that renders the terminal node's results table in the thread.\n\nUse this tool when a single source cannot answer the question — e.g. joining a semantic layer metric query with an uploaded CSV, joining with raw warehouse SQL, or post-processing prior results with SQL. A pipeline may also be a single node: a lone \"sql\" node is how raw warehouse SQL runs when no standalone runSql tool is available.\n\nHow to build a pipeline:\n- Every query is a node. Name each node with \"nodeId\" (letters, digits, underscores; starting with a letter or underscore).\n- \"semanticLayer\" nodes run a metric query against an explore. Result columns are named by field id — exactly the dimensions and metrics requested (e.g. metric \"payments_total_revenue\" yields column \"payments_total_revenue\").\n- \"sql\" nodes run raw SQL against the project's data warehouse, in the warehouse's SQL dialect. Result columns are the SELECT output names. SQL execution may require the user to approve the SQL first.\n- \"external\" nodes run DuckDB SQL over durable external tables such as uploaded CSVs and connected Google Sheets. Declare the tables via \"tables\": an array of table names, or a map of {sqlAlias: tableNameOrTableUuid}. Use the exact table name or UUID supplied in the user's attached-table context. Result columns are the SELECT output names. A single external node can read multiple external tables.\n- \"duckdb\" nodes run DuckDB SQL over other queries' results. Declare which results the SQL reads via \"references\": the shorthand array form lists node ids from this submission, each exposed as a table named by its node id ([\"orders\", \"revenue\"] lets the SQL run SELECT * FROM orders JOIN revenue ...); the map form aliases tables or references stored results by queryUuid ({\"o\": \"orders\", \"prev\": \"<queryUuid>\"}). A referenced table's columns are the upstream result's columns.\n- The \"terminal\" node is the one whose results the artifact shows and whose rows are returned to you. By default it is the unique sink (the one node no other node references); pass \"terminalNodeId\" explicitly when the pipeline has multiple sinks.\n\nResults are reusable across calls:\n- Every call returns a queryUuid per node. Any of them — not just the terminal one — can be referenced by a later call via the map form of \"references\".\n- Referencing a queryUuid reads the stored result; the query behind it is NOT re-run. A duckdb-only submission over stored results touches no source and needs no SQL approval, however many times you iterate.\n- This supports step-by-step work: run a source query once, then explore its result with as many follow-up duckdb submissions over the same queryUuid as you need.\n- The artifact shown in the thread always renders your LATEST call's terminal result, so finish with the submission that produces the table the user should see — referencing earlier queryUuids keeps that final pipeline small.\n\nReturns the terminal node's result columns and a CSV preview of its rows, plus per-node queryUuids.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -2659,6 +2659,53 @@
                                         "nodeId",
                                         "sql",
                                         "references"
+                                    ],
+                                    "type": "object"
+                                },
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "limit": {
+                                            "$ref": "#/properties/queries/items/anyOf/0/properties/limit",
+                                            "default": 500,
+                                            "description": "Maximum number of rows this node returns. Defaults to 500, max 5000."
+                                        },
+                                        "nodeId": {
+                                            "description": "Names this query so other queries in the same submission can reference its results. Also the DuckDB table name its results are exposed as.",
+                                            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]{0,62}$",
+                                            "type": "string"
+                                        },
+                                        "sourceType": {
+                                            "const": "external",
+                                            "type": "string"
+                                        },
+                                        "sql": {
+                                            "description": "DuckDB SQL over the declared external source tables. Each table is exposed under its name or map alias.",
+                                            "type": "string"
+                                        },
+                                        "tables": {
+                                            "anyOf": [
+                                                {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            ],
+                                            "description": "External tables read by this query: an array of table names, or a map of {sqlAlias: tableNameOrTableUuid}. Prefer the table UUID from attached-table context so renames cannot break the query."
+                                        }
+                                    },
+                                    "required": [
+                                        "sourceType",
+                                        "nodeId",
+                                        "sql",
+                                        "tables"
                                     ],
                                     "type": "object"
                                 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactTableVisualization.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactTableVisualization.module.css
@@ -1,0 +1,4 @@
+.tableContainer {
+    flex-shrink: 1;
+    overflow: hidden;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactTableVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactTableVisualization.tsx
@@ -1,0 +1,86 @@
+import { type RawResultRow, type ResultRow } from '@lightdash/common';
+import { Center, Loader, Paper, Stack } from '@mantine/core';
+import { useEffect, useMemo, type FC, type ReactNode } from 'react';
+import { ROW_HEIGHT_PX } from '../../../../../components/common/Table/constants';
+import { ChartDataTable } from '../../../../../components/DataViz/visualizations/ChartDataTable';
+import { type InfiniteQueryResults } from '../../../../../hooks/useQueryResults';
+import styles from './AiArtifactTableVisualization.module.css';
+import { getAiArtifactTableConfig } from './AiArtifactTableVisualization.utils';
+
+const TABLE_HEADER_HEIGHT_PX = 34;
+
+const unwrapRows = (rows: ResultRow[]): RawResultRow[] =>
+    rows.map((row) =>
+        Object.fromEntries(
+            Object.entries(row).map(([key, value]) => [key, value.value.raw]),
+        ),
+    );
+
+type Props = {
+    results: InfiniteQueryResults;
+    headerContent: ReactNode;
+    loadingMessage: string;
+};
+
+export const AiArtifactTableVisualization: FC<Props> = ({
+    results,
+    headerContent,
+    loadingMessage,
+}) => {
+    const columns = useMemo(
+        () => Object.values(results.columns ?? {}),
+        [results.columns],
+    );
+    const columnNames = useMemo(
+        () => columns.map((column) => column.reference),
+        [columns],
+    );
+    const rows = useMemo(() => unwrapRows(results.rows), [results.rows]);
+
+    useEffect(() => {
+        if (!results.hasFetchedAllRows && !results.fetchAll) {
+            results.setFetchAll(true);
+        }
+    }, [results]);
+
+    if (
+        results.isInitialLoading ||
+        results.isFetchingFirstPage ||
+        columns.length === 0
+    ) {
+        return (
+            <Center h={300}>
+                <Loader
+                    type="dots"
+                    color="ldGray.6"
+                    delayedMessage={loadingMessage}
+                />
+            </Center>
+        );
+    }
+
+    const contentHeight = TABLE_HEADER_HEIGHT_PX + rows.length * ROW_HEIGHT_PX;
+
+    return (
+        <Stack gap="md" h="100%" mih={0}>
+            {headerContent}
+            <Paper
+                h={contentHeight}
+                mah="100%"
+                mih={0}
+                pos="relative"
+                withBorder
+                radius="md"
+                bg="ldGray.0"
+                className={styles.tableContainer}
+            >
+                <ChartDataTable
+                    columnNames={columnNames}
+                    rows={rows}
+                    columnsConfig={getAiArtifactTableConfig(columns).columns}
+                    flexProps={{ h: '100%', mah: '100%' }}
+                />
+            </Paper>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactTableVisualization.utils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactTableVisualization.utils.ts
@@ -1,0 +1,24 @@
+import {
+    ChartKind,
+    type ResultColumn,
+    type VizTableConfig,
+} from '@lightdash/common';
+
+export const getAiArtifactTableConfig = (
+    columns: ResultColumn[],
+): VizTableConfig => ({
+    metadata: { version: 1 },
+    type: ChartKind.TABLE,
+    columns: Object.fromEntries(
+        columns.map((column) => [
+            column.reference,
+            {
+                visible: true,
+                reference: column.reference,
+                label: column.reference,
+                frozen: false,
+            },
+        ]),
+    ),
+    display: undefined,
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiComposerArtifactVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiComposerArtifactVisualization.tsx
@@ -1,46 +1,9 @@
-import {
-    ChartKind,
-    type RawResultRow,
-    type ResultColumn,
-    type ResultRow,
-    type VizTableConfig,
-} from '@lightdash/common';
-import { Center, Loader, Paper, Stack, Text } from '@mantine/core';
+import { Center, Stack, Text } from '@mantine/core';
 import { IconClockOff } from '@tabler/icons-react';
-import { useEffect, useMemo, type FC, type ReactNode } from 'react';
+import { type FC, type ReactNode } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { ROW_HEIGHT_PX } from '../../../../../components/common/Table/constants';
-import { ChartDataTable } from '../../../../../components/DataViz/visualizations/ChartDataTable';
 import { type InfiniteQueryResults } from '../../../../../hooks/useQueryResults';
-
-const unwrapRows = (rows: ResultRow[]): RawResultRow[] =>
-    rows.map((row) =>
-        Object.fromEntries(
-            Object.entries(row).map(([key, value]) => [key, value.value.raw]),
-        ),
-    );
-
-// Same shrink-to-fit behavior as the SQL artifact table: a compact chat panel
-// reads as broken with a mostly-empty card.
-const MAX_SHRINK_TO_FIT_HEIGHT_PX = 300;
-const TABLE_HEADER_HEIGHT_PX = 34;
-
-const getTableConfig = (columns: ResultColumn[]): VizTableConfig => ({
-    metadata: { version: 1 },
-    type: ChartKind.TABLE,
-    columns: Object.fromEntries(
-        columns.map((column) => [
-            column.reference,
-            {
-                visible: true,
-                reference: column.reference,
-                label: column.reference,
-                frozen: false,
-            },
-        ]),
-    ),
-    display: undefined,
-});
+import { AiArtifactTableVisualization } from './AiArtifactTableVisualization';
 
 type ContentProps = {
     results: InfiniteQueryResults;
@@ -56,22 +19,6 @@ export const AiComposerArtifactVisualization: FC<ContentProps> = ({
     results,
     headerContent,
 }) => {
-    const columns = useMemo(
-        () => Object.values(results.columns ?? {}),
-        [results.columns],
-    );
-    const columnNames = useMemo(
-        () => columns.map((column) => column.reference),
-        [columns],
-    );
-    const rows = useMemo(() => unwrapRows(results.rows), [results.rows]);
-
-    useEffect(() => {
-        if (!results.hasFetchedAllRows && !results.fetchAll && !results.error) {
-            results.setFetchAll(true);
-        }
-    }, [results]);
-
     if (results.error) {
         return (
             <Stack gap="md" h="100%" mih={300}>
@@ -89,50 +36,11 @@ export const AiComposerArtifactVisualization: FC<ContentProps> = ({
         );
     }
 
-    if (
-        results.isInitialLoading ||
-        results.isFetchingFirstPage ||
-        columns.length === 0
-    ) {
-        return (
-            <Center h={300}>
-                <Loader
-                    type="dots"
-                    color="gray"
-                    delayedMessage="Loading composer query results..."
-                />
-            </Center>
-        );
-    }
-
-    const estimatedContentHeight =
-        TABLE_HEADER_HEIGHT_PX + rows.length * ROW_HEIGHT_PX;
-    const shrinkToFit = estimatedContentHeight <= MAX_SHRINK_TO_FIT_HEIGHT_PX;
-
     return (
-        <Stack
-            gap="md"
-            h={shrinkToFit ? undefined : '100%'}
-            mih={shrinkToFit ? undefined : 300}
-        >
-            {headerContent}
-            <Paper
-                flex={shrinkToFit ? undefined : 1}
-                mah={shrinkToFit ? estimatedContentHeight : undefined}
-                mih={0}
-                pos="relative"
-                withBorder
-                radius="md"
-                bg="ldGray.0"
-                style={{ overflow: 'hidden' }}
-            >
-                <ChartDataTable
-                    columnNames={columnNames}
-                    rows={rows}
-                    columnsConfig={getTableConfig(columns).columns}
-                    flexProps={{ mah: '100%' }}
-                />
-            </Paper>
-        </Stack>
+        <AiArtifactTableVisualization
+            results={results}
+            headerContent={headerContent}
+            loadingMessage="Loading composer query results..."
+        />
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSqlArtifactVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSqlArtifactVisualization.tsx
@@ -1,60 +1,23 @@
 import { subject } from '@casl/ability';
-import {
-    ChartKind,
-    type RawResultRow,
-    type ResultColumn,
-    type ResultRow,
-    type VizTableConfig,
-} from '@lightdash/common';
-import { ActionIcon, Center, Loader, Menu, Paper, Stack } from '@mantine/core';
+import { type ResultColumn } from '@lightdash/common';
+import { ActionIcon, Menu } from '@mantine/core';
 import {
     IconDeviceFloppy,
     IconDots,
     IconDownload,
     IconTerminal2,
 } from '@tabler/icons-react';
-import { useEffect, useMemo, useState, type FC, type ReactNode } from 'react';
+import { useState, type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { ROW_HEIGHT_PX } from '../../../../../components/common/Table/constants';
-import { ChartDataTable } from '../../../../../components/DataViz/visualizations/ChartDataTable';
 import { SaveSqlChartModalContent } from '../../../../../features/sqlRunner/components/SaveSqlChartModal';
 import { type InfiniteQueryResults } from '../../../../../hooks/useQueryResults';
 import useCreateInAnySpaceAccess from '../../../../../hooks/user/useCreateInAnySpaceAccess';
 import useApp from '../../../../../providers/App/useApp';
 import { useUpdateArtifactVersionSavedSql } from '../../hooks/useProjectAiAgents';
+import { AiArtifactTableVisualization } from './AiArtifactTableVisualization';
+import { getAiArtifactTableConfig } from './AiArtifactTableVisualization.utils';
 import { AiSqlArtifactDownloadModal } from './AiSqlArtifactDownloadModal';
-
-const unwrapRows = (rows: ResultRow[]): RawResultRow[] =>
-    rows.map((row) =>
-        Object.fromEntries(
-            Object.entries(row).map(([key, value]) => [key, value.value.raw]),
-        ),
-    );
-
-// Below this, the panel shrinks to fit the table instead of filling all
-// available height — unlike SQL Runner's results table, which always fills
-// the page. A compact chat panel reads as broken with a mostly-empty card;
-// a full page reads as normal whitespace.
-const MAX_SHRINK_TO_FIT_HEIGHT_PX = 300;
-const TABLE_HEADER_HEIGHT_PX = 34;
-
-const getTableConfig = (columns: ResultColumn[]): VizTableConfig => ({
-    metadata: { version: 1 },
-    type: ChartKind.TABLE,
-    columns: Object.fromEntries(
-        columns.map((column) => [
-            column.reference,
-            {
-                visible: true,
-                reference: column.reference,
-                label: column.reference,
-                frozen: false,
-            },
-        ]),
-    ),
-    display: undefined,
-});
 
 type ContentProps = {
     results: InfiniteQueryResults;
@@ -171,7 +134,7 @@ export const AiSqlArtifactActions: FC<ActionsProps> = ({
                 description={description}
                 sql={sql}
                 limit={limit}
-                currentVizConfig={getTableConfig(columns)}
+                currentVizConfig={getAiArtifactTableConfig(columns)}
                 hasUnrunChanges={false}
                 redirectOnSuccess={false}
                 onSaved={async ({ savedSqlUuid: newSavedSqlUuid }) => {
@@ -186,66 +149,11 @@ export const AiSqlArtifactVisualization: FC<ContentProps> = ({
     results,
     headerContent,
 }) => {
-    const columns = useMemo(
-        () => Object.values(results.columns ?? {}),
-        [results.columns],
-    );
-    const columnNames = useMemo(
-        () => columns.map((column) => column.reference),
-        [columns],
-    );
-    const rows = useMemo(() => unwrapRows(results.rows), [results.rows]);
-
-    useEffect(() => {
-        if (!results.hasFetchedAllRows && !results.fetchAll) {
-            results.setFetchAll(true);
-        }
-    }, [results]);
-
-    if (
-        results.isInitialLoading ||
-        results.isFetchingFirstPage ||
-        columns.length === 0
-    ) {
-        return (
-            <Center h={300}>
-                <Loader
-                    type="dots"
-                    color="gray"
-                    delayedMessage="Loading SQL results..."
-                />
-            </Center>
-        );
-    }
-
-    const estimatedContentHeight =
-        TABLE_HEADER_HEIGHT_PX + rows.length * ROW_HEIGHT_PX;
-    const shrinkToFit = estimatedContentHeight <= MAX_SHRINK_TO_FIT_HEIGHT_PX;
-
     return (
-        <Stack
-            gap="md"
-            h={shrinkToFit ? undefined : '100%'}
-            mih={shrinkToFit ? undefined : 300}
-        >
-            {headerContent}
-            <Paper
-                flex={shrinkToFit ? undefined : 1}
-                mah={shrinkToFit ? estimatedContentHeight : undefined}
-                mih={0}
-                pos="relative"
-                withBorder
-                radius="md"
-                bg="ldGray.0"
-                style={{ overflow: 'hidden' }}
-            >
-                <ChartDataTable
-                    columnNames={columnNames}
-                    rows={rows}
-                    columnsConfig={getTableConfig(columns).columns}
-                    flexProps={{ mah: '100%' }}
-                />
-            </Paper>
-        </Stack>
+        <AiArtifactTableVisualization
+            results={results}
+            headerContent={headerContent}
+            loadingMessage="Loading SQL results..."
+        />
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.test.tsx
@@ -1,0 +1,47 @@
+import { QuerySourceType } from '@lightdash/common';
+import { screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../../../../testing/testUtils';
+import { LiveActivityCard } from './LiveActivityCard';
+
+describe('LiveActivityCard composer queries', () => {
+    it('shows composer SQL by default while the query is running', async () => {
+        renderWithProviders(
+            <LiveActivityCard
+                isLive
+                toolGroups={[
+                    {
+                        keyId: 'composer-call',
+                        toolName: 'runComposerQueries',
+                        calls: [
+                            {
+                                toolCallId: 'composer-call',
+                                toolName: 'runComposerQueries',
+                                toolArgs: {
+                                    title: 'Compare targets',
+                                    description: null,
+                                    terminalNodeId: null,
+                                    queries: [
+                                        {
+                                            sourceType:
+                                                QuerySourceType.EXTERNAL,
+                                            nodeId: 'targets',
+                                            sql: 'select * from targets_csv',
+                                            tables: ['targets_csv'],
+                                            limit: 500,
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                ]}
+            />,
+        );
+
+        await waitFor(() =>
+            expect(screen.getByText('External data')).toBeVisible(),
+        );
+        expect(screen.getByRole('button', { name: 'Copy' })).toBeVisible();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
@@ -584,10 +584,8 @@ export const LiveActivityCard: FC<Props> = ({
 }) => {
     const [userExpanded, setUserExpanded] = useState(false);
 
-    // When the latest tool changes, auto-expand for runSql (so users see the
-    // query immediately) and auto-collapse otherwise. The user's explicit
-    // toggle is reset on every tool change so the bento has fresh "default
-    // state" for each new step.
+    // Query tools expand by default so their SQL is legible while running.
+    // The user's explicit toggle resets when the active tool changes.
     const latestKeyId =
         toolGroups.length > 0
             ? toolGroups[toolGroups.length - 1].keyId
@@ -597,7 +595,11 @@ export const LiveActivityCard: FC<Props> = ({
             ? toolGroups[toolGroups.length - 1].toolName
             : undefined;
     useEffect(() => {
-        if (latestToolName === 'runSql') setUserExpanded(true);
+        if (
+            latestToolName === 'runSql' ||
+            latestToolName === 'runComposerQueries'
+        )
+            setUserExpanded(true);
         else setUserExpanded(false);
     }, [latestKeyId, latestToolName]);
 
@@ -626,7 +628,9 @@ export const LiveActivityCard: FC<Props> = ({
     // sees it immediately, without needing to click the chevron.
     const expanded = hasPending || userExpanded;
 
-    const latestNeedsExpandedBody = latest?.toolName === 'runSql';
+    const latestNeedsExpandedBody =
+        latest?.toolName === 'runSql' ||
+        latest?.toolName === 'runComposerQueries';
     const showBody =
         expanded && (hasHistory || hasPending || latestNeedsExpandedBody);
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/ToolCallRow.tsx
@@ -48,7 +48,7 @@ const TOOLS_WITHOUT_DESCRIPTION = new Set<ToolName>([
 
 // Tools whose description renders something tall (e.g. a code block) and can't
 // be sensibly clipped to a single-line preview — collapse to verb + chevron.
-const HIDE_INLINE_PREVIEW = new Set<ToolName>(['runSql']);
+const HIDE_INLINE_PREVIEW = new Set<ToolName>(['runComposerQueries', 'runSql']);
 
 const INLINE_CHIP_PREVIEW_TOOLS = new Set<ToolName>([
     'readContent',

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.module.css
@@ -1,0 +1,59 @@
+.pipeline {
+    min-width: 0;
+}
+
+.node {
+    min-width: 0;
+    padding-left: 10px;
+    border-left: 2px solid var(--mantine-color-ldGray-3);
+}
+
+.header {
+    min-width: 0;
+    margin-bottom: 5px;
+}
+
+.nodeId {
+    flex-shrink: 0;
+    color: var(--mantine-color-ldGray-9);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+}
+
+.badge {
+    flex-shrink: 0;
+    font-weight: 500;
+    letter-spacing: 0;
+    text-transform: none;
+}
+
+.detail {
+    min-width: 0;
+    flex: 1;
+}
+
+.code {
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-radius: 6px;
+    background: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldGray-1)
+    );
+}
+
+.code :global(.mantine-CodeHighlight-codeHighlight) {
+    background: transparent;
+}
+
+.code :global(.mantine-CodeHighlight-code) {
+    max-height: 220px;
+    overflow: auto;
+    padding: 9px 34px 9px 11px;
+    background: transparent;
+    font-size: 11px;
+    line-height: 1.55;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.test.tsx
@@ -1,0 +1,41 @@
+import { QuerySourceType } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../../../../../testing/testUtils';
+import { ComposerQueriesToolCallDescription } from './ComposerQueriesToolCallDescription';
+
+describe('ComposerQueriesToolCallDescription', () => {
+    it('renders source context and formatted SQL for a composed pipeline', () => {
+        const { container } = renderWithProviders(
+            <ComposerQueriesToolCallDescription
+                queries={[
+                    {
+                        sourceType: QuerySourceType.EXTERNAL,
+                        nodeId: 'targets',
+                        sql: 'select payment_method,target_revenue from targets_csv',
+                        tables: { targets_csv: 'table-uuid' },
+                        limit: 500,
+                    },
+                    {
+                        sourceType: QuerySourceType.DUCKDB,
+                        nodeId: 'comparison',
+                        sql: 'select * from actual join targets using (payment_method)',
+                        references: ['actual', 'targets'],
+                        limit: 500,
+                    },
+                ]}
+            />,
+        );
+
+        expect(screen.getByText('External data')).toBeInTheDocument();
+        expect(screen.getByText('Reads targets_csv')).toBeInTheDocument();
+        expect(screen.getByText('DuckDB compose')).toBeInTheDocument();
+        expect(
+            screen.getByText('Combines actual, targets'),
+        ).toBeInTheDocument();
+        expect(screen.getAllByRole('button', { name: 'Copy' })).toHaveLength(2);
+        expect(container.querySelector('code')).toHaveTextContent(
+            'select payment_method, target_revenue from targets_csv',
+        );
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.tsx
@@ -1,60 +1,102 @@
 import {
+    formatSql,
     QuerySourceType,
     type ToolComposerQueriesArgs,
+    type ToolComposerQueryNode,
+    WarehouseTypes,
 } from '@lightdash/common';
-import { Code, Stack, Text } from '@mantine/core';
-import type { FC } from 'react';
+import { Badge, Box, Group, Stack, Text } from '@mantine/core';
+import { useMemo, type FC } from 'react';
+import CodeBlock from '../../../../../../../components/common/CodeBlock/CodeBlock';
+import styles from './ComposerQueriesToolCallDescription.module.css';
 
 type ComposerQueriesToolCallDescriptionProps = {
     queries: ToolComposerQueriesArgs['queries'];
 };
 
-const nodeSummary = (
-    node: ToolComposerQueriesArgs['queries'][number],
-): string => {
+const referenceAliases = (items: string[] | Record<string, string>) =>
+    Array.isArray(items) ? items : Object.keys(items);
+
+const getNodePresentation = (node: ToolComposerQueryNode) => {
     switch (node.sourceType) {
         case QuerySourceType.SEMANTIC_LAYER:
-            return `${node.nodeId} — metric query on ${node.exploreName}`;
+            return {
+                badge: 'Semantic layer',
+                color: 'indigo',
+                detail: `${node.exploreName} · ${node.dimensions.length} dimension${node.dimensions.length === 1 ? '' : 's'} · ${node.metrics.length} metric${node.metrics.length === 1 ? '' : 's'}`,
+            } as const;
         case QuerySourceType.SQL:
-            return `${node.nodeId} — warehouse SQL`;
-        case QuerySourceType.DUCKDB:
-            return `${node.nodeId} — DuckDB over ${
-                Array.isArray(node.references)
-                    ? node.references.join(', ')
-                    : Object.values(node.references).join(', ')
-            }`;
-        default:
-            return '';
+            return {
+                badge: 'Warehouse SQL',
+                color: 'ldGray.6',
+                detail: 'Project warehouse',
+            } as const;
+        case QuerySourceType.EXTERNAL: {
+            const tables = referenceAliases(node.tables);
+            return {
+                badge: 'External data',
+                color: 'cyan',
+                detail: `Reads ${tables.join(', ')}`,
+            } as const;
+        }
+        case QuerySourceType.DUCKDB: {
+            const references = referenceAliases(node.references);
+            return {
+                badge: 'DuckDB compose',
+                color: 'violet',
+                detail: `Combines ${references.join(', ')}`,
+            } as const;
+        }
     }
+};
+
+const ComposerQueryNode: FC<{ node: ToolComposerQueryNode }> = ({ node }) => {
+    const presentation = getNodePresentation(node);
+    const formattedSql = useMemo(() => {
+        if (!('sql' in node) || !node.sql) return null;
+
+        return formatSql(
+            node.sql,
+            node.sourceType === QuerySourceType.DUCKDB ||
+                node.sourceType === QuerySourceType.EXTERNAL
+                ? WarehouseTypes.DUCKDB
+                : undefined,
+        );
+    }, [node]);
+
+    return (
+        <Box className={styles.node}>
+            <Group gap={6} wrap="nowrap" className={styles.header}>
+                <Text component="span" className={styles.nodeId}>
+                    {node.nodeId}
+                </Text>
+                <Badge
+                    color={presentation.color}
+                    size="xs"
+                    variant="light"
+                    className={styles.badge}
+                >
+                    {presentation.badge}
+                </Badge>
+                <Text size="xs" c="dimmed" truncate className={styles.detail}>
+                    {presentation.detail}
+                </Text>
+            </Group>
+            {formattedSql ? (
+                <Box className={styles.code}>
+                    <CodeBlock code={formattedSql} language="sql" />
+                </Box>
+            ) : null}
+        </Box>
+    );
 };
 
 export const ComposerQueriesToolCallDescription: FC<
     ComposerQueriesToolCallDescriptionProps
-> = ({ queries }) => {
-    return (
-        <Stack gap={6} align="stretch" w="100%">
-            {queries.map((node) => (
-                <Stack gap={2} key={node.nodeId}>
-                    <Text c="dimmed" size="xs">
-                        {nodeSummary(node)}
-                    </Text>
-                    {'sql' in node && node.sql ? (
-                        <Code
-                            block
-                            style={{
-                                boxSizing: 'border-box',
-                                display: 'block',
-                                fontSize: 11,
-                                maxHeight: 160,
-                                overflow: 'auto',
-                                width: '100%',
-                            }}
-                        >
-                            {node.sql}
-                        </Code>
-                    ) : null}
-                </Stack>
-            ))}
-        </Stack>
-    );
-};
+> = ({ queries }) => (
+    <Stack gap={10} align="stretch" w="100%" className={styles.pipeline}>
+        {queries.map((node) => (
+            <ComposerQueryNode key={node.nodeId} node={node} />
+        ))}
+    </Stack>
+);


### PR DESCRIPTION
## Summary

- give web-chat agents the composer query tool when multi-source-query and compose-sql-runner are enabled
- execute semantic-layer, warehouse SQL, external-data, and DuckDB composition nodes through one query graph
- render running and completed composer SQL as labelled, formatted query nodes with copy controls
- share one responsive result-table renderer between SQL and composer artifacts; short tables fit their rows and long tables scroll

## Testing

- common, backend, and frontend typechecks
- backend, frontend, and common lint/format
- focused composer tool, contract snapshot, live activity, SQL rendering, and result-table tests

## Stack

Depends on #27793.