### PR TITLE
fix: search custom chart types by name and description

### DIFF
--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -45,6 +45,7 @@ import {
     acquireProjectSlugLock,
     generateUniqueSlugScopedToProject,
 } from '../utils/SlugUtils';
+import { getFullTextSearchFilterSql } from './SearchModel/utils/search';
 
 type AppModelArguments = {
     database: Knex;
@@ -983,7 +984,13 @@ export class AppModel {
             )
             .orderBy(`${AppsTableName}.created_at`, 'desc');
         if (search) {
-            void query.whereILike(`${AppsTableName}.name`, `%${search}%`);
+            void query.whereRaw(
+                getFullTextSearchFilterSql({
+                    database: this.database,
+                    searchVectorColumn: `${AppsTableName}.search_vector`,
+                    searchQuery: search,
+                }),
+            );
         }
         return KnexPaginate.paginate(query, paginateArgs);
     }

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/CustomChartTypePicker.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/CustomChartTypePicker.test.tsx
@@ -151,12 +151,11 @@ describe('CustomChartTypePicker', () => {
         try {
             setData([]);
             render();
-            // The project search is served by the endpoint; the built-in entry
-            // is filtered here, so a non-matching term must drop it from the
-            // list once the shared debounce settles.
+            // Project search is served by the endpoint; the built-in entry is
+            // filtered here.
             fireEvent.change(
                 screen.getByPlaceholderText('Search custom chart types…'),
-                { target: { value: 'cohort' } },
+                { target: { value: 'rank' } },
             );
             act(() => {
                 vi.advanceTimersByTime(500);
@@ -165,7 +164,7 @@ describe('CustomChartTypePicker', () => {
             expect(screen.queryByText('Vega (JSON editor)')).toBeNull();
             expect(mockedUseDataAppVisualizations).toHaveBeenLastCalledWith(
                 'project-1',
-                'cohort',
+                'rank',
             );
         } finally {
             vi.useRealTimers();

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -260,18 +260,28 @@ describe('ChartTypeGallery', () => {
             screen.getByText(/Chart types are custom visualizations/),
         ).toBeInTheDocument();
         expect(
-            screen.queryByPlaceholderText('Search by name'),
+            screen.queryByPlaceholderText('Search by name or description'),
         ).not.toBeInTheDocument();
     });
 
-    it('shows a no-results message when a search matches nothing', async () => {
+    it('shows a no-results message for an empty searched page', async () => {
         setData([makeDataAppViz({})]);
         renderPage();
 
-        fireEvent.change(screen.getByPlaceholderText('Search by name'), {
-            target: { value: 'nonexistent' },
-        });
+        fireEvent.change(
+            screen.getByPlaceholderText('Search by name or description'),
+            {
+                target: { value: 'prog' },
+            },
+        );
         setData([]);
+
+        await waitFor(() =>
+            expect(mockedUseDataAppVisualizations).toHaveBeenLastCalledWith(
+                'project-1',
+                'prog',
+            ),
+        );
 
         await waitFor(() =>
             expect(

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -116,7 +116,7 @@ const ChartTypeGallery = () => {
                                 <TextInput
                                     size="xs"
                                     w={220}
-                                    placeholder="Search by name"
+                                    placeholder="Search by name or description"
                                     leftSection={
                                         <MantineIcon
                                             icon={IconSearch}


### PR DESCRIPTION
### Description

- Search project visualizations through `apps.search_vector`
- Match name and description word prefixes; preserve creation ordering
- Clarify gallery search copy

### Verification

- `pnpm --filter backend lint`
- `pnpm --filter backend typecheck`
- `pnpm --filter frontend lint`
- `pnpm --filter frontend typecheck`
- Focused frontend tests: 20 passed
- Curl: name/description prefixes match; mid-word substrings do not; ordering preserved

### Risk assessment

- [ ] This is a high-risk change