### PR TITLE
refactor(viz-config): select project chart types through one hook

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -39,12 +39,14 @@ type FieldSelectProps = {
 };
 
 const {
+    dispatch,
     fieldSelectItems,
     fieldSelectProps,
     locationSearch,
     navigate,
     pickerProps,
 } = vi.hoisted(() => ({
+    dispatch: vi.fn(),
     fieldSelectItems: [] as Item[][],
     fieldSelectProps: [] as FieldSelectProps[],
     locationSearch: { current: '' },
@@ -52,6 +54,22 @@ const {
     pickerProps: [] as PickerProps[],
 }));
 
+// The picker routes project-type selection through the Redux-based
+// useSelectProjectChartType hook; assert on what it dispatches.
+vi.mock('../../../features/explorer/store', () => ({
+    useExplorerDispatch: () => dispatch,
+    explorerActions: {
+        setChartType: (payload: unknown) => ({ type: 'setChartType', payload }),
+        setChartConfig: (payload: unknown) => ({
+            type: 'setChartConfig',
+            payload,
+        }),
+        setPivotConfig: (payload: unknown) => ({
+            type: 'setPivotConfig',
+            payload,
+        }),
+    },
+}));
 vi.mock('../CustomChartType/CustomChartTypePicker', () => ({
     default: (props: PickerProps) => {
         pickerProps.push(props);
@@ -237,6 +255,7 @@ describe('DataAppVizConfigTabs', () => {
         } as unknown as ReturnType<typeof useVisualizationContext>);
 
     beforeEach(() => {
+        dispatch.mockClear();
         fieldSelectItems.length = 0;
         fieldSelectProps.length = 0;
         pickerProps.length = 0;
@@ -319,7 +338,7 @@ describe('DataAppVizConfigTabs', () => {
         expect(screen.getByTestId('color-palette-section')).toBeInTheDocument();
     });
 
-    it('binds the picked viz contract to the query columns', () => {
+    it('binds the picked viz contract to the query columns via the shared selector', () => {
         renderWithProviders(<ConfigTabs />);
 
         const picked = {
@@ -342,12 +361,34 @@ describe('DataAppVizConfigTabs', () => {
             pickerProps[pickerProps.length - 1].onSelectProjectType(picked),
         );
 
-        expect(setDataAppVizUuid).toHaveBeenCalledWith('picked-uuid', {
-            source: 'orders_visible',
-            value: 'orders_visible_metric',
-            breakdown: 'custom-dimension',
+        expect(dispatch).toHaveBeenCalledWith({
+            type: 'setChartType',
+            payload: { chartType: ChartType.DATA_APP_VIZ },
         });
-        expect(setPivotDimensions).toHaveBeenCalledWith(['custom-dimension']);
+        expect(dispatch).toHaveBeenCalledWith({
+            type: 'setChartConfig',
+            payload: {
+                chartConfig: {
+                    type: ChartType.DATA_APP_VIZ,
+                    config: {
+                        dataAppVizUuid: 'picked-uuid',
+                        fieldMapping: {
+                            source: 'orders_visible',
+                            value: 'orders_visible_metric',
+                            breakdown: 'custom-dimension',
+                        },
+                        optionValues: {},
+                    },
+                },
+            },
+        });
+        expect(dispatch).toHaveBeenLastCalledWith({
+            type: 'setPivotConfig',
+            payload: { columns: ['custom-dimension'] },
+        });
+        // The legacy path no longer bypasses the store via the local context.
+        expect(setDataAppVizUuid).not.toHaveBeenCalled();
+        expect(setPivotDimensions).not.toHaveBeenCalled();
     });
 
     it('updates pivot dimensions when a series mapping changes', () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -11,10 +11,7 @@ import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
-import {
-    autoMapDataAppVizFields,
-    reconcileDataAppVizFieldMapping,
-} from '../../../features/chartTypes/utils/autoMapDataAppVizFields';
+import { reconcileDataAppVizFieldMapping } from '../../../features/chartTypes/utils/autoMapDataAppVizFields';
 import { getDataAppVizFieldItems } from '../../../features/chartTypes/utils/getDataAppVizFieldItems';
 import { useIsInsideChartGallery } from '../../common/ChartGallery/ChartGalleryContext';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
@@ -22,6 +19,7 @@ import { useVisualizationContext } from '../../LightdashVisualization/useVisuali
 import { ColorPaletteSection } from '../common/ColorPaletteSection';
 import { type CustomChartTypeOption } from '../CustomChartType/customChartTypeOption';
 import CustomChartTypeSection from '../CustomChartType/CustomChartTypeSection';
+import { useSelectProjectChartType } from '../CustomChartType/useSelectProjectChartType';
 import classes from './DataAppVizConfigTabs.module.css';
 import DataAppVizOptionTabs from './DataAppVizOptionTabs';
 import DataAppVizSettings from './DataAppVizSettings';
@@ -35,6 +33,7 @@ export const ConfigTabs: FC = memo(() => {
     const navigate = useNavigate();
     const { visualizationConfig, itemsMap, setChartType, setPivotDimensions } =
         useVisualizationContext();
+    const selectProjectChartType = useSelectProjectChartType();
 
     const isDataAppViz = isDataAppVizVisualizationConfig(visualizationConfig);
     const dataAppVizUuid = isDataAppViz
@@ -170,21 +169,12 @@ export const ConfigTabs: FC = memo(() => {
                         selectedDataAppViz={dataAppViz ?? null}
                         hasColumns={hasColumns}
                         onSelectVega={() => setChartType(ChartType.CUSTOM)}
-                        onSelectProjectType={(picked) => {
-                            const pickedFields = picked.schema?.fields ?? [];
-                            const pickedMapping = autoMapDataAppVizFields(
-                                pickedFields,
+                        onSelectProjectType={(picked) =>
+                            selectProjectChartType(
+                                picked,
                                 itemsMap ?? NO_COLUMNS,
-                            );
-                            setDataAppVizUuid(
-                                picked.dataAppVizUuid,
-                                pickedMapping,
-                            );
-                            setMappingPivotDimensions(
-                                pickedFields,
-                                pickedMapping,
-                            );
-                        }}
+                            )
+                        }
                         onClear={() => {
                             setDataAppVizUuid('', {});
                             setPivotDimensions(undefined);


### PR DESCRIPTION
## Summary

The legacy data-app-viz config picker (`CustomChartTypeSection` inside `DataAppVizConfigTabs`) hand-rolled the same type+config+pivot sequence that `useSelectProjectChartType` already encapsulates for the chart gallery and custom-vis pickers. This routes `onSelectProjectType` through that shared hook instead, so there's one place that knows how to land a project chart type on the store.

`setMappingPivotDimensions` stays in place since `handleFieldChange` (per-field mapping edits) still needs it.

## Testing

- `../../node_modules/.bin/oxfmt` on changed files — no changes needed
- `pnpm exec oxlint -c .oxlintrc.json` on changed files — 0 warnings, 0 errors
- `npx vitest run src/components/VisualizationConfigs/DataAppVizConfig src/components/VisualizationConfigs/CustomChartType src/hooks/useDataAppVizVisualizationConfig.test.ts` — 58 passed
- `npx vitest run src/components/Explorer/ChartGallery src/components/VisualizationConfigs/ChartConfigPanel/CustomVis` — 51 passed (other callers of the shared hook, unaffected)
- `pnpm typecheck` — clean

Relates: GLITCH-674