### PR TITLE
fix(dashboards): hide metric filter chips on non-applicable tabs 

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/index.tsx
@@ -342,6 +342,17 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                         allFilterableMetricsMap[item.target.fieldId];
                     const appliesToTabs = getTabsUsingFilter(item);
 
+                    const isOrphanedFilter = appliesToTabs.length === 0;
+                    const appliedToCurrentTab =
+                        !activeTabUuid ||
+                        appliesToTabs.includes(activeTabUuid);
+
+                    // Hide filter if it doesn't apply to the current tab
+                    // But always show orphaned filters so users can see and fix them
+                    if (!appliedToCurrentTab && !isOrphanedFilter) {
+                        return null;
+                    }
+
                     return metricField ? (
                         <DroppableArea key={item.id} id={item.id}>
                             <DraggableItem
@@ -393,6 +404,17 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                 const metricField =
                     allFilterableMetricsMap[item.target.fieldId];
                 const appliesToTabs = getTabsUsingFilter(item);
+
+                const isOrphanedFilter = appliesToTabs.length === 0;
+                const appliedToCurrentTab =
+                    !activeTabUuid ||
+                    appliesToTabs.includes(activeTabUuid);
+
+                // Hide filter if it doesn't apply to the current tab
+                // But always show orphaned filters so users can see and fix them
+                if (!appliedToCurrentTab && !isOrphanedFilter) {
+                    return null;
+                }
 
                 return metricField ? (
                     <Filter


### PR DESCRIPTION
## Problem

On multi-tab dashboards, metric filter chips appear on every tab, regardless of whether the filter applies to any charts on the current tab.

Dimension filter chips already handle this correctly by hiding when the filter does not apply to the active tab. Metric filters, however, were missing this visibility check.

### Steps to Reproduce

1. Create a dashboard with two tabs, each containing a different chart.
2. Add a metric filter that targets only the chart on Tab 2.
3. Switch to Tab 1.
4. Observe that the metric filter chip is still displayed even though it has no effect on Tab 1.

### Expected Behavior

Metric filter chips should behave consistently with dimension filter chips and only be displayed on tabs containing charts affected by the filter.

## Root Cause

In `packages/frontend/src/features/dashboardFilters/ActiveFilters/index.tsx`, dimension filters use an `appliedToCurrentTab` check (lines 268–276) to hide filters that do not apply to the active tab.

Metric filters, both permanent and temporary, already calculate `appliesToTabs` using `getTabsUsingFilter()`, but this value was not used to conditionally hide the filter chip.

## Fix

Added the same `appliedToCurrentTab` visibility check used by dimension filters to:

* Permanent metric filters (line 345)
* Temporary metric filters (line 408)

The check:

1. Determines which tabs the filter applies to using `getTabsUsingFilter()`.
2. Hides the filter chip when it does not apply to the current tab.
3. Continues to show orphaned filters (filters that do not apply to any tab), allowing users to identify and fix them.

This brings metric filter behavior in line with the existing dimension filter behavior.


## close : #27626 