### PR TITLE
refactor(chart-types): build the chart type builder path in one helper

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -25,6 +25,7 @@ import { useMemo, useState, type FC } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useDataAppVisualizations } from '../../../features/chartTypes/hooks/useDataAppVisualizations';
+import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
@@ -298,7 +299,9 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
                       onCreateNew: canCreateChartType
                           ? () =>
                                 void navigate({
-                                    pathname: `/projects/${projectUuid}/chart-types/new`,
+                                    pathname: chartTypeBuilderPath(
+                                        projectUuid ?? '',
+                                    ),
                                     search: location.search,
                                 })
                           : null,

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -20,6 +20,7 @@ import { useState, type FC } from 'react';
 import { Link, useLocation, useParams } from 'react-router';
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
+import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
 import { ChartGalleryContext } from '../../common/ChartGallery/ChartGalleryContext';
 import MantineIcon from '../../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
@@ -162,7 +163,12 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
                                                 <Anchor
                                                     component={Link}
                                                     to={{
-                                                        pathname: `/projects/${projectUuid}/chart-types/${selectedProjectType.dataAppVizUuid}`,
+                                                        pathname:
+                                                            chartTypeBuilderPath(
+                                                                projectUuid ??
+                                                                    '',
+                                                                selectedProjectType.dataAppVizUuid,
+                                                            ),
                                                         search: location.search,
                                                     }}
                                                     fz="xs"

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -13,6 +13,7 @@ import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useDeepCompareEffect } from 'react-use';
 import { useCanCreateDataApp } from '../../../../features/apps/hooks/useCanCreateDataApp';
+import { chartTypeBuilderPath } from '../../../../features/chartTypes/utils/chartTypeBuilderPath';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import { useIsInsideChartGallery } from '../../../common/ChartGallery/ChartGalleryContext';
 import DocumentationHelpButton from '../../../DocumentationHelpButton';
@@ -271,7 +272,9 @@ export const ConfigTabs: React.FC = memo(() => {
                             canCreateApp
                                 ? () =>
                                       void navigate({
-                                          pathname: `/projects/${projectUuid}/chart-types/new`,
+                                          pathname: chartTypeBuilderPath(
+                                              projectUuid ?? '',
+                                          ),
                                           search: location.search,
                                       })
                                 : null

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -12,6 +12,7 @@ import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDa
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
 import { reconcileDataAppVizFieldMapping } from '../../../features/chartTypes/utils/autoMapDataAppVizFields';
+import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
 import { getDataAppVizFieldItems } from '../../../features/chartTypes/utils/getDataAppVizFieldItems';
 import { useIsInsideChartGallery } from '../../common/ChartGallery/ChartGalleryContext';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
@@ -143,7 +144,10 @@ export const ConfigTabs: FC = memo(() => {
                         <Anchor
                             component={Link}
                             to={{
-                                pathname: `/projects/${projectUuid}/chart-types/${dataAppViz.dataAppVizUuid}`,
+                                pathname: chartTypeBuilderPath(
+                                    projectUuid ?? '',
+                                    dataAppViz.dataAppVizUuid,
+                                ),
                                 search: location.search,
                             }}
                             fz="xs"
@@ -183,7 +187,9 @@ export const ConfigTabs: FC = memo(() => {
                             canCreateApp
                                 ? () =>
                                       void navigate({
-                                          pathname: `/projects/${projectUuid}/chart-types/new`,
+                                          pathname: chartTypeBuilderPath(
+                                              projectUuid ?? '',
+                                          ),
                                           search: location.search,
                                       })
                                 : null
@@ -218,7 +224,9 @@ export const ConfigTabs: FC = memo(() => {
                                 <Anchor
                                     component={Link}
                                     to={{
-                                        pathname: `/projects/${projectUuid}/chart-types/new`,
+                                        pathname: chartTypeBuilderPath(
+                                            projectUuid ?? '',
+                                        ),
                                         search: location.search,
                                     }}
                                     size="xs"

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
@@ -8,6 +8,7 @@ import MantineModal from '../../../components/common/MantineModal';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { useAppVersionHistory } from '../../apps/hooks/useAppVersionHistory';
 import { useCanEditDataApp } from '../../apps/hooks/useCanEditDataApp';
+import { chartTypeBuilderPath } from '../utils/chartTypeBuilderPath';
 import classes from './ChartTypeDetailModal.module.css';
 import ChartTypeSamplePreview from './ChartTypeSamplePreview';
 
@@ -70,7 +71,10 @@ const ChartTypeDetailModal: FC<Props> = ({
             actions={
                 <Button
                     component={Link}
-                    to={`/projects/${projectUuid}/chart-types/${dataAppViz.dataAppVizUuid}`}
+                    to={chartTypeBuilderPath(
+                        projectUuid,
+                        dataAppViz.dataAppVizUuid,
+                    )}
                     variant="default"
                     leftSection={<MantineIcon icon={IconFilePencil} />}
                 >

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryCard.tsx
@@ -12,6 +12,7 @@ import { FloatingActionsPill } from '../../../components/common/FloatingActionsP
 import MantineIcon from '../../../components/common/MantineIcon';
 import { PolymorphicPaperButton } from '../../../components/common/PolymorphicPaperButton';
 import { useCanEditDataApp } from '../../apps/hooks/useCanEditDataApp';
+import { chartTypeBuilderPath } from '../utils/chartTypeBuilderPath';
 import classes from './ChartTypeGalleryCard.module.css';
 import ChartTypeSamplePreview from './ChartTypeSamplePreview';
 
@@ -59,7 +60,10 @@ const ChartTypeGalleryCard: FC<Props> = ({ dataAppViz, onClick, onDelete }) => {
                             variant="subtle"
                             color="gray"
                             component={Link}
-                            to={`/projects/${dataAppViz.projectUuid}/chart-types/${dataAppViz.dataAppVizUuid}`}
+                            to={chartTypeBuilderPath(
+                                dataAppViz.projectUuid,
+                                dataAppViz.dataAppVizUuid,
+                            )}
                             aria-label={`Edit ${displayName}`}
                             onClick={(e) => e.stopPropagation()}
                         >

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryEmptyState.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryEmptyState.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
+import { chartTypeBuilderPath } from '../utils/chartTypeBuilderPath';
 
 type Props = {
     projectUuid: string;
@@ -42,7 +43,7 @@ const ChartTypeGalleryEmptyState: FC<Props> = ({ projectUuid }) => {
                 <Button
                     mt="xs"
                     component={Link}
-                    to={`/projects/${projectUuid}/chart-types/new`}
+                    to={chartTypeBuilderPath(projectUuid)}
                     leftSection={<MantineIcon icon={IconPlus} size={18} />}
                 >
                     New chart type

--- a/packages/frontend/src/features/chartTypes/utils/chartTypeBuilderPath.test.ts
+++ b/packages/frontend/src/features/chartTypes/utils/chartTypeBuilderPath.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { chartTypeBuilderPath } from './chartTypeBuilderPath';
+
+describe('chartTypeBuilderPath', () => {
+    it('builds the create path when no dataAppVizUuid is given', () => {
+        expect(chartTypeBuilderPath('project-uuid')).toBe(
+            '/projects/project-uuid/chart-types/new',
+        );
+    });
+
+    it('builds the create path when dataAppVizUuid is explicitly null', () => {
+        expect(chartTypeBuilderPath('project-uuid', null)).toBe(
+            '/projects/project-uuid/chart-types/new',
+        );
+    });
+
+    it('builds the edit path when a dataAppVizUuid is given', () => {
+        expect(chartTypeBuilderPath('project-uuid', 'viz-uuid')).toBe(
+            '/projects/project-uuid/chart-types/viz-uuid',
+        );
+    });
+});

--- a/packages/frontend/src/features/chartTypes/utils/chartTypeBuilderPath.ts
+++ b/packages/frontend/src/features/chartTypes/utils/chartTypeBuilderPath.ts
@@ -1,0 +1,7 @@
+export const chartTypeBuilderPath = (
+    projectUuid: string,
+    dataAppVizUuid: string | null = null,
+) =>
+    `/projects/${projectUuid}/chart-types/${
+        dataAppVizUuid ? dataAppVizUuid : 'new'
+    }`;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -148,6 +148,7 @@ import { getVersionNarration } from '../features/apps/utils/versionNarration';
 import { versionsToChatMessages } from '../features/apps/utils/versionsToChatMessages';
 import DataAppVizResultCard from '../features/chartTypes/components/DataAppVizResultCard';
 import DataAppVizTestPanel from '../features/chartTypes/components/DataAppVizTestPanel';
+import { chartTypeBuilderPath } from '../features/chartTypes/utils/chartTypeBuilderPath';
 import { useAppExternalConnections } from '../features/externalConnections/hooks/useAppExternalConnections';
 import { ThemePicker } from '../features/organizationDesigns/components/ThemePicker';
 import { useOrganizationDesigns } from '../features/organizationDesigns/hooks/useOrganizationDesigns';
@@ -1366,7 +1367,7 @@ const AppGenerate: FC = () => {
     ) {
         return (
             <Navigate
-                to={`/projects/${projectUuid}/chart-types/${activeAppUuid}`}
+                to={chartTypeBuilderPath(projectUuid ?? '', activeAppUuid)}
                 replace
             />
         );

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -53,6 +53,7 @@ import {
     useDataAppVizBuild,
     type VizBuildRequest,
 } from '../features/chartTypes/hooks/useDataAppVizBuild';
+import { chartTypeBuilderPath } from '../features/chartTypes/utils/chartTypeBuilderPath';
 import { buildSampleVizContext } from '../features/chartTypes/utils/sampleVizContext';
 import { useResolvedColorPalette } from '../hooks/appearance/useResolvedColorPalette';
 import {
@@ -160,7 +161,7 @@ const ChartTypeBuilder: FC = () => {
         if (!urlVizUuid && build.appUuid && projectUuid) {
             void navigate(
                 {
-                    pathname: `/projects/${projectUuid}/chart-types/${build.appUuid}`,
+                    pathname: chartTypeBuilderPath(projectUuid, build.appUuid),
                     search: location.search,
                 },
                 { replace: true },

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -23,6 +23,7 @@ import ChartTypeDetailModal from '../features/chartTypes/components/ChartTypeDet
 import ChartTypeGalleryCard from '../features/chartTypes/components/ChartTypeGalleryCard';
 import ChartTypeGalleryEmptyState from '../features/chartTypes/components/ChartTypeGalleryEmptyState';
 import { useDataAppVisualizations } from '../features/chartTypes/hooks/useDataAppVisualizations';
+import { chartTypeBuilderPath } from '../features/chartTypes/utils/chartTypeBuilderPath';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
@@ -138,7 +139,7 @@ const ChartTypeGallery = () => {
                                     <Button
                                         size="xs"
                                         component={Link}
-                                        to={`/projects/${projectUuid}/chart-types/new`}
+                                        to={chartTypeBuilderPath(projectUuid)}
                                         leftSection={
                                             <MantineIcon
                                                 icon={IconPlus}


### PR DESCRIPTION
## Summary

The chart type builder URL (`/projects/:projectUuid/chart-types/new` or `/chart-types/:dataAppVizUuid`) was string-built independently in ten places across the frontend. Adds `chartTypeBuilderPath(projectUuid, dataAppVizUuid?)` in `features/chartTypes/utils` and switches every call site to use it instead of ad hoc template literals, so the route only needs to change in one place going forward.

No behaviour change — same URLs are produced, `search: location.search` is preserved wherever the caller already passed it along.

## Testing

- `../../node_modules/.bin/oxfmt <changed files>` — clean
- `pnpm exec oxlint -c .oxlintrc.json <changed files>` — 0 warnings, 0 errors (12 files)
- `npx vitest run src/features/chartTypes src/components/Explorer/ChartGallery src/components/VisualizationConfigs src/pages/ChartTypeGallery.test.tsx` — 235 passed (28 test files)
- `pnpm typecheck` — clean

Relates: GLITCH-674