### PR TITLE
feat(mcp): enable metric query expressions

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -5,6 +5,7 @@ import {
     QueryExecutionContext,
     QueryHistoryStatus,
 } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
 import * as runQueryTool from '../ai/tools/runQuery';
 import { McpService, McpToolName } from './McpService';
 
@@ -73,6 +74,7 @@ const makeSpaceMetadata = (spaceUuid: string) => ({
 });
 
 const account = {
+    authentication: { type: 'session' },
     isRegisteredUser: () => true,
     isServiceAccount: () => false,
     user: { id: userUuid },
@@ -221,6 +223,7 @@ const makeMcpService = ({
     verifiedContent = [],
     artifactVerifiedContent = [],
     runtimeErrors = {},
+    filterExpressionsEnabled = false,
 }: {
     context?: {
         projectUuid: string;
@@ -247,6 +250,7 @@ const makeMcpService = ({
         findFields?: string;
         findFieldsByQuery?: Record<string, string>;
     };
+    filterExpressionsEnabled?: boolean;
 } = {}) => {
     const asyncQueryService = {
         executeAsyncSqlQuery: vi.fn(),
@@ -259,6 +263,10 @@ const makeMcpService = ({
 
     const mcpContextModel = {
         getContext: vi.fn().mockResolvedValue({ context }),
+    };
+    const mcpToolCallModel = {
+        createToolCall: vi.fn().mockResolvedValue(undefined),
+        findClientInfo: vi.fn().mockResolvedValue(undefined),
     };
 
     const shareService = {
@@ -558,6 +566,7 @@ const makeMcpService = ({
             siteUrl: 'https://lightdash.example',
         },
         mcpContextModel,
+        mcpToolCallModel,
         projectModel,
         projectService,
         searchModel,
@@ -575,6 +584,7 @@ const makeMcpService = ({
         mcpContentWritesEnabled: true,
         scheduledDeliveryEnabled: true,
         runSqlEnabled: true,
+        filterExpressionsEnabled,
     });
 
     return {
@@ -584,6 +594,7 @@ const makeMcpService = ({
         catalogService,
         contentVerificationService,
         mcpContextModel,
+        mcpToolCallModel,
         projectModel,
         projectService,
         searchModel,
@@ -969,6 +980,125 @@ describe('MCP async query polling', () => {
             verifiedChart,
             artifactOnlyChart,
         ]);
+    });
+
+    it('resolves run_metric_query filter expressions before execution', async () => {
+        const { asyncQueryService } = makeMcpService({
+            filterExpressionsEnabled: true,
+        });
+        asyncQueryService.executeAsyncMetricQuery.mockResolvedValue({
+            queryUuid,
+        });
+        asyncQueryService.pollQueryHistoryUntilDeadline.mockResolvedValue(
+            makeQueryHistory(
+                QueryHistoryStatus.QUEUED,
+                QueryExecutionContext.MCP_RUN_METRIC_QUERY,
+            ),
+        );
+
+        const result = await getToolCallback(McpToolName.RUN_METRIC_QUERY)(
+            {
+                title: 'Orders',
+                description: 'Orders count',
+                queryConfig: {
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: ['orders_count'],
+                    sorts: [],
+                    limit: 10,
+                    customMetrics: null,
+                    tableCalculations: null,
+                    filters: {
+                        dimensions: null,
+                        metrics: 'orders_orders_count greaterThan=1',
+                        tableCalculations: null,
+                    },
+                },
+                chartConfig: null,
+            },
+            extra,
+        );
+
+        expect(result).toMatchObject({
+            structuredContent: {
+                result: { status: 'running', queryUuid },
+            },
+        });
+        expect(asyncQueryService.executeAsyncMetricQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                metricQuery: expect.objectContaining({
+                    filters: expect.objectContaining({
+                        metrics: expect.objectContaining({
+                            and: [
+                                expect.objectContaining({
+                                    target: expect.objectContaining({
+                                        fieldId: 'orders_orders_count',
+                                    }),
+                                    values: [1],
+                                }),
+                            ],
+                        }),
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it('tracks located filter-expression failures without executing or capturing Sentry', async () => {
+        vi.mocked(Sentry.captureException).mockClear();
+        const { asyncQueryService, mcpToolCallModel } = makeMcpService({
+            filterExpressionsEnabled: true,
+        });
+
+        const result = await getToolCallback(McpToolName.RUN_METRIC_QUERY)(
+            {
+                title: 'Orders',
+                description: 'Orders count',
+                queryConfig: {
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: ['orders_count'],
+                    sorts: [],
+                    limit: 10,
+                    customMetrics: null,
+                    tableCalculations: null,
+                    filters: {
+                        dimensions: null,
+                        metrics: 'unknown_metric greaterThan=1',
+                        tableCalculations: null,
+                    },
+                },
+                chartConfig: null,
+            },
+            extra,
+        );
+
+        expect(result).toMatchObject({
+            isError: true,
+            content: [
+                {
+                    type: 'text',
+                    text: expect.stringContaining(
+                        '[FILTER_EXPRESSION_UNKNOWN_FIELD]',
+                    ),
+                },
+            ],
+        });
+        expect(
+            asyncQueryService.executeAsyncMetricQuery,
+        ).not.toHaveBeenCalled();
+        expect(Sentry.captureException).not.toHaveBeenCalled();
+        await vi.waitFor(() => {
+            expect(mcpToolCallModel.createToolCall).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    tool_name: McpToolName.RUN_METRIC_QUERY,
+                    status: 'error',
+                    error_message: expect.stringContaining(
+                        '[FILTER_EXPRESSION_UNKNOWN_FIELD]',
+                    ),
+                }),
+            );
+        });
     });
 
     it('uses explicit agent tags for run_metric_query', async () => {

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -5,6 +5,7 @@ import {
     QueryExecutionContext,
     QueryHistoryStatus,
 } from '@lightdash/common';
+import * as Sentry from '@sentry/node';
 import * as runQueryTool from '../ai/tools/runQuery';
 import { McpService, McpToolName } from './McpService';
 
@@ -73,6 +74,7 @@ const makeSpaceMetadata = (spaceUuid: string) => ({
 });
 
 const account = {
+    authentication: { type: 'session' },
     isRegisteredUser: () => true,
     isServiceAccount: () => false,
     user: { id: userUuid },
@@ -221,6 +223,7 @@ const makeMcpService = ({
     verifiedContent = [],
     artifactVerifiedContent = [],
     runtimeErrors = {},
+    filterExpressionsEnabled = false,
 }: {
     context?: {
         projectUuid: string;
@@ -247,6 +250,7 @@ const makeMcpService = ({
         findFields?: string;
         findFieldsByQuery?: Record<string, string>;
     };
+    filterExpressionsEnabled?: boolean;
 } = {}) => {
     const asyncQueryService = {
         executeAsyncSqlQuery: vi.fn(),
@@ -259,6 +263,10 @@ const makeMcpService = ({
 
     const mcpContextModel = {
         getContext: vi.fn().mockResolvedValue({ context }),
+    };
+    const mcpToolCallModel = {
+        createToolCall: vi.fn().mockResolvedValue(undefined),
+        findClientInfo: vi.fn().mockResolvedValue(undefined),
     };
 
     const shareService = {
@@ -558,6 +566,7 @@ const makeMcpService = ({
             siteUrl: 'https://lightdash.example',
         },
         mcpContextModel,
+        mcpToolCallModel,
         projectModel,
         projectService,
         searchModel,
@@ -576,6 +585,7 @@ const makeMcpService = ({
         scheduledDeliveryEnabled: true,
         runSqlEnabled: true,
         runMetricQueryEnabled: true,
+        filterExpressionsEnabled,
     });
 
     return {
@@ -585,6 +595,7 @@ const makeMcpService = ({
         catalogService,
         contentVerificationService,
         mcpContextModel,
+        mcpToolCallModel,
         projectModel,
         projectService,
         searchModel,
@@ -970,6 +981,125 @@ describe('MCP async query polling', () => {
             verifiedChart,
             artifactOnlyChart,
         ]);
+    });
+
+    it('resolves run_metric_query filter expressions before execution', async () => {
+        const { asyncQueryService } = makeMcpService({
+            filterExpressionsEnabled: true,
+        });
+        asyncQueryService.executeAsyncMetricQuery.mockResolvedValue({
+            queryUuid,
+        });
+        asyncQueryService.pollQueryHistoryUntilDeadline.mockResolvedValue(
+            makeQueryHistory(
+                QueryHistoryStatus.QUEUED,
+                QueryExecutionContext.MCP_RUN_METRIC_QUERY,
+            ),
+        );
+
+        const result = await getToolCallback(McpToolName.RUN_METRIC_QUERY)(
+            {
+                title: 'Orders',
+                description: 'Orders count',
+                queryConfig: {
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: ['orders_count'],
+                    sorts: [],
+                    limit: 10,
+                    customMetrics: null,
+                    tableCalculations: null,
+                    filters: {
+                        dimensions: null,
+                        metrics: 'orders_orders_count greaterThan=1',
+                        tableCalculations: null,
+                    },
+                },
+                chartConfig: null,
+            },
+            extra,
+        );
+
+        expect(result).toMatchObject({
+            structuredContent: {
+                result: { status: 'running', queryUuid },
+            },
+        });
+        expect(asyncQueryService.executeAsyncMetricQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                metricQuery: expect.objectContaining({
+                    filters: expect.objectContaining({
+                        metrics: expect.objectContaining({
+                            and: [
+                                expect.objectContaining({
+                                    target: expect.objectContaining({
+                                        fieldId: 'orders_orders_count',
+                                    }),
+                                    values: [1],
+                                }),
+                            ],
+                        }),
+                    }),
+                }),
+            }),
+        );
+    });
+
+    it('tracks located filter-expression failures without executing or capturing Sentry', async () => {
+        vi.mocked(Sentry.captureException).mockClear();
+        const { asyncQueryService, mcpToolCallModel } = makeMcpService({
+            filterExpressionsEnabled: true,
+        });
+
+        const result = await getToolCallback(McpToolName.RUN_METRIC_QUERY)(
+            {
+                title: 'Orders',
+                description: 'Orders count',
+                queryConfig: {
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: ['orders_count'],
+                    sorts: [],
+                    limit: 10,
+                    customMetrics: null,
+                    tableCalculations: null,
+                    filters: {
+                        dimensions: null,
+                        metrics: 'unknown_metric greaterThan=1',
+                        tableCalculations: null,
+                    },
+                },
+                chartConfig: null,
+            },
+            extra,
+        );
+
+        expect(result).toMatchObject({
+            isError: true,
+            content: [
+                {
+                    type: 'text',
+                    text: expect.stringContaining(
+                        '[FILTER_EXPRESSION_UNKNOWN_FIELD]',
+                    ),
+                },
+            ],
+        });
+        expect(
+            asyncQueryService.executeAsyncMetricQuery,
+        ).not.toHaveBeenCalled();
+        expect(Sentry.captureException).not.toHaveBeenCalled();
+        await vi.waitFor(() => {
+            expect(mcpToolCallModel.createToolCall).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    tool_name: McpToolName.RUN_METRIC_QUERY,
+                    status: 'error',
+                    error_message: expect.stringContaining(
+                        '[FILTER_EXPRESSION_UNKNOWN_FIELD]',
+                    ),
+                }),
+            );
+        });
     });
 
     it('uses explicit agent tags for run_metric_query', async () => {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -70,6 +70,7 @@ import {
     resolveUrlToolDefinition,
     routeAgentToolDefinition,
     runAiWritebackToolDefinition,
+    runQueryFilterExpressionToolDefinition,
     runQueryToolDefinition,
     runSqlToolDefinition,
     searchFieldValuesToolDefinition,
@@ -80,9 +81,12 @@ import {
     toolRenderChartArgsSchemaTransformed,
     ToolRenderChartArgsTransformed,
     toolRunQueryArgsSchemaTransformed,
-    ToolRunQueryArgsTransformed,
+    toolRunQueryExpressionArgsSchemaV2Mcp,
     UnexpectedServerError,
     UserAttributeValueMap,
+    type ToolRunQueryArgsTransformed,
+    type ToolRunQueryArgsV2,
+    type ToolRunQueryExpressionArgsMcp,
 } from '@lightdash/common';
 // eslint-disable-next-line import/extensions
 import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
@@ -154,6 +158,10 @@ import {
 } from '../ai/tools/runQuery';
 import { getSearchFieldValues } from '../ai/tools/searchFieldValues';
 import { formatToolJsonOutput } from '../ai/tools/toolOutputFormat';
+import {
+    formatFilterExpressionError,
+    resolveFilterExpressionArgs,
+} from '../ai/utils/filterExpressions';
 import { getPivotedResults } from '../ai/utils/getPivotedResults';
 import {
     expandMetricsWithPopAdditionalMetrics,
@@ -322,6 +330,9 @@ const mcpGetCurrentAgentTool = withProjectUuidInput(
 const mcpRunMetricQueryTool = withProjectScopeInput(
     runQueryToolDefinition.for('mcp'),
 );
+const mcpRunMetricQueryFilterExpressionTool = withProjectScopeInput(
+    runQueryFilterExpressionToolDefinition.for('mcp'),
+);
 const mcpRenderChartTool = withProjectScopeInput(
     renderChartToolDefinition.for('mcp'),
 );
@@ -383,6 +394,14 @@ type McpEffectiveScope = {
     spaceAccess: string[] | null;
     agentUuid: string | null;
     agentName: string | null;
+};
+
+type McpRunMetricQueryArgs = (
+    | ToolRunQueryArgsV2
+    | ToolRunQueryExpressionArgsMcp
+) & {
+    projectUuid: string;
+    agentUuid?: string;
 };
 
 // Narrows the SDK's loosely-typed `RequestHandlerExtra` into the shape the
@@ -1886,6 +1905,7 @@ export class McpService extends BaseService {
             scheduledDeliveryEnabled: boolean;
             runSqlEnabled: boolean;
             runMetricQueryEnabled: boolean;
+            filterExpressionsEnabled: boolean;
         } = {
             projectPinned: false,
             aiWritebackEnabled: false,
@@ -1893,6 +1913,7 @@ export class McpService extends BaseService {
             scheduledDeliveryEnabled: true,
             runSqlEnabled: false,
             runMetricQueryEnabled: true,
+            filterExpressionsEnabled: false,
         },
     ): void {
         this.registerTrackedTool(
@@ -2876,16 +2897,25 @@ export class McpService extends BaseService {
         );
 
         if (options.runMetricQueryEnabled) {
+            const runMetricQueryTool = options.filterExpressionsEnabled
+                ? mcpRunMetricQueryFilterExpressionTool
+                : mcpRunMetricQueryTool;
             this.registerTrackedTool(
-                mcpRunMetricQueryTool.name,
+                runMetricQueryTool.name,
                 {
-                    title: mcpRunMetricQueryTool.title,
-                    description: mcpRunMetricQueryTool.description,
-                    inputSchema: mcpRunMetricQueryTool.inputSchema.shape,
-                    outputSchema: mcpRunMetricQueryTool.outputSchema,
-                    annotations: mcpRunMetricQueryTool.annotations,
+                    title: runMetricQueryTool.title,
+                    description: runMetricQueryTool.description,
+                    inputSchema: runMetricQueryTool.inputSchema.shape,
+                    outputSchema: runMetricQueryTool.outputSchema,
+                    annotations: runMetricQueryTool.annotations,
                 },
-                async (args, extra) => {
+                async (
+                    args: McpRunMetricQueryArgs,
+                    extra: RequestHandlerExtra<
+                        ServerRequest,
+                        ServerNotification
+                    >,
+                ) => {
                     const ctx = getMcpContext(extra);
 
                     const projectUuid = await this.resolveToolProjectUuid(
@@ -2898,10 +2928,47 @@ export class McpService extends BaseService {
                         const deadlineMs =
                             Date.now() + McpService.getMcpQueryWaitMs(extra);
                         const { account } = McpService.getAccount(ctx);
-                        const queryTool =
-                            toolRunQueryArgsSchemaTransformed.parse(
-                                argsWithProject,
+                        let queryTool: ToolRunQueryArgsTransformed;
+                        if (options.filterExpressionsEnabled) {
+                            const expressionToolArgs =
+                                toolRunQueryExpressionArgsSchemaV2Mcp.parse(
+                                    argsWithProject,
+                                );
+                            const toolsRuntime = await this.getToolsRuntime(
+                                ctx,
+                                projectUuid,
+                                args.agentUuid,
                             );
+                            // Model Context Protocol (MCP) does not advertise
+                            // mergeConfig; resolution consumes one normalized
+                            // current shape after the boundary parse.
+                            const resolution =
+                                await resolveFilterExpressionArgs({
+                                    toolArgs: {
+                                        ...expressionToolArgs,
+                                        mergeConfig: null,
+                                    },
+                                    getExplore: async (exploreName) =>
+                                        unwrapMcpRuntimeResult(
+                                            await toolsRuntime.getExplore({
+                                                table: exploreName,
+                                            }),
+                                        ),
+                                });
+                            if (!resolution.success) {
+                                return runMetricQueryTool.result.error(
+                                    formatFilterExpressionError(
+                                        resolution.error,
+                                    ),
+                                );
+                            }
+                            queryTool = resolution.data.transformed;
+                        } else {
+                            queryTool =
+                                toolRunQueryArgsSchemaTransformed.parse(
+                                    argsWithProject,
+                                );
+                        }
                         const {
                             query,
                             userAttributeOverrides,
@@ -3922,6 +3989,7 @@ export class McpService extends BaseService {
         scheduledDeliveryEnabled?: boolean;
         runSqlEnabled?: boolean;
         runMetricQueryEnabled?: boolean;
+        filterExpressionsEnabled?: boolean;
     }): Promise<McpServer> {
         const newServer = this.buildMcpServer({
             runSqlEnabled: options?.runSqlEnabled ?? false,
@@ -3940,6 +4008,8 @@ export class McpService extends BaseService {
             scheduledDeliveryEnabled: options?.scheduledDeliveryEnabled ?? true,
             runSqlEnabled: options?.runSqlEnabled ?? false,
             runMetricQueryEnabled: options?.runMetricQueryEnabled ?? false,
+            filterExpressionsEnabled:
+                options?.filterExpressionsEnabled ?? false,
         });
         this.mcpServer = originalServer;
 
@@ -4166,6 +4236,16 @@ export class McpService extends BaseService {
             settingEnabled &&
             this.createAuditedAbility(user).can('create', 'ScheduledDeliveries')
         );
+    }
+
+    public async isFilterExpressionsEnabled(
+        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
+    ): Promise<boolean> {
+        const { enabled } = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.AiFilterExpressions,
+        });
+        return enabled;
     }
 
     /**

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -70,6 +70,7 @@ import {
     resolveUrlToolDefinition,
     routeAgentToolDefinition,
     runAiWritebackToolDefinition,
+    runQueryFilterExpressionToolDefinition,
     runQueryToolDefinition,
     runSqlToolDefinition,
     searchFieldValuesToolDefinition,
@@ -80,9 +81,12 @@ import {
     toolRenderChartArgsSchemaTransformed,
     ToolRenderChartArgsTransformed,
     toolRunQueryArgsSchemaTransformed,
-    ToolRunQueryArgsTransformed,
+    toolRunQueryExpressionArgsSchemaV2,
     UnexpectedServerError,
     UserAttributeValueMap,
+    type ToolRunQueryArgsTransformed,
+    type ToolRunQueryArgsV2,
+    type ToolRunQueryExpressionArgsV2,
 } from '@lightdash/common';
 // eslint-disable-next-line import/extensions
 import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
@@ -154,6 +158,10 @@ import {
 } from '../ai/tools/runQuery';
 import { getSearchFieldValues } from '../ai/tools/searchFieldValues';
 import { formatToolJsonOutput } from '../ai/tools/toolOutputFormat';
+import {
+    formatFilterExpressionError,
+    resolveFilterExpressionArgs,
+} from '../ai/utils/filterExpressions';
 import { getPivotedResults } from '../ai/utils/getPivotedResults';
 import {
     expandMetricsWithPopAdditionalMetrics,
@@ -322,6 +330,9 @@ const mcpGetCurrentAgentTool = withProjectUuidInput(
 const mcpRunMetricQueryTool = withProjectScopeInput(
     runQueryToolDefinition.for('mcp'),
 );
+const mcpRunMetricQueryFilterExpressionTool = withProjectScopeInput(
+    runQueryFilterExpressionToolDefinition.for('mcp'),
+);
 const mcpRenderChartTool = withProjectScopeInput(
     renderChartToolDefinition.for('mcp'),
 );
@@ -383,6 +394,14 @@ type McpEffectiveScope = {
     spaceAccess: string[] | null;
     agentUuid: string | null;
     agentName: string | null;
+};
+
+type McpRunMetricQueryArgs = (
+    | ToolRunQueryArgsV2
+    | ToolRunQueryExpressionArgsV2
+) & {
+    projectUuid: string;
+    agentUuid?: string;
 };
 
 // Narrows the SDK's loosely-typed `RequestHandlerExtra` into the shape the
@@ -1880,6 +1899,7 @@ export class McpService extends BaseService {
             scheduledDeliveryEnabled: boolean;
             runSqlEnabled: boolean;
             runMetricQueryEnabled?: boolean;
+            filterExpressionsEnabled?: boolean;
         } = {
             projectPinned: false,
             aiWritebackEnabled: false,
@@ -1887,6 +1907,7 @@ export class McpService extends BaseService {
             scheduledDeliveryEnabled: true,
             runSqlEnabled: false,
             runMetricQueryEnabled: true,
+            filterExpressionsEnabled: false,
         },
     ): void {
         this.registerTrackedTool(
@@ -2862,16 +2883,25 @@ export class McpService extends BaseService {
         );
 
         if (options.runMetricQueryEnabled ?? true) {
+            const runMetricQueryTool = options.filterExpressionsEnabled
+                ? mcpRunMetricQueryFilterExpressionTool
+                : mcpRunMetricQueryTool;
             this.registerTrackedTool(
-                mcpRunMetricQueryTool.name,
+                runMetricQueryTool.name,
                 {
-                    title: mcpRunMetricQueryTool.title,
-                    description: mcpRunMetricQueryTool.description,
-                    inputSchema: mcpRunMetricQueryTool.inputSchema.shape,
-                    outputSchema: mcpRunMetricQueryTool.outputSchema,
-                    annotations: mcpRunMetricQueryTool.annotations,
+                    title: runMetricQueryTool.title,
+                    description: runMetricQueryTool.description,
+                    inputSchema: runMetricQueryTool.inputSchema.shape,
+                    outputSchema: runMetricQueryTool.outputSchema,
+                    annotations: runMetricQueryTool.annotations,
                 },
-                async (args, extra) => {
+                async (
+                    args: McpRunMetricQueryArgs,
+                    extra: RequestHandlerExtra<
+                        ServerRequest,
+                        ServerNotification
+                    >,
+                ) => {
                     const ctx = getMcpContext(extra);
 
                     const projectUuid = await this.resolveToolProjectUuid(
@@ -2884,10 +2914,41 @@ export class McpService extends BaseService {
                         const deadlineMs =
                             Date.now() + McpService.getMcpQueryWaitMs(extra);
                         const { account } = McpService.getAccount(ctx);
-                        const queryTool =
-                            toolRunQueryArgsSchemaTransformed.parse(
-                                argsWithProject,
+                        let queryTool: ToolRunQueryArgsTransformed;
+                        if (options.filterExpressionsEnabled) {
+                            const expressionToolArgs =
+                                toolRunQueryExpressionArgsSchemaV2.parse(
+                                    argsWithProject,
+                                );
+                            const toolsRuntime = await this.getToolsRuntime(
+                                ctx,
+                                projectUuid,
+                                args.agentUuid,
                             );
+                            const resolution =
+                                await resolveFilterExpressionArgs({
+                                    toolArgs: expressionToolArgs,
+                                    getExplore: async (exploreName) =>
+                                        unwrapMcpRuntimeResult(
+                                            await toolsRuntime.getExplore({
+                                                table: exploreName,
+                                            }),
+                                        ),
+                                });
+                            if (!resolution.success) {
+                                return runMetricQueryTool.result.error(
+                                    formatFilterExpressionError(
+                                        resolution.error,
+                                    ),
+                                );
+                            }
+                            queryTool = resolution.data.transformed;
+                        } else {
+                            queryTool =
+                                toolRunQueryArgsSchemaTransformed.parse(
+                                    argsWithProject,
+                                );
+                        }
                         const {
                             query,
                             userAttributeOverrides,
@@ -3876,6 +3937,7 @@ export class McpService extends BaseService {
         scheduledDeliveryEnabled?: boolean;
         runSqlEnabled?: boolean;
         runMetricQueryEnabled?: boolean;
+        filterExpressionsEnabled?: boolean;
     }): Promise<McpServer> {
         const newServer = this.buildMcpServer({
             runSqlEnabled: options?.runSqlEnabled ?? false,
@@ -3893,6 +3955,8 @@ export class McpService extends BaseService {
             scheduledDeliveryEnabled: options?.scheduledDeliveryEnabled ?? true,
             runSqlEnabled: options?.runSqlEnabled ?? false,
             runMetricQueryEnabled: options?.runMetricQueryEnabled ?? false,
+            filterExpressionsEnabled:
+                options?.filterExpressionsEnabled ?? false,
         });
         this.mcpServer = originalServer;
 
@@ -4119,6 +4183,16 @@ export class McpService extends BaseService {
             settingEnabled &&
             this.createAuditedAbility(user).can('create', 'ScheduledDeliveries')
         );
+    }
+
+    public async isFilterExpressionsEnabled(
+        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
+    ): Promise<boolean> {
+        const { enabled } = await this.featureFlagService.get({
+            user,
+            featureFlagId: FeatureFlags.AiFilterExpressions,
+        });
+        return enabled;
     }
 
     /**

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -8673,6 +8673,594 @@ Response shape (MCP CallToolResult):
 }
 `;
 
+exports[`MCP tool contracts > matches the filter-expression run_metric_query tools/list snapshot 1`] = `
+{
+  "annotations": {
+    "destructiveHint": false,
+    "idempotentHint": true,
+    "openWorldHint": false,
+    "readOnlyHint": true,
+  },
+  "description": "Execute a metric query.
+
+If any selected field is marked "requires parameters" in field discovery or metadata, set the right values in queryConfig.parameters — an unset parameter silently resolves to its default, which can make the query return data that does not match the question.
+
+This tool returns metric query data only. If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, call render_chart after run_metric_query returns done.
+
+Response shape (MCP CallToolResult):
+- content: [{ type: "text", text: string }] — human-readable fallback. Completed queries return bare CSV text. CSV headers are display labels, not stable field IDs; running queries return polling status text; errors return an error message.
+- If the query finishes before the MCP wait window, structuredContent: {
+    result: {
+      status: "done",
+      queryUuid: string,
+      rows: Array<Record<string, unknown>>,
+      fields: Record<string, unknown>,
+      exploreUrl: string | null
+    }
+  }
+- If the query is still running, structuredContent: {
+    result: {
+      status: "running",
+      queryUuid: string,
+      nextPollAfterMs: number,
+      heartbeatAt: string
+    }
+  }
+  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.
+
+Notes:
+- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.
+- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.
+- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.
+
+Filter expression syntax:
+Filter expressions use the form "field operator=value".
+
+Available operators: isNull, notNull, equals, notEquals, startsWith, endsWith, include, doesNotInclude, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, inThePast, notInThePast, inTheNext, inTheCurrent, notInTheCurrent, inBetween, notInBetween.
+
+- Join flat rules with AND or OR. Do not mix both connectors in one expression.
+- Quote values containing commas, braces, equals signs, whitespace, parentheses, backslashes, or reserved words with single or double quotes.
+- Inside quotes, commas and braces are literal; do not backslash-escape them. Backslash escapes quotes, backslashes, slashes, control characters, and four-digit Unicode sequences.
+- Quote unusual field IDs with backticks. AND and OR are reserved field IDs unless quoted.
+- Use isNull/notNull without values. equals=null and notEquals=null are equivalent null checks.
+- Presence operators take no values. Other operators require one or more comma-separated values according to the field type.
+- Relative dates use a count followed by named settings (for example inThePast=30{unit:days,completed:false}). completed=false includes the current partial period; completed=true uses completed periods only.
+- Current dates use one unit (for example inTheCurrent=months).
+- Safety limits: 256 rules per expression, 256 values (including settings) per rule, 256 characters per literal, and 16384 characters per expression.
+- Nested groups and parentheses are not supported yet.",
+  "inputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "agentUuid": {
+        "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+        "format": "uuid",
+        "type": "string",
+      },
+      "chartConfig": {
+        "additionalProperties": false,
+        "description": ", ",
+        "properties": {
+          "defaultVizType": {
+            "description": "The default visualization type to render",
+            "enum": [
+              "table",
+              "bar",
+              "horizontal",
+              "line",
+              "scatter",
+              "pie",
+              "funnel",
+            ],
+            "type": "string",
+          },
+          "groupBy": {
+            "description": "Dimensions to split metrics into separate series (e.g., one line per region, one bar per status). IMPORTANT: Do NOT include the x-axis dimension in groupBy - only include dimensions you want to use for breaking down the data into multiple series. Example: dimensions=["order_date", "status"], groupBy=["status"] creates separate series for each status value. Leave null for simple single-series charts., ",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "lineType": {
+            "description": "default line. The type of line to display. If area then the area under the line will be filled in., ",
+            "enum": [
+              "line",
+              "area",
+            ],
+            "type": "string",
+          },
+          "secondaryYAxisLabel": {
+            "description": "A helpful label for the secondary y-axis, ",
+            "type": "string",
+          },
+          "secondaryYAxisMetric": {
+            "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count)., ",
+            "type": "string",
+          },
+          "stackBars": {
+            "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts., ",
+            "type": "boolean",
+          },
+          "xAxisDimension": {
+            "description": "The dimension field ID to use for the x-axis. Must be included in queryConfig.dimensions, ",
+            "type": "string",
+          },
+          "xAxisLabel": {
+            "description": "A helpful label to explain the x-axis",
+            "type": "string",
+          },
+          "xAxisType": {
+            "description": "The x-axis type can be categorical for string value or time if the dimension is a date or timestamp. Applies to bar, horizontal, and scatter charts., ",
+            "enum": [
+              "category",
+              "time",
+            ],
+            "type": "string",
+          },
+          "yAxisLabel": {
+            "description": "A helpful label to explain the y-axis",
+            "type": "string",
+          },
+          "yAxisMetrics": {
+            "description": "The metric field IDs to display on the y-axis. Must be included in queryConfig.metrics or come from tableCalculations, ",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "defaultVizType",
+          "xAxisLabel",
+          "yAxisLabel",
+        ],
+        "type": "object",
+      },
+      "description": {
+        "description": "A descriptive summary or explanation for the chart.",
+        "type": "string",
+      },
+      "projectUuid": {
+        "description": "Project UUID for this operation.",
+        "format": "uuid",
+        "type": "string",
+      },
+      "queryConfig": {
+        "additionalProperties": false,
+        "properties": {
+          "customMetrics": {
+            "description": "Define new metric columns the explore doesn't already have. Two kinds:
+
+(1) kind: "aggregation" — a NEW metric built by aggregating a base dimension
+    (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).
+    Use when the requested metric doesn't exist in the explore.
+
+(2) kind: "periodComparison" — a column that is an EXISTING metric shifted
+    back in time. Use whenever the user asks for "year-over-year",
+    "month-over-month", "vs last quarter", "compare to previous period",
+    "N periods ago".
+
+For period comparisons, every successful chart has three things:
+- The time dimension in queryConfig.dimensions
+- The base metric in queryConfig.metrics
+- A customMetric of kind "periodComparison" pointing at that base metric and time dimension
+
+The server generates the comparison column automatically and appends it next to the base metric. Do NOT add the comparison column id to queryConfig.metrics yourself.
+
+DO NOT simulate a period comparison by adding a second time-dimension granularity (e.g. _year) and using groupBy. groupBy is for categorical splits (region, product). Time comparisons use a kind: "periodComparison" customMetric.
+
+For aggregation entries:
+1. Add the entry to customMetrics with kind: "aggregation"
+2. Reference it in queryConfig.metrics using the format "table_name" (e.g. "customers_avg_customer_age")
+3. Reference it the same way in sorts, filters, chartConfig.yAxisMetrics
+
+Example A — "Average customer age sorted descending"
+  customMetrics: [{ kind: "aggregation", name: "avg_customer_age", label: "Average Customer Age", description: "...", type: "AVERAGE", baseDimensionName: "age", table: "customers", filters: null }]
+  queryConfig.metrics: ["customers_avg_customer_age"]
+  sorts: [{ fieldId: "customers_avg_customer_age", descending: true }]
+
+Example B — "Revenue by month with year-over-year comparison"
+  queryConfig.dimensions: ["orders_order_date_month"]
+  queryConfig.metrics: ["orders_revenue"]
+  customMetrics: [{ kind: "periodComparison", baseMetricId: "orders_revenue", timeDimensionId: "orders_order_date_month", granularity: "MONTH", periodOffset: 12 }], ",
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "baseDimensionName": {
+                      "description": "Field ID (e.g. "customers_age") or bare column name (e.g. "age") of the base dimension to aggregate. Must be a dimension that already EXISTS in this explore — confirm it exists with your field discovery tools first. Do NOT guess an id/primary-key column: many explores do not expose "<table>_id" as a queryable dimension.",
+                      "type": "string",
+                    },
+                    "description": {
+                      "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                      "type": "string",
+                    },
+                    "filters": {
+                      "description": "Optional flat AND expression for conditional metric filters., ",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string",
+                    },
+                    "kind": {
+                      "const": "aggregation",
+                      "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
+                      "type": "string",
+                    },
+                    "label": {
+                      "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                      "type": "string",
+                    },
+                    "table": {
+                      "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                      "type": "string",
+                    },
+                    "type": {
+                      "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
+                      "enum": [
+                        "average",
+                        "count",
+                        "count_distinct",
+                        "max",
+                        "min",
+                        "sum",
+                        "percentile",
+                        "median",
+                      ],
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "kind",
+                    "name",
+                    "label",
+                    "description",
+                    "baseDimensionName",
+                    "table",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "baseMetricId": {
+                      "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
+                      "type": "string",
+                    },
+                    "granularity": {
+                      "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
+                      "enum": [
+                        "DAY",
+                        "WEEK",
+                        "MONTH",
+                        "QUARTER",
+                        "YEAR",
+                      ],
+                      "type": "string",
+                    },
+                    "kind": {
+                      "const": "periodComparison",
+                      "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
+                      "type": "string",
+                    },
+                    "periodOffset": {
+                      "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                      "minimum": 1,
+                      "type": "integer",
+                    },
+                    "timeDimensionId": {
+                      "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "kind",
+                    "baseMetricId",
+                    "timeDimensionId",
+                    "granularity",
+                    "periodOffset",
+                  ],
+                  "type": "object",
+                },
+              ],
+            },
+            "type": "array",
+          },
+          "dimensions": {
+            "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "exploreName": {
+            "description": "The name of the explore containing the metrics and dimensions used for the chart.",
+            "type": "string",
+          },
+          "filters": {
+            "additionalProperties": false,
+            "description": "Separate flat expressions for dimensions, metrics, and table calculations. Each category chooses AND or OR independently. Non-null categories combine implicitly with AND. For example, dimensions "D1 AND D2" and metrics "M1 OR M2" mean "(D1 AND D2) AND (M1 OR M2)", where D1, D2, M1, and M2 are complete filter rules. Use null when a category has no filters., Separate flat expressions for dimensions, metrics, and table calculations. Each category chooses AND or OR independently. Non-null categories combine implicitly with AND. For example, dimensions "D1 AND D2" and metrics "M1 OR M2" mean "(D1 AND D2) AND (M1 OR M2)", where D1, D2, M1, and M2 are complete filter rules. Use null when a category has no filters.",
+            "properties": {
+              "dimensions": {
+                "description": "Flat filter expression for dimension fields., ",
+                "maxLength": 16384,
+                "minLength": 1,
+                "type": "string",
+              },
+              "metrics": {
+                "description": "Flat filter expression for metric fields., ",
+                "maxLength": 16384,
+                "minLength": 1,
+                "type": "string",
+              },
+              "tableCalculations": {
+                "description": "Flat filter expression for table calculations., ",
+                "maxLength": 16384,
+                "minLength": 1,
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "limit": {
+            "description": "The total number of data points / rows allowed on the chart. null means this tool's maximum, not "no data" — use it unless the user asked for a specific number of rows. Row limits documented for other tools do not apply here., ",
+            "type": "number",
+          },
+          "metrics": {
+            "description": "The field ids of the metrics to be calculated. They will be grouped by the dimensions.",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "parameters": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                    },
+                    {
+                      "type": "number",
+                    },
+                    {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "items": {
+                        "type": "number",
+                      },
+                      "type": "array",
+                    },
+                  ],
+                },
+                "type": "object",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "default": null,
+            "description": "Lightdash parameter values for this query, keyed by parameter name exactly as shown in the explore metadata (e.g. {"orders.metric": "active_users"}). REQUIRED whenever a selected field is marked "requires parameters" and the default value does not match what the user asked for — an unset parameter silently resolves to its default, which can return the wrong data. null when the explore has no parameters or the defaults are correct.",
+          },
+          "sorts": {
+            "description": "Sort configuration for the query, it can use a combination of metrics and dimensions.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "descending": {
+                  "description": "If true sorts in descending order, if false sorts in ascending order",
+                  "type": "boolean",
+                },
+                "fieldId": {
+                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                  "type": "string",
+                },
+                "nullsFirst": {
+                  "description": "If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default, If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default",
+                  "type": "boolean",
+                },
+              },
+              "required": [
+                "fieldId",
+                "descending",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "tableCalculations": {
+            "description": "
+Table calculations perform row-by-row calculations on query results without collapsing rows, using spreadsheet-like formulas.
+
+Use them whenever the question needs math the metric query alone can't express: arithmetic across metrics (\`metric_a + metric_b\`), ratios, percent of total, period-over-period change, running totals, moving averages, ranking, row-level comparisons, or aggregating already-aggregated metrics.
+
+**Technical Requirements:**
+- Appear as additional columns in query results
+- Can be used in sorts and filters alongside dimensions/metrics
+- Multiple calculations can be combined in a single query; a formula can reference another table calculation by name
+- All fields referenced must be selected in the query (dimensions, metrics, custom metrics, or other table calculations)
+, ",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "displayName": {
+                  "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                  "type": "string",
+                },
+                "format": {
+                  "description": "Display format. Use "percent" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to "number"., ",
+                  "enum": [
+                    "number",
+                    "percent",
+                  ],
+                  "type": "string",
+                },
+                "formula": {
+                  "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).
+Reference fields by their field id directly, e.g. \`orders_total_revenue / orders_order_count\`. No prefix, no braces, no leading \`=\`.
+Any selected dimension, metric, custom metric (\`<table>_<name>\`), or another table calculation name can be referenced.
+Operators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.
+Functions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).
+Window functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. \`LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)\`.
+MOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is \`MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)\`.
+All branches of an IF must return the same type.",
+                  "type": "string",
+                },
+                "name": {
+                  "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                  "pattern": "^[a-zA-Z0-9_]+$",
+                  "type": "string",
+                },
+                "resultType": {
+                  "description": "Data type the formula evaluates to. null defaults to "number"., ",
+                  "enum": [
+                    "number",
+                    "string",
+                    "date",
+                    "timestamp",
+                    "boolean",
+                  ],
+                  "type": "string",
+                },
+                "type": {
+                  "const": "formula",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "name",
+                "displayName",
+                "type",
+                "formula",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "exploreName",
+          "dimensions",
+          "metrics",
+          "sorts",
+        ],
+        "type": "object",
+      },
+      "title": {
+        "description": "A descriptive title for the chart",
+        "type": "string",
+      },
+    },
+    "required": [
+      "title",
+      "description",
+      "queryConfig",
+      "projectUuid",
+    ],
+    "type": "object",
+  },
+  "name": "run_metric_query",
+  "outputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "result": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "exploreUrl": {
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "fields": {
+                "additionalProperties": {},
+                "type": "object",
+              },
+              "queryUuid": {
+                "format": "uuid",
+                "type": "string",
+              },
+              "rows": {
+                "items": {
+                  "additionalProperties": {},
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "status": {
+                "const": "done",
+                "type": "string",
+              },
+            },
+            "required": [
+              "rows",
+              "fields",
+              "status",
+              "queryUuid",
+              "exploreUrl",
+            ],
+            "type": "object",
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "heartbeatAt": {
+                "description": "ISO timestamp for when Lightdash last checked this async query and confirmed it is still running.",
+                "type": "string",
+              },
+              "nextPollAfterMs": {
+                "description": "Suggested delay before polling get_query_result for this query.",
+                "exclusiveMinimum": 0,
+                "type": "integer",
+              },
+              "queryUuid": {
+                "description": "Async query UUID to pass to get_query_result when status is running.",
+                "format": "uuid",
+                "type": "string",
+              },
+              "status": {
+                "const": "running",
+                "description": "Present when the query is still running and should be polled with get_query_result.",
+                "type": "string",
+              },
+            },
+            "required": [
+              "status",
+              "queryUuid",
+              "nextPollAfterMs",
+              "heartbeatAt",
+            ],
+            "type": "object",
+          },
+        ],
+      },
+    },
+    "required": [
+      "result",
+    ],
+    "type": "object",
+  },
+  "title": "Run query",
+}
+`;
+
 exports[`MCP tool contracts > matches the shared MCP tool definition names snapshot 1`] = `
 [
   "find_content",

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -9075,6 +9075,998 @@ Response shape (MCP CallToolResult):
 }
 `;
 
+exports[`MCP tool contracts > matches the filter-expression run_metric_query tools/list snapshot 1`] = `
+{
+  "annotations": {
+    "destructiveHint": false,
+    "idempotentHint": true,
+    "openWorldHint": false,
+    "readOnlyHint": true,
+  },
+  "description": "Execute a metric query.
+
+If any selected field is marked "requires parameters" in field discovery or metadata, set the right values in queryConfig.parameters — an unset parameter silently resolves to its default, which can make the query return data that does not match the question.
+
+This tool returns metric query data only. If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, call render_chart after run_metric_query returns done.
+
+Response shape (MCP CallToolResult):
+- content: [{ type: "text", text: string }] — human-readable fallback. Completed queries return bare CSV text. CSV headers are display labels, not stable field IDs; running queries return polling status text; errors return an error message.
+- If the query finishes before the MCP wait window, structuredContent: {
+    result: {
+      status: "done",
+      queryUuid: string,
+      rows: Array<Record<string, unknown>>,
+      fields: Record<string, unknown>,
+      exploreUrl: string | null
+    }
+  }
+- If the query is still running, structuredContent: {
+    result: {
+      status: "running",
+      queryUuid: string,
+      nextPollAfterMs: number,
+      heartbeatAt: string
+    }
+  }
+  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.
+
+Notes:
+- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.
+- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.
+- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.
+
+Filter expression syntax:
+Filter expressions use the form "field operator=value".
+
+Available operators: isNull, notNull, equals, notEquals, startsWith, endsWith, include, doesNotInclude, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, inThePast, notInThePast, inTheNext, inTheCurrent, notInTheCurrent, inBetween, notInBetween.
+
+- Join flat rules with AND or OR. Do not mix both connectors in one expression.
+- If multiple category expressions contain multiple rules, they must use the same connector.
+- Quote values containing commas, whitespace, or reserved words with single or double quotes.
+- Quote unusual field IDs with backticks. AND and OR are reserved field IDs unless quoted.
+- Use isNull/notNull without values. equals=null and notEquals=null are equivalent null checks.
+- Presence operators take no values. Other operators require one or more comma-separated values according to the field type.
+- Relative dates use count,unit,completed (for example inThePast=30,days,false).
+- Current dates use one unit (for example inTheCurrent=months).
+- Nested groups and parentheses are not supported yet.",
+  "inputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "agentUuid": {
+        "description": "Optional AI agent UUID for this operation. Omit it to use the full project scope.",
+        "format": "uuid",
+        "type": "string",
+      },
+      "chartConfig": {
+        "additionalProperties": false,
+        "description": ", ",
+        "properties": {
+          "defaultVizType": {
+            "description": "The default visualization type to render",
+            "enum": [
+              "table",
+              "bar",
+              "horizontal",
+              "line",
+              "scatter",
+              "pie",
+              "funnel",
+            ],
+            "type": "string",
+          },
+          "groupBy": {
+            "description": "Dimensions to split metrics into separate series (e.g., one line per region, one bar per status). IMPORTANT: Do NOT include the x-axis dimension in groupBy - only include dimensions you want to use for breaking down the data into multiple series. Example: dimensions=["order_date", "status"], groupBy=["status"] creates separate series for each status value. Leave null for simple single-series charts., ",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "lineType": {
+            "description": "default line. The type of line to display. If area then the area under the line will be filled in., ",
+            "enum": [
+              "line",
+              "area",
+            ],
+            "type": "string",
+          },
+          "secondaryYAxisLabel": {
+            "description": "A helpful label for the secondary y-axis, ",
+            "type": "string",
+          },
+          "secondaryYAxisMetric": {
+            "description": "(Optional) A single metric field ID to display on a secondary (right) y-axis. Must NOT be included in yAxisMetrics. Use when one metric has a very different scale than others (e.g., percentage vs count)., ",
+            "type": "string",
+          },
+          "stackBars": {
+            "description": "If groupBy is provided then this will stack the bars on top of each other instead of side by side. Applies to bar and horizontal charts., ",
+            "type": "boolean",
+          },
+          "xAxisDimension": {
+            "description": "The dimension field ID to use for the x-axis. Must be included in queryConfig.dimensions, ",
+            "type": "string",
+          },
+          "xAxisLabel": {
+            "description": "A helpful label to explain the x-axis",
+            "type": "string",
+          },
+          "xAxisType": {
+            "description": "The x-axis type can be categorical for string value or time if the dimension is a date or timestamp. Applies to bar, horizontal, and scatter charts., ",
+            "enum": [
+              "category",
+              "time",
+            ],
+            "type": "string",
+          },
+          "yAxisLabel": {
+            "description": "A helpful label to explain the y-axis",
+            "type": "string",
+          },
+          "yAxisMetrics": {
+            "description": "The metric field IDs to display on the y-axis. Must be included in queryConfig.metrics or come from tableCalculations, ",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "defaultVizType",
+          "xAxisLabel",
+          "yAxisLabel",
+        ],
+        "type": "object",
+      },
+      "description": {
+        "description": "A descriptive summary or explanation for the chart.",
+        "type": "string",
+      },
+      "projectUuid": {
+        "description": "Project UUID for this operation.",
+        "format": "uuid",
+        "type": "string",
+      },
+      "queryConfig": {
+        "additionalProperties": false,
+        "properties": {
+          "customMetrics": {
+            "description": "Define new metric columns the explore doesn't already have. Two kinds:
+
+(1) kind: "aggregation" — a NEW metric built by aggregating a base dimension
+    (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).
+    Use when the requested metric doesn't exist in the explore.
+
+(2) kind: "periodComparison" — a column that is an EXISTING metric shifted
+    back in time. Use whenever the user asks for "year-over-year",
+    "month-over-month", "vs last quarter", "compare to previous period",
+    "N periods ago".
+
+For period comparisons, every successful chart has three things:
+- The time dimension in queryConfig.dimensions
+- The base metric in queryConfig.metrics
+- A customMetric of kind "periodComparison" pointing at that base metric and time dimension
+
+The server generates the comparison column automatically and appends it next to the base metric. Do NOT add the comparison column id to queryConfig.metrics yourself.
+
+DO NOT simulate a period comparison by adding a second time-dimension granularity (e.g. _year) and using groupBy. groupBy is for categorical splits (region, product). Time comparisons use a kind: "periodComparison" customMetric.
+
+For aggregation entries:
+1. Add the entry to customMetrics with kind: "aggregation"
+2. Reference it in queryConfig.metrics using the format "table_name" (e.g. "customers_avg_customer_age")
+3. Reference it the same way in sorts, filters, chartConfig.yAxisMetrics
+
+Example A — "Average customer age sorted descending"
+  customMetrics: [{ kind: "aggregation", name: "avg_customer_age", label: "Average Customer Age", description: "...", type: "AVERAGE", baseDimensionName: "age", table: "customers", filters: null }]
+  queryConfig.metrics: ["customers_avg_customer_age"]
+  sorts: [{ fieldId: "customers_avg_customer_age", descending: true }]
+
+Example B — "Revenue by month with year-over-year comparison"
+  queryConfig.dimensions: ["orders_order_date_month"]
+  queryConfig.metrics: ["orders_revenue"]
+  customMetrics: [{ kind: "periodComparison", baseMetricId: "orders_revenue", timeDimensionId: "orders_order_date_month", granularity: "MONTH", periodOffset: 12 }], ",
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "baseDimensionName": {
+                      "description": "Field ID (e.g. "customers_age") or bare column name (e.g. "age") of the base dimension to aggregate. Must be a dimension that already EXISTS in this explore — confirm it exists with your field discovery tools first. Do NOT guess an id/primary-key column: many explores do not expose "<table>_id" as a queryable dimension.",
+                      "type": "string",
+                    },
+                    "description": {
+                      "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                      "type": "string",
+                    },
+                    "filters": {
+                      "description": "Optional flat AND expression for conditional metric filters., ",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string",
+                    },
+                    "kind": {
+                      "const": "aggregation",
+                      "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
+                      "type": "string",
+                    },
+                    "label": {
+                      "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                      "type": "string",
+                    },
+                    "table": {
+                      "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                      "type": "string",
+                    },
+                    "type": {
+                      "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
+                      "enum": [
+                        "average",
+                        "count",
+                        "count_distinct",
+                        "max",
+                        "min",
+                        "sum",
+                        "percentile",
+                        "median",
+                      ],
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "kind",
+                    "name",
+                    "label",
+                    "description",
+                    "baseDimensionName",
+                    "table",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "baseMetricId": {
+                      "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
+                      "type": "string",
+                    },
+                    "granularity": {
+                      "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
+                      "enum": [
+                        "DAY",
+                        "WEEK",
+                        "MONTH",
+                        "QUARTER",
+                        "YEAR",
+                      ],
+                      "type": "string",
+                    },
+                    "kind": {
+                      "const": "periodComparison",
+                      "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
+                      "type": "string",
+                    },
+                    "periodOffset": {
+                      "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                      "minimum": 1,
+                      "type": "integer",
+                    },
+                    "timeDimensionId": {
+                      "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "kind",
+                    "baseMetricId",
+                    "timeDimensionId",
+                    "granularity",
+                    "periodOffset",
+                  ],
+                  "type": "object",
+                },
+              ],
+            },
+            "type": "array",
+          },
+          "dimensions": {
+            "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "exploreName": {
+            "description": "The name of the explore containing the metrics and dimensions used for the chart.",
+            "type": "string",
+          },
+          "filters": {
+            "additionalProperties": false,
+            "description": "Separate flat expressions for dimensions, metrics, and table calculations. Use null when a category has no filters., Separate flat expressions for dimensions, metrics, and table calculations. Use null when a category has no filters.",
+            "properties": {
+              "dimensions": {
+                "description": "Flat filter expression for dimension fields., ",
+                "maxLength": 16384,
+                "minLength": 1,
+                "type": "string",
+              },
+              "metrics": {
+                "description": "Flat filter expression for metric fields., ",
+                "maxLength": 16384,
+                "minLength": 1,
+                "type": "string",
+              },
+              "tableCalculations": {
+                "description": "Flat filter expression for table calculations., ",
+                "maxLength": 16384,
+                "minLength": 1,
+                "type": "string",
+              },
+            },
+            "type": "object",
+          },
+          "limit": {
+            "description": "The total number of data points / rows allowed on the chart. null means this tool's maximum, not "no data" — use it unless the user asked for a specific number of rows. Row limits documented for other tools do not apply here., ",
+            "type": "number",
+          },
+          "metrics": {
+            "description": "The field ids of the metrics to be calculated. They will be grouped by the dimensions.",
+            "items": {
+              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "parameters": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                    },
+                    {
+                      "type": "number",
+                    },
+                    {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    {
+                      "items": {
+                        "type": "number",
+                      },
+                      "type": "array",
+                    },
+                  ],
+                },
+                "type": "object",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "default": null,
+            "description": "Lightdash parameter values for this query, keyed by parameter name exactly as shown in the explore metadata (e.g. {"orders.metric": "active_users"}). REQUIRED whenever a selected field is marked "requires parameters" and the default value does not match what the user asked for — an unset parameter silently resolves to its default, which can return the wrong data. null when the explore has no parameters or the defaults are correct.",
+          },
+          "sorts": {
+            "description": "Sort configuration for the query, it can use a combination of metrics and dimensions.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "descending": {
+                  "description": "If true sorts in descending order, if false sorts in ascending order",
+                  "type": "boolean",
+                },
+                "fieldId": {
+                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                  "type": "string",
+                },
+                "nullsFirst": {
+                  "description": "If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default, If true sorts nulls first, if false sorts nulls last, otherwise sorts by warehouse default",
+                  "type": "boolean",
+                },
+              },
+              "required": [
+                "fieldId",
+                "descending",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "tableCalculations": {
+            "description": "
+Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
+
+**Prefer type "formula"** — it expresses arithmetic across fields, ratios, comparisons, conditionals, and partitioned window calculations. The other types are legacy single-field templates kept for backwards compatibility.
+
+**Technical Requirements:**
+- Appear as additional columns in query results
+- Can be used in sorts and filters alongside dimensions/metrics
+- Multiple calculations can be combined in a single query
+- All fields referenced must exist in the query (dimensions, metrics, or other table calculations)
+, ",
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "format": {
+                      "description": "Display format. Use "percent" for ratios/shares/percent changes (value 0.12 renders as 12%). null defaults to "number"., ",
+                      "enum": [
+                        "number",
+                        "percent",
+                      ],
+                      "type": "string",
+                    },
+                    "formula": {
+                      "description": "Spreadsheet-like formula evaluated row-by-row over the query results (after aggregation).
+Reference fields by their field id directly, e.g. \`orders_total_revenue / orders_order_count\`. No prefix, no braces, no leading \`=\`.
+Any selected dimension, metric, custom metric (\`<table>_<name>\`), or another table calculation name can be referenced.
+Operators: + - * / % ^, comparisons = < > <= >= <>, boolean AND/OR/NOT, string literals in double quotes, parentheses for grouping.
+Functions include IF, COALESCE, ROUND, ABS, CONCAT, date functions (YEAR, DATE_TRUNC, DATE_DIFF, DATE_ADD), aggregates over the whole result (SUM, AVG, MIN, MAX, COUNT, SUMIF), and window functions (RUNNING_TOTAL, MOVING_SUM, MOVING_AVG, LAG, LEAD, RANK, DENSE_RANK, ROW_NUMBER, FIRST, LAST).
+Window functions accept optional PARTITION BY / ORDER BY clauses as trailing arguments, e.g. \`LAG(orders_total_revenue, PARTITION BY orders_status, ORDER BY orders_order_date)\`.
+MOVING_SUM and MOVING_AVG take the count of preceding rows as second argument; the current row is always included, so a trailing 3-period average is \`MOVING_AVG(orders_total_revenue, 2, ORDER BY orders_order_month)\`.
+All branches of an IF must return the same type.",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "resultType": {
+                      "description": "Data type the formula evaluates to. null defaults to "number"., ",
+                      "enum": [
+                        "number",
+                        "string",
+                        "date",
+                        "timestamp",
+                        "boolean",
+                      ],
+                      "type": "string",
+                    },
+                    "type": {
+                      "const": "formula",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "formula",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "orderBy": {
+                      "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "fieldId": {
+                            "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "order": {
+                            "description": ", ",
+                            "enum": [
+                              "asc",
+                              "desc",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "fieldId",
+                        ],
+                        "type": "object",
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                    },
+                    "partitionBy": {
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows)., ",
+                      "items": {
+                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "type": {
+                      "const": "percent_change_from_previous",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                    "orderBy",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "orderBy": {
+                      "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "fieldId": {
+                            "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "order": {
+                            "description": ", ",
+                            "enum": [
+                              "asc",
+                              "desc",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "fieldId",
+                        ],
+                        "type": "object",
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                    },
+                    "partitionBy": {
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows)., ",
+                      "items": {
+                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "type": {
+                      "const": "percent_of_previous_value",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                    "orderBy",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "partitionBy": {
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows)., ",
+                      "items": {
+                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "type": {
+                      "const": "percent_of_column_total",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "type": {
+                      "const": "rank_in_column",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "type": {
+                      "const": "running_total",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "fieldId",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "displayName": {
+                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                      "type": "string",
+                    },
+                    "fieldId": {
+                      "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error, Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                      "type": "string",
+                    },
+                    "frame": {
+                      "additionalProperties": false,
+                      "description": "Defines which rows to include in calculation. Null uses database defaults.
+
+**Common patterns:**
+- Moving average (N periods): {frameType: "rows", start: {type: "preceding", offset: N-1}, end: {type: "current_row"}}
+- Running total: {frameType: "rows", start: {type: "unbounded_preceding"}, end: {type: "current_row"}}
+- Centered window: {frameType: "rows", start: {type: "preceding", offset: 1}, end: {type: "following", offset: 1}}
+
+**Default when null:**
+- Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)
+- Aggregates WITHOUT ORDER BY: Entire partition (all rows)
+- Ranking functions: Always use entire partition (frame clause has no effect), ",
+                      "properties": {
+                        "end": {
+                          "additionalProperties": false,
+                          "description": "End boundary (required)",
+                          "properties": {
+                            "offset": {
+                              "description": "Number of rows for PRECEDING/FOLLOWING, ",
+                              "exclusiveMinimum": 0,
+                              "type": "integer",
+                            },
+                            "type": {
+                              "enum": [
+                                "unbounded_preceding",
+                                "preceding",
+                                "current_row",
+                                "following",
+                                "unbounded_following",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "type",
+                          ],
+                          "type": "object",
+                        },
+                        "frameType": {
+                          "description": "Frame type:
+- rows: Physical row count
+- range: Logical value-based (includes peer rows with same ORDER BY value)",
+                          "enum": [
+                            "rows",
+                            "range",
+                          ],
+                          "type": "string",
+                        },
+                        "start": {
+                          "additionalProperties": false,
+                          "description": "Start boundary. Null for single-boundary syntax., ",
+                          "properties": {
+                            "offset": {
+                              "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING"), ",
+                              "exclusiveMinimum": 0,
+                              "type": "integer",
+                            },
+                            "type": {
+                              "enum": [
+                                "unbounded_preceding",
+                                "preceding",
+                                "current_row",
+                                "following",
+                                "unbounded_following",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "type",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "frameType",
+                        "end",
+                      ],
+                      "type": "object",
+                    },
+                    "name": {
+                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                      "type": "string",
+                    },
+                    "orderBy": {
+                      "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first., ",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "fieldId": {
+                            "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "order": {
+                            "description": ", ",
+                            "enum": [
+                              "asc",
+                              "desc",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "fieldId",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "partitionBy": {
+                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows)., ",
+                      "items": {
+                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "type": {
+                      "const": "window_function",
+                      "type": "string",
+                    },
+                    "windowFunction": {
+                      "description": "Type of window function to apply.
+
+**Ranking functions** (fieldId optional, ignored if provided):
+- row_number: Sequential numbering (1, 2, 3...)
+- percent_rank: Relative rank as percentage (0.0-1.0)
+- cume_dist: Cumulative distribution as percentage (0.0-1.0)
+- rank: Positional rank (1, 2, 3...) with ties
+
+**Aggregate functions** (fieldId required):
+- sum: Sum values within frame
+- avg: Average values within frame
+- count: Count values within frame
+- min: Minimum value within frame
+- max: Maximum value within frame",
+                      "enum": [
+                        "row_number",
+                        "percent_rank",
+                        "cume_dist",
+                        "rank",
+                        "sum",
+                        "avg",
+                        "count",
+                        "min",
+                        "max",
+                      ],
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "displayName",
+                    "type",
+                    "windowFunction",
+                  ],
+                  "type": "object",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "exploreName",
+          "dimensions",
+          "metrics",
+          "sorts",
+        ],
+        "type": "object",
+      },
+      "title": {
+        "description": "A descriptive title for the chart",
+        "type": "string",
+      },
+    },
+    "required": [
+      "title",
+      "description",
+      "queryConfig",
+      "projectUuid",
+    ],
+    "type": "object",
+  },
+  "name": "run_metric_query",
+  "outputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "result": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "exploreUrl": {
+                "type": [
+                  "string",
+                  "null",
+                ],
+              },
+              "fields": {
+                "additionalProperties": {},
+                "type": "object",
+              },
+              "queryUuid": {
+                "format": "uuid",
+                "type": "string",
+              },
+              "rows": {
+                "items": {
+                  "additionalProperties": {},
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "status": {
+                "const": "done",
+                "type": "string",
+              },
+            },
+            "required": [
+              "rows",
+              "fields",
+              "status",
+              "queryUuid",
+              "exploreUrl",
+            ],
+            "type": "object",
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "heartbeatAt": {
+                "description": "ISO timestamp for when Lightdash last checked this async query and confirmed it is still running.",
+                "type": "string",
+              },
+              "nextPollAfterMs": {
+                "description": "Suggested delay before polling get_query_result for this query.",
+                "exclusiveMinimum": 0,
+                "type": "integer",
+              },
+              "queryUuid": {
+                "description": "Async query UUID to pass to get_query_result when status is running.",
+                "format": "uuid",
+                "type": "string",
+              },
+              "status": {
+                "const": "running",
+                "description": "Present when the query is still running and should be polled with get_query_result.",
+                "type": "string",
+              },
+            },
+            "required": [
+              "status",
+              "queryUuid",
+              "nextPollAfterMs",
+              "heartbeatAt",
+            ],
+            "type": "object",
+          },
+        ],
+      },
+    },
+    "required": [
+      "result",
+    ],
+    "type": "object",
+  },
+  "title": "Run query",
+}
+`;
+
 exports[`MCP tool contracts > matches the shared MCP tool definition names snapshot 1`] = `
 [
   "find_content",

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -1,6 +1,7 @@
 import { Ability } from '@casl/ability';
 import {
     defineUserAbility,
+    FeatureFlags,
     mcpToolDefinitions,
     OrganizationMemberRole,
     ProjectMemberRole,
@@ -96,7 +97,12 @@ const schemaToJson = (
     );
 };
 
-const makeMcpService = (mcpContentWritesEnabled = true): McpService =>
+const makeMcpService = (
+    mcpContentWritesEnabled = true,
+    featureFlagService = {
+        get: vi.fn().mockResolvedValue({ enabled: false }),
+    },
+): McpService =>
     new McpService({
         aiAgentService: {},
         aiAgentToolsService: { createRuntime: vi.fn() },
@@ -112,7 +118,7 @@ const makeMcpService = (mcpContentWritesEnabled = true): McpService =>
         catalogService: {},
         contentService: {},
         contentVerificationService: {},
-        featureFlagService: {},
+        featureFlagService,
         lightdashConfig: {
             mcp: {
                 runSqlMaxLimit: 500,
@@ -162,6 +168,19 @@ describe('MCP tool contracts', () => {
 
     it('matches the shared MCP tool definition names snapshot', () => {
         expect(sharedMcpToolDefinitionNames).toMatchSnapshot();
+    });
+
+    it('resolves the filter-expression feature flag for the request user', async () => {
+        const get = vi.fn().mockResolvedValue({ enabled: true });
+        const mcpService = makeMcpService(true, { get });
+
+        await expect(
+            mcpService.isFilterExpressionsEnabled(defaultSessionUser),
+        ).resolves.toBe(true);
+        expect(get).toHaveBeenCalledWith({
+            user: defaultSessionUser,
+            featureFlagId: FeatureFlags.AiFilterExpressions,
+        });
     });
 
     it('uses the grep-fields MCP analyst prompt', () => {
@@ -243,6 +262,29 @@ describe('MCP tool contracts', () => {
         expect(registeredNames).not.toContain(McpToolName.RUN_METRIC_QUERY);
         expect(registeredNames).toContain(McpToolName.FIND_CONTENT);
         expect(registeredNames).toContain(McpToolName.LIST_CONTENT);
+    });
+
+    it('matches the filter-expression run_metric_query tools/list snapshot', async () => {
+        const mcpService = makeMcpService();
+
+        mockRegisteredMcpTools.length = 0;
+        await mcpService.createServer({
+            runMetricQueryEnabled: true,
+            filterExpressionsEnabled: true,
+        });
+
+        const registered = mockRegisteredMcpTools.find(
+            ({ name }) => name === McpToolName.RUN_METRIC_QUERY,
+        );
+        expect(registered).toBeDefined();
+        expect({
+            name: registered?.name,
+            title: registered?.config.title,
+            description: registered?.config.description,
+            annotations: registered?.config.annotations,
+            inputSchema: schemaToJson(registered?.config.inputSchema),
+            outputSchema: schemaToJson(registered?.config.outputSchema),
+        }).toMatchSnapshot();
     });
 
     it('registers generate_hashes without project scope', async () => {

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -1,6 +1,7 @@
 import { Ability } from '@casl/ability';
 import {
     defineUserAbility,
+    FeatureFlags,
     mcpToolDefinitions,
     OrganizationMemberRole,
     ProjectMemberRole,
@@ -96,7 +97,12 @@ const schemaToJson = (
     );
 };
 
-const makeMcpService = (mcpContentWritesEnabled = true): McpService =>
+const makeMcpService = (
+    mcpContentWritesEnabled = true,
+    featureFlagService = {
+        get: vi.fn().mockResolvedValue({ enabled: false }),
+    },
+): McpService =>
     new McpService({
         aiAgentService: {},
         aiAgentToolsService: { createRuntime: vi.fn() },
@@ -112,7 +118,7 @@ const makeMcpService = (mcpContentWritesEnabled = true): McpService =>
         catalogService: {},
         contentService: {},
         contentVerificationService: {},
-        featureFlagService: {},
+        featureFlagService,
         lightdashConfig: {
             mcp: {
                 runSqlMaxLimit: 500,
@@ -162,6 +168,19 @@ describe('MCP tool contracts', () => {
 
     it('matches the shared MCP tool definition names snapshot', () => {
         expect(sharedMcpToolDefinitionNames).toMatchSnapshot();
+    });
+
+    it('resolves the filter-expression feature flag for the request user', async () => {
+        const get = vi.fn().mockResolvedValue({ enabled: true });
+        const mcpService = makeMcpService(true, { get });
+
+        await expect(
+            mcpService.isFilterExpressionsEnabled(defaultSessionUser),
+        ).resolves.toBe(true);
+        expect(get).toHaveBeenCalledWith({
+            user: defaultSessionUser,
+            featureFlagId: FeatureFlags.AiFilterExpressions,
+        });
     });
 
     it('uses the grep-fields MCP analyst prompt', () => {
@@ -223,6 +242,29 @@ describe('MCP tool contracts', () => {
         ).toEqual([]);
 
         expect({ prompts, tools }).toMatchSnapshot();
+    });
+
+    it('matches the filter-expression run_metric_query tools/list snapshot', async () => {
+        const mcpService = makeMcpService();
+
+        mockRegisteredMcpTools.length = 0;
+        await mcpService.createServer({
+            runMetricQueryEnabled: true,
+            filterExpressionsEnabled: true,
+        });
+
+        const registered = mockRegisteredMcpTools.find(
+            ({ name }) => name === McpToolName.RUN_METRIC_QUERY,
+        );
+        expect(registered).toBeDefined();
+        expect({
+            name: registered?.name,
+            title: registered?.config.title,
+            description: registered?.config.description,
+            annotations: registered?.config.annotations,
+            inputSchema: schemaToJson(registered?.config.inputSchema),
+            outputSchema: schemaToJson(registered?.config.outputSchema),
+        }).toMatchSnapshot();
     });
 
     it('registers generate_hashes without project scope', async () => {

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -8179,6 +8179,7 @@ Available operators: isNull, notNull, equals, notEquals, startsWith, endsWith, i
 - Presence operators take no values. Other operators require one or more comma-separated values according to the field type.
 - Relative dates use a count followed by named settings (for example inThePast=30{unit:days,completed:false}). completed=false includes the current partial period; completed=true uses completed periods only.
 - Current dates use one unit (for example inTheCurrent=months).
+- Safety limits: 256 rules per expression, 256 values (including settings) per rule, 256 characters per literal, and 16384 characters per expression.
 - Nested groups and parentheses are not supported yet.",
   "inputSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/packages/backend/src/routers/mcpRouter.authorization.test.ts
+++ b/packages/backend/src/routers/mcpRouter.authorization.test.ts
@@ -63,6 +63,7 @@ const createMcpService = () =>
         isContentToolsEnabled: vi.fn().mockResolvedValue(false),
         isCreateScheduledDeliveryEnabled: vi.fn().mockResolvedValue(false),
         isEnabled: vi.fn().mockResolvedValue(true),
+        isFilterExpressionsEnabled: vi.fn().mockResolvedValue(true),
         isRunMetricQueryEnabled: vi.fn().mockResolvedValue(false),
         isRunSqlEnabled: vi.fn().mockResolvedValue(false),
     }) as McpService;
@@ -301,8 +302,14 @@ describe('project-scoped MCP route', () => {
             expect.objectContaining({ userUuid: 'user-uuid' }),
             PROJECT_UUID,
         );
+        expect(mcpService.isFilterExpressionsEnabled).toHaveBeenCalledWith(
+            expect.objectContaining({ userUuid: 'user-uuid' }),
+        );
         expect(mcpService.createServer).toHaveBeenCalledWith(
-            expect.objectContaining({ projectPinned: true }),
+            expect.objectContaining({
+                projectPinned: true,
+                filterExpressionsEnabled: true,
+            }),
         );
         expect(transport.handleRequest).toHaveBeenCalledOnce();
     });

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -376,6 +376,7 @@ mcpRouter.all(
                     scheduledDeliveryEnabled,
                     runSqlEnabled,
                     runMetricQueryEnabled,
+                    filterExpressionsEnabled,
                 ] = await Promise.all([
                     mcpService.isContentToolsEnabled(req.user!),
                     mcpService.isCreateScheduledDeliveryEnabled(req.user!),
@@ -384,6 +385,7 @@ mcpRouter.all(
                         req.user!,
                         pinnedProjectUuid,
                     ),
+                    mcpService.isFilterExpressionsEnabled(req.user!),
                 ]);
                 const mcpServer = await mcpService.createServer({
                     projectPinned: pinnedProjectUuid !== undefined,
@@ -394,6 +396,7 @@ mcpRouter.all(
                     scheduledDeliveryEnabled,
                     runSqlEnabled,
                     runMetricQueryEnabled,
+                    filterExpressionsEnabled,
                 });
                 const transport = new StreamableHTTPServerTransport({
                     enableJsonResponse: true,

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.test.ts
@@ -39,7 +39,12 @@ import {
     type ToolRunQueryExpressionRuntimeArgs,
 } from './expressionSchemas';
 import { filterExpressionOperators } from './operators';
-import { FILTER_EXPRESSION_MAX_LENGTH } from './parse';
+import {
+    FILTER_EXPRESSION_MAX_LENGTH,
+    FILTER_EXPRESSION_MAX_LITERAL_LENGTH,
+    FILTER_EXPRESSION_MAX_RULES,
+    FILTER_EXPRESSION_MAX_VALUES_PER_RULE,
+} from './parse';
 
 const baseQueryConfig = {
     exploreName: 'orders',
@@ -167,6 +172,21 @@ describe('filter expression input schemas', () => {
         );
         expect(filterExpressionsSchema.description).toContain(
             '(D1 AND D2) AND (M1 OR M2)',
+        );
+    });
+
+    it('documents parser safety limits', () => {
+        expect(FILTER_EXPRESSION_GRAMMAR_DESCRIPTION).toContain(
+            `${FILTER_EXPRESSION_MAX_RULES} rules per expression`,
+        );
+        expect(FILTER_EXPRESSION_GRAMMAR_DESCRIPTION).toContain(
+            `${FILTER_EXPRESSION_MAX_VALUES_PER_RULE} values (including settings) per rule`,
+        );
+        expect(FILTER_EXPRESSION_GRAMMAR_DESCRIPTION).toContain(
+            `${FILTER_EXPRESSION_MAX_LITERAL_LENGTH} characters per literal`,
+        );
+        expect(FILTER_EXPRESSION_GRAMMAR_DESCRIPTION).toContain(
+            `${FILTER_EXPRESSION_MAX_LENGTH} characters per expression`,
         );
     });
 

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/expressionSchemas.ts
@@ -18,7 +18,12 @@ import {
 import { createToolSchema } from '../toolSchemaBuilder';
 import visualizationMetadataSchema from '../visualizationMetadata';
 import { filterExpressionOperators } from './operators';
-import { FILTER_EXPRESSION_MAX_LENGTH } from './parse';
+import {
+    FILTER_EXPRESSION_MAX_LENGTH,
+    FILTER_EXPRESSION_MAX_LITERAL_LENGTH,
+    FILTER_EXPRESSION_MAX_RULES,
+    FILTER_EXPRESSION_MAX_VALUES_PER_RULE,
+} from './parse';
 
 export const FILTER_EXPRESSION_GRAMMAR_DESCRIPTION = `Filter expressions use the form "field operator=value".
 
@@ -32,6 +37,7 @@ Available operators: ${filterExpressionOperators.join(', ')}.
 - Presence operators take no values. Other operators require one or more comma-separated values according to the field type.
 - Relative dates use a count followed by named settings (for example inThePast=30{unit:days,completed:false}). completed=false includes the current partial period; completed=true uses completed periods only.
 - Current dates use one unit (for example inTheCurrent=months).
+- Safety limits: ${FILTER_EXPRESSION_MAX_RULES} rules per expression, ${FILTER_EXPRESSION_MAX_VALUES_PER_RULE} values (including settings) per rule, ${FILTER_EXPRESSION_MAX_LITERAL_LENGTH} characters per literal, and ${FILTER_EXPRESSION_MAX_LENGTH} characters per expression.
 - Nested groups and parentheses are not supported yet.`;
 
 export const filterExpressionInputSchema = z

--- a/packages/common/src/ee/AiAgent/schemas/filterExpressions/parse.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filterExpressions/parse.ts
@@ -13,9 +13,9 @@ import { FILTER_EXPRESSION_MIXED_CONNECTORS_CODE } from './grammar';
 import { filterExpressionParser } from './parser';
 
 export const FILTER_EXPRESSION_MAX_LENGTH = 16_384;
-export const FILTER_EXPRESSION_MAX_RULES = 100;
-export const FILTER_EXPRESSION_MAX_VALUES_PER_RULE = 100;
-export const FILTER_EXPRESSION_MAX_LITERAL_LENGTH = 4_096;
+export const FILTER_EXPRESSION_MAX_RULES = 256;
+export const FILTER_EXPRESSION_MAX_VALUES_PER_RULE = 256;
+export const FILTER_EXPRESSION_MAX_LITERAL_LENGTH = 256;
 
 const generatedMixedConnectorsResultSchema = z
     .object({


### PR DESCRIPTION
Related: ZAP-963
Related: ZAP-920
Related: #28262

## Summary

- Select the compact expression contract for Model Context Protocol (MCP) `run_metric_query` under the shared feature flag.
- Type the live callback from the exact MCP schema and normalize absent `mergeConfig` to null only after boundary parsing; historical V2 remains persistence-only.
- Preserve the MCP boundary's formula-only table calculations and builtin-only chart configuration.
- Resolve scoped filter expressions before the existing metric-query builder and execution path.
- Enforce and advertise safety bounds of 256 rules, 256 values per rule, and 256 characters per literal.
- Return typed repair errors without Sentry capture while preserving failed-activity tracking.
- Keep the flag-off contract unchanged and reduce the current flag-on definition from about 81 KB / 19k tokens to 18 KB / 4k tokens.
- Carry the shared category-composition algebra into the flag-on runtime MCP snapshot. The committed `mcp-tools-1.0.json` release-safety artifact intentionally remains the stable/default contract until rollout promotion.

This completes the stack by enabling the same compact filter contract for MCP.

## Verification

- 65 common parser, schema, and contract tests.
- 284 backend resolver and contract tests.
- 16 focused shared expression-schema tests and 28 MCP contract snapshot tests after restacking.
- Regenerated the stable/default MCP artifact and passed its freshness check; no JSON change is expected for an off-by-default rollout variant.
- Parser and committed MCP snapshot drift checks.
- Common typecheck and lint; common and backend format checks.

Risk: high — changes a public MCP query contract and query boundary behind an off-by-default flag; human review is required.
