### PR TITLE
fix(page): stop the right sidebar toggle causing horizontal scroll

### DIFF
--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -124,19 +124,13 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
         );
     }
 
+    // Both positions collapse with a negative inline-start margin. A right
+    // sidebar closed with a negative margin-right keeps its box hanging past
+    // the page edge for the length of the animation, which shows a horizontal
+    // scrollbar on every toggle.
     const transition: MantineTransition = {
-        in: {
-            opacity: 1,
-            ...(position === SidebarPosition.LEFT
-                ? { marginLeft: 0 }
-                : { marginRight: 0 }),
-        },
-        out: {
-            opacity: 0,
-            ...(position === SidebarPosition.LEFT
-                ? { marginLeft: -sidebarWidth }
-                : { marginRight: -sidebarWidth }),
-        },
+        in: { opacity: 1, marginLeft: 0 },
+        out: { opacity: 0, marginLeft: -sidebarWidth },
         transitionProperty: isResizing
             ? 'opacity, margin'
             : 'opacity, margin, width',


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-10434/prevent-horizontal-scroll-on-chart-configuration-sidebar-toggle

### Description:

Toggling the chart configuration sidebar flashed a horizontal scrollbar for the length of the open/close animation.

The right sidebar collapses via a negative `margin-right` on the panel. That removes it from the layout (so the container width animates to 0) but doesn't move the panel's box — it stays hanging up to `sidebarWidth` past the page's right edge until the transition finishes and Mantine's `Transition` applies `display: none`. Hence a scrollbar that appears only while animating, in both directions.

Collapsing with a negative `margin-left` instead has the same layout effect but keeps the panel pinned inside the page, so nothing overflows. Side effect: the right panel now fades in place while the content area squeezes, rather than sliding in from off-screen. The left sidebar is unchanged (a negative `margin-left` there both removes it from the layout and slides it off-screen, as before), which also lets the two branches collapse into one.

Not visually verified — no browser or dev server available in this environment, so the fix is derived from the layout maths rather than observed. Worth a quick local toggle before merge.

**Before**
https://github.com/user-attachments/assets/b2fd7d87-2138-4cc8-86c4-fbc57ac30d59



**After**
https://github.com/user-attachments/assets/1a571502-3f32-497a-b30f-753013b1eced

### Risk assessment:

- [ ] This is a high-risk change
