### PR TITLE
feat(pgwire): support count(*) row counts

### DIFF
--- a/packages/backend/src/ee/postgresWire/sqlToMetricQuery.test.ts
+++ b/packages/backend/src/ee/postgresWire/sqlToMetricQuery.test.ts
@@ -1079,10 +1079,13 @@ describe('compileSqlToMetricQuery', () => {
             );
             expect(probe.columns.map((c) => c.name)).toEqual(['?column?']);
             expect(probe.metricQuery.dimensions).toEqual(['orders_status']);
-            // aggregates still point at metrics
+            // aggregates other than row counts still point at metrics
             expect(() =>
-                compileSqlToMetricQuery('SELECT count(1) FROM orders', CATALOG),
-            ).toThrow(/Aggregate function "count" is not supported/);
+                compileSqlToMetricQuery(
+                    'SELECT sum(orders_amount) FROM orders',
+                    CATALOG,
+                ),
+            ).toThrow(/Aggregate function "sum" is not supported/);
         });
     });
 
@@ -1399,6 +1402,59 @@ describe('compileSqlToMetricQuery', () => {
                 'aov',
             ]);
         });
+    });
+});
+
+describe('row counts', () => {
+    it('compiles count(*) to a system COUNT metric', () => {
+        const compiled = compileSqlToMetricQuery(
+            'SELECT count(*) FROM orders',
+            CATALOG,
+        );
+        expect(compiled.columns).toEqual([
+            {
+                name: 'count',
+                source: 'orders_pgwire_row_count',
+                kind: 'metric',
+                type: 'count',
+            },
+        ]);
+        expect(compiled.metricQuery.metrics).toEqual([
+            'orders_pgwire_row_count',
+        ]);
+        expect(compiled.metricQuery.additionalMetrics).toEqual([
+            {
+                name: 'pgwire_row_count',
+                table: 'orders',
+                sql: '*',
+                type: 'count',
+            },
+        ]);
+        expect(compiled.metricQuery.dimensions).toEqual([]);
+    });
+
+    it('supports count(1), aliases, filters and grouped counts', () => {
+        expect(
+            compileSqlToMetricQuery(
+                "SELECT count(1) AS n FROM orders WHERE orders_status = 'completed'",
+                CATALOG,
+            ).columns[0],
+        ).toMatchObject({ name: 'n', kind: 'metric' });
+        const grouped = compileSqlToMetricQuery(
+            'SELECT orders_status, count(*) FROM orders GROUP BY orders_status',
+            CATALOG,
+        );
+        expect(grouped.metricQuery.dimensions).toEqual(['orders_status']);
+        expect(grouped.metricQuery.metrics).toEqual([
+            'orders_pgwire_row_count',
+        ]);
+        // count(distinct x) still points at metrics
+        expect(() =>
+            compileSqlToMetricQuery(
+                'SELECT count(distinct orders_status) FROM orders',
+                CATALOG,
+            ),
+        ).toThrow(/not supported/);
     });
 });
 

--- a/packages/backend/src/ee/postgresWire/sqlToMetricQuery.ts
+++ b/packages/backend/src/ee/postgresWire/sqlToMetricQuery.ts
@@ -1,5 +1,7 @@
 import {
     FilterOperator,
+    MetricType,
+    type AdditionalMetric,
     type FilterGroup,
     type FilterGroupItem,
     type FilterRule,
@@ -736,6 +738,38 @@ function compileSelect(
                 whereConjuncts.some(isContradiction),
         };
     };
+    /**
+     * `count(*)`, `count(1)` and `count()`: row counts, which connectors ask for
+     * when registering a dataset. They compile to a system COUNT(*) metric, so a
+     * bare count is the table's row count and a grouped one counts rows per group.
+     */
+    const isCountStar = (expr: Expr): boolean => {
+        if (
+            expr.type !== 'call' ||
+            expr.function.name.toLowerCase() !== 'count' ||
+            expr.distinct === 'distinct' ||
+            expr.over
+        ) {
+            return false;
+        }
+        if (expr.args.length === 0) {
+            return true;
+        }
+        if (expr.args.length !== 1) {
+            return false;
+        }
+        const [arg] = expr.args;
+        return (
+            (arg.type === 'ref' && arg.name === '*') ||
+            arg.type === 'integer' ||
+            arg.type === 'numeric' ||
+            arg.type === 'string' ||
+            arg.type === 'boolean'
+        );
+    };
+
+    const ROW_COUNT_METRIC_NAME = 'pgwire_row_count';
+
     /** Postgres-style default output name for an unaliased expression, unique within the statement */
     const autoName = (ctx: CompilerContext, expr: Expr): string => {
         const base =
@@ -820,6 +854,8 @@ function compileSelect(
     // SELECT list
     const dimensions: string[] = [];
     const metrics: string[] = [];
+    const additionalMetrics: AdditionalMetric[] = [];
+    const rowCountFieldId = `${table.name}_${ROW_COUNT_METRIC_NAME}`;
     const tableCalculations: TableCalculation[] = [];
     const columns: PgWireColumn[] = [];
     const selectedSources = new Set<string>();
@@ -850,6 +886,25 @@ function compileSelect(
 
     const handleSelectedColumn = (col: SelectedColumn): void => {
         const { expr } = col;
+        // count(*): a system COUNT(*) metric on the explore's base table
+        if (isCountStar(expr)) {
+            if (additionalMetrics.length === 0) {
+                additionalMetrics.push({
+                    name: ROW_COUNT_METRIC_NAME,
+                    table: table.name,
+                    sql: '*',
+                    type: MetricType.COUNT,
+                });
+                metrics.push(rowCountFieldId);
+            }
+            columns.push({
+                name: col.alias?.name ?? 'count',
+                source: rowCountFieldId,
+                kind: 'metric',
+                type: 'count',
+            });
+            return;
+        }
         // SELECT * or SELECT table.*
         if (expr.type === 'ref' && expr.name === '*') {
             if (expr.table && !ctx.fromNames.has(expr.table.name)) {
@@ -1090,6 +1145,7 @@ function compileSelect(
         sorts,
         limit,
         tableCalculations,
+        ...(additionalMetrics.length > 0 ? { additionalMetrics } : {}),
     };
 
     return {


### PR DESCRIPTION
## Summary

Domo Cloud Amplifier's final dataset-creation step asks the source for a row count (`SELECT count(*)`), and the Metrics SQL API rejected it (`Aggregate function "count" is not supported`), leaving CREATE disabled — the last blocker after #27725 and #27822; the customer's preview now renders real metric values. BI tools also count rows per group.

## How it works

`count(*)`, `count(1)` and `count()` compile to a system additional metric (`type: count`, `sql: '*'`) on the explore, flowing through the standard `runExploreQuery` path:

- bare `SELECT count(*) FROM t [WHERE …]` → the table's row count from the warehouse (verified against the source table: 208 = 208)
- `SELECT dim, count(*) … GROUP BY dim` → rows per group (groups sum to the table total)
- `count(DISTINCT x)` and other raw aggregates (`sum`, `avg`, …) are still rejected with the existing hint to use pre-defined metrics — re-aggregating a semantic layer remains intentionally unsupported

## Test plan

- [x] `pnpm -F backend typecheck` / `lint` / `oxfmt --check` — clean
- [x] `pnpm -F backend exec vitest run src/ee/postgresWire` — 218 tests (new: bare/aliased/filtered/grouped counts, `count(distinct …)` still rejected, other aggregates unchanged)
- [x] Manual over TLS: `SELECT count(*) FROM "db"."public"."payments"` → 208, equal to `select count(*)` on the underlying warehouse table; filtered → 19; grouped → 93/60/36/19

Relates: PROD-10307
Relates: #27624

🤖 Generated with [Claude Code](https://claude.com/claude-code)