### PR TITLE
fix(dbt): apply dbt selectors when a project has multiple dbt sources

### DIFF
--- a/packages/backend/src/projectAdapters/dbtManifestProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtManifestProjectAdapter.ts
@@ -14,8 +14,11 @@ import { DbtBaseProjectAdapter } from './dbtBaseProjectAdapter';
 class ManifestDbtClient implements DbtClient {
     private readonly manifest: string;
 
-    constructor(manifest: string) {
+    private readonly selectedModelIds?: string[];
+
+    constructor(manifest: string, selectedModelIds?: string[]) {
         this.manifest = manifest;
+        this.selectedModelIds = selectedModelIds;
     }
 
     // eslint-disable-next-line class-methods-use-this
@@ -35,7 +38,12 @@ class ManifestDbtClient implements DbtClient {
         };
 
         if (isDbtRpcManifestResults(rawManifest)) {
-            return rawManifest;
+            return {
+                ...rawManifest,
+                ...(this.selectedModelIds
+                    ? { selectedModelIds: this.selectedModelIds }
+                    : {}),
+            };
         }
         throw new DbtError(
             'Cannot read response from dbt, manifest.json not valid',
@@ -58,6 +66,7 @@ type DbtManifestProjectAdapterArgs = {
     // from. Used by the multiple-dbt-sources merge to point the merged manifest
     // adapter at the primary source's checkout so its project config is kept.
     dbtProjectDir?: string;
+    selectedModelIds?: string[];
 };
 
 export class DbtManifestProjectAdapter extends DbtBaseProjectAdapter {
@@ -68,9 +77,13 @@ export class DbtManifestProjectAdapter extends DbtBaseProjectAdapter {
         analytics,
         manifest,
         dbtProjectDir,
+        selectedModelIds,
     }: DbtManifestProjectAdapterArgs) {
         // Create a dummy dbt client since we don't need it for manifest-based compilation
-        const manifestDbtClient = new ManifestDbtClient(manifest);
+        const manifestDbtClient = new ManifestDbtClient(
+            manifest,
+            selectedModelIds,
+        );
 
         super(
             manifestDbtClient,

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -27,10 +27,9 @@ export const projectAdapterFromConfig = async (
     dbtVersionOption: DbtVersionOption,
     environmentVariableAllowlist: string[],
     analytics?: LightdashAnalytics,
-    // MANIFEST-only: dbt project dir to read lightdash.config.yml /
-    // project_context.yml from (the multiple-dbt-sources merge passes the
-    // primary source's checkout here). Ignored by every other adapter type.
-    manifestProjectDir?: string,
+    // MANIFEST-only: project dir for Lightdash config and selected model ids.
+    // Ignored by every other adapter type.
+    manifestOptions?: { projectDir?: string; selectedModelIds?: string[] },
 ): Promise<ProjectAdapter> => {
     Logger.debug(
         `Initialize warehouse client of type ${warehouseCredentials.type}`,
@@ -69,7 +68,8 @@ export const projectAdapterFromConfig = async (
                 dbtVersion,
                 analytics,
                 manifest: config.manifest,
-                dbtProjectDir: manifestProjectDir,
+                dbtProjectDir: manifestOptions?.projectDir,
+                selectedModelIds: manifestOptions?.selectedModelIds,
             });
 
         case DbtProjectType.DBT_CLOUD_IDE:

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -4553,9 +4553,15 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
         docs: {},
     });
 
-    const buildAdapterWithManifest = (manifest: DbtManifest) =>
+    const buildAdapterWithManifest = (
+        manifest: DbtManifest,
+        selectedModelIds?: string[],
+    ) =>
         ({
-            getDbtManifest: vi.fn(async () => ({ manifest })),
+            getDbtManifest: vi.fn(async () => ({
+                manifest,
+                ...(selectedModelIds ? { selectedModelIds } : {}),
+            })),
         }) as unknown as ProjectAdapter;
 
     const buildSource = (name: string): ProjectDbtSource => ({
@@ -4573,12 +4579,16 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
     const buildMergedAdapter = async (
         primaryManifest: DbtManifest,
         sourceManifest: DbtManifest,
+        selectedModelIds: {
+            primary?: string[];
+            source?: string[];
+        } = {},
     ) => {
         const projectService = getMockedProjectService(
             lightdashConfigMock,
         ) as unknown as ProjectServiceInternals;
         vi.spyOn(projectService, 'buildSourceAdapter').mockResolvedValue(
-            buildAdapterWithManifest(sourceManifest),
+            buildAdapterWithManifest(sourceManifest, selectedModelIds.source),
         );
 
         return projectService.buildMergedManifestAdapter({
@@ -4586,12 +4596,189 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
             organizationUuid: 'org-uuid',
             primary: {
                 ...primary,
-                adapter: buildAdapterWithManifest(primaryManifest),
+                adapter: buildAdapterWithManifest(
+                    primaryManifest,
+                    selectedModelIds.primary,
+                ),
             },
             sources: [buildSource('source-b')],
             manifestFetchAdapters: [],
         });
     };
+
+    it('returns the deduplicated union when both sources select models', async () => {
+        const primaryManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_a.orders',
+                name: 'orders',
+                packageName: 'pkg_a',
+            },
+        ]);
+        const sourceManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_b.customers',
+                name: 'customers',
+                packageName: 'pkg_b',
+            },
+        ]);
+
+        const adapter = await buildMergedAdapter(
+            primaryManifest,
+            sourceManifest,
+            {
+                primary: ['model.pkg_a.orders', 'model.pkg_a.orders'],
+                source: ['model.pkg_b.customers', 'model.pkg_b.customers'],
+            },
+        );
+
+        await expect(adapter.getDbtManifest()).resolves.toMatchObject({
+            selectedModelIds: ['model.pkg_a.orders', 'model.pkg_b.customers'],
+        });
+    });
+
+    it('omits selected model ids when neither source has a selector', async () => {
+        const primaryManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_a.orders',
+                name: 'orders',
+                packageName: 'pkg_a',
+            },
+        ]);
+        const sourceManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_b.customers',
+                name: 'customers',
+                packageName: 'pkg_b',
+            },
+        ]);
+
+        const adapter = await buildMergedAdapter(
+            primaryManifest,
+            sourceManifest,
+        );
+        const result = await adapter.getDbtManifest();
+
+        expect(result).not.toHaveProperty('selectedModelIds');
+    });
+
+    it('preserves an empty selection when every selector matches nothing', async () => {
+        const primaryManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_a.orders',
+                name: 'orders',
+                packageName: 'pkg_a',
+            },
+        ]);
+        const sourceManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_b.customers',
+                name: 'customers',
+                packageName: 'pkg_b',
+            },
+        ]);
+
+        const adapter = await buildMergedAdapter(
+            primaryManifest,
+            sourceManifest,
+            { primary: [], source: [] },
+        );
+        const result = await adapter.getDbtManifest();
+
+        expect(result).toHaveProperty('selectedModelIds', []);
+    });
+
+    it('includes every model from the selector-less source', async () => {
+        const primaryManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_a.orders',
+                name: 'orders',
+                packageName: 'pkg_a',
+            },
+            {
+                uniqueId: 'model.pkg_a.payments',
+                name: 'payments',
+                packageName: 'pkg_a',
+            },
+        ]);
+        const sourceManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_b.customers',
+                name: 'customers',
+                packageName: 'pkg_b',
+            },
+            {
+                uniqueId: 'model.pkg_b.products',
+                name: 'products',
+                packageName: 'pkg_b',
+            },
+        ]);
+
+        const primarySelectedAdapter = await buildMergedAdapter(
+            primaryManifest,
+            sourceManifest,
+            { primary: ['model.pkg_a.orders'] },
+        );
+        const sourceSelectedAdapter = await buildMergedAdapter(
+            primaryManifest,
+            sourceManifest,
+            { source: ['model.pkg_b.customers'] },
+        );
+
+        await expect(
+            primarySelectedAdapter.getDbtManifest(),
+        ).resolves.toMatchObject({
+            selectedModelIds: [
+                'model.pkg_a.orders',
+                'model.pkg_b.customers',
+                'model.pkg_b.products',
+            ],
+        });
+        await expect(
+            sourceSelectedAdapter.getDbtManifest(),
+        ).resolves.toMatchObject({
+            selectedModelIds: [
+                'model.pkg_a.orders',
+                'model.pkg_a.payments',
+                'model.pkg_b.customers',
+            ],
+        });
+    });
+
+    it('keeps unselected models in the merged manifest', async () => {
+        const primaryManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_a.orders',
+                name: 'orders',
+                packageName: 'pkg_a',
+            },
+            {
+                uniqueId: 'model.pkg_a.staging_orders',
+                name: 'staging_orders',
+                packageName: 'pkg_a',
+            },
+        ]);
+        const sourceManifest = buildManifest([
+            {
+                uniqueId: 'model.pkg_b.customers',
+                name: 'customers',
+                packageName: 'pkg_b',
+            },
+        ]);
+
+        const adapter = await buildMergedAdapter(
+            primaryManifest,
+            sourceManifest,
+            { primary: ['model.pkg_a.orders'] },
+        );
+        const result = await adapter.getDbtManifest();
+
+        expect(result.manifest.nodes).toHaveProperty(
+            'model.pkg_a.staging_orders',
+        );
+        expect(result.selectedModelIds).not.toContain(
+            'model.pkg_a.staging_orders',
+        );
+    });
 
     it('rejects cross-source bare model name collisions before returning a merged adapter', async () => {
         const primaryManifest = buildManifest([

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -87,6 +87,7 @@ import {
     getAvailableFilterFieldIds,
     getAvailableParametersFromTables,
     getColumnTimezone,
+    getCompiledModels,
     getCustomSqlFieldKey,
     getDashboardFilterRulesForTables,
     getDbtEnvironmentVariableKeyError,
@@ -4591,8 +4592,10 @@ export class ProjectService extends BaseService {
         // The primary git adapter is only read for its manifest here; the merged
         // MANIFEST adapter is what compiles, so destroy the primary clone in finally.
         manifestFetchAdapters.push(primary.adapter);
-        const { manifest: primaryManifest } =
-            await primary.adapter.getDbtManifest();
+        const {
+            manifest: primaryManifest,
+            selectedModelIds: primarySelectedModelIds,
+        } = await primary.adapter.getDbtManifest();
 
         // A credential error fails the whole deploy by name, matching every
         // other per-source failure below (broken clone, broken manifest) — a
@@ -4650,11 +4653,13 @@ export class ProjectService extends BaseService {
                 // destroys this clone even if the fetch below throws.
                 manifestFetchAdapters.push(sourceAdapter);
                 try {
-                    const { manifest } = await sourceAdapter.getDbtManifest();
+                    const { manifest, selectedModelIds } =
+                        await sourceAdapter.getDbtManifest();
                     return {
                         name: source.name,
                         precedence: source.precedence,
                         manifest,
+                        selectedModelIds,
                     };
                 } catch (e) {
                     throw new ParameterError(
@@ -4713,6 +4718,33 @@ export class ProjectService extends BaseService {
             );
         }
 
+        const sourceSelections = [
+            {
+                manifest: primaryManifest,
+                selectedModelIds: primarySelectedModelIds,
+            },
+            ...built.map(({ manifest, selectedModelIds }) => ({
+                manifest,
+                selectedModelIds,
+            })),
+        ];
+        // Selector-less sources contribute every model when any source uses a selector.
+        const selectedModelIds = sourceSelections.every(
+            (source) => source.selectedModelIds === undefined,
+        )
+            ? undefined
+            : Array.from(
+                  new Set(
+                      sourceSelections.flatMap((source) =>
+                          source.selectedModelIds === undefined
+                              ? getCompiledModels(
+                                    getModelsFromManifest(source.manifest),
+                                ).map((model) => model.unique_id)
+                              : source.selectedModelIds,
+                      ),
+                  ),
+              );
+
         return projectAdapterFromConfig(
             {
                 type: DbtProjectType.MANIFEST,
@@ -4728,7 +4760,10 @@ export class ProjectService extends BaseService {
             // (spotlight categories, table_groups, parameters, AI context). The
             // primary clone is alive until the caller destroys manifestFetchAdapters
             // after compile, so the merged adapter can read these during compile.
-            primary.adapter.dbtProjectDir,
+            {
+                projectDir: primary.adapter.dbtProjectDir,
+                selectedModelIds,
+            },
         );
     }
 


### PR DESCRIPTION
Fixes #27846
Linear: SPK-1248

## Problem

A project with more than one dbt source compiled every model in every repository. The dbt selector on each source did nothing, so staging and intermediate models became Explores. A single-source project was not affected.

## Cause

Lightdash does not prune the manifest to apply a selector. `DbtCliClient.getDbtManifest()` runs `dbt ls --select` and returns the matching model ids as `selectedModelIds`. `DbtBaseProjectAdapter.compileAllExplores()` gives that list to `getCompiledModels()`, which keeps only those ids. The manifest keeps every node so that `ref()` still resolves.

The multi-source merge dropped the list. `ProjectService.buildMergedManifestAdapter()` read only the manifest from the primary fetch and from each source fetch, then wrapped the merged manifest in a MANIFEST adapter whose client could not carry a selection.

With no ids to filter on, `getCompiledModels()` fell back to `isAnyModelCompiled ? model.compiled : true`. A `dbt ls` manifest has no compiled nodes, so the fallback kept every model.

## Change

The merge now collects `selectedModelIds` from the primary fetch and from each source fetch, and passes the union to the merged adapter.

| Case | Result |
| --- | --- |
| No source has a selector | `undefined`. Behaviour does not change. |
| Any source has a selector | The deduplicated union. A source without a selector contributes every model it would compile on its own. |
| A selector matches nothing | Stays empty. It does not fall back to every model. |

Unselected models stay in the merged manifest, so joins and references across sources still resolve. Only the compile filter narrows.

`projectAdapterFromConfig` takes the MANIFEST-only trailing argument as an options object now, because the merge passes both a project directory and the selected ids.

## Scope

Backend only. The frontend already captures a selector per source, since `DbtSourcesPanel` reuses `DbtSettingsForm`. The CLI merge path is unchanged.

## Tests

New cases in the `MultiDbtSources` block in `ProjectService.test.ts`:

- Both sides select. The union is deduplicated.
- Neither side selects. The adapter reports no selection.
- One side selects. The selector-less side contributes all of its models. Asserted in both directions.
- An excluded model stays in the merged manifest but is absent from the selection.
- Every selector matches nothing. The empty selection is preserved.

The empty-selection test was checked by mutation: changing the spread guard to `selectedModelIds?.length` makes it fail.

`pnpm -F backend typecheck`, the backend `ProjectService` and `projectAdapters` suites (171 tests), and lint on the touched paths all pass.
