### PR TITLE
feat: use project slugs in core frontend URLs

### DIFF
--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -197,6 +197,7 @@ export async function seed(knex: Knex): Promise<void> {
     )
         .insert({
             ...SEED_PROJECT,
+            slug: generateSlug(SEED_PROJECT.name),
             organization_id: organizationId,
             dbt_connection: encryptedProjectSettings,
             dbt_version: SupportedDbtVersions.V1_12,

--- a/packages/e2e/cypress/e2e/app/globalSearch.cy.ts
+++ b/packages/e2e/cypress/e2e/app/globalSearch.cy.ts
@@ -37,10 +37,7 @@ describe('Global search', () => {
             .findByRole('menuitem', { name: 'Jaffle shop' })
             .scrollIntoView()
             .click();
-        cy.url().should(
-            'include',
-            `/projects/${SEED_PROJECT.project_uuid}/spaces/`,
-        );
+        cy.url().should('match', /\/projects\/[^/]+\/spaces\//);
         cy.contains('Spaces').should('be.visible');
 
         // search and select dashboard
@@ -50,10 +47,7 @@ describe('Global search', () => {
             .first()
             .scrollIntoView()
             .click();
-        cy.url().should(
-            'include',
-            `/projects/${SEED_PROJECT.project_uuid}/dashboards/`,
-        );
+        cy.url().should('match', /\/projects\/[^/]+\/dashboards\//);
         cy.contains('Jaffle dashboard').should('be.visible');
 
         // search and select saved chart
@@ -64,10 +58,7 @@ describe('Global search', () => {
             })
             .scrollIntoView()
             .click();
-        cy.url().should(
-            'include',
-            `/projects/${SEED_PROJECT.project_uuid}/saved/`,
-        );
+        cy.url().should('match', /\/projects\/[^/]+\/saved\//);
 
         //  wait for table to render
         cy.findAllByText('Customer id').should('have.length', 1);

--- a/packages/e2e/cypress/e2e/app/savedDashboards.cy.ts
+++ b/packages/e2e/cypress/e2e/app/savedDashboards.cy.ts
@@ -25,10 +25,7 @@ describe('Dashboard List', () => {
         cy.findByText('Next').click();
         cy.findByText('Create').click();
 
-        cy.url().should(
-            'match',
-            /\/projects\/[0-9a-f-]{36}\/dashboards\/[^/]+\/edit$/,
-        );
+        cy.url().should('match', /\/projects\/[^/]+\/dashboards\/[^/]+\/edit$/);
         cy.findByText('Untitled dashboard').should('exist');
     });
 

--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -22,8 +22,10 @@ import {
     IconVideo,
 } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate } from 'react-router';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
+import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
@@ -71,6 +73,7 @@ const AddTileButton: FC<Props> = ({
 
     const { storeDashboard } = useDashboardStorage();
     const navigate = useNavigate();
+    const projectRoute = useOptionalProjectRoute();
     const { health } = useApp();
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const dataAppsEnabled = dataAppsFlag.data?.enabled === true;
@@ -122,9 +125,9 @@ const AddTileButton: FC<Props> = ({
         },
         [onAddTiles],
     );
-    const { projectUuid } = useParams<{
-        projectUuid: string;
-    }>();
+    const projectUuid = useProjectUuid();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
 
     return (
         <>
@@ -181,7 +184,7 @@ const AddTileButton: FC<Props> = ({
                                         dashboard?.slug,
                                     );
                                     void navigate(
-                                        `/projects/${projectUuid}/tables`,
+                                        `/projects/${projectUrlIdentifier}/tables`,
                                     );
                                 }}
                                 leftSection={<MantineIcon icon={IconPlus} />}

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -70,7 +70,6 @@ import React, {
     type FC,
     type RefObject,
 } from 'react';
-import { useParams } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
 import { useProjectColorPalette } from '../../hooks/appearance/useProjectColorPalette';
 import { type EChartsReact } from '../EChartsReactWrapper';
@@ -140,6 +139,7 @@ import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
 import { useRefreshPreAggregateByDefinitionName } from '../../hooks/usePreAggregateRefresh';
+import { useProjectUrlIdentifier } from '../../hooks/useProjectRoute';
 import { useProjectUuid } from '../../hooks/useProjectUuid';
 import {
     useInfiniteQueryResults,
@@ -648,6 +648,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
 
         const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
         const projectUuid = useProjectUuid();
+        const projectUrlIdentifier = useProjectUrlIdentifier();
         const { canViewExplore, canViewUnderlyingData, canDrillInto } =
             useContextMenuPermissions({ minimal: false });
 
@@ -1525,7 +1526,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                     title={title || chart.name || ''}
                     chartName={chart.name}
                     verification={chart.verification ?? null}
-                    titleHref={`/projects/${projectUuid}/saved/${chart.slug}/`}
+                    titleHref={`/projects/${projectUrlIdentifier}/saved/${chart.slug}/`}
                     description={chart.description}
                     belongsToDashboard={belongsToDashboard}
                     extraMenuItems={
@@ -2206,10 +2207,7 @@ export const GenericDashboardChartTile: FC<
     darkColorPaletteOverride,
     ...rest
 }) => {
-    const { projectUuid } = useParams<{
-        projectUuid: string;
-        dashboardUuid: string;
-    }>();
+    const projectUuid = useProjectUuid();
     const { user } = useApp();
 
     // Resolve the dashboard-aware palette via the shared resolver endpoint.

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -7,7 +7,6 @@ import {
 import { Box, Loader, Stack, Text } from '@mantine/core';
 import { IconAppsOff, IconCode } from '@tabler/icons-react';
 import React, { useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import AppIframePreview from '../../features/apps/AppIframePreview';
 import { getVisiblePreviewTokenError } from '../../features/apps/hooks/previewTokenQueryOptions';
 import { useAppPreviewToken } from '../../features/apps/hooks/useAppPreviewToken';
@@ -16,6 +15,7 @@ import { usePreviewOrigin } from '../../features/apps/previewOrigin';
 import { DashboardTileComments } from '../../features/comments';
 import useDashboardFiltersForTile from '../../hooks/dashboard/useDashboardFiltersForTile';
 import { useProject } from '../../hooks/useProject';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { useSpaceSummaries } from '../../hooks/useSpaces';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
@@ -38,7 +38,7 @@ const DataAppTile: FC<Props> = (props) => {
             uuid,
         },
     } = props;
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     const [isCommentsMenuOpen, setIsCommentsMenuOpen] = useState(false);
     const showComments = useDashboardContext(

--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -22,9 +22,9 @@ import {
     useState,
     type FC,
 } from 'react';
-import { useParams } from 'react-router';
 import { useSavedSqlChartResults } from '../../features/sqlRunner/hooks/useSavedSqlChartResults';
 import useDashboardFiltersForTile from '../../hooks/dashboard/useDashboardFiltersForTile';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import useSearchParams from '../../hooks/useSearchParams';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
@@ -88,9 +88,7 @@ const SqlChartTile: FC<Props> = ({
     ...rest
 }) => {
     const { user } = useApp();
-    const { projectUuid } = useParams<{
-        projectUuid: string;
-    }>();
+    const projectUuid = useProjectUuid();
     const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
     const effectiveProjectUuid = projectUuidOverride ?? projectUuid;
     const effectiveDashboardUuid = dashboardUuidOverride ?? dashboardUuid;

--- a/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EditChartMenuItem.tsx
@@ -1,8 +1,8 @@
 import { type DashboardChartTile } from '@lightdash/common';
 import { IconFilePencil } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useParams } from 'react-router';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
+import { useProjectUrlIdentifier } from '../../hooks/useProjectRoute';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import LinkMenuItem, { type LinkMenuItemProps } from '../common/LinkMenuItem';
@@ -25,9 +25,7 @@ const EditChartMenuItem: FC<Props> = ({ tile, chartSlug, ...props }) => {
 
     const { storeDashboard } = useDashboardStorage();
 
-    const { projectUuid } = useParams<{
-        projectUuid: string;
-    }>();
+    const projectUrlIdentifier = useProjectUrlIdentifier();
 
     const userCanManageExplore = user.data?.ability?.can('manage', 'Explore');
 
@@ -51,7 +49,7 @@ const EditChartMenuItem: FC<Props> = ({ tile, chartSlug, ...props }) => {
                     );
                 }
             }}
-            href={`/projects/${projectUuid}/saved/${chartSlug ?? tile.properties.savedChartUuid}/edit?fromDashboard=${dashboard?.uuid}`}
+            href={`/projects/${projectUrlIdentifier}/saved/${chartSlug ?? tile.properties.savedChartUuid}/edit?fromDashboard=${dashboard?.uuid}`}
             {...props}
         >
             Edit chart

--- a/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmptyStateNoTiles/index.tsx
@@ -6,8 +6,9 @@ import {
     IconPlayerPlay,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useParams } from 'react-router';
 import { useProjectSavedChartStatus } from '../../../hooks/useOnboardingStatus';
+import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
@@ -39,7 +40,10 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
     activeTabUuid,
     dashboardTabs,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
     const { user } = useApp();
     const { data: hasSavedCharts } = useProjectSavedChartStatus(projectUuid);
 
@@ -101,7 +105,7 @@ const EmptyStateNoTiles: FC<SavedChartsAvailableProps> = ({
                                     leftSection={
                                         <MantineIcon icon={IconPlayerPlay} />
                                     }
-                                    href={`/projects/${projectUuid}/tables`}
+                                    href={`/projects/${projectUrlIdentifier}/tables`}
                                 >
                                     Run a query
                                 </MantineLinkButton>

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -29,9 +29,9 @@ import React, {
     useState,
     type FC,
 } from 'react';
-import { useParams } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
 import { useChartSummariesV2 } from '../../../hooks/useChartSummariesV2';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import MantineModal from '../../common/MantineModal';
 import { MultiSelectCombobox } from '../../common/MultiSelectCombobox/MultiSelectCombobox';
@@ -107,11 +107,7 @@ const AddChartTilesModal: FC<Props> = ({
     spaceUuid,
     maxSelectedValues,
 }) => {
-    const { projectUuid: projectUuidFromParams } = useParams<{
-        projectUuid: string;
-    }>();
-    const projectUuidFromContext = useDashboardContext((c) => c.projectUuid);
-    const projectUuid = projectUuidFromParams ?? projectUuidFromContext;
+    const projectUuid = useProjectUuid();
     const [searchQuery, setSearchQuery] = useState<string>('');
     const [debouncedSearchQuery] = useDebouncedValue(searchQuery, 300);
     const {

--- a/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
@@ -11,8 +11,8 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { IconEye, IconEyeOff, IconPencil } from '@tabler/icons-react';
 import uniqBy from 'lodash/uniqBy';
 import { useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router';
 import { useChartSummariesV2 } from '../../../hooks/useChartSummariesV2';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 import { SelectWithFooter } from '../../common/Select/SelectWithFooter';
@@ -47,7 +47,7 @@ const ChartUpdateModal = ({
             hideTitle,
         },
     });
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [searchQuery, setSearchQuery] = useState<string>('');
     const [debouncedSearchQuery] = useDebouncedValue(searchQuery, 300);
     const selectScrollRef = useRef<HTMLDivElement>(null);

--- a/packages/frontend/src/components/DashboardTiles/TileForms/DataAppTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/DataAppTileForm.tsx
@@ -10,8 +10,8 @@ import { type UseFormReturnType } from '@mantine/form';
 import { useDebouncedValue } from '@mantine/hooks';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../../../api';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 
 interface DataAppTileFormProps {
     form: UseFormReturnType<DashboardDataAppTileProperties['properties']>;
@@ -38,7 +38,7 @@ const useProjectDataApps = (projectUuid: string | undefined, search: string) =>
     });
 
 const DataAppTileForm = ({ form }: DataAppTileFormProps) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [searchValue, setSearchValue] = useState('');
     const [debouncedSearch] = useDebouncedValue(searchValue, 300);
     const { data, isLoading, isFetching, error } = useProjectDataApps(

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -19,6 +19,7 @@ import { useLocation, useNavigate } from 'react-router';
 import { AddDataModal } from '../../../features/externalSources/components/AddDataModal';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useExplores } from '../../../hooks/useExplores';
+import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
 import { useProjectTableGroups } from '../../../hooks/useProjectTableGroups';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
@@ -53,6 +54,9 @@ const BasePanel = ({ onExploreClick, onExploreCreated }: Props) => {
     const navigate = useNavigate();
     const location = useLocation();
     const projectUuid = useProjectUuid();
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
     const [search, setSearch] = useState<string>('');
     const [debouncedSearch] = useDebouncedValue(search, 300);
     const [, startTransition] = useTransition();
@@ -181,14 +185,14 @@ const BasePanel = ({ onExploreClick, onExploreCreated }: Props) => {
                     return;
                 }
                 void navigate({
-                    pathname: `/projects/${projectUuid}/tables/${explore.name}`,
+                    pathname: `/projects/${projectUrlIdentifier}/tables/${explore.name}`,
                     search: location.search,
                 });
             });
         },
         [
             navigate,
-            projectUuid,
+            projectUrlIdentifier,
             location.search,
             startTransition,
             onExploreClick,

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -17,6 +17,7 @@ import {
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
 import { defaultState } from '../../../providers/Explorer/defaultState';
@@ -36,6 +37,9 @@ type Props = {
 
 const ExploreSideBar = memo(({ onExploreClick, onBackToTables }: Props) => {
     const projectUuid = useProjectUuid();
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
 
     const tableName = useExplorerSelector(selectTableName);
     const deferredTableName = useDeferredValue(tableName);
@@ -68,8 +72,8 @@ const ExploreSideBar = memo(({ onExploreClick, onBackToTables }: Props) => {
             onBackToTables();
             return;
         }
-        void navigate(`/projects/${projectUuid}/tables`);
-    }, [clearExplore, navigate, projectUuid, onBackToTables]);
+        void navigate(`/projects/${projectUrlIdentifier}/tables`);
+    }, [clearExplore, navigate, projectUrlIdentifier, onBackToTables]);
 
     // When transitioning back to tables it's relatively fast so we don't show any skeleton
     const isTransitioningToExplore = useMemo(

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.tsx
@@ -2,6 +2,7 @@ import { ActionIcon, Anchor, Group, Text, Tooltip } from '@mantine/core';
 import { IconFolder } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
+import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
 import MantineIcon from '../../common/MantineIcon';
 
 type Props = {
@@ -29,6 +30,9 @@ export const TitleBreadCrumbs: FC<Props> = ({
     dashboardSlug,
     dashboardName,
 }) => {
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
     const isChartWithinDashboard = !!(dashboardUuid && dashboardName);
     return (
         <>
@@ -53,7 +57,7 @@ export const TitleBreadCrumbs: FC<Props> = ({
                                 <ActionIcon
                                     variant="subtle"
                                     component={Link}
-                                    to={`/projects/${projectUuid}/dashboards/${dashboardSlug ?? dashboardUuid}`}
+                                    to={`/projects/${projectUrlIdentifier}/dashboards/${dashboardSlug ?? dashboardUuid}`}
                                 >
                                     <MantineIcon
                                         color="ldGray.4"
@@ -66,7 +70,7 @@ export const TitleBreadCrumbs: FC<Props> = ({
                                     fz="md"
                                     c="ldGray.6"
                                     component={Link}
-                                    to={`/projects/${projectUuid}/spaces/${spaceUuid}`}
+                                    to={`/projects/${projectUrlIdentifier}/spaces/${spaceUuid}`}
                                     style={{
                                         maxWidth: `${MAX_WIDTH_TITLE_PX}px`,
                                         whiteSpace: 'nowrap',
@@ -104,7 +108,7 @@ export const TitleBreadCrumbs: FC<Props> = ({
                             c="ldGray.6"
                             fz="md"
                             component={Link}
-                            to={`/projects/${projectUuid}/dashboards/${dashboardSlug ?? dashboardUuid}`}
+                            to={`/projects/${projectUrlIdentifier}/dashboards/${dashboardSlug ?? dashboardUuid}`}
                             truncate
                             display="inline-block"
                             maw={MAX_WIDTH_TITLE_PX}

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -53,7 +53,7 @@ import {
     useState,
     type FC,
 } from 'react';
-import { useBlocker, useLocation, useNavigate, useParams } from 'react-router';
+import { useBlocker, useLocation, useNavigate } from 'react-router';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import ChartAsCodeModal from '../../../features/contentAsCode/components/ChartAsCodeModal';
 import {
@@ -90,6 +90,8 @@ import {
 } from '../../../hooks/useContentVerification';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUrlIdentifier } from '../../../hooks/useProjectRoute';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useUpdateMutation } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
@@ -142,9 +144,8 @@ const SavedChartsHeader: FC = () => {
     const changeChartExploreEnabled = changeChartExploreFlag?.enabled === true;
 
     const { search, pathname } = useLocation();
-    const { projectUuid } = useParams<{
-        projectUuid: string;
-    }>();
+    const projectUuid = useProjectUuid();
+    const projectUrlIdentifier = useProjectUrlIdentifier();
     const dashboardUuid = useSearchParams('fromDashboard');
     const isFromDashboard = !!dashboardUuid;
 
@@ -329,19 +330,19 @@ const SavedChartsHeader: FC = () => {
             !isSaveModalOpen &&
             !isChartPath(
                 nextLocation.pathname,
-                projectUuid,
+                projectUrlIdentifier,
                 savedChart?.slug,
             ) &&
             !isChartPath(
                 nextLocation.pathname,
-                projectUuid,
+                projectUrlIdentifier,
                 savedChart?.uuid,
             ) &&
             !nextLocation.pathname.includes(
-                `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
+                `/projects/${projectUrlIdentifier}/dashboards/${dashboardUuid}`,
             ) &&
             !nextLocation.pathname.includes(
-                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}`,
+                `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}`,
             )
         ) {
             return true; //blocks navigation
@@ -438,7 +439,7 @@ const SavedChartsHeader: FC = () => {
 
     const handleGoBackClick = () => {
         void navigate({
-            pathname: `/projects/${savedChart?.projectUuid}/dashboards/${dashboardIdentifier}`,
+            pathname: `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}`,
         });
     };
 
@@ -470,9 +471,16 @@ const SavedChartsHeader: FC = () => {
 
         if (!isFromDashboard)
             void navigate({
-                pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.slug}/view`,
+                pathname: `/projects/${projectUrlIdentifier}/saved/${savedChart?.slug}/view`,
             });
-    }, [dispatch, isEditMode, savedChart, isFromDashboard, navigate]);
+    }, [
+        dispatch,
+        isEditMode,
+        savedChart,
+        isFromDashboard,
+        navigate,
+        projectUrlIdentifier,
+    ]);
 
     const promoteDisabled = !(
         project?.upstreamProjectUuid !== undefined && userCanPromoteChart
@@ -642,7 +650,7 @@ const SavedChartsHeader: FC = () => {
                                                 }
                                                 onClick={() =>
                                                     navigate({
-                                                        pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.slug}/edit`,
+                                                        pathname: `/projects/${projectUrlIdentifier}/saved/${savedChart?.slug}/edit`,
                                                     })
                                                 }
                                             >
@@ -849,7 +857,7 @@ const SavedChartsHeader: FC = () => {
                                         }
                                         onClick={() =>
                                             navigate({
-                                                pathname: `/projects/${savedChart?.projectUuid}/saved/${savedChart?.slug}/history`,
+                                                pathname: `/projects/${projectUrlIdentifier}/saved/${savedChart?.slug}/history`,
                                             })
                                         }
                                     >
@@ -1057,7 +1065,7 @@ const SavedChartsHeader: FC = () => {
                     onConfirm={() => {
                         if (dashboardUuid) {
                             void navigate(
-                                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}`,
+                                `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}`,
                             );
                         } else {
                             void navigate(`/`);
@@ -1107,7 +1115,7 @@ const SavedChartsHeader: FC = () => {
                     onConfirm={() => {
                         clearDashboardStorage();
                         void navigate(
-                            `/projects/${projectUuid}/saved/${savedChart.slug}/edit`,
+                            `/projects/${projectUrlIdentifier}/saved/${savedChart.slug}/edit`,
                         );
                     }}
                 />

--- a/packages/frontend/src/components/Explorer/SpaceBrowser/CreateResourceToSpace.tsx
+++ b/packages/frontend/src/components/Explorer/SpaceBrowser/CreateResourceToSpace.tsx
@@ -2,6 +2,8 @@ import { assertUnreachable } from '@lightdash/common';
 import { useEffect, type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { useCreateMutation } from '../../../hooks/dashboard/useDashboard';
+import { useProjectUrlIdentifier } from '../../../hooks/useProjectRoute';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { AddToSpaceResources } from './types';
 
 interface Props {
@@ -12,8 +14,9 @@ const DEFAULT_DASHBOARD_NAME = 'Untitled dashboard';
 
 const CreateResourceToSpace: FC<Props> = ({ resourceType }) => {
     const navigate = useNavigate();
-    const { projectUuid, spaceUuid } = useParams<{
-        projectUuid: string;
+    const projectUuid = useProjectUuid();
+    const projectUrlIdentifier = useProjectUrlIdentifier();
+    const { spaceUuid } = useParams<{
         spaceUuid: string;
     }>();
 
@@ -26,10 +29,10 @@ const CreateResourceToSpace: FC<Props> = ({ resourceType }) => {
     useEffect(() => {
         if (hasCreatedDashboard && newDashboard) {
             void navigate(
-                `/projects/${projectUuid}/dashboards/${newDashboard.slug}`,
+                `/projects/${projectUrlIdentifier}/dashboards/${newDashboard.slug}`,
             );
         }
-    }, [navigate, hasCreatedDashboard, newDashboard, projectUuid]);
+    }, [navigate, hasCreatedDashboard, newDashboard, projectUrlIdentifier]);
 
     useEffect(() => {
         switch (resourceType) {

--- a/packages/frontend/src/components/Home/HomepageContentPanel/index.tsx
+++ b/packages/frontend/src/components/Home/HomepageContentPanel/index.tsx
@@ -20,9 +20,14 @@ import ResourceView from '../../common/ResourceView';
 interface Props {
     data: MostPopularAndRecentlyUpdated | undefined;
     projectUuid: string;
+    projectUrlIdentifier: string;
 }
 
-export const HomepageContentPanel: FC<Props> = ({ data, projectUuid }) => {
+export const HomepageContentPanel: FC<Props> = ({
+    data,
+    projectUuid,
+    projectUrlIdentifier,
+}) => {
     const MAX_NUMBER_OF_ITEMS_IN_PANEL = 10;
     const navigate = useNavigate();
     const { health } = useApp();
@@ -65,7 +70,7 @@ export const HomepageContentPanel: FC<Props> = ({ data, projectUuid }) => {
     }, [data?.mostPopular, data?.recentlyUpdated, verifiedContentData]);
 
     const handleCreateChart = () => {
-        void navigate(`/projects/${projectUuid}/tables`);
+        void navigate(`/projects/${projectUrlIdentifier}/tables`);
     };
 
     const isDemo = health.data?.mode === LightdashMode.DEMO;

--- a/packages/frontend/src/components/Home/LandingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/index.tsx
@@ -9,9 +9,14 @@ import MantineLinkButton from '../../common/MantineLinkButton';
 interface Props {
     userName: string | undefined;
     projectUuid: string;
+    projectUrlIdentifier: string;
 }
 
-const LandingPanel: FC<Props> = ({ userName, projectUuid }) => {
+const LandingPanel: FC<Props> = ({
+    userName,
+    projectUuid,
+    projectUrlIdentifier,
+}) => {
     const { user } = useApp();
     return (
         <Group justify="space-between" my="xl">
@@ -33,7 +38,7 @@ const LandingPanel: FC<Props> = ({ userName, projectUuid }) => {
                 })}
             >
                 <MantineLinkButton
-                    href={`/projects/${projectUuid}/tables`}
+                    href={`/projects/${projectUrlIdentifier}/tables`}
                     trackingEvent={{
                         name: EventName.LANDING_RUN_QUERY_CLICKED,
                         properties: {

--- a/packages/frontend/src/components/Home/OnboardingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/OnboardingPanel/index.tsx
@@ -7,7 +7,7 @@ import { EventName } from '../../../types/Events';
 import MantineLinkButton from '../../common/MantineLinkButton';
 
 interface Props {
-    projectUuid: string;
+    projectUrlIdentifier: string;
     userName?: string;
 }
 
@@ -29,7 +29,7 @@ const onboardingSteps = [
     },
 ];
 
-const OnboardingPanel: FC<Props> = ({ projectUuid, userName }) => {
+const OnboardingPanel: FC<Props> = ({ projectUrlIdentifier, userName }) => {
     return (
         <Stack justify="flex-start" gap="xs" mt="4xl">
             <Title order={3}>
@@ -55,7 +55,7 @@ const OnboardingPanel: FC<Props> = ({ projectUuid, userName }) => {
                         </Card>
                     ))}
                     <MantineLinkButton
-                        href={`/projects/${projectUuid}/tables`}
+                        href={`/projects/${projectUrlIdentifier}/tables`}
                         trackingEvent={{
                             name: EventName.ONBOARDING_STEP_CLICKED,
                             properties: {

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -32,6 +32,7 @@ import { useState, type FC } from 'react';
 import { Link } from 'react-router';
 import { useHasMetricsInCatalog } from '../../features/metricsCatalog/hooks/useMetricsCatalog';
 import { useFavorites } from '../../hooks/favorites/useFavorites';
+import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { useSpaceSummaries } from '../../hooks/useSpaces';
 import useApp from '../../providers/App/useApp';
@@ -45,14 +46,18 @@ interface Props {
     projectUuid: string;
 }
 
-const getFavoriteItemUrl = (projectUuid: string, item: ResourceViewItem) => {
+const getFavoriteItemUrl = (
+    projectUuid: string,
+    projectUrlIdentifier: string,
+    item: ResourceViewItem,
+) => {
     switch (item.type) {
         case ResourceViewItemType.DASHBOARD:
-            return `/projects/${projectUuid}/dashboards/${item.data.slug}/view`;
+            return `/projects/${projectUrlIdentifier}/dashboards/${item.data.slug}/view`;
         case ResourceViewItemType.CHART:
-            return `/projects/${projectUuid}/saved/${item.data.slug}`;
+            return `/projects/${projectUrlIdentifier}/saved/${item.data.slug}`;
         case ResourceViewItemType.SPACE:
-            return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
+            return `/projects/${projectUrlIdentifier}/spaces/${item.data.uuid}`;
         case ResourceViewItemType.DATA_APP:
             return `/projects/${projectUuid}/apps/${item.data.uuid}/view`;
         default:
@@ -76,6 +81,9 @@ const getFavoriteItemIcon = (item: ResourceViewItem) => {
 };
 
 const BrowseMenu: FC<Props> = ({ projectUuid }) => {
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
     // Track if menu has ever been opened to defer loading spaces
     const [hasBeenOpened, setHasBeenOpened] = useState(false);
     const [spacesExpanded, setSpacesExpanded] = useState(false);
@@ -139,7 +147,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
             <Menu.Dropdown>
                 <Menu.Item
                     component={Link}
-                    to={`/projects/${projectUuid}/spaces`}
+                    to={`/projects/${projectUrlIdentifier}/spaces`}
                     leftSection={<MantineIcon icon={IconFolders} />}
                 >
                     All Spaces
@@ -147,7 +155,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
 
                 <Menu.Item
                     component={Link}
-                    to={`/projects/${projectUuid}/dashboards`}
+                    to={`/projects/${projectUrlIdentifier}/dashboards`}
                     leftSection={<MantineIcon icon={IconLayoutDashboard} />}
                 >
                     All dashboards
@@ -155,7 +163,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
 
                 <Menu.Item
                     component={Link}
-                    to={`/projects/${projectUuid}/saved`}
+                    to={`/projects/${projectUrlIdentifier}/saved`}
                     leftSection={<MantineIcon icon={IconChartAreaLine} />}
                 >
                     All saved charts
@@ -204,6 +212,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                                         component={Link}
                                         to={getFavoriteItemUrl(
                                             projectUuid,
+                                            projectUrlIdentifier,
                                             item,
                                         )}
                                         leftSection={
@@ -272,7 +281,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                                                 <Menu.Item
                                                     key={space.uuid}
                                                     component={Link}
-                                                    to={`/projects/${projectUuid}/spaces/${space.uuid}`}
+                                                    to={`/projects/${projectUrlIdentifier}/spaces/${space.uuid}`}
                                                     leftSection={
                                                         <MantineIcon
                                                             icon={IconFolder}

--- a/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
+++ b/packages/frontend/src/components/NavBar/DashboardExplorerBanner.tsx
@@ -4,6 +4,7 @@ import { IconInfoCircle } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
+import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
 import MantineIcon from '../common/MantineIcon';
 
 type Props = {
@@ -11,6 +12,9 @@ type Props = {
 };
 
 export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
     const navigate = useNavigate();
     const { savedQueryUuid, mode } = useParams<{
         savedQueryUuid: string;
@@ -71,7 +75,7 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
     }, [action]);
 
     const handleOnCancel = useCallback(() => {
-        if (!projectUuid) {
+        if (!projectUrlIdentifier) {
             return;
         }
         // Cancel the action and navigate back to the dashboard, restoring the existing state (in case there were some unsaved changes)
@@ -79,7 +83,7 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
         // so do not clear the storage here
         setIsCancelling(true);
 
-        let returnUrl = `/projects/${projectUuid}/dashboards/${dashboardSlug ?? dashboardUuid}/${
+        let returnUrl = `/projects/${projectUrlIdentifier}/dashboards/${dashboardSlug ?? dashboardUuid}/${
             savedQueryUuid ? 'view' : 'edit'
         }`;
 
@@ -98,7 +102,7 @@ export const DashboardExplorerBanner: FC<Props> = ({ projectUuid }) => {
         dashboardUuid,
         activeTabUuid,
         navigate,
-        projectUuid,
+        projectUrlIdentifier,
         savedQueryUuid,
     ]);
 

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -12,6 +12,7 @@ import {
 } from '@tabler/icons-react';
 import { memo, useState, type FC } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router';
+import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../providers/Ability';
 import useApp from '../../providers/App/useApp';
@@ -23,9 +24,17 @@ import { ActionType } from '../common/SpaceActionModal/types';
 
 type Props = {
     projectUuid: string;
+    projectUrlIdentifier?: string;
 };
 
-const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
+const ExploreMenu: FC<Props> = memo((props) => {
+    const { projectUuid, projectUrlIdentifier: projectUrlIdentifierProp } =
+        props;
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ??
+        projectUrlIdentifierProp ??
+        projectUuid;
     const navigate = useNavigate();
     const location = useLocation();
 
@@ -77,7 +86,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                             component={Link}
                             title="Chart"
                             description="Build queries and save them as charts."
-                            to={`/projects/${projectUuid}/tables`}
+                            to={`/projects/${projectUrlIdentifier}/tables`}
                             icon={IconTable}
                         />
 
@@ -92,18 +101,18 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 component={Link}
                                 title="Query using SQL runner"
                                 description="Access your database to run ad-hoc queries."
-                                to={`/projects/${projectUuid}/sql-runner`}
+                                to={`/projects/${projectUrlIdentifier}/sql-runner`}
                                 onClick={(
                                     event: React.MouseEvent<HTMLAnchorElement>,
                                 ) => {
                                     if (
                                         location.pathname.startsWith(
-                                            `/projects/${projectUuid}/sql-runner`,
+                                            `/projects/${projectUrlIdentifier}/sql-runner`,
                                         )
                                     ) {
                                         event.preventDefault();
                                         window.open(
-                                            `/projects/${projectUuid}/sql-runner`,
+                                            `/projects/${projectUrlIdentifier}/sql-runner`,
                                             '_blank',
                                         );
                                     }
@@ -176,7 +185,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                     onSubmitForm={(space) => {
                         if (space)
                             void navigate(
-                                `/projects/${projectUuid}/spaces/${space.uuid}`,
+                                `/projects/${projectUrlIdentifier}/spaces/${space.uuid}`,
                             );
                     }}
                     parentSpaceUuid={null}
@@ -189,7 +198,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                     onClose={() => setIsCreateDashboardOpen(false)}
                     onConfirm={(dashboard) => {
                         void navigate(
-                            `/projects/${projectUuid}/dashboards/${dashboard.slug}/edit`,
+                            `/projects/${projectUrlIdentifier}/dashboards/${dashboard.slug}/edit`,
                         );
 
                         setIsCreateDashboardOpen(false);

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -3,6 +3,7 @@ import { lazy, Suspense, type FC } from 'react';
 import { Link } from 'react-router';
 import { useHasMetricsInCatalog } from '../../features/metricsCatalog/hooks/useMetricsCatalog';
 import Omnibar from '../../features/omnibar';
+import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
 import useApp from '../../providers/App/useApp';
 import Logo from '../../svgs/logo-icon.svg?react';
 import { AutopilotNavButton } from './AutopilotNavButton';
@@ -26,15 +27,20 @@ const AiAgentsButton = lazy(() =>
 
 type Props = {
     activeProjectUuid: string | undefined;
+    activeProjectUrlIdentifier: string | undefined;
     isLoadingActiveProject: boolean;
 };
 
 export const MainNavBarContent: FC<Props> = ({
     activeProjectUuid,
+    activeProjectUrlIdentifier,
     isLoadingActiveProject,
 }) => {
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? activeProjectUrlIdentifier;
     const homeUrl = activeProjectUuid
-        ? `/projects/${activeProjectUuid}/home`
+        ? `/projects/${projectUrlIdentifier}/home`
         : '/';
     const { data: hasMetrics } = useHasMetricsInCatalog({
         projectUuid: activeProjectUuid,
@@ -57,7 +63,10 @@ export const MainNavBarContent: FC<Props> = ({
                 {!isLoadingActiveProject && activeProjectUuid && (
                     <>
                         <Button.Group>
-                            <ExploreMenu projectUuid={activeProjectUuid} />
+                            <ExploreMenu
+                                projectUuid={activeProjectUuid}
+                                projectUrlIdentifier={projectUrlIdentifier}
+                            />
                             <BrowseMenu projectUuid={activeProjectUuid} />
                             {hasMetrics && (
                                 <MetricsLink projectUuid={activeProjectUuid} />

--- a/packages/frontend/src/components/NavBar/MetricsLink.tsx
+++ b/packages/frontend/src/components/NavBar/MetricsLink.tsx
@@ -7,6 +7,7 @@ import { useProject } from '../../hooks/useProject';
 import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
+import { getProjectUrlIdentifier } from '../../utils/projectUrl';
 import MantineIcon from '../common/MantineIcon';
 
 interface Props {
@@ -18,6 +19,9 @@ export const MetricsLink: FC<Props> = ({ projectUuid, asMenu }) => {
     const { user } = useApp();
     const navigate = useNavigate();
     const { data: project } = useProject(projectUuid);
+    const projectUrlIdentifier = project
+        ? getProjectUrlIdentifier(project)
+        : projectUuid;
     const { track } = useTracking();
 
     const metricsSubject = subject('MetricsTree', {
@@ -47,8 +51,8 @@ export const MetricsLink: FC<Props> = ({ projectUuid, asMenu }) => {
 
     const handleMetricsCatalogClick = useCallback(() => {
         trackMetricsCatalogClick();
-        void navigate(`/projects/${projectUuid}/metrics`);
-    }, [trackMetricsCatalogClick, navigate, projectUuid]);
+        void navigate(`/projects/${projectUrlIdentifier}/metrics`);
+    }, [trackMetricsCatalogClick, navigate, projectUrlIdentifier]);
 
     if (!canViewMetrics) return null;
 
@@ -56,7 +60,7 @@ export const MetricsLink: FC<Props> = ({ projectUuid, asMenu }) => {
         return (
             <Menu.Item
                 component={Link}
-                to={`/projects/${projectUuid}/metrics`}
+                to={`/projects/${projectUrlIdentifier}/metrics`}
                 leftSection={<MantineIcon icon={IconHash} />}
                 onClick={trackMetricsCatalogClick}
             >

--- a/packages/frontend/src/components/NavBar/MetricsLink.tsx
+++ b/packages/frontend/src/components/NavBar/MetricsLink.tsx
@@ -6,6 +6,7 @@ import { useProject } from '../../hooks/useProject';
 import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
+import { getProjectUrlIdentifier } from '../../utils/projectUrl';
 import MantineIcon from '../common/MantineIcon';
 
 interface Props {
@@ -17,6 +18,9 @@ export const MetricsLink: FC<Props> = ({ projectUuid, asMenu }) => {
     const { user } = useApp();
     const navigate = useNavigate();
     const { data: project } = useProject(projectUuid);
+    const projectUrlIdentifier = project
+        ? getProjectUrlIdentifier(project)
+        : projectUuid;
     const { track } = useTracking();
 
     const trackMetricsCatalogClick = useCallback(() => {
@@ -34,14 +38,14 @@ export const MetricsLink: FC<Props> = ({ projectUuid, asMenu }) => {
 
     const handleMetricsCatalogClick = useCallback(() => {
         trackMetricsCatalogClick();
-        void navigate(`/projects/${projectUuid}/metrics`);
-    }, [trackMetricsCatalogClick, navigate, projectUuid]);
+        void navigate(`/projects/${projectUrlIdentifier}/metrics`);
+    }, [trackMetricsCatalogClick, navigate, projectUrlIdentifier]);
 
     if (asMenu) {
         return (
             <Menu.Item
                 component={Link}
-                to={`/projects/${projectUuid}/metrics`}
+                to={`/projects/${projectUrlIdentifier}/metrics`}
                 leftSection={<MantineIcon icon={IconHash} />}
                 onClick={trackMetricsCatalogClick}
             >

--- a/packages/frontend/src/components/NavBar/PreviewBanner.tsx
+++ b/packages/frontend/src/components/NavBar/PreviewBanner.tsx
@@ -3,6 +3,7 @@ import { IconArrowLeft, IconTool } from '@tabler/icons-react';
 import { useCallback, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { useUpdateActiveProjectMutation } from '../../hooks/useActiveProject';
+import { getProjectUrlIdentifier } from '../../utils/projectUrl';
 import MantineIcon from '../common/MantineIcon';
 import { BANNER_HEIGHT } from '../common/Page/constants';
 import classes from './PreviewBanner.module.css';
@@ -22,7 +23,11 @@ const formatExpirationSuffix = (expiresAt: Date): string => {
 
 export const PreviewBanner: FC<{
     expiresAt: Date | null;
-    upstreamProject: { projectUuid: string; name: string } | null;
+    upstreamProject: {
+        projectUuid: string;
+        slug?: string;
+        name: string;
+    } | null;
 }> = ({ expiresAt, upstreamProject }) => {
     const navigate = useNavigate();
     const { mutate: setActiveProject } = useUpdateActiveProjectMutation();
@@ -30,7 +35,9 @@ export const PreviewBanner: FC<{
     const handleBackToUpstream = useCallback(() => {
         if (!upstreamProject) return;
         setActiveProject(upstreamProject.projectUuid);
-        void navigate(`/projects/${upstreamProject.projectUuid}/home`);
+        void navigate(
+            `/projects/${getProjectUrlIdentifier(upstreamProject)}/home`,
+        );
     }, [navigate, setActiveProject, upstreamProject]);
 
     return (

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -38,8 +38,10 @@ import {
 } from '../../hooks/useActiveProject';
 import { useIsTruncated } from '../../hooks/useIsTruncated';
 import { useProject } from '../../hooks/useProject';
+import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
 import { useProjects } from '../../hooks/useProjects';
 import useApp from '../../providers/App/useApp';
+import { getProjectUrlIdentifier } from '../../utils/projectUrl';
 import MantineIcon from '../common/MantineIcon';
 import { CreatePreviewModal } from './CreatePreviewProjectModal';
 import classes from './ProjectSwitcher.module.css';
@@ -282,32 +284,39 @@ const PreviewRow: FC<{
     );
 };
 
-const swappableProjectRoutes = (activeProjectUuid: string) => [
-    `/projects/${activeProjectUuid}/home`,
-    `/projects/${activeProjectUuid}/saved`,
-    `/projects/${activeProjectUuid}/dashboards`,
-    `/projects/${activeProjectUuid}/spaces`,
-    `/projects/${activeProjectUuid}/sqlRunner`,
-    `/projects/${activeProjectUuid}/tables`,
-    `/projects/${activeProjectUuid}/user-activity`,
-    `/projects/${activeProjectUuid}`,
-    `/generalSettings`,
-    `/generalSettings/password`,
-    `/generalSettings/myWarehouseConnections`,
-    `/generalSettings/personalAccessTokens`,
-    `/generalSettings/scimAccessTokens`,
-    `/generalSettings/organization`,
-    `/generalSettings/userManagement`,
-    `/generalSettings/appearance`,
-    `/generalSettings/projectManagement`,
-    `/generalSettings/projectManagement/${activeProjectUuid}/settings`,
-    `/generalSettings/projectManagement/${activeProjectUuid}/tablesConfiguration`,
-    `/generalSettings/projectManagement/${activeProjectUuid}/projectAccess`,
-    `/generalSettings/projectManagement/${activeProjectUuid}/integrations/dbtCloud`,
-    `/generalSettings/projectManagement/${activeProjectUuid}/usageAnalytics`,
-    `/generalSettings/projectManagement/${activeProjectUuid}/scheduledDeliveries`,
-    `/generalSettings/projectManagement/${activeProjectUuid}/validator`,
-    `/generalSettings/projectManagement/${activeProjectUuid}`,
+const swappableProjectRoutes = (
+    activeProjectUuid: string,
+    activeProjectUrlIdentifier: string,
+) => [
+    ...[
+        `/projects/${activeProjectUrlIdentifier}/home`,
+        `/projects/${activeProjectUrlIdentifier}/saved`,
+        `/projects/${activeProjectUrlIdentifier}/dashboards`,
+        `/projects/${activeProjectUrlIdentifier}/spaces`,
+        `/projects/${activeProjectUrlIdentifier}`,
+    ].map((path) => ({ path, handle: { useProjectSlug: true } })),
+    ...[
+        `/projects/${activeProjectUuid}/sqlRunner`,
+        `/projects/${activeProjectUuid}/tables`,
+        `/projects/${activeProjectUuid}/user-activity`,
+        `/generalSettings`,
+        `/generalSettings/password`,
+        `/generalSettings/myWarehouseConnections`,
+        `/generalSettings/personalAccessTokens`,
+        `/generalSettings/scimAccessTokens`,
+        `/generalSettings/organization`,
+        `/generalSettings/userManagement`,
+        `/generalSettings/appearance`,
+        `/generalSettings/projectManagement`,
+        `/generalSettings/projectManagement/${activeProjectUuid}/settings`,
+        `/generalSettings/projectManagement/${activeProjectUuid}/tablesConfiguration`,
+        `/generalSettings/projectManagement/${activeProjectUuid}/projectAccess`,
+        `/generalSettings/projectManagement/${activeProjectUuid}/integrations/dbtCloud`,
+        `/generalSettings/projectManagement/${activeProjectUuid}/usageAnalytics`,
+        `/generalSettings/projectManagement/${activeProjectUuid}/scheduledDeliveries`,
+        `/generalSettings/projectManagement/${activeProjectUuid}/validator`,
+        `/generalSettings/projectManagement/${activeProjectUuid}`,
+    ].map((path) => ({ path, handle: { useProjectSlug: false } })),
 ];
 
 const ProjectSwitcher = () => {
@@ -324,10 +333,14 @@ const ProjectSwitcher = () => {
             enabled: isMenuOpen,
         },
     );
+    const projectRoute = useOptionalProjectRoute();
     const { isLoading: isLoadingActiveProjectUuid, activeProjectUuid } =
-        useActiveProjectUuid();
+        useActiveProjectUuid({ projectUuid: projectRoute?.projectUuid });
     // Fetch only the active project for the button label (lightweight)
     const { data: activeProject } = useProject(activeProjectUuid);
+    const activeProjectUrlIdentifier = activeProject
+        ? getProjectUrlIdentifier(activeProject)
+        : activeProjectUuid;
     // When inside a preview, fetch its upstream project to show in the breadcrumb
     const upstreamProjectUuid =
         activeProject?.type === ProjectType.PREVIEW
@@ -337,7 +350,9 @@ const ProjectSwitcher = () => {
 
     const { mutate: setLastProjectMutation } = useUpdateActiveProjectMutation();
     const location = useLocation();
-    const isHomePage = !!useMatch(`/projects/${activeProjectUuid}/home`);
+    const isHomePage = !!useMatch(
+        `/projects/${activeProjectUrlIdentifier}/home`,
+    );
 
     const [isCreatePreviewOpen, setIsCreatePreview] = useState(false);
     // Project drilled into to view its previews; null = top-level project list
@@ -354,10 +369,11 @@ const ProjectSwitcher = () => {
 
     const routeMatches =
         matchRoutes(
-            activeProjectUuid
-                ? swappableProjectRoutes(activeProjectUuid).map((path) => ({
-                      path,
-                  }))
+            activeProjectUuid && activeProjectUrlIdentifier
+                ? swappableProjectRoutes(
+                      activeProjectUuid,
+                      activeProjectUrlIdentifier,
+                  )
                 : [],
             location,
         ) || [];
@@ -384,7 +400,7 @@ const ProjectSwitcher = () => {
                               icon: IconArrowRight,
                               onClick: () => {
                                   void navigate(
-                                      `/projects/${project.projectUuid}/home`,
+                                      `/projects/${getProjectUrlIdentifier(project)}/home`,
                                   );
                               },
                           }
@@ -392,18 +408,36 @@ const ProjectSwitcher = () => {
             });
 
             if (shouldSwapProjectRoute) {
+                const useProjectSlug = Boolean(
+                    swappableRouteMatch.handle?.useProjectSlug,
+                );
+                const currentProjectIdentifier = useProjectSlug
+                    ? activeProjectUrlIdentifier
+                    : activeProjectUuid;
+                const nextProjectIdentifier = useProjectSlug
+                    ? getProjectUrlIdentifier(project)
+                    : project.projectUuid;
+                if (!currentProjectIdentifier) {
+                    void navigate(
+                        `/projects/${getProjectUrlIdentifier(project)}/home`,
+                    );
+                    return;
+                }
                 void navigate(
                     swappableRouteMatch.path.replace(
-                        activeProjectUuid,
-                        project.projectUuid,
+                        currentProjectIdentifier,
+                        nextProjectIdentifier,
                     ),
                 );
             } else {
-                void navigate(`/projects/${project.projectUuid}/home`);
+                void navigate(
+                    `/projects/${getProjectUrlIdentifier(project)}/home`,
+                );
             }
         },
         [
             activeProjectUuid,
+            activeProjectUrlIdentifier,
             navigate,
             isHomePage,
             projects,

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -2,15 +2,16 @@ import { OrganizationAccessStatus, ProjectType } from '@lightdash/common';
 import { Box } from '@mantine/core';
 import { clsx } from 'clsx';
 import { memo } from 'react';
-import { useParams } from 'react-router';
 import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import { useOrganizationAccess } from '../../hooks/organization/useOrganizationAccess';
 import { useActiveProjectUuid } from '../../hooks/useActiveProject';
 import { useProject } from '../../hooks/useProject';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { useImpersonation } from '../../hooks/user/useImpersonation';
 import useFullscreen from '../../providers/Fullscreen/useFullscreen';
 import MantineBaseProvider from '../../providers/MantineBaseProvider';
 import { isPlaygroundProvisioningSource } from '../../utils/playgroundProject';
+import { getProjectUrlIdentifier } from '../../utils/projectUrl';
 import { BANNER_HEIGHT, NAVBAR_HEIGHT } from '../common/Page/constants';
 import { DashboardExplorerBanner } from './DashboardExplorerBanner';
 import { ImpersonationBanner } from './ImpersonationBanner';
@@ -41,13 +42,15 @@ interface NavBarProps {
 const NavBarContent = ({
     navBarMode,
     activeProjectUuid,
+    activeProjectUrlIdentifier,
     isLoadingActiveProject,
 }: {
     navBarMode: NavBarMode;
     activeProjectUuid: string | undefined;
+    activeProjectUrlIdentifier: string | undefined;
     isLoadingActiveProject: boolean;
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     if (navBarMode === NavBarMode.EDITING_DASHBOARD_CHART) {
         return <DashboardExplorerBanner projectUuid={projectUuid} />;
     }
@@ -55,6 +58,7 @@ const NavBarContent = ({
     return (
         <MainNavBarContent
             activeProjectUuid={activeProjectUuid}
+            activeProjectUrlIdentifier={activeProjectUrlIdentifier}
             isLoadingActiveProject={isLoadingActiveProject}
         />
     );
@@ -65,9 +69,13 @@ const getNavBarRootElement = () =>
 
 const NavBar = memo(({ isFixed = true }: NavBarProps) => {
     const { isFullscreen } = useFullscreen();
+    const routeProjectUuid = useProjectUuid();
 
     const { activeProjectUuid, isLoading: isLoadingActiveProject } =
-        useActiveProjectUuid({ refetchOnMount: true });
+        useActiveProjectUuid({
+            refetchOnMount: true,
+            projectUuid: routeProjectUuid,
+        });
     const { data: project } = useProject(activeProjectUuid);
 
     const isCurrentProjectPreview = project?.type === ProjectType.PREVIEW;
@@ -119,6 +127,7 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
                             upstreamProject
                                 ? {
                                       projectUuid: upstreamProject.projectUuid,
+                                      slug: upstreamProject.slug,
                                       name: upstreamProject.name,
                                   }
                                 : null
@@ -145,6 +154,11 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
                     <NavBarContent
                         navBarMode={navBarMode}
                         activeProjectUuid={activeProjectUuid}
+                        activeProjectUrlIdentifier={
+                            project
+                                ? getProjectUrlIdentifier(project)
+                                : activeProjectUuid
+                        }
                         isLoadingActiveProject={isLoadingActiveProject}
                     />
                 </Box>

--- a/packages/frontend/src/components/ProjectRoute.test.tsx
+++ b/packages/frontend/src/components/ProjectRoute.test.tsx
@@ -1,44 +1,115 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
+import { useOptionalProjectRoute } from '../hooks/useProjectRoute';
 import ProjectRoute from './ProjectRoute';
+
+const PROJECT_UUID = '3675b69e-8324-4110-bdca-059031aa8da3';
 
 const state = vi.hoisted(() => ({
     useActiveProjectUuid: vi.fn(),
+    useProject: vi.fn(),
+    useProjects: vi.fn(),
 }));
 
 vi.mock('../hooks/useActiveProject', () => ({
     useActiveProjectUuid: state.useActiveProjectUuid,
 }));
 
+vi.mock('../hooks/useProject', () => ({
+    useProject: state.useProject,
+}));
+
+vi.mock('../hooks/useProjects', () => ({
+    useProjects: state.useProjects,
+}));
+
+vi.mock('../providers/App/useApp', () => ({
+    default: () => ({ user: { data: { organizationUuid: 'org-uuid' } } }),
+}));
+
+vi.mock('../providers/Ability', () => ({
+    Can: ({ children }: { children: (allowed: boolean) => React.ReactNode }) =>
+        children(true),
+}));
+
+const ProjectDetails = () => {
+    const projectRoute = useOptionalProjectRoute();
+
+    return (
+        <div>
+            {projectRoute?.projectUuid}:{projectRoute?.projectUrlIdentifier}
+        </div>
+    );
+};
+
+const renderProjectRoute = (projectIdentifier: string) =>
+    render(
+        <MemoryRouter initialEntries={[`/projects/${projectIdentifier}`]}>
+            <Routes>
+                <Route
+                    path="/projects/:projectUuid"
+                    element={
+                        <ProjectRoute>
+                            <ProjectDetails />
+                        </ProjectRoute>
+                    }
+                />
+                <Route path="/projects" element={<div>project fallback</div>} />
+            </Routes>
+        </MemoryRouter>,
+    );
+
 describe('ProjectRoute', () => {
     beforeEach(() => {
-        state.useActiveProjectUuid.mockReset();
+        vi.clearAllMocks();
+        state.useActiveProjectUuid.mockReturnValue({
+            activeProjectUuid: PROJECT_UUID,
+            isLoading: false,
+        });
+        state.useProject.mockReturnValue({
+            data: {
+                projectUuid: PROJECT_UUID,
+                slug: 'jaffle-shop',
+            },
+            isError: false,
+        });
+        state.useProjects.mockReturnValue({
+            data: [{ projectUuid: PROJECT_UUID, slug: 'jaffle-shop' }],
+            isInitialLoading: false,
+            isError: false,
+        });
     });
 
-    it('redirects a malformed project UUID before resolving the project', () => {
-        render(
-            <MemoryRouter
-                initialEntries={['/projects/3675b69e-8324-4110-bdca']}
-            >
-                <Routes>
-                    <Route
-                        path="/projects/:projectUuid"
-                        element={
-                            <ProjectRoute>
-                                <div>project home</div>
-                            </ProjectRoute>
-                        }
-                    />
-                    <Route
-                        path="/projects"
-                        element={<div>project fallback</div>}
-                    />
-                </Routes>
-            </MemoryRouter>,
-        );
+    it('keeps UUID routes working without resolving the project list', () => {
+        renderProjectRoute(PROJECT_UUID);
+
+        expect(
+            screen.getByText(`${PROJECT_UUID}:jaffle-shop`),
+        ).toBeInTheDocument();
+        expect(state.useProjects).toHaveBeenCalledWith({ enabled: false });
+        expect(state.useProject).toHaveBeenCalledWith(PROJECT_UUID);
+    });
+
+    it('resolves a project slug to the canonical project UUID', () => {
+        renderProjectRoute('jaffle-shop');
+
+        expect(
+            screen.getByText(`${PROJECT_UUID}:jaffle-shop`),
+        ).toBeInTheDocument();
+        expect(state.useProjects).toHaveBeenCalledWith({ enabled: true });
+        expect(state.useProject).toHaveBeenCalledWith(PROJECT_UUID);
+    });
+
+    it('redirects when a project slug cannot be resolved', () => {
+        state.useProjects.mockReturnValue({
+            data: [],
+            isInitialLoading: false,
+            isError: false,
+        });
+
+        renderProjectRoute('missing-project');
 
         expect(screen.getByText('project fallback')).toBeInTheDocument();
-        expect(screen.queryByText('project home')).not.toBeInTheDocument();
-        expect(state.useActiveProjectUuid).not.toHaveBeenCalled();
+        expect(state.useProject).not.toHaveBeenCalled();
     });
 });

--- a/packages/frontend/src/components/ProjectRoute.tsx
+++ b/packages/frontend/src/components/ProjectRoute.tsx
@@ -5,18 +5,26 @@ import { validate as isUuidString } from 'uuid';
 import ErrorState from '../components/common/ErrorState';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
 import { useProject } from '../hooks/useProject';
+import {
+    ProjectRouteContext,
+    type ProjectRouteContextValue,
+} from '../hooks/useProjectRoute';
+import { useProjects } from '../hooks/useProjects';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
+import { getProjectUrlIdentifier } from '../utils/projectUrl';
 import PageSpinner from './PageSpinner';
 
 const ResolvedProjectRoute: FC<
     React.PropsWithChildren<{ projectUuid: string }>
 > = ({ children, projectUuid }) => {
     const { user } = useApp();
-    const { activeProjectUuid, isLoading: isInitialLoading } =
-        useActiveProjectUuid({ refetchOnMount: true });
+    const { isLoading: isInitialLoading } = useActiveProjectUuid({
+        refetchOnMount: true,
+        projectUuid,
+    });
 
-    const { data: project, isError, error } = useProject(activeProjectUuid);
+    const { data: project, isError, error } = useProject(projectUuid);
     if (isInitialLoading) {
         return <PageSpinner />;
     }
@@ -29,6 +37,12 @@ const ResolvedProjectRoute: FC<
         return <Navigate to="/no-access" />;
     }
 
+    const projectRouteContext: ProjectRouteContextValue = {
+        project,
+        projectUuid,
+        projectUrlIdentifier: getProjectUrlIdentifier(project),
+    };
+
     return (
         <Can
             I="view"
@@ -40,7 +54,9 @@ const ResolvedProjectRoute: FC<
         >
             {(isAllowed) => {
                 return isAllowed ? (
-                    children
+                    <ProjectRouteContext.Provider value={projectRouteContext}>
+                        {children}
+                    </ProjectRouteContext.Provider>
                 ) : (
                     <Navigate to="/no-project-access" />
                 );
@@ -50,9 +66,31 @@ const ResolvedProjectRoute: FC<
 };
 
 const ProjectRoute: FC<React.PropsWithChildren> = ({ children }) => {
-    const { projectUuid } = useParams();
+    const { projectUuid: projectIdentifier } = useParams();
+    const isProjectUuid = isUuidString(projectIdentifier ?? '');
+    const projectsQuery = useProjects({
+        enabled: !!projectIdentifier && !isProjectUuid,
+    });
 
-    if (!projectUuid || !isUuidString(projectUuid)) {
+    if (!projectIdentifier) {
+        return <Navigate to="/projects" replace />;
+    }
+
+    if (!isProjectUuid && projectsQuery.isInitialLoading) {
+        return <PageSpinner />;
+    }
+
+    if (!isProjectUuid && projectsQuery.isError) {
+        return <ErrorState error={projectsQuery.error.error} />;
+    }
+
+    const projectUuid = isProjectUuid
+        ? projectIdentifier
+        : projectsQuery.data?.find(
+              (project) => project.slug === projectIdentifier,
+          )?.projectUuid;
+
+    if (!projectUuid) {
         return <Navigate to="/projects" replace />;
     }
 

--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -12,8 +12,8 @@ import {
 } from '@mantine/core';
 import { IconRefresh } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import { useProject } from '../../hooks/useProject';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { useRefreshServer } from '../../hooks/useRefreshServer';
 import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
 import useActiveJob from '../../providers/ActiveJob/useActiveJob';
@@ -34,7 +34,7 @@ const RefreshDbtButton: FC<{
     defaultTextOverride,
     refreshingTextOverride,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { data } = useProject(projectUuid);
     const { activeJob } = useActiveJob();
     const { mutate: refreshDbtServer } = useRefreshServer();

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -46,7 +46,7 @@ import {
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { useToggle } from 'react-use';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import DashboardAsCodeModal from '../../../features/contentAsCode/components/DashboardAsCodeModal';
@@ -66,6 +66,8 @@ import {
     useVerifyDashboardMutation,
 } from '../../../hooks/useContentVerification';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUrlIdentifier } from '../../../hooks/useProjectRoute';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useApp from '../../../providers/App/useApp';
 import { type TilePreAggregateStatus } from '../../../providers/Dashboard/types';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -156,10 +158,8 @@ const DashboardHeader = memo(
         );
         const { search, pathname } = useLocation();
         const navigate = useNavigate();
-        const { projectUuid } = useParams<{
-            projectUuid: string;
-            organizationUuid: string;
-        }>();
+        const projectUuid = useProjectUuid();
+        const projectUrlIdentifier = useProjectUrlIdentifier();
         const dashboardUuid = dashboard.uuid;
         const dashboardIdentifier = dashboard.slug;
 
@@ -887,7 +887,7 @@ const DashboardHeader = memo(
                                                 }
                                                 onClick={() =>
                                                     navigate(
-                                                        `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/history`,
+                                                        `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}/history`,
                                                     )
                                                 }
                                             >

--- a/packages/frontend/src/components/common/PageHeader/DashboardInfoOverlay.tsx
+++ b/packages/frontend/src/components/common/PageHeader/DashboardInfoOverlay.tsx
@@ -19,6 +19,7 @@ import {
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
+import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import MantineIcon from '../MantineIcon';
 import styles from './DashboardInfoOverlay.module.css';
@@ -34,6 +35,9 @@ const DashboardInfoOverlay: FC<DashboardInfoOverlayProps> = ({
     projectUuid,
 }) => {
     const timeAgo = useTimeAgo(dashboard.updatedAt);
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
 
     return (
         <Stack gap="sm" w={320} p="md" className={styles.dashboardInfoOverlay}>
@@ -61,7 +65,7 @@ const DashboardInfoOverlay: FC<DashboardInfoOverlayProps> = ({
                     <InfoRow icon={IconFolder} label="Space">
                         <Anchor
                             component={Link}
-                            to={`/projects/${projectUuid}/spaces/${dashboard.spaceUuid}`}
+                            to={`/projects/${projectUrlIdentifier}/spaces/${dashboard.spaceUuid}`}
                             fz={12}
                             fw={500}
                         >

--- a/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
@@ -27,6 +27,7 @@ import {
 import dayjs from 'dayjs';
 import { type FC } from 'react';
 import { Link } from 'react-router';
+import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import MantineIcon from '../MantineIcon';
 import InfoRow from '../PageHeader/InfoRow';
@@ -89,6 +90,9 @@ export const ResourceInfoPopupContent: FC<ResourceInfoPopupProps> = ({
     withChartData = false,
     latestVersion,
 }) => {
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
     const timeAgo = useTimeAgo(updatedAt ?? new Date());
     const label =
         firstViewedAt && viewStats
@@ -161,7 +165,7 @@ export const ResourceInfoPopupContent: FC<ResourceInfoPopupProps> = ({
                     <InfoRow icon={IconFolder} label="Space">
                         <Anchor
                             component={Link}
-                            to={`/projects/${projectUuid}/spaces/${spaceUuid}`}
+                            to={`/projects/${projectUrlIdentifier}/spaces/${spaceUuid}`}
                             fz={12}
                             fw={500}
                         >

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -43,6 +43,7 @@ import {
     type ContentArgs,
 } from '../../../hooks/useContent';
 import { useInfiniteScroll } from '../../../hooks/useInfiniteScroll';
+import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import { useValidationUserAbility } from '../../../hooks/validation/useValidation';
@@ -179,6 +180,9 @@ const InfiniteResourceTable = ({
     showDataAppVersionStatus = false,
     ...contentTableProps
 }: ResourceView2Props) => {
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? filters.projectUuid;
     const [selectedAdminContentType, setSelectedAdminContentType] = useState<
         'all' | 'shared'
     >(initialAdminContentViewValue);
@@ -230,6 +234,7 @@ const InfiniteResourceTable = ({
                     <InfiniteResourceTableColumnName
                         item={row.original}
                         projectUuid={filters.projectUuid}
+                        projectUrlIdentifier={projectUrlIdentifier}
                         canUserManageValidation={canUserManageValidation}
                         showDataAppVersionStatus={showDataAppVersionStatus}
                     />
@@ -256,7 +261,7 @@ const InfiniteResourceTable = ({
                         <Anchor
                             c="ldGray.7"
                             component={Link}
-                            to={`/projects/${space.projectUuid}/spaces/${space.uuid}`}
+                            to={`/projects/${projectUrlIdentifier}/spaces/${space.uuid}`}
                             onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
                                 e.stopPropagation()
                             }
@@ -607,7 +612,11 @@ const InfiniteResourceTable = ({
                         row.toggleSelected();
                     } else if (!isInitialLoading) {
                         void navigate(
-                            getResourceUrl(filters.projectUuid, row.original),
+                            getResourceUrl(
+                                filters.projectUuid,
+                                row.original,
+                                projectUrlIdentifier,
+                            ),
                         );
                     }
                 },

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -141,6 +141,7 @@ const ResourceVerifiedInlineBadge = ({
 type InfiniteResourceTableColumnNameProps = {
     item: ResourceViewItem;
     projectUuid: string;
+    projectUrlIdentifier: string;
     canUserManageValidation: boolean;
     showDataAppVersionStatus: boolean;
 };
@@ -148,6 +149,7 @@ type InfiniteResourceTableColumnNameProps = {
 const InfiniteResourceTableColumnName = ({
     item,
     projectUuid,
+    projectUrlIdentifier,
     canUserManageValidation,
     showDataAppVersionStatus,
 }: InfiniteResourceTableColumnNameProps) => {
@@ -193,7 +195,7 @@ const InfiniteResourceTableColumnName = ({
             component={Link}
             c="unset"
             underline="never"
-            to={getResourceUrl(projectUuid, item)}
+            to={getResourceUrl(projectUuid, item, projectUrlIdentifier)}
             onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
                 e.stopPropagation()
             }

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -14,7 +14,6 @@ import {
     IconFolderX,
 } from '@tabler/icons-react';
 import { useCallback, useEffect, type FC } from 'react';
-import { useParams } from 'react-router';
 import { MoveAppToSpaceModal } from '../../../features/apps/components/MoveAppToSpaceModal';
 import { useAppPinningMutation } from '../../../features/apps/hooks/useAppPinningMutation';
 import { DeleteSqlChartModal } from '../../../features/sqlRunner/components/DeleteSqlChartModal';
@@ -22,6 +21,7 @@ import { useChartPinningMutation } from '../../../hooks/pinning/useChartPinningM
 import { useDashboardPinningMutation } from '../../../hooks/pinning/useDashboardPinningMutation';
 import { useSpacePinningMutation } from '../../../hooks/pinning/useSpaceMutation';
 import { useContentAction } from '../../../hooks/useContent';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useSpace } from '../../../hooks/useSpaces';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
 import AppDeleteModal from '../modal/AppDeleteModal';
@@ -79,7 +79,7 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
     action,
     onAction,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     const { mutateAsync: contentAction, isLoading: isContentActionLoading } =
         useContentAction(projectUuid);

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -27,7 +27,7 @@ import {
     IconUsers,
 } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import { FavoritePersonalDataAppModal } from '../../../features/apps/components/FavoritePersonalDataAppModal';
 import { PromoteAppModal } from '../../../features/apps/components/PromoteAppModal';
@@ -48,6 +48,7 @@ import {
     useVerifyDashboardMutation,
 } from '../../../hooks/useContentVerification';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import useApp from '../../../providers/App/useApp';
 import useFavoritesContext from '../../../providers/Favorites/useFavoritesContext';
@@ -84,7 +85,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     const { user } = useApp();
     const location = useLocation();
     const navigate = useNavigate();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { data: project } = useProject(projectUuid);
     const [isPromoteAppOpen, setIsPromoteAppOpen] = useState(false);
     const [isFavoriteSpaceModalOpen, setIsFavoriteSpaceModalOpen] =

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
@@ -37,7 +37,9 @@ import {
     type FC,
     type ReactNode,
 } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate } from 'react-router';
+import { useProjectUrlIdentifier } from '../../../../hooks/useProjectRoute';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 import usePinnedItemsContext from '../../../../providers/PinnedItems/usePinnedItemsContext';
 import MantineIcon from '../../MantineIcon';
 import { getResourceName, getResourceUrl } from '../resourceUtils';
@@ -66,6 +68,7 @@ type DraggableItemProps = Pick<ResourceViewGridProps, 'onAction'> & {
     allowDelete?: boolean;
     onAction: (newAction: ResourceViewItemActionState) => void;
     projectUuid: string;
+    projectUrlIdentifier: string;
     hasReorder: boolean;
     shouldSuppressClick: () => boolean;
     markHandleInteraction: () => void;
@@ -139,6 +142,7 @@ const DraggableItem: FC<DraggableItemProps> = ({
     allowDelete,
     onAction,
     projectUuid,
+    projectUrlIdentifier,
     hasReorder,
     shouldSuppressClick,
     markHandleInteraction,
@@ -161,7 +165,7 @@ const DraggableItem: FC<DraggableItemProps> = ({
     });
 
     const showDragIcon = (isHovered && hasReorder) || isDragging;
-    const resourceUrl = getResourceUrl(projectUuid, item);
+    const resourceUrl = getResourceUrl(projectUuid, item, projectUrlIdentifier);
 
     const style = {
         transform: CSS.Transform.toString(transform),
@@ -256,7 +260,8 @@ const ResourceViewGrid: FC<ResourceViewGridProps> = ({
     hasReorder = false,
 }) => {
     const { reorderItems, allowDelete } = usePinnedItemsContext();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
+    const projectUrlIdentifier = useProjectUrlIdentifier();
     const [activeId, setActiveId] = useState<string | null>(null);
     const dragStateRef = useRef({
         isDragging: false,
@@ -433,6 +438,9 @@ const ResourceViewGrid: FC<ResourceViewGridProps> = ({
                                             allowDelete={allowDelete}
                                             onAction={onAction}
                                             projectUuid={projectUuid}
+                                            projectUrlIdentifier={
+                                                projectUrlIdentifier
+                                            }
                                             hasReorder={hasReorder}
                                             shouldSuppressClick={
                                                 shouldSuppressClick

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -12,7 +12,9 @@ import {
     IconChevronUp,
 } from '@tabler/icons-react';
 import React, { useMemo, useState, type FC } from 'react';
-import { Link, useNavigate, useParams } from 'react-router';
+import { Link, useNavigate } from 'react-router';
+import { useProjectUrlIdentifier } from '../../../../hooks/useProjectRoute';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 import { useSpaceSummaries } from '../../../../hooks/useSpaces';
 import { useValidationUserAbility } from '../../../../hooks/validation/useValidation';
 import { ResourceIcon, ResourceIndicator } from '../../ResourceIcon';
@@ -80,7 +82,8 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
     onAction,
 }) => {
     const navigate = useNavigate();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
+    const projectUrlIdentifier = useProjectUrlIdentifier();
     const { data: spaces = [] } = useSpaceSummaries(projectUuid);
     const canUserManageValidation = useValidationUserAbility(projectUuid);
 
@@ -126,7 +129,11 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                         <Anchor
                             component={Link}
                             className={classes.anchor}
-                            to={getResourceUrl(projectUuid, item)}
+                            to={getResourceUrl(
+                                projectUuid,
+                                item,
+                                projectUrlIdentifier,
+                            )}
                             onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
                                 e.stopPropagation()
                             }
@@ -278,7 +285,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                         <Anchor
                             c="ldGray.7"
                             component={Link}
-                            to={`/projects/${projectUuid}/spaces/${space.uuid}`}
+                            to={`/projects/${projectUrlIdentifier}/spaces/${space.uuid}`}
                             onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
                                 e.stopPropagation()
                             }
@@ -367,6 +374,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
             enableSorting,
             columnVisibility,
             projectUuid,
+            projectUrlIdentifier,
             canUserManageValidation,
             spaces,
             onAction,
@@ -465,7 +473,13 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                         key={item.data.uuid}
                         onClick={() =>
                             projectUuid &&
-                            navigate(getResourceUrl(projectUuid, item))
+                            navigate(
+                                getResourceUrl(
+                                    projectUuid,
+                                    item,
+                                    projectUrlIdentifier,
+                                ),
+                            )
                         }
                         onMouseEnter={() => setHoveredItem(item.data.uuid)}
                         onMouseLeave={() => setHoveredItem(undefined)}

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -61,6 +61,7 @@ export const getResourceTypeName = (item: ResourceViewItem) => {
 
 const getChartResourceUrl = (
     projectUuid: string,
+    projectUrlIdentifier: string,
     item: ResourceViewChartItem,
 ) => {
     switch (item.data.source) {
@@ -68,7 +69,7 @@ const getChartResourceUrl = (
             return `/projects/${projectUuid}/sql-runner/${item.data.slug}`;
         case ChartSourceType.DBT_EXPLORE:
         case undefined:
-            return `/projects/${projectUuid}/saved/${item.data.slug}`;
+            return `/projects/${projectUrlIdentifier}/saved/${item.data.slug}`;
         default:
             return assertUnreachable(
                 item.data.source,
@@ -77,15 +78,19 @@ const getChartResourceUrl = (
     }
 };
 
-export const getResourceUrl = (projectUuid: string, item: ResourceViewItem) => {
+export const getResourceUrl = (
+    projectUuid: string,
+    item: ResourceViewItem,
+    projectUrlIdentifier = projectUuid,
+) => {
     const itemType = item.type;
     switch (item.type) {
         case ResourceViewItemType.DASHBOARD:
-            return `/projects/${projectUuid}/dashboards/${item.data.slug}/view`;
+            return `/projects/${projectUrlIdentifier}/dashboards/${item.data.slug}/view`;
         case ResourceViewItemType.CHART:
-            return getChartResourceUrl(projectUuid, item);
+            return getChartResourceUrl(projectUuid, projectUrlIdentifier, item);
         case ResourceViewItemType.SPACE:
-            return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
+            return `/projects/${projectUrlIdentifier}/spaces/${item.data.uuid}`;
         case ResourceViewItemType.DATA_APP:
             return `/projects/${projectUuid}/apps/${item.data.uuid}/view`;
         default:

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalContent.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalContent.tsx
@@ -30,6 +30,7 @@ import {
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import useToaster from '../../../hooks/toaster/useToaster';
+import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
 import useSearchParams from '../../../hooks/useSearchParams';
 import { useSpaceAccess } from '../../../hooks/useSpaceAccess';
 import {
@@ -181,6 +182,9 @@ const ShareSpaceModalContent: FC<ShareSpaceProps> = ({
     onClose: externalOnClose,
 }) => {
     const navigate = useNavigate();
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
     const shareSpaceModalSearchParam = useSearchParams('shareSpaceModal');
     const { user: sessionUser } = useApp();
     const { showToastError } = useToaster();
@@ -254,9 +258,16 @@ const ShareSpaceModalContent: FC<ShareSpaceProps> = ({
     useEffect(() => {
         if (shareSpaceModalSearchParam === 'true') {
             setInternalIsOpen(true);
-            void navigate(`/projects/${projectUuid}/spaces/${space.uuid}`);
+            void navigate(
+                `/projects/${projectUrlIdentifier}/spaces/${space.uuid}`,
+            );
         }
-    }, [navigate, projectUuid, shareSpaceModalSearchParam, space.uuid]);
+    }, [
+        navigate,
+        projectUrlIdentifier,
+        shareSpaceModalSearchParam,
+        space.uuid,
+    ]);
 
     const { mutate: unshareSpaceMutation } = useDeleteSpaceShareMutation(
         projectUuid,

--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -10,6 +10,7 @@ import { useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { z } from 'zod';
 import useToaster from '../../../hooks/toaster/useToaster';
+import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
 import {
     useCreateMutation,
     useSpace,
@@ -179,6 +180,9 @@ const SpaceActionModal: FC<
     parentSpaceUuid,
     ...props
 }) => {
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
     const { data, isInitialLoading } = useSpace(projectUuid, spaceUuid, {
         enabled: !!spaceUuid,
     });
@@ -190,7 +194,7 @@ const SpaceActionModal: FC<
             onSuccess: (space) => {
                 if (shouldRedirect) {
                     void navigate(
-                        `/projects/${projectUuid}/spaces/${space.uuid}`,
+                        `/projects/${projectUrlIdentifier}/spaces/${space.uuid}`,
                     );
                 }
             },

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../../hooks/dashboard/useDashboard';
 import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage';
 import useToaster from '../../../../hooks/toaster/useToaster';
+import { useOptionalProjectRoute } from '../../../../hooks/useProjectRoute';
 import { useCreateMutation } from '../../../../hooks/useSavedQuery';
 import classes from './ChartCreateModal.module.css';
 import { DEFAULT_CHART_METADATA, type ChartMetadata } from './types';
@@ -51,6 +52,9 @@ export const SaveToDashboard: FC<Props> = ({
     defaults = DEFAULT_CHART_METADATA,
     colorPaletteUuid,
 }) => {
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
     const [dashboardInfoFromStorage, setDashboardInfoFromStorage] = useState({
         name: dashboardName,
         dashboardUuid,
@@ -141,8 +145,8 @@ export const SaveToDashboard: FC<Props> = ({
             );
             void navigate(
                 activeTabUuid
-                    ? `/projects/${projectUuid}/dashboards/${selectedDashboard?.slug ?? dashboardUuid}/edit/tabs/${activeTabUuid}`
-                    : `/projects/${projectUuid}/dashboards/${selectedDashboard?.slug ?? dashboardUuid}/edit`,
+                    ? `/projects/${projectUrlIdentifier}/dashboards/${selectedDashboard?.slug ?? dashboardUuid}/edit/tabs/${activeTabUuid}`
+                    : `/projects/${projectUrlIdentifier}/dashboards/${selectedDashboard?.slug ?? dashboardUuid}/edit`,
             );
             showToastSuccess({
                 title: `Success! ${values.name} was added to ${dashboardName}`,
@@ -158,6 +162,7 @@ export const SaveToDashboard: FC<Props> = ({
             setUnsavedDashboardTiles,
             navigate,
             projectUuid,
+            projectUrlIdentifier,
             showToastSuccess,
             dashboardName,
             selectedDashboard?.tiles,

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -39,6 +39,7 @@ import {
 import { useDashboards } from '../../../../hooks/dashboard/useDashboards';
 import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage';
 import useToaster from '../../../../hooks/toaster/useToaster';
+import { useOptionalProjectRoute } from '../../../../hooks/useProjectRoute';
 import { useCreateMutation } from '../../../../hooks/useSavedQuery';
 import { useSpaceManagement } from '../../../../hooks/useSpaceManagement';
 import {
@@ -116,6 +117,9 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
     redirectOnSuccess = true,
     showViewChartAction = true,
 }) => {
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
     const { user } = useApp();
     const navigate = useNavigate();
     const { showToastSuccess } = useToaster();
@@ -412,8 +416,8 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
                 );
                 void navigate(
                     activeTabUuid
-                        ? `/projects/${projectUuid}/dashboards/${originatingDashboardData?.slug ?? originatingDashboard.dashboardUuid}/edit/tabs/${activeTabUuid}`
-                        : `/projects/${projectUuid}/dashboards/${originatingDashboardData?.slug ?? originatingDashboard.dashboardUuid}/edit`,
+                        ? `/projects/${projectUrlIdentifier}/dashboards/${originatingDashboardData?.slug ?? originatingDashboard.dashboardUuid}/edit/tabs/${activeTabUuid}`
+                        : `/projects/${projectUrlIdentifier}/dashboards/${originatingDashboardData?.slug ?? originatingDashboard.dashboardUuid}/edit`,
                 );
                 showToastSuccess({
                     title: `Success! ${values.name} was added to ${originatingDashboard.dashboardName}`,
@@ -561,6 +565,7 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
             originatingDashboard,
             originatingDashboardData,
             projectUuid,
+            projectUrlIdentifier,
             navigate,
             showToastSuccess,
             getUnsavedDashboardTiles,

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
@@ -4,8 +4,8 @@ import {
 } from '@lightdash/common';
 import { IconChartBar } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 import MantineModal, { type MantineModalProps } from '../../MantineModal';
 import { SaveToDashboard } from './SaveToDashboard';
 import { SaveToSpaceOrDashboard } from './SaveToSpaceOrDashboard';
@@ -81,7 +81,7 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
         return SaveMode.DEFAULT;
     }, [editingDashboardInfo, forceSpaceOrDashboardChoice]);
 
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     const getModalTitle = useCallback(() => {
         if (isSaveAs) {

--- a/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
@@ -2,6 +2,7 @@ import { Anchor, List, ScrollArea, type ModalProps } from '@mantine/core';
 import { type FC } from 'react';
 import { Link } from 'react-router';
 import { useDashboardsContainingChart } from '../../../hooks/dashboard/useDashboards';
+import { useProjectUrlIdentifier } from '../../../hooks/useProjectRoute';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import {
     useSavedQuery,
@@ -22,6 +23,7 @@ const ChartDeleteModal: FC<ChartDeleteModalProps> = ({
     ...modalProps
 }) => {
     const projectUuid = useProjectUuid();
+    const projectUrlIdentifier = useProjectUrlIdentifier();
     const { health } = useApp();
     const softDeleteEnabled = health.data?.softDelete.enabled;
     const retentionDays = health.data?.softDelete.retentionDays;
@@ -85,7 +87,7 @@ const ChartDeleteModal: FC<ChartDeleteModalProps> = ({
                                         component={Link}
                                         fz="sm"
                                         target="_blank"
-                                        to={`/projects/${projectUuid}/dashboards/${dashboard.slug}`}
+                                        to={`/projects/${projectUrlIdentifier}/dashboards/${dashboard.slug}`}
                                     >
                                         {dashboard.name}
                                     </Anchor>

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
@@ -19,6 +19,7 @@ import useSearch, {
 } from '../../../../features/omnibar/hooks/useSearch';
 import { type SearchItem } from '../../../../features/omnibar/types/searchItem';
 import { getSearchItemLabel } from '../../../../features/omnibar/utils/getSearchItemLabel';
+import { useOptionalProjectRoute } from '../../../../hooks/useProjectRoute';
 import { useValidationUserAbility } from '../../../../hooks/validation/useValidation';
 import styles from './SearchDropdown.module.css';
 
@@ -44,6 +45,7 @@ export const SearchDropdown: FC<Props> = ({
     onHeaderClick,
 }) => {
     const navigate = useNavigate();
+    const projectRoute = useOptionalProjectRoute();
     const canUserManageValidation = useValidationUserAbility(projectUuid);
     const combobox = useCombobox({
         onDropdownClose: () => combobox.resetSelectedOption(),
@@ -52,6 +54,7 @@ export const SearchDropdown: FC<Props> = ({
     const [debouncedQuery] = useDebouncedValue(value, 200);
     const { data: searchResults, isFetching } = useSearch({
         projectUuid,
+        projectUrlIdentifier: projectRoute?.projectUrlIdentifier,
         query: debouncedQuery,
         keepPreviousData: true,
         source: 'ai_search_box',

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -16,6 +16,7 @@ import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
 import { getResourceUrl } from '../../../../components/common/ResourceView/resourceUtils';
+import { useProjectUrlIdentifier } from '../../../../hooks/useProjectRoute';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import classes from './blockStyles.module.css';
 
@@ -141,9 +142,14 @@ export const ContentCard: FC<Props> = ({
     star,
     variant = 'row',
 }) => {
+    const projectUrlIdentifier = useProjectUrlIdentifier();
     const to = onRemove
         ? null
-        : getResourceUrl(projectUuid, contentToResourceViewItem(content));
+        : getResourceUrl(
+              projectUuid,
+              contentToResourceViewItem(content),
+              projectUrlIdentifier,
+          );
     const cardClass = `${classes.hoverCard}${to ? ` ${classes.clickable}` : ''}`;
 
     // A single dense line — visibly lighter than the two-line card variant.

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.tsx
@@ -22,6 +22,7 @@ import { type CSSProperties, type FC } from 'react';
 import { Link } from 'react-router';
 import { useProjectColorPalette } from '../../../../hooks/appearance/useProjectColorPalette';
 import { useOrganizationBrand } from '../../../../hooks/organization/useOrganizationBrand';
+import { useProjectUrlIdentifier } from '../../../../hooks/useProjectRoute';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
 import { useHomepageAiState } from '../hooks/useHomepageAiState';
@@ -31,18 +32,22 @@ import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 type CtaConfig = HomepageCtaBlock['config'];
 
-const targetUrl = (target: HomepageCtaTarget, projectUuid: string): string => {
+const targetUrl = (
+    target: HomepageCtaTarget,
+    projectUuid: string,
+    projectUrlIdentifier: string,
+): string => {
     switch (target.type) {
         case 'ask-ai':
             return `/projects/${projectUuid}/ai-agents`;
         case 'run-query':
             return `/projects/${projectUuid}/tables`;
         case 'browse-dashboards':
-            return `/projects/${projectUuid}/dashboards`;
+            return `/projects/${projectUrlIdentifier}/dashboards`;
         case 'browse-spaces':
-            return `/projects/${projectUuid}/spaces`;
+            return `/projects/${projectUrlIdentifier}/spaces`;
         case 'dashboard':
-            return `/projects/${projectUuid}/dashboards/${target.dashboardUuid}/view`;
+            return `/projects/${projectUrlIdentifier}/dashboards/${target.dashboardUuid}/view`;
         case 'link':
             return target.url;
         default:
@@ -121,6 +126,7 @@ const CtaBanner: FC<{
     interactive: boolean;
     onNavigate?: () => void;
 }> = ({ config, projectUuid, interactive, onNavigate }) => {
+    const projectUrlIdentifier = useProjectUrlIdentifier();
     const { data: brand } = useOrganizationBrand();
     const theme = config.theme ?? 'brand';
     const background = config.background ?? 'none';
@@ -168,7 +174,7 @@ const CtaBanner: FC<{
     if (!interactive) {
         return <div {...shared}>{body}</div>;
     }
-    const url = targetUrl(config.target, projectUuid);
+    const url = targetUrl(config.target, projectUuid, projectUrlIdentifier);
     return config.target.type === 'link' ? (
         <a
             href={url}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -16,6 +16,7 @@ import { getResourceUrl } from '../../../../components/common/ResourceView/resou
 import TruncatedText from '../../../../components/common/TruncatedText';
 import { useFavoriteMutation } from '../../../../hooks/favorites/useFavoriteMutation';
 import { useFavorites } from '../../../../hooks/favorites/useFavorites';
+import { useProjectUrlIdentifier } from '../../../../hooks/useProjectRoute';
 import layout from '../homepageLayout.module.css';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
@@ -40,6 +41,7 @@ const FavoritePills: FC<{
     emptyText: string | null;
     justify?: 'flex-start' | 'center';
 }> = ({ projectUuid, isInteractive, emptyText, justify = 'flex-start' }) => {
+    const projectUrlIdentifier = useProjectUrlIdentifier();
     const { data: favorites } = useFavorites(projectUuid);
     const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
     const [expanded, setExpanded] = useState(false);
@@ -69,7 +71,7 @@ const FavoritePills: FC<{
             {visible.map((item) => (
                 <Link
                     key={item.data.uuid}
-                    to={getResourceUrl(projectUuid, item)}
+                    to={getResourceUrl(projectUuid, item, projectUrlIdentifier)}
                     className={classes.favPill}
                 >
                     <MantineIcon

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/KeySpaces.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/KeySpaces.tsx
@@ -2,6 +2,7 @@ import { Box, Text } from '@mantine/core';
 import { IconFolder, IconFolders } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
+import { useOptionalProjectRoute } from '../../../../hooks/useProjectRoute';
 import { type KeySpace } from '../hooks/rankKeySpaces';
 import { BlockHeader, IconSquare } from './BlockShell';
 import classes from './blockStyles.module.css';
@@ -9,25 +10,27 @@ import { PageGrid, PageGridItem } from './PageGrid';
 
 const itemLabel = (count: number) => `${count} item${count === 1 ? '' : 's'}`;
 
-const KeySpaceCard: FC<{ space: KeySpace; projectUuid: string }> = ({
-    space,
-    projectUuid,
-}) => (
-    <Link
-        to={`/projects/${projectUuid}/spaces/${space.uuid}`}
-        className={`${classes.hoverCard} ${classes.clickable} ${classes.plainLink} ${classes.contentTile}`}
-    >
-        <IconSquare icon={IconFolder} />
-        <Box className={classes.tileBody}>
-            <Text size="sm" fw={600} truncate>
-                {space.name}
-            </Text>
-            <Text size="xs" c="dimmed">
-                {itemLabel(space.itemCount)}
-            </Text>
-        </Box>
-    </Link>
-);
+const KeySpaceCard: FC<{
+    space: KeySpace;
+    projectUrlIdentifier: string;
+}> = ({ space, projectUrlIdentifier }) => {
+    return (
+        <Link
+            to={`/projects/${projectUrlIdentifier}/spaces/${space.uuid}`}
+            className={`${classes.hoverCard} ${classes.clickable} ${classes.plainLink} ${classes.contentTile}`}
+        >
+            <IconSquare icon={IconFolder} />
+            <Box className={classes.tileBody}>
+                <Text size="sm" fw={600} truncate>
+                    {space.name}
+                </Text>
+                <Text size="xs" c="dimmed">
+                    {itemLabel(space.itemCount)}
+                </Text>
+            </Box>
+        </Link>
+    );
+};
 
 /** The spaces a viewer should start from. Renders nothing when the project has
  * none with content — an empty header is worse than no section. */
@@ -36,6 +39,10 @@ export const KeySpaces: FC<{
     projectUuid: string;
     title?: string;
 }> = ({ spaces, projectUuid, title = 'Spaces' }) => {
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
+
     if (spaces.length === 0) return null;
     return (
         <Box>
@@ -43,7 +50,10 @@ export const KeySpaces: FC<{
             <PageGrid itemSpan={3}>
                 {spaces.map((space) => (
                     <PageGridItem key={space.uuid}>
-                        <KeySpaceCard space={space} projectUuid={projectUuid} />
+                        <KeySpaceCard
+                            space={space}
+                            projectUrlIdentifier={projectUrlIdentifier}
+                        />
                     </PageGridItem>
                 ))}
             </PageGrid>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -31,6 +31,7 @@ import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { useInfiniteContent } from '../../../../hooks/useContent';
+import { useProjectUrlIdentifier } from '../../../../hooks/useProjectRoute';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
 import { useHomepageAiState } from '../hooks/useHomepageAiState';
@@ -82,17 +83,22 @@ const actionKey = (action: HomepageQuickAction): string =>
 const actionPresentation = (
     action: HomepageQuickAction,
     projectUuid: string,
+    projectUrlIdentifier = projectUuid,
 ): Omit<StaticActionDefinition, 'url'> & { url: string } => {
     if (action.type === 'dashboard') {
         return {
             icon: IconLayoutDashboard,
             title: action.label,
             description: 'Open this dashboard.',
-            url: `/projects/${projectUuid}/dashboards/${action.dashboardUuid}/view`,
+            url: `/projects/${projectUrlIdentifier}/dashboards/${action.dashboardUuid}/view`,
         };
     }
     const { url, ...definition } = STATIC_ACTIONS[action.type];
-    return { ...definition, url: url(projectUuid) };
+    const identifier =
+        action.type === 'browse-dashboards' || action.type === 'browse-spaces'
+            ? projectUrlIdentifier
+            : projectUuid;
+    return { ...definition, url: url(identifier) };
 };
 
 export const QuickActionCards: FC<{
@@ -101,6 +107,7 @@ export const QuickActionCards: FC<{
     // Centred under the composer; left-aligned when it follows a page heading
     justify?: 'center' | 'flex-start';
 }> = ({ actions, projectUuid, justify = 'center' }) => {
+    const projectUrlIdentifier = useProjectUrlIdentifier();
     const { track } = useTracking();
     const { canAskAi } = useHomepageAiState(projectUuid);
     const visibleActions = actions.filter(
@@ -110,7 +117,11 @@ export const QuickActionCards: FC<{
     return (
         <Group gap={8} justify={justify}>
             {visibleActions.map((action) => {
-                const presentation = actionPresentation(action, projectUuid);
+                const presentation = actionPresentation(
+                    action,
+                    projectUuid,
+                    projectUrlIdentifier,
+                );
                 const trackClick = () =>
                     track({
                         name: EventName.HOMEPAGE_QUICK_ACTION_CLICKED,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
@@ -13,6 +13,7 @@ import { type FC } from 'react';
 import { Link } from 'react-router';
 import { getResourceUrl } from '../../../../components/common/ResourceView/resourceUtils';
 import TruncatedText from '../../../../components/common/TruncatedText';
+import { useProjectUrlIdentifier } from '../../../../hooks/useProjectRoute';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import { useRecentContents } from '../hooks/useRecentContents';
 import { BlockHeader } from './BlockShell';
@@ -24,11 +25,16 @@ const RecentRow: FC<{
     projectUuid: string;
     viewedAt: Date | undefined;
 }> = ({ content, projectUuid, viewedAt }) => {
+    const projectUrlIdentifier = useProjectUrlIdentifier();
     const timeAgo = useTimeAgo(viewedAt ?? new Date(0));
     const isDashboard = content.contentType === ContentType.DASHBOARD;
     return (
         <Link
-            to={getResourceUrl(projectUuid, contentToResourceViewItem(content))}
+            to={getResourceUrl(
+                projectUuid,
+                contentToResourceViewItem(content),
+                projectUrlIdentifier,
+            )}
             className={`${classes.listRow} ${classes.clickable} ${classes.plainLink}`}
         >
             <div className={classes.iconSquare}>

--- a/packages/frontend/src/features/dashboardFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/index.tsx
@@ -5,9 +5,9 @@ import {
     type FilterOperator,
 } from '@lightdash/common';
 import { useCallback, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import FiltersProvider from '../../components/common/Filters/FiltersProvider';
 import { useProject } from '../../hooks/useProject';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
@@ -21,7 +21,7 @@ interface Props {
 
 const DashboardFilters: FC<Props> = ({ isEditMode, activeTabUuid }) => {
     const { track } = useTracking();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [openPopoverId, setPopoverId] = useState<string>();
 
     const project = useProject(projectUuid);

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -36,6 +36,7 @@ import { useIsLauncherMounted } from '../../ee/features/aiCopilot/components/Lau
 import { useActiveTabParameters } from '../../hooks/dashboard/useActiveTabParameters';
 import useToaster from '../../hooks/toaster/useToaster';
 import { useProject } from '../../hooks/useProject';
+import { useProjectUrlIdentifier } from '../../hooks/useProjectRoute';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
@@ -317,6 +318,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     const dashboardUuid = dashboard?.uuid;
     const dashboardIdentifier = dashboard?.slug;
     const projectUuid = useDashboardContext((c) => c.projectUuid);
+    const projectUrlIdentifier = useProjectUrlIdentifier();
     const setHaveTabsChanged = useDashboardContext((c) => c.setHaveTabsChanged);
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
@@ -670,8 +672,8 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             void navigate(
                 {
                     pathname: isEditMode
-                        ? `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/edit/tabs/${tab?.uuid}`
-                        : `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/view/tabs/${tab?.uuid}`,
+                        ? `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}/edit/tabs/${tab?.uuid}`
+                        : `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}/view/tabs/${tab?.uuid}`,
                     search: newParams.toString(),
                 },
                 { replace: true },
@@ -776,7 +778,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
             // If this is the last tab, navigate to the non-tab URL.
             // See `const = sortedTabs` for more context.
             void navigate(
-                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/edit`,
+                `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}/edit`,
                 { replace: true },
             );
 

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -20,6 +20,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import RefreshDbtButton from '../../../components/RefreshDbtButton';
 import useEmbed from '../../../ee/providers/Embed/useEmbed';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useAccount } from '../../../hooks/user/useAccount';
 import useSearchParams from '../../../hooks/useSearchParams';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
@@ -212,7 +213,7 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
     const timeAgo = useTimeAgo(
         lastDbtRefreshAt ?? fallbackLastDbtRefreshAtRef.current,
     );
-    const params = useParams<{ projectUuid: string }>();
+    const routeProjectUuid = useProjectUuid();
     const { data: project } = useProject(projectUuid);
     const { data: account } = useAccount();
     const { embedToken } = useEmbed();
@@ -244,12 +245,12 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
 
     useEffect(() => {
         if (
-            params.projectUuid &&
-            (!projectUuid || projectUuid !== params.projectUuid)
+            routeProjectUuid &&
+            (!projectUuid || projectUuid !== routeProjectUuid)
         ) {
-            dispatch(setProjectUuid(params.projectUuid));
+            dispatch(setProjectUuid(routeProjectUuid));
         }
-    }, [params.projectUuid, dispatch, projectUuid]);
+    }, [routeProjectUuid, dispatch, projectUuid]);
 
     useEffect(() => {
         if (

--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -42,6 +42,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { AiAgentIcon } from '../../../ee/features/aiCopilot/components/AiAgentIcon';
 import { useAiAgentButtonVisibility } from '../../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useProject } from '../../../hooks/useProject';
+import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import { useValidationUserAbility } from '../../../hooks/validation/useValidation';
 import useApp from '../../../providers/App/useApp';
@@ -73,6 +74,9 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
     const navigate = useNavigate();
     const location = useLocation();
     const { data: projectData } = useProject(projectUuid);
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
     const { track } = useTracking();
     const canUserManageValidation = useValidationUserAbility(projectUuid);
     const [searchFilters, setSearchFilters] = useState<SearchFilters>();
@@ -88,6 +92,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
 
     const { data: searchResults, isFetching } = useSearch({
         projectUuid,
+        projectUrlIdentifier: projectRoute?.projectUrlIdentifier,
         query: debouncedValue,
         filters: searchFilters,
         source: 'omnibar',
@@ -541,7 +546,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
                                         }
                                         onClick={() =>
                                             handleQuickAction(
-                                                `/projects/${projectUuid}/tables`,
+                                                `/projects/${projectUrlIdentifier}/tables`,
                                             )
                                         }
                                     >

--- a/packages/frontend/src/features/omnibar/hooks/useSearch.ts
+++ b/packages/frontend/src/features/omnibar/hooks/useSearch.ts
@@ -31,6 +31,7 @@ export const hasMinQueryLength = (query: string | undefined): boolean => {
 
 type Params = UseQueryOptions<SearchResults, ApiError, SearchResultMap> & {
     projectUuid: string;
+    projectUrlIdentifier?: string;
     query?: string;
     filters?: SearchFilters;
     source: 'omnibar' | 'ai_search_box';
@@ -38,6 +39,7 @@ type Params = UseQueryOptions<SearchResults, ApiError, SearchResultMap> & {
 
 const useSearch = ({
     projectUuid,
+    projectUrlIdentifier = projectUuid,
     query = '',
     filters,
     source,
@@ -49,7 +51,8 @@ const useSearch = ({
             getSearchResults({ projectUuid, query, filters, source }),
         retry: false,
         enabled: hasMinQueryLength(query),
-        select: (data) => getSearchItemMap(data, projectUuid),
+        select: (data) =>
+            getSearchItemMap(data, projectUuid, projectUrlIdentifier),
         ...params,
     });
 

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemMap.test.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemMap.test.ts
@@ -15,7 +15,7 @@ const emptyResults = {
 } as SearchResults;
 
 describe('getSearchItemMap', () => {
-    it('uses dashboard slugs for dashboard and dashboard tab results', () => {
+    it('uses the project URL identifier for core content results', () => {
         const result = getSearchItemMap(
             {
                 ...emptyResults,
@@ -36,22 +36,42 @@ describe('getSearchItemMap', () => {
                         spaceUuid: 'space-uuid',
                     },
                 ],
+                spaces: [
+                    {
+                        uuid: 'space-uuid',
+                        name: 'Space',
+                    },
+                ],
+                savedCharts: [
+                    {
+                        uuid: 'chart-uuid',
+                        slug: 'chart-slug',
+                        name: 'Chart',
+                    },
+                ],
             } as SearchResults,
             'project-uuid',
+            'project-slug',
         );
 
         expect(result.dashboards[0]).toMatchObject({
             type: SearchItemType.DASHBOARD,
             location: {
-                pathname: '/projects/project-uuid/dashboards/dashboard-slug',
+                pathname: '/projects/project-slug/dashboards/dashboard-slug',
             },
         });
         expect(result.dashboardTabs[0]).toMatchObject({
             type: SearchItemType.DASHBOARD_TAB,
             location: {
                 pathname:
-                    '/projects/project-uuid/dashboards/dashboard-slug/view/tabs/tab-uuid',
+                    '/projects/project-slug/dashboards/dashboard-slug/view/tabs/tab-uuid',
             },
         });
+        expect(result.spaces[0].location.pathname).toBe(
+            '/projects/project-slug/spaces/space-uuid',
+        );
+        expect(result.savedCharts[0].location.pathname).toBe(
+            '/projects/project-slug/saved/chart-slug',
+        );
     });
 });

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
@@ -13,6 +13,7 @@ import { type SearchItem } from '../types/searchItem';
 export const getSearchItemMap = (
     results: SearchResults,
     projectUuid: string,
+    projectUrlIdentifier = projectUuid,
 ) => {
     const spaces = results.spaces.map<SearchItem>((item) => ({
         type: SearchItemType.SPACE,
@@ -20,7 +21,7 @@ export const getSearchItemMap = (
         item: item,
         searchRank: item.search_rank,
         location: {
-            pathname: `/projects/${projectUuid}/spaces/${item.uuid}`,
+            pathname: `/projects/${projectUrlIdentifier}/spaces/${item.uuid}`,
         },
     }));
 
@@ -31,7 +32,7 @@ export const getSearchItemMap = (
         item: item,
         searchRank: item.search_rank,
         location: {
-            pathname: `/projects/${projectUuid}/dashboards/${item.slug}`,
+            pathname: `/projects/${projectUrlIdentifier}/dashboards/${item.slug}`,
         },
     }));
 
@@ -41,7 +42,7 @@ export const getSearchItemMap = (
         description: `Dashboard: ${item.dashboardName}`,
         item: item,
         location: {
-            pathname: `/projects/${projectUuid}/dashboards/${item.dashboardSlug}/view/tabs/${item.uuid}`,
+            pathname: `/projects/${projectUrlIdentifier}/dashboards/${item.dashboardSlug}/view/tabs/${item.uuid}`,
         },
     }));
 
@@ -52,7 +53,7 @@ export const getSearchItemMap = (
         item: item,
         searchRank: item.search_rank,
         location: {
-            pathname: `/projects/${projectUuid}/saved/${item.slug}`,
+            pathname: `/projects/${projectUrlIdentifier}/saved/${item.slug}`,
         },
     }));
 

--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -108,12 +108,15 @@ export const useDeleteActiveProjectMutation = () => {
 };
 
 export const useActiveProjectUuid = (useQueryFetchOptions?: {
-    refetchOnMount: boolean;
+    refetchOnMount?: boolean;
+    projectUuid?: string;
 }) => {
     const params = useParams<{ projectUuid?: string }>();
-    const paramProjectUuid = isUuidString(params.projectUuid ?? '')
-        ? params.projectUuid
-        : undefined;
+    const paramProjectUuid =
+        useQueryFetchOptions?.projectUuid ??
+        (isUuidString(params.projectUuid ?? '')
+            ? params.projectUuid
+            : undefined);
     const { data: lastProjectUuid, isFetched: isLastProjectUuidFetched } =
         useActiveProject();
     const { mutate } = useUpdateActiveProjectMutation();

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -25,6 +25,7 @@ import { buildQueryArgs } from './explorer/buildQueryArgs';
 import { useExploreByProjectUuid } from './useExplore';
 import { useDateZoomGranularitySearch } from './useExplorerRoute';
 import { usePreAggregateCacheEnabled } from './usePreAggregateCacheEnabled';
+import { useProjectUuid } from './useProjectUuid';
 
 type ExplorerQueryManagerArgs = {
     projectUuid?: string;
@@ -69,16 +70,16 @@ export const useExplorerQueryManager = ({
     );
 
     const embed = useEmbed();
+    const routeProjectUuid = useProjectUuid();
     const params = useParams<{
         savedQueryUuid: string;
-        projectUuid: string;
     }>();
     const savedQueryUuid =
         explicitSavedQueryUuid ||
         embed?.savedQueryUuid ||
         params.savedQueryUuid;
     const projectUuid =
-        explicitProjectUuid || embed?.projectUuid || params.projectUuid!;
+        explicitProjectUuid || embed?.projectUuid || routeProjectUuid!;
     const viewModeQueryArgs = useMemo(() => {
         return savedQueryUuid ? { chartUuid: savedQueryUuid } : undefined;
     }, [savedQueryUuid]);

--- a/packages/frontend/src/hooks/useProjectRoute.ts
+++ b/packages/frontend/src/hooks/useProjectRoute.ts
@@ -1,0 +1,26 @@
+import { type Project } from '@lightdash/common';
+import { createContext, useContext } from 'react';
+
+export type ProjectRouteContextValue = {
+    project: Project;
+    projectUuid: string;
+    projectUrlIdentifier: string;
+};
+
+export const ProjectRouteContext =
+    createContext<ProjectRouteContextValue | null>(null);
+
+const useProjectRoute = () => {
+    const context = useContext(ProjectRouteContext);
+
+    if (!context) {
+        throw new Error('useProjectRoute must be used within a ProjectRoute');
+    }
+
+    return context;
+};
+
+export const useOptionalProjectRoute = () => useContext(ProjectRouteContext);
+
+export const useProjectUrlIdentifier = () =>
+    useProjectRoute().projectUrlIdentifier;

--- a/packages/frontend/src/hooks/useProjectUuid.ts
+++ b/packages/frontend/src/hooks/useProjectUuid.ts
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router';
 import useEmbed from '../ee/providers/Embed/useEmbed';
+import { useOptionalProjectRoute } from './useProjectRoute';
 
 /**
  * We have a couple ways to derive the projectUuid:
@@ -9,10 +10,13 @@ import useEmbed from '../ee/providers/Embed/useEmbed';
  * We prioritize the URL over the embed context to facilitate the most use-cases.
  */
 export function useProjectUuid() {
+    const projectRoute = useOptionalProjectRoute();
     const { projectUuid: projectUuidFromParams } = useParams<{
         projectUuid: string;
     }>();
     const { projectUuid: embedProjectUuid } = useEmbed();
 
-    return projectUuidFromParams || embedProjectUuid;
+    return (
+        projectRoute?.projectUuid || projectUuidFromParams || embedProjectUuid
+    );
 }

--- a/packages/frontend/src/hooks/useRefreshServer.ts
+++ b/packages/frontend/src/hooks/useRefreshServer.ts
@@ -8,10 +8,10 @@ import {
     type JobStep,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../api';
 import useActiveJob from '../providers/ActiveJob/useActiveJob';
 import useToaster from './toaster/useToaster';
+import { useProjectUuid } from './useProjectUuid';
 
 export const jobStepStatusLabel = (status: JobStepStatusType) => {
     switch (status) {
@@ -124,7 +124,7 @@ export const useJob = (
 };
 
 export const useRefreshServer = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const queryClient = useQueryClient();
     const { setActiveJobId } = useActiveJob();
     const { showToastApiError } = useToaster();

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -22,6 +22,7 @@ import useApp from '../providers/App/useApp';
 import { convertDateFilters } from '../utils/dateFilter';
 import useToaster from './toaster/useToaster';
 import { invalidateContent } from './useContent';
+import { useProjectUuid } from './useProjectUuid';
 import useSearchParams from './useSearchParams';
 
 const isCustomSqlDimensionForbiddenError = (
@@ -368,7 +369,7 @@ export const useCreateMutation = ({
     showViewChartAction?: boolean;
 } = {}) => {
     const navigate = useNavigate();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const queryClient = useQueryClient();
     const { embedToken } = useEmbed();
     const isEmbedded = embedToken !== undefined;
@@ -436,7 +437,7 @@ export const useDuplicateChartMutation = (
     options?: DuplicateChartMutationOptions,
 ) => {
     const navigate = useNavigate();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<

--- a/packages/frontend/src/pages/ChartHistory.tsx
+++ b/packages/frontend/src/pages/ChartHistory.tsx
@@ -32,6 +32,8 @@ import {
 } from '../features/explorer/store';
 import { MergeProvider } from '../features/mergeQuery/context/MergeContext';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
+import { useProjectUrlIdentifier } from '../hooks/useProjectRoute';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import {
     useChartHistory,
     useChartVersion,
@@ -112,9 +114,10 @@ const ChartHistoryExplorer = memo<ChartHistoryExplorerProps>(
 
 const ChartHistory = () => {
     const navigate = useNavigate();
-    const { savedQueryUuid: chartIdentifier, projectUuid } = useParams<{
+    const projectUuid = useProjectUuid();
+    const projectUrlIdentifier = useProjectUrlIdentifier();
+    const { savedQueryUuid: chartIdentifier } = useParams<{
         savedQueryUuid: string;
-        projectUuid: string;
     }>();
     const [selectedVersionUuid, selectVersionUuid] = useState<string>();
     const [isRollbackModalOpen, setIsRollbackModalOpen] = useState(false);
@@ -135,7 +138,9 @@ const ChartHistory = () => {
 
     const rollbackMutation = useChartVersionRollbackMutation(chartUuid, {
         onSuccess: () => {
-            void navigate(`/projects/${projectUuid}/saved/${chartSlug}/view`);
+            void navigate(
+                `/projects/${projectUrlIdentifier}/saved/${chartSlug}/view`,
+            );
         },
     });
 
@@ -171,7 +176,7 @@ const ChartHistory = () => {
                             items={[
                                 {
                                     title: 'Chart',
-                                    to: `/projects/${projectUuid}/saved/${chartSlug}/view`,
+                                    to: `/projects/${projectUrlIdentifier}/saved/${chartSlug}/view`,
                                 },
                                 { title: 'Version history', active: true },
                             ]}

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -44,6 +44,8 @@ import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
+import { useProjectUrlIdentifier } from '../hooks/useProjectRoute';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import useApp from '../providers/App/useApp';
 import DashboardAiAgentContextBridge from '../providers/Dashboard/DashboardAiAgentContextBridge';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
@@ -54,12 +56,9 @@ import '../styles/react-grid.css';
 
 const Dashboard: FC = () => {
     const navigate = useNavigate();
-    const {
-        projectUuid,
-        dashboardUuid: routeDashboardIdentifier,
-        mode,
-    } = useParams<{
-        projectUuid: string;
+    const projectUuid = useProjectUuid();
+    const projectUrlIdentifier = useProjectUrlIdentifier();
+    const { dashboardUuid: routeDashboardIdentifier, mode } = useParams<{
         dashboardUuid: string;
         mode?: string;
     }>();
@@ -388,12 +387,12 @@ const Dashboard: FC = () => {
             reset();
             if (dashboardTabs.length > 1) {
                 void navigate(
-                    `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/view/tabs/${activeTab?.uuid}`,
+                    `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}/view/tabs/${activeTab?.uuid}`,
                     { replace: true },
                 );
             } else {
                 void navigate(
-                    `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/view`,
+                    `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}/view`,
                     { replace: true },
                 );
             }
@@ -402,7 +401,7 @@ const Dashboard: FC = () => {
         dashboardIdentifier,
         navigate,
         isSuccess,
-        projectUuid,
+        projectUrlIdentifier,
         reset,
         setDashboardTemporaryFilters,
         setHaveFiltersChanged,
@@ -640,12 +639,12 @@ const Dashboard: FC = () => {
 
         if (dashboardTabs.length > 0) {
             void navigate(
-                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/view/tabs/${activeTab?.uuid}`,
+                `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}/view/tabs/${activeTab?.uuid}`,
                 { replace: true },
             );
         } else {
             void navigate(
-                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/view`,
+                `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}/view`,
                 { replace: true },
             );
         }
@@ -653,7 +652,7 @@ const Dashboard: FC = () => {
         dashboard,
         dashboardIdentifier,
         navigate,
-        projectUuid,
+        projectUrlIdentifier,
         setDashboardTiles,
         setHaveFiltersChanged,
         setDashboardFilters,
@@ -712,11 +711,11 @@ const Dashboard: FC = () => {
             isEditMode &&
             (haveTilesChanged || haveFiltersChanged || haveTabsChanged) &&
             !nextLocation.pathname.includes(
-                `/projects/${projectUuid}/dashboards/${dashboardIdentifier}`,
+                `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}`,
             ) &&
             (!dashboardUuid ||
                 !nextLocation.pathname.includes(
-                    `/projects/${projectUuid}/dashboards/${dashboardUuid}`,
+                    `/projects/${projectUrlIdentifier}/dashboards/${dashboardUuid}`,
                 )) &&
             // Allow user to add a new table
             !sessionStorage.getItem(`unsavedDashboardTiles:${dashboardUuid}`)
@@ -737,15 +736,15 @@ const Dashboard: FC = () => {
                 {
                     pathname:
                         dashboardTabs.length > 0
-                            ? `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/edit/tabs/${activeTab?.uuid}`
-                            : `/projects/${projectUuid}/dashboards/${dashboardIdentifier}/edit`,
+                            ? `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}/edit/tabs/${activeTab?.uuid}`
+                            : `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}/edit`,
                     search: '',
                 },
                 { replace: true },
             );
         });
     }, [
-        projectUuid,
+        projectUrlIdentifier,
         dashboardIdentifier,
         resetDashboardFilters,
         refreshDashboardVersion,
@@ -1055,7 +1054,7 @@ const Dashboard: FC = () => {
                         onClose={deleteModalHandlers.close}
                         onConfirm={() => {
                             void navigate(
-                                `/projects/${projectUuid}/dashboards`,
+                                `/projects/${projectUrlIdentifier}/dashboards`,
                                 {
                                     replace: true,
                                 },
@@ -1085,8 +1084,8 @@ const Dashboard: FC = () => {
 };
 
 const DashboardPage: FC = () => {
-    const { projectUuid, dashboardUuid } = useParams<{
-        projectUuid: string;
+    const projectUuid = useProjectUuid();
+    const { dashboardUuid } = useParams<{
         dashboardUuid: string;
     }>();
     const { user } = useApp();

--- a/packages/frontend/src/pages/DashboardHistory.tsx
+++ b/packages/frontend/src/pages/DashboardHistory.tsx
@@ -31,15 +31,18 @@ import {
     useDashboardQuery,
     useDashboardVersionRollbackMutation,
 } from '../hooks/dashboard/useDashboard';
+import { useProjectUrlIdentifier } from '../hooks/useProjectRoute';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { Can } from '../providers/Ability';
 import NoTableIcon from '../svgs/emptystate-no-table.svg?react';
 import DashboardVersionComparison from './DashboardVersionComparison';
 
 const DashboardHistory = () => {
     const navigate = useNavigate();
-    const { dashboardUuid: routeDashboardIdentifier, projectUuid } = useParams<{
+    const projectUuid = useProjectUuid();
+    const projectUrlIdentifier = useProjectUrlIdentifier();
+    const { dashboardUuid: routeDashboardIdentifier } = useParams<{
         dashboardUuid: string;
-        projectUuid: string;
     }>();
     const [isRollbackModalOpen, setIsRollbackModalOpen] = useState(false);
     const [selectedVersionUuid, setSelectedVersionUuid] = useState<string>();
@@ -89,7 +92,7 @@ const DashboardHistory = () => {
                             items={[
                                 {
                                     title: 'Dashboard',
-                                    to: `/projects/${projectUuid}/dashboards/${dashboardIdentifier}`,
+                                    to: `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}`,
                                 },
                                 { title: 'Version history', active: true },
                             ]}
@@ -224,7 +227,7 @@ const DashboardHistory = () => {
                                     onSuccess: () => {
                                         setIsRollbackModalOpen(false);
                                         void navigate(
-                                            `/projects/${projectUuid}/dashboards/${dashboardIdentifier}`,
+                                            `/projects/${projectUrlIdentifier}/dashboards/${dashboardIdentifier}`,
                                         );
                                     },
                                 });

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -24,6 +24,7 @@ import {
     useExplorerRoute,
     useExplorerUrlState,
 } from '../hooks/useExplorerRoute';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import useApp from '../providers/App/useApp';
 import { defaultState } from '../providers/Explorer/defaultState';
 
@@ -105,10 +106,10 @@ const ExplorerWithUrlParams = memo(() => {
 });
 
 const ExplorerPage = memo(() => {
-    const { projectUuid, tableId } = useParams<{
-        projectUuid: string;
+    const { tableId } = useParams<{
         tableId?: string;
     }>();
+    const projectUuid = useProjectUuid();
 
     const { user } = useApp();
 

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -2,7 +2,6 @@ import { subject } from '@casl/ability';
 import { DbtProjectType, ProjectType } from '@lightdash/common';
 import { Stack } from '@mantine/core';
 import { useState, type FC, type ReactNode } from 'react';
-import { useParams } from 'react-router';
 import { useUnmount } from 'react-use';
 import ErrorState from '../components/common/ErrorState';
 import Page from '../components/common/Page/Page';
@@ -34,14 +33,15 @@ import {
     useMostPopularAndRecentlyUpdated,
     useProject,
 } from '../hooks/useProject';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import useApp from '../providers/App/useApp';
 import { FavoritesProvider } from '../providers/Favorites/FavoritesProvider';
 import { PinnedItemsProvider } from '../providers/PinnedItems/PinnedItemsProvider';
+import { getProjectUrlIdentifier } from '../utils/projectUrl';
 
 const Home: FC = () => {
-    const params = useParams<{ projectUuid: string }>();
     const [isTryNewHomepageOpen, setIsTryNewHomepageOpen] = useState(false);
-    const selectedProjectUuid = params.projectUuid;
+    const selectedProjectUuid = useProjectUuid();
     const project = useProject(selectedProjectUuid);
     const onboarding = useOnboardingStatus();
     const pinnedItems = usePinnedItems(
@@ -114,6 +114,7 @@ const Home: FC = () => {
     const isGitHubProject =
         project.data.type !== ProjectType.PREVIEW &&
         project.data.dbtConnection.type === DbtProjectType.GITHUB;
+    const projectUrlIdentifier = getProjectUrlIdentifier(project.data);
 
     let body: ReactNode;
     if (
@@ -176,7 +177,7 @@ const Home: FC = () => {
                 <Stack gap="xl">
                     {!onboarding.data.ranQuery ? (
                         <OnboardingPanel
-                            projectUuid={project.data.projectUuid}
+                            projectUrlIdentifier={projectUrlIdentifier}
                             userName={user.data?.firstName}
                         />
                     ) : (
@@ -186,6 +187,7 @@ const Home: FC = () => {
                             <LandingPanel
                                 userName={user.data?.firstName}
                                 projectUuid={project.data.projectUuid}
+                                projectUrlIdentifier={projectUrlIdentifier}
                             />
                             {/* Below the greeting on purpose: an admin-only promo
                             shouldn't outrank the page's own hero */}
@@ -232,6 +234,7 @@ const Home: FC = () => {
                             <HomepageContentPanel
                                 data={mostPopularAndRecentlyUpdated}
                                 projectUuid={project.data.projectUuid}
+                                projectUrlIdentifier={projectUrlIdentifier}
                             />
                         </FavoritesProvider>
                     )}

--- a/packages/frontend/src/pages/Projects.tsx
+++ b/packages/frontend/src/pages/Projects.tsx
@@ -2,21 +2,32 @@ import { type FC } from 'react';
 import { Navigate } from 'react-router';
 import PageSpinner from '../components/PageSpinner';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
+import { useProject } from '../hooks/useProject';
+import { getProjectUrlIdentifier } from '../utils/projectUrl';
 
 const Projects: FC = () => {
     const { isLoading: isActiveProjectLoading, activeProjectUuid } =
         useActiveProjectUuid();
+    const activeProjectQuery = useProject(activeProjectUuid);
 
     // If loading is done and there's no active project, user has no projects
     if (!isActiveProjectLoading && !activeProjectUuid) {
         return <Navigate to="/no-access" />;
     }
 
-    if (isActiveProjectLoading || !activeProjectUuid) {
+    if (
+        isActiveProjectLoading ||
+        activeProjectQuery.isInitialLoading ||
+        !activeProjectUuid
+    ) {
         return <PageSpinner />;
     }
 
-    return <Navigate to={`/projects/${activeProjectUuid}/home`} />;
+    const projectUrlIdentifier = activeProjectQuery.data
+        ? getProjectUrlIdentifier(activeProjectQuery.data)
+        : activeProjectUuid;
+
+    return <Navigate to={`/projects/${projectUrlIdentifier}/home`} />;
 };
 
 export default Projects;

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -2,20 +2,23 @@ import { ContentType, LightdashMode } from '@lightdash/common';
 import { Group, Stack, Button } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate } from 'react-router';
 import EmptyStateLoader from '../components/common/EmptyStateLoader';
 import DashboardCreateModal from '../components/common/modal/DashboardCreateModal';
 import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import InfiniteResourceTable from '../components/common/ResourceView/InfiniteResourceTable';
 import { useDashboards } from '../hooks/dashboard/useDashboards';
+import { useProjectUrlIdentifier } from '../hooks/useProjectRoute';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import useCreateInAnySpaceAccess from '../hooks/user/useCreateInAnySpaceAccess';
 import useApp from '../providers/App/useApp';
 import { FavoritesProvider } from '../providers/Favorites/FavoritesProvider';
 
 const SavedDashboards = () => {
     const navigate = useNavigate();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
+    const projectUrlIdentifier = useProjectUrlIdentifier();
     const { isInitialLoading, data: dashboards = [] } =
         useDashboards(projectUuid);
     const [isCreateDashboardOpen, setIsCreateDashboardOpen] =
@@ -85,7 +88,7 @@ const SavedDashboards = () => {
                     onClose={() => setIsCreateDashboardOpen(false)}
                     onConfirm={(dashboard) => {
                         void navigate(
-                            `/projects/${projectUuid}/dashboards/${dashboard.slug}/edit`,
+                            `/projects/${projectUrlIdentifier}/dashboards/${dashboard.slug}/edit`,
                         );
 
                         setIsCreateDashboardOpen(false);

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -16,6 +16,7 @@ import {
 import { MergeProvider } from '../features/mergeQuery/context/MergeContext';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useSavedQuery } from '../hooks/useSavedQuery';
 import useApp from '../providers/App/useApp';
 import { ExplorerSection } from '../providers/Explorer/types';
@@ -56,9 +57,9 @@ const SavedExplorerContent = memo(() => {
 const SavedExplorer = () => {
     const { health } = useApp();
 
-    const { savedQueryUuid, projectUuid, mode } = useParams<{
+    const projectUuid = useProjectUuid();
+    const { savedQueryUuid, mode } = useParams<{
         savedQueryUuid: string;
-        projectUuid: string;
         mode?: string;
     }>();
 

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -2,16 +2,17 @@ import { ContentType, LightdashMode } from '@lightdash/common';
 import { Group, Stack, Button } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate } from 'react-router';
 import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import InfiniteResourceTable from '../components/common/ResourceView/InfiniteResourceTable';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import useCreateInAnySpaceAccess from '../hooks/user/useCreateInAnySpaceAccess';
 import useApp from '../providers/App/useApp';
 import { FavoritesProvider } from '../providers/Favorites/FavoritesProvider';
 
 const SavedQueries: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { health } = useApp();
     const navigate = useNavigate();
     const isDemo = health.data?.mode === LightdashMode.DEMO;

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -37,6 +37,8 @@ import { AddToSpaceResources } from '../components/Explorer/SpaceBrowser/types';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import { useSpacePinningMutation } from '../hooks/pinning/useSpaceMutation';
 import { useContentAction } from '../hooks/useContent';
+import { useProjectUrlIdentifier } from '../hooks/useProjectRoute';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useSpace } from '../hooks/useSpaces';
 import { Can } from '../providers/Ability';
@@ -46,11 +48,11 @@ import useTracking from '../providers/Tracking/useTracking';
 import { EventName } from '../types/Events';
 
 const Space: FC = () => {
-    const { projectUuid, spaceUuid } = useParams<{
-        projectUuid: string;
+    const projectUuid = useProjectUuid()!;
+    const projectUrlIdentifier = useProjectUrlIdentifier();
+    const { spaceUuid } = useParams<{
         spaceUuid: string;
     }>() as {
-        projectUuid: string;
         spaceUuid: string;
     };
     const {
@@ -175,7 +177,7 @@ const Space: FC = () => {
                             items={[
                                 {
                                     title: 'Spaces',
-                                    to: `/projects/${projectUuid}/spaces`,
+                                    to: `/projects/${projectUrlIdentifier}/spaces`,
                                 },
                                 ...(space.breadcrumbs?.map(
                                     (breadcrumb, index) => {
@@ -208,7 +210,7 @@ const Space: FC = () => {
                                             active: isLastBreadcrumb,
                                             ...(isAccessible
                                                 ? {
-                                                      to: `/projects/${projectUuid}/spaces/${breadcrumb.uuid}`,
+                                                      to: `/projects/${projectUrlIdentifier}/spaces/${breadcrumb.uuid}`,
                                                       onClick: () => {
                                                           if (
                                                               user.data
@@ -399,11 +401,11 @@ const Space: FC = () => {
                                             ) {
                                                 if (space?.parentSpaceUuid) {
                                                     void navigate(
-                                                        `/projects/${projectUuid}/spaces/${space.parentSpaceUuid}`,
+                                                        `/projects/${projectUrlIdentifier}/spaces/${space.parentSpaceUuid}`,
                                                     );
                                                 } else {
                                                     void navigate(
-                                                        `/projects/${projectUuid}/home`,
+                                                        `/projects/${projectUrlIdentifier}/home`,
                                                     );
                                                 }
                                             }
@@ -468,7 +470,7 @@ const Space: FC = () => {
                         onClose={() => setIsCreateDashboardOpen(false)}
                         onConfirm={(dashboard) => {
                             void navigate(
-                                `/projects/${projectUuid}/dashboards/${dashboard.slug}/edit`,
+                                `/projects/${projectUrlIdentifier}/dashboards/${dashboard.slug}/edit`,
                             );
 
                             setIsCreateDashboardOpen(false);

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -3,7 +3,6 @@ import { ContentType, LightdashMode } from '@lightdash/common';
 import { Group, Stack, Button } from '@mantine/core';
 import { IconFolderPlus, IconPlus } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import InfiniteResourceTable from '../components/common/ResourceView/InfiniteResourceTable';
@@ -11,13 +10,12 @@ import { ColumnVisibility } from '../components/common/ResourceView/types';
 import SpaceActionModal from '../components/common/SpaceActionModal';
 import { ActionType } from '../components/common/SpaceActionModal/types';
 import ForbiddenPanel from '../components/ForbiddenPanel';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import useApp from '../providers/App/useApp';
 import { FavoritesProvider } from '../providers/Favorites/FavoritesProvider';
 
 const Spaces: FC = () => {
-    const { projectUuid } = useParams() as {
-        projectUuid: string;
-    };
+    const projectUuid = useProjectUuid()!;
 
     const { user, health } = useApp();
 

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -40,6 +40,7 @@ import { HeaderVirtualView } from '../features/virtualView';
 import { type VirtualViewState } from '../features/virtualView/components/HeaderVirtualView';
 import useToaster from '../hooks/toaster/useToaster';
 import { useProject } from '../hooks/useProject';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import useSearchParams from '../hooks/useSearchParams';
 
 const SqlRunner = ({
@@ -56,7 +57,8 @@ const SqlRunner = ({
         (state) => state.sqlRunner.warehouseConnectionType,
     );
 
-    const params = useParams<{ projectUuid: string; slug?: string }>();
+    const routeProjectUuid = useProjectUuid();
+    const params = useParams<{ slug?: string }>();
     const share = useSearchParams('share');
     const shareState = useSqlRunnerShareUrl(share || undefined);
 
@@ -122,10 +124,10 @@ const SqlRunner = ({
     });
 
     useEffect(() => {
-        if (!projectUuid && params.projectUuid) {
-            dispatch(setProjectUuid(params.projectUuid));
+        if (!projectUuid && routeProjectUuid) {
+            dispatch(setProjectUuid(routeProjectUuid));
         }
-    }, [dispatch, params.projectUuid, projectUuid]);
+    }, [dispatch, routeProjectUuid, projectUuid]);
 
     // Use the SQL string from the location state if available
     useEffect(() => {

--- a/packages/frontend/src/utils/projectUrl.ts
+++ b/packages/frontend/src/utils/projectUrl.ts
@@ -1,0 +1,9 @@
+import { type OrganizationProject, type Project } from '@lightdash/common';
+
+type ProjectWithUrlIdentifier = Pick<
+    Project | OrganizationProject,
+    'projectUuid' | 'slug'
+>;
+
+export const getProjectUrlIdentifier = (project: ProjectWithUrlIdentifier) =>
+    project.slug ?? project.projectUuid;


### PR DESCRIPTION
## Summary

- resolve project slug route segments to canonical project UUIDs in the frontend
- emit project slugs for core home, space, chart, and dashboard navigation
- preserve UUIDs for API calls, state keys, unsupported routes, and rolling-version fallback
- keep existing UUID project URLs fully supported

## Validation

- `pnpm -F frontend lint`
- `pnpm -F frontend typecheck`
- focused ProjectRoute and omnibar tests (4 passing)
- live: project slug home, spaces, chart, chart alias, and dashboard routes
- live: legacy project UUID route still loads and core navigation emits the project slug

## Scope

Frontend only. No backend resolver, endpoint, model, or service changes. Unsupported routes continue using canonical project UUIDs.

Closes: SPK-1206