### PR TITLE
feat: add organization-scoped project slugs

### DIFF
--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -17,6 +17,7 @@ export const CachedWarehouseTableName = 'cached_warehouse';
 export type DbProject = {
     project_id: number;
     project_uuid: string;
+    slug: string;
     name: string;
     project_type: ProjectType;
     created_at: Date;
@@ -58,6 +59,7 @@ type CreateDbProject = Pick<
     | 'created_by_user_uuid'
     | 'organization_warehouse_credentials_uuid'
 > & {
+    slug?: string;
     scheduler_timezone?: string; // On create it will default to 'UTC' as per migration
     query_timezone?: string | null;
     use_project_timezone_in_filters?: boolean; // On create it will default to false as per migration

--- a/packages/backend/src/database/migrations/20260821081500_add_slug_to_projects.ts
+++ b/packages/backend/src/database/migrations/20260821081500_add_slug_to_projects.ts
@@ -1,0 +1,72 @@
+import { Knex } from 'knex';
+
+const ProjectsTableName = 'projects';
+const SlugUniqueConstraint = 'projects_organization_id_slug_unique';
+
+const slugifyName = (name: string): string =>
+    name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds a defaulted project slug without breaking older writers',
+} as const;
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+
+    await knex.schema.alterTable(ProjectsTableName, (table) => {
+        table
+            .text('slug')
+            .notNullable()
+            .defaultTo(knex.raw(`'project-' || uuid_generate_v4()::text`));
+    });
+
+    const projects = await knex(ProjectsTableName)
+        .select('project_uuid', 'organization_id', 'name')
+        .orderBy('organization_id')
+        .orderBy('created_at')
+        .orderBy('project_uuid');
+
+    const slugsByOrganization = new Map<number, Set<string>>();
+    /* eslint-disable no-await-in-loop */
+    for (const project of projects) {
+        const organizationSlugs =
+            slugsByOrganization.get(project.organization_id) ??
+            new Set<string>();
+        slugsByOrganization.set(project.organization_id, organizationSlugs);
+
+        const generatedBase = slugifyName(project.name);
+        const baseSlug = generatedBase || `project-${project.project_uuid}`;
+        let slug = baseSlug;
+        let suffix = 1;
+        while (organizationSlugs.has(slug)) {
+            slug = `${baseSlug}-${suffix}`;
+            suffix += 1;
+        }
+        organizationSlugs.add(slug);
+
+        await knex.raw(
+            `UPDATE ${ProjectsTableName} SET slug = ? WHERE project_uuid = ?`,
+            [slug, project.project_uuid],
+        );
+    }
+    /* eslint-enable no-await-in-loop */
+
+    await knex.schema.alterTable(ProjectsTableName, (table) => {
+        table.unique(['organization_id', 'slug'], {
+            indexName: SlugUniqueConstraint,
+        });
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+
+    await knex.schema.alterTable(ProjectsTableName, (table) => {
+        table.dropUnique(['organization_id', 'slug'], SlugUniqueConstraint);
+        table.dropColumn('slug');
+    });
+}

--- a/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.test.ts
+++ b/packages/backend/src/ee/services/HomepageRecommendedActionSkipsService.test.ts
@@ -25,6 +25,7 @@ const projectSummary = (
 ): ProjectSummary => ({
     name: 'Project',
     projectUuid: PROJECT_UUID,
+    slug: 'project',
     organizationUuid,
     type: ProjectType.DEFAULT,
     upstreamProjectUuid: undefined,

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
@@ -49,6 +49,7 @@ const user: SessionUser = {
 
 const makeProject = (projectUuid: string): OrganizationProject => ({
     projectUuid,
+    slug: 'project',
     name: 'Project',
     type: ProjectType.DEFAULT,
     createdByUserUuid: USER_UUID,

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
@@ -43,6 +43,7 @@ const user = {
 
 const project = (source: string | null = null): OrganizationProject => ({
     projectUuid,
+    slug: 'project',
     name: 'Project',
     type: ProjectType.DEFAULT,
     provisioningSource: source,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
@@ -51,6 +51,7 @@ export const projectUuid = 'project uuid';
 
 export const projectMock = {
     name: 'my project',
+    slug: 'my-project',
     project_type: ProjectType.DEFAULT,
     dbt_connection: Buffer.from(JSON.stringify(dbtCloudIDEProjectConfigMock)),
     encrypted_credentials: Buffer.from(JSON.stringify(bigqueryCredentials)),
@@ -91,6 +92,7 @@ export const expectedTablesConfiguration: TablesConfiguration = {
 export const expectedProject: Project = {
     organizationUuid: 'organizationUuid',
     projectUuid,
+    slug: 'my-project',
     name: 'my project',
     type: ProjectType.DEFAULT,
     dbtConnection: {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -149,6 +149,7 @@ import {
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
     acquireProjectSlugLock,
+    generateUniqueProjectSlug,
     generateUniqueSlugScopedToProject,
 } from '../../utils/SlugUtils';
 import { clearProjectExtraRoles } from '../roleSetUtils';
@@ -454,6 +455,7 @@ export class ProjectModel {
             )
             .select(
                 'projects.project_uuid',
+                'projects.slug',
                 'projects.name',
                 'projects.project_type',
                 'projects.created_at',
@@ -495,6 +497,7 @@ export class ProjectModel {
             ({
                 name,
                 project_uuid,
+                slug,
                 project_type,
                 created_at,
                 created_by_user_uuid,
@@ -506,6 +509,7 @@ export class ProjectModel {
             }) => ({
                 name,
                 projectUuid: project_uuid,
+                slug,
                 type: project_type,
                 createdByUserUuid: created_by_user_uuid,
                 createdByUserName: created_by_user_name ?? null,
@@ -618,6 +622,11 @@ export class ProjectModel {
             throw new NotFoundError('Cannot find organization');
         }
         return this.database.transaction(async (trx) => {
+            const projectSlug = await generateUniqueProjectSlug(
+                trx,
+                orgs[0].organization_id,
+                data.name,
+            );
             let encryptedCredentials: Buffer;
             try {
                 encryptedCredentials = this.encryptionUtil.encrypt(
@@ -636,6 +645,7 @@ export class ProjectModel {
             const [project] = await trx('projects')
                 .insert({
                     name: data.name,
+                    slug: projectSlug,
                     project_type: data.type,
                     organization_id: orgs[0].organization_id,
                     dbt_connection_type: data.dbtConnection.type,
@@ -942,6 +952,7 @@ export class ProjectModel {
         type QueryResult = (
             | {
                   name: string;
+                  slug: string;
                   project_type: ProjectType;
                   dbt_connection: Buffer | null;
                   encrypted_credentials: null;
@@ -967,6 +978,7 @@ export class ProjectModel {
               }
             | {
                   name: string;
+                  slug: string;
                   project_type: ProjectType;
                   dbt_connection: Buffer | null;
                   encrypted_credentials: Buffer;
@@ -1013,6 +1025,7 @@ export class ProjectModel {
                     )
                     .column([
                         this.database.ref('name').withSchema(ProjectTableName),
+                        this.database.ref('slug').withSchema(ProjectTableName),
                         this.database
                             .ref('project_type')
                             .withSchema(ProjectTableName),
@@ -1107,6 +1120,7 @@ export class ProjectModel {
                 const result: Omit<Project, 'warehouseConnection'> = {
                     organizationUuid: project.organization_uuid,
                     projectUuid,
+                    slug: project.slug,
                     name: project.name,
                     type: project.project_type,
                     dbtConnection: dbtSensitiveCredentials,
@@ -1186,6 +1200,7 @@ export class ProjectModel {
                     DbProject,
                     | 'name'
                     | 'project_uuid'
+                    | 'slug'
                     | 'project_type'
                     | 'copied_from_project_uuid'
                     | 'created_by_user_uuid'
@@ -1195,6 +1210,7 @@ export class ProjectModel {
             >([
                 `${ProjectTableName}.name`,
                 `${ProjectTableName}.project_uuid`,
+                `${ProjectTableName}.slug`,
                 `${OrganizationTableName}.organization_uuid`,
                 `${ProjectTableName}.copied_from_project_uuid`,
                 `${ProjectTableName}.project_type`,
@@ -1211,6 +1227,7 @@ export class ProjectModel {
         return {
             organizationUuid: project.organization_uuid,
             projectUuid: project.project_uuid,
+            slug: project.slug,
             name: project.name,
             type: project.project_type,
             upstreamProjectUuid: project.copied_from_project_uuid || undefined,
@@ -1342,6 +1359,7 @@ export class ProjectModel {
         return {
             organizationUuid: project.organizationUuid,
             projectUuid,
+            slug: project.slug,
             name: project.name,
             type: project.type,
             dbtConnection: nonSensitiveDbtCredentials,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -369,6 +369,7 @@ export const sessionAccount = buildAccount();
 export const projectWithSensitiveFields: Project = {
     organizationUuid: sessionAccount.organization.organizationUuid!,
     projectUuid: 'projectUuid',
+    slug: 'name',
     name: 'name',
     type: ProjectType.DEFAULT,
     dbtVersion: DefaultSupportedDbtVersion,
@@ -393,12 +394,14 @@ export const projectWithSensitiveFields: Project = {
 export const projectSummary: ProjectSummary = {
     organizationUuid: sessionAccount.organization.organizationUuid!,
     projectUuid: 'projectUuid',
+    slug: 'name',
     name: 'name',
     type: ProjectType.DEFAULT,
     createdByUserUuid: sessionAccount.user.id,
 };
 export const defaultProject: OrganizationProject = {
     projectUuid: 'projectUuid',
+    slug: 'name',
     name: 'name',
     type: ProjectType.DEFAULT,
     createdByUserUuid: sessionAccount.user.id,

--- a/packages/backend/src/utils/SlugUtils.test.ts
+++ b/packages/backend/src/utils/SlugUtils.test.ts
@@ -2,11 +2,15 @@ import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { AppsTableName } from '../database/entities/apps';
 import { DashboardsTableName } from '../database/entities/dashboards';
+import { ProjectTableName } from '../database/entities/projects';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { SavedChartSlugMappingsTableName } from '../database/entities/savedChartSlugMappings';
 import { SavedSqlTableName } from '../database/entities/savedSql';
 import { SpaceTableName } from '../database/entities/spaces';
-import { generateUniqueSlugScopedToProject } from './SlugUtils';
+import {
+    generateUniqueProjectSlug,
+    generateUniqueSlugScopedToProject,
+} from './SlugUtils';
 
 describe('generateUniqueSlugScopedToProject', () => {
     const database = knex({ client: MockClient, dialect: 'pg' });
@@ -208,5 +212,64 @@ describe('generateUniqueSlugScopedToProject', () => {
         );
 
         expect(slug).toHaveLength(255);
+    });
+
+    describe('generateUniqueProjectSlug', () => {
+        it('generates a slug scoped to the organization', async () => {
+            tracker.on.select(ProjectTableName).responseOnce([]);
+
+            const slug = await generateUniqueProjectSlug(
+                database,
+                42,
+                'Jaffle Shop',
+            );
+
+            expect(slug).toBe('jaffle-shop');
+            const projectQuery = tracker.history.select.find(({ sql }) =>
+                sql.includes(ProjectTableName),
+            );
+            expect(projectQuery?.bindings).toEqual(
+                expect.arrayContaining([42, 'jaffle-shop']),
+            );
+            const lockQuery = tracker.history.select.find(({ sql }) =>
+                sql.includes('pg_advisory_xact_lock'),
+            );
+            expect(lockQuery?.bindings).toContain('42:jaffle-shop');
+        });
+
+        it('adds a suffix when the organization already owns the slug', async () => {
+            tracker.on
+                .select(ProjectTableName)
+                .responseOnce([{ slug: 'jaffle-shop' }]);
+            tracker.on.select(ProjectTableName).responseOnce([]);
+
+            const slug = await generateUniqueProjectSlug(
+                database,
+                42,
+                'Jaffle Shop',
+            );
+
+            expect(slug).toBe('jaffle-shop-1');
+        });
+
+        it('uses the same generated slug format as other resources', async () => {
+            tracker.on.select(ProjectTableName).responseOnce([]);
+
+            const slug = await generateUniqueProjectSlug(
+                database,
+                42,
+                '22222222-2222-4222-8222-222222222222',
+            );
+
+            expect(slug).toBe('22222222-2222-4222-8222-222222222222');
+        });
+
+        it('generates a valid slug when the name has no slug characters', async () => {
+            tracker.on.select(ProjectTableName).responseOnce([]);
+
+            const slug = await generateUniqueProjectSlug(database, 42, '🚀');
+
+            expect(slug).toMatch(/^[a-z0-9]+$/);
+        });
     });
 });

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -2,6 +2,7 @@ import { assertUnreachable, generateSlug } from '@lightdash/common';
 import { Knex } from 'knex';
 import { AppsTableName } from '../database/entities/apps';
 import { DashboardsTableName } from '../database/entities/dashboards';
+import { ProjectTableName } from '../database/entities/projects';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { SavedChartSlugMappingsTableName } from '../database/entities/savedChartSlugMappings';
 import { SavedSqlTableName } from '../database/entities/savedSql';
@@ -17,9 +18,11 @@ type SlugTable = ProjectUuidSlugTable | typeof SpaceTableName;
 
 const PROJECT_SLUG_LOCK_NAMESPACE = 2;
 const SPACE_ACCESS_LOCK_NAMESPACE = 3;
+const ORGANIZATION_PROJECT_SLUG_LOCK_NAMESPACE = 5;
 
 const MAX_GENERATED_SAVED_CHART_SLUG_LENGTH = 255;
 const MAX_GENERATED_APP_SLUG_LENGTH = 255;
+const MAX_GENERATED_PROJECT_SLUG_LENGTH = 255;
 
 const getSlugCandidate = (
     tableName: SlugTable,
@@ -71,6 +74,39 @@ export const acquireSpaceAccessLock = async (
         SPACE_ACCESS_LOCK_NAMESPACE,
         spaceUuid,
     ]);
+};
+
+export const generateUniqueProjectSlug = async (
+    trx: Knex,
+    organizationId: number,
+    name: string,
+): Promise<string> => {
+    const generatedSlug = generateSlug(name).slice(
+        0,
+        MAX_GENERATED_PROJECT_SLUG_LENGTH,
+    );
+    const baseSlug = generatedSlug || 'project';
+
+    let increment = 0;
+    for (;;) {
+        const suffix = increment === 0 ? '' : `-${increment}`;
+        const candidate = `${baseSlug.slice(
+            0,
+            MAX_GENERATED_PROJECT_SLUG_LENGTH - suffix.length,
+        )}${suffix}`;
+        // eslint-disable-next-line no-await-in-loop
+        await trx.raw('SELECT pg_advisory_xact_lock(?, hashtext(?))', [
+            ORGANIZATION_PROJECT_SLUG_LOCK_NAMESPACE,
+            `${organizationId}:${candidate}`,
+        ]);
+        // eslint-disable-next-line no-await-in-loop
+        const existing = await trx(ProjectTableName)
+            .select('slug')
+            .where({ organization_id: organizationId, slug: candidate })
+            .first();
+        if (!existing) return candidate;
+        increment += 1;
+    }
 };
 
 export function generateUniqueSlugScopedToProject(

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -815,6 +815,7 @@ export enum CreateProjectTableConfiguration {
 export type CreateProject = Omit<
     Project,
     | 'projectUuid'
+    | 'slug'
     | 'organizationUuid'
     | 'schedulerTimezone'
     | 'queryTimezone'
@@ -854,6 +855,7 @@ export const hasWarehouseCredentials = (
 export type UpdateProject = Omit<
     Project,
     | 'projectUuid'
+    | 'slug'
     | 'organizationUuid'
     | 'type'
     | 'schedulerTimezone'

--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -81,6 +81,7 @@ export type OrganizationProject = {
      * @format uuid
      */
     projectUuid: string;
+    slug?: string;
     name: string;
     type: ProjectType;
     createdByUserUuid: string | null;

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -1159,6 +1159,7 @@ export const maybeOverrideDbtConnection = <T extends DbtProjectConfig>(
 export type Project = {
     organizationUuid: string;
     projectUuid: string;
+    slug?: string;
     name: string;
     type: ProjectType;
     dbtConnection: DbtProjectConfig;
@@ -1186,6 +1187,7 @@ export type ProjectSummary = Pick<
     Project,
     | 'name'
     | 'projectUuid'
+    | 'slug'
     | 'organizationUuid'
     | 'type'
     | 'upstreamProjectUuid'

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -223,8 +223,10 @@ describe('Admin access to spaces', () => {
             cy.contains(spaceName);
         }
 
-        cy.contains('Parent Space 4').click();
-        cy.contains('Child Space 4.1');
+        cy.get('.mantine-Modal-body').within(() => {
+            cy.contains('Parent Space 4').click();
+            cy.contains('Child Space 4.1');
+        });
     });
 });
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -74,6 +74,7 @@ const organizationProject = (
     overrides: Partial<OrganizationProject>,
 ): OrganizationProject => ({
     projectUuid: 'project-uuid',
+    slug: 'project',
     name: 'Project',
     type: ProjectType.DEFAULT,
     createdByUserUuid: null,


### PR DESCRIPTION
Closes: SPK-1205

<img width="1318" height="288" alt="CleanShot 2026-08-21 at 10 34 55@2x" src="https://github.com/user-attachments/assets/e2258ae1-576f-4d03-b093-b916dc298246" />


## Summary

- add an immutable, organization-scoped slug to projects with deterministic backfill and database constraints
- generate collision-safe slugs inside the existing project creation transaction
- expose project slugs through existing project read and list responses without changing routes

## Validation

- migrated the isolated local database up, down, and up again
- live-tested duplicate and concurrent project creation, same-name preview creation, rename immutability, hard-delete reuse, API responses, and legacy-writer fallback
- confirmed database rejection of duplicate and UUID-shaped slugs and reuse across organizations
- passed common/backend/frontend/CLI/API typechecks, focused lint, migration safety lint, and 96 focused backend tests
