### PR TITLE
test: remove flaky spotlight category API tests

### DIFF
--- a/packages/api-tests/tests/v2/metricsWithTimeDimensions.test.ts
+++ b/packages/api-tests/tests/v2/metricsWithTimeDimensions.test.ts
@@ -53,33 +53,6 @@ describe('v2 metrics with time dimensions', () => {
         });
     });
 
-    it('should filter by spotlight categories', async () => {
-        const resp = await admin.get<PaginatedMetrics>(
-            `${v2Url}?page=1&pageSize=100&categories=sales`,
-        );
-        expect(resp.status).toBe(200);
-        expect(resp.body.results.pagination!.totalResults).toBeGreaterThan(0);
-        resp.body.results.data.forEach((metric) => {
-            const refs = metric.categories.map((c) => c.yamlReference);
-            expect(refs).toContain('sales');
-        });
-    });
-
-    it('should filter by multiple spotlight categories (OR)', async () => {
-        const resp = await admin.get<PaginatedMetrics>(
-            `${v2Url}?page=1&pageSize=100&categories=sales&categories=revenue_growth`,
-        );
-        expect(resp.status).toBe(200);
-        expect(resp.body.results.pagination!.totalResults).toBeGreaterThan(0);
-
-        resp.body.results.data.forEach((metric) => {
-            const refs = metric.categories.map((c) => c.yamlReference);
-            const hasSales = refs.includes('sales');
-            const hasRevenueGrowth = refs.includes('revenue_growth');
-            expect(hasSales || hasRevenueGrowth).toBe(true);
-        });
-    });
-
     it('should return empty results for non-existent category', async () => {
         const resp = await admin.get<PaginatedMetrics>(
             `${v2Url}?page=1&pageSize=50&categories=nonexistent`,


### PR DESCRIPTION
### Description:

- Remove two flaky spotlight-category API assertions
- Keep dbt-tag and nonexistent-category coverage
- CI evidence: [both failed](https://github.com/lightdash/lightdash/actions/runs/32474934713), [only OR failed](https://github.com/lightdash/lightdash/actions/runs/32479010484), [suite passed](https://github.com/lightdash/lightdash/actions/runs/32477032566)

### Tests:

- `direnv exec . pnpm --dir packages/api-tests exec vitest run tests/v2/metricsWithTimeDimensions.test.ts --config vitest.config.ts` (3 passed)

### Risk assessment:

- [ ] This is a high-risk change