### PR TITLE
fix(pgwire): accept database-qualified table names

### DIFF
--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
@@ -178,6 +178,36 @@ describe('lightdash pgwire handlers: describe vs query', () => {
         expect(runExploreQuery).not.toHaveBeenCalled();
     });
 
+    it('accepts database-qualified table names the way Postgres does', async () => {
+        const sql =
+            'SELECT "orders_status" FROM "project-uuid"."public"."orders" LIMIT 1';
+        await expect(handlers.describe(session, sql)).resolves.toEqual([
+            { name: 'orders_status', oid: 25 },
+        ]);
+        await expect(handlers.query(session, sql)).resolves.toMatchObject({
+            type: 'rows',
+            rows: [['completed']],
+        });
+        // catalog queries too
+        await expect(
+            handlers.query(
+                session,
+                'select relname from "project-uuid"."pg_catalog"."pg_class" where relnamespace = 2200 order by 1',
+            ),
+        ).resolves.toMatchObject({ rows: [['orders']] });
+        // a parseable statement that merely mentions the database name is untouched
+        await expect(
+            handlers.query(session, `select '"project-uuid"."a"."b"' as s`),
+        ).resolves.toMatchObject({ rows: [['"project-uuid"."a"."b"']] });
+        // a different database's qualifier still fails like Postgres
+        await expect(
+            handlers.query(
+                session,
+                'SELECT "orders_status" FROM "other-db"."public"."orders"',
+            ),
+        ).rejects.toMatchObject({ code: '42601' });
+    });
+
     it('surfaces compile errors from describe with the same SQLSTATE as query', async () => {
         const sql = 'SELECT nope FROM orders';
         await expect(handlers.describe(session, sql)).rejects.toMatchObject({

--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
@@ -199,6 +199,17 @@ describe('lightdash pgwire handlers: describe vs query', () => {
         await expect(
             handlers.query(session, `select '"project-uuid"."a"."b"' as s`),
         ).resolves.toMatchObject({ rows: [['"project-uuid"."a"."b"']] });
+        // identifiers with escaped quotes still get the qualifier stripped
+        await expect(
+            handlers.query(
+                session,
+                'SELECT x FROM "project-uuid"."public"."weird""name"',
+            ),
+        ).rejects.toMatchObject({
+            message: expect.stringMatching(
+                /Table "weird""name" does not exist/,
+            ),
+        });
         // a different database's qualifier still fails like Postgres
         await expect(
             handlers.query(

--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
@@ -171,7 +171,7 @@ const stripDatabaseQualifier = (sql: string, databaseName: string): string => {
         ? `|\\b${escapeRegex(databaseName)}\\b`
         : '';
     const qualifier = new RegExp(
-        `(?:${quoted}${bare})\\.(?=(?:"[^"]+"|[A-Za-z_][\\w$]*)\\.)`,
+        `(?:${quoted}${bare})\\.(?=(?:"(?:[^"]|"")+"|[A-Za-z_][\\w$]*)\\.)`,
         'g',
     );
     return sql.replace(qualifier, '');

--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
@@ -9,6 +9,7 @@ import {
     type Account,
     type ResultRow,
 } from '@lightdash/common';
+import { parse } from 'pgsql-ast-parser';
 import { fromApiKey, fromServiceAccount } from '../../auth/account/account';
 import Logger from '../../logging/logger';
 import type { ServiceRepository } from '../../services/ServiceRepository';
@@ -145,6 +146,45 @@ const tryHandleSessionStatement = (sql: string): PgWireQueryResult | null => {
 const redactLiterals = (sql: string): string =>
     sql.replace(/'(?:[^']|'')*'/g, "'?'");
 
+const parses = (sql: string): boolean => {
+    try {
+        parse(sql);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const escapeRegex = (text: string): string =>
+    text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Postgres accepts fully qualified `database.schema.table` names when the
+ * database is the current one, but the SQL parser used here only understands
+ * two parts. Connectors (e.g. Domo previews) fully qualify, so when a
+ * statement only parses after removing the session database qualifier, use
+ * the stripped form.
+ */
+const stripDatabaseQualifier = (sql: string, databaseName: string): string => {
+    const quoted = `"${escapeRegex(databaseName)}"`;
+    const bare = /^[a-z_][a-z0-9_]*$/.test(databaseName)
+        ? `|\\b${escapeRegex(databaseName)}\\b`
+        : '';
+    const qualifier = new RegExp(
+        `(?:${quoted}${bare})\\.(?=(?:"[^"]+"|[A-Za-z_][\\w$]*)\\.)`,
+        'g',
+    );
+    return sql.replace(qualifier, '');
+};
+
+const normalizeSql = (session: LightdashPgWireSession, sql: string): string => {
+    if (!sql.includes(session.databaseName) || parses(sql)) {
+        return sql;
+    }
+    const stripped = stripDatabaseQualifier(sql, session.databaseName);
+    return stripped !== sql && parses(stripped) ? stripped : sql;
+};
+
 const UUID_PATTERN =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -159,8 +199,9 @@ type ResolvedStatement =
 
 const resolveStatement = (
     session: LightdashPgWireSession,
-    sql: string,
+    rawSql: string,
 ): ResolvedStatement => {
+    const sql = normalizeSql(session, rawSql);
     const sessionResult = tryHandleSessionStatement(sql);
     if (sessionResult) {
         return { kind: 'result', result: sessionResult };


### PR DESCRIPTION
## Summary

Domo previews a dataset with `SELECT "col", … FROM "db"."public"."table" LIMIT 50` — a fully qualified three-part name, which Postgres accepts when the database matches the current one. `pgsql-ast-parser` only understands `schema.table`, so the Metrics SQL API answered with a raw syntax error and the preview failed (customer screenshot shows exactly this statement and error). Registration itself now succeeds after #27725.

## How it works

When a statement fails to parse and mentions the session's database name, the database qualifier (`"db".` before `schema.table`, quoted or bare) is stripped and the statement re-parsed; only if that parse succeeds is the stripped form used — for session statements, catalog queries and explore queries alike. Parseable statements that merely mention the database name (e.g. in a string literal) and other databases' qualifiers are untouched, so `FROM "other-db"."public"."t"` still errors like Postgres.

## Test plan

- [x] `pnpm -F backend typecheck` / `lint` / `oxfmt --check` — clean
- [x] `pnpm -F backend exec vitest run src/ee/postgresWire` — 216 tests (new: describe+query with the exact Domo shape, catalog query with three-part `pg_catalog`, string-literal false positive, other-database rejection)
- [x] Manual over TLS: the customer's exact preview statement shape (all columns of an explore, three-part name, `LIMIT 50`) returns rows; two-part and unqualified names unchanged

Relates: PROD-10307
Relates: #27624

🤖 Generated with [Claude Code](https://claude.com/claude-code)