### PR TITLE
refactor(explorer): tidy chart gallery types, tokens and hidden state

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
@@ -41,11 +41,11 @@
     place-items: center;
     overflow: hidden;
     border: 1px solid
-        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-dark-5));
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-5));
     border-radius: var(--mantine-radius-sm);
     background: light-dark(
         var(--mantine-color-white),
-        var(--mantine-color-dark-7)
+        var(--mantine-color-ldDark-7)
     );
 }
 

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.module.css
@@ -9,7 +9,7 @@
     flex: 0 0 auto;
     padding-bottom: var(--mantine-spacing-md);
     border-bottom: 1px solid
-        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-dark-5));
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-5));
 }
 
 .body {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -41,6 +41,9 @@ type Props = {
 
 type Mode = 'choose' | 'configure';
 
+const isMode = (value: string): value is Mode =>
+    value === 'choose' || value === 'configure';
+
 const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
     const [mode, setMode] = useState<Mode>('configure');
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -110,7 +113,9 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
                     <SegmentedControl
                         fullWidth
                         value={mode}
-                        onChange={(value) => setMode(value as Mode)}
+                        onChange={(value) => {
+                            if (isMode(value)) setMode(value);
+                        }}
                         data={[
                             { value: 'choose', label: 'Choose type' },
                             { value: 'configure', label: 'Configure' },

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.module.css
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.module.css
@@ -1,0 +1,7 @@
+.panel {
+    flex-grow: 1;
+}
+
+.panel[data-hidden='true'] {
+    display: none;
+}

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.test.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.test.tsx
@@ -167,7 +167,11 @@ describe('ExplorePanel chart configuration placement', () => {
         expect(
             document.getElementById('visualization-config-portal'),
         ).not.toBeNull();
-        expect(screen.getByTestId('explore-tree')).not.toBeVisible();
+        // The hidden state is applied via a CSS module class (`[data-hidden='true']`),
+        // which jsdom doesn't resolve, so assert the attribute directly.
+        expect(
+            screen.getByTestId('explore-tree').closest('[data-hidden]'),
+        ).toHaveAttribute('data-hidden', 'true');
     });
 
     it('keeps fields mounted and leaves the portal to the right rail when enabled', () => {
@@ -178,7 +182,9 @@ describe('ExplorePanel chart configuration placement', () => {
         expect(
             document.getElementById('visualization-config-portal'),
         ).toBeNull();
-        expect(screen.getByTestId('explore-tree')).toBeVisible();
+        expect(
+            screen.getByTestId('explore-tree').closest('[data-hidden]'),
+        ).toHaveAttribute('data-hidden', 'false');
     });
 });
 

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -67,6 +67,7 @@ import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailProvider'
 import VisualizationConfigPortal from '../VisualizationCard/VisualizationConfigPortal';
 import WarningsHoverCardContent from '../WarningsHoverCardContent';
 import { useIsGitProject } from '../WriteBackModal/hooks';
+import classes from './index.module.css';
 
 interface ExplorePanelProps {
     onBack?: () => void;
@@ -271,13 +272,10 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
 
             <Stack
                 h="100%"
-                style={{
-                    flexGrow: 1,
-                    display:
-                        !isChartGalleryEnabled && isVisualizationConfigOpen
-                            ? 'none'
-                            : 'flex',
-                }}
+                className={classes.panel}
+                data-hidden={
+                    !isChartGalleryEnabled && isVisualizationConfigOpen
+                }
             >
                 {merge?.isMerging && merge.readOnly && <MergeJoinBar />}
                 {/* The breadcrumbs, warnings and menu all belong to the


### PR DESCRIPTION
## Summary

Three small style-guide follow-ups in the Explorer chart gallery, no behaviour change:

- `ExplorerChartSidebar.tsx`: replaced an unsound `value as Mode` cast on the SegmentedControl's `onChange` with an `isMode` type guard.
- `ChartTypeGallery.module.css` / `ExplorerChartSidebar.module.css`: swapped raw `--mantine-color-dark-5` / `--mantine-color-dark-7` tokens for the `ldDark` palette (`ldDark-5` for borders, `ldDark-7` for backgrounds), matching the shades other CSS modules already use for the same roles.
- `ExplorePanel/index.tsx`: moved the visibility toggle off the `style` prop into a new `index.module.css`, using a `data-hidden` attribute instead of an inline `display` calculation.

## Testing

- `npx vitest run src/components/Explorer/ChartGallery src/components/Explorer/ExplorePanel` — 22 passed. The two `ExplorePanel` "chart configuration placement" tests were changed from `toBeVisible()`/`not.toBeVisible()` to asserting the `data-hidden` attribute directly, since jsdom doesn't resolve CSS module rules and can't see the `display: none` set via `[data-hidden='true']`.
- `../../node_modules/.bin/oxfmt <changed files>` — clean.
- `pnpm exec oxlint -c .oxlintrc.json <changed ts/tsx files>` — 0 warnings, 0 errors.
- `pnpm typecheck` — passes with no errors touching the changed files.

Relates: GLITCH-674