### PR TITLE
refactor(viz-config): share one tabs helper across config panels

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
@@ -1,34 +1,19 @@
-import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
-import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
+import { VisualizationConfigTabs } from '../common/VisualizationConfigTabs';
 import { Comparison } from './BigNumberComparison';
 import { BigNumberConditionalFormatting } from './BigNumberConditionalFormatting';
 import { Layout } from './BigNumberLayout';
 
-export const ConfigTabs: FC = memo(() => {
-    return (
-        <Tabs defaultValue="layout" keepMounted={false}>
-            <ConfigTabsList mb="sm">
-                <Tabs.Tab px="sm" value="layout">
-                    Layout
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="comparison">
-                    Comparison
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="conditionalFormatting">
-                    Conditional formatting
-                </Tabs.Tab>
-            </ConfigTabsList>
-
-            <Tabs.Panel value="layout">
-                <Layout />
-            </Tabs.Panel>
-            <Tabs.Panel value="comparison">
-                <Comparison />
-            </Tabs.Panel>
-            <Tabs.Panel value="conditionalFormatting">
-                <BigNumberConditionalFormatting />
-            </Tabs.Panel>
-        </Tabs>
-    );
-});
+export const ConfigTabs: FC = memo(() => (
+    <VisualizationConfigTabs
+        tabs={[
+            { value: 'layout', label: 'Layout', panel: <Layout /> },
+            { value: 'comparison', label: 'Comparison', panel: <Comparison /> },
+            {
+                value: 'conditionalFormatting',
+                label: 'Conditional formatting',
+                panel: <BigNumberConditionalFormatting />,
+            },
+        ]}
+    />
+));

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ConfigTabs/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/ConfigTabs/index.tsx
@@ -1,7 +1,6 @@
-import { Tabs } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
-import ConfigTabsList from '../../../common/ChartGallery/ConfigTabsList';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
+import { VisualizationConfigTabs } from '../../common/VisualizationConfigTabs';
 import { Axes } from '../Axes';
 import { Grid } from '../Grid';
 import { Layout } from '../Layout';
@@ -14,39 +13,30 @@ export const ConfigTabs: FC = memo(() => {
     const items = useMemo(() => Object.values(itemsMap || {}), [itemsMap]);
 
     return (
-        <Tabs defaultValue="layout" keepMounted={false}>
-            <ConfigTabsList mb="sm">
-                <Tabs.Tab px="sm" value="layout">
-                    Layout
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="series">
-                    Series
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="axes">
-                    Axes
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="legend">
-                    Display
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="grid">
-                    Margins
-                </Tabs.Tab>
-            </ConfigTabsList>
-            <Tabs.Panel value="layout">
-                <Layout items={items} />
-            </Tabs.Panel>
-            <Tabs.Panel value="series">
-                <Series items={items} />
-            </Tabs.Panel>
-            <Tabs.Panel value="axes">
-                <Axes itemsMap={itemsMap} />
-            </Tabs.Panel>
-            <Tabs.Panel value="legend">
-                <Legend items={items} />
-            </Tabs.Panel>
-            <Tabs.Panel value="grid">
-                <Grid />
-            </Tabs.Panel>
-        </Tabs>
+        <VisualizationConfigTabs
+            tabs={[
+                {
+                    value: 'layout',
+                    label: 'Layout',
+                    panel: <Layout items={items} />,
+                },
+                {
+                    value: 'series',
+                    label: 'Series',
+                    panel: <Series items={items} />,
+                },
+                {
+                    value: 'axes',
+                    label: 'Axes',
+                    panel: <Axes itemsMap={itemsMap} />,
+                },
+                {
+                    value: 'legend',
+                    label: 'Display',
+                    panel: <Legend items={items} />,
+                },
+                { value: 'grid', label: 'Margins', panel: <Grid /> },
+            ]}
+        />
     );
 });

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
@@ -15,18 +15,17 @@ import {
     Collapse,
     Group,
     Stack,
-    Tabs,
     SegmentedControl,
     Switch,
     Tooltip,
 } from '@mantine/core';
 import { memo, type FC } from 'react';
-import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
 import FieldSelect from '../../common/FieldSelect';
 import { isFunnelVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { ColorPaletteSection } from '../common/ColorPaletteSection';
 import { Config } from '../common/Config';
+import { VisualizationConfigTabs } from '../common/VisualizationConfigTabs';
 import compactStyles from '../mantineTheme.module.css';
 import { StepConfig } from './StepConfig';
 
@@ -61,245 +60,266 @@ export const ConfigTabs: FC = memo(() => {
     } = visualizationConfig.chartConfig;
 
     return (
-        <Tabs defaultValue="general" keepMounted={false}>
-            <ConfigTabsList mb="sm">
-                <Tabs.Tab px="sm" value="general">
-                    General
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="steps">
-                    Steps
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="display">
-                    Display
-                </Tabs.Tab>
-            </ConfigTabsList>
+        <VisualizationConfigTabs
+            tabs={[
+                {
+                    value: 'general',
+                    label: 'General',
+                    panel: (
+                        <Stack>
+                            <Config>
+                                <Config.Section>
+                                    <Config.Heading>
+                                        Data orientation
+                                    </Config.Heading>
+                                    <Group gap="xs">
+                                        <Config.Label>Steps are</Config.Label>
+                                        <SegmentedControl
+                                            size="xs"
+                                            value={dataInput}
+                                            data={[
+                                                {
+                                                    value: FunnelChartDataInput.COLUMN,
+                                                    label: 'Rows',
+                                                },
+                                                {
+                                                    value: FunnelChartDataInput.ROW,
+                                                    label: 'Columns',
+                                                },
+                                            ]}
+                                            onChange={(value) =>
+                                                setDataInput(
+                                                    value ===
+                                                        FunnelChartDataInput.ROW
+                                                        ? FunnelChartDataInput.ROW
+                                                        : FunnelChartDataInput.COLUMN,
+                                                )
+                                            }
+                                        />
+                                    </Group>
+                                </Config.Section>
+                            </Config>
+                            <Config>
+                                {dataInput === FunnelChartDataInput.COLUMN && (
+                                    <Config.Section>
+                                        <Config.Heading>
+                                            Data field
+                                        </Config.Heading>
 
-            <Tabs.Panel value="general">
-                <Stack>
-                    <Config>
-                        <Config.Section>
-                            <Config.Heading>Data orientation</Config.Heading>
-                            <Group gap="xs">
-                                <Config.Label>Steps are</Config.Label>
-                                <SegmentedControl
-                                    size="xs"
-                                    value={dataInput}
-                                    data={[
-                                        {
-                                            value: FunnelChartDataInput.COLUMN,
-                                            label: 'Rows',
-                                        },
-                                        {
-                                            value: FunnelChartDataInput.ROW,
-                                            label: 'Columns',
-                                        },
-                                    ]}
-                                    onChange={(value) =>
-                                        setDataInput(
-                                            value === FunnelChartDataInput.ROW
-                                                ? FunnelChartDataInput.ROW
-                                                : FunnelChartDataInput.COLUMN,
-                                        )
-                                    }
-                                />
-                            </Group>
-                        </Config.Section>
-                    </Config>
-                    <Config>
-                        {dataInput === FunnelChartDataInput.COLUMN && (
-                            <Config.Section>
-                                <Config.Heading>Data field</Config.Heading>
-
-                                <Tooltip
-                                    disabled={
-                                        numericFields &&
-                                        numericFields.length > 0
-                                    }
-                                    label="You must select at least one numeric metric to create a pie chart"
-                                >
-                                    <Box>
-                                        <FieldSelect<Metric | TableCalculation>
-                                            placeholder="Select metric"
+                                        <Tooltip
                                             disabled={
-                                                numericFields.length === 0
+                                                numericFields &&
+                                                numericFields.length > 0
                                             }
-                                            item={selectedField}
-                                            items={numericFields}
-                                            onChange={(newField) => {
-                                                if (
-                                                    newField &&
-                                                    isField(newField)
-                                                )
-                                                    onFieldChange(
-                                                        getItemId(newField),
-                                                    );
-                                                else if (
-                                                    newField &&
-                                                    isTableCalculation(newField)
-                                                )
-                                                    onFieldChange(
-                                                        newField.name,
-                                                    );
-                                                else onFieldChange(null);
+                                            label="You must select at least one numeric metric to create a pie chart"
+                                        >
+                                            <Box>
+                                                <FieldSelect<
+                                                    Metric | TableCalculation
+                                                >
+                                                    placeholder="Select metric"
+                                                    disabled={
+                                                        numericFields.length ===
+                                                        0
+                                                    }
+                                                    item={selectedField}
+                                                    items={numericFields}
+                                                    onChange={(newField) => {
+                                                        if (
+                                                            newField &&
+                                                            isField(newField)
+                                                        )
+                                                            onFieldChange(
+                                                                getItemId(
+                                                                    newField,
+                                                                ),
+                                                            );
+                                                        else if (
+                                                            newField &&
+                                                            isTableCalculation(
+                                                                newField,
+                                                            )
+                                                        )
+                                                            onFieldChange(
+                                                                newField.name,
+                                                            );
+                                                        else
+                                                            onFieldChange(null);
+                                                    }}
+                                                    hasGrouping
+                                                />
+                                            </Box>
+                                        </Tooltip>
+                                    </Config.Section>
+                                )}
+                            </Config>
+                        </Stack>
+                    ),
+                },
+                {
+                    value: 'steps',
+                    label: 'Steps',
+                    panel: (
+                        <Stack>
+                            <ColorPaletteSection />
+                            <Config>
+                                <Config.Section>
+                                    <Config.Heading>Labels</Config.Heading>
+
+                                    <Group gap="xs" wrap="nowrap">
+                                        <Config.Label>Position</Config.Label>
+                                        <SegmentedControl
+                                            size="xs"
+                                            value={labels?.position}
+                                            data={[
+                                                {
+                                                    value: FunnelChartLabelPosition.LEFT,
+                                                    label: 'Left',
+                                                },
+
+                                                {
+                                                    value: FunnelChartLabelPosition.INSIDE,
+                                                    label: 'Inside',
+                                                },
+                                                {
+                                                    value: FunnelChartLabelPosition.RIGHT,
+                                                    label: 'Right',
+                                                },
+                                                {
+                                                    value: FunnelChartLabelPosition.HIDDEN,
+                                                    label: 'Hidden',
+                                                },
+                                            ]}
+                                            onChange={(newPosition) =>
+                                                onLabelsChange({
+                                                    position:
+                                                        newPosition as FunnelChartLabelPosition,
+                                                })
+                                            }
+                                        />
+                                    </Group>
+
+                                    <Group gap="xs">
+                                        <Checkbox
+                                            size="xs"
+                                            classNames={{
+                                                label: compactStyles.compactCheckboxLabel,
                                             }}
-                                            hasGrouping
+                                            checked={labels?.showValue}
+                                            onChange={(newValue) =>
+                                                onLabelsChange({
+                                                    showValue:
+                                                        newValue.currentTarget
+                                                            .checked,
+                                                })
+                                            }
+                                            label="Show value"
                                         />
-                                    </Box>
-                                </Tooltip>
-                            </Config.Section>
-                        )}
-                    </Config>
-                </Stack>
-            </Tabs.Panel>
-            <Tabs.Panel value="steps">
-                <Stack>
-                    <ColorPaletteSection />
-                    <Config>
-                        <Config.Section>
-                            <Config.Heading>Labels</Config.Heading>
 
-                            <Group gap="xs" wrap="nowrap">
-                                <Config.Label>Position</Config.Label>
-                                <SegmentedControl
-                                    size="xs"
-                                    value={labels?.position}
-                                    data={[
-                                        {
-                                            value: FunnelChartLabelPosition.LEFT,
-                                            label: 'Left',
-                                        },
-
-                                        {
-                                            value: FunnelChartLabelPosition.INSIDE,
-                                            label: 'Inside',
-                                        },
-                                        {
-                                            value: FunnelChartLabelPosition.RIGHT,
-                                            label: 'Right',
-                                        },
-                                        {
-                                            value: FunnelChartLabelPosition.HIDDEN,
-                                            label: 'Hidden',
-                                        },
-                                    ]}
-                                    onChange={(newPosition) =>
-                                        onLabelsChange({
-                                            position:
-                                                newPosition as FunnelChartLabelPosition,
-                                        })
-                                    }
-                                />
-                            </Group>
-
-                            <Group gap="xs">
-                                <Checkbox
-                                    size="xs"
-                                    classNames={{
-                                        label: compactStyles.compactCheckboxLabel,
-                                    }}
-                                    checked={labels?.showValue}
-                                    onChange={(newValue) =>
-                                        onLabelsChange({
-                                            showValue:
-                                                newValue.currentTarget.checked,
-                                        })
-                                    }
-                                    label="Show value"
-                                />
-
-                                <Checkbox
-                                    size="xs"
-                                    classNames={{
-                                        label: compactStyles.compactCheckboxLabel,
-                                    }}
-                                    checked={labels?.showPercentage}
-                                    onChange={(newValue) =>
-                                        onLabelsChange({
-                                            showPercentage:
-                                                newValue.currentTarget.checked,
-                                        })
-                                    }
-                                    label="Show percentage"
-                                />
-                            </Group>
-                        </Config.Section>
-                    </Config>
-                    <Config>
-                        <Config.Section>
-                            <Config.Heading>Steps</Config.Heading>
-                            {data
-                                .sort((a, b) => b.value - a.value)
-                                .map((step) => {
-                                    return (
-                                        <StepConfig
-                                            key={step.id}
-                                            id={step.id}
-                                            defaultColor={
-                                                colorDefaults[step.id]
+                                        <Checkbox
+                                            size="xs"
+                                            classNames={{
+                                                label: compactStyles.compactCheckboxLabel,
+                                            }}
+                                            checked={labels?.showPercentage}
+                                            onChange={(newValue) =>
+                                                onLabelsChange({
+                                                    showPercentage:
+                                                        newValue.currentTarget
+                                                            .checked,
+                                                })
                                             }
-                                            defaultLabel={step.name}
-                                            swatches={[]}
-                                            color={colorOverrides[step.id]}
-                                            label={labelOverrides[step.id]}
-                                            granularityFields={
-                                                granularityFields
-                                            }
-                                            onColorChange={
-                                                onColorOverridesChange
-                                            }
-                                            onLabelChange={
-                                                onLabelOverridesChange
-                                            }
+                                            label="Show percentage"
                                         />
-                                    );
-                                })}
-                        </Config.Section>
-                    </Config>
-                </Stack>
-            </Tabs.Panel>
-            <Tabs.Panel value="display">
-                <Stack>
-                    <Config>
-                        <Group>
-                            <Config.Heading>Show legend</Config.Heading>
-                            <Switch
-                                size="xs"
-                                classNames={{
-                                    label: compactStyles.compactCheckboxLabel,
-                                }}
-                                checked={showLegend}
-                                onChange={toggleShowLegend}
-                            />
-                        </Group>
-                    </Config>
+                                    </Group>
+                                </Config.Section>
+                            </Config>
+                            <Config>
+                                <Config.Section>
+                                    <Config.Heading>Steps</Config.Heading>
+                                    {data
+                                        .sort((a, b) => b.value - a.value)
+                                        .map((step) => {
+                                            return (
+                                                <StepConfig
+                                                    key={step.id}
+                                                    id={step.id}
+                                                    defaultColor={
+                                                        colorDefaults[step.id]
+                                                    }
+                                                    defaultLabel={step.name}
+                                                    swatches={[]}
+                                                    color={
+                                                        colorOverrides[step.id]
+                                                    }
+                                                    label={
+                                                        labelOverrides[step.id]
+                                                    }
+                                                    granularityFields={
+                                                        granularityFields
+                                                    }
+                                                    onColorChange={
+                                                        onColorOverridesChange
+                                                    }
+                                                    onLabelChange={
+                                                        onLabelOverridesChange
+                                                    }
+                                                />
+                                            );
+                                        })}
+                                </Config.Section>
+                            </Config>
+                        </Stack>
+                    ),
+                },
+                {
+                    value: 'display',
+                    label: 'Display',
+                    panel: (
+                        <Stack>
+                            <Config>
+                                <Group>
+                                    <Config.Heading>Show legend</Config.Heading>
+                                    <Switch
+                                        size="xs"
+                                        classNames={{
+                                            label: compactStyles.compactCheckboxLabel,
+                                        }}
+                                        checked={showLegend}
+                                        onChange={toggleShowLegend}
+                                    />
+                                </Group>
+                            </Config>
 
-                    <Collapse in={showLegend}>
-                        <Group gap="xs">
-                            <Config.Label>Orientation</Config.Label>
-                            <SegmentedControl
-                                size="xs"
-                                name="orient"
-                                value={legendPosition}
-                                onChange={(value) =>
-                                    legendPositionChange(
-                                        value as FunnelChartLegendPosition,
-                                    )
-                                }
-                                data={[
-                                    {
-                                        value: FunnelChartLegendPosition.HORIZONTAL,
-                                        label: 'Horizontal',
-                                    },
-                                    {
-                                        value: FunnelChartLegendPosition.VERTICAL,
-                                        label: 'Vertical',
-                                    },
-                                ]}
-                            />
-                        </Group>
-                    </Collapse>
-                </Stack>
-            </Tabs.Panel>
-        </Tabs>
+                            <Collapse in={showLegend}>
+                                <Group gap="xs">
+                                    <Config.Label>Orientation</Config.Label>
+                                    <SegmentedControl
+                                        size="xs"
+                                        name="orient"
+                                        value={legendPosition}
+                                        onChange={(value) =>
+                                            legendPositionChange(
+                                                value as FunnelChartLegendPosition,
+                                            )
+                                        }
+                                        data={[
+                                            {
+                                                value: FunnelChartLegendPosition.HORIZONTAL,
+                                                label: 'Horizontal',
+                                            },
+                                            {
+                                                value: FunnelChartLegendPosition.VERTICAL,
+                                                label: 'Vertical',
+                                            },
+                                        ]}
+                                    />
+                                </Group>
+                            </Collapse>
+                        </Stack>
+                    ),
+                },
+            ]}
+        />
     );
 });

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeConfigTabs.tsx
@@ -1,28 +1,17 @@
-import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
-import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
+import { VisualizationConfigTabs } from '../common/VisualizationConfigTabs';
 import { GaugeDisplayConfig } from './GaugeDisplayConfig';
 import { GaugeFieldsConfig } from './GaugeFieldsConfig';
 
-export const ConfigTabs: FC = memo(() => {
-    return (
-        <Tabs defaultValue="fields" keepMounted={false}>
-            <ConfigTabsList mb="sm">
-                <Tabs.Tab px="sm" value="fields">
-                    Layout
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="display">
-                    Display
-                </Tabs.Tab>
-            </ConfigTabsList>
-
-            <Tabs.Panel value="fields">
-                <GaugeFieldsConfig />
-            </Tabs.Panel>
-
-            <Tabs.Panel value="display">
-                <GaugeDisplayConfig />
-            </Tabs.Panel>
-        </Tabs>
-    );
-});
+export const ConfigTabs: FC = memo(() => (
+    <VisualizationConfigTabs
+        tabs={[
+            { value: 'fields', label: 'Layout', panel: <GaugeFieldsConfig /> },
+            {
+                value: 'display',
+                label: 'Display',
+                panel: <GaugeDisplayConfig />,
+            },
+        ]}
+    />
+));

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapConfigTabs.tsx
@@ -1,28 +1,13 @@
-import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
-import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
+import { VisualizationConfigTabs } from '../common/VisualizationConfigTabs';
 import { Display } from './MapDisplayConfig';
 import { Layout } from './MapLayoutConfig';
 
-export const ConfigTabs: FC = memo(() => {
-    return (
-        <Tabs defaultValue="general" keepMounted={false}>
-            <ConfigTabsList mb="sm">
-                <Tabs.Tab px="sm" value="general">
-                    General
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="display">
-                    Map display
-                </Tabs.Tab>
-            </ConfigTabsList>
-
-            <Tabs.Panel value="general">
-                <Layout />
-            </Tabs.Panel>
-
-            <Tabs.Panel value="display">
-                <Display />
-            </Tabs.Panel>
-        </Tabs>
-    );
-});
+export const ConfigTabs: FC = memo(() => (
+    <VisualizationConfigTabs
+        tabs={[
+            { value: 'general', label: 'General', panel: <Layout /> },
+            { value: 'display', label: 'Map display', panel: <Display /> },
+        ]}
+    />
+));

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartConfigTabs.tsx
@@ -1,36 +1,15 @@
-import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
-import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
+import { VisualizationConfigTabs } from '../common/VisualizationConfigTabs';
 import { Display } from './PieChartDisplayConfig';
 import { Layout } from './PieChartLayoutConfig';
 import { Series } from './PieChartSeriesConfig';
 
-export const ConfigTabs: FC = memo(() => {
-    return (
-        <Tabs defaultValue="layout" keepMounted={false}>
-            <ConfigTabsList mb="sm">
-                <Tabs.Tab px="sm" value="layout">
-                    Layout
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="series">
-                    Series
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="display">
-                    Display
-                </Tabs.Tab>
-            </ConfigTabsList>
-
-            <Tabs.Panel value="layout">
-                <Layout />
-            </Tabs.Panel>
-
-            <Tabs.Panel value="series">
-                <Series />
-            </Tabs.Panel>
-
-            <Tabs.Panel value="display">
-                <Display />
-            </Tabs.Panel>
-        </Tabs>
-    );
-});
+export const ConfigTabs: FC = memo(() => (
+    <VisualizationConfigTabs
+        tabs={[
+            { value: 'layout', label: 'Layout', panel: <Layout /> },
+            { value: 'series', label: 'Series', panel: <Series /> },
+            { value: 'display', label: 'Display', panel: <Display /> },
+        ]}
+    />
+));

--- a/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/SankeyConfig/SankeyConfigTabs.tsx
@@ -9,13 +9,13 @@ import {
     type SankeyNodeLayout,
     type TableCalculation,
 } from '@lightdash/common';
-import { Stack, Tabs, Text, SegmentedControl } from '@mantine/core';
+import { Stack, Text, SegmentedControl } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
-import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
 import FieldSelect from '../../common/FieldSelect';
 import { isSankeyVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';
+import { VisualizationConfigTabs } from '../common/VisualizationConfigTabs';
 
 export const ConfigTabs: FC = memo(() => {
     const { visualizationConfig } = useVisualizationContext();
@@ -89,195 +89,205 @@ export const ConfigTabs: FC = memo(() => {
         nodeLayout === 'merged' && data.hasCycle ? 'multi-step' : nodeLayout;
 
     return (
-        <Tabs defaultValue="general" keepMounted={false}>
-            <ConfigTabsList mb="sm">
-                <Tabs.Tab px="sm" value="general">
-                    General
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="display">
-                    Display
-                </Tabs.Tab>
-            </ConfigTabsList>
-
-            <Tabs.Panel value="general">
-                <Stack>
-                    <Config>
-                        <Config.Section>
-                            <Config.Heading>Source</Config.Heading>
-                            <FieldSelect<Dimension | CustomDimension>
-                                placeholder="Select source dimension"
-                                disabled={allDimensions.length === 0}
-                                item={selectedSource}
-                                items={allDimensions}
-                                onChange={(newField) => {
-                                    if (newField && isField(newField))
-                                        onSourceFieldChange(
-                                            getItemId(newField),
-                                        );
-                                    else if (
-                                        newField &&
-                                        isCustomDimension(newField)
-                                    )
-                                        onSourceFieldChange(newField.id);
-                                    else onSourceFieldChange(null);
-                                }}
-                                hasGrouping
-                            />
-                        </Config.Section>
-                    </Config>
-                    <Config>
-                        <Config.Section>
-                            <Config.Heading>Target</Config.Heading>
-                            <FieldSelect<Dimension | CustomDimension>
-                                placeholder="Select target dimension"
-                                disabled={allDimensions.length === 0}
-                                item={selectedTarget}
-                                items={allDimensions}
-                                onChange={(newField) => {
-                                    if (newField && isField(newField))
-                                        onTargetFieldChange(
-                                            getItemId(newField),
-                                        );
-                                    else if (
-                                        newField &&
-                                        isCustomDimension(newField)
-                                    )
-                                        onTargetFieldChange(newField.id);
-                                    else onTargetFieldChange(null);
-                                }}
-                                hasGrouping
-                            />
-                        </Config.Section>
-                    </Config>
-                    <Config>
-                        <Config.Section>
-                            <Config.Heading>Value</Config.Heading>
-                            <FieldSelect<Metric | TableCalculation>
-                                placeholder="Select metric"
-                                disabled={numericFields.length === 0}
-                                item={selectedMetric}
-                                items={numericFields}
-                                onChange={(newField) => {
-                                    if (newField && isField(newField))
-                                        onMetricFieldChange(
-                                            getItemId(newField),
-                                        );
-                                    else if (
-                                        newField &&
-                                        isTableCalculation(newField)
-                                    )
-                                        onMetricFieldChange(newField.name);
-                                    else onMetricFieldChange(null);
-                                }}
-                                hasGrouping
-                            />
-                        </Config.Section>
-                    </Config>
-                </Stack>
-            </Tabs.Panel>
-
-            <Tabs.Panel value="display">
-                <Stack>
-                    <Config>
-                        <Config.Section>
-                            <Config.Heading>Orientation</Config.Heading>
-                            <SegmentedControl
-                                size="xs"
-                                value={orient}
-                                data={[
-                                    {
-                                        value: 'horizontal',
-                                        label: 'Horizontal',
-                                    },
-                                    {
-                                        value: 'vertical',
-                                        label: 'Vertical',
-                                    },
-                                ]}
-                                onChange={(value) =>
-                                    onOrientChange(
-                                        value as 'horizontal' | 'vertical',
-                                    )
-                                }
-                            />
-                        </Config.Section>
-                    </Config>
-                    <Config>
-                        <Config.Section>
-                            <Config.Heading>Node layout</Config.Heading>
-                            <SegmentedControl
-                                size="xs"
-                                value={effectiveLayout}
-                                data={[
-                                    {
-                                        value: 'multi-step',
-                                        label: 'Multi-step',
-                                    },
-                                    {
-                                        value: 'merged',
-                                        label: 'Merged',
-                                        disabled: data.hasCycle,
-                                    },
-                                    {
-                                        value: 'direct',
-                                        label: 'Direct',
-                                    },
-                                ]}
-                                onChange={(value) =>
-                                    onNodeLayoutChange(
-                                        value as SankeyNodeLayout,
-                                    )
-                                }
-                            />
-                            {data.hasCycle && (
-                                <Text size="xs" c="dimmed" mt="xs">
-                                    Merging isn't available for flows that loop
-                                    back on themselves.
-                                </Text>
+        <VisualizationConfigTabs
+            tabs={[
+                {
+                    value: 'general',
+                    label: 'General',
+                    panel: (
+                        <Stack>
+                            <Config>
+                                <Config.Section>
+                                    <Config.Heading>Source</Config.Heading>
+                                    <FieldSelect<Dimension | CustomDimension>
+                                        placeholder="Select source dimension"
+                                        disabled={allDimensions.length === 0}
+                                        item={selectedSource}
+                                        items={allDimensions}
+                                        onChange={(newField) => {
+                                            if (newField && isField(newField))
+                                                onSourceFieldChange(
+                                                    getItemId(newField),
+                                                );
+                                            else if (
+                                                newField &&
+                                                isCustomDimension(newField)
+                                            )
+                                                onSourceFieldChange(
+                                                    newField.id,
+                                                );
+                                            else onSourceFieldChange(null);
+                                        }}
+                                        hasGrouping
+                                    />
+                                </Config.Section>
+                            </Config>
+                            <Config>
+                                <Config.Section>
+                                    <Config.Heading>Target</Config.Heading>
+                                    <FieldSelect<Dimension | CustomDimension>
+                                        placeholder="Select target dimension"
+                                        disabled={allDimensions.length === 0}
+                                        item={selectedTarget}
+                                        items={allDimensions}
+                                        onChange={(newField) => {
+                                            if (newField && isField(newField))
+                                                onTargetFieldChange(
+                                                    getItemId(newField),
+                                                );
+                                            else if (
+                                                newField &&
+                                                isCustomDimension(newField)
+                                            )
+                                                onTargetFieldChange(
+                                                    newField.id,
+                                                );
+                                            else onTargetFieldChange(null);
+                                        }}
+                                        hasGrouping
+                                    />
+                                </Config.Section>
+                            </Config>
+                            <Config>
+                                <Config.Section>
+                                    <Config.Heading>Value</Config.Heading>
+                                    <FieldSelect<Metric | TableCalculation>
+                                        placeholder="Select metric"
+                                        disabled={numericFields.length === 0}
+                                        item={selectedMetric}
+                                        items={numericFields}
+                                        onChange={(newField) => {
+                                            if (newField && isField(newField))
+                                                onMetricFieldChange(
+                                                    getItemId(newField),
+                                                );
+                                            else if (
+                                                newField &&
+                                                isTableCalculation(newField)
+                                            )
+                                                onMetricFieldChange(
+                                                    newField.name,
+                                                );
+                                            else onMetricFieldChange(null);
+                                        }}
+                                        hasGrouping
+                                    />
+                                </Config.Section>
+                            </Config>
+                        </Stack>
+                    ),
+                },
+                {
+                    value: 'display',
+                    label: 'Display',
+                    panel: (
+                        <Stack>
+                            <Config>
+                                <Config.Section>
+                                    <Config.Heading>Orientation</Config.Heading>
+                                    <SegmentedControl
+                                        size="xs"
+                                        value={orient}
+                                        data={[
+                                            {
+                                                value: 'horizontal',
+                                                label: 'Horizontal',
+                                            },
+                                            {
+                                                value: 'vertical',
+                                                label: 'Vertical',
+                                            },
+                                        ]}
+                                        onChange={(value) =>
+                                            onOrientChange(
+                                                value as
+                                                    | 'horizontal'
+                                                    | 'vertical',
+                                            )
+                                        }
+                                    />
+                                </Config.Section>
+                            </Config>
+                            <Config>
+                                <Config.Section>
+                                    <Config.Heading>Node layout</Config.Heading>
+                                    <SegmentedControl
+                                        size="xs"
+                                        value={effectiveLayout}
+                                        data={[
+                                            {
+                                                value: 'multi-step',
+                                                label: 'Multi-step',
+                                            },
+                                            {
+                                                value: 'merged',
+                                                label: 'Merged',
+                                                disabled: data.hasCycle,
+                                            },
+                                            {
+                                                value: 'direct',
+                                                label: 'Direct',
+                                            },
+                                        ]}
+                                        onChange={(value) =>
+                                            onNodeLayoutChange(
+                                                value as SankeyNodeLayout,
+                                            )
+                                        }
+                                    />
+                                    {data.hasCycle && (
+                                        <Text size="xs" c="dimmed" mt="xs">
+                                            Merging isn't available for flows
+                                            that loop back on themselves.
+                                        </Text>
+                                    )}
+                                </Config.Section>
+                            </Config>
+                            {effectiveLayout !== 'direct' && (
+                                <Config>
+                                    <Config.Section>
+                                        <Config.Heading>
+                                            Node alignment
+                                        </Config.Heading>
+                                        <SegmentedControl
+                                            size="xs"
+                                            value={nodeAlign}
+                                            data={[
+                                                {
+                                                    value: 'left',
+                                                    label:
+                                                        orient === 'vertical'
+                                                            ? 'Top'
+                                                            : 'Left',
+                                                },
+                                                {
+                                                    value: 'right',
+                                                    label:
+                                                        orient === 'vertical'
+                                                            ? 'Bottom'
+                                                            : 'Right',
+                                                },
+                                                {
+                                                    value: 'justify',
+                                                    label: 'Justify',
+                                                },
+                                            ]}
+                                            onChange={(value) =>
+                                                onNodeAlignChange(
+                                                    value as
+                                                        | 'left'
+                                                        | 'right'
+                                                        | 'justify',
+                                                )
+                                            }
+                                        />
+                                    </Config.Section>
+                                </Config>
                             )}
-                        </Config.Section>
-                    </Config>
-                    {effectiveLayout !== 'direct' && (
-                        <Config>
-                            <Config.Section>
-                                <Config.Heading>Node alignment</Config.Heading>
-                                <SegmentedControl
-                                    size="xs"
-                                    value={nodeAlign}
-                                    data={[
-                                        {
-                                            value: 'left',
-                                            label:
-                                                orient === 'vertical'
-                                                    ? 'Top'
-                                                    : 'Left',
-                                        },
-                                        {
-                                            value: 'right',
-                                            label:
-                                                orient === 'vertical'
-                                                    ? 'Bottom'
-                                                    : 'Right',
-                                        },
-                                        {
-                                            value: 'justify',
-                                            label: 'Justify',
-                                        },
-                                    ]}
-                                    onChange={(value) =>
-                                        onNodeAlignChange(
-                                            value as
-                                                | 'left'
-                                                | 'right'
-                                                | 'justify',
-                                        )
-                                    }
-                                />
-                            </Config.Section>
-                        </Config>
-                    )}
-                </Stack>
-            </Tabs.Panel>
-        </Tabs>
+                        </Stack>
+                    ),
+                },
+            ]}
+        />
     );
 });

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/TableConfigTabs.tsx
@@ -1,34 +1,23 @@
-import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
-import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
+import { VisualizationConfigTabs } from '../common/VisualizationConfigTabs';
 import { ColumnCellDisplay } from './ColumnCellDisplay';
 import ConditionalFormattingList from './ConditionalFormattingList';
 import GeneralSettings from './GeneralSettings';
 
-export const ConfigTabs: FC = memo(() => {
-    return (
-        <Tabs defaultValue="general" keepMounted={false}>
-            <ConfigTabsList mb="sm">
-                <Tabs.Tab px="sm" value="general">
-                    General
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="conditional-formatting">
-                    Conditional formatting
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="cell-display">
-                    Cell display
-                </Tabs.Tab>
-            </ConfigTabsList>
-
-            <Tabs.Panel value="general">
-                <GeneralSettings />
-            </Tabs.Panel>
-            <Tabs.Panel value="conditional-formatting">
-                <ConditionalFormattingList />
-            </Tabs.Panel>
-            <Tabs.Panel value="cell-display">
-                <ColumnCellDisplay />
-            </Tabs.Panel>
-        </Tabs>
-    );
-});
+export const ConfigTabs: FC = memo(() => (
+    <VisualizationConfigTabs
+        tabs={[
+            { value: 'general', label: 'General', panel: <GeneralSettings /> },
+            {
+                value: 'conditional-formatting',
+                label: 'Conditional formatting',
+                panel: <ConditionalFormattingList />,
+            },
+            {
+                value: 'cell-display',
+                label: 'Cell display',
+                panel: <ColumnCellDisplay />,
+            },
+        ]}
+    />
+));

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapConfigTabs.tsx
@@ -1,28 +1,13 @@
-import { Tabs } from '@mantine/core';
 import { memo, type FC } from 'react';
-import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
+import { VisualizationConfigTabs } from '../common/VisualizationConfigTabs';
 import { Display } from './TreemapDisplayConfig';
 import { Layout } from './TreemapLayoutConfig';
 
-export const ConfigTabs: FC = memo(() => {
-    return (
-        <Tabs defaultValue="layout" keepMounted={false}>
-            <ConfigTabsList mb="sm">
-                <Tabs.Tab px="sm" value="layout">
-                    Layout
-                </Tabs.Tab>
-                <Tabs.Tab px="sm" value="display">
-                    Display
-                </Tabs.Tab>
-            </ConfigTabsList>
-
-            <Tabs.Panel value="layout">
-                <Layout />
-            </Tabs.Panel>
-
-            <Tabs.Panel value="display">
-                <Display />
-            </Tabs.Panel>
-        </Tabs>
-    );
-});
+export const ConfigTabs: FC = memo(() => (
+    <VisualizationConfigTabs
+        tabs={[
+            { value: 'layout', label: 'Layout', panel: <Layout /> },
+            { value: 'display', label: 'Display', panel: <Display /> },
+        ]}
+    />
+));

--- a/packages/frontend/src/components/VisualizationConfigs/common/VisualizationConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/VisualizationConfigTabs.test.tsx
@@ -1,0 +1,42 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { VisualizationConfigTabs } from './VisualizationConfigTabs';
+
+const tabs = [
+    { value: 'layout', label: 'Layout', panel: <div>Layout panel</div> },
+    { value: 'display', label: 'Display', panel: <div>Display panel</div> },
+];
+
+describe('VisualizationConfigTabs', () => {
+    it('renders every tab and opens the first one by default', () => {
+        renderWithProviders(<VisualizationConfigTabs tabs={tabs} />);
+
+        expect(screen.getByRole('tab', { name: 'Layout' })).toBeInTheDocument();
+        expect(
+            screen.getByRole('tab', { name: 'Display' }),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Layout panel')).toBeInTheDocument();
+        expect(screen.queryByText('Display panel')).not.toBeInTheDocument();
+    });
+
+    it('honours an explicit default tab', () => {
+        renderWithProviders(
+            <VisualizationConfigTabs tabs={tabs} defaultValue="display" />,
+        );
+
+        expect(screen.getByText('Display panel')).toBeInTheDocument();
+        expect(screen.queryByText('Layout panel')).not.toBeInTheDocument();
+    });
+
+    it('shows the matching panel when a tab is selected', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<VisualizationConfigTabs tabs={tabs} />);
+
+        await user.click(screen.getByRole('tab', { name: 'Display' }));
+
+        expect(screen.getByText('Display panel')).toBeInTheDocument();
+        expect(screen.queryByText('Layout panel')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/VisualizationConfigs/common/VisualizationConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/VisualizationConfigTabs.tsx
@@ -1,0 +1,32 @@
+import { Tabs } from '@mantine/core';
+import { type FC, type ReactNode } from 'react';
+import ConfigTabsList from '../../common/ChartGallery/ConfigTabsList';
+
+type VisualizationConfigTab = {
+    value: string;
+    label: string;
+    panel: ReactNode;
+};
+
+type Props = {
+    tabs: VisualizationConfigTab[];
+    defaultValue?: string;
+};
+
+export const VisualizationConfigTabs: FC<Props> = ({ tabs, defaultValue }) => (
+    <Tabs defaultValue={defaultValue ?? tabs[0]?.value} keepMounted={false}>
+        <ConfigTabsList mb="sm">
+            {tabs.map(({ value, label }) => (
+                <Tabs.Tab key={value} px="sm" value={value}>
+                    {label}
+                </Tabs.Tab>
+            ))}
+        </ConfigTabsList>
+
+        {tabs.map(({ value, panel }) => (
+            <Tabs.Panel key={value} value={value}>
+                {panel}
+            </Tabs.Panel>
+        ))}
+    </Tabs>
+);


### PR DESCRIPTION
## Summary

Nine chart config panels each hand-rolled the same `Tabs` scaffold: `Tabs` with `keepMounted={false}`, a `ConfigTabsList mb="sm"`, `Tabs.Tab px="sm"` per tab and a matching `Tabs.Panel`. Adding a tab or restyling the strip meant editing every copy, and they had already started to drift.

`VisualizationConfigTabs` (in `VisualizationConfigs/common/`) renders that scaffold once from `{ value, label, panel }` entries, defaulting to the first tab. Each per-chart file keeps its existing `ConfigTabs` export (they are imported by name elsewhere) and now only declares its tabs. Files with extra logic keep it: the ChartConfigPanel one still reads `itemsMap` from the visualization context and passes `items` down.

Rendered output is unchanged: same tab order, labels, values, panels and default tab. The Funnel and Sankey diffs look large only because their inline panel JSX shifted one level deeper and re-wrapped; `git diff -w` shows no content change.

## Testing

From `packages/frontend`, on the 11 changed files:

- `oxfmt` - clean
- `oxlint -c .oxlintrc.json` - 0 warnings, 0 errors (11 files)
- `vitest run src/components/VisualizationConfigs` - 12 files, 93 tests passed, including 3 new tests for the helper (renders every tab, honours an explicit default, switches panel on click)
- `tsc --project tsconfig.json --noEmit` - 142 errors, byte-identical to the same run on `main`; all come from an unrelated stale `@lightdash/common` build in the local workspace, none in `VisualizationConfigs`

Relates: GLITCH-674