### PR TITLE
feat: add hidden dashboard access container foundation

### DIFF
--- a/packages/backend/src/database/entities/spaces.ts
+++ b/packages/backend/src/database/entities/spaces.ts
@@ -18,6 +18,8 @@ export type DbSpace = {
     deleted_by_user_uuid: string | null;
     is_default_user_space: boolean;
     color_palette_uuid: string | null;
+    is_access_container: boolean;
+    access_container_dashboard_uuid: string | null;
 };
 
 export type CreateDbSpace = Pick<

--- a/packages/backend/src/database/migrations/20260821110409_add_dashboard_access_container_to_spaces.ts
+++ b/packages/backend/src/database/migrations/20260821110409_add_dashboard_access_container_to_spaces.ts
@@ -1,0 +1,153 @@
+import { Knex } from 'knex';
+
+export const config = { transaction: false };
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds a nullable internal relation without changing existing rows',
+} as const;
+
+const SpacesTableName = 'spaces';
+const DashboardsTableName = 'dashboards';
+const AccessContainerColumnName = 'is_access_container';
+const DashboardColumnName = 'access_container_dashboard_uuid';
+const ForeignKeyName = 'spaces_access_container_dashboard_uuid_foreign';
+const UniqueIndexName = 'spaces_access_container_dashboard_uuid_unique';
+const VisibleSpacesIndexName = 'spaces_customer_visible_project_id_index';
+const ShapeCheckName = 'spaces_access_container_shape_check';
+const LockTimeout = '5s';
+
+const getRowCount = (result: { rowCount?: number }): number =>
+    result.rowCount ?? 0;
+
+async function addColumnsAndConstraints(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${SpacesTableName}
+        ADD COLUMN IF NOT EXISTS ${AccessContainerColumnName} boolean NOT NULL DEFAULT false,
+        ADD COLUMN IF NOT EXISTS ${DashboardColumnName} uuid
+    `);
+
+    const foreignKey = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_constraint
+         WHERE conname = ? AND conrelid = ?::regclass`,
+        [ForeignKeyName, SpacesTableName],
+    );
+    if (getRowCount(foreignKey) === 0) {
+        await knex.raw(`
+            ALTER TABLE ${SpacesTableName}
+            ADD CONSTRAINT ${ForeignKeyName}
+            FOREIGN KEY (${DashboardColumnName})
+            REFERENCES ${DashboardsTableName}(dashboard_uuid)
+            ON DELETE CASCADE
+            NOT VALID
+        `);
+    }
+
+    const shapeCheck = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_constraint
+         WHERE conname = ? AND conrelid = ?::regclass`,
+        [ShapeCheckName, SpacesTableName],
+    );
+    if (getRowCount(shapeCheck) === 0) {
+        await knex.raw(`
+            ALTER TABLE ${SpacesTableName}
+            ADD CONSTRAINT ${ShapeCheckName}
+            CHECK (
+                (
+                    ${AccessContainerColumnName}
+                    AND ${DashboardColumnName} IS NOT NULL
+                    AND parent_space_uuid IS NULL
+                    AND inherit_parent_permissions IS FALSE
+                    AND is_default_user_space IS FALSE
+                ) OR (
+                    NOT ${AccessContainerColumnName}
+                    AND ${DashboardColumnName} IS NULL
+                )
+            ) NOT VALID
+        `);
+    }
+}
+
+async function createUniqueIndex(knex: Knex): Promise<void> {
+    const invalidIndex = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_class
+         JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+         WHERE pg_class.relname = ? AND NOT pg_index.indisvalid`,
+        [UniqueIndexName],
+    );
+    if (getRowCount(invalidIndex) > 0) {
+        await knex.raw(`DROP INDEX CONCURRENTLY ${UniqueIndexName}`);
+    }
+
+    await knex.raw(`
+        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ${UniqueIndexName}
+        ON ${SpacesTableName} (${DashboardColumnName})
+        WHERE ${DashboardColumnName} IS NOT NULL
+    `);
+}
+
+async function createVisibleSpacesIndex(knex: Knex): Promise<void> {
+    const invalidIndex = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_class
+         JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+         WHERE pg_class.relname = ? AND NOT pg_index.indisvalid`,
+        [VisibleSpacesIndexName],
+    );
+    if (getRowCount(invalidIndex) > 0) {
+        await knex.raw(`DROP INDEX CONCURRENTLY ${VisibleSpacesIndexName}`);
+    }
+
+    await knex.raw(`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS ${VisibleSpacesIndexName}
+        ON ${SpacesTableName} (project_id)
+        WHERE deleted_at IS NULL AND ${AccessContainerColumnName} = FALSE
+    `);
+}
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET lock_timeout = '${LockTimeout}'`);
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await addColumnsAndConstraints(knex);
+        await createUniqueIndex(knex);
+        await createVisibleSpacesIndex(knex);
+        await knex.raw(`
+            ALTER TABLE ${SpacesTableName}
+            VALIDATE CONSTRAINT ${ForeignKeyName}
+        `);
+        await knex.raw(`
+            ALTER TABLE ${SpacesTableName}
+            VALIDATE CONSTRAINT ${ShapeCheckName}
+        `);
+    } finally {
+        await knex.raw('RESET statement_timeout');
+        await knex.raw('RESET lock_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET lock_timeout = '${LockTimeout}'`);
+    try {
+        await knex.raw(`
+            ALTER TABLE ${SpacesTableName}
+            DROP CONSTRAINT IF EXISTS ${ShapeCheckName},
+            DROP CONSTRAINT IF EXISTS ${UniqueIndexName}
+        `);
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${UniqueIndexName}`);
+        await knex.raw(
+            `DROP INDEX CONCURRENTLY IF EXISTS ${VisibleSpacesIndexName}`,
+        );
+        await knex.raw(`
+            ALTER TABLE ${SpacesTableName}
+            DROP CONSTRAINT IF EXISTS ${ForeignKeyName},
+            DROP COLUMN IF EXISTS ${DashboardColumnName},
+            DROP COLUMN IF EXISTS ${AccessContainerColumnName}
+        `);
+    } finally {
+        await knex.raw('RESET lock_timeout');
+    }
+}

--- a/packages/backend/src/models/DashboardAccessContainerModel.integration.test.ts
+++ b/packages/backend/src/models/DashboardAccessContainerModel.integration.test.ts
@@ -1,0 +1,367 @@
+import { SpaceMemberRole, type UUID } from '@lightdash/common';
+import { type Knex } from 'knex';
+import { DashboardsTableName } from '../database/entities/dashboards';
+import { ProjectTableName } from '../database/entities/projects';
+import {
+    SpaceTableName,
+    SpaceUserAccessTableName,
+} from '../database/entities/spaces';
+import { SpacePermissionService } from '../services/SpaceService/SpacePermissionService';
+import { getTestContext } from '../vitest.setup.integration';
+import { DashboardAccessContainerModel } from './DashboardAccessContainerModel';
+import { SpaceModel } from './SpaceModel';
+import { SpacePermissionModel } from './SpacePermissionModel';
+
+type DashboardLocation = {
+    dashboardUuid: UUID;
+    logicalSpaceId: number;
+    logicalSpaceUuid: UUID;
+    projectId: number;
+    projectUuid: UUID;
+};
+
+const requireRow = <T>(row: T | undefined, message: string): T => {
+    if (row === undefined) {
+        throw new Error(message);
+    }
+    return row;
+};
+
+describe('DashboardAccessContainerModel', () => {
+    let transaction: Knex.Transaction;
+    let containerModel: DashboardAccessContainerModel;
+    let spaceModel: SpaceModel;
+    let permissionService: SpacePermissionService;
+    let dashboard: DashboardLocation;
+    let userId: number;
+    let userUuid: UUID;
+
+    beforeEach(async () => {
+        transaction = await getTestContext().db.transaction();
+        containerModel = new DashboardAccessContainerModel(transaction);
+        spaceModel = new SpaceModel({ database: transaction });
+        permissionService = new SpacePermissionService(
+            spaceModel,
+            new SpacePermissionModel(transaction),
+        );
+
+        const dashboardRow = await transaction(DashboardsTableName)
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${DashboardsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .whereNull(`${DashboardsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .select<DashboardLocation>({
+                dashboardUuid: `${DashboardsTableName}.dashboard_uuid`,
+                logicalSpaceId: `${SpaceTableName}.space_id`,
+                logicalSpaceUuid: `${SpaceTableName}.space_uuid`,
+                projectId: `${ProjectTableName}.project_id`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+            })
+            .first();
+        dashboard = requireRow(dashboardRow, 'Dashboard fixture not found');
+
+        const user = requireRow(
+            await transaction('users')
+                .select<{ userId: number; userUuid: UUID }>({
+                    userId: 'user_id',
+                    userUuid: 'user_uuid',
+                })
+                .first(),
+            'User fixture not found',
+        );
+        userId = user.userId;
+        userUuid = user.userUuid;
+    });
+
+    afterEach(async () => transaction.rollback());
+
+    test('creates one container without changing the dashboard location', async () => {
+        const first = await containerModel.getOrCreate(
+            dashboard.dashboardUuid,
+            userId,
+            { trx: transaction },
+        );
+        const second = await containerModel.getOrCreate(
+            dashboard.dashboardUuid,
+            userId,
+            { trx: transaction },
+        );
+
+        expect(second).toEqual(first);
+        const container = requireRow(
+            await transaction(SpaceTableName)
+                .where('space_uuid', first.spaceUuid)
+                .first(),
+            'Container was not created',
+        );
+        expect(container).toMatchObject({
+            project_id: dashboard.projectId,
+            parent_space_uuid: null,
+            inherit_parent_permissions: false,
+            is_access_container: true,
+            access_container_dashboard_uuid: dashboard.dashboardUuid,
+        });
+
+        const unchangedDashboard = await transaction(DashboardsTableName)
+            .where('dashboard_uuid', dashboard.dashboardUuid)
+            .first('space_id');
+        if (unchangedDashboard === undefined) {
+            throw new Error(
+                'Dashboard was not found after creating its container',
+            );
+        }
+        expect(unchangedDashboard.space_id).toBe(dashboard.logicalSpaceId);
+    });
+
+    test('serializes concurrent creation into one container', async () => {
+        const database = getTestContext().db;
+        const createdDashboard = requireRow(
+            (
+                await database(DashboardsTableName)
+                    .insert({
+                        project_uuid: dashboard.projectUuid,
+                        space_id: dashboard.logicalSpaceId,
+                        name: 'Concurrent access container test',
+                        slug: `access-container-concurrent-${crypto.randomUUID()}`,
+                    })
+                    .returning<{ dashboard_uuid: UUID }[]>('dashboard_uuid')
+            )[0],
+            'Failed to create concurrent dashboard fixture',
+        );
+
+        try {
+            const concurrentModel = new DashboardAccessContainerModel(database);
+            const [first, second] = await Promise.all([
+                concurrentModel.getOrCreate(
+                    createdDashboard.dashboard_uuid,
+                    userId,
+                ),
+                concurrentModel.getOrCreate(
+                    createdDashboard.dashboard_uuid,
+                    userId,
+                ),
+            ]);
+
+            expect(second).toEqual(first);
+            await expect(
+                database(SpaceTableName)
+                    .where(
+                        'access_container_dashboard_uuid',
+                        createdDashboard.dashboard_uuid,
+                    )
+                    .count<{ count: bigint }[]>('* as count')
+                    .first(),
+            ).resolves.toEqual({ count: 1n });
+        } finally {
+            await database(DashboardsTableName)
+                .where('dashboard_uuid', createdDashboard.dashboard_uuid)
+                .delete();
+        }
+    });
+
+    test('hides containers from public space and permission lookups', async () => {
+        const container = await containerModel.getOrCreate(
+            dashboard.dashboardUuid,
+            userId,
+            { trx: transaction },
+        );
+        await transaction(SpaceUserAccessTableName).insert({
+            space_uuid: container.spaceUuid,
+            user_uuid: userUuid,
+            space_role: SpaceMemberRole.VIEWER,
+        });
+
+        await expect(spaceModel.get(container.spaceUuid)).rejects.toThrow(
+            'does not exist',
+        );
+        await expect(
+            spaceModel.find({ spaceUuid: container.spaceUuid }),
+        ).resolves.toEqual([]);
+        await expect(
+            SpaceModel.getSpaceIdAndName(transaction, container.spaceUuid),
+        ).resolves.toBeUndefined();
+        await expect(
+            spaceModel.getSpacesByProjectUuid(dashboard.projectUuid),
+        ).resolves.not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ uuid: container.spaceUuid }),
+            ]),
+        );
+        await expect(
+            permissionService.getSpacesAccessContext(userUuid, [
+                container.spaceUuid,
+            ]),
+        ).resolves.toEqual({});
+
+        const internalContext =
+            await permissionService.getAccessContainerContext(
+                userUuid,
+                [container.spaceUuid],
+                { trx: transaction },
+            );
+        expect(internalContext[container.spaceUuid]?.access).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    userUuid,
+                    role: SpaceMemberRole.VIEWER,
+                }),
+            ]),
+        );
+
+        await expect(
+            spaceModel.update(container.spaceUuid, { name: 'Visible name' }),
+        ).rejects.toThrow('does not exist');
+        await expect(
+            spaceModel.addSpaceAccess(
+                container.spaceUuid,
+                userUuid,
+                SpaceMemberRole.EDITOR,
+            ),
+        ).rejects.toThrow('does not exist');
+        await spaceModel.softDelete(container.spaceUuid, userUuid);
+        await spaceModel.permanentDelete(container.spaceUuid);
+        await expect(
+            transaction(SpaceTableName)
+                .where('space_uuid', container.spaceUuid)
+                .first(['deleted_at', 'space_uuid']),
+        ).resolves.toMatchObject({
+            deleted_at: null,
+            space_uuid: container.spaceUuid,
+        });
+    });
+
+    test('cascades the container and its grants when the dashboard is deleted', async () => {
+        const [createdDashboard] = await transaction(DashboardsTableName)
+            .insert({
+                project_uuid: dashboard.projectUuid,
+                space_id: dashboard.logicalSpaceId,
+                name: 'Access container cascade test',
+                slug: `access-container-test-${crypto.randomUUID()}`,
+            })
+            .returning<{ dashboard_uuid: UUID }[]>('dashboard_uuid');
+        if (createdDashboard === undefined) {
+            throw new Error('Failed to create dashboard fixture');
+        }
+
+        const container = await containerModel.getOrCreate(
+            createdDashboard.dashboard_uuid,
+            userId,
+            { trx: transaction },
+        );
+        await transaction(SpaceUserAccessTableName).insert({
+            space_uuid: container.spaceUuid,
+            user_uuid: userUuid,
+            space_role: SpaceMemberRole.VIEWER,
+        });
+
+        await transaction(DashboardsTableName)
+            .where('dashboard_uuid', createdDashboard.dashboard_uuid)
+            .delete();
+
+        await expect(
+            transaction(SpaceTableName)
+                .where('space_uuid', container.spaceUuid)
+                .first(),
+        ).resolves.toBeUndefined();
+        await expect(
+            transaction(SpaceUserAccessTableName)
+                .where('space_uuid', container.spaceUuid)
+                .first(),
+        ).resolves.toBeUndefined();
+    });
+
+    test('rejects dashboards stored inside access containers', async () => {
+        const container = await containerModel.getOrCreate(
+            dashboard.dashboardUuid,
+            userId,
+            { trx: transaction },
+        );
+        const containerSpace = requireRow(
+            await transaction(SpaceTableName)
+                .where('space_uuid', container.spaceUuid)
+                .first<{ space_id: number }>('space_id'),
+            'Container was not created',
+        );
+        const [nestedDashboard] = await transaction(DashboardsTableName)
+            .insert({
+                project_uuid: dashboard.projectUuid,
+                space_id: containerSpace.space_id,
+                name: 'Dashboard in an access container',
+                slug: `access-container-nested-${crypto.randomUUID()}`,
+            })
+            .returning<{ dashboard_uuid: UUID }[]>('dashboard_uuid');
+        if (nestedDashboard === undefined) {
+            throw new Error('Failed to create nested dashboard fixture');
+        }
+
+        await expect(
+            containerModel.getOrCreate(nestedDashboard.dashboard_uuid, userId, {
+                trx: transaction,
+            }),
+        ).rejects.toThrow('Dashboard not found');
+    });
+
+    test('enforces the access-container shape in the database', async () => {
+        const container = await containerModel.getOrCreate(
+            dashboard.dashboardUuid,
+            userId,
+            { trx: transaction },
+        );
+
+        await expect(
+            transaction(SpaceTableName)
+                .where('space_uuid', container.spaceUuid)
+                .update({ inherit_parent_permissions: true }),
+        ).rejects.toThrow('spaces_access_container_shape_check');
+    });
+
+    test('enforces one access container per dashboard in the database', async () => {
+        const container = await containerModel.getOrCreate(
+            dashboard.dashboardUuid,
+            userId,
+            { trx: transaction },
+        );
+        const duplicateSlug = `duplicate-access-container-${crypto.randomUUID()}`;
+
+        await expect(
+            transaction.raw(
+                `
+                INSERT INTO ${SpaceTableName} (
+                    project_id,
+                    name,
+                    created_by_user_id,
+                    slug,
+                    parent_space_uuid,
+                    path,
+                    inherit_parent_permissions,
+                    is_default_user_space,
+                    is_access_container,
+                    access_container_dashboard_uuid
+                )
+                SELECT
+                    project_id,
+                    'Duplicate dashboard access container',
+                    created_by_user_id,
+                    ?,
+                    NULL,
+                    text2ltree(replace(?, '-', '_')),
+                    FALSE,
+                    FALSE,
+                    TRUE,
+                    access_container_dashboard_uuid
+                FROM ${SpaceTableName}
+                WHERE space_uuid = ?
+                `,
+                [duplicateSlug, duplicateSlug, container.spaceUuid],
+            ),
+        ).rejects.toThrow('spaces_access_container_dashboard_uuid_unique');
+    });
+});

--- a/packages/backend/src/models/DashboardAccessContainerModel.ts
+++ b/packages/backend/src/models/DashboardAccessContainerModel.ts
@@ -1,0 +1,175 @@
+import {
+    getLtreePathFromSlug,
+    NotFoundError,
+    type UUID,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { DashboardsTableName } from '../database/entities/dashboards';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectTableName } from '../database/entities/projects';
+import {
+    SpaceTableName,
+    type CreateDbSpace,
+    type DbSpace,
+} from '../database/entities/spaces';
+
+const LogicalSpaceTableName = 'logical_space';
+
+export type DashboardAccessContainer = {
+    dashboardUuid: UUID;
+    spaceUuid: UUID;
+    projectUuid: UUID;
+    organizationUuid: UUID;
+};
+
+type DashboardLocation = {
+    dashboardUuid: UUID;
+    projectId: number;
+    projectUuid: UUID;
+    organizationUuid: UUID;
+};
+
+type CreateDashboardAccessContainer = CreateDbSpace &
+    Pick<DbSpace, 'is_access_container' | 'access_container_dashboard_uuid'>;
+
+export class DashboardAccessContainerModel {
+    constructor(private readonly database: Knex) {}
+
+    async getByDashboardUuids(
+        dashboardUuids: UUID[],
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<Record<UUID, DashboardAccessContainer>> {
+        if (dashboardUuids.length === 0) {
+            return {};
+        }
+
+        const rows = await trx(SpaceTableName)
+            .innerJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${SpaceTableName}.access_container_dashboard_uuid`,
+            )
+            .innerJoin(
+                `${SpaceTableName} as ${LogicalSpaceTableName}`,
+                function joinLogicalSpace() {
+                    this.on(
+                        `${LogicalSpaceTableName}.space_id`,
+                        `${DashboardsTableName}.space_id`,
+                    ).andOn(
+                        `${LogicalSpaceTableName}.project_id`,
+                        `${SpaceTableName}.project_id`,
+                    );
+                },
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .whereIn(
+                `${SpaceTableName}.access_container_dashboard_uuid`,
+                dashboardUuids,
+            )
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .where(`${SpaceTableName}.is_access_container`, true)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
+            .whereNull(`${LogicalSpaceTableName}.deleted_at`)
+            .where(`${LogicalSpaceTableName}.is_access_container`, false)
+            .select<DashboardAccessContainer[]>({
+                dashboardUuid: `${SpaceTableName}.access_container_dashboard_uuid`,
+                spaceUuid: `${SpaceTableName}.space_uuid`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+            });
+
+        return Object.fromEntries(rows.map((row) => [row.dashboardUuid, row]));
+    }
+
+    async getOrCreate(
+        dashboardUuid: UUID,
+        createdByUserId: number,
+        { trx }: { trx?: Knex.Transaction } = {},
+    ): Promise<DashboardAccessContainer> {
+        const create = async (transaction: Knex.Transaction) => {
+            const dashboard = await transaction(DashboardsTableName)
+                .innerJoin(
+                    SpaceTableName,
+                    `${SpaceTableName}.space_id`,
+                    `${DashboardsTableName}.space_id`,
+                )
+                .innerJoin(
+                    ProjectTableName,
+                    `${ProjectTableName}.project_id`,
+                    `${SpaceTableName}.project_id`,
+                )
+                .innerJoin(
+                    OrganizationTableName,
+                    `${OrganizationTableName}.organization_id`,
+                    `${ProjectTableName}.organization_id`,
+                )
+                .where(`${DashboardsTableName}.dashboard_uuid`, dashboardUuid)
+                .whereNull(`${DashboardsTableName}.deleted_at`)
+                .whereNull(`${SpaceTableName}.deleted_at`)
+                .where(`${SpaceTableName}.is_access_container`, false)
+                .select<DashboardLocation>({
+                    dashboardUuid: `${DashboardsTableName}.dashboard_uuid`,
+                    projectId: `${ProjectTableName}.project_id`,
+                    projectUuid: `${ProjectTableName}.project_uuid`,
+                    organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                })
+                .first()
+                .forUpdate(DashboardsTableName);
+
+            if (dashboard === undefined) {
+                throw new NotFoundError('Dashboard not found');
+            }
+
+            const existing = await this.getByDashboardUuids([dashboardUuid], {
+                trx: transaction,
+            });
+            if (existing[dashboardUuid] !== undefined) {
+                return existing[dashboardUuid];
+            }
+
+            const key = uuidv4();
+            const slug = `access-container-${key}`;
+            const accessContainer: CreateDashboardAccessContainer = {
+                project_id: dashboard.projectId,
+                name: 'Dashboard access container',
+                created_by_user_id: createdByUserId,
+                slug,
+                parent_space_uuid: null,
+                path: getLtreePathFromSlug(slug),
+                inherit_parent_permissions: false,
+                is_default_user_space: false,
+                is_access_container: true,
+                access_container_dashboard_uuid: dashboardUuid,
+            };
+            const [space] = await transaction(SpaceTableName)
+                .insert(accessContainer)
+                .returning<{ space_uuid: UUID }[]>('space_uuid');
+
+            if (space === undefined) {
+                throw new Error('Failed to create dashboard access container');
+            }
+
+            return {
+                dashboardUuid,
+                spaceUuid: space.space_uuid,
+                projectUuid: dashboard.projectUuid,
+                organizationUuid: dashboard.organizationUuid,
+            };
+        };
+
+        if (trx !== undefined) {
+            return create(trx);
+        }
+        return this.database.transaction(create);
+    }
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -138,6 +138,8 @@ export const spaceEntry: SpaceTable['base'] = {
     project_member_access_role: null,
     is_default_user_space: false,
     color_palette_uuid: null,
+    is_access_container: false,
+    access_container_dashboard_uuid: null,
 
     deleted_at: null,
     deleted_by_user_uuid: null,

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -9,6 +9,7 @@ import { CatalogModel } from './CatalogModel/CatalogModel';
 import { CommentModel } from './CommentModel/CommentModel';
 import { ContentModel } from './ContentModel/ContentModel';
 import { ContentVerificationModel } from './ContentVerificationModel';
+import { DashboardAccessContainerModel } from './DashboardAccessContainerModel';
 import { DashboardModel } from './DashboardModel/DashboardModel';
 import { PersonalAccessTokenModel } from './DashboardModel/PersonalAccessTokenModel';
 import { DeploySessionModel } from './DeploySessionModel';
@@ -82,6 +83,7 @@ export type ModelManifest = {
     analyticsModel: AnalyticsModel;
     appModel: AppModel;
     commentModel: CommentModel;
+    dashboardAccessContainerModel: DashboardAccessContainerModel;
     dashboardModel: DashboardModel;
     deploySessionModel: DeploySessionModel;
     downloadFileModel: DownloadFileModel;
@@ -289,6 +291,13 @@ export class ModelRepository
         return this.getModel(
             'commentModel',
             () => new CommentModel({ database: this.database }),
+        );
+    }
+
+    public getDashboardAccessContainerModel(): DashboardAccessContainerModel {
+        return this.getModel(
+            'dashboardAccessContainerModel',
+            () => new DashboardAccessContainerModel(this.database),
         );
     }
 

--- a/packages/backend/src/models/SpaceModel.test.ts
+++ b/packages/backend/src/models/SpaceModel.test.ts
@@ -834,6 +834,9 @@ describe('SpaceModel space access as code', () => {
     });
 
     it('serializes interactive direct access writes with as-code replacement', async () => {
+        tracker.on.select(SpaceTableName).responseOnce({
+            space_uuid: 'space-uuid',
+        });
         tracker.on.insert(SpaceUserAccessTableName).responseOnce(1);
 
         await model.addSpaceAccess(
@@ -869,6 +872,9 @@ describe('SpaceModel space access as code', () => {
         });
         expect(tracker.history.update).toHaveLength(1);
         expect(tracker.history.update[0].sql).toContain('set "name" = $1');
+        expect(tracker.history.update[0].sql).toContain(
+            '"is_access_container" = $4',
+        );
         expect(tracker.history.update[0].sql).not.toContain(
             'inherit_parent_permissions',
         );
@@ -892,6 +898,12 @@ describe('SpaceModel space access as code', () => {
                 sql.includes('pg_advisory_xact_lock'),
             ),
         ).toBe(true);
+        const pathIdentityQuery = tracker.history.select.find(({ sql }) =>
+            sql.includes('"path" ='),
+        );
+        expect(pathIdentityQuery?.sql).toContain(
+            `"${SpaceTableName}"."is_access_container" = $1`,
+        );
     });
 
     it('locks the full access chain before taking the target row update lock', async () => {
@@ -946,6 +958,17 @@ describe('SpaceModel space access as code', () => {
         const lastShareLockIndex = tracker.history.select.findLastIndex(
             ({ sql }) => sql.includes('for share'),
         );
+        const lockedSpaceQueries = tracker.history.select.filter(
+            ({ sql }) =>
+                sql.includes(`from "${SpaceTableName}"`) &&
+                sql.includes('for share'),
+        );
+        expect(lockedSpaceQueries).not.toHaveLength(0);
+        expect(
+            lockedSpaceQueries.every(({ sql }) =>
+                sql.includes(`"${SpaceTableName}"."is_access_container" = $1`),
+            ),
+        ).toBe(true);
         const updateLockIndex = tracker.history.select.findIndex(({ sql }) =>
             sql.includes('for update'),
         );

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -129,6 +129,27 @@ export class SpaceModel {
         this.MOST_POPULAR_OR_RECENTLY_UPDATED_LIMIT = 10;
     }
 
+    private static getCustomerVisibleSpacesQuery(database: Knex) {
+        return database<DbSpace>(SpaceTableName).where(
+            `${SpaceTableName}.is_access_container`,
+            false,
+        );
+    }
+
+    private static async assertCustomerVisibleSpace(
+        database: Knex,
+        spaceUuid: string,
+    ): Promise<void> {
+        const space = await SpaceModel.getCustomerVisibleSpacesQuery(database)
+            .where(`${SpaceTableName}.space_uuid`, spaceUuid)
+            .first(`${SpaceTableName}.space_uuid`);
+        if (space === undefined) {
+            throw new NotFoundError(
+                `space with spaceUuid ${spaceUuid} does not exist`,
+            );
+        }
+    }
+
     private static async querySpacesForCode(
         {
             projectUuid,
@@ -141,7 +162,7 @@ export class SpaceModel {
         },
         trx: Knex,
     ): Promise<SpaceCodeModel[]> {
-        const query = trx(SpaceTableName)
+        const query = SpaceModel.getCustomerVisibleSpacesQuery(trx)
             .innerJoin(
                 ProjectTableName,
                 `${ProjectTableName}.project_id`,
@@ -213,16 +234,13 @@ export class SpaceModel {
         visitedSpaceUuids.add(startingSpaceUuid);
 
         await acquireSpaceAccessLock(trx, startingSpaceUuid);
-        const space: { parentSpaceUuid: string | null } | undefined = await trx(
-            SpaceTableName,
-        )
-            .where({
-                project_id: projectId,
-                space_uuid: startingSpaceUuid,
-            })
-            .whereNull('deleted_at')
-            .first({ parentSpaceUuid: 'parent_space_uuid' })
-            .forShare();
+        const space: { parentSpaceUuid: string | null } | undefined =
+            await SpaceModel.getCustomerVisibleSpacesQuery(trx)
+                .where(`${SpaceTableName}.project_id`, projectId)
+                .where(`${SpaceTableName}.space_uuid`, startingSpaceUuid)
+                .whereNull(`${SpaceTableName}.deleted_at`)
+                .first({ parentSpaceUuid: 'parent_space_uuid' })
+                .forShare();
 
         if (space === undefined) {
             throw new ParameterError(
@@ -809,12 +827,12 @@ export class SpaceModel {
                     input.access !== undefined ? requestedSpaceUuid : null,
             });
 
-            const pathMatches = await transaction(SpaceTableName)
-                .where({
-                    project_id: project.projectId,
-                    path: input.path,
-                })
-                .whereNull('deleted_at')
+            const pathMatches = await SpaceModel.getCustomerVisibleSpacesQuery(
+                transaction,
+            )
+                .where(`${SpaceTableName}.project_id`, project.projectId)
+                .where(`${SpaceTableName}.path`, input.path)
+                .whereNull(`${SpaceTableName}.deleted_at`)
                 .select<
                     Array<{
                         spaceUuid: string;
@@ -858,20 +876,27 @@ export class SpaceModel {
                     ? input.path.slice(0, input.path.lastIndexOf('.'))
                     : null;
                 if (input.parentSpaceUuid !== null) {
-                    const parent = await transaction(SpaceTableName)
-                        .where({
-                            space_uuid: input.parentSpaceUuid,
-                            project_id: project.projectId,
-                        })
-                        .whereNull('deleted_at')
-                        .first<{
-                            path: string;
-                            isDefaultUserSpace: boolean;
-                        }>({
-                            path: 'path',
-                            isDefaultUserSpace: 'is_default_user_space',
-                        })
-                        .forUpdate();
+                    const parent =
+                        await SpaceModel.getCustomerVisibleSpacesQuery(
+                            transaction,
+                        )
+                            .where(
+                                `${SpaceTableName}.space_uuid`,
+                                input.parentSpaceUuid,
+                            )
+                            .where(
+                                `${SpaceTableName}.project_id`,
+                                project.projectId,
+                            )
+                            .whereNull(`${SpaceTableName}.deleted_at`)
+                            .first<{
+                                path: string;
+                                isDefaultUserSpace: boolean;
+                            }>({
+                                path: 'path',
+                                isDefaultUserSpace: 'is_default_user_space',
+                            })
+                            .forUpdate();
                     if (parent === undefined) {
                         throw new NotFoundError(
                             `Parent space with uuid ${input.parentSpaceUuid} does not exist in project ${input.projectUuid}`,
@@ -921,6 +946,7 @@ export class SpaceModel {
                     .where({
                         space_uuid: spaceUuid,
                         project_id: project.projectId,
+                        is_access_container: false,
                     })
                     .update({
                         name: input.name,
@@ -962,6 +988,7 @@ export class SpaceModel {
                     .where({
                         space_uuid: spaceUuid,
                         project_id: project.projectId,
+                        is_access_container: false,
                     })
                     .update({ name: input.name });
             } else if (
@@ -1034,14 +1061,19 @@ export class SpaceModel {
     static async getSpaceIdAndName(db: Knex, spaceUuid: string | undefined) {
         if (spaceUuid === undefined) return undefined;
 
-        const [space] = await db(SpaceTableName)
+        const [space] = await SpaceModel.getCustomerVisibleSpacesQuery(db)
             .select(['space_id', 'name'])
             .where('space_uuid', spaceUuid);
+        if (space === undefined) {
+            return undefined;
+        }
         return { spaceId: space.space_id, name: space.name };
     }
 
     async getRootSpaceUuidsForProject(projectUuid: string): Promise<string[]> {
-        const spaces = await this.database(SpaceTableName)
+        const spaces = await SpaceModel.getCustomerVisibleSpacesQuery(
+            this.database,
+        )
             .innerJoin(
                 ProjectTableName,
                 `${ProjectTableName}.project_id`,
@@ -1065,7 +1097,9 @@ export class SpaceModel {
     }): Promise<boolean> {
         if (spaceUuids.length === 0) return false;
 
-        const space = await this.database(SpaceTableName)
+        const space = await SpaceModel.getCustomerVisibleSpacesQuery(
+            this.database,
+        )
             .innerJoin(
                 ProjectTableName,
                 `${ProjectTableName}.project_id`,
@@ -1084,7 +1118,9 @@ export class SpaceModel {
         parentSpaceUuids: string[],
     ): Promise<string[]> {
         if (parentSpaceUuids.length === 0) return [];
-        const rows = await this.database(SpaceTableName)
+        const rows = await SpaceModel.getCustomerVisibleSpacesQuery(
+            this.database,
+        )
             .whereIn(`${SpaceTableName}.parent_space_uuid`, parentSpaceUuids)
             .whereNull(`${SpaceTableName}.deleted_at`)
             .select(`${SpaceTableName}.space_uuid`);
@@ -1110,7 +1146,7 @@ export class SpaceModel {
                 name: 'SpaceModel.find',
             },
             async () => {
-                const query = trx(SpaceTableName)
+                const query = SpaceModel.getCustomerVisibleSpacesQuery(trx)
                     .innerJoin(
                         ProjectTableName,
                         `${ProjectTableName}.project_id`,
@@ -1271,7 +1307,9 @@ export class SpaceModel {
             | 'inheritsFromOrgOrProject'
         >
     > {
-        const [row] = await this.database(SpaceTableName)
+        const [row] = await SpaceModel.getCustomerVisibleSpacesQuery(
+            this.database,
+        )
             .leftJoin(
                 ProjectTableName,
                 `${ProjectTableName}.project_id`,
@@ -1879,6 +1917,7 @@ export class SpaceModel {
                     FROM ${SpaceTableName}
                     WHERE space_uuid = ?
                       AND deleted_at IS NULL
+                      AND is_access_container = FALSE
 
                     UNION ALL
 
@@ -1886,6 +1925,7 @@ export class SpaceModel {
                     FROM ${SpaceTableName} s
                     JOIN ancestors a ON s.space_uuid = a.parent_space_uuid
                     WHERE s.deleted_at IS NULL
+                      AND s.is_access_container = FALSE
                 )
                 SELECT space_uuid, name FROM ancestors
                 ORDER BY depth DESC
@@ -1912,7 +1952,9 @@ export class SpaceModel {
         spaceUuid: string;
         projectUuid: string;
     }) {
-        const space = await this.database(SpaceTableName)
+        const space = await SpaceModel.getCustomerVisibleSpacesQuery(
+            this.database,
+        )
             .select('path')
             .where('space_uuid', spaceUuid)
             .first();
@@ -1923,7 +1965,9 @@ export class SpaceModel {
             );
         }
 
-        const ancestors = await this.database(SpaceTableName)
+        const ancestors = await SpaceModel.getCustomerVisibleSpacesQuery(
+            this.database,
+        )
             .select('space_uuid')
             .innerJoin(
                 `${ProjectTableName}`,
@@ -1944,7 +1988,9 @@ export class SpaceModel {
         path: string;
         projectUuid: string;
     }) {
-        const closestAncestor = await this.database(SpaceTableName)
+        const closestAncestor = await SpaceModel.getCustomerVisibleSpacesQuery(
+            this.database,
+        )
             .select('space_uuid')
             .innerJoin(
                 `${ProjectTableName}`,
@@ -1970,7 +2016,7 @@ export class SpaceModel {
             return getLtreePathFromSlug(spaceSlug);
         }
 
-        const parentSpace = await trx(SpaceTableName)
+        const parentSpace = await SpaceModel.getCustomerVisibleSpacesQuery(trx)
             .select('path')
             .where('space_uuid', parentSpaceUuid)
             .where('project_id', projectId)
@@ -2059,7 +2105,7 @@ export class SpaceModel {
             `space:${path ?? baseSlug}`,
         );
         if (path !== undefined) {
-            const existing = await trx(SpaceTableName)
+            const existing = await SpaceModel.getCustomerVisibleSpacesQuery(trx)
                 .where('project_id', project.project_id)
                 .where('path', path)
                 .first();
@@ -2108,6 +2154,7 @@ export class SpaceModel {
     async permanentDelete(spaceUuid: string): Promise<void> {
         await this.database(SpaceTableName)
             .where('space_uuid', spaceUuid)
+            .where('is_access_container', false)
             .delete();
     }
 
@@ -2118,6 +2165,7 @@ export class SpaceModel {
                 deleted_by_user_uuid: userUuid,
             })
             .where('space_uuid', spaceUuid)
+            .where('is_access_container', false)
             .whereNull('deleted_at');
     }
 
@@ -2128,6 +2176,7 @@ export class SpaceModel {
                 deleted_by_user_uuid: null,
             })
             .where('space_uuid', spaceUuid)
+            .where('is_access_container', false)
             .whereNotNull('deleted_at');
 
         if (updateCount !== 1) {
@@ -2147,6 +2196,7 @@ export class SpaceModel {
                     FROM ${SpaceTableName}
                     WHERE parent_space_uuid = ?
                       AND deleted_at IS NULL
+                      AND is_access_container = FALSE
 
                     UNION ALL
 
@@ -2154,6 +2204,7 @@ export class SpaceModel {
                     FROM ${SpaceTableName} s
                     JOIN descendants d ON s.parent_space_uuid = d.space_uuid
                     WHERE s.deleted_at IS NULL
+                      AND s.is_access_container = FALSE
                 )
                 SELECT space_uuid FROM descendants
                 `,
@@ -2168,7 +2219,7 @@ export class SpaceModel {
         options?: { deleted?: boolean; deletedByUserUuid?: string },
     ): Promise<string[]> {
         // Direct children only — callers recurse to handle full depth
-        const query = this.database(SpaceTableName)
+        const query = SpaceModel.getCustomerVisibleSpacesQuery(this.database)
             .select('space_uuid')
             .where('parent_space_uuid', spaceUuid);
 
@@ -2304,6 +2355,7 @@ export class SpaceModel {
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
             await acquireSpaceAccessLock(trx, spaceUuid);
+            await SpaceModel.assertCustomerVisibleSpace(trx, spaceUuid);
             const updateData: Record<string, unknown> = {
                 name: space.name,
                 inherit_parent_permissions: space.inheritParentPermissions,
@@ -2334,6 +2386,7 @@ export class SpaceModel {
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
             await acquireSpaceAccessLock(trx, spaceUuid);
+            await SpaceModel.assertCustomerVisibleSpace(trx, spaceUuid);
             if (userAccessEntries.length > 0) {
                 await trx(SpaceUserAccessTableName)
                     .insert(
@@ -2397,6 +2450,11 @@ export class SpaceModel {
             throw new NotFoundError(
                 `Project with uuid ${projectUuid} does not exist`,
             );
+        }
+
+        await SpaceModel.assertCustomerVisibleSpace(tx, spaceUuid);
+        if (targetSpaceUuid !== null) {
+            await SpaceModel.assertCustomerVisibleSpace(tx, targetSpaceUuid);
         }
 
         // check if parent space is not subtree of space
@@ -2480,6 +2538,7 @@ export class SpaceModel {
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
             await acquireSpaceAccessLock(trx, spaceUuid);
+            await SpaceModel.assertCustomerVisibleSpace(trx, spaceUuid);
             await trx(SpaceUserAccessTableName)
                 .insert({
                     space_uuid: spaceUuid,
@@ -2497,6 +2556,7 @@ export class SpaceModel {
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
             await acquireSpaceAccessLock(trx, spaceUuid);
+            await SpaceModel.assertCustomerVisibleSpace(trx, spaceUuid);
             await trx(SpaceUserAccessTableName)
                 .where('space_uuid', spaceUuid)
                 .andWhere('user_uuid', userUuid)
@@ -2511,6 +2571,7 @@ export class SpaceModel {
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
             await acquireSpaceAccessLock(trx, spaceUuid);
+            await SpaceModel.assertCustomerVisibleSpace(trx, spaceUuid);
             await trx(SpaceGroupAccessTableName)
                 .insert({
                     space_uuid: spaceUuid,
@@ -2528,6 +2589,7 @@ export class SpaceModel {
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
             await acquireSpaceAccessLock(trx, spaceUuid);
+            await SpaceModel.assertCustomerVisibleSpace(trx, spaceUuid);
             await trx(SpaceGroupAccessTableName)
                 .where('space_uuid', spaceUuid)
                 .andWhere('group_uuid', groupUuid)

--- a/packages/backend/src/models/SpacePermissionModel.test.ts
+++ b/packages/backend/src/models/SpacePermissionModel.test.ts
@@ -123,7 +123,25 @@ describe('SpacePermissionModel', () => {
             expect(mockRaw).toHaveBeenCalledTimes(1);
             expect(capturedSql).toContain('WITH RECURSIVE');
             expect(capturedSql).toContain('parent_space_uuid');
+            expect(capturedSql).toContain('is_access_container = FALSE');
             expect(capturedSql).not.toContain('@>');
+        });
+
+        it('only resolves hidden containers through the explicit internal mode', async () => {
+            let capturedSql = '';
+            const mockDatabase = {
+                raw: vi.fn(async (sql: string) => {
+                    capturedSql = sql;
+                    return { rows: [] };
+                }),
+            } as unknown as Knex;
+            const model = new SpacePermissionModel(mockDatabase);
+
+            await model.getInheritanceChains(['container-uuid'], {
+                accessContainerMode: 'only',
+            });
+
+            expect(capturedSql).toContain('is_access_container = TRUE');
         });
     });
 

--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -898,13 +898,22 @@ export class SpacePermissionModel {
      */
     async getInheritanceChains(
         spaceUuids: string[],
-        { trx = this.database }: { trx?: Knex } = {},
+        {
+            trx = this.database,
+            accessContainerMode = 'exclude',
+        }: {
+            trx?: Knex;
+            accessContainerMode?: 'exclude' | 'only';
+        } = {},
     ): Promise<Record<string, SpaceInheritanceChain>> {
         return wrapSentryTransaction(
             'SpacePermissionModel.getInheritanceChains',
             { spaceUuidsCount: spaceUuids.length },
             async () => {
                 if (spaceUuids.length === 0) return {};
+
+                const accessContainerPredicate =
+                    accessContainerMode === 'only' ? '= TRUE' : '= FALSE';
 
                 // NOTE: use a CTE instead of ltree path @> joins to walk the space
                 // hierarchy via parent_space_uuid FK. We have duplicate paths in the
@@ -927,6 +936,7 @@ export class SpacePermissionModel {
                         FROM ${SpaceTableName}
                         WHERE space_uuid = ANY(?)
                           AND deleted_at IS NULL
+                          AND is_access_container ${accessContainerPredicate}
 
                         UNION ALL
 
@@ -936,6 +946,7 @@ export class SpacePermissionModel {
                         FROM ${SpaceTableName} s
                         JOIN chain c ON s.space_uuid = c.parent_space_uuid
                         WHERE s.deleted_at IS NULL
+                          AND s.is_access_container ${accessContainerPredicate}
                     )
                     SELECT requested_space_uuid, space_uuid, name, inherit_parent_permissions, parent_space_uuid
                     FROM chain

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -63,6 +63,8 @@ export const space: SpaceTable['base'] = {
     project_member_access_role: null,
     is_default_user_space: false,
     color_palette_uuid: null,
+    is_access_container: false,
+    access_container_dashboard_uuid: null,
     deleted_at: null,
     deleted_by_user_uuid: null,
 };

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -25,7 +25,10 @@ const createMockSpacePermissionModel = () => ({
         vi.fn<
             (
                 spaceUuids: string[],
-                options?: { trx?: Knex },
+                options?: {
+                    trx?: Knex;
+                    accessContainerMode?: 'exclude' | 'only';
+                },
             ) => Promise<Record<string, SpaceInheritanceChain>>
         >(),
     getDirectSpaceAccess:
@@ -148,7 +151,7 @@ describe('SpacePermissionService', () => {
 
         expect(mockPermissionModel.getInheritanceChains).toHaveBeenCalledWith(
             [spaceUuid],
-            { trx },
+            { trx, accessContainerMode: 'exclude' },
         );
         expect(mockPermissionModel.getDirectSpaceAccess).toHaveBeenCalledWith(
             [spaceUuid],
@@ -167,6 +170,14 @@ describe('SpacePermissionService', () => {
             [spaceUuid],
             { trx },
         );
+
+        await service.getAccessContainerContext(userUuid, [spaceUuid], { trx });
+        expect(
+            mockPermissionModel.getInheritanceChains,
+        ).toHaveBeenLastCalledWith([spaceUuid], {
+            trx,
+            accessContainerMode: 'only',
+        });
     });
 
     describe('getSpacesCaslContext (via getAllSpaceAccessContext)', () => {

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -173,6 +173,18 @@ export class SpacePermissionService extends BaseService {
         return this.getSpacesCaslContext(spaceUuids, { userUuid }, { trx });
     }
 
+    async getAccessContainerContext(
+        userUuid: string,
+        spaceUuids: string[],
+        { trx }: { trx?: Knex } = {},
+    ): Promise<Record<string, SpaceAccessContextForCasl>> {
+        return this.getSpacesCaslContext(
+            spaceUuids,
+            { userUuid },
+            { trx, accessContainerMode: 'only' },
+        );
+    }
+
     /**
      * Returns the CASL context for a space with ALL users' resolved access
      * (not filtered to a single user). Used for access propagation and
@@ -389,14 +401,20 @@ export class SpacePermissionService extends BaseService {
     private async getSpacesCaslContext(
         spaceUuidsArg: string[],
         filters?: { userUuid?: string; userUuids?: string[] },
-        { trx }: { trx?: Knex } = {},
+        {
+            trx,
+            accessContainerMode = 'exclude',
+        }: {
+            trx?: Knex;
+            accessContainerMode?: 'exclude' | 'only';
+        } = {},
     ): Promise<Record<string, SpaceAccessContextForCasl>> {
         const uniqueSpaceUuids = [...new Set(spaceUuidsArg)];
 
         // Get inheritance chains for all spaces in a single batched query
         const chainMap = await this.spacePermissionModel.getInheritanceChains(
             uniqueSpaceUuids,
-            { trx },
+            { trx, accessContainerMode },
         );
         const chains = uniqueSpaceUuids
             .filter((uuid) => chainMap[uuid] !== undefined)


### PR DESCRIPTION
## Summary

Adds the inert backend foundation for [SPK-1242](https://linear.app/lightdash/issue/SPK-1242/spike-hidden-access-containers-behind-the-resource-access-api): a dashboard can have a hidden, system-managed space as its permission container while remaining in its original logical space.

This is an intentionally narrow checkpoint. It proves storage, lifecycle, invisibility, and internal permission resolution; it does not expose an API, change dashboard authorization, or enable customer-visible sharing.

## How it works

```text
dashboard.space_id ───────────────> visible logical space

hidden space.access_container_dashboard_uuid ──> dashboard
hidden space ──> existing user/group space grants
```

### Backend

- Adds a generic `spaces.is_access_container` discriminator and a nullable dashboard association.
- Enforces container shape, one container per dashboard, and dashboard-to-container cascade cleanup in PostgreSQL.
- Creates containers lazily inside a transaction while locking only the dashboard row, making concurrent calls idempotent.
- Keeps dashboards in their visible spaces; container names, slugs, and UUIDs are internal only.
- Centralizes the customer-visible space query boundary and applies it to normal listing, hierarchy, content-as-code, and mutation paths.
- Excludes containers from ordinary permission-chain resolution; an explicit internal service method resolves their existing space ACL context.
- Adds a partial visible-space project index so container cardinality does not degrade normal project-space listing.

## Regression analysis

| Group | Effect |
|---|---|
| Existing projects and spaces | No behavior change; new columns default to normal visible-space semantics. |
| Dashboard viewers and editors | No behavior change; artifact authorization is not switched in this PR. |
| Space APIs and content-as-code | Hidden containers are treated as nonexistent. |
| Internal callers | A new model can lazily create or batch-resolve dashboard containers. |
| Charts and data apps | Unchanged and explicitly unsupported by this checkpoint. |

No public route, generated API type, feature flag, or frontend behavior is added.

## Migration

```bash
pnpm -F backend migrate
```

The additive migration:

- adds `is_access_container` and `access_container_dashboard_uuid`;
- creates a dashboard FK with `ON DELETE CASCADE`;
- validates a database shape constraint;
- creates partial unique and visible-space indexes concurrently;
- uses finite lock timeouts and recovers interrupted concurrent-index creation;
- includes and has been exercised through a real rollback.

## Test plan

- [x] `pnpm -F backend format` — clean
- [x] `pnpm -F backend lint` — clean
- [x] `pnpm -F backend typecheck` — clean
- [x] Focused unit suite — 49 tests passed
- [x] Dashboard access-container integration suite — 7 tests passed against PostgreSQL
- [x] `pnpm -F backend build` — clean
- [x] `pnpm test:release-safety` — clean
- [x] Migration apply, rollback, reapply, constraint validation, and policy evaluation
- [x] Runtime negative probes: hidden and random UUIDs produce equivalent 404/403 behavior; no search, content-list, targeted-content, or content-as-code leak
- [x] Local query-shape benchmark with 5,000 synthetic containers: visible-space list uses the partial index; 1,000-container batch lookup and 100-container permission resolution remain batched

## Follow-ups (separate PRs)

- Define the resource-native access API, principal validation, audit events, and reset/unshare concurrency semantics.
- Integrate dashboard metadata, query execution, exports, workers, dependencies, lifecycle, and recipient discovery behind a default-off flag.
- Add independent chart and data-app verticals, including personal-app behavior.
- Complete the permission-path inventory and production-scale performance validation before enablement.

Closes: https://linear.app/lightdash/issue/SPK-1242/spike-hidden-access-containers-behind-the-resource-access-api
