### PR TITLE
fix(release-safety): keep definitive AI verdicts with incomplete metadata

### DIFF
--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -264,14 +264,14 @@ test('incomplete migration metadata blocks deterministic safety', () => {
 });
 
 test('existing deterministic false verdicts cannot be loosened', () => {
-    const inputs = [
-        {
-            sqlLint: {
-                ran: true,
-                breaking: true,
-                findings: ['unsupported SQL'],
-            },
+    const linterFinding = {
+        sqlLint: {
+            ran: true,
+            breaking: true,
+            findings: ['unsupported SQL'],
         },
+    };
+    const deterministicBreakInputs = [
         {
             config: {
                 checked: true,
@@ -289,7 +289,7 @@ test('existing deterministic false verdicts cannot be loosened', () => {
             ],
         },
     ];
-    for (const override of inputs) {
+    for (const override of [linterFinding, ...deterministicBreakInputs]) {
         const input = {
             ...base,
             migrations: migration,
@@ -305,6 +305,18 @@ test('existing deterministic false verdicts cannot be loosened', () => {
             buildMarker(input).compatibility.rollingUpdateSafe,
             false,
         );
+    }
+    for (const override of deterministicBreakInputs) {
+        const input = {
+            ...base,
+            migrations: migration,
+            migrationDetails,
+            migrationOperations: compatibleOperations,
+            migrationMetadataComplete: true,
+            declarationMetadataComplete: true,
+            ...checkedSurfaces,
+            ...override,
+        };
         assert.strictEqual(
             buildMarker({
                 ...input,
@@ -316,6 +328,53 @@ test('existing deterministic false verdicts cannot be loosened', () => {
             }).compatibility.rollingUpdateSafe,
             false,
         );
+    }
+});
+
+test('a definitive AI verdict clears a linter finding and publishes its floor', () => {
+    const marker = buildMarker({
+        ...base,
+        migrations: migration,
+        migrationDetails,
+        ...checkedSurfaces,
+        sqlLint: {
+            ran: true,
+            breaking: true,
+            findings: ['drop-column'],
+        },
+        aiReview: {
+            rollingUpdateSafe: true,
+            recommendedStrategy: 'RollingUpdate',
+            summary: 'cleared',
+        },
+        expandContractFloor: '1.100.0',
+    });
+    assert.strictEqual(marker.compatibility.rollingUpdateSafe, true);
+    assert.strictEqual(marker.upgrade.minPreviousVersion, '1.100.0');
+});
+
+test('a linter finding stays unsafe without a definitive AI verdict', () => {
+    for (const aiReview of [
+        undefined,
+        {
+            rollingUpdateSafe: 'unknown' as const,
+            recommendedStrategy: 'unknown' as const,
+            summary: 'unknown',
+        },
+    ]) {
+        const marker = buildMarker({
+            ...base,
+            migrations: migration,
+            migrationDetails,
+            ...checkedSurfaces,
+            sqlLint: {
+                ran: true,
+                breaking: true,
+                findings: ['drop-column'],
+            },
+            aiReview,
+        });
+        assert.strictEqual(marker.compatibility.rollingUpdateSafe, false);
     }
 });
 
@@ -589,7 +648,7 @@ test('ownExpandContractFloor matches the marker floor', () => {
     const marker = buildMarker(input);
     assert.strictEqual(ownExpandContractFloor(input), '1.100.0');
     assert.strictEqual(marker.upgrade.minPreviousVersion, '1.100.0');
-    assert.strictEqual(marker.compatibility.rollingUpdateSafe, false);
+    assert.strictEqual(marker.compatibility.rollingUpdateSafe, true);
 });
 
 if (failures.length > 0) {

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -305,6 +305,17 @@ test('existing deterministic false verdicts cannot be loosened', () => {
             buildMarker(input).compatibility.rollingUpdateSafe,
             false,
         );
+        assert.strictEqual(
+            buildMarker({
+                ...input,
+                aiReview: {
+                    rollingUpdateSafe: true,
+                    recommendedStrategy: 'RollingUpdate',
+                    summary: 'verified',
+                },
+            }).compatibility.rollingUpdateSafe,
+            false,
+        );
     }
 });
 
@@ -378,7 +389,7 @@ test('definitive AI review can prove a migration safe', () => {
     assert.strictEqual(marker.compatibility.rollingUpdateSafe, true);
 });
 
-test('incomplete declaration metadata stays unknown after a definitive AI verdict', () => {
+test('a definitive AI verdict stands when declaration metadata is incomplete', () => {
     const marker = buildMarker({
         ...base,
         migrations: migration,
@@ -391,7 +402,39 @@ test('incomplete declaration metadata stays unknown after a definitive AI verdic
             summary: 'verified',
         },
     });
-    assert.strictEqual(marker.compatibility.rollingUpdateSafe, 'unknown');
+    assert.strictEqual(marker.compatibility.rollingUpdateSafe, true);
+});
+
+test('a definitive AI verdict stands when migration metadata is incomplete', () => {
+    const marker = buildMarker({
+        ...base,
+        migrations: migration,
+        migrationDetails,
+        ...checkedSurfaces,
+        migrationMetadataComplete: false,
+        aiReview: {
+            rollingUpdateSafe: true,
+            recommendedStrategy: 'RollingUpdate',
+            summary: 'verified',
+        },
+    });
+    assert.strictEqual(marker.compatibility.rollingUpdateSafe, true);
+});
+
+test('a definitive AI false stands when metadata is incomplete', () => {
+    const marker = buildMarker({
+        ...base,
+        migrations: migration,
+        migrationDetails,
+        ...checkedSurfaces,
+        migrationMetadataComplete: false,
+        aiReview: {
+            rollingUpdateSafe: false,
+            recommendedStrategy: 'Recreate',
+            summary: 'unsafe',
+        },
+    });
+    assert.strictEqual(marker.compatibility.rollingUpdateSafe, false);
 });
 
 test('a declared break stays unsafe when declaration metadata is incomplete', () => {
@@ -451,6 +494,22 @@ test('declared break uses the frozen shape and contributes a required stop', () 
     });
     assert.strictEqual(marker.compatibility.rollingUpdateSafe, false);
     assert.deepStrictEqual(marker.upgrade.requiredStops, ['1.115.0']);
+});
+
+test('a carried required stop for this version cannot be loosened', () => {
+    const marker = buildMarker({
+        ...base,
+        migrations: migration,
+        migrationDetails,
+        ...checkedSurfaces,
+        requiredStops: [base.version],
+        aiReview: {
+            rollingUpdateSafe: true,
+            recommendedStrategy: 'RollingUpdate',
+            summary: 'verified',
+        },
+    });
+    assert.strictEqual(marker.compatibility.rollingUpdateSafe, false);
 });
 
 test('a spent required stop is not pinned again by a later marker', () => {
@@ -530,7 +589,7 @@ test('ownExpandContractFloor matches the marker floor', () => {
     const marker = buildMarker(input);
     assert.strictEqual(ownExpandContractFloor(input), '1.100.0');
     assert.strictEqual(marker.upgrade.minPreviousVersion, '1.100.0');
-    assert.strictEqual(marker.compatibility.rollingUpdateSafe, true);
+    assert.strictEqual(marker.compatibility.rollingUpdateSafe, false);
 });
 
 if (failures.length > 0) {

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -293,8 +293,9 @@ export function ownExpandContractFloor(input: {
 
 /**
  * PURE. Assemble the marker from already-gathered inputs. Encodes the honesty
- * rules: definitive AI verdicts stand despite incomplete metadata, while
- * deterministic breaks, linter findings, and required stops remain unsafe.
+ * rules: definitive AI verdicts stand despite incomplete metadata. Declared
+ * and config breaks plus required stops remain unsafe; a linter finding holds
+ * unless a definitive AI verdict clears it.
  */
 export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     const present: TriState = input.migrations
@@ -347,6 +348,9 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     ) {
         rollingUpdateSafe = true;
     }
+    if (linterFlagged || deterministicBreak) {
+        rollingUpdateSafe = false;
+    }
     if (
         input.aiReview &&
         input.aiReview.rollingUpdateSafe !== 'unknown' &&
@@ -354,11 +358,7 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     ) {
         rollingUpdateSafe = input.aiReview.rollingUpdateSafe;
     }
-    if (
-        deterministicBreak ||
-        linterFlagged ||
-        requiredStops.includes(input.version)
-    ) {
+    if (deterministicBreak || requiredStops.includes(input.version)) {
         rollingUpdateSafe = false;
     }
 

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -293,8 +293,8 @@ export function ownExpandContractFloor(input: {
 
 /**
  * PURE. Assemble the marker from already-gathered inputs. Encodes the honesty
- * rules: rollingUpdateSafe is never silently true/false for a migration-bearing
- * (or unknown) release.
+ * rules: definitive AI verdicts stand despite incomplete metadata, while
+ * deterministic breaks, linter findings, and required stops remain unsafe.
  */
 export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     const present: TriState = input.migrations
@@ -326,6 +326,16 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     const fullyChecked =
         rest.checked && mcp.checked && config.checked && metadataComplete;
     const deterministicallySafe = isDeterministicallyRollingUpdateSafe(input);
+    const requiredStops = [
+        ...new Set([
+            ...(input.requiredStops ?? []),
+            ...(declaredBreaks.some(
+                (declaredBreak) => declaredBreak.requiredStop,
+            )
+                ? [input.version]
+                : []),
+        ]),
+    ].sort(compareVersions);
 
     let rollingUpdateSafe: TriState = 'unknown';
     if (
@@ -337,9 +347,6 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     ) {
         rollingUpdateSafe = true;
     }
-    if (linterFlagged || deterministicBreak) {
-        rollingUpdateSafe = false;
-    }
     if (
         input.aiReview &&
         input.aiReview.rollingUpdateSafe !== 'unknown' &&
@@ -347,10 +354,11 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     ) {
         rollingUpdateSafe = input.aiReview.rollingUpdateSafe;
     }
-    if (!metadataComplete) {
-        rollingUpdateSafe = 'unknown';
-    }
-    if (deterministicBreak) {
+    if (
+        deterministicBreak ||
+        linterFlagged ||
+        requiredStops.includes(input.version)
+    ) {
         rollingUpdateSafe = false;
     }
 
@@ -376,16 +384,6 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
         minPreviousVersion = carriedFloor;
     }
 
-    const requiredStops = [
-        ...new Set([
-            ...(input.requiredStops ?? []),
-            ...(declaredBreaks.some(
-                (declaredBreak) => declaredBreak.requiredStop,
-            )
-                ? [input.version]
-                : []),
-        ]),
-    ].sort(compareVersions);
     const migrationDetails = input.migrationDetails ?? [];
     const coreCount = migrationDetails.filter(
         (migration) => migration.edition === 'core',


### PR DESCRIPTION
A definitive AI safety verdict now stands when migration or declaration metadata is incomplete.

The old metadata veto flipped four AI-true releases to unknown in a nine-day window. It never caught an unsafe release and delayed our internal instance's automatic upgrades.

Declared breaks, config breaks, and required stops still force an unsafe verdict. Linter semantics are unchanged from main: a definitive AI review can still clear a linter finding and publish the expand-contract floor.

Measurement, preflight inputs, and metadataComplete publication do not change.

Linear: SPK-1232