### PR TITLE
refactor(explorer): derive the selected chart type in one place

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -1,8 +1,4 @@
-import {
-    FeatureFlags,
-    getAppDisplayName,
-    type DataAppViz,
-} from '@lightdash/common';
+import { FeatureFlags, type DataAppViz } from '@lightdash/common';
 import {
     Box,
     Button,
@@ -15,12 +11,7 @@ import {
     UnstyledButton,
 } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
-import {
-    IconChevronRight,
-    IconPlus,
-    IconPuzzle,
-    IconSearch,
-} from '@tabler/icons-react';
+import { IconChevronRight, IconPlus, IconSearch } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
@@ -31,6 +22,7 @@ import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/ty
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { useSelectProjectChartType } from '../../VisualizationConfigs/CustomChartType/useSelectProjectChartType';
 import {
+    projectChartTypeItem,
     useChartTypeOptions,
     type ChartTypeOption,
 } from '../VisualizationCardOptions/useChartTypeOptions';
@@ -257,24 +249,25 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
             },
         }));
     const projectItems = projectTypes.map(
-        (dataAppViz: DataAppViz): ChartTypeGalleryItem => ({
-            key: dataAppViz.dataAppVizUuid,
-            label: getAppDisplayName(
-                dataAppViz.name,
-                dataAppViz.dataAppVizUuid,
-            ),
-            description:
-                dataAppViz.description ||
-                `${dataAppViz.schema?.fields.length ?? 0} fields`,
-            icon: IconPuzzle,
-            rotatedIcon: false,
-            selected: selectedProjectUuid === dataAppViz.dataAppVizUuid,
-            disabled,
-            select: () => {
-                selectProjectChartType(dataAppViz, itemsMap ?? {});
-                onSelected();
-            },
-        }),
+        (dataAppViz: DataAppViz): ChartTypeGalleryItem => {
+            const { label, icon, rotatedIcon } =
+                projectChartTypeItem(dataAppViz);
+            return {
+                key: dataAppViz.dataAppVizUuid,
+                label,
+                description:
+                    dataAppViz.description ||
+                    `${dataAppViz.schema?.fields.length ?? 0} fields`,
+                icon,
+                rotatedIcon,
+                selected: selectedProjectUuid === dataAppViz.dataAppVizUuid,
+                disabled,
+                select: () => {
+                    selectProjectChartType(dataAppViz, itemsMap ?? {});
+                    onSelected();
+                },
+            };
+        },
     );
 
     const sections: ChartTypeGallerySection[] = [

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
@@ -1,5 +1,5 @@
 import { ChartKind, ChartType } from '@lightdash/common';
-import { IconCode, IconTable } from '@tabler/icons-react';
+import { IconTable } from '@tabler/icons-react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
@@ -28,21 +28,18 @@ vi.mock('../../LightdashVisualization/useVisualizationContext', () => ({
         },
     }),
 }));
+
+const { getSelectedChartTypeItem } = vi.hoisted(() => ({
+    getSelectedChartTypeItem: vi.fn(() => ({
+        id: ChartKind.TABLE,
+        label: 'Table',
+        icon: IconTable,
+        rotatedIcon: false,
+    })),
+}));
+
 vi.mock('../VisualizationCardOptions/useChartTypeOptions', () => ({
-    useChartTypeOptions: () => ({
-        selectedChartType: {
-            id: ChartKind.TABLE,
-            label: 'Table',
-            icon: IconTable,
-            rotatedIcon: false,
-        },
-        vegaOption: {
-            id: ChartKind.CUSTOM,
-            label: 'Vega (JSON editor)',
-            icon: IconCode,
-            rotatedIcon: false,
-        },
-    }),
+    useChartTypeOptions: () => ({ getSelectedChartTypeItem }),
 }));
 
 const ReopenHarness = () => {
@@ -74,6 +71,10 @@ describe('ExplorerChartSidebar', () => {
 
         expect(screen.getByText('Configure controls')).toBeInTheDocument();
         expect(screen.getByText('Table')).toBeInTheDocument();
+        expect(getSelectedChartTypeItem).toHaveBeenCalledWith(
+            ChartType.TABLE,
+            null,
+        );
         await userEvent.click(screen.getByText('Choose type'));
         await userEvent.click(
             screen.getByRole('button', { name: 'Select chart' }),

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -1,4 +1,4 @@
-import { ChartKind, ChartType, getAppDisplayName } from '@lightdash/common';
+import { ChartType } from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
@@ -10,12 +10,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
-import {
-    IconArrowLeft,
-    IconPuzzle,
-    IconSettings,
-    IconX,
-} from '@tabler/icons-react';
+import { IconArrowLeft, IconSettings, IconX } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Link, useLocation, useParams } from 'react-router';
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
@@ -25,10 +20,7 @@ import MantineIcon from '../../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import VisualizationConfig from '../VisualizationCard/VisualizationConfig';
-import {
-    useChartTypeOptions,
-    type SelectedChartType,
-} from '../VisualizationCardOptions/useChartTypeOptions';
+import { useChartTypeOptions } from '../VisualizationCardOptions/useChartTypeOptions';
 import ExplorerChartTypeGallery, {
     ChartTypeThumbnail,
 } from './ChartTypeGallery';
@@ -46,7 +38,7 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const location = useLocation();
     const { visualizationConfig } = useVisualizationContext();
-    const { selectedChartType, vegaOption } = useChartTypeOptions();
+    const { getSelectedChartTypeItem } = useChartTypeOptions();
     const dataAppVizUuid = isDataAppVizVisualizationConfig(visualizationConfig)
         ? visualizationConfig.chartConfig.dataAppVizUuid
         : undefined;
@@ -62,21 +54,10 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
     });
 
     const isProjectType = chartType === ChartType.DATA_APP_VIZ;
-    const selectedItem: SelectedChartType = isProjectType
-        ? {
-              id: ChartKind.DATA_APP_VIZ,
-              label: selectedProjectType
-                  ? getAppDisplayName(
-                        selectedProjectType.name,
-                        selectedProjectType.dataAppVizUuid,
-                    )
-                  : 'Project chart type',
-              icon: IconPuzzle,
-              rotatedIcon: false,
-          }
-        : chartType === ChartType.CUSTOM
-          ? vegaOption
-          : selectedChartType;
+    const selectedItem = getSelectedChartTypeItem(
+        chartType,
+        selectedProjectType ?? null,
+    );
 
     return (
         <ChartGalleryContext.Provider value={true}>

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/useChartTypeOptions.test.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/useChartTypeOptions.test.tsx
@@ -1,0 +1,71 @@
+import { ChartKind, ChartType, type DataAppViz } from '@lightdash/common';
+import { describe, expect, it, vi } from 'vitest';
+import { renderHookWithProviders } from '../../../testing/testUtils';
+import { useChartTypeOptions } from './useChartTypeOptions';
+
+vi.mock('../../LightdashVisualization/useVisualizationContext', () => ({
+    useVisualizationContext: () => ({
+        visualizationConfig: {
+            chartType: ChartType.TABLE,
+            chartConfig: {},
+        },
+        setChartType: vi.fn(),
+        setCartesianType: vi.fn(),
+        setStacking: vi.fn(),
+        isLoading: false,
+        resultsData: { rows: [{}] },
+        pivotDimensions: undefined,
+    }),
+}));
+
+const projectChartType = {
+    dataAppVizUuid: 'project-chart-type',
+    name: 'Event pulse',
+    description: 'Reusable ranked bars',
+    projectUuid: 'project-uuid',
+    spaceUuid: null,
+    createdAt: new Date('2026-08-20T00:00:00Z'),
+    createdByUserUuid: 'user-uuid',
+    schema: { fields: [], configOptions: [], colorPalette: null },
+} satisfies DataAppViz;
+
+const getSelectedItem = (
+    chartType: ChartType,
+    dataAppViz: DataAppViz | null,
+) => {
+    const { result } = renderHookWithProviders(() => useChartTypeOptions());
+    return result.current.getSelectedChartTypeItem(chartType, dataAppViz);
+};
+
+describe('getSelectedChartTypeItem', () => {
+    it('names the loaded project chart type', () => {
+        expect(
+            getSelectedItem(ChartType.DATA_APP_VIZ, projectChartType),
+        ).toMatchObject({
+            id: ChartKind.DATA_APP_VIZ,
+            label: 'Event pulse',
+            rotatedIcon: false,
+        });
+    });
+
+    it('keeps a generic label while the project chart type loads', () => {
+        expect(getSelectedItem(ChartType.DATA_APP_VIZ, null)).toMatchObject({
+            id: ChartKind.DATA_APP_VIZ,
+            label: 'Project chart type',
+        });
+    });
+
+    it('uses the Vega entry for custom charts', () => {
+        expect(getSelectedItem(ChartType.CUSTOM, null)).toMatchObject({
+            id: ChartKind.CUSTOM,
+            label: 'Vega (JSON editor)',
+        });
+    });
+
+    it('uses the matching built-in entry for every other chart type', () => {
+        expect(getSelectedItem(ChartType.TABLE, null)).toMatchObject({
+            id: ChartKind.TABLE,
+            label: 'Table',
+        });
+    });
+});

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/useChartTypeOptions.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/useChartTypeOptions.tsx
@@ -2,7 +2,9 @@ import {
     CartesianSeriesType,
     ChartKind,
     ChartType,
+    getAppDisplayName,
     isSeriesWithMixedChartTypes,
+    type DataAppViz,
 } from '@lightdash/common';
 import {
     IconChartArea,
@@ -17,6 +19,7 @@ import {
     IconGauge,
     IconGitMerge,
     IconMap,
+    IconPuzzle,
     IconSquareNumber1,
     IconTable,
     type Icon as TablerIcon,
@@ -64,6 +67,18 @@ const CUSTOM_CHART_TYPE: SelectedChartType = {
     icon: IconCode,
     rotatedIcon: false,
 };
+
+/** Pass `null` while the project chart type is still loading. */
+export const projectChartTypeItem = (
+    dataAppViz: DataAppViz | null,
+): SelectedChartType => ({
+    id: ChartKind.DATA_APP_VIZ,
+    label: dataAppViz
+        ? getAppDisplayName(dataAppViz.name, dataAppViz.dataAppVizUuid)
+        : 'Project chart type',
+    icon: IconPuzzle,
+    rotatedIcon: false,
+});
 
 export const useChartTypeOptions = () => {
     const {
@@ -287,8 +302,22 @@ export const useChartTypeOptions = () => {
         ? CUSTOM_CHART_TYPE
         : (options.find((option) => option.selected) ?? MIXED_CHART_TYPE);
 
+    // The picker collapses Vega and project chart types into a single "Custom"
+    // entry, so callers showing the active type resolve it by chart type.
+    const getSelectedChartTypeItem = (
+        chartType: ChartType,
+        dataAppViz: DataAppViz | null,
+    ): SelectedChartType => {
+        if (chartType === ChartType.DATA_APP_VIZ) {
+            return projectChartTypeItem(dataAppViz);
+        }
+        if (chartType === ChartType.CUSTOM) return vegaOption;
+        return selectedChartType;
+    };
+
     return {
         disabled,
+        getSelectedChartTypeItem,
         isCustomChart,
         options,
         resetCartesianState,


### PR DESCRIPTION
## Summary

The chart sidebar re-derived which chart-type item to show (icon, label, rotated flag) for `DATA_APP_VIZ` / `CUSTOM` / built-in types, and the gallery separately built the project chart-type row from the same `IconPuzzle` + `getAppDisplayName` literals. That mapping now lives once:

- `useChartTypeOptions` returns `getSelectedChartTypeItem(chartType, dataAppViz)`. The fetched project chart type is passed in, so the hook keeps no server state.
- `projectChartTypeItem(dataAppViz)` is the single builder for the project row (icon, `rotatedIcon`, display name, and the 'Project chart type' fallback while it loads); both the sidebar and the gallery use it.
- `ChartKind.DATA_APP_VIZ` and `IconPuzzle` no longer appear in the sidebar.

No behaviour change: same labels, icons, and loading fallback.

## Testing

Run from `packages/frontend`:

- `oxfmt <changed files>` - clean
- `oxlint -c .oxlintrc.json <changed files>` - 0 warnings, 0 errors
- `vitest run src/components/Explorer` - 14 files, 74 tests passed (4 new tests for `getSelectedChartTypeItem`, covering the loaded project type, the loading fallback, Vega, and built-in types)
- `tsc --project tsconfig.json --noEmit` - no new errors versus the base commit (identical output before and after the change)

Relates: GLITCH-674