### PR TITLE
ci: also publish the plain version tag to the private registries

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -103,12 +103,15 @@ jobs:
           tags: |
             lightdash/lightdash:${{ steps.version.outputs.version }}
             lightdash/lightdash:latest
+            us-docker.pkg.dev/lightdash-containers/lightdash/lightdash:${{ steps.version.outputs.version }}
             us-docker.pkg.dev/lightdash-containers/lightdash/lightdash:${{ steps.version.outputs.version }}-commercial
             us-docker.pkg.dev/lightdash-containers/lightdash/lightdash:beta
             us-docker.pkg.dev/lightdash-containers/lightdash/lightdash:${{ steps.version.outputs.timestamp }}
+            europe-docker.pkg.dev/lightdash-containers/lightdash/lightdash:${{ steps.version.outputs.version }}
             europe-docker.pkg.dev/lightdash-containers/lightdash/lightdash:${{ steps.version.outputs.version }}-commercial
             europe-docker.pkg.dev/lightdash-containers/lightdash/lightdash:beta
             europe-docker.pkg.dev/lightdash-containers/lightdash/lightdash:${{ steps.version.outputs.timestamp }}
+            europe-west2-docker.pkg.dev/lightdash-containers/lightdash/lightdash:${{ steps.version.outputs.version }}
             europe-west2-docker.pkg.dev/lightdash-containers/lightdash/lightdash:${{ steps.version.outputs.version }}-commercial
             europe-west2-docker.pkg.dev/lightdash-containers/lightdash/lightdash:beta
             europe-west2-docker.pkg.dev/lightdash-containers/lightdash/lightdash:${{ steps.version.outputs.timestamp }}


### PR DESCRIPTION
## What changes

Three lines. Each release already pushes the same image to Docker Hub as a plain version and to the private registries as `<version>-commercial`. This adds the plain version to the private registries too, in all three regions.

The same `build-push-action` step produces every tag, so the plain tag and the `-commercial` tag point at identical bytes.

## Why

The suffix is a leftover. In January 2025 the first GCP build script built from a fork and pushed to a repository named `lightdash-commercial`, logging `fork version`. The suffix marked which artifact you were looking at. In February 2025 the registry path was renamed to `lightdash-containers/lightdash/lightdash`, dropping the word. In December 2025 the Depot refactor merged the two builds. The image has been identical since. Only the suffix survived.

It is not harmless any more. Semantic versioning treats any text after a hyphen as a prerelease, meaning an unfinished build. Anything that parses the tag as a version therefore classifies released images as prereleases.

That already cost us. The Helm chart chooses the backend readiness endpoint from the image tag and skips prereleases deliberately, so every Cloud instance silently kept the older endpoint. We found it only by rendering all 155 customer configurations.

## What does not change

Nothing, yet. This is purely additive:

- The `-commercial` tag is still published.
- Every existing tag stays in the registry.
- No consumer needs to do anything.

Consumers move to the plain tag in a later change, and the suffix is removed once nothing reads it. Sequencing matters, so those steps are deliberately separate.

## Verification

The workflow file still parses as YAML. The change adds three tag lines inside the existing `tags:` block and touches nothing else.

The first release after this merges should show both `<version>` and `<version>-commercial` in each private registry, resolving to the same digest.

Linear: SPK-1155