### PR TITLE
feat(ai): enable filter expressions for agents

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -62,6 +62,108 @@ describe('AiAgentModel prompt activity', () => {
         return row?.updated_at ?? null;
     };
 
+    it('normalizes filter-expression artifacts on every model read path', async () => {
+        const threadUuid = await createWebAppThread();
+        const promptUuid = await model.createWebAppPrompt({
+            threadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'Persist a filter expression',
+        });
+        const resolvedArgs = {
+            title: 'Orders by status',
+            description: 'Completed orders',
+            queryConfig: {
+                exploreName: 'orders',
+                dimensions: ['orders_status'],
+                metrics: ['orders_count'],
+                sorts: [],
+                limit: 500,
+                customMetrics: null,
+                tableCalculations: null,
+                filters: {
+                    type: 'and',
+                    dimensions: [
+                        {
+                            fieldId: 'orders_status',
+                            fieldType: 'string',
+                            fieldFilterType: 'string',
+                            operator: 'equals',
+                            values: ['complete'],
+                        },
+                    ],
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            },
+            chartConfig: null,
+            mergeConfig: null,
+        };
+        const persistedConfig = {
+            source: 'filterExpression',
+            schemaVersion: 1,
+            expressionArgs: {
+                ...resolvedArgs,
+                queryConfig: {
+                    ...resolvedArgs.queryConfig,
+                    filters: {
+                        dimensions: 'orders_status equals=complete',
+                        metrics: null,
+                        tableCalculations: null,
+                    },
+                },
+            },
+            resolvedArgs,
+        };
+
+        const created = await model.createArtifact({
+            threadUuid,
+            promptUuid,
+            artifactType: 'chart',
+            title: 'Orders by status',
+            description: 'Completed orders',
+            vizConfig: persistedConfig,
+        });
+        const version = await model.createArtifactVersion({
+            artifactUuid: created.artifactUuid,
+            promptUuid,
+            title: 'Orders by status',
+            description: 'Completed orders',
+            vizConfig: persistedConfig,
+        });
+        const fetched = await model.getArtifact(created.artifactUuid);
+        const byThread = await model.findArtifactsByThreadUuid(
+            threadUuid,
+            'chart',
+        );
+        const byPrompt =
+            await model.findArtifactVersionsByPromptUuid(promptUuid);
+
+        for (const artifact of [
+            created,
+            version,
+            fetched,
+            ...byThread,
+            ...byPrompt,
+        ]) {
+            expect(artifact.chartConfig).toMatchObject({
+                source: 'semantic',
+                config: {
+                    queryConfig: {
+                        filters: {
+                            dimensions: [
+                                {
+                                    fieldId: 'orders_status',
+                                    values: ['complete'],
+                                },
+                            ],
+                        },
+                    },
+                    mergeConfig: null,
+                },
+            });
+        }
+    });
+
     it('sets thread updated_at to the inserted web prompt created_at', async () => {
         const threadUuid = await createWebAppThread();
         expect(await getThreadUpdatedAt(threadUuid)).toBeNull();

--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -69,6 +69,120 @@ describe('AiAgentModel prompt activity', () => {
         return row?.updated_at ?? null;
     };
 
+    it('normalizes resolved expression args on every model read path', async () => {
+        const resolvedArgs = {
+            title: 'Orders by status',
+            description: 'Completed orders',
+            queryConfig: {
+                exploreName: 'orders',
+                dimensions: ['orders_status'],
+                metrics: ['orders_count'],
+                sorts: [],
+                limit: 500,
+                customMetrics: null,
+                tableCalculations: null,
+                filters: {
+                    dimensions: {
+                        connector: 'and',
+                        rules: [
+                            {
+                                fieldId: 'orders_status',
+                                fieldType: 'string',
+                                fieldFilterType: 'string',
+                                operator: 'equals',
+                                values: ['complete'],
+                            },
+                        ],
+                    },
+                    metrics: {
+                        connector: 'or',
+                        rules: [
+                            {
+                                fieldId: 'orders_count',
+                                fieldType: 'count',
+                                fieldFilterType: 'number',
+                                operator: 'greaterThan',
+                                values: [10],
+                            },
+                        ],
+                    },
+                    tableCalculations: null,
+                },
+            },
+            chartConfig: null,
+            mergeConfig: null,
+        };
+        const persistedConfig = {
+            source: 'semantic',
+            config: resolvedArgs,
+        };
+        const threadUuid = await createWebAppThread();
+        const promptUuid = await model.createWebAppPrompt({
+            threadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'Persist a filter expression',
+        });
+        const created = await model.createArtifact({
+            threadUuid,
+            promptUuid,
+            artifactType: 'chart',
+            title: 'Orders by status',
+            description: 'Completed orders',
+            vizConfig: persistedConfig,
+        });
+        const version = await model.createArtifactVersion({
+            artifactUuid: created.artifactUuid,
+            promptUuid,
+            title: 'Orders by status',
+            description: 'Completed orders',
+            vizConfig: persistedConfig,
+        });
+        const fetched = await model.getArtifact(created.artifactUuid);
+        const byThread = await model.findArtifactsByThreadUuid(
+            threadUuid,
+            'chart',
+        );
+        const byPrompt =
+            await model.findArtifactVersionsByPromptUuid(promptUuid);
+
+        for (const artifact of [
+            created,
+            version,
+            fetched,
+            ...byThread,
+            ...byPrompt,
+        ]) {
+            expect(artifact.chartConfig).toMatchObject({
+                source: 'semantic',
+                config: {
+                    queryConfig: {
+                        filters: {
+                            dimensions: {
+                                connector: 'and',
+                                rules: [
+                                    {
+                                        fieldId: 'orders_status',
+                                        values: ['complete'],
+                                    },
+                                ],
+                            },
+                            metrics: {
+                                connector: 'or',
+                                rules: [
+                                    {
+                                        fieldId: 'orders_count',
+                                        values: [10],
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                    mergeConfig: null,
+                },
+            });
+        }
+    });
+
     it('sets thread updated_at to the inserted web prompt created_at', async () => {
         const threadUuid = await createWebAppThread();
         expect(await getThreadUpdatedAt(threadUuid)).toBeNull();

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -10240,6 +10240,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             agentSettings.enableDataAccess &&
             !isSlackPrompt(prompt) &&
             responseExecution.mode !== 'deep_research';
+        const { enabled: filterExpressionsEnabled } =
+            await this.featureFlagService.get({
+                user,
+                featureFlagId: FeatureFlags.AiFilterExpressions,
+            });
         let aiWritebackEnabled = hasTrustedPromptUserIdentity;
         if (!aiWritebackEnabled) {
             this.logger.info(
@@ -10502,6 +10507,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enablePreviewDeploySetup: aiPreviewDeploySetupEnabled,
             enableRepoDiscovery: repoDiscoveryEnabled,
             enableMergeQueries: mergeQueriesEnabled,
+            enableFilterExpressions: filterExpressionsEnabled,
             repoFsRoot,
             repoFsSupportsCodeSearch,
             canRunSql,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -108,7 +108,7 @@ import {
     OpenIdIdentityIssuerType,
     ParameterError,
     ParametersValuesMap,
-    parsePersistedRunQueryArgs,
+    parsePersistedRunQueryPayload,
     parseVizConfig,
     PersistentDownloadFileAccessMode,
     ProjectType,
@@ -7118,7 +7118,7 @@ export class AiAgentService extends BaseService {
             if (!mergeQueriesEnabled) {
                 throw new ForbiddenError('Merge queries are not enabled');
             }
-            const parsed = parsePersistedRunQueryArgs(
+            const parsed = parsePersistedRunQueryPayload(
                 artifact.chartConfig.config,
             );
             if (!parsed?.mergeConfig) {
@@ -10667,6 +10667,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             agentSettings.enableDataAccess &&
             !isSlackPrompt(prompt) &&
             responseExecution.mode !== 'deep_research';
+        const { enabled: filterExpressionsEnabled } =
+            await this.featureFlagService.get({
+                user,
+                featureFlagId: FeatureFlags.AiFilterExpressions,
+            });
         let aiWritebackEnabled = hasTrustedPromptUserIdentity;
         if (!aiWritebackEnabled) {
             this.logger.info(
@@ -10936,6 +10941,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enablePreviewDeploySetup: aiPreviewDeploySetupEnabled,
             enableRepoDiscovery: repoDiscoveryEnabled,
             enableMergeQueries: mergeQueriesEnabled,
+            enableFilterExpressions: filterExpressionsEnabled,
             repoFsRoot,
             repoFsSupportsCodeSearch,
             canRunSql,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -847,6 +847,7 @@ export const getAgentTools = (
         enableDataAccess: args.enableDataAccess,
         projectParameterDefinitions,
         enableMergeQueries: args.enableMergeQueries,
+        enableFilterExpressions: args.enableFilterExpressions,
     });
 
     const runSavedChart = getRunSavedChart({

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -861,6 +861,7 @@ export const getAgentTools = (
         enableDataAccess: args.enableDataAccess,
         projectParameterDefinitions,
         enableMergeQueries: args.enableMergeQueries,
+        enableFilterExpressions: args.enableFilterExpressions,
         resolveCustomChartType: dependencies.resolveCustomChartType,
         exportCustomChartTypeImage: dependencies.exportCustomChartTypeImage,
     });

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -7848,6 +7848,789 @@ Usage Tips:
 ]
 `;
 
+exports[`AI agent tool contracts > matches the filter-expression visualization contract snapshot 1`] = `
+{
+  "description": "Execute a metric query.
+
+If any selected field is marked "requires parameters" in field discovery or metadata, set the right values in queryConfig.parameters — an unset parameter silently resolves to its default, which can make the query return data that does not match the question.
+
+This tool returns metric query data only. If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, call render_chart after run_metric_query returns done.
+
+Response shape (MCP CallToolResult):
+- content: [{ type: "text", text: string }] — human-readable fallback. Completed queries return bare CSV text. CSV headers are display labels, not stable field IDs; running queries return polling status text; errors return an error message.
+- If the query finishes before the MCP wait window, structuredContent: {
+    result: {
+      status: "done",
+      queryUuid: string,
+      rows: Array<Record<string, unknown>>,
+      fields: Record<string, unknown>,
+      exploreUrl: string | null
+    }
+  }
+- If the query is still running, structuredContent: {
+    result: {
+      status: "running",
+      queryUuid: string,
+      nextPollAfterMs: number,
+      heartbeatAt: string
+    }
+  }
+  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.
+
+Notes:
+- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.
+- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.
+- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.
+
+Filter expression syntax:
+Filter expressions use the form "field operator=value".
+
+Available operators: isNull, notNull, equals, notEquals, startsWith, endsWith, include, doesNotInclude, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, inThePast, notInThePast, inTheNext, inTheCurrent, notInTheCurrent, inBetween, notInBetween.
+
+- Join flat rules with AND or OR. Do not mix both connectors in one expression.
+- If multiple category expressions contain multiple rules, they must use the same connector.
+- Quote values containing commas, whitespace, or reserved words with single or double quotes.
+- Quote unusual field IDs with backticks. AND and OR are reserved field IDs unless quoted.
+- Use isNull/notNull without values. equals=null and notEquals=null are equivalent null checks.
+- Presence operators take no values. Other operators require one or more comma-separated values according to the field type.
+- Relative dates use count,unit,completed (for example inThePast=30,days,false).
+- Current dates use one unit (for example inTheCurrent=months).
+- Nested groups and parentheses are not supported yet.",
+  "inputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "chartConfig": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "defaultVizType": {
+                "description": "The default visualization type to render",
+                "enum": [
+                  "table",
+                  "bar",
+                  "horizontal",
+                  "line",
+                  "scatter",
+                  "pie",
+                  "funnel",
+                ],
+                "type": "string",
+              },
+              "groupBy": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "description": "Dimensions to split metrics into separate series (e.g., one line per region, one bar per status). IMPORTANT: Do NOT include the x-axis dimension in groupBy - only include dimensions you want to use for breaking down the data into multiple series. Example: dimensions=["order_date", "status"], groupBy=["status"] creates separate series for each status value. Leave null for simple single-series charts.",
+              },
+              "lineType": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "line",
+                      "area",
+                    ],
+                    "type": "string",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "description": "default line. The type of line to display. If area then the area under the line will be filled in.",
+              },
+              "secondaryYAxisLabel": {
+                "description": "A helpful label for the secondary y-axis",
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "secondaryYAxisMetric": {
+                "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "stackBars": {
+                "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.",
+                "type": [
+                  "boolean",
+                  "null",
+                ],
+              },
+              "xAxisDimension": {
+                "description": "The dimension field ID to use for the x-axis. Must be included in queryConfig.dimensions",
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "xAxisLabel": {
+                "description": "A helpful label to explain the x-axis",
+                "type": "string",
+              },
+              "xAxisType": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "category",
+                      "time",
+                    ],
+                    "type": "string",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "description": "The x-axis type can be categorical for string value or time if the dimension is a date or timestamp. Applies to bar, horizontal, and scatter charts.",
+              },
+              "yAxisLabel": {
+                "description": "A helpful label to explain the y-axis",
+                "type": "string",
+              },
+              "yAxisMetrics": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                  {
+                    "type": "null",
+                  },
+                ],
+                "description": "The metric field IDs to display on the y-axis. Must be included in queryConfig.metrics or come from tableCalculations",
+              },
+            },
+            "required": [
+              "defaultVizType",
+              "xAxisDimension",
+              "yAxisMetrics",
+              "groupBy",
+              "xAxisType",
+              "stackBars",
+              "lineType",
+              "xAxisLabel",
+              "yAxisLabel",
+              "secondaryYAxisMetric",
+              "secondaryYAxisLabel",
+            ],
+            "type": "object",
+          },
+          {
+            "type": "null",
+          },
+        ],
+      },
+      "description": {
+        "description": "A descriptive summary or explanation for the chart.",
+        "type": "string",
+      },
+      "mergeConfig": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "additionalSources": {
+                "description": "The additional query to merge with queryConfig. Merge queries currently support exactly two sources.",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "minLength": 1,
+                      "type": "string",
+                    },
+                    "queryConfig": {
+                      "additionalProperties": false,
+                      "description": "A second semantic-layer query. The primary query limit and parameter values apply to the whole merge.",
+                      "properties": {
+                        "customMetrics": {
+                          "$ref": "#/properties/queryConfig/properties/customMetrics",
+                        },
+                        "dimensions": {
+                          "$ref": "#/properties/queryConfig/properties/dimensions",
+                        },
+                        "exploreName": {
+                          "$ref": "#/properties/queryConfig/properties/exploreName",
+                        },
+                        "filters": {
+                          "$ref": "#/properties/queryConfig/properties/filters",
+                        },
+                        "metrics": {
+                          "$ref": "#/properties/queryConfig/properties/metrics",
+                        },
+                        "sorts": {
+                          "$ref": "#/properties/queryConfig/properties/sorts",
+                        },
+                      },
+                      "required": [
+                        "exploreName",
+                        "dimensions",
+                        "metrics",
+                        "sorts",
+                        "customMetrics",
+                        "filters",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "queryConfig",
+                  ],
+                  "type": "object",
+                },
+                "maxItems": 1,
+                "minItems": 1,
+                "type": "array",
+              },
+              "joinKey": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "fields": {
+                      "description": "One selected dimension from each source. Both must represent the same grain and value type.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "fieldId": {
+                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "sourceId": {
+                            "minLength": 1,
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "sourceId",
+                          "fieldId",
+                        ],
+                        "type": "object",
+                      },
+                      "maxItems": 2,
+                      "minItems": 2,
+                      "type": "array",
+                    },
+                    "name": {
+                      "description": "Stable output name for this shared join-key column.",
+                      "minLength": 1,
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "fields",
+                  ],
+                  "type": "object",
+                },
+                "minItems": 1,
+                "type": "array",
+              },
+              "joinType": {
+                "enum": [
+                  "full",
+                  "left",
+                  "inner",
+                ],
+                "type": "string",
+              },
+              "primarySourceId": {
+                "description": "Stable id assigned to the primary queryConfig.",
+                "minLength": 1,
+                "type": "string",
+              },
+            },
+            "required": [
+              "primarySourceId",
+              "additionalSources",
+              "joinKey",
+              "joinType",
+            ],
+            "type": "object",
+          },
+          {
+            "type": "null",
+          },
+        ],
+        "default": null,
+        "description": "null for a normal visualization. Set this to combine queryConfig with one additional semantic-layer query. Every source may contain only join-key dimensions plus metrics; other dimensions cause fan-out and are refused. In chartConfig, join-key field ids are merge_<joinKeyName>. Metric field ids are <sourceId>_<originalFieldId>. Replace dots in either name with two underscores.",
+      },
+      "queryConfig": {
+        "additionalProperties": false,
+        "properties": {
+          "customMetrics": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "baseDimensionName": {
+                          "description": "Field ID (e.g. "customers_age") or bare column name (e.g. "age") of the base dimension to aggregate. Must be a dimension that already EXISTS in this explore — confirm it exists with your field discovery tools first. Do NOT guess an id/primary-key column: many explores do not expose "<table>_id" as a queryable dimension.",
+                          "type": "string",
+                        },
+                        "description": {
+                          "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                          "type": "string",
+                        },
+                        "filters": {
+                          "anyOf": [
+                            {
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "Optional flat AND expression for conditional metric filters.",
+                        },
+                        "kind": {
+                          "const": "aggregation",
+                          "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
+                          "type": "string",
+                        },
+                        "label": {
+                          "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
+                          "type": "string",
+                        },
+                        "name": {
+                          "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                          "type": "string",
+                        },
+                        "table": {
+                          "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                          "type": "string",
+                        },
+                        "type": {
+                          "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
+                          "enum": [
+                            "average",
+                            "count",
+                            "count_distinct",
+                            "max",
+                            "min",
+                            "sum",
+                            "percentile",
+                            "median",
+                          ],
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "kind",
+                        "name",
+                        "label",
+                        "description",
+                        "baseDimensionName",
+                        "table",
+                        "type",
+                        "filters",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "baseMetricId": {
+                          "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
+                          "type": "string",
+                        },
+                        "granularity": {
+                          "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
+                          "enum": [
+                            "DAY",
+                            "WEEK",
+                            "MONTH",
+                            "QUARTER",
+                            "YEAR",
+                          ],
+                          "type": "string",
+                        },
+                        "kind": {
+                          "const": "periodComparison",
+                          "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
+                          "type": "string",
+                        },
+                        "periodOffset": {
+                          "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                          "minimum": 1,
+                          "type": "integer",
+                        },
+                        "timeDimensionId": {
+                          "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "kind",
+                        "baseMetricId",
+                        "timeDimensionId",
+                        "granularity",
+                        "periodOffset",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+                "type": "array",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "description": "Define new metric columns the explore doesn't already have. Two kinds:
+
+(1) kind: "aggregation" — a NEW metric built by aggregating a base dimension
+    (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).
+    Use when the requested metric doesn't exist in the explore.
+
+(2) kind: "periodComparison" — a column that is an EXISTING metric shifted
+    back in time. Use whenever the user asks for "year-over-year",
+    "month-over-month", "vs last quarter", "compare to previous period",
+    "N periods ago".
+
+For period comparisons, every successful chart has three things:
+- The time dimension in queryConfig.dimensions
+- The base metric in queryConfig.metrics
+- A customMetric of kind "periodComparison" pointing at that base metric and time dimension
+
+The server generates the comparison column automatically and appends it next to the base metric. Do NOT add the comparison column id to queryConfig.metrics yourself.
+
+DO NOT simulate a period comparison by adding a second time-dimension granularity (e.g. _year) and using groupBy. groupBy is for categorical splits (region, product). Time comparisons use a kind: "periodComparison" customMetric.
+
+For aggregation entries:
+1. Add the entry to customMetrics with kind: "aggregation"
+2. Reference it in queryConfig.metrics using the format "table_name" (e.g. "customers_avg_customer_age")
+3. Reference it the same way in sorts, filters, chartConfig.yAxisMetrics
+
+Example A — "Average customer age sorted descending"
+  customMetrics: [{ kind: "aggregation", name: "avg_customer_age", label: "Average Customer Age", description: "...", type: "AVERAGE", baseDimensionName: "age", table: "customers", filters: null }]
+  queryConfig.metrics: ["customers_avg_customer_age"]
+  sorts: [{ fieldId: "customers_avg_customer_age", descending: true }]
+
+Example B — "Revenue by month with year-over-year comparison"
+  queryConfig.dimensions: ["orders_order_date_month"]
+  queryConfig.metrics: ["orders_revenue"]
+  customMetrics: [{ kind: "periodComparison", baseMetricId: "orders_revenue", timeDimensionId: "orders_order_date_month", granularity: "MONTH", periodOffset: 12 }]",
+          },
+          "dimensions": {
+            "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "exploreName": {
+            "description": "The name of the explore containing the metrics and dimensions used for the chart.",
+            "type": "string",
+          },
+          "filters": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Separate flat expressions for dimensions, metrics, and table calculations. Use null when a category has no filters.",
+                "properties": {
+                  "dimensions": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "Flat filter expression for dimension fields.",
+                  },
+                  "metrics": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "Flat filter expression for metric fields.",
+                  },
+                  "tableCalculations": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "Flat filter expression for table calculations.",
+                  },
+                },
+                "required": [
+                  "dimensions",
+                  "metrics",
+                  "tableCalculations",
+                ],
+                "type": "object",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "description": "Separate flat expressions for dimensions, metrics, and table calculations. Use null when a category has no filters.",
+          },
+          "limit": {
+            "description": "The total number of data points / rows allowed on the chart. null means this tool's maximum, not "no data" — use it unless the user asked for a specific number of rows. Row limits documented for other tools do not apply here.",
+            "type": [
+              "number",
+              "null",
+            ],
+          },
+          "metrics": {
+            "description": "The field ids of the metrics to be calculated. They will be grouped by the dimensions.",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "parameters": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                    },
+                    {
+                      "type": "number",
+                    },
+                    {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "items": {
+                        "type": "number",
+                      },
+                      "type": "array",
+                    },
+                  ],
+                },
+                "type": "object",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "default": null,
+            "description": "Lightdash parameter values for this query, keyed by parameter name exactly as shown in the explore metadata (e.g. {"orders.metric": "active_users"}). REQUIRED whenever a selected field is marked "requires parameters" and the default value does not match what the user asked for — an unset parameter silently resolves to its default, which can return the wrong data. null when the explore has no parameters or the defaults are correct.",
+          },
+          "sorts": {
+            "description": "Sort configuration for the query, it can use a combination of metrics and dimensions.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "descending": {
+                  "description": "If true sorts in descending order, if false sorts in ascending order",
+                  "type": "boolean",
+                },
+                "fieldId": {
+                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                  "type": "string",
+                },
+                "nullsFirst": {
+                  "description": "If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default",
+                  "type": [
+                    "boolean",
+                    "null",
+                  ],
+                },
+              },
+              "required": [
+                "fieldId",
+                "descending",
+                "nullsFirst",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "tableCalculations": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "format": {
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "number",
+                            "percent",
+                          ],
+                          "type": "string",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                      "description": "Display format. Use "percent" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to "number".",
+                    },
+                    "formula": {
+                      "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).
+Reference fields by their field id directly, e.g. \`orders_total_revenue / orders_order_count\`. No prefix, no braces, no leading \`=\`.
+Any selected dimension, metric, custom metric (\`<table>_<name>\`), or another table calculation name can be referenced.
+Operators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.
+Functions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).
+Window functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. \`LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)\`.
+MOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is \`MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)\`.
+All branches of an IF must return the same type.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "resultType": {
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "number",
+                            "string",
+                            "date",
+                            "timestamp",
+                            "boolean",
+                          ],
+                          "type": "string",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                      "description": "Data type the formula evaluates to. null defaults to "number".",
+                    },
+                    "type": {
+                      "const": "formula",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "formula",
+                    "format",
+                    "resultType",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "description": "
+Table calculations perform row-by-row calculations on query results without collapsing rows, using spreadsheet-like formulas.
+
+Use them whenever the question needs math the metric query alone can't express: arithmetic across metrics (\`metric_a + metric_b\`), ratios, percent of total, period-over-period change, running totals, moving averages, ranking, row-level comparisons, or aggregating already-aggregated metrics.
+
+**Technical Requirements:**
+- Appear as additional columns in query results
+- Can be used in sorts and filters alongside dimensions/metrics
+- Multiple calculations can be combined in a single query; a formula can reference another table calculation by name
+- All fields referenced must be selected in the query (dimensions, metrics, custom metrics, or other table calculations)
+",
+          },
+        },
+        "required": [
+          "exploreName",
+          "dimensions",
+          "metrics",
+          "sorts",
+          "limit",
+          "customMetrics",
+          "tableCalculations",
+          "filters",
+        ],
+        "type": "object",
+      },
+      "title": {
+        "description": "A descriptive title for the chart",
+        "type": "string",
+      },
+    },
+    "required": [
+      "title",
+      "description",
+      "queryConfig",
+      "chartConfig",
+    ],
+    "type": "object",
+  },
+  "name": "generateVisualization",
+  "outputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "metadata": {
+        "additionalProperties": false,
+        "properties": {
+          "chartImageUrl": {
+            "type": [
+              "string",
+              "null",
+            ],
+          },
+          "status": {
+            "enum": [
+              "success",
+              "error",
+            ],
+            "type": "string",
+          },
+        },
+        "required": [
+          "status",
+        ],
+        "type": "object",
+      },
+      "result": {
+        "type": "string",
+      },
+    },
+    "required": [
+      "result",
+      "metadata",
+    ],
+    "type": "object",
+  },
+}
+`;
+
 exports[`AI agent tool contracts > matches the shared agent tool definition names snapshot 1`] = `
 [
   "findExplores",

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -8132,6 +8132,835 @@ Usage Tips:
 ]
 `;
 
+exports[`AI agent tool contracts > matches the filter-expression visualization contract snapshot 1`] = `
+{
+  "description": "Execute a metric query.
+
+If any selected field is marked "requires parameters" in field discovery or metadata, set the right values in queryConfig.parameters — an unset parameter silently resolves to its default, which can make the query return data that does not match the question.
+
+This tool returns metric query data only. If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, call render_chart after run_metric_query returns done.
+
+Response shape (MCP CallToolResult):
+- content: [{ type: "text", text: string }] — human-readable fallback. Completed queries return bare CSV text. CSV headers are display labels, not stable field IDs; running queries return polling status text; errors return an error message.
+- If the query finishes before the MCP wait window, structuredContent: {
+    result: {
+      status: "done",
+      queryUuid: string,
+      rows: Array<Record<string, unknown>>,
+      fields: Record<string, unknown>,
+      exploreUrl: string | null
+    }
+  }
+- If the query is still running, structuredContent: {
+    result: {
+      status: "running",
+      queryUuid: string,
+      nextPollAfterMs: number,
+      heartbeatAt: string
+    }
+  }
+  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.
+
+Notes:
+- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.
+- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.
+- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.
+
+Filter expression syntax:
+Filter expressions use the form "field operator=value".
+
+Available operators: isNull, notNull, equals, notEquals, startsWith, endsWith, include, doesNotInclude, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, inThePast, notInThePast, inTheNext, inTheCurrent, notInTheCurrent, inBetween, notInBetween.
+
+- Join flat rules with AND or OR. Do not mix both connectors in one expression.
+- Quote values containing commas, braces, equals signs, whitespace, parentheses, backslashes, or reserved words with single or double quotes.
+- Inside quotes, commas and braces are literal; do not backslash-escape them. Backslash escapes quotes, backslashes, slashes, control characters, and four-digit Unicode sequences.
+- Quote unusual field IDs with backticks. AND and OR are reserved field IDs unless quoted.
+- Use isNull/notNull without values. equals=null and notEquals=null are equivalent null checks.
+- Presence operators take no values. Other operators require one or more comma-separated values according to the field type.
+- Relative dates use a count followed by named settings (for example inThePast=30{unit:days,completed:false}). completed=false includes the current partial period; completed=true uses completed periods only.
+- Current dates use one unit (for example inTheCurrent=months).
+- Nested groups and parentheses are not supported yet.",
+  "inputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "chartConfig": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "defaultVizType": {
+                    "description": "The default visualization type to render",
+                    "enum": [
+                      "table",
+                      "bar",
+                      "horizontal",
+                      "line",
+                      "scatter",
+                      "pie",
+                      "funnel",
+                    ],
+                    "type": "string",
+                  },
+                  "groupBy": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "Dimensions to split metrics into separate series (e.g., one line per region, one bar per status). IMPORTANT: Do NOT include the x-axis dimension in groupBy - only include dimensions you want to use for breaking down the data into multiple series. Example: dimensions=["order_date", "status"], groupBy=["status"] creates separate series for each status value. Leave null for simple single-series charts.",
+                  },
+                  "lineType": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "line",
+                          "area",
+                        ],
+                        "type": "string",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "default line. The type of line to display. If area then the area under the line will be filled in.",
+                  },
+                  "secondaryYAxisLabel": {
+                    "description": "A helpful label for the secondary y-axis",
+                    "type": [
+                      "string",
+                      "null",
+                    ],
+                  },
+                  "secondaryYAxisMetric": {
+                    "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count).",
+                    "type": [
+                      "string",
+                      "null",
+                    ],
+                  },
+                  "stackBars": {
+                    "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts.",
+                    "type": [
+                      "boolean",
+                      "null",
+                    ],
+                  },
+                  "xAxisDimension": {
+                    "description": "The dimension field ID to use for the x-axis. Must be included in queryConfig.dimensions",
+                    "type": [
+                      "string",
+                      "null",
+                    ],
+                  },
+                  "xAxisLabel": {
+                    "description": "A helpful label to explain the x-axis",
+                    "type": "string",
+                  },
+                  "xAxisType": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "category",
+                          "time",
+                        ],
+                        "type": "string",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "The x-axis type can be categorical for string value or time if the dimension is a date or timestamp. Applies to bar, horizontal, and scatter charts.",
+                  },
+                  "yAxisLabel": {
+                    "description": "A helpful label to explain the y-axis",
+                    "type": "string",
+                  },
+                  "yAxisMetrics": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "The metric field IDs to display on the y-axis. Must be included in queryConfig.metrics or come from tableCalculations",
+                  },
+                },
+                "required": [
+                  "defaultVizType",
+                  "xAxisDimension",
+                  "yAxisMetrics",
+                  "groupBy",
+                  "xAxisType",
+                  "stackBars",
+                  "lineType",
+                  "xAxisLabel",
+                  "yAxisLabel",
+                  "secondaryYAxisMetric",
+                  "secondaryYAxisLabel",
+                ],
+                "type": "object",
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "customChartTypeSlug": {
+                    "description": "Slug of the custom chart type to render this answer through. Must be a slug from availableCustomChartTypes or findCustomChartTypes.",
+                    "type": "string",
+                  },
+                  "fieldMapping": {
+                    "additionalProperties": {
+                      "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "description": "Binds the custom chart type's field slots to this query's fields: slot name (from the type's schema) → a field id selected in queryConfig. Every required slot must be bound.",
+                    "type": "object",
+                  },
+                  "options": {
+                    "anyOf": [
+                      {
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "number",
+                            "boolean",
+                          ],
+                        },
+                        "type": "object",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "default": null,
+                    "description": "Values for the type's config options, keyed by option name from the type's schema. null to use the type's defaults.",
+                  },
+                },
+                "required": [
+                  "customChartTypeSlug",
+                  "fieldMapping",
+                ],
+                "type": "object",
+              },
+            ],
+          },
+          {
+            "type": "null",
+          },
+        ],
+      },
+      "description": {
+        "description": "A descriptive summary or explanation for the chart.",
+        "type": "string",
+      },
+      "mergeConfig": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "additionalSources": {
+                "description": "The additional query to merge with queryConfig. Merge queries currently support exactly two sources.",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "minLength": 1,
+                      "type": "string",
+                    },
+                    "queryConfig": {
+                      "additionalProperties": false,
+                      "description": "A second semantic-layer query. The primary query limit and parameter values apply to the whole merge.",
+                      "properties": {
+                        "customMetrics": {
+                          "$ref": "#/properties/queryConfig/properties/customMetrics",
+                        },
+                        "dimensions": {
+                          "$ref": "#/properties/queryConfig/properties/dimensions",
+                        },
+                        "exploreName": {
+                          "$ref": "#/properties/queryConfig/properties/exploreName",
+                        },
+                        "filters": {
+                          "$ref": "#/properties/queryConfig/properties/filters",
+                        },
+                        "metrics": {
+                          "$ref": "#/properties/queryConfig/properties/metrics",
+                        },
+                        "sorts": {
+                          "$ref": "#/properties/queryConfig/properties/sorts",
+                        },
+                      },
+                      "required": [
+                        "exploreName",
+                        "dimensions",
+                        "metrics",
+                        "sorts",
+                        "customMetrics",
+                        "filters",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "queryConfig",
+                  ],
+                  "type": "object",
+                },
+                "maxItems": 1,
+                "minItems": 1,
+                "type": "array",
+              },
+              "joinKey": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "fields": {
+                      "description": "One selected dimension from each source. Both must represent the same grain and value type.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "fieldId": {
+                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "sourceId": {
+                            "minLength": 1,
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "sourceId",
+                          "fieldId",
+                        ],
+                        "type": "object",
+                      },
+                      "maxItems": 2,
+                      "minItems": 2,
+                      "type": "array",
+                    },
+                    "name": {
+                      "description": "Stable output name for this shared join-key column.",
+                      "minLength": 1,
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "fields",
+                  ],
+                  "type": "object",
+                },
+                "minItems": 1,
+                "type": "array",
+              },
+              "joinType": {
+                "enum": [
+                  "full",
+                  "left",
+                  "inner",
+                ],
+                "type": "string",
+              },
+              "primarySourceId": {
+                "description": "Stable id assigned to the primary queryConfig.",
+                "minLength": 1,
+                "type": "string",
+              },
+            },
+            "required": [
+              "primarySourceId",
+              "additionalSources",
+              "joinKey",
+              "joinType",
+            ],
+            "type": "object",
+          },
+          {
+            "type": "null",
+          },
+        ],
+        "default": null,
+        "description": "null for a normal visualization. Set this to combine queryConfig with one additional semantic-layer query. Every source may contain only join-key dimensions plus metrics; other dimensions cause fan-out and are refused. In chartConfig, join-key field ids are merge_<joinKeyName>. Metric field ids are <sourceId>_<originalFieldId>. Replace dots in either name with two underscores.",
+      },
+      "queryConfig": {
+        "additionalProperties": false,
+        "properties": {
+          "customMetrics": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "baseDimensionName": {
+                          "description": "Field ID (e.g. "customers_age") or bare column name (e.g. "age") of the base dimension to aggregate. Must be a dimension that already EXISTS in this explore — confirm it exists with your field discovery tools first. Do NOT guess an id/primary-key column: many explores do not expose "<table>_id" as a queryable dimension.",
+                          "type": "string",
+                        },
+                        "description": {
+                          "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                          "type": "string",
+                        },
+                        "filters": {
+                          "anyOf": [
+                            {
+                              "maxLength": 16384,
+                              "minLength": 1,
+                              "type": "string",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "Optional flat AND expression for conditional metric filters.",
+                        },
+                        "kind": {
+                          "const": "aggregation",
+                          "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
+                          "type": "string",
+                        },
+                        "label": {
+                          "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
+                          "type": "string",
+                        },
+                        "name": {
+                          "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                          "type": "string",
+                        },
+                        "table": {
+                          "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                          "type": "string",
+                        },
+                        "type": {
+                          "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
+                          "enum": [
+                            "average",
+                            "count",
+                            "count_distinct",
+                            "max",
+                            "min",
+                            "sum",
+                            "percentile",
+                            "median",
+                          ],
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "kind",
+                        "name",
+                        "label",
+                        "description",
+                        "baseDimensionName",
+                        "table",
+                        "type",
+                        "filters",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "baseMetricId": {
+                          "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
+                          "type": "string",
+                        },
+                        "granularity": {
+                          "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
+                          "enum": [
+                            "DAY",
+                            "WEEK",
+                            "MONTH",
+                            "QUARTER",
+                            "YEAR",
+                          ],
+                          "type": "string",
+                        },
+                        "kind": {
+                          "const": "periodComparison",
+                          "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
+                          "type": "string",
+                        },
+                        "periodOffset": {
+                          "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                          "minimum": 1,
+                          "type": "integer",
+                        },
+                        "timeDimensionId": {
+                          "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "kind",
+                        "baseMetricId",
+                        "timeDimensionId",
+                        "granularity",
+                        "periodOffset",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+                "type": "array",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "description": "Define new metric columns the explore doesn't already have. Two kinds:
+
+(1) kind: "aggregation" — a NEW metric built by aggregating a base dimension
+    (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).
+    Use when the requested metric doesn't exist in the explore.
+
+(2) kind: "periodComparison" — a column that is an EXISTING metric shifted
+    back in time. Use whenever the user asks for "year-over-year",
+    "month-over-month", "vs last quarter", "compare to previous period",
+    "N periods ago".
+
+For period comparisons, every successful chart has three things:
+- The time dimension in queryConfig.dimensions
+- The base metric in queryConfig.metrics
+- A customMetric of kind "periodComparison" pointing at that base metric and time dimension
+
+The server generates the comparison column automatically and appends it next to the base metric. Do NOT add the comparison column id to queryConfig.metrics yourself.
+
+DO NOT simulate a period comparison by adding a second time-dimension granularity (e.g. _year) and using groupBy. groupBy is for categorical splits (region, product). Time comparisons use a kind: "periodComparison" customMetric.
+
+For aggregation entries:
+1. Add the entry to customMetrics with kind: "aggregation"
+2. Reference it in queryConfig.metrics using the format "table_name" (e.g. "customers_avg_customer_age")
+3. Reference it the same way in sorts, filters, chartConfig.yAxisMetrics
+
+Example A — "Average customer age sorted descending"
+  customMetrics: [{ kind: "aggregation", name: "avg_customer_age", label: "Average Customer Age", description: "...", type: "AVERAGE", baseDimensionName: "age", table: "customers", filters: null }]
+  queryConfig.metrics: ["customers_avg_customer_age"]
+  sorts: [{ fieldId: "customers_avg_customer_age", descending: true }]
+
+Example B — "Revenue by month with year-over-year comparison"
+  queryConfig.dimensions: ["orders_order_date_month"]
+  queryConfig.metrics: ["orders_revenue"]
+  customMetrics: [{ kind: "periodComparison", baseMetricId: "orders_revenue", timeDimensionId: "orders_order_date_month", granularity: "MONTH", periodOffset: 12 }]",
+          },
+          "dimensions": {
+            "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "exploreName": {
+            "description": "The name of the explore containing the metrics and dimensions used for the chart.",
+            "type": "string",
+          },
+          "filters": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Separate flat expressions for dimensions, metrics, and table calculations. Each category chooses AND or OR independently. Non-null categories combine implicitly with AND. For example, dimensions "D1 AND D2" and metrics "M1 OR M2" mean "(D1 AND D2) AND (M1 OR M2)", where D1, D2, M1, and M2 are complete filter rules. Use null when a category has no filters.",
+                "properties": {
+                  "dimensions": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "Flat filter expression for dimension fields.",
+                  },
+                  "metrics": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "Flat filter expression for metric fields.",
+                  },
+                  "tableCalculations": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "Flat filter expression for table calculations.",
+                  },
+                },
+                "required": [
+                  "dimensions",
+                  "metrics",
+                  "tableCalculations",
+                ],
+                "type": "object",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "description": "Separate flat expressions for dimensions, metrics, and table calculations. Each category chooses AND or OR independently. Non-null categories combine implicitly with AND. For example, dimensions "D1 AND D2" and metrics "M1 OR M2" mean "(D1 AND D2) AND (M1 OR M2)", where D1, D2, M1, and M2 are complete filter rules. Use null when a category has no filters.",
+          },
+          "limit": {
+            "description": "The total number of data points / rows allowed on the chart. null means this tool's maximum, not "no data" — use it unless the user asked for a specific number of rows. Row limits documented for other tools do not apply here.",
+            "type": [
+              "number",
+              "null",
+            ],
+          },
+          "metrics": {
+            "description": "The field ids of the metrics to be calculated. They will be grouped by the dimensions.",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "parameters": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                    },
+                    {
+                      "type": "number",
+                    },
+                    {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "items": {
+                        "type": "number",
+                      },
+                      "type": "array",
+                    },
+                  ],
+                },
+                "type": "object",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "default": null,
+            "description": "Lightdash parameter values for this query, keyed by parameter name exactly as shown in the explore metadata (e.g. {"orders.metric": "active_users"}). REQUIRED whenever a selected field is marked "requires parameters" and the default value does not match what the user asked for — an unset parameter silently resolves to its default, which can return the wrong data. null when the explore has no parameters or the defaults are correct.",
+          },
+          "sorts": {
+            "description": "Sort configuration for the query, it can use a combination of metrics and dimensions.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "descending": {
+                  "description": "If true sorts in descending order, if false sorts in ascending order",
+                  "type": "boolean",
+                },
+                "fieldId": {
+                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                  "type": "string",
+                },
+                "nullsFirst": {
+                  "description": "If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default",
+                  "type": [
+                    "boolean",
+                    "null",
+                  ],
+                },
+              },
+              "required": [
+                "fieldId",
+                "descending",
+                "nullsFirst",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "tableCalculations": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "format": {
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "number",
+                            "percent",
+                          ],
+                          "type": "string",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                      "description": "Display format. Use "percent" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to "number".",
+                    },
+                    "formula": {
+                      "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).
+Reference fields by their field id directly, e.g. \`orders_total_revenue / orders_order_count\`. No prefix, no braces, no leading \`=\`.
+Any selected dimension, metric, custom metric (\`<table>_<name>\`), or another table calculation name can be referenced.
+Operators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.
+Functions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).
+Window functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. \`LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)\`.
+MOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is \`MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)\`.
+All branches of an IF must return the same type.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "pattern": "^[a-zA-Z0-9_]+$",
+                      "type": "string",
+                    },
+                    "resultType": {
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "number",
+                            "string",
+                            "date",
+                            "timestamp",
+                            "boolean",
+                          ],
+                          "type": "string",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                      "description": "Data type the formula evaluates to. null defaults to "number".",
+                    },
+                    "type": {
+                      "const": "formula",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "formula",
+                    "format",
+                    "resultType",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "description": "
+Table calculations perform row-by-row calculations on query results without collapsing rows, using spreadsheet-like formulas.
+
+Use them whenever the question needs math the metric query alone can't express: arithmetic across metrics (\`metric_a + metric_b\`), ratios, percent of total, period-over-period change, running totals, moving averages, ranking, row-level comparisons, or aggregating already-aggregated metrics.
+
+**Technical Requirements:**
+- Appear as additional columns in query results
+- Can be used in sorts and filters alongside dimensions/metrics
+- Multiple calculations can be combined in a single query; a formula can reference another table calculation by name
+- All fields referenced must be selected in the query (dimensions, metrics, custom metrics, or other table calculations)
+",
+          },
+        },
+        "required": [
+          "exploreName",
+          "dimensions",
+          "metrics",
+          "sorts",
+          "limit",
+          "customMetrics",
+          "tableCalculations",
+          "filters",
+        ],
+        "type": "object",
+      },
+      "title": {
+        "description": "A descriptive title for the chart",
+        "type": "string",
+      },
+    },
+    "required": [
+      "title",
+      "description",
+      "queryConfig",
+      "chartConfig",
+    ],
+    "type": "object",
+  },
+  "name": "generateVisualization",
+  "outputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "metadata": {
+        "additionalProperties": false,
+        "properties": {
+          "chartImageUrl": {
+            "type": [
+              "string",
+              "null",
+            ],
+          },
+          "status": {
+            "enum": [
+              "success",
+              "error",
+            ],
+            "type": "string",
+          },
+        },
+        "required": [
+          "status",
+        ],
+        "type": "object",
+      },
+      "result": {
+        "type": "string",
+      },
+    },
+    "required": [
+      "result",
+      "metadata",
+    ],
+    "type": "object",
+  },
+}
+`;
+
 exports[`AI agent tool contracts > matches the shared agent tool definition names snapshot 1`] = `
 [
   "findExplores",

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -70,7 +70,7 @@ const sharedAgentToolDefinitionNames = agentToolDefinitions.map(
     (toolDefinition) => toolDefinition.for('agent').name,
 );
 
-const makeAgentTools = () => {
+const makeAgentTools = (enableFilterExpressions = false) => {
     const noop = vi.fn();
     const noopAsync = vi.fn().mockResolvedValue(undefined);
 
@@ -171,6 +171,7 @@ const makeAgentTools = () => {
             createOrUpdateArtifact: noop,
             enableDataAccess: true,
             enableMergeQueries: true,
+            enableFilterExpressions,
             getPrompt: noop,
             maxLimit: 500,
             projectParameterDefinitions: {},
@@ -235,6 +236,14 @@ describe('AI agent tool contracts', () => {
             Object.entries(agentTools).map(([name, definition]) =>
                 agentToolSnapshot(name, definition as SnapshotTool),
             ),
+        ).toMatchSnapshot();
+    });
+
+    it('matches the filter-expression visualization contract snapshot', () => {
+        const { generateVisualization } = makeAgentTools(true);
+
+        expect(
+            agentToolSnapshot('generateVisualization', generateVisualization),
         ).toMatchSnapshot();
     });
 

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -68,7 +68,7 @@ const sharedAgentToolDefinitionNames = agentToolDefinitions.map(
     (toolDefinition) => toolDefinition.for('agent').name,
 );
 
-const makeAgentTools = () => {
+const makeAgentTools = (enableFilterExpressions = false) => {
     const noop = vi.fn();
     const noopAsync = vi.fn().mockResolvedValue(undefined);
 
@@ -164,6 +164,7 @@ const makeAgentTools = () => {
             createOrUpdateArtifact: noop,
             enableDataAccess: true,
             enableMergeQueries: true,
+            enableFilterExpressions,
             getPrompt: noop,
             maxLimit: 500,
             projectParameterDefinitions: {},
@@ -226,6 +227,14 @@ describe('AI agent tool contracts', () => {
             Object.entries(agentTools).map(([name, definition]) =>
                 agentToolSnapshot(name, definition as SnapshotTool),
             ),
+        ).toMatchSnapshot();
+    });
+
+    it('matches the filter-expression visualization contract snapshot', () => {
+        const { generateVisualization } = makeAgentTools(true);
+
+        expect(
+            agentToolSnapshot('generateVisualization', generateVisualization),
         ).toMatchSnapshot();
     });
 

--- a/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
@@ -1,4 +1,9 @@
-import { type AiWebAppPrompt, type SlackPrompt } from '@lightdash/common';
+import {
+    TimeFrames,
+    type AiWebAppPrompt,
+    type SlackPrompt,
+} from '@lightdash/common';
+import * as Sentry from '@sentry/node';
 import {
     metricQueryMock,
     validExplore,
@@ -9,11 +14,17 @@ import type {
 } from '../types/aiAgentDependencies';
 import { AgentContext } from '../utils/AgentContext';
 import { renderEcharts } from '../utils/renderEcharts';
+import { mockOrdersExplore } from '../utils/validationExplore.mock';
 import { getRunQuery } from './runQuery';
 
 // The Slack path renders a real chart via echarts + node-canvas. A native
 // render has no place in a unit test — it's slow and fails on runners without
 // the canvas binding or fonts — so it's stubbed with a fake PNG buffer.
+vi.mock('@sentry/node', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@sentry/node')>();
+    return { ...actual, captureException: vi.fn() };
+});
+
 vi.mock('../utils/renderEcharts', () => ({
     renderEcharts: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
 }));
@@ -69,6 +80,47 @@ const toolInput = {
         yAxisLabel: 'Metric',
         secondaryYAxisMetric: null,
         secondaryYAxisLabel: null,
+    },
+};
+
+const mergeInput = {
+    ...toolInput,
+    chartConfig: {
+        ...toolInput.chartConfig,
+        xAxisDimension: 'merge_key',
+        yAxisMetrics: ['primary_a_met1', 'comparison_a_met1'],
+    },
+    mergeConfig: {
+        primarySourceId: 'primary',
+        additionalSources: [
+            {
+                id: 'comparison',
+                queryConfig: {
+                    exploreName: validExplore.name,
+                    dimensions: metricQueryMock.dimensions,
+                    metrics: metricQueryMock.metrics,
+                    sorts: [],
+                    customMetrics: null,
+                    filters: null,
+                },
+            },
+        ],
+        joinKey: [
+            {
+                name: 'key',
+                fields: [
+                    {
+                        sourceId: 'primary',
+                        fieldId: metricQueryMock.dimensions[0],
+                    },
+                    {
+                        sourceId: 'comparison',
+                        fieldId: metricQueryMock.dimensions[0],
+                    },
+                ],
+            },
+        ],
+        joinType: 'full' as const,
     },
 };
 
@@ -131,47 +183,6 @@ describe('getRunQuery', () => {
             exposeQueryUuid: false,
             enableDataAccess: true,
         });
-        const mergeInput = {
-            ...toolInput,
-            chartConfig: {
-                ...toolInput.chartConfig,
-                xAxisDimension: 'merge_key',
-                yAxisMetrics: ['primary_a_met1', 'comparison_a_met1'],
-            },
-            mergeConfig: {
-                primarySourceId: 'primary',
-                additionalSources: [
-                    {
-                        id: 'comparison',
-                        queryConfig: {
-                            exploreName: validExplore.name,
-                            dimensions: metricQueryMock.dimensions,
-                            metrics: metricQueryMock.metrics,
-                            sorts: [],
-                            customMetrics: null,
-                            filters: null,
-                        },
-                    },
-                ],
-                joinKey: [
-                    {
-                        name: 'key',
-                        fields: [
-                            {
-                                sourceId: 'primary',
-                                fieldId: metricQueryMock.dimensions[0],
-                            },
-                            {
-                                sourceId: 'comparison',
-                                fieldId: metricQueryMock.dimensions[0],
-                            },
-                        ],
-                    },
-                ],
-                joinType: 'full' as const,
-            },
-        };
-
         const output = await queryTool.execute!(mergeInput, {
             messages: [],
             toolCallId: 'tool-call-1',
@@ -205,6 +216,413 @@ describe('getRunQuery', () => {
             status: 'success',
             queryUuid: '22222222-2222-4222-8222-222222222222',
         });
+    });
+
+    it('resolves and persists each merge source expression in its explore scope', async () => {
+        const runAsyncMergeQuery: RunAsyncMergeQueryFn = vi
+            .fn()
+            .mockResolvedValue({
+                queryUuid: '22222222-2222-4222-8222-222222222222',
+                rows: [{ merge_key: 'one', primary_a_met1: 1 }],
+                cacheMetadata: { cacheHit: false },
+                fields: {},
+                metricQuery: metricQueryMock,
+            });
+        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+        const queryTool = getRunQuery({
+            updateProgress: vi.fn().mockResolvedValue(undefined),
+            runAsyncQuery: vi.fn() as RunAsyncQueryFn,
+            runAsyncMergeQuery,
+            enableMergeQueries: true,
+            enableFilterExpressions: true,
+            projectParameterDefinitions: {},
+            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+            sendFile: vi.fn().mockResolvedValue(undefined),
+            createOrUpdateArtifact,
+            maxLimit: 500,
+            maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
+            enableDataAccess: true,
+        });
+        const expressionMergeInput = {
+            ...mergeInput,
+            queryConfig: {
+                ...mergeInput.queryConfig,
+                filters: {
+                    dimensions: 'a_dim1 equals=primary',
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            },
+            mergeConfig: {
+                ...mergeInput.mergeConfig,
+                additionalSources: mergeInput.mergeConfig.additionalSources.map(
+                    (source) => ({
+                        ...source,
+                        queryConfig: {
+                            ...source.queryConfig,
+                            filters: {
+                                dimensions: 'a_dim1 equals=comparison',
+                                metrics: null,
+                                tableCalculations: null,
+                            },
+                        },
+                    }),
+                ),
+            },
+        };
+
+        const output = await queryTool.execute!(expressionMergeInput, {
+            messages: [],
+            toolCallId: 'tool-call-1',
+            experimental_context: new AgentContext([validExplore]),
+        });
+        if (Symbol.asyncIterator in output) {
+            throw new Error('Expected a non-streaming tool result');
+        }
+
+        expect(output.metadata.status).toBe('success');
+        expect(runAsyncMergeQuery).toHaveBeenCalledOnce();
+        expect(createOrUpdateArtifact).toHaveBeenCalledWith(
+            expect.objectContaining({
+                vizConfig: expect.objectContaining({
+                    source: 'filterExpression',
+                    schemaVersion: 1,
+                    expressionArgs: expect.objectContaining({
+                        queryConfig: expect.objectContaining({
+                            filters: expressionMergeInput.queryConfig.filters,
+                        }),
+                        mergeConfig: expect.objectContaining({
+                            additionalSources: [
+                                expect.objectContaining({
+                                    queryConfig: expect.objectContaining({
+                                        filters:
+                                            expressionMergeInput.mergeConfig
+                                                .additionalSources[0]
+                                                .queryConfig.filters,
+                                    }),
+                                }),
+                            ],
+                        }),
+                    }),
+                    resolvedArgs: expect.objectContaining({
+                        queryConfig: expect.objectContaining({
+                            filters: expect.objectContaining({
+                                dimensions: [
+                                    expect.objectContaining({
+                                        fieldId: 'a_dim1',
+                                        values: ['primary'],
+                                    }),
+                                ],
+                            }),
+                        }),
+                        mergeConfig: expect.objectContaining({
+                            additionalSources: [
+                                expect.objectContaining({
+                                    queryConfig: expect.objectContaining({
+                                        filters: expect.objectContaining({
+                                            dimensions: [
+                                                expect.objectContaining({
+                                                    fieldId: 'a_dim1',
+                                                    values: ['comparison'],
+                                                }),
+                                            ],
+                                        }),
+                                    }),
+                                }),
+                            ],
+                        }),
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it('keeps flag-off semantic artifact writes unchanged', async () => {
+        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+        const runAsyncQuery: RunAsyncQueryFn = vi.fn().mockResolvedValue({
+            queryUuid: '11111111-1111-4111-8111-111111111111',
+            rows: [{ a_dim1: 'one', a_met1: 1 }],
+            cacheMetadata: { cacheHit: false },
+            fields: {},
+        });
+        const queryTool = getRunQuery({
+            updateProgress: vi.fn().mockResolvedValue(undefined),
+            runAsyncQuery,
+            runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
+            enableMergeQueries: false,
+            enableFilterExpressions: false,
+            projectParameterDefinitions: {},
+            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+            sendFile: vi.fn().mockResolvedValue(undefined),
+            createOrUpdateArtifact,
+            maxLimit: 500,
+            maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
+            enableDataAccess: true,
+        });
+
+        await queryTool.execute!(toolInput, {
+            messages: [],
+            toolCallId: 'tool-call-1',
+            experimental_context: new AgentContext([validExplore]),
+        });
+
+        expect(createOrUpdateArtifact).toHaveBeenCalledWith(
+            expect.objectContaining({
+                vizConfig: {
+                    source: 'semantic',
+                    config: toolInput,
+                },
+            }),
+        );
+    });
+
+    it('resolves filter expressions before query execution and persists both forms', async () => {
+        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+        const runAsyncQuery: RunAsyncQueryFn = vi.fn().mockResolvedValue({
+            queryUuid: '11111111-1111-4111-8111-111111111111',
+            rows: [{ a_dim1: 'one', a_met1: 1 }],
+            cacheMetadata: { cacheHit: false },
+            fields: {},
+        });
+        const queryTool = getRunQuery({
+            updateProgress: vi.fn().mockResolvedValue(undefined),
+            runAsyncQuery,
+            runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
+            enableMergeQueries: false,
+            enableFilterExpressions: true,
+            projectParameterDefinitions: {},
+            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+            sendFile: vi.fn().mockResolvedValue(undefined),
+            createOrUpdateArtifact,
+            maxLimit: 500,
+            maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
+            enableDataAccess: true,
+        });
+        const expressionInput = {
+            ...toolInput,
+            queryConfig: {
+                ...toolInput.queryConfig,
+                filters: {
+                    dimensions: 'a_dim1 equals=one',
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            },
+        };
+
+        const output = await queryTool.execute!(expressionInput, {
+            messages: [],
+            toolCallId: 'tool-call-1',
+            experimental_context: new AgentContext([validExplore]),
+        });
+        if (Symbol.asyncIterator in output) {
+            throw new Error('Expected a non-streaming tool result');
+        }
+
+        expect(output.metadata.status).toBe('success');
+        expect(runAsyncQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                filters: expect.objectContaining({
+                    dimensions: expect.objectContaining({
+                        and: [
+                            expect.objectContaining({
+                                target: expect.objectContaining({
+                                    fieldId: 'a_dim1',
+                                }),
+                                values: ['one'],
+                            }),
+                        ],
+                    }),
+                }),
+            }),
+            expect.anything(),
+            undefined,
+        );
+        expect(createOrUpdateArtifact).toHaveBeenCalledWith(
+            expect.objectContaining({
+                vizConfig: expect.objectContaining({
+                    source: 'filterExpression',
+                    schemaVersion: 1,
+                    expressionArgs: expect.objectContaining({
+                        queryConfig: expect.objectContaining({
+                            filters: expressionInput.queryConfig.filters,
+                        }),
+                    }),
+                    resolvedArgs: expect.objectContaining({
+                        queryConfig: expect.objectContaining({
+                            filters: expect.objectContaining({
+                                dimensions: [
+                                    expect.objectContaining({
+                                        fieldId: 'a_dim1',
+                                        values: ['one'],
+                                    }),
+                                ],
+                            }),
+                        }),
+                        mergeConfig: null,
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it('expands period-comparison chart metrics in both persisted forms', async () => {
+        const popExplore = {
+            ...mockOrdersExplore,
+            tables: {
+                ...mockOrdersExplore.tables,
+                orders: {
+                    ...mockOrdersExplore.tables.orders,
+                    dimensions: {
+                        ...mockOrdersExplore.tables.orders.dimensions,
+                        order_date: {
+                            ...mockOrdersExplore.tables.orders.dimensions
+                                .order_date,
+                            timeInterval: TimeFrames.MONTH,
+                        },
+                    },
+                },
+            },
+        };
+        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+        const runAsyncQuery: RunAsyncQueryFn = vi.fn().mockResolvedValue({
+            queryUuid: '11111111-1111-4111-8111-111111111111',
+            rows: [{ orders_order_date: '2025-01-01' }],
+            cacheMetadata: { cacheHit: false },
+            fields: {},
+        });
+        const queryTool = getRunQuery({
+            updateProgress: vi.fn().mockResolvedValue(undefined),
+            runAsyncQuery,
+            runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
+            enableMergeQueries: false,
+            enableFilterExpressions: true,
+            projectParameterDefinitions: {},
+            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+            sendFile: vi.fn().mockResolvedValue(undefined),
+            createOrUpdateArtifact,
+            maxLimit: 500,
+            maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
+            enableDataAccess: true,
+        });
+        const expressionInput = {
+            title: 'Revenue by month',
+            description: 'Monthly revenue and prior period',
+            queryConfig: {
+                exploreName: popExplore.name,
+                dimensions: ['orders_order_date'],
+                metrics: ['orders_total_revenue'],
+                sorts: [],
+                limit: 500,
+                parameters: null,
+                customMetrics: [
+                    {
+                        kind: 'periodComparison' as const,
+                        baseMetricId: 'orders_total_revenue',
+                        timeDimensionId: 'orders_order_date',
+                        granularity: TimeFrames.MONTH,
+                        periodOffset: 1,
+                    },
+                ],
+                tableCalculations: null,
+                filters: null,
+            },
+            chartConfig: {
+                ...toolInput.chartConfig,
+                xAxisDimension: 'orders_order_date',
+                yAxisMetrics: ['orders_total_revenue'],
+                xAxisType: 'time' as const,
+            },
+        };
+
+        await queryTool.execute!(expressionInput, {
+            messages: [],
+            toolCallId: 'tool-call-1',
+            experimental_context: new AgentContext([popExplore]),
+        });
+
+        expect(createOrUpdateArtifact).toHaveBeenCalledWith(
+            expect.objectContaining({
+                vizConfig: expect.objectContaining({
+                    source: 'filterExpression',
+                    expressionArgs: expect.objectContaining({
+                        chartConfig: expect.objectContaining({
+                            yAxisMetrics: [
+                                'orders_total_revenue',
+                                expect.any(String),
+                            ],
+                        }),
+                    }),
+                    resolvedArgs: expect.objectContaining({
+                        chartConfig: expect.objectContaining({
+                            yAxisMetrics: [
+                                'orders_total_revenue',
+                                expect.any(String),
+                            ],
+                        }),
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it('returns located filter-expression errors without execution or Sentry capture', async () => {
+        vi.mocked(Sentry.captureException).mockClear();
+        const runAsyncQuery = vi.fn() as RunAsyncQueryFn;
+        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+        const queryTool = getRunQuery({
+            updateProgress: vi.fn().mockResolvedValue(undefined),
+            runAsyncQuery,
+            runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
+            enableMergeQueries: false,
+            enableFilterExpressions: true,
+            projectParameterDefinitions: {},
+            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+            sendFile: vi.fn().mockResolvedValue(undefined),
+            createOrUpdateArtifact,
+            maxLimit: 500,
+            maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
+            enableDataAccess: true,
+        });
+
+        const output = await queryTool.execute!(
+            {
+                ...toolInput,
+                queryConfig: {
+                    ...toolInput.queryConfig,
+                    filters: {
+                        dimensions: 'unknown_field equals=one',
+                        metrics: null,
+                        tableCalculations: null,
+                    },
+                },
+            },
+            {
+                messages: [],
+                toolCallId: 'tool-call-1',
+                experimental_context: new AgentContext([validExplore]),
+            },
+        );
+        if (Symbol.asyncIterator in output) {
+            throw new Error('Expected a non-streaming tool result');
+        }
+
+        expect(output).toMatchObject({
+            result: expect.stringContaining(
+                '[FILTER_EXPRESSION_UNKNOWN_FIELD]',
+            ),
+            metadata: { status: 'error' },
+        });
+        expect(output.result).toContain('Problem:');
+        expect(output.result).toContain('How to fix:');
+        expect(runAsyncQuery).not.toHaveBeenCalled();
+        expect(createOrUpdateArtifact).not.toHaveBeenCalled();
+        expect(Sentry.captureException).not.toHaveBeenCalled();
     });
 
     it('returns the query UUID in successful visualization metadata', async () => {

--- a/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
@@ -1,8 +1,11 @@
 import {
+    MergeJoinType,
+    TimeFrames,
     type AiWebAppPrompt,
     type SlackPrompt,
     type ToolRunQueryCustomChartTypeConfig,
 } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
 import {
     metricQueryMock,
     validExplore,
@@ -16,7 +19,13 @@ import type {
 } from '../types/aiAgentDependencies';
 import { AgentContext } from '../utils/AgentContext';
 import { renderEcharts } from '../utils/renderEcharts';
+import { mockOrdersExplore } from '../utils/validationExplore.mock';
 import { getRunQuery } from './runQuery';
+
+vi.mock('@sentry/node', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@sentry/node')>();
+    return { ...actual, captureException: vi.fn() };
+});
 
 // The Slack path renders a real chart via echarts + node-canvas. A native
 // render has no place in a unit test — it's slow and fails on runners without
@@ -79,6 +88,47 @@ const toolInput = {
     },
 };
 
+const mergeInput = {
+    ...toolInput,
+    chartConfig: {
+        ...toolInput.chartConfig,
+        xAxisDimension: 'merge_key',
+        yAxisMetrics: ['primary_a_met1', 'comparison_a_met1'],
+    },
+    mergeConfig: {
+        primarySourceId: 'primary',
+        additionalSources: [
+            {
+                id: 'comparison',
+                queryConfig: {
+                    exploreName: validExplore.name,
+                    dimensions: metricQueryMock.dimensions,
+                    metrics: metricQueryMock.metrics,
+                    sorts: [],
+                    customMetrics: null,
+                    filters: null,
+                },
+            },
+        ],
+        joinKey: [
+            {
+                name: 'key',
+                fields: [
+                    {
+                        sourceId: 'primary',
+                        fieldId: metricQueryMock.dimensions[0],
+                    },
+                    {
+                        sourceId: 'comparison',
+                        fieldId: metricQueryMock.dimensions[0],
+                    },
+                ],
+            },
+        ],
+        joinType: MergeJoinType.FULL,
+    },
+};
+
 const executeTool = async (
     runAsyncQuery: RunAsyncQueryFn,
     enableDataAccess = true,
@@ -90,6 +140,7 @@ const executeTool = async (
         runAsyncQuery,
         runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
         enableMergeQueries: false,
+        enableFilterExpressions: false,
         projectParameterDefinitions: {},
         getPrompt: vi.fn().mockResolvedValue(prompt),
         sendFile: vi.fn().mockResolvedValue(undefined),
@@ -131,6 +182,7 @@ describe('getRunQuery', () => {
             runAsyncQuery,
             runAsyncMergeQuery,
             enableMergeQueries: true,
+            enableFilterExpressions: false,
             projectParameterDefinitions: {},
             getPrompt: vi.fn().mockResolvedValue(makePrompt()),
             sendFile: vi.fn().mockResolvedValue(undefined),
@@ -142,47 +194,6 @@ describe('getRunQuery', () => {
             resolveCustomChartType: vi.fn().mockResolvedValue(null),
             exportCustomChartTypeImage: vi.fn() as ExportCustomChartTypeImageFn,
         });
-        const mergeInput = {
-            ...toolInput,
-            chartConfig: {
-                ...toolInput.chartConfig,
-                xAxisDimension: 'merge_key',
-                yAxisMetrics: ['primary_a_met1', 'comparison_a_met1'],
-            },
-            mergeConfig: {
-                primarySourceId: 'primary',
-                additionalSources: [
-                    {
-                        id: 'comparison',
-                        queryConfig: {
-                            exploreName: validExplore.name,
-                            dimensions: metricQueryMock.dimensions,
-                            metrics: metricQueryMock.metrics,
-                            sorts: [],
-                            customMetrics: null,
-                            filters: null,
-                        },
-                    },
-                ],
-                joinKey: [
-                    {
-                        name: 'key',
-                        fields: [
-                            {
-                                sourceId: 'primary',
-                                fieldId: metricQueryMock.dimensions[0],
-                            },
-                            {
-                                sourceId: 'comparison',
-                                fieldId: metricQueryMock.dimensions[0],
-                            },
-                        ],
-                    },
-                ],
-                joinType: 'full' as const,
-            },
-        };
-
         const output = await queryTool.execute!(mergeInput, {
             messages: [],
             toolCallId: 'tool-call-1',
@@ -216,6 +227,395 @@ describe('getRunQuery', () => {
             status: 'success',
             queryUuid: '22222222-2222-4222-8222-222222222222',
         });
+    });
+
+    it('resolves and persists each merge source expression in its explore scope', async () => {
+        const runAsyncMergeQuery: RunAsyncMergeQueryFn = vi
+            .fn()
+            .mockResolvedValue({
+                queryUuid: '22222222-2222-4222-8222-222222222222',
+                rows: [{ merge_key: 'one', primary_a_met1: 1 }],
+                cacheMetadata: { cacheHit: false },
+                fields: {},
+                metricQuery: metricQueryMock,
+            });
+        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+        const queryTool = getRunQuery({
+            updateProgress: vi.fn().mockResolvedValue(undefined),
+            runAsyncQuery: vi.fn() as RunAsyncQueryFn,
+            runAsyncMergeQuery,
+            enableMergeQueries: true,
+            enableFilterExpressions: true,
+            projectParameterDefinitions: {},
+            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+            sendFile: vi.fn().mockResolvedValue(undefined),
+            createOrUpdateArtifact,
+            maxLimit: 500,
+            maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
+            enableDataAccess: true,
+            resolveCustomChartType: vi.fn().mockResolvedValue(null),
+            exportCustomChartTypeImage: vi.fn() as ExportCustomChartTypeImageFn,
+        });
+        const expressionMergeInput = {
+            ...mergeInput,
+            queryConfig: {
+                ...mergeInput.queryConfig,
+                filters: {
+                    dimensions: 'a_dim1 equals=primary',
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            },
+            mergeConfig: {
+                ...mergeInput.mergeConfig,
+                additionalSources: mergeInput.mergeConfig.additionalSources.map(
+                    (source) => ({
+                        ...source,
+                        queryConfig: {
+                            ...source.queryConfig,
+                            filters: {
+                                dimensions: 'a_dim1 equals=comparison',
+                                metrics: null,
+                                tableCalculations: null,
+                            },
+                        },
+                    }),
+                ),
+            },
+        };
+
+        const output = await queryTool.execute!(expressionMergeInput, {
+            messages: [],
+            toolCallId: 'tool-call-1',
+            experimental_context: new AgentContext([validExplore]),
+        });
+        if (Symbol.asyncIterator in output) {
+            throw new Error('Expected a non-streaming tool result');
+        }
+
+        expect(output.metadata.status).toBe('success');
+        expect(runAsyncMergeQuery).toHaveBeenCalledOnce();
+        expect(createOrUpdateArtifact).toHaveBeenCalledWith(
+            expect.objectContaining({
+                vizConfig: expect.objectContaining({
+                    source: 'merge',
+                    schemaVersion: 1,
+                    config: expect.objectContaining({
+                        queryConfig: expect.objectContaining({
+                            filters: expect.objectContaining({
+                                dimensions: [
+                                    expect.objectContaining({
+                                        fieldId: 'a_dim1',
+                                        values: ['primary'],
+                                    }),
+                                ],
+                            }),
+                        }),
+                        mergeConfig: expect.objectContaining({
+                            additionalSources: [
+                                expect.objectContaining({
+                                    queryConfig: expect.objectContaining({
+                                        filters: expect.objectContaining({
+                                            dimensions: [
+                                                expect.objectContaining({
+                                                    fieldId: 'a_dim1',
+                                                    values: ['comparison'],
+                                                }),
+                                            ],
+                                        }),
+                                    }),
+                                }),
+                            ],
+                        }),
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it('keeps flag-off semantic artifact writes unchanged', async () => {
+        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+        const runAsyncQuery: RunAsyncQueryFn = vi.fn().mockResolvedValue({
+            queryUuid: '11111111-1111-4111-8111-111111111111',
+            rows: [{ a_dim1: 'one', a_met1: 1 }],
+            cacheMetadata: { cacheHit: false },
+            fields: {},
+        });
+        const queryTool = getRunQuery({
+            updateProgress: vi.fn().mockResolvedValue(undefined),
+            runAsyncQuery,
+            runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
+            enableMergeQueries: false,
+            enableFilterExpressions: false,
+            projectParameterDefinitions: {},
+            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+            sendFile: vi.fn().mockResolvedValue(undefined),
+            createOrUpdateArtifact,
+            maxLimit: 500,
+            maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
+            enableDataAccess: true,
+            resolveCustomChartType: vi.fn().mockResolvedValue(null),
+            exportCustomChartTypeImage: vi.fn() as ExportCustomChartTypeImageFn,
+        });
+
+        await queryTool.execute!(toolInput, {
+            messages: [],
+            toolCallId: 'tool-call-1',
+            experimental_context: new AgentContext([validExplore]),
+        });
+
+        expect(createOrUpdateArtifact).toHaveBeenCalledWith(
+            expect.objectContaining({
+                vizConfig: {
+                    source: 'semantic',
+                    config: toolInput,
+                },
+            }),
+        );
+    });
+
+    it('resolves filter expressions before execution and persists replay args', async () => {
+        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+        const runAsyncQuery: RunAsyncQueryFn = vi.fn().mockResolvedValue({
+            queryUuid: '11111111-1111-4111-8111-111111111111',
+            rows: [{ a_dim1: 'one', a_met1: 1 }],
+            cacheMetadata: { cacheHit: false },
+            fields: {},
+        });
+        const queryTool = getRunQuery({
+            updateProgress: vi.fn().mockResolvedValue(undefined),
+            runAsyncQuery,
+            runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
+            enableMergeQueries: false,
+            enableFilterExpressions: true,
+            projectParameterDefinitions: {},
+            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+            sendFile: vi.fn().mockResolvedValue(undefined),
+            createOrUpdateArtifact,
+            maxLimit: 500,
+            maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
+            enableDataAccess: true,
+            resolveCustomChartType: vi.fn().mockResolvedValue(null),
+            exportCustomChartTypeImage: vi.fn() as ExportCustomChartTypeImageFn,
+        });
+        const expressionInput = {
+            ...toolInput,
+            queryConfig: {
+                ...toolInput.queryConfig,
+                filters: {
+                    dimensions: 'a_dim1 equals=one',
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            },
+        };
+
+        const output = await queryTool.execute!(expressionInput, {
+            messages: [],
+            toolCallId: 'tool-call-1',
+            experimental_context: new AgentContext([validExplore]),
+        });
+        if (Symbol.asyncIterator in output) {
+            throw new Error('Expected a non-streaming tool result');
+        }
+
+        expect(output.metadata.status).toBe('success');
+        expect(runAsyncQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                filters: expect.objectContaining({
+                    dimensions: expect.objectContaining({
+                        and: [
+                            expect.objectContaining({
+                                target: expect.objectContaining({
+                                    fieldId: 'a_dim1',
+                                }),
+                                values: ['one'],
+                            }),
+                        ],
+                    }),
+                }),
+            }),
+            expect.anything(),
+            undefined,
+        );
+        expect(createOrUpdateArtifact).toHaveBeenCalledWith(
+            expect.objectContaining({
+                vizConfig: expect.objectContaining({
+                    source: 'semantic',
+                    config: expect.objectContaining({
+                        queryConfig: expect.objectContaining({
+                            filters: expect.objectContaining({
+                                dimensions: [
+                                    expect.objectContaining({
+                                        fieldId: 'a_dim1',
+                                        values: ['one'],
+                                    }),
+                                ],
+                            }),
+                        }),
+                        mergeConfig: null,
+                    }),
+                }),
+            }),
+        );
+        expect(createOrUpdateArtifact.mock.calls[0]?.[0]).not.toHaveProperty(
+            'vizConfig.inputProvenance',
+        );
+    });
+
+    it('expands period-comparison output in persisted replay args', async () => {
+        const popExplore = {
+            ...mockOrdersExplore,
+            tables: {
+                ...mockOrdersExplore.tables,
+                orders: {
+                    ...mockOrdersExplore.tables.orders,
+                    dimensions: {
+                        ...mockOrdersExplore.tables.orders.dimensions,
+                        order_date: {
+                            ...mockOrdersExplore.tables.orders.dimensions
+                                .order_date,
+                            timeInterval: TimeFrames.MONTH,
+                        },
+                    },
+                },
+            },
+        };
+        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+        const runAsyncQuery: RunAsyncQueryFn = vi.fn().mockResolvedValue({
+            queryUuid: '11111111-1111-4111-8111-111111111111',
+            rows: [{ orders_order_date: '2025-01-01' }],
+            cacheMetadata: { cacheHit: false },
+            fields: {},
+        });
+        const queryTool = getRunQuery({
+            updateProgress: vi.fn().mockResolvedValue(undefined),
+            runAsyncQuery,
+            runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
+            enableMergeQueries: false,
+            enableFilterExpressions: true,
+            projectParameterDefinitions: {},
+            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+            sendFile: vi.fn().mockResolvedValue(undefined),
+            createOrUpdateArtifact,
+            maxLimit: 500,
+            maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
+            enableDataAccess: true,
+            resolveCustomChartType: vi.fn().mockResolvedValue(null),
+            exportCustomChartTypeImage: vi.fn() as ExportCustomChartTypeImageFn,
+        });
+        const expressionInput = {
+            title: 'Revenue by month',
+            description: 'Monthly revenue and prior period',
+            queryConfig: {
+                exploreName: popExplore.name,
+                dimensions: ['orders_order_date'],
+                metrics: ['orders_total_revenue'],
+                sorts: [],
+                limit: 500,
+                parameters: null,
+                customMetrics: [
+                    {
+                        kind: 'periodComparison' as const,
+                        baseMetricId: 'orders_total_revenue',
+                        timeDimensionId: 'orders_order_date',
+                        granularity: TimeFrames.MONTH,
+                        periodOffset: 1,
+                    },
+                ],
+                tableCalculations: null,
+                filters: null,
+            },
+            chartConfig: {
+                ...toolInput.chartConfig,
+                xAxisDimension: 'orders_order_date',
+                yAxisMetrics: ['orders_total_revenue'],
+                xAxisType: 'time' as const,
+            },
+        };
+
+        await queryTool.execute!(expressionInput, {
+            messages: [],
+            toolCallId: 'tool-call-1',
+            experimental_context: new AgentContext([popExplore]),
+        });
+
+        expect(createOrUpdateArtifact).toHaveBeenCalledWith(
+            expect.objectContaining({
+                vizConfig: expect.objectContaining({
+                    source: 'semantic',
+                    config: expect.objectContaining({
+                        chartConfig: expect.objectContaining({
+                            yAxisMetrics: [
+                                'orders_total_revenue',
+                                expect.any(String),
+                            ],
+                        }),
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it('returns located filter-expression errors without execution or Sentry capture', async () => {
+        vi.mocked(Sentry.captureException).mockClear();
+        const runAsyncQuery = vi.fn() as RunAsyncQueryFn;
+        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+        const queryTool = getRunQuery({
+            updateProgress: vi.fn().mockResolvedValue(undefined),
+            runAsyncQuery,
+            runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
+            enableMergeQueries: false,
+            enableFilterExpressions: true,
+            projectParameterDefinitions: {},
+            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+            sendFile: vi.fn().mockResolvedValue(undefined),
+            createOrUpdateArtifact,
+            maxLimit: 500,
+            maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
+            enableDataAccess: true,
+            resolveCustomChartType: vi.fn().mockResolvedValue(null),
+            exportCustomChartTypeImage: vi.fn() as ExportCustomChartTypeImageFn,
+        });
+
+        const output = await queryTool.execute!(
+            {
+                ...toolInput,
+                queryConfig: {
+                    ...toolInput.queryConfig,
+                    filters: {
+                        dimensions: 'unknown_field equals=one',
+                        metrics: null,
+                        tableCalculations: null,
+                    },
+                },
+            },
+            {
+                messages: [],
+                toolCallId: 'tool-call-1',
+                experimental_context: new AgentContext([validExplore]),
+            },
+        );
+        if (Symbol.asyncIterator in output) {
+            throw new Error('Expected a non-streaming tool result');
+        }
+
+        expect(output).toMatchObject({
+            result: expect.stringContaining(
+                '[FILTER_EXPRESSION_UNKNOWN_FIELD]',
+            ),
+            metadata: { status: 'error' },
+        });
+        expect(output.result).toContain('Problem:');
+        expect(output.result).toContain('How to fix:');
+        expect(runAsyncQuery).not.toHaveBeenCalled();
+        expect(createOrUpdateArtifact).not.toHaveBeenCalled();
+        expect(Sentry.captureException).not.toHaveBeenCalled();
     });
 
     it('returns the query UUID in successful visualization metadata', async () => {
@@ -331,11 +731,13 @@ describe('getRunQuery custom chart types', () => {
             .fn()
             .mockResolvedValue(makeQueryResults()) as RunAsyncQueryFn,
         exportCustomChartTypeImage = vi.fn() as ExportCustomChartTypeImageFn,
+        enableFilterExpressions = false,
     }: {
         chartConfig: ToolRunQueryCustomChartTypeConfig;
         resolveCustomChartType?: ResolveCustomChartTypeFn;
         runAsyncQuery?: RunAsyncQueryFn;
         exportCustomChartTypeImage?: ExportCustomChartTypeImageFn;
+        enableFilterExpressions?: boolean;
     }) => {
         const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
         const queryTool = getRunQuery({
@@ -343,6 +745,7 @@ describe('getRunQuery custom chart types', () => {
             runAsyncQuery,
             runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
             enableMergeQueries: false,
+            enableFilterExpressions,
             projectParameterDefinitions: {},
             getPrompt: vi.fn().mockResolvedValue(makePrompt()),
             sendFile: vi.fn().mockResolvedValue(undefined),
@@ -354,7 +757,20 @@ describe('getRunQuery custom chart types', () => {
             resolveCustomChartType,
             exportCustomChartTypeImage,
         });
-        const input = { ...toolInput, chartConfig };
+        const input = {
+            ...toolInput,
+            queryConfig: {
+                ...toolInput.queryConfig,
+                filters: enableFilterExpressions
+                    ? {
+                          dimensions: 'a_dim1 equals=one',
+                          metrics: null,
+                          tableCalculations: null,
+                      }
+                    : null,
+            },
+            chartConfig,
+        };
         const output = await queryTool.execute!(input, {
             messages: [],
             toolCallId: 'tool-call-1',
@@ -387,6 +803,37 @@ describe('getRunQuery custom chart types', () => {
                     // Model output stored unmodified — slug config intact.
                     config: input,
                 },
+            }),
+        );
+    });
+
+    it('persists resolved expression args for custom chart types', async () => {
+        const { output, createOrUpdateArtifact } = await executeCustom({
+            chartConfig: customChartConfig,
+            enableFilterExpressions: true,
+        });
+
+        expect(output.metadata).toMatchObject({ status: 'success' });
+        expect(createOrUpdateArtifact).toHaveBeenCalledWith(
+            expect.objectContaining({
+                vizConfig: expect.objectContaining({
+                    source: 'customChartType',
+                    schemaVersion: 1,
+                    dataAppVizUuid: '4c25c1d5-cbc9-4d76-b58e-b1c9ee399fd9',
+                    config: expect.objectContaining({
+                        queryConfig: expect.objectContaining({
+                            filters: expect.objectContaining({
+                                dimensions: [
+                                    expect.objectContaining({
+                                        fieldId: 'a_dim1',
+                                        values: ['one'],
+                                    }),
+                                ],
+                            }),
+                        }),
+                        chartConfig: customChartConfig,
+                    }),
+                }),
             }),
         );
     });
@@ -492,6 +939,7 @@ describe('getRunQuery custom chart types', () => {
             runAsyncQuery,
             runAsyncMergeQuery,
             enableMergeQueries: true,
+            enableFilterExpressions: false,
             projectParameterDefinitions: {},
             getPrompt: vi.fn().mockResolvedValue(makePrompt()),
             sendFile: vi.fn().mockResolvedValue(undefined),
@@ -540,7 +988,7 @@ describe('getRunQuery custom chart types', () => {
                         ],
                     },
                 ],
-                joinType: 'full' as const,
+                joinType: MergeJoinType.FULL,
             },
         };
         const output = await queryTool.execute!(mergeCustomInput, {
@@ -602,6 +1050,7 @@ describe('getRunQuery custom chart types', () => {
                     .mockResolvedValue(makeQueryResults()) as RunAsyncQueryFn,
                 runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
                 enableMergeQueries: false,
+                enableFilterExpressions: false,
                 projectParameterDefinitions: {},
                 getPrompt: vi.fn().mockResolvedValue(makeSlackPrompt()),
                 sendFile,
@@ -813,6 +1262,7 @@ describe('getRunQuery parameters', () => {
             runAsyncQuery,
             runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
             enableMergeQueries: false,
+            enableFilterExpressions: false,
             projectParameterDefinitions: {},
             getPrompt: vi.fn().mockResolvedValue(makePrompt()),
             sendFile: vi.fn().mockResolvedValue(undefined),
@@ -935,6 +1385,7 @@ describe('getRunQuery parameters', () => {
             runAsyncQuery,
             runAsyncMergeQuery: vi.fn() as RunAsyncMergeQueryFn,
             enableMergeQueries: false,
+            enableFilterExpressions: false,
             projectParameterDefinitions: {},
             getPrompt: vi.fn().mockResolvedValue(makePrompt()),
             sendFile: vi.fn().mockResolvedValue(undefined),

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -3,10 +3,12 @@ import {
     AiResultType,
     convertAiTableCalcsSchemaToTableCalcs,
     filterAggregationCustomMetrics,
+    generateVisualizationFilterExpressionToolDefinition,
     generateVisualizationToolDefinition,
     getItemId,
     getReferencedExploreParameterDefinitions,
     getRunQueryAgentViewRejectingMerge,
+    getRunQueryFilterExpressionAgentViewRejectingMerge,
     getSlackAiEchartsConfig,
     getTotalFilterRules,
     getValidAiQueryLimit,
@@ -14,14 +16,20 @@ import {
     isSlackPrompt,
     MERGE_TABLE_NAME,
     toolRunQueryArgsSchemaTransformed,
+    toolRunQueryExpressionArgsSchema,
+    toolRunQueryExpressionArgsSchemaV2RejectingMerge,
+    type AiFilterExpressionArtifactConfigV1,
     type Explore,
     type ItemsMap,
     type ParameterDefinitions,
     type ParametersValuesMap,
     type SlackPrompt,
+    type ToolRunQueryArgs,
     type ToolRunQueryArgsTransformed,
+    type ToolRunQueryExpressionArgs,
+    type ToolRunQueryExpressionArgsV2,
 } from '@lightdash/common';
-import { tool } from 'ai';
+import { tool, type Schema } from 'ai';
 import { NO_RESULTS_RETRY_PROMPT } from '../prompts/noResultsRetry';
 import type {
     CreateOrUpdateArtifactFn,
@@ -37,6 +45,10 @@ import {
     buildAiMergeSourceConfigs,
 } from '../utils/buildAiMergeQuery';
 import { convertQueryResultsToCsv } from '../utils/convertQueryResultsToCsv';
+import {
+    formatFilterExpressionError,
+    resolveFilterExpressionArgs,
+} from '../utils/filterExpressions';
 import { getPivotedResults } from '../utils/getPivotedResults';
 import {
     expandMetricsWithPopAdditionalMetrics,
@@ -65,6 +77,11 @@ import {
     validateTableCalculations,
 } from '../utils/validators';
 
+type RunQueryToolInput =
+    | ToolRunQueryArgs
+    | ToolRunQueryExpressionArgs
+    | ToolRunQueryExpressionArgsV2;
+
 type Dependencies = {
     updateProgress: UpdateProgressFn;
     runAsyncQuery: RunAsyncQueryFn;
@@ -79,6 +96,7 @@ type Dependencies = {
     // Project-level parameter definitions; model-level ones come from the explore.
     projectParameterDefinitions: ParameterDefinitions;
     enableMergeQueries: boolean;
+    enableFilterExpressions?: boolean;
     runAsyncMergeQuery: RunAsyncMergeQueryFn;
 };
 
@@ -289,19 +307,67 @@ export const getRunQuery = ({
     enableDataAccess,
     projectParameterDefinitions,
     enableMergeQueries,
+    enableFilterExpressions = false,
     runAsyncMergeQuery,
-}: Dependencies) =>
-    tool({
-        ...(enableMergeQueries
+}: Dependencies) => {
+    const toolView = (() => {
+        if (enableFilterExpressions) {
+            return enableMergeQueries
+                ? generateVisualizationFilterExpressionToolDefinition.for(
+                      'agent',
+                  )
+                : getRunQueryFilterExpressionAgentViewRejectingMerge();
+        }
+        return enableMergeQueries
             ? generateVisualizationToolDefinition.for('agent')
-            : getRunQueryAgentViewRejectingMerge()),
+            : getRunQueryAgentViewRejectingMerge();
+    })();
+    const inputSchema: Schema<RunQueryToolInput> = toolView.inputSchema;
+
+    return tool({
+        ...toolView,
+        inputSchema,
         execute: async (toolArgs, { experimental_context: context }) => {
             try {
                 await updateProgress('Running your query...');
 
-                const queryTool =
-                    toolRunQueryArgsSchemaTransformed.parse(toolArgs);
                 const ctx = AgentContext.from(context);
+                let queryTool: ToolRunQueryArgsTransformed;
+                let filterExpressionArtifact: AiFilterExpressionArtifactConfigV1 | null =
+                    null;
+
+                if (enableFilterExpressions) {
+                    const expressionToolArgs = enableMergeQueries
+                        ? toolRunQueryExpressionArgsSchema.parse(toolArgs)
+                        : toolRunQueryExpressionArgsSchemaV2RejectingMerge.parse(
+                              toolArgs,
+                          );
+                    const resolution = await resolveFilterExpressionArgs({
+                        toolArgs: expressionToolArgs,
+                        getExplore: (exploreName) =>
+                            ctx.getExplore(exploreName),
+                    });
+                    if (!resolution.success) {
+                        return {
+                            result: formatFilterExpressionError(
+                                resolution.error,
+                            ),
+                            metadata: { status: 'error' as const },
+                        };
+                    }
+
+                    queryTool = resolution.data.transformed;
+                    filterExpressionArtifact = {
+                        source: 'filterExpression',
+                        schemaVersion: 1,
+                        expressionArgs: expressionToolArgs,
+                        resolvedArgs: resolution.data.rawArgs,
+                    };
+                } else {
+                    queryTool =
+                        toolRunQueryArgsSchemaTransformed.parse(toolArgs);
+                }
+
                 const explore = ctx.getExplore(
                     queryTool.queryConfig.exploreName,
                 );
@@ -402,7 +468,7 @@ export const getRunQuery = ({
                             artifactType: 'chart',
                             title: toolArgs.title,
                             description: toolArgs.description,
-                            vizConfig: {
+                            vizConfig: filterExpressionArtifact ?? {
                                 source: 'merge',
                                 schemaVersion: 1,
                                 config: toolArgs,
@@ -501,6 +567,45 @@ export const getRunQuery = ({
                           }
                         : toolArgs;
 
+                const expandedFilterExpressionArtifact =
+                    filterExpressionArtifact &&
+                    expandedMetrics.length >
+                        queryTool.queryConfig.metrics.length &&
+                    filterExpressionArtifact.expressionArgs.chartConfig &&
+                    filterExpressionArtifact.resolvedArgs.chartConfig
+                        ? {
+                              ...filterExpressionArtifact,
+                              expressionArgs: {
+                                  ...filterExpressionArtifact.expressionArgs,
+                                  chartConfig: {
+                                      ...filterExpressionArtifact.expressionArgs
+                                          .chartConfig,
+                                      yAxisMetrics:
+                                          expandMetricsWithPopAdditionalMetrics(
+                                              filterExpressionArtifact
+                                                  .expressionArgs.chartConfig
+                                                  .yAxisMetrics,
+                                              populatedCustomMetrics,
+                                          ),
+                                  },
+                              },
+                              resolvedArgs: {
+                                  ...filterExpressionArtifact.resolvedArgs,
+                                  chartConfig: {
+                                      ...filterExpressionArtifact.resolvedArgs
+                                          .chartConfig,
+                                      yAxisMetrics:
+                                          expandMetricsWithPopAdditionalMetrics(
+                                              filterExpressionArtifact
+                                                  .resolvedArgs.chartConfig
+                                                  .yAxisMetrics,
+                                              populatedCustomMetrics,
+                                          ),
+                                  },
+                              },
+                          }
+                        : filterExpressionArtifact;
+
                 const createOrUpdateArtifactHook = () =>
                     createOrUpdateArtifact({
                         threadUuid: prompt.threadUuid,
@@ -508,7 +613,7 @@ export const getRunQuery = ({
                         artifactType: 'chart',
                         title: toolArgs.title,
                         description: toolArgs.description,
-                        vizConfig: {
+                        vizConfig: expandedFilterExpressionArtifact ?? {
                             source: 'semantic',
                             config: expandedToolArgs,
                         },
@@ -637,3 +742,4 @@ export const getRunQuery = ({
         },
         toModelOutput: ({ output }) => toModelOutput(output),
     });
+};

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -3,10 +3,12 @@ import {
     AiResultType,
     convertAiTableCalcsSchemaToTableCalcs,
     filterAggregationCustomMetrics,
+    generateVisualizationFilterExpressionToolDefinition,
     generateVisualizationToolDefinition,
     getItemId,
     getReferencedExploreParameterDefinitions,
     getRunQueryAgentViewRejectingMerge,
+    getRunQueryFilterExpressionAgentViewRejectingMerge,
     getSlackAiEchartsConfig,
     getTotalFilterRules,
     getValidAiQueryLimit,
@@ -15,14 +17,23 @@ import {
     isSlackPrompt,
     MERGE_TABLE_NAME,
     toolRunQueryArgsSchemaTransformed,
+    toolRunQueryExpressionArgsSchema,
+    toolRunQueryExpressionArgsSchemaV2RejectingMerge,
+    type AiCustomChartTypeChartArtifactConfig,
+    type AiMergeChartArtifactConfig,
+    type AiSemanticChartArtifactConfig,
     type Explore,
     type ItemsMap,
     type ParameterDefinitions,
     type ParametersValuesMap,
     type SlackPrompt,
+    type ToolRunQueryArgs,
     type ToolRunQueryArgsTransformed,
+    type ToolRunQueryExpressionArgs,
+    type ToolRunQueryExpressionResolvedArgs,
+    type ToolRunQueryExpressionRuntimeArgs,
 } from '@lightdash/common';
-import { tool } from 'ai';
+import { tool, type Schema } from 'ai';
 import { NO_RESULTS_RETRY_PROMPT } from '../prompts/noResultsRetry';
 import type {
     CreateOrUpdateArtifactFn,
@@ -40,6 +51,10 @@ import {
     buildAiMergeSourceConfigs,
 } from '../utils/buildAiMergeQuery';
 import { convertQueryResultsToCsv } from '../utils/convertQueryResultsToCsv';
+import {
+    formatFilterExpressionError,
+    resolveFilterExpressionArgs,
+} from '../utils/filterExpressions';
 import { getPivotedResults } from '../utils/getPivotedResults';
 import {
     expandMetricsWithPopAdditionalMetrics,
@@ -69,6 +84,8 @@ import {
     validateTableCalculations,
 } from '../utils/validators';
 
+type RunQueryToolInput = ToolRunQueryArgs | ToolRunQueryExpressionRuntimeArgs;
+
 type Dependencies = {
     updateProgress: UpdateProgressFn;
     runAsyncQuery: RunAsyncQueryFn;
@@ -83,6 +100,7 @@ type Dependencies = {
     // Project-level parameter definitions; model-level ones come from the explore.
     projectParameterDefinitions: ParameterDefinitions;
     enableMergeQueries: boolean;
+    enableFilterExpressions: boolean;
     runAsyncMergeQuery: RunAsyncMergeQueryFn;
     resolveCustomChartType: ResolveCustomChartTypeFn;
     exportCustomChartTypeImage: ExportCustomChartTypeImageFn;
@@ -249,6 +267,41 @@ export const validateRunQueryTool = (
 const CUSTOM_CHART_TYPE_IMAGE_BUDGET_MS = 60_000;
 const CUSTOM_CHART_TYPE_IMAGE_ATTEMPTS = 2;
 
+type ResolvedRunQueryArtifactConfig =
+    | AiSemanticChartArtifactConfig
+    | AiMergeChartArtifactConfig
+    | AiCustomChartTypeChartArtifactConfig;
+
+const buildResolvedRunQueryArtifactConfig = ({
+    persistedArgs,
+    dataAppVizUuid,
+}: {
+    persistedArgs: ToolRunQueryExpressionResolvedArgs;
+    dataAppVizUuid: string | null;
+}): ResolvedRunQueryArtifactConfig => {
+    if (persistedArgs.mergeConfig !== null) {
+        return {
+            source: 'merge',
+            schemaVersion: 1,
+            config: persistedArgs,
+        };
+    }
+
+    if (dataAppVizUuid !== null) {
+        return {
+            source: 'customChartType',
+            schemaVersion: 1,
+            dataAppVizUuid,
+            config: persistedArgs,
+        };
+    }
+
+    return {
+        source: 'semantic',
+        config: persistedArgs,
+    };
+};
+
 // One retry inside a total wall-clock budget. An image failure must never
 // fail the answer — null means fall back to CSV.
 const exportCustomChartTypeImageBounded = async (
@@ -360,21 +413,73 @@ export const getRunQuery = ({
     enableDataAccess,
     projectParameterDefinitions,
     enableMergeQueries,
+    enableFilterExpressions,
     runAsyncMergeQuery,
     resolveCustomChartType,
     exportCustomChartTypeImage,
-}: Dependencies) =>
-    tool({
-        ...(enableMergeQueries
+}: Dependencies) => {
+    const toolView = (() => {
+        if (enableFilterExpressions) {
+            return enableMergeQueries
+                ? generateVisualizationFilterExpressionToolDefinition.for(
+                      'agent',
+                  )
+                : getRunQueryFilterExpressionAgentViewRejectingMerge();
+        }
+        return enableMergeQueries
             ? generateVisualizationToolDefinition.for('agent')
-            : getRunQueryAgentViewRejectingMerge()),
+            : getRunQueryAgentViewRejectingMerge();
+    })();
+    const inputSchema: Schema<RunQueryToolInput> = toolView.inputSchema;
+
+    return tool({
+        ...toolView,
+        inputSchema,
         execute: async (toolArgs, { experimental_context: context }) => {
             try {
                 await updateProgress('Running your query...');
 
-                const queryTool =
-                    toolRunQueryArgsSchemaTransformed.parse(toolArgs);
                 const ctx = AgentContext.from(context);
+                let queryTool: ToolRunQueryArgsTransformed;
+                let persistedExpressionArgs: ToolRunQueryExpressionResolvedArgs | null =
+                    null;
+
+                if (enableFilterExpressions) {
+                    let normalizedExpressionToolArgs: ToolRunQueryExpressionArgs;
+                    if (enableMergeQueries) {
+                        normalizedExpressionToolArgs =
+                            toolRunQueryExpressionArgsSchema.parse(toolArgs);
+                    } else {
+                        const parsedExpressionToolArgs =
+                            toolRunQueryExpressionArgsSchemaV2RejectingMerge.parse(
+                                toolArgs,
+                            );
+                        normalizedExpressionToolArgs = {
+                            ...parsedExpressionToolArgs,
+                            mergeConfig: null,
+                        };
+                    }
+                    const resolution = await resolveFilterExpressionArgs({
+                        toolArgs: normalizedExpressionToolArgs,
+                        getExplore: (exploreName) =>
+                            ctx.getExplore(exploreName),
+                    });
+                    if (!resolution.success) {
+                        return {
+                            result: formatFilterExpressionError(
+                                resolution.error,
+                            ),
+                            metadata: { status: 'error' as const },
+                        };
+                    }
+
+                    queryTool = resolution.data.transformed;
+                    persistedExpressionArgs = resolution.data.persistedArgs;
+                } else {
+                    queryTool =
+                        toolRunQueryArgsSchemaTransformed.parse(toolArgs);
+                }
+
                 const explore = ctx.getExplore(
                     queryTool.queryConfig.exploreName,
                 );
@@ -491,11 +596,18 @@ export const getRunQuery = ({
                             artifactType: 'chart',
                             title: toolArgs.title,
                             description: toolArgs.description,
-                            vizConfig: {
-                                source: 'merge',
-                                schemaVersion: 1,
-                                config: toolArgs,
-                            },
+                            vizConfig:
+                                persistedExpressionArgs === null
+                                    ? {
+                                          source: 'merge',
+                                          schemaVersion: 1,
+                                          config: toolArgs,
+                                      }
+                                    : buildResolvedRunQueryArtifactConfig({
+                                          persistedArgs:
+                                              persistedExpressionArgs,
+                                          dataAppVizUuid: null,
+                                      }),
                         });
 
                     if (!enableDataAccess && !isSlackPrompt(prompt)) {
@@ -562,8 +674,7 @@ export const getRunQuery = ({
 
                 // Custom chart type answers: resolve the slug project-scoped
                 // and validate the field mapping against the type's schema.
-                // The resolved uuid is persisted beside the verbatim tool
-                // args in the artifact envelope.
+                // The resolved uuid is persisted beside the replay payload.
                 let customChartTypeDataAppVizUuid: string | null = null;
                 if (isCustomChartTypeSlugChartConfig(queryTool.chartConfig)) {
                     const customChartConfig = queryTool.chartConfig;
@@ -629,6 +740,50 @@ export const getRunQuery = ({
                     };
                 }
 
+                const expandedPersistedExpressionArgs =
+                    persistedExpressionArgs !== null &&
+                    expandedMetrics.length >
+                        queryTool.queryConfig.metrics.length &&
+                    persistedExpressionArgs.chartConfig &&
+                    !isCustomChartTypeSlugChartConfig(
+                        persistedExpressionArgs.chartConfig,
+                    )
+                        ? {
+                              ...persistedExpressionArgs,
+                              chartConfig: {
+                                  ...persistedExpressionArgs.chartConfig,
+                                  yAxisMetrics:
+                                      expandMetricsWithPopAdditionalMetrics(
+                                          persistedExpressionArgs.chartConfig
+                                              .yAxisMetrics,
+                                          populatedCustomMetrics,
+                                      ),
+                              },
+                          }
+                        : persistedExpressionArgs;
+
+                const structuredArtifactConfig =
+                    customChartTypeDataAppVizUuid === null
+                        ? {
+                              source: 'semantic',
+                              config: expandedToolArgs,
+                          }
+                        : {
+                              // Envelope: model output verbatim,
+                              // server-derived uuid beside it.
+                              source: 'customChartType',
+                              schemaVersion: 1,
+                              dataAppVizUuid: customChartTypeDataAppVizUuid,
+                              config: toolArgs,
+                          };
+                const artifactConfig =
+                    expandedPersistedExpressionArgs === null
+                        ? structuredArtifactConfig
+                        : buildResolvedRunQueryArtifactConfig({
+                              persistedArgs: expandedPersistedExpressionArgs,
+                              dataAppVizUuid: customChartTypeDataAppVizUuid,
+                          });
+
                 const createOrUpdateArtifactHook = () =>
                     createOrUpdateArtifact({
                         threadUuid: prompt.threadUuid,
@@ -636,19 +791,7 @@ export const getRunQuery = ({
                         artifactType: 'chart',
                         title: toolArgs.title,
                         description: toolArgs.description,
-                        vizConfig: customChartTypeDataAppVizUuid
-                            ? {
-                                  // Envelope: model output verbatim, server-
-                                  // derived uuid beside it.
-                                  source: 'customChartType',
-                                  schemaVersion: 1,
-                                  dataAppVizUuid: customChartTypeDataAppVizUuid,
-                                  config: toolArgs,
-                              }
-                            : {
-                                  source: 'semantic',
-                                  config: expandedToolArgs,
-                              },
+                        vizConfig: artifactConfig,
                     });
 
                 // Early artifact creation for non-data-access mode
@@ -775,3 +918,4 @@ export const getRunQuery = ({
         },
         toModelOutput: ({ output }) => toModelOutput(output),
     });
+};

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -223,6 +223,7 @@ export type AiAgentArgs = AnyAiModel & {
     enablePreviewDeploySetup: boolean;
     enableRepoDiscovery: boolean;
     enableMergeQueries: boolean;
+    enableFilterExpressions: boolean;
     // Whether the general-purpose coding agent (`editRepo`) is available — the
     // CodingAgent flag, the org has a writable Git installation, and (in Slack)
     // a trusted prompt identity. Independent of enableAiWriteback.

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -230,6 +230,7 @@ export type AiAgentArgs = AnyAiModel & {
     enablePreviewDeploySetup: boolean;
     enableRepoDiscovery: boolean;
     enableMergeQueries: boolean;
+    enableFilterExpressions: boolean;
     // Whether the general-purpose coding agent (`editRepo`) is available — the
     // CodingAgent flag, the org has a writable Git installation, and (in Slack)
     // a trusted prompt identity. Independent of enableAiWriteback.

--- a/packages/backend/src/ee/services/ai/utils/filterExpressions/resolveFilterExpressionArgs.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/filterExpressions/resolveFilterExpressionArgs.test.ts
@@ -112,7 +112,7 @@ const expectLegacyRawFilters = (filters: ResolvedRawFilters) => {
 };
 
 const expectPerCategoryRawFilters = (filters: ResolvedRawFilters) => {
-    if (!filters || !('schemaVersion' in filters)) {
+    if (!filters || 'type' in filters) {
         throw new Error('Expected per-category resolved raw filters');
     }
     return filters;
@@ -195,9 +195,10 @@ describe('resolveFilterExpressionArgs', () => {
         );
 
         expect(
-            toolRunQueryArgsSchemaPersisted.safeParse(data.rawArgs).success,
+            toolRunQueryArgsSchemaPersisted.safeParse(data.persistedArgs)
+                .success,
         ).toBe(true);
-        expect(data.rawArgs.queryConfig.filters).toMatchObject({
+        expect(data.persistedArgs.queryConfig.filters).toMatchObject({
             type: 'and',
             dimensions: [
                 {
@@ -228,29 +229,31 @@ describe('resolveFilterExpressionArgs', () => {
                 },
             ],
         });
-        expect(data.rawArgs.queryConfig.customMetrics?.[0]).toMatchObject({
-            kind: 'aggregation',
-            filters: [
-                {
-                    table: 'orders',
-                    filter: {
-                        fieldId: 'orders_customer_name',
-                        values: ['Acme, Inc.'],
-                    },
-                },
-                {
-                    table: 'orders',
-                    filter: {
-                        fieldId: 'orders_order_date',
-                        values: [30],
-                        settings: {
-                            unitOfTime: 'days',
-                            completed: false,
+        expect(data.persistedArgs.queryConfig.customMetrics?.[0]).toMatchObject(
+            {
+                kind: 'aggregation',
+                filters: [
+                    {
+                        table: 'orders',
+                        filter: {
+                            fieldId: 'orders_customer_name',
+                            values: ['Acme, Inc.'],
                         },
                     },
-                },
-            ],
-        });
+                    {
+                        table: 'orders',
+                        filter: {
+                            fieldId: 'orders_order_date',
+                            values: [30],
+                            settings: {
+                                unitOfTime: 'days',
+                                completed: false,
+                            },
+                        },
+                    },
+                ],
+            },
+        );
         expect(rulesWithoutIds(data.transformed.queryConfig.filters)).toEqual([
             expect.objectContaining({
                 target: {
@@ -303,7 +306,7 @@ describe('resolveFilterExpressionArgs', () => {
         );
 
         const rawFilters = expectLegacyRawFilters(
-            data.rawArgs.queryConfig.filters,
+            data.persistedArgs.queryConfig.filters,
         );
         const rawPresenceRules = [
             ...(rawFilters.dimensions ?? []),
@@ -331,7 +334,8 @@ describe('resolveFilterExpressionArgs', () => {
             values: [],
         });
 
-        const rawCustomMetric = data.rawArgs.queryConfig.customMetrics?.[0];
+        const rawCustomMetric =
+            data.persistedArgs.queryConfig.customMetrics?.[0];
         if (!rawCustomMetric || rawCustomMetric.kind !== 'aggregation') {
             throw new Error('Expected raw aggregation custom metric');
         }
@@ -368,11 +372,14 @@ describe('resolveFilterExpressionArgs', () => {
         // Agreeing connectors keep the legacy shared-connector raw shape, so
         // resolved data stays byte-compatible with previously persisted
         // artifacts and the legacy persisted contract.
+        const persistedFilters = expectLegacyRawFilters(
+            data.persistedArgs.queryConfig.filters,
+        );
+        expect(persistedFilters.type).toBe('or');
+        expect(persistedFilters).not.toHaveProperty('schemaVersion');
         expect(
-            expectLegacyRawFilters(data.rawArgs.queryConfig.filters).type,
-        ).toBe('or');
-        expect(
-            toolRunQueryArgsSchemaPersisted.safeParse(data.rawArgs).success,
+            toolRunQueryArgsSchemaPersisted.safeParse(data.persistedArgs)
+                .success,
         ).toBe(true);
         expect(data.transformed.queryConfig.filters.dimensions).toMatchObject({
             or: [{ target: { fieldId: 'orders_customer_name' } }],
@@ -429,9 +436,9 @@ describe('resolveFilterExpressionArgs', () => {
 
             // Raw resolved data preserves each category connector exactly.
             const rawFilters = expectPerCategoryRawFilters(
-                data.rawArgs.queryConfig.filters,
+                data.persistedArgs.queryConfig.filters,
             );
-            expect(rawFilters.schemaVersion).toBe(1);
+            expect(rawFilters).not.toHaveProperty('schemaVersion');
             expect(rawFilters.dimensions?.connector ?? null).toBe(
                 dimensions === null ? null : dimensions.toLowerCase(),
             );
@@ -481,12 +488,14 @@ describe('resolveFilterExpressionArgs', () => {
             // New-artifact round-trip: the persisted resolved data replays
             // to the exact same domain filters without Explore metadata.
             expect(
-                toolRunQueryExpressionResolvedArgsSchema.parse(data.rawArgs),
-            ).toEqual(data.rawArgs);
+                toolRunQueryExpressionResolvedArgsSchema.parse(
+                    data.persistedArgs,
+                ),
+            ).toEqual(data.persistedArgs);
             expect(
                 withoutGeneratedIds(
                     toolRunQueryExpressionResolvedArgsSchemaTransformed.parse(
-                        data.rawArgs,
+                        data.persistedArgs,
                     ),
                 ),
             ).toEqual(withoutGeneratedIds(data.transformed));
@@ -612,7 +621,7 @@ describe('resolveFilterExpressionArgs', () => {
         );
 
         expect(
-            expectLegacyRawFilters(data.rawArgs.queryConfig.filters)
+            expectLegacyRawFilters(data.persistedArgs.queryConfig.filters)
                 .metrics?.[0],
         ).toMatchObject({
             fieldId: 'orders_completed_revenue',
@@ -714,7 +723,7 @@ describe('resolveFilterExpressionArgs', () => {
             }),
         );
         expect(
-            expectLegacyRawFilters(data.rawArgs.queryConfig.filters).type,
+            expectLegacyRawFilters(data.persistedArgs.queryConfig.filters).type,
         ).toBe('or');
     });
 
@@ -888,7 +897,7 @@ describe('resolveFilterExpressionArgs', () => {
         expect(getExplore).toHaveBeenCalledWith(usersExplore.name);
         expect(
             expectLegacyRawFilters(
-                data.rawArgs.mergeConfig?.additionalSources[0].queryConfig
+                data.persistedArgs.mergeConfig?.additionalSources[0].queryConfig
                     .filters ?? null,
             ).dimensions?.[0],
         ).toMatchObject({
@@ -919,7 +928,7 @@ describe('resolveFilterExpressionArgs', () => {
         // Primary connectors diverge, so its resolved data uses the
         // per-category shape.
         const primaryFilters = expectPerCategoryRawFilters(
-            data.rawArgs.queryConfig.filters,
+            data.persistedArgs.queryConfig.filters,
         );
         expect(primaryFilters.dimensions?.connector).toBe('and');
         expect(primaryFilters.metrics?.connector).toBe('or');
@@ -927,7 +936,7 @@ describe('resolveFilterExpressionArgs', () => {
         // The additional source agrees internally, so it keeps the legacy
         // shape with its own connector, unaffected by the primary query.
         const sourceFilters = expectLegacyRawFilters(
-            data.rawArgs.mergeConfig?.additionalSources[0].queryConfig
+            data.persistedArgs.mergeConfig?.additionalSources[0].queryConfig
                 .filters ?? null,
         );
         expect(sourceFilters.type).toBe('or');
@@ -951,7 +960,7 @@ describe('resolveFilterExpressionArgs', () => {
         expect(
             withoutGeneratedIds(
                 toolRunQueryExpressionResolvedArgsSchemaTransformed.parse(
-                    data.rawArgs,
+                    data.persistedArgs,
                 ),
             ),
         ).toEqual(withoutGeneratedIds(data.transformed));
@@ -982,7 +991,7 @@ describe('strict expression value interpretation', () => {
 
         expect(
             expectLegacyRawFilters(
-                data.rawArgs.queryConfig.filters,
+                data.persistedArgs.queryConfig.filters,
             ).dimensions?.map((rule) =>
                 'values' in rule ? rule.values : undefined,
             ),

--- a/packages/backend/src/ee/services/ai/utils/filterExpressions/resolveFilterExpressionArgs.ts
+++ b/packages/backend/src/ee/services/ai/utils/filterExpressions/resolveFilterExpressionArgs.ts
@@ -81,7 +81,7 @@ type ResolvedQueryConfigParts = {
 };
 
 export type ResolveFilterExpressionArgsResult = ResolutionResult<{
-    rawArgs: ToolRunQueryExpressionResolvedArgs;
+    persistedArgs: ToolRunQueryExpressionResolvedArgs;
     transformed: ToolRunQueryArgsTransformed;
 }>;
 
@@ -1080,7 +1080,7 @@ const resolveQueryFilters = ({
     // different connectors. When every explicit connector agrees, emit the
     // legacy shared-connector filters object so resolved data stays
     // byte-identical to previously persisted artifacts; only diverging
-    // connectors need the per-category V1 shape.
+    // connectors need the per-category V2 shape.
     const explicitConnectors = [
         ...new Set(
             categories.flatMap((category) => {
@@ -1105,7 +1105,6 @@ const resolveQueryFilters = ({
             : { connector: group.connector ?? 'and', rules: group.rules };
 
     return success({
-        schemaVersion: 1,
         dimensions: toResolvedGroup(resolvedGroups.dimensions),
         metrics: toResolvedGroup(resolvedGroups.metrics),
         tableCalculations: toResolvedGroup(resolvedGroups.tableCalculations),
@@ -1192,12 +1191,14 @@ export const resolveFilterExpressionArgs = async ({
         mergeConfig = { ...inputMergeConfig, additionalSources };
     }
 
-    const rawArgs = toolRunQueryExpressionResolvedArgsSchema.parse({
+    const persistedArgs = toolRunQueryExpressionResolvedArgsSchema.parse({
         ...toolArgs,
         queryConfig,
         mergeConfig,
     });
     const transformed =
-        toolRunQueryExpressionResolvedArgsSchemaTransformed.parse(rawArgs);
-    return success({ rawArgs, transformed });
+        toolRunQueryExpressionResolvedArgsSchemaTransformed.parse(
+            persistedArgs,
+        );
+    return success({ persistedArgs, transformed });
 };

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -3,6 +3,8 @@ import {
     DimensionType,
     FilterOperator,
     FilterType,
+    MetricType,
+    parseAiArtifactChartConfig,
 } from '@lightdash/common';
 import type { AgentSelectOption } from './getSlackBlocks';
 import {
@@ -18,6 +20,28 @@ import {
     getSqlArtifactCardBlocks,
 } from './getSlackBlocks';
 import { mockOrdersExplore } from './validationExplore.mock';
+
+const parseStoredChartConfig = (raw: unknown) => {
+    const parsed = parseAiArtifactChartConfig(raw);
+    if (parsed === null) throw new Error('Expected a valid chart config');
+    return parsed;
+};
+
+const parseStoredArtifact = <
+    const Artifact extends { artifactType: unknown; chartConfig: unknown },
+>(
+    artifact: Artifact,
+) => {
+    const { artifactType } = artifact;
+    if (artifactType !== 'chart' && artifactType !== 'dashboard') {
+        throw new Error('Expected a valid artifact type');
+    }
+    return {
+        ...artifact,
+        artifactType,
+        chartConfig: parseStoredChartConfig(artifact.chartConfig),
+    };
+};
 
 describe('Slack AI agent blocks', () => {
     it('maps known tool names to readable task titles', () => {
@@ -314,6 +338,120 @@ describe('Slack AI agent blocks', () => {
         ]);
     });
 
+    it('renders filter expression artifacts with independent category connectors', async () => {
+        let sharedParams: string | undefined;
+        const queryConfig = {
+            exploreName: 'test_explore',
+            dimensions: ['orders_customer_name'],
+            metrics: ['orders_order_count'],
+            sorts: [],
+            limit: 500,
+            parameters: null,
+            customMetrics: null,
+            tableCalculations: null,
+        };
+        const artifact = parseStoredArtifact({
+            artifactUuid: 'artifact-1',
+            threadUuid: 'thread-1',
+            promptUuid: 'prompt-1',
+            artifactType: 'chart',
+            savedQueryUuid: null,
+            savedDashboardUuid: null,
+            createdAt: new Date(),
+            versionNumber: 1,
+            versionUuid: 'version-1',
+            title: 'Orders by customer',
+            description: null,
+            dashboardConfig: null,
+            versionCreatedAt: new Date(),
+            verifiedByUserUuid: null,
+            verifiedAt: null,
+            chartConfig: {
+                source: 'semantic',
+                config: {
+                    title: 'Orders by customer',
+                    description: 'Orders by customer',
+                    queryConfig: {
+                        ...queryConfig,
+                        filters: {
+                            dimensions: {
+                                connector: 'and',
+                                rules: [
+                                    {
+                                        fieldId: 'orders_customer_name',
+                                        fieldType: DimensionType.STRING,
+                                        fieldFilterType: FilterType.STRING,
+                                        operator: FilterOperator.EQUALS,
+                                        values: ['Acme'],
+                                    },
+                                    {
+                                        fieldId: 'orders_product_category',
+                                        fieldType: DimensionType.STRING,
+                                        fieldFilterType: FilterType.STRING,
+                                        operator: FilterOperator.EQUALS,
+                                        values: ['Hardware'],
+                                    },
+                                ],
+                            },
+                            metrics: {
+                                connector: 'or',
+                                rules: [
+                                    {
+                                        fieldId: 'orders_total_revenue',
+                                        fieldType: MetricType.SUM,
+                                        fieldFilterType: FilterType.NUMBER,
+                                        operator: FilterOperator.GREATER_THAN,
+                                        values: [10],
+                                    },
+                                    {
+                                        fieldId: 'orders_order_count',
+                                        fieldType: MetricType.COUNT,
+                                        fieldFilterType: FilterType.NUMBER,
+                                        operator: FilterOperator.LESS_THAN,
+                                        values: [2],
+                                    },
+                                ],
+                            },
+                            tableCalculations: null,
+                        },
+                    },
+                    chartConfig: null,
+                    mergeConfig: null,
+                },
+            },
+        });
+
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async (_path, params) => {
+                sharedParams = params;
+                return 'https://lightdash.example.com/share/chart';
+            },
+            async () => mockOrdersExplore,
+            async () => true,
+            'agent-1',
+            [artifact],
+            [],
+        );
+
+        expect(blocks).toMatchObject([
+            { type: 'card', title: { text: 'Orders by customer' } },
+        ]);
+        const savedRaw = new URLSearchParams(sharedParams).get(
+            'create_saved_chart_version',
+        );
+        if (savedRaw === null) throw new Error('Expected saved chart state');
+        const saved = JSON.parse(savedRaw);
+        expect(saved.metricQuery.filters.dimensions).toHaveProperty('and');
+        expect(saved.metricQuery.filters.metrics).toHaveProperty('or');
+    });
+
     it('uses generateVisualization chart image URLs as card hero images', async () => {
         const blocks = await getModernArtifactCardBlocks(
             {
@@ -328,7 +466,7 @@ describe('Slack AI agent blocks', () => {
             async () => true,
             'agent-1',
             [
-                {
+                parseStoredArtifact({
                     artifactUuid: 'artifact-1',
                     threadUuid: 'thread-1',
                     promptUuid: 'prompt-1',
@@ -360,7 +498,7 @@ describe('Slack AI agent blocks', () => {
                         },
                         chartConfig: null,
                     },
-                },
+                }),
             ],
             [
                 {
@@ -599,7 +737,7 @@ describe('Slack AI agent blocks', () => {
             async () => false,
             'agent-1',
             [
-                {
+                parseStoredArtifact({
                     artifactUuid: 'artifact-1',
                     threadUuid: 'thread-1',
                     promptUuid: 'prompt-1',
@@ -631,7 +769,7 @@ describe('Slack AI agent blocks', () => {
                         },
                         chartConfig: null,
                     },
-                },
+                }),
             ],
             [
                 {
@@ -730,7 +868,7 @@ describe('Slack AI agent blocks', () => {
             async () => ({}) as never,
             async () => true,
             'agent-1',
-            [artifact],
+            [parseStoredArtifact(artifact)],
             [
                 attempt(
                     'call-1',
@@ -842,7 +980,7 @@ describe('Slack AI agent blocks', () => {
                     'Completed orders by month',
                     'completed',
                 ),
-            ],
+            ].map(parseStoredArtifact),
             [
                 attempt('call-1', 'https://files.slack.com/placed.png'),
                 attempt('call-2', 'https://files.slack.com/shipped.png'),
@@ -942,7 +1080,7 @@ describe('Slack AI agent blocks', () => {
                 retryVersion('version-1'),
                 retryVersion('version-2'),
                 retryVersion('version-3'),
-            ],
+            ].map(parseStoredArtifact),
             [
                 attempt('call-1', 'https://files.slack.com/attempt-1.png'),
                 attempt('call-2', 'https://files.slack.com/attempt-2.png'),
@@ -1012,7 +1150,7 @@ describe('Slack AI agent blocks', () => {
             [
                 retryVersion('version-1', 'day'),
                 retryVersion('version-2', 'month'),
-            ],
+            ].map(parseStoredArtifact),
             [],
         );
 
@@ -1074,7 +1212,7 @@ describe('Slack AI agent blocks', () => {
             [
                 chartVersion('version-1', 'Placed orders', 'placed'),
                 chartVersion('version-2', 'Completed orders', 'completed'),
-            ],
+            ].map(parseStoredArtifact),
             [],
         );
 
@@ -1160,7 +1298,7 @@ describe('Slack AI agent blocks', () => {
             [
                 chartVersion('version-1', 'line', 'line'),
                 chartVersion('version-2', 'bar', null),
-            ],
+            ].map(parseStoredArtifact),
             [],
         );
 
@@ -1192,7 +1330,7 @@ describe('Slack AI agent blocks', () => {
             async () => true,
             'agent-1',
             [
-                {
+                parseStoredArtifact({
                     artifactUuid: 'artifact-1',
                     threadUuid: 'thread-1',
                     promptUuid: 'prompt-1',
@@ -1236,7 +1374,7 @@ describe('Slack AI agent blocks', () => {
                             secondaryYAxisMetric: null,
                         },
                     },
-                },
+                }),
             ],
             [],
         );
@@ -1276,7 +1414,7 @@ describe('Slack AI agent blocks', () => {
             async () => true,
             'agent-1',
             [
-                {
+                parseStoredArtifact({
                     artifactUuid: 'artifact-1',
                     threadUuid: 'thread-1',
                     promptUuid: 'prompt-1',
@@ -1308,7 +1446,7 @@ describe('Slack AI agent blocks', () => {
                         },
                         chartConfig: null,
                     },
-                },
+                }),
             ],
             [],
         );
@@ -1339,7 +1477,7 @@ describe('Slack AI agent blocks', () => {
             async () => true,
             'agent-1',
             [
-                {
+                parseStoredArtifact({
                     artifactUuid: 'artifact-1',
                     threadUuid: 'thread-1',
                     promptUuid: 'prompt-1',
@@ -1371,7 +1509,7 @@ describe('Slack AI agent blocks', () => {
                         },
                         chartConfig: null,
                     },
-                },
+                }),
             ],
             [],
         );

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -13,10 +13,8 @@ import {
     isAiSqlChartArtifactConfig,
     isToolEditDbtProjectResult,
     isToolSetupPreviewDeployResult,
-    parseAiArtifactChartConfig,
     parseVizConfig,
     SlackPrompt,
-    type AiLegacySemanticChartArtifactConfig,
     type ChartConfig,
     type DataAppVizField,
     type Explore,
@@ -541,10 +539,7 @@ export async function getModernArtifactCardBlocks(
     isImageUrlReachable: (url: string) => Promise<boolean>,
     agentUuid?: string,
     artifacts?: Array<
-        Omit<AiArtifact, 'chartConfig' | 'savedSqlUuid'> & {
-            chartConfig:
-                | AiArtifact['chartConfig']
-                | AiLegacySemanticChartArtifactConfig;
+        Omit<AiArtifact, 'savedSqlUuid'> & {
             savedSqlUuid?: string | null;
         }
     >,
@@ -560,7 +555,6 @@ export async function getModernArtifactCardBlocks(
     const normalizedArtifacts: AiArtifact[] = artifacts.map((artifact) => ({
         ...artifact,
         savedSqlUuid: artifact.savedSqlUuid ?? null,
-        chartConfig: parseAiArtifactChartConfig(artifact.chartConfig),
     }));
 
     const chartImageUrls = (toolResults ?? [])

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -76,6 +76,7 @@
     "@types/pegjs": "0.10.3",
     "@types/sanitize-html": "2.11.0",
     "@types/uuid": "10.0.0",
+    "js-tiktoken": "1.0.16",
     "oxlint": "1.75.0",
     "oxlint-tsgolint": "7.0.2001",
     "typescript": "7.0.2",

--- a/packages/common/src/ee/AiAgent/chartConfig/web/getWebAiChartConfig.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/web/getWebAiChartConfig.ts
@@ -1,6 +1,6 @@
 import { type ItemsMap } from '../../../../types/field';
 import { type MetricQuery } from '../../../../types/metricQuery';
-import { type ToolRunQueryArgs } from '../../schemas';
+import { type PersistedRunQueryPayload } from '../../schemas';
 import { parseVizConfig } from '../../utils';
 import { getRunQueryChartConfig } from './runQueryTool/getRunQueryChartConfig';
 
@@ -11,7 +11,7 @@ export const getWebAiChartConfig = ({
     fieldsMap,
     overrideChartType,
 }: {
-    vizConfig: ToolRunQueryArgs;
+    vizConfig: PersistedRunQueryPayload;
     metricQuery: MetricQuery;
     maxQueryLimit?: number;
     fieldsMap: ItemsMap;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -12,7 +12,6 @@ import type {
     ToolDashboardV2Args,
     ToolName,
     ToolRunQueryArgs,
-    ToolRunQueryArgsV3,
 } from '../..';
 import {
     MAX_RETENTION_WINDOW_HOURS,
@@ -31,6 +30,10 @@ import {
     type AiThreadCreatedFrom,
 } from './requestTypes';
 import { type AgentToolOutput } from './schemas';
+import type {
+    PersistedMergeRunQueryPayload,
+    PersistedRunQueryPayload,
+} from './schemas/persistedRunQueryArgs';
 import { ToolNameSchema } from './schemas/visualizations';
 import { type AiMetricQuery, type AiResultType } from './types';
 
@@ -1041,23 +1044,23 @@ export type AiLegacySemanticChartArtifactConfig = ToolRunQueryArgs;
 
 export type AiSemanticChartArtifactConfig = {
     source: 'semantic';
-    config: AiLegacySemanticChartArtifactConfig;
+    config: PersistedRunQueryPayload;
 };
 
 export type AiMergeChartArtifactConfig = {
     source: 'merge';
     schemaVersion: 1;
-    config: ToolRunQueryArgsV3;
+    config: PersistedMergeRunQueryPayload;
 };
 
-// Custom chart type answer envelope: the model's tool args are stored
-// verbatim (slug chartConfig intact) and everything the server derives —
-// the resolved dataAppVizUuid — sits beside them.
+// Custom chart type answer envelope: the persisted query payload keeps the
+// slug chartConfig intact, while the server-derived dataAppVizUuid sits beside
+// it.
 export type AiCustomChartTypeChartArtifactConfig = {
     source: 'customChartType';
     schemaVersion: 1;
     dataAppVizUuid: string;
-    config: ToolRunQueryArgs;
+    config: PersistedRunQueryPayload;
 };
 
 export type AiChartArtifactConfig =

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -1,11 +1,15 @@
+import { getEncoding } from 'js-tiktoken';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { defineTool } from './defineTool';
+import { FILTER_EXPRESSION_GRAMMAR_DESCRIPTION } from './filterExpressions';
 import {
     agentToolNames,
     findContentToolDefinition,
+    generateVisualizationFilterExpressionToolDefinition,
     generateVisualizationToolDefinition,
     mcpToolDefinitions,
+    runQueryFilterExpressionToolDefinition,
     runQueryToolDefinition,
 } from './tools';
 import { ToolNameSchema } from './visualizations';
@@ -19,6 +23,113 @@ describe('defineTool', () => {
         expect(mcpView.name).toBe('run_metric_query');
         expect(mcpView.canonicalName).toBe('runQuery');
         expect(mcpView.outputSchema).toBeDefined();
+    });
+
+    it('keeps runtime-selected filter expression definitions out of default arrays', () => {
+        expect(
+            mcpToolDefinitions.includes(runQueryFilterExpressionToolDefinition),
+        ).toBe(false);
+        expect(
+            generateVisualizationFilterExpressionToolDefinition.for('agent')
+                .name,
+        ).toBe('generateVisualization');
+        expect(runQueryFilterExpressionToolDefinition.for('mcp').name).toBe(
+            'run_metric_query',
+        );
+    });
+
+    it('keeps compact query contracts within size and token budgets', () => {
+        const agentLegacy = generateVisualizationToolDefinition.for('agent');
+        const agentExpression =
+            generateVisualizationFilterExpressionToolDefinition.for('agent');
+        const mcpLegacy = runQueryToolDefinition.for('mcp');
+        const mcpExpression = runQueryFilterExpressionToolDefinition.for('mcp');
+        const serializeAgent = (
+            view: typeof agentLegacy | typeof agentExpression,
+        ) =>
+            JSON.stringify({
+                description: view.description,
+                inputSchema: view.inputSchema.jsonSchema,
+            });
+        const serializeMcp = (view: typeof mcpLegacy | typeof mcpExpression) =>
+            JSON.stringify({
+                description: view.description,
+                inputSchema: zodToJsonSchema(view.inputSchema),
+            });
+        const contracts = {
+            agentLegacy: serializeAgent(agentLegacy),
+            agentExpression: serializeAgent(agentExpression),
+            mcpLegacy: serializeMcp(mcpLegacy),
+            mcpExpression: serializeMcp(mcpExpression),
+        };
+        const cl100k = getEncoding('cl100k_base');
+        const o200k = getEncoding('o200k_base');
+        const measure = (contract: string) => ({
+            bytes: new TextEncoder().encode(contract).length,
+            cl100kTokens: cl100k.encode(contract).length,
+            o200kTokens: o200k.encode(contract).length,
+        });
+        const measurementKeys = [
+            'bytes',
+            'cl100kTokens',
+            'o200kTokens',
+        ] satisfies (keyof ReturnType<typeof measure>)[];
+        const expectWithinBudget = (
+            measurement: ReturnType<typeof measure>,
+            budget: ReturnType<typeof measure>,
+        ) => {
+            measurementKeys.forEach((key) => {
+                expect(measurement[key]).toBeLessThanOrEqual(budget[key]);
+            });
+        };
+        const expectAtMostRatio = (
+            expression: ReturnType<typeof measure>,
+            legacy: ReturnType<typeof measure>,
+            maximumRatio: number,
+        ) => {
+            measurementKeys.forEach((key) => {
+                expect(expression[key] / legacy[key]).toBeLessThanOrEqual(
+                    maximumRatio,
+                );
+            });
+        };
+
+        expect(contracts.agentExpression).not.toContain('fieldFilterType');
+        expect(contracts.mcpExpression).not.toContain('fieldFilterType');
+        expect(
+            mcpExpression.description.split(
+                FILTER_EXPRESSION_GRAMMAR_DESCRIPTION,
+            ),
+        ).toHaveLength(2);
+
+        const measurements = {
+            agentLegacy: measure(contracts.agentLegacy),
+            agentExpression: measure(contracts.agentExpression),
+            mcpLegacy: measure(contracts.mcpLegacy),
+            mcpExpression: measure(contracts.mcpExpression),
+        };
+        expectWithinBudget(measurements.agentExpression, {
+            bytes: 25_000,
+            cl100kTokens: 5_500,
+            o200kTokens: 5_600,
+        });
+        expectWithinBudget(measurements.mcpExpression, {
+            bytes: 20_000,
+            cl100kTokens: 4_500,
+            o200kTokens: 4_600,
+        });
+        // Preserve at least a 45% agent reduction and a 60% Model Context
+        // Protocol (MCP) reduction across bytes and both tokenizers.
+        expectAtMostRatio(
+            measurements.agentExpression,
+            measurements.agentLegacy,
+            0.55,
+        );
+        expectAtMostRatio(
+            measurements.mcpExpression,
+            measurements.mcpLegacy,
+            0.4,
+        );
     });
 
     it('uses runtime-available dashboard detail tools', () => {

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -1,11 +1,15 @@
+import { getEncoding } from 'js-tiktoken';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { defineTool } from './defineTool';
+import { FILTER_EXPRESSION_GRAMMAR_DESCRIPTION } from './filterExpressions';
 import {
     agentToolNames,
     findContentToolDefinition,
+    generateVisualizationFilterExpressionToolDefinition,
     generateVisualizationToolDefinition,
     mcpToolDefinitions,
+    runQueryFilterExpressionToolDefinition,
     runQueryToolDefinition,
 } from './tools';
 import { ToolNameSchema } from './visualizations';
@@ -19,6 +23,89 @@ describe('defineTool', () => {
         expect(mcpView.name).toBe('run_metric_query');
         expect(mcpView.canonicalName).toBe('runQuery');
         expect(mcpView.outputSchema).toBeDefined();
+    });
+
+    it('keeps runtime-selected filter expression definitions out of default arrays', () => {
+        expect(
+            mcpToolDefinitions.includes(runQueryFilterExpressionToolDefinition),
+        ).toBe(false);
+        expect(
+            generateVisualizationFilterExpressionToolDefinition.for('agent')
+                .name,
+        ).toBe('generateVisualization');
+        expect(runQueryFilterExpressionToolDefinition.for('mcp').name).toBe(
+            'run_metric_query',
+        );
+    });
+
+    it('snapshots compact query contracts and tokenizer counts', () => {
+        const agentLegacy = generateVisualizationToolDefinition.for('agent');
+        const agentExpression =
+            generateVisualizationFilterExpressionToolDefinition.for('agent');
+        const mcpLegacy = runQueryToolDefinition.for('mcp');
+        const mcpExpression = runQueryFilterExpressionToolDefinition.for('mcp');
+        const serializeAgent = (
+            view: typeof agentLegacy | typeof agentExpression,
+        ) =>
+            JSON.stringify({
+                description: view.description,
+                inputSchema: view.inputSchema.jsonSchema,
+            });
+        const serializeMcp = (view: typeof mcpLegacy | typeof mcpExpression) =>
+            JSON.stringify({
+                description: view.description,
+                inputSchema: zodToJsonSchema(view.inputSchema),
+            });
+        const contracts = {
+            agentLegacy: serializeAgent(agentLegacy),
+            agentExpression: serializeAgent(agentExpression),
+            mcpLegacy: serializeMcp(mcpLegacy),
+            mcpExpression: serializeMcp(mcpExpression),
+        };
+        const cl100k = getEncoding('cl100k_base');
+        const o200k = getEncoding('o200k_base');
+        const measure = (contract: string) => ({
+            bytes: new TextEncoder().encode(contract).length,
+            cl100kTokens: cl100k.encode(contract).length,
+            o200kTokens: o200k.encode(contract).length,
+        });
+
+        expect(contracts.agentExpression).not.toContain('fieldFilterType');
+        expect(contracts.mcpExpression).not.toContain('fieldFilterType');
+        expect(
+            mcpExpression.description.split(
+                FILTER_EXPRESSION_GRAMMAR_DESCRIPTION,
+            ),
+        ).toHaveLength(2);
+        expect({
+            agentLegacy: measure(contracts.agentLegacy),
+            agentExpression: measure(contracts.agentExpression),
+            mcpLegacy: measure(contracts.mcpLegacy),
+            mcpExpression: measure(contracts.mcpExpression),
+        }).toMatchInlineSnapshot(`
+          {
+            "agentExpression": {
+              "bytes": 20835,
+              "cl100kTokens": 4608,
+              "o200kTokens": 4682,
+            },
+            "agentLegacy": {
+              "bytes": 42556,
+              "cl100kTokens": 10240,
+              "o200kTokens": 10444,
+            },
+            "mcpExpression": {
+              "bytes": 27096,
+              "cl100kTokens": 5991,
+              "o200kTokens": 6104,
+            },
+            "mcpLegacy": {
+              "bytes": 90074,
+              "cl100kTokens": 21125,
+              "o200kTokens": 21616,
+            },
+          }
+        `);
     });
 
     it('uses runtime-available dashboard detail tools', () => {

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/artifact.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/artifact.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+import {
+    toolRunQueryArgsSchemaPersisted,
+    type ToolRunQueryArgsV3,
+} from '../tools/toolRunQueryArgs';
+import {
+    toolRunQueryExpressionArgsSchema,
+    toolRunQueryExpressionArgsSchemaV2,
+    type ToolRunQueryExpressionArgs,
+    type ToolRunQueryExpressionArgsV2,
+} from './expressionSchemas';
+
+const filterExpressionArtifactEnvelopeSchema = z
+    .object({
+        source: z.literal('filterExpression'),
+        schemaVersion: z.literal(1),
+        expressionArgs: z.unknown(),
+        resolvedArgs: z.unknown(),
+    })
+    .strict();
+
+export type AiFilterExpressionArtifactConfigV1 = {
+    source: 'filterExpression';
+    schemaVersion: 1;
+    expressionArgs: ToolRunQueryExpressionArgs | ToolRunQueryExpressionArgsV2;
+    resolvedArgs: ToolRunQueryArgsV3;
+};
+
+const hasMergeConfigProperty = (
+    value: unknown,
+): value is Record<string, unknown> & { mergeConfig: unknown } =>
+    value !== null && typeof value === 'object' && 'mergeConfig' in value;
+
+/**
+ * Parses the persistence-only filter-expression envelope. Runtime readers must
+ * normalize it to an existing semantic or merge artifact before exposing it.
+ */
+export const parseAiFilterExpressionArtifactConfigV1 = (
+    raw: unknown,
+): AiFilterExpressionArtifactConfigV1 | null => {
+    const envelope = filterExpressionArtifactEnvelopeSchema.safeParse(raw);
+    if (!envelope.success) return null;
+
+    const expressionArgs = hasMergeConfigProperty(envelope.data.expressionArgs)
+        ? toolRunQueryExpressionArgsSchema.safeParse(
+              envelope.data.expressionArgs,
+          )
+        : toolRunQueryExpressionArgsSchemaV2.safeParse(
+              envelope.data.expressionArgs,
+          );
+    if (!expressionArgs.success) return null;
+
+    const resolvedArgs = toolRunQueryArgsSchemaPersisted.safeParse(
+        envelope.data.resolvedArgs,
+    );
+    if (!resolvedArgs.success) return null;
+
+    const expressionHasMerge =
+        'mergeConfig' in expressionArgs.data &&
+        expressionArgs.data.mergeConfig !== null;
+    const resolvedHasMerge = resolvedArgs.data.mergeConfig !== null;
+    if (expressionHasMerge !== resolvedHasMerge) return null;
+
+    return {
+        source: 'filterExpression',
+        schemaVersion: 1,
+        expressionArgs: expressionArgs.data,
+        resolvedArgs: resolvedArgs.data,
+    };
+};

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.test.ts
@@ -161,6 +161,15 @@ describe('filter expression input schemas', () => {
         expectTypeOf<ToolRunQueryExpressionArgsNoMerge>().not.toExtend<ToolRunQueryExpressionArgs>();
     });
 
+    it('documents independent category connectors and their implicit AND', () => {
+        expect(filterExpressionsSchema.description).toContain(
+            'Each category chooses AND or OR independently',
+        );
+        expect(filterExpressionsSchema.description).toContain(
+            '(D1 AND D2) AND (M1 OR M2)',
+        );
+    });
+
     it('requires a strict, separately nullable category shape', () => {
         expect(
             filterExpressionsSchema.safeParse({

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.ts
@@ -53,7 +53,7 @@ export const filterExpressionsSchema = z
     })
     .strict()
     .describe(
-        'Separate flat expressions for dimensions, metrics, and table calculations. Use null when a category has no filters.',
+        'Separate flat expressions for dimensions, metrics, and table calculations. Each category chooses AND or OR independently. Non-null categories combine implicitly with AND. For example, dimensions "D1 AND D2" and metrics "M1 OR M2" mean "(D1 AND D2) AND (M1 OR M2)", where D1, D2, M1, and M2 are complete filter rules. Use null when a category has no filters.',
     );
 
 export const aggregationCustomMetricExpressionSchema =

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/index.ts
@@ -1,3 +1,4 @@
+export * from './artifact';
 export * from './ast';
 export * from './expressionSchemas';
 export * from './operators';

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/resolvedArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/resolvedArgs.test.ts
@@ -9,6 +9,7 @@ import {
     filterExpressionResolvedFiltersSchema,
     filterExpressionResolvedFiltersSchemaTransformed,
     filterExpressionResolvedFiltersSchemaV1,
+    filterExpressionResolvedFiltersSchemaV2,
     toolRunQueryExpressionResolvedArgsSchema,
     toolRunQueryExpressionResolvedArgsSchemaTransformed,
 } from './resolvedArgs';
@@ -46,7 +47,6 @@ const tableCalculationRule = {
 };
 
 const perCategoryFilters = {
-    schemaVersion: 1,
     dimensions: {
         connector: 'and',
         rules: [stringRule, secondStringRule],
@@ -81,33 +81,47 @@ const withoutGeneratedIds = (value: unknown): unknown => {
 };
 
 describe('filterExpressionResolvedFiltersSchema', () => {
-    it('parses the strict per-category V1 shape', () => {
+    it('parses the strict per-category V2 shape', () => {
         expect(
-            filterExpressionResolvedFiltersSchemaV1.parse(perCategoryFilters),
+            filterExpressionResolvedFiltersSchemaV2.parse(perCategoryFilters),
         ).toEqual(perCategoryFilters);
     });
 
-    it('rejects malformed V1 payloads instead of stripping them', () => {
+    it('keeps an all-null V1 payload out of the strict V2 parser', () => {
+        const allNullV1 = {
+            type: 'and',
+            dimensions: null,
+            metrics: null,
+            tableCalculations: null,
+        };
+
         expect(
-            filterExpressionResolvedFiltersSchemaV1.safeParse({
-                ...perCategoryFilters,
-                schemaVersion: 2,
-            }).success,
+            filterExpressionResolvedFiltersSchemaV2.safeParse(allNullV1)
+                .success,
         ).toBe(false);
         expect(
-            filterExpressionResolvedFiltersSchemaV1.safeParse({
+            filterExpressionResolvedFiltersSchemaV1.parse(allNullV1),
+        ).toEqual(allNullV1);
+        expect(filterExpressionResolvedFiltersSchema.parse(allNullV1)).toEqual(
+            allNullV1,
+        );
+    });
+
+    it('rejects malformed V2 payloads instead of stripping them', () => {
+        expect(
+            filterExpressionResolvedFiltersSchemaV2.safeParse({
                 ...perCategoryFilters,
                 unknownKey: true,
             }).success,
         ).toBe(false);
         expect(
-            filterExpressionResolvedFiltersSchemaV1.safeParse({
+            filterExpressionResolvedFiltersSchemaV2.safeParse({
                 ...perCategoryFilters,
                 dimensions: { connector: 'and', rules: [] },
             }).success,
         ).toBe(false);
         expect(
-            filterExpressionResolvedFiltersSchemaV1.safeParse({
+            filterExpressionResolvedFiltersSchemaV2.safeParse({
                 ...perCategoryFilters,
                 tableCalculations: {
                     connector: 'and',
@@ -117,13 +131,13 @@ describe('filterExpressionResolvedFiltersSchema', () => {
         ).toBe(false);
     });
 
-    it('still parses the legacy shared-connector object unchanged', () => {
+    it('still parses the V1 shared-connector object unchanged', () => {
         expect(
             filterExpressionResolvedFiltersSchema.parse(legacyFilters),
         ).toEqual(legacyFilters);
     });
 
-    it('normalizes V1 payloads to independent domain filter groups', () => {
+    it('normalizes V2 payloads to independent domain filter groups', () => {
         const filters =
             filterExpressionResolvedFiltersSchemaTransformed.parse(
                 perCategoryFilters,
@@ -249,7 +263,6 @@ describe('toolRunQueryExpressionResolvedArgsSchema', () => {
                             ...legacyResolvedArgs.mergeConfig
                                 .additionalSources[0].queryConfig,
                             filters: {
-                                schemaVersion: 1,
                                 dimensions: null,
                                 metrics: {
                                     connector: 'or',

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/resolvedArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/resolvedArgs.ts
@@ -26,7 +26,7 @@ import visualizationMetadataSchema from '../visualizationMetadata';
 // queries. Each query category (dimensions, metrics, tableCalculations) owns
 // an independent FilterGroup, so categories may resolve to different
 // connectors — which the legacy shared-connector filters object
-// (filtersSchemaV2's single `type`) cannot represent. The V1 shape below
+// (filtersSchemaV2's single `type`) cannot represent. The V2 shape below
 // carries one connector per category. Resolved data emitted before this shape
 // existed (and resolved data whose categories agree) uses the legacy object,
 // so parsers accept both. None of this is advertised to models; the model
@@ -48,11 +48,13 @@ const resolvedNumberFilterGroupSchema = z
     })
     .strict();
 
-// Discriminated from the legacy filters object by `schemaVersion` (the legacy
-// shape has a required `type` and no schemaVersion).
-export const filterExpressionResolvedFiltersSchemaV1 = z
+// These versions describe persisted filter shapes, independently from the
+// run-query tool schema versions. The historical filtersSchemaV2 tool shape is
+// V1 here; its required root `type` distinguishes it from V2.
+export const filterExpressionResolvedFiltersSchemaV1 = filtersSchemaV2;
+
+export const filterExpressionResolvedFiltersSchemaV2 = z
     .object({
-        schemaVersion: z.literal(1),
         dimensions: resolvedFilterGroupSchema.nullable(),
         metrics: resolvedFilterGroupSchema.nullable(),
         tableCalculations: resolvedNumberFilterGroupSchema.nullable(),
@@ -60,12 +62,15 @@ export const filterExpressionResolvedFiltersSchemaV1 = z
     .strict();
 
 export const filterExpressionResolvedFiltersSchema = z.union([
+    filterExpressionResolvedFiltersSchemaV2,
     filterExpressionResolvedFiltersSchemaV1,
-    filtersSchemaV2,
 ]);
 
 export type FilterExpressionResolvedFiltersV1 = z.infer<
     typeof filterExpressionResolvedFiltersSchemaV1
+>;
+export type FilterExpressionResolvedFiltersV2 = z.infer<
+    typeof filterExpressionResolvedFiltersSchemaV2
 >;
 export type FilterExpressionResolvedFilters = z.infer<
     typeof filterExpressionResolvedFiltersSchema
@@ -99,9 +104,11 @@ const toFilterGroup = (
     }
 };
 
-const filterExpressionResolvedFiltersSchemaV1Transformed = z
+const filterExpressionResolvedFiltersSchemaV1Transformed =
+    filtersSchemaTransformed;
+
+const filterExpressionResolvedFiltersSchemaV2Transformed = z
     .object({
-        schemaVersion: z.literal(1),
         dimensions: resolvedFilterGroupTransformed.nullable(),
         metrics: resolvedFilterGroupTransformed.nullable(),
         tableCalculations: resolvedFilterGroupTransformed.nullable(),
@@ -115,12 +122,13 @@ const filterExpressionResolvedFiltersSchemaV1Transformed = z
         }),
     );
 
-// Accepts the V1 per-category shape, the legacy shared-connector object, and
-// null; always normalizes to domain Filters. Replay needs neither the Explore
-// nor the feature flag.
+// Try the current per-category V2 shape first, then the historical
+// shared-connector V1 shape. The V1 parser remains last because it also accepts
+// null. Both normalize to domain Filters without Explore metadata or a feature
+// flag.
 export const filterExpressionResolvedFiltersSchemaTransformed = z.union([
+    filterExpressionResolvedFiltersSchemaV2Transformed,
     filterExpressionResolvedFiltersSchemaV1Transformed,
-    filtersSchemaTransformed,
 ]);
 
 const resolvedQueryConfigSchema = queryConfigBaseSchema.extend({

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -33,6 +33,7 @@ export * from './filterExpressions';
 export * from './filters';
 export * from './McpSchemaCompatLayer';
 export * from './outputMetadata';
+export * from './persistedRunQueryArgs';
 export * from './sortField';
 export * from './tableCalcs/tableCalcFormula';
 export * from './tableCalcs/tableCalcs';

--- a/packages/common/src/ee/AiAgent/schemas/persistedRunQueryArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/persistedRunQueryArgs.test.ts
@@ -1,0 +1,111 @@
+import { DimensionType, MetricType } from '../../../types/field';
+import { FilterOperator, FilterType } from '../../../types/filter';
+import { parsePersistedRunQueryPayload } from './persistedRunQueryArgs';
+import { parsePersistedRunQueryArgs } from './tools/toolRunQueryArgs';
+
+const dimensionRule = {
+    fieldId: 'orders_status',
+    fieldType: DimensionType.STRING,
+    fieldFilterType: FilterType.STRING,
+    operator: FilterOperator.EQUALS,
+    values: ['completed'],
+};
+
+const secondDimensionRule = {
+    ...dimensionRule,
+    fieldId: 'orders_region',
+    values: ['emea'],
+};
+
+const metricRule = {
+    fieldId: 'orders_revenue',
+    fieldType: MetricType.SUM,
+    fieldFilterType: FilterType.NUMBER,
+    operator: FilterOperator.GREATER_THAN,
+    values: [100],
+};
+
+const secondMetricRule = {
+    ...metricRule,
+    fieldId: 'orders_count',
+    fieldType: MetricType.COUNT,
+    values: [10],
+};
+
+const runQueryPayload = (filters: unknown) => ({
+    title: 'Revenue by status',
+    description: 'Resolved query',
+    queryConfig: {
+        exploreName: 'orders',
+        dimensions: ['orders_status'],
+        metrics: ['orders_revenue'],
+        sorts: [],
+        limit: 500,
+        parameters: null,
+        customMetrics: null,
+        tableCalculations: null,
+        filters,
+    },
+    chartConfig: null,
+    mergeConfig: null,
+});
+
+const withoutGeneratedIds = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(withoutGeneratedIds);
+    if (value !== null && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value)
+                .filter(([key]) => key !== 'id')
+                .map(([key, entry]) => [key, withoutGeneratedIds(entry)]),
+        );
+    }
+    return value;
+};
+
+describe('parsePersistedRunQueryPayload', () => {
+    it('keeps per-category connectors out of the existing parser', () => {
+        const payload = runQueryPayload({
+            dimensions: {
+                connector: 'and',
+                rules: [dimensionRule, secondDimensionRule],
+            },
+            metrics: {
+                connector: 'or',
+                rules: [metricRule, secondMetricRule],
+            },
+            tableCalculations: null,
+        });
+
+        expect(parsePersistedRunQueryArgs(payload)).toBeNull();
+
+        const parsed = parsePersistedRunQueryPayload(payload);
+        expect(parsed?.queryConfig.filters.dimensions).toMatchObject({
+            and: [
+                { target: { fieldId: 'orders_status' } },
+                { target: { fieldId: 'orders_region' } },
+            ],
+        });
+        expect(parsed?.queryConfig.filters.metrics).toMatchObject({
+            or: [
+                { target: { fieldId: 'orders_revenue' } },
+                { target: { fieldId: 'orders_count' } },
+            ],
+        });
+    });
+
+    it('preserves the existing parser result for shared connectors', () => {
+        const payload = runQueryPayload({
+            type: 'or',
+            dimensions: [dimensionRule],
+            metrics: [metricRule],
+            tableCalculations: null,
+        });
+        const existing = parsePersistedRunQueryArgs(payload);
+        const parsed = parsePersistedRunQueryPayload(payload);
+
+        expect(existing).not.toBeNull();
+        expect(withoutGeneratedIds(parsed)).toEqual(
+            withoutGeneratedIds(existing),
+        );
+    });
+});

--- a/packages/common/src/ee/AiAgent/schemas/persistedRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/persistedRunQueryArgs.ts
@@ -1,0 +1,39 @@
+import {
+    toolRunQueryExpressionResolvedArgsSchemaTransformed,
+    type ToolRunQueryExpressionResolvedArgs,
+} from './filterExpressions/resolvedArgs';
+import {
+    parsePersistedRunQueryArgs,
+    type ToolRunQueryArgs,
+    type ToolRunQueryArgsTransformed,
+    type ToolRunQueryArgsV3,
+} from './tools/toolRunQueryArgs';
+
+/**
+ * Opaque run-query data stored for replay. Existing formats use one shared
+ * filter connector; filter-expression results can store one connector per
+ * category. Always parse this payload before reading its filters.
+ */
+export type PersistedRunQueryPayload =
+    | ToolRunQueryArgs
+    | ToolRunQueryExpressionResolvedArgs;
+
+export type PersistedMergeRunQueryPayload =
+    | ToolRunQueryArgsV3
+    | ToolRunQueryExpressionResolvedArgs;
+
+/**
+ * Parses every supported persisted run-query shape. Existing formats take
+ * their unchanged parser path; only per-category filter payloads use the
+ * filter-expression transform.
+ */
+export const parsePersistedRunQueryPayload = (
+    raw: unknown,
+): ToolRunQueryArgsTransformed | null => {
+    const existing = parsePersistedRunQueryArgs(raw);
+    if (existing !== null) return existing;
+
+    const resolved =
+        toolRunQueryExpressionResolvedArgsSchemaTransformed.safeParse(raw);
+    return resolved.success ? resolved.data : null;
+};

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -23,6 +23,13 @@ import {
     type ToolDefinitionWithoutMcpOutput,
 } from '../defineTool';
 import {
+    FILTER_EXPRESSION_GRAMMAR_DESCRIPTION,
+    toolRunQueryExpressionArgsSchema,
+    toolRunQueryExpressionArgsSchemaV2Mcp,
+    toolRunQueryExpressionArgsSchemaV2RejectingMerge,
+    type toolRunQueryExpressionArgsSchemaV2FormulaOnly,
+} from '../filterExpressions';
+import {
     MCP_TOOL_LIST_EXPLORES_DESCRIPTION,
     mcpToolListExploresArgsSchema,
 } from './mcpToolListExploresArgs';
@@ -531,6 +538,23 @@ export const generateVisualizationToolDefinition: ToolDefinitionWithoutMcpOutput
     agent: { outputSchema: toolRunQueryOutputSchema },
 });
 
+const TOOL_RUN_QUERY_FILTER_EXPRESSION_DESCRIPTION = `${TOOL_RUN_QUERY_DESCRIPTION}\nFilter expression syntax:\n${FILTER_EXPRESSION_GRAMMAR_DESCRIPTION}`;
+
+export const generateVisualizationFilterExpressionToolDefinition: ToolDefinitionWithoutMcpOutput<
+    'generateVisualization',
+    typeof toolRunQueryExpressionArgsSchema,
+    typeof toolRunQueryExpressionArgsSchema,
+    typeof toolRunQueryOutputSchema
+> = defineTool({
+    name: 'generateVisualization',
+    title: 'Generate visualization',
+    description: TOOL_RUN_QUERY_FILTER_EXPRESSION_DESCRIPTION,
+    availability: ['agent'],
+    inputSchema: toolRunQueryExpressionArgsSchema,
+    inputSchemaTransformed: toolRunQueryExpressionArgsSchema,
+    agent: { outputSchema: toolRunQueryOutputSchema },
+});
+
 export const runQueryToolDefinition: ToolDefinitionWithMcpOutput<
     'runQuery',
     typeof toolRunQueryArgsSchemaV2Mcp,
@@ -556,6 +580,29 @@ export const runQueryToolDefinition: ToolDefinitionWithMcpOutput<
     },
 });
 
+export const runQueryFilterExpressionToolDefinition: ToolDefinitionWithMcpOutput<
+    'runQuery',
+    typeof toolRunQueryExpressionArgsSchemaV2Mcp,
+    typeof toolRunQueryExpressionArgsSchemaV2Mcp,
+    typeof toolRunQueryOutputSchema,
+    typeof mcpRunMetricQueryStructuredOutputSchema
+> = defineTool({
+    name: 'runQuery',
+    title: 'Run query',
+    description: TOOL_RUN_QUERY_FILTER_EXPRESSION_DESCRIPTION,
+    availability: ['agent', 'mcp'],
+    // Match the legacy MCP boundary: formula-only table calculations and
+    // builtin chart configs. Persisted expression V2 parsing remains wide.
+    inputSchema: toolRunQueryExpressionArgsSchemaV2Mcp,
+    inputSchemaTransformed: toolRunQueryExpressionArgsSchemaV2Mcp,
+    agent: { outputSchema: toolRunQueryOutputSchema },
+    mcp: {
+        name: 'run_metric_query',
+        annotations: readOnlyAnnotations,
+        structuredContentSchema: mcpRunMetricQueryStructuredOutputSchema,
+    },
+});
+
 // The agent view of runQuery for runtimes without merge queries: identical
 // contract, but a merge-shaped payload fails validation instead of being
 // stripped to the primary query by Zod. Lazy, like `.for('agent')`.
@@ -567,6 +614,18 @@ export const getRunQueryAgentViewRejectingMerge = (): AgentToolView<
     ...runQueryToolDefinition.for('agent'),
     inputSchema: createAgentInputSchema(toolRunQueryArgsSchemaV2RejectingMerge),
 });
+
+export const getRunQueryFilterExpressionAgentViewRejectingMerge =
+    (): AgentToolView<
+        'runQuery',
+        typeof toolRunQueryExpressionArgsSchemaV2FormulaOnly,
+        typeof toolRunQueryOutputSchema
+    > => ({
+        ...runQueryFilterExpressionToolDefinition.for('agent'),
+        inputSchema: createAgentInputSchema(
+            toolRunQueryExpressionArgsSchemaV2RejectingMerge,
+        ),
+    });
 
 export const runSqlToolDefinition: ToolDefinitionWithMcpOutput<
     'runSql',

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -24,6 +24,12 @@ import {
     type ToolDefinitionWithoutMcpOutput,
 } from '../defineTool';
 import {
+    FILTER_EXPRESSION_GRAMMAR_DESCRIPTION,
+    toolRunQueryExpressionArgsSchema,
+    toolRunQueryExpressionArgsSchemaV2,
+    toolRunQueryExpressionArgsSchemaV2RejectingMerge,
+} from '../filterExpressions';
+import {
     MCP_TOOL_LIST_EXPLORES_DESCRIPTION,
     mcpToolListExploresArgsSchema,
 } from './mcpToolListExploresArgs';
@@ -530,6 +536,23 @@ export const generateVisualizationToolDefinition: ToolDefinitionWithoutMcpOutput
     agent: { outputSchema: toolRunQueryOutputSchema },
 });
 
+const TOOL_RUN_QUERY_FILTER_EXPRESSION_DESCRIPTION = `${TOOL_RUN_QUERY_DESCRIPTION}\nFilter expression syntax:\n${FILTER_EXPRESSION_GRAMMAR_DESCRIPTION}`;
+
+export const generateVisualizationFilterExpressionToolDefinition: ToolDefinitionWithoutMcpOutput<
+    'generateVisualization',
+    typeof toolRunQueryExpressionArgsSchema,
+    typeof toolRunQueryExpressionArgsSchema,
+    typeof toolRunQueryOutputSchema
+> = defineTool({
+    name: 'generateVisualization',
+    title: 'Generate visualization',
+    description: TOOL_RUN_QUERY_FILTER_EXPRESSION_DESCRIPTION,
+    availability: ['agent'],
+    inputSchema: toolRunQueryExpressionArgsSchema,
+    inputSchemaTransformed: toolRunQueryExpressionArgsSchema,
+    agent: { outputSchema: toolRunQueryOutputSchema },
+});
+
 export const runQueryToolDefinition: ToolDefinitionWithMcpOutput<
     'runQuery',
     typeof toolRunQueryArgsSchemaV2,
@@ -551,6 +574,27 @@ export const runQueryToolDefinition: ToolDefinitionWithMcpOutput<
     },
 });
 
+export const runQueryFilterExpressionToolDefinition: ToolDefinitionWithMcpOutput<
+    'runQuery',
+    typeof toolRunQueryExpressionArgsSchemaV2,
+    typeof toolRunQueryExpressionArgsSchemaV2,
+    typeof toolRunQueryOutputSchema,
+    typeof mcpRunMetricQueryStructuredOutputSchema
+> = defineTool({
+    name: 'runQuery',
+    title: 'Run query',
+    description: TOOL_RUN_QUERY_FILTER_EXPRESSION_DESCRIPTION,
+    availability: ['agent', 'mcp'],
+    inputSchema: toolRunQueryExpressionArgsSchemaV2,
+    inputSchemaTransformed: toolRunQueryExpressionArgsSchemaV2,
+    agent: { outputSchema: toolRunQueryOutputSchema },
+    mcp: {
+        name: 'run_metric_query',
+        annotations: readOnlyAnnotations,
+        structuredContentSchema: mcpRunMetricQueryStructuredOutputSchema,
+    },
+});
+
 // The agent view of runQuery for runtimes without merge queries: identical
 // contract, but a merge-shaped payload fails validation instead of being
 // stripped to the primary query by Zod. Lazy, like `.for('agent')`.
@@ -562,6 +606,18 @@ export const getRunQueryAgentViewRejectingMerge = (): AgentToolView<
     ...runQueryToolDefinition.for('agent'),
     inputSchema: createAgentInputSchema(toolRunQueryArgsSchemaV2RejectingMerge),
 });
+
+export const getRunQueryFilterExpressionAgentViewRejectingMerge =
+    (): AgentToolView<
+        'runQuery',
+        typeof toolRunQueryExpressionArgsSchemaV2,
+        typeof toolRunQueryOutputSchema
+    > => ({
+        ...runQueryFilterExpressionToolDefinition.for('agent'),
+        inputSchema: createAgentInputSchema(
+            toolRunQueryExpressionArgsSchemaV2RejectingMerge,
+        ),
+    });
 
 export const runSqlToolDefinition: ToolDefinitionWithMcpOutput<
     'runSql',

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -493,7 +493,10 @@ export const migrateRunQueryArgsV1ToV2 = (
     },
 });
 
-// Single entry point for re-parsing a persisted artifact of either version.
+// Existing persisted filter formats have one shared connector across every
+// category, so they cannot represent dimensions using AND while metrics use
+// OR. Keep this parser unchanged for existing records; the wider persistence
+// boundary handles the per-category filter-expression format separately.
 export const parsePersistedRunQueryArgs = (
     raw: unknown,
 ): ToolRunQueryArgsTransformed | null => {

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -1,7 +1,7 @@
 import type { Filters } from '../../types/filter';
 import type { AdditionalMetric, MetricQuery } from '../../types/metricQuery';
 import type { TransformedCustomMetric } from './schemas/customMetrics';
-import type { ToolRunQueryArgs } from './schemas/tools';
+import type { PersistedRunQueryPayload } from './schemas/persistedRunQueryArgs';
 
 export enum AiResultType {
     TIME_SERIES_RESULT = 'time_series_chart',
@@ -36,7 +36,7 @@ export type AiMetricQueryWithFilters = AiMetricQuery & {
 
 export type AiAgentVizConfig = {
     type: 'query_result';
-    config: ToolRunQueryArgs;
+    config: PersistedRunQueryPayload;
 };
 
 export const AGENT_SUGGESTION_TOOLS = [

--- a/packages/common/src/ee/AiAgent/utils.test.ts
+++ b/packages/common/src/ee/AiAgent/utils.test.ts
@@ -38,6 +38,56 @@ const customChartTypeSlugChartConfig = {
     options: { showLegend: true },
 };
 
+const statusRule = {
+    fieldId: 'orders_status',
+    fieldType: 'string',
+    fieldFilterType: 'string',
+    operator: 'equals',
+    values: ['completed'],
+};
+
+const regionRule = {
+    fieldId: 'orders_region',
+    fieldType: 'string',
+    fieldFilterType: 'string',
+    operator: 'equals',
+    values: ['emea'],
+};
+
+const revenueRule = {
+    fieldId: 'orders_revenue',
+    fieldType: 'sum',
+    fieldFilterType: 'number',
+    operator: 'greaterThan',
+    values: [100],
+};
+
+const countRule = {
+    fieldId: 'orders_count',
+    fieldType: 'count',
+    fieldFilterType: 'number',
+    operator: 'greaterThan',
+    values: [10],
+};
+
+const perCategoryResolvedConfig = {
+    ...semanticConfig,
+    queryConfig: {
+        ...semanticConfig.queryConfig,
+        filters: {
+            dimensions: {
+                connector: 'and',
+                rules: [statusRule, regionRule],
+            },
+            metrics: {
+                connector: 'or',
+                rules: [revenueRule, countRule],
+            },
+            tableCalculations: null,
+        },
+    },
+};
+
 describe('parseAiArtifactChartConfig', () => {
     it('normalizes legacy semantic configs', () => {
         expect(parseAiArtifactChartConfig(semanticConfig)).toEqual({
@@ -120,6 +170,82 @@ describe('parseAiArtifactChartConfig', () => {
         ).toBeNull();
     });
 
+    it('replays independent category connectors from persisted args', () => {
+        const artifact = parseAiArtifactChartConfig({
+            source: 'semantic',
+            config: perCategoryResolvedConfig,
+        });
+        if (artifact?.source !== 'semantic') {
+            throw new Error('Expected a semantic artifact');
+        }
+
+        const replayed = parseVizConfig(artifact.config);
+        expect(replayed?.metricQuery.filters.dimensions).toMatchObject({
+            and: [
+                { target: { fieldId: 'orders_status' } },
+                { target: { fieldId: 'orders_region' } },
+            ],
+        });
+        expect(replayed?.metricQuery.filters.metrics).toMatchObject({
+            or: [
+                { target: { fieldId: 'orders_revenue' } },
+                { target: { fieldId: 'orders_count' } },
+            ],
+        });
+    });
+
+    it('normalizes per-category filters under their semantic source', () => {
+        const normalized = {
+            source: 'semantic',
+            config: {
+                ...perCategoryResolvedConfig,
+                queryConfig: {
+                    ...perCategoryResolvedConfig.queryConfig,
+                    parameters: null,
+                },
+                mergeConfig: null,
+            },
+        };
+
+        expect(parseAiArtifactChartConfig(perCategoryResolvedConfig)).toEqual(
+            normalized,
+        );
+        expect(
+            parseAiArtifactChartConfig({
+                source: 'semantic',
+                config: perCategoryResolvedConfig,
+            }),
+        ).toEqual(normalized);
+    });
+
+    it('normalizes resolved custom chart expression args', () => {
+        const resolvedArgs = {
+            ...perCategoryResolvedConfig,
+            chartConfig: customChartTypeSlugChartConfig,
+        };
+
+        expect(
+            parseAiArtifactChartConfig({
+                source: 'customChartType',
+                schemaVersion: 1,
+                dataAppVizUuid: '4c25c1d5-cbc9-4d76-b58e-b1c9ee399fd9',
+                config: resolvedArgs,
+            }),
+        ).toEqual({
+            source: 'customChartType',
+            schemaVersion: 1,
+            dataAppVizUuid: '4c25c1d5-cbc9-4d76-b58e-b1c9ee399fd9',
+            config: {
+                ...resolvedArgs,
+                queryConfig: {
+                    ...resolvedArgs.queryConfig,
+                    parameters: null,
+                },
+                mergeConfig: null,
+            },
+        });
+    });
+
     it('drops legacy SQL execution UUIDs', () => {
         expect(
             parseAiArtifactChartConfig({
@@ -186,13 +312,141 @@ describe('parseAiArtifactChartConfig', () => {
         });
     });
 
+    it('normalizes resolved merge expression args', () => {
+        const resolvedConfig = {
+            ...perCategoryResolvedConfig,
+            mergeConfig: {
+                primarySourceId: 'orders',
+                additionalSources: [
+                    {
+                        id: 'targets',
+                        queryConfig: {
+                            exploreName: 'targets',
+                            dimensions: ['targets_month'],
+                            metrics: ['targets_target'],
+                            sorts: [],
+                            customMetrics: null,
+                            filters: {
+                                dimensions: {
+                                    connector: 'or',
+                                    rules: [
+                                        {
+                                            fieldId: 'targets_month',
+                                            fieldType: 'date',
+                                            fieldFilterType: 'date',
+                                            operator: 'equals',
+                                            values: ['2025-01-01'],
+                                        },
+                                    ],
+                                },
+                                metrics: null,
+                                tableCalculations: null,
+                            },
+                        },
+                    },
+                ],
+                joinKey: [
+                    {
+                        name: 'month',
+                        fields: [
+                            {
+                                sourceId: 'orders',
+                                fieldId: 'orders_created_month',
+                            },
+                            {
+                                sourceId: 'targets',
+                                fieldId: 'targets_month',
+                            },
+                        ],
+                    },
+                ],
+                joinType: 'full',
+            },
+        } as const;
+        const normalized = {
+            source: 'merge',
+            schemaVersion: 1,
+            config: {
+                ...resolvedConfig,
+                queryConfig: {
+                    ...resolvedConfig.queryConfig,
+                    parameters: null,
+                },
+            },
+        };
+
+        expect(
+            parseAiArtifactChartConfig({
+                source: 'merge',
+                schemaVersion: 1,
+                config: resolvedConfig,
+            }),
+        ).toEqual(normalized);
+    });
+
+    it('rejects source/config mismatches', () => {
+        const mergeResolvedConfig = {
+            ...perCategoryResolvedConfig,
+            mergeConfig: {
+                primarySourceId: 'orders',
+                additionalSources: [
+                    {
+                        id: 'targets',
+                        queryConfig: {
+                            exploreName: 'targets',
+                            dimensions: ['targets_month'],
+                            metrics: ['targets_target'],
+                            sorts: [],
+                            customMetrics: null,
+                            filters: null,
+                        },
+                    },
+                ],
+                joinKey: [
+                    {
+                        name: 'month',
+                        fields: [
+                            {
+                                sourceId: 'orders',
+                                fieldId: 'orders_created_month',
+                            },
+                            {
+                                sourceId: 'targets',
+                                fieldId: 'targets_month',
+                            },
+                        ],
+                    },
+                ],
+                joinType: 'full',
+            },
+        };
+        expect(
+            parseAiArtifactChartConfig({
+                source: 'semantic',
+                config: mergeResolvedConfig,
+            }),
+        ).toBeNull();
+        // Older releases persisted merge + custom-slug configs before new
+        // writes rejected that combination. Keep those artifacts readable.
+        expect(
+            parseAiArtifactChartConfig({
+                source: 'merge',
+                schemaVersion: 1,
+                config: {
+                    ...mergeResolvedConfig,
+                    chartConfig: customChartTypeSlugChartConfig,
+                },
+            }),
+        ).toMatchObject({ source: 'merge' });
+    });
+
     it('rejects invalid configs', () => {
         expect(parseAiArtifactChartConfig({ source: 'sql' })).toBeNull();
     });
 });
 
 describe('getDataAppVizChartFromArtifact', () => {
-    it('builds the saved-chart shape from envelope uuid + verbatim tool args', () => {
+    it('builds the saved-chart shape from its persisted envelope', () => {
         expect(
             getDataAppVizChartFromArtifact({
                 source: 'customChartType',

--- a/packages/common/src/ee/AiAgent/utils.test.ts
+++ b/packages/common/src/ee/AiAgent/utils.test.ts
@@ -45,6 +45,127 @@ describe('parseAiArtifactChartConfig', () => {
         expect(parseAiArtifactChartConfig(config)).toEqual(config);
     });
 
+    it('normalizes a persisted filter expression independently of its feature flag', () => {
+        const config = {
+            source: 'filterExpression',
+            schemaVersion: 1,
+            expressionArgs: {
+                ...semanticConfig,
+                queryConfig: {
+                    ...semanticConfig.queryConfig,
+                    filters: {
+                        dimensions: 'orders_status equals=complete',
+                        metrics: null,
+                        tableCalculations: null,
+                    },
+                },
+            },
+            resolvedArgs: semanticConfig,
+        };
+
+        const normalized = {
+            source: 'semantic',
+            config: {
+                ...semanticConfig,
+                queryConfig: {
+                    ...semanticConfig.queryConfig,
+                    parameters: null,
+                },
+                mergeConfig: null,
+            },
+        };
+
+        expect(parseAiArtifactChartConfig(config)).toEqual(normalized);
+        expect(
+            parseAiArtifactChartConfig({
+                ...config,
+                expressionArgs: {
+                    ...config.expressionArgs,
+                    mergeConfig: null,
+                },
+            }),
+        ).toEqual(normalized);
+    });
+
+    it('rejects malformed or inconsistent filter expression artifacts', () => {
+        const expressionArgs = {
+            ...semanticConfig,
+            queryConfig: {
+                ...semanticConfig.queryConfig,
+                filters: {
+                    dimensions: 'orders_status equals=complete',
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            },
+        };
+
+        expect(
+            parseAiArtifactChartConfig({
+                source: 'filterExpression',
+                schemaVersion: 1,
+                expressionArgs: {
+                    ...expressionArgs,
+                    queryConfig: {
+                        ...expressionArgs.queryConfig,
+                        filters: {
+                            ...expressionArgs.queryConfig.filters,
+                            dimensions: '',
+                        },
+                    },
+                },
+                resolvedArgs: semanticConfig,
+            }),
+        ).toBeNull();
+
+        expect(
+            parseAiArtifactChartConfig({
+                source: 'filterExpression',
+                schemaVersion: 1,
+                expressionArgs,
+                resolvedArgs: {
+                    ...semanticConfig,
+                    queryConfig: {
+                        ...semanticConfig.queryConfig,
+                        filters: {
+                            dimensions: 'orders_status equals=complete',
+                            metrics: null,
+                            tableCalculations: null,
+                        },
+                    },
+                },
+            }),
+        ).toBeNull();
+
+        expect(
+            parseAiArtifactChartConfig({
+                source: 'filterExpression',
+                schemaVersion: 1,
+                expressionArgs,
+                resolvedArgs: {
+                    ...semanticConfig,
+                    mergeConfig: {
+                        primarySourceId: 'orders',
+                        additionalSources: [],
+                        joinKey: [],
+                        joinType: 'full',
+                    },
+                },
+            }),
+        ).toBeNull();
+
+        // A malformed envelope must not fall through to legacy V1 parsing.
+        expect(
+            parseAiArtifactChartConfig({
+                ...semanticConfig,
+                source: 'filterExpression',
+                schemaVersion: 1,
+                expressionArgs,
+                resolvedArgs: semanticConfig,
+            }),
+        ).toBeNull();
+    });
+
     it('drops legacy SQL execution UUIDs', () => {
         expect(
             parseAiArtifactChartConfig({
@@ -109,6 +230,101 @@ describe('parseAiArtifactChartConfig', () => {
                 queryConfig: { ...config.config.queryConfig, parameters: null },
             },
         });
+    });
+
+    it('normalizes a persisted merge filter expression', () => {
+        const resolvedConfig = {
+            ...semanticConfig,
+            mergeConfig: {
+                primarySourceId: 'orders',
+                additionalSources: [
+                    {
+                        id: 'targets',
+                        queryConfig: {
+                            exploreName: 'targets',
+                            dimensions: ['targets_month'],
+                            metrics: ['targets_target'],
+                            sorts: [],
+                            customMetrics: null,
+                            filters: null,
+                        },
+                    },
+                ],
+                joinKey: [
+                    {
+                        name: 'month',
+                        fields: [
+                            {
+                                sourceId: 'orders',
+                                fieldId: 'orders_created_month',
+                            },
+                            {
+                                sourceId: 'targets',
+                                fieldId: 'targets_month',
+                            },
+                        ],
+                    },
+                ],
+                joinType: 'full',
+            },
+        } as const;
+        const expressionArgs = {
+            ...resolvedConfig,
+            queryConfig: {
+                ...resolvedConfig.queryConfig,
+                filters: {
+                    dimensions: 'orders_created_month equals=2025-01-01',
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            },
+            mergeConfig: {
+                ...resolvedConfig.mergeConfig,
+                additionalSources:
+                    resolvedConfig.mergeConfig.additionalSources.map(
+                        (source) => ({
+                            ...source,
+                            queryConfig: {
+                                ...source.queryConfig,
+                                filters: {
+                                    dimensions:
+                                        'targets_month equals=2025-01-01',
+                                    metrics: null,
+                                    tableCalculations: null,
+                                },
+                            },
+                        }),
+                    ),
+            },
+        };
+
+        expect(
+            parseAiArtifactChartConfig({
+                source: 'filterExpression',
+                schemaVersion: 1,
+                expressionArgs,
+                resolvedArgs: resolvedConfig,
+            }),
+        ).toEqual({
+            source: 'merge',
+            schemaVersion: 1,
+            config: {
+                ...resolvedConfig,
+                queryConfig: {
+                    ...resolvedConfig.queryConfig,
+                    parameters: null,
+                },
+            },
+        });
+
+        expect(
+            parseAiArtifactChartConfig({
+                source: 'filterExpression',
+                schemaVersion: 1,
+                expressionArgs,
+                resolvedArgs: semanticConfig,
+            }),
+        ).toBeNull();
     });
 
     it('rejects invalid configs', () => {

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -10,6 +10,7 @@ import {
     metricQueryTableViz,
     metricQueryTimeSeriesViz,
     metricQueryVerticalBarViz,
+    parseAiFilterExpressionArtifactConfigV1,
     parsePersistedRunQueryArgs,
     toolRunQueryArgsSchemaPersisted,
     toolTableVizArgsSchemaTransformed,
@@ -151,6 +152,24 @@ export const parseAiArtifactChartConfig = (
     config: unknown,
 ): AiChartArtifactConfig | null => {
     if (!config || typeof config !== 'object') return null;
+
+    if ('source' in config && config.source === 'filterExpression') {
+        const parsed = parseAiFilterExpressionArtifactConfigV1(config);
+        if (!parsed || !parseVizConfig(parsed.resolvedArgs)) return null;
+
+        if (parsed.resolvedArgs.mergeConfig) {
+            return {
+                source: 'merge',
+                schemaVersion: 1,
+                config: parsed.resolvedArgs,
+            };
+        }
+
+        return {
+            source: 'semantic',
+            config: parsed.resolvedArgs,
+        };
+    }
 
     if (isAiComposerChartArtifactConfig(config)) {
         return config;

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -11,7 +11,9 @@ import {
     filterAggregationCustomMetrics,
     isCustomChartTypeSlugChartConfig,
     parsePersistedRunQueryArgs,
+    parsePersistedRunQueryPayload,
     toolRunQueryArgsSchemaPersisted,
+    toolRunQueryExpressionResolvedArgsSchema,
 } from './schemas';
 import { AiResultType } from './types';
 import { getValidAiQueryLimit } from './validators';
@@ -40,9 +42,9 @@ export const parseVizConfig = (
         return null;
     }
 
-    // Parse runQuery tool. Persisted artifacts may be V1 or V2;
-    // parsePersistedRunQueryArgs normalizes both to the V2 internal shape.
-    const vizTool = parsePersistedRunQueryArgs(vizConfigUnknown);
+    // Parse every persisted run-query shape to the existing internal domain
+    // type before rendering or replaying it.
+    const vizTool = parsePersistedRunQueryPayload(vizConfigUnknown);
     if (vizTool) {
         const metricQuery = {
             exploreName: vizTool.queryConfig.exploreName,
@@ -80,15 +82,38 @@ export const parseVizConfig = (
     return null;
 };
 
-// Semantic artifacts are builtin-only: a custom chart type answer is stored
-// in its own envelope, never as a slug config under source 'semantic'.
-const isBuiltinSemanticVizConfig = (raw: object): boolean => {
-    const parsed = parseVizConfig(raw);
-    if (!parsed) return false;
-    return !(
-        parsed.type === AiResultType.QUERY_RESULT &&
-        isCustomChartTypeSlugChartConfig(parsed.vizTool.chartConfig)
-    );
+// Semantic artifacts accept every persisted query format, including resolved
+// per-category filter connectors. Custom charts and merges use their own
+// replay envelopes.
+const parseBuiltinSemanticVizConfig = (raw: object) => {
+    const existing = parsePersistedRunQueryArgs(raw);
+    if (existing) {
+        if (
+            existing.mergeConfig !== null ||
+            isCustomChartTypeSlugChartConfig(existing.chartConfig)
+        ) {
+            return null;
+        }
+        return raw as AiLegacySemanticChartArtifactConfig;
+    }
+
+    const resolved = toolRunQueryExpressionResolvedArgsSchema.safeParse(raw);
+    if (
+        !resolved.success ||
+        resolved.data.mergeConfig !== null ||
+        isCustomChartTypeSlugChartConfig(resolved.data.chartConfig)
+    ) {
+        return null;
+    }
+    return resolved.data;
+};
+
+const parseVersionedArtifactQueryConfig = (raw: unknown) => {
+    const existing = toolRunQueryArgsSchemaPersisted.safeParse(raw);
+    if (existing.success) return existing.data;
+
+    const resolved = toolRunQueryExpressionResolvedArgsSchema.safeParse(raw);
+    return resolved.success ? resolved.data : null;
 };
 
 export const parseAiArtifactChartConfig = (
@@ -107,19 +132,20 @@ export const parseAiArtifactChartConfig = (
         config.schemaVersion === 1 &&
         'dataAppVizUuid' in config &&
         typeof config.dataAppVizUuid === 'string' &&
+        config.dataAppVizUuid.length > 0 &&
         'config' in config
     ) {
-        const parsed = toolRunQueryArgsSchemaPersisted.safeParse(config.config);
+        const parsed = parseVersionedArtifactQueryConfig(config.config);
         if (
-            parsed.success &&
-            !parsed.data.mergeConfig &&
-            isCustomChartTypeSlugChartConfig(parsed.data.chartConfig)
+            parsed !== null &&
+            parsed.mergeConfig === null &&
+            isCustomChartTypeSlugChartConfig(parsed.chartConfig)
         ) {
             return {
                 source: 'customChartType',
                 schemaVersion: 1,
                 dataAppVizUuid: config.dataAppVizUuid,
-                config: parsed.data,
+                config: parsed,
             };
         }
         return null;
@@ -132,12 +158,12 @@ export const parseAiArtifactChartConfig = (
         config.schemaVersion === 1 &&
         'config' in config
     ) {
-        const parsed = toolRunQueryArgsSchemaPersisted.safeParse(config.config);
-        if (parsed.success && parsed.data.mergeConfig) {
+        const parsed = parseVersionedArtifactQueryConfig(config.config);
+        if (parsed !== null && parsed.mergeConfig !== null) {
             return {
                 source: 'merge',
                 schemaVersion: 1,
-                config: parsed.data,
+                config: parsed,
             };
         }
         return null;
@@ -163,19 +189,23 @@ export const parseAiArtifactChartConfig = (
         config.source === 'semantic' &&
         'config' in config &&
         config.config &&
-        typeof config.config === 'object' &&
-        isBuiltinSemanticVizConfig(config.config)
+        typeof config.config === 'object'
     ) {
-        return {
-            source: 'semantic',
-            config: config.config as AiLegacySemanticChartArtifactConfig,
-        };
+        const parsed = parseBuiltinSemanticVizConfig(config.config);
+        if (parsed !== null) {
+            return {
+                source: 'semantic',
+                config: parsed,
+            };
+        }
+        return null;
     }
 
-    if (isBuiltinSemanticVizConfig(config)) {
+    const semantic = parseBuiltinSemanticVizConfig(config);
+    if (semantic !== null) {
         return {
             source: 'semantic',
-            config: config as AiLegacySemanticChartArtifactConfig,
+            config: semantic,
         };
     }
 
@@ -183,8 +213,8 @@ export const parseAiArtifactChartConfig = (
 };
 
 // The saved-chart shape a custom chart type answer renders and saves with:
-// the server-derived uuid from the envelope plus the model's field mapping
-// and option values from the verbatim tool args.
+// the server-derived uuid from the envelope plus the persisted field mapping
+// and option values.
 export const getDataAppVizChartFromArtifact = (
     artifactConfig: AiCustomChartTypeChartArtifactConfig,
 ): DataAppVizChart | null => {

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -310,6 +310,13 @@ export enum FeatureFlags {
      */
     EmailWhitelabel = 'email-whitelabel',
 
+    /**
+     * Advertise compact filter expressions to AI agent and MCP metric-query
+     * tools, resolving them to the existing filter model at the tool boundary.
+     * Off by default while the public contract is rolled out per organization.
+     */
+    AiFilterExpressions = 'ai-filter-expressions',
+
     /* Merge two or more queries into one warehouse statement from the
        explorer. Gated because it compiles novel SQL shapes (multi-CTE joins,
        conditional-aggregation widening) that no other path exercises. */

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -293,6 +293,13 @@ export enum FeatureFlags {
      */
     EmailWhitelabel = 'email-whitelabel',
 
+    /**
+     * Advertise compact filter expressions to AI agent and MCP metric-query
+     * tools, resolving them to the existing filter model at the tool boundary.
+     * Off by default while the public contract is rolled out per organization.
+     */
+    AiFilterExpressions = 'ai-filter-expressions',
+
     /* Merge two or more queries into one warehouse statement from the
        explorer. Gated because it compiles novel SQL shapes (multi-CTE joins,
        conditional-aggregation widening) that no other path exercises. */

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -9,7 +9,7 @@ import {
     type ChartConfig,
     type DataAppVizChart,
     type EChartsSeries,
-    type ToolRunQueryArgs,
+    type PersistedRunQueryPayload,
 } from '@lightdash/common';
 import {
     Box,
@@ -57,7 +57,7 @@ import {
 type Props = {
     vizQueryData: ApiAiAgentThreadMessageVizQuery;
     results: InfiniteQueryResults;
-    chartConfig: ToolRunQueryArgs;
+    chartConfig: PersistedRunQueryPayload;
     // Set for custom chart type answers (from the artifact envelope): the
     // saved-chart shape the dedicated renderer mounts with.
     customChartType?: DataAppVizChart | null;

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiArtifactChart.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiArtifactChart.ts
@@ -2,8 +2,8 @@ import {
     assertUnreachable,
     getDataAppVizChartFromArtifact,
     type AiChartArtifactConfig,
-    type AiLegacySemanticChartArtifactConfig,
     type ApiAiAgentThreadMessageVizQuery,
+    type PersistedRunQueryPayload,
     type DataAppVizChart,
 } from '@lightdash/common';
 import { useCompiledSqlFromMetricQuery } from '../../../../hooks/useCompiledSql';
@@ -12,7 +12,7 @@ import { useAiMergeCompiledSql } from './useAiMergeCompiledSql';
 type AiArtifactChartSource = {
     isMergeArtifact: boolean;
     /** Tool args driving the semantic query render paths, when any. */
-    semanticChartConfig: AiLegacySemanticChartArtifactConfig | null;
+    semanticChartConfig: PersistedRunQueryPayload | null;
     /** Set for custom chart type answers: uuid from the envelope + mapping. */
     customChartType: DataAppVizChart | null;
 };

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.test.ts
@@ -1,0 +1,76 @@
+import { parseStreamRawToolCall } from './parseStreamRawToolResult';
+
+const expressionToolArgs = {
+    title: 'Orders by status',
+    description: 'Order count by status',
+    queryConfig: {
+        exploreName: 'orders',
+        dimensions: ['orders_status'],
+        metrics: ['orders_count'],
+        sorts: [],
+        limit: 500,
+        parameters: null,
+        customMetrics: null,
+        tableCalculations: null,
+        filters: {
+            dimensions: 'orders_status equals=complete',
+            metrics: null,
+            tableCalculations: null,
+        },
+    },
+    chartConfig: null,
+};
+
+describe('parseStreamRawToolCall', () => {
+    it('keeps filter-expression visualization cards in the stream', () => {
+        expect(
+            parseStreamRawToolCall({
+                toolName: 'generateVisualization',
+                toolArgs: expressionToolArgs,
+            }),
+        ).toMatchObject({
+            toolName: 'generateVisualization',
+            toolArgs: {
+                queryConfig: {
+                    filters: {
+                        dimensions: 'orders_status equals=complete',
+                    },
+                },
+            },
+        });
+    });
+
+    it('keeps merge-disabled expression cards with legacy table calculations', () => {
+        expect(
+            parseStreamRawToolCall({
+                toolName: 'generateVisualization',
+                toolArgs: {
+                    ...expressionToolArgs,
+                    queryConfig: {
+                        ...expressionToolArgs.queryConfig,
+                        tableCalculations: [
+                            {
+                                type: 'running_total',
+                                name: 'running_orders',
+                                displayName: 'Running orders',
+                                fieldId: 'orders_count',
+                            },
+                        ],
+                    },
+                },
+            }),
+        ).toMatchObject({
+            toolName: 'generateVisualization',
+            toolArgs: {
+                queryConfig: {
+                    tableCalculations: [
+                        {
+                            type: 'running_total',
+                            name: 'running_orders',
+                        },
+                    ],
+                },
+            },
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
@@ -3,6 +3,8 @@ import {
     isAiAgentMcpToolName,
     toolDashboardV2ArgsSchemaPersisted,
     toolRunQueryArgsSchemaPersisted,
+    toolRunQueryExpressionArgsSchema,
+    toolRunQueryExpressionArgsSchemaV2,
     type ToolDefinition,
     type ToolName,
 } from '@lightdash/common';
@@ -16,7 +18,9 @@ type McpStreamToolName = `mcp_${string}`;
 // resuming old threads may echo legacy template table calcs the backend still
 // executes. Parse those tools with the wide persisted schemas so they render.
 const wideInputSchemaOverrides = {
-    generateVisualization: toolRunQueryArgsSchemaPersisted,
+    generateVisualization: toolRunQueryArgsSchemaPersisted
+        .or(toolRunQueryExpressionArgsSchema)
+        .or(toolRunQueryExpressionArgsSchemaV2),
     generateDashboard: toolDashboardV2ArgsSchemaPersisted,
 } as const;
 

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
@@ -4,6 +4,8 @@ import {
     parsePartialToolComposerQueriesArgs,
     toolDashboardV2ArgsSchemaPersisted,
     toolRunQueryArgsSchemaPersisted,
+    toolRunQueryExpressionArgsSchema,
+    toolRunQueryExpressionArgsSchemaV2,
     type ToolDefinition,
     type ToolName,
 } from '@lightdash/common';
@@ -17,7 +19,9 @@ type McpStreamToolName = `mcp_${string}`;
 // resuming old threads may echo legacy template table calcs the backend still
 // executes. Parse those tools with the wide persisted schemas so they render.
 const wideInputSchemaOverrides = {
-    generateVisualization: toolRunQueryArgsSchemaPersisted,
+    generateVisualization: toolRunQueryArgsSchemaPersisted
+        .or(toolRunQueryExpressionArgsSchema)
+        .or(toolRunQueryExpressionArgsSchemaV2),
     generateDashboard: toolDashboardV2ArgsSchemaPersisted,
 } as const;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -955,6 +955,9 @@ importers:
       '@types/uuid':
         specifier: 10.0.0
         version: 10.0.0
+      js-tiktoken:
+        specifier: 1.0.16
+        version: 1.0.16
       oxlint:
         specifier: 1.75.0
         version: 1.75.0(oxlint-tsgolint@7.0.2001)


### PR DESCRIPTION
Related: ZAP-963
Related: ZAP-920
Related: #28262

## Summary

- Add the off-by-default `AiFilterExpressions` flag and switch agent contracts only when enabled.
- Require every run-query tool factory caller to pass `enableFilterExpressions` explicitly so an omitted dependency cannot silently select the legacy contract.
- Resolve expressions before the unchanged validation and query execution paths while preserving merge guards.
- Keep merge-disabled agent contracts formula-only, reject non-null `mergeConfig`, preserve the existing tool-call audit shape, and normalize to `mergeConfig: null` only after contract selection; retain wide V2 parsing only for replay.
- Persist resolved expression arguments through the existing semantic, merge, or custom-chart artifact envelopes and existing Zod transformation pipeline. Original model arguments remain in `ai_agent_tool_call.tool_args`; artifacts do not duplicate them.
- Parse persisted filters as explicit V2-then-V1 shapes without an embedded version field: V1 preserves the shared root connector, while V2 stores independent per-category connectors.
- Document the result-level algebra shared by agent and Model Context Protocol (MCP) schemas: each category chooses AND or OR independently, while non-null dimension, metric, and table-calculation categories combine with AND; for example, dimensions `D1 AND D2` plus metrics `M1 OR M2` mean `(D1 AND D2) AND (M1 OR M2)`. Query execution and its staged SQL evaluation remain unchanged.
- Accept both expression schema generations in frontend streaming.
- Guard compact agent and Model Context Protocol (MCP) contracts with absolute size/token budgets and minimum 45%/60% reductions while leaving default tool-definition arrays unchanged.

This layer enables filter expressions for AI agents; MCP remains on the legacy contract.

## Verification

- 291 common AI tests on the cumulative stack.
- 2,419 backend AI, AgentService, and Model Context Protocol tests on the cumulative stack, including query, Slack, and unfurl coverage.
- Frontend streaming tests.
- Common, backend, and frontend typecheck; common/backend lint and format checks.
- Database-backed model read-path coverage for the resolved per-category persistence shape; CI runs it with the licensed integration environment.
- 15 focused shared expression-schema tests and 4 agent contract snapshot tests for the category-composition clarification.
- 33 focused run-query tool tests plus backend typecheck, lint, and format for the explicit feature dependency.

## Retention note

Artifact replay is self-contained in the resolved configuration. If a prompt and its cascading tool-call row are ever deleted while an artifact version remains, the original expression input is intentionally not retained as a second artifact copy. No current path deletes prompts independently.

Risk: high — changes the AI query boundary and persisted-artifact compatibility behind an off-by-default flag; human review is required.
