### PR TITLE
fix: preserve OAuth loopback redirects in Chromium

### DIFF
--- a/packages/api-tests/tests/oauthLogin.test.ts
+++ b/packages/api-tests/tests/oauthLogin.test.ts
@@ -44,14 +44,27 @@ const PKCE_TEST_VALUES = {
 
 const getRedirectLocation = (response: {
     status: number;
+    body: unknown;
     headers: Headers;
 }): string => {
-    expect(response.status).toBe(302);
-    const location = response.headers.get('location');
-    if (!location) {
-        throw new Error('Missing OAuth redirect location');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('location')).toBeNull();
+    if (typeof response.body !== 'string') {
+        throw new Error('Missing OAuth redirect page');
     }
-    return location;
+    const match = /<meta http-equiv="refresh" content="0;url=([^"]+)" \/>/.exec(
+        response.body,
+    );
+    if (!match) {
+        throw new Error('Missing OAuth meta refresh');
+    }
+    return match[1]
+        .replaceAll('&amp;', '&')
+        .replaceAll('&#x3D;', '=')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&#x27;', "'")
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>');
 };
 
 /**

--- a/packages/backend/src/routers/oauthRouter.test.ts
+++ b/packages/backend/src/routers/oauthRouter.test.ts
@@ -14,6 +14,22 @@ vi.mock('../logging/logger', () => ({
 
 type OAuthServiceStub = Pick<OAuthService, 'authorize' | 'validateRedirectUri'>;
 
+const getRedirectUrl = (body: string): string => {
+    const match = /<meta http-equiv="refresh" content="0;url=([^"]+)" \/>/.exec(
+        body,
+    );
+    if (!match) {
+        throw new Error('Missing OAuth meta refresh');
+    }
+    return match[1]
+        .replaceAll('&amp;', '&')
+        .replaceAll('&#x3D;', '=')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&#x27;', "'")
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>');
+};
+
 const createOAuthService = () => ({
     authorize: vi.fn<OAuthServiceStub['authorize']>(),
     validateRedirectUri: vi.fn<OAuthServiceStub['validateRedirectUri']>(),
@@ -133,8 +149,9 @@ describe('OAuth authorize redirects', () => {
             oauthService,
         });
 
-        expect(response.status).toBe(302);
-        expect(response.headers.location).toBe(
+        expect(response.status).toBe(200);
+        expect(response.headers.location).toBeUndefined();
+        expect(getRedirectUrl(response.body)).toBe(
             'https://registered.example/callback?existing=1&error=access_denied&state=request-state',
         );
         expect(oauthService.authorize).not.toHaveBeenCalled();
@@ -157,8 +174,9 @@ describe('OAuth authorize redirects', () => {
             oauthService,
         });
 
-        expect(response.status).toBe(302);
-        expect(response.headers.location).toBe(
+        expect(response.status).toBe(200);
+        expect(response.headers.location).toBeUndefined();
+        expect(getRedirectUrl(response.body)).toBe(
             'https://registered.example/callback?code=authorization-code&state=request-state',
         );
     });
@@ -178,8 +196,9 @@ describe('OAuth authorize redirects', () => {
             oauthService,
         });
 
-        expect(response.status).toBe(302);
-        expect(response.headers.location).toBe(
+        expect(response.status).toBe(200);
+        expect(response.headers.location).toBeUndefined();
+        expect(getRedirectUrl(response.body)).toBe(
             'https://registered.example/callback?error=server_error&state=request-state',
         );
     });
@@ -191,7 +210,7 @@ describe('OAuth authorize redirects', () => {
             authorizationCode: 'authorization-code',
         } as OAuth2Server.AuthorizationCode);
         const redirectSpy = vi
-            .spyOn(express.response, 'redirect')
+            .spyOn(express.response, 'send')
             .mockImplementationOnce(() => {
                 throw new Error('redirect failed');
             });
@@ -207,8 +226,8 @@ describe('OAuth authorize redirects', () => {
                 oauthService,
             });
 
-            expect(response.status).toBe(302);
-            const location = new URL(response.headers.location ?? '');
+            expect(response.status).toBe(200);
+            const location = new URL(getRedirectUrl(response.body));
             expect(location.searchParams.get('error')).toBe('server_error');
             expect(location.searchParams.has('code')).toBe(false);
             expect(location.searchParams.get('state')).toBe('request-state');

--- a/packages/backend/src/routers/oauthRouter.ts
+++ b/packages/backend/src/routers/oauthRouter.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {
     generateOAuthAuthorizePage,
+    generateOAuthRedirectPage,
     getErrorMessage,
     OAuthIntrospectResponse,
     parseScopeString,
@@ -56,6 +57,20 @@ const sendInvalidRedirectResponse = (res: express.Response) =>
         error: 'invalid_request',
         error_description: 'Invalid client_id or redirect_uri',
     });
+
+const sendOAuthRedirectResponse = (
+    res: express.Response,
+    redirectUrl: URL,
+    message: string,
+) => {
+    res.set('Content-Type', 'text/html');
+    return res.send(
+        generateOAuthRedirectPage({
+            redirectUrl: redirectUrl.toString(),
+            message,
+        }),
+    );
+};
 
 // Get authorization - use OAuth2Server
 oauthRouter.get('/authorize', async (req, res, next) => {
@@ -151,7 +166,11 @@ oauthRouter.post('/authorize', async (req, res) => {
         if (req.body.state) {
             redirectUrl.searchParams.set('state', req.body.state);
         }
-        return res.redirect(302, redirectUrl.toString());
+        return sendOAuthRedirectResponse(
+            res,
+            redirectUrl,
+            'Access denied. Redirecting you back to your application...',
+        );
     }
 
     // Normalize scope parameter directly on the request object
@@ -182,7 +201,11 @@ oauthRouter.post('/authorize', async (req, res) => {
             redirectUrl.searchParams.set('state', req.body.state);
         }
 
-        return res.redirect(302, redirectUrl.toString());
+        return sendOAuthRedirectResponse(
+            res,
+            redirectUrl,
+            'Redirecting you back to your application...',
+        );
     } catch (error) {
         Logger.error(`Authorization error: ${error}`);
         const errorUrl = new URL(req.body.redirect_uri);
@@ -190,7 +213,11 @@ oauthRouter.post('/authorize', async (req, res) => {
         if (req.body.state) {
             errorUrl.searchParams.set('state', req.body.state);
         }
-        return res.redirect(302, errorUrl.toString());
+        return sendOAuthRedirectResponse(
+            res,
+            errorUrl,
+            'An error occurred. Redirecting you back to your application...',
+        );
     }
 });
 

--- a/packages/common/src/utils/oauth.test.ts
+++ b/packages/common/src/utils/oauth.test.ts
@@ -1,5 +1,6 @@
 import {
     generateOAuthAuthorizePage,
+    generateOAuthRedirectPage,
     generateOAuthSuccessResponse,
     parseScopeString,
 } from './oauth';
@@ -42,5 +43,21 @@ describe('OAuth page templates', () => {
         expect(containerRule).toBeDefined();
         expect(containerRule).toContain('box-sizing: border-box;');
         expect(containerRule).toContain('width: 100%;');
+    });
+
+    it('renders OAuth redirects without an executable injection context', () => {
+        const redirectPage = generateOAuthRedirectPage({
+            redirectUrl:
+                'https://example.com/callback?</script><img src=x onerror=alert(document.domain)>',
+            message: 'Redirecting',
+        });
+
+        expect(redirectPage).toContain('http-equiv="refresh"');
+        expect(redirectPage).not.toContain('<script');
+        expect(redirectPage).not.toContain('</script>');
+        expect(redirectPage).not.toContain('<img src=x');
+        expect(redirectPage).not.toContain('onerror=');
+        expect(redirectPage).not.toContain('href=');
+        expect(redirectPage).toContain('&lt;/script&gt;');
     });
 });

--- a/packages/common/src/utils/oauth.ts
+++ b/packages/common/src/utils/oauth.ts
@@ -105,6 +105,30 @@ const OAUTH_RESPONSE_TEMPLATE = `
 </html>
 `;
 
+// OAuth redirect page template. This intentionally uses a meta refresh instead
+// of an HTTP redirect: Chromium applies the authorize page's form-action CSP to
+// HTTP redirects after the consent form POST, which blocks OAuth loopback URIs.
+// Handlebars escapes redirectUrl in the refresh attribute context.
+const OAUTH_REDIRECT_TEMPLATE = `
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta http-equiv="refresh" content="0;url={{redirectUrl}}" />
+        <title>Redirecting...</title>
+        <style>{{{styles}}}</style>
+    </head>
+    <body>
+        <div class="stack">
+            <div class="container">
+                {{{logo}}}
+                <h1>Redirecting...</h1>
+                <p>{{message}}</p>
+            </div>
+        </div>
+    </body>
+</html>
+`;
+
 // OAuth authorization page template
 const OAUTH_AUTHORIZE_TEMPLATE = `
 <html>
@@ -382,6 +406,7 @@ const OAUTH_ICONS = {
 
 // Compile the templates once with proper type safety
 const compiledResponseTemplate = compile(OAUTH_RESPONSE_TEMPLATE);
+const compiledRedirectTemplate = compile(OAUTH_REDIRECT_TEMPLATE);
 const compiledAuthorizeTemplate = compile(OAUTH_AUTHORIZE_TEMPLATE);
 
 export type OAuthResponseStatus = 'success' | 'error';
@@ -415,6 +440,11 @@ export interface OAuthAuthorizeParams {
     /** Where "Switch account" sends the user after logging out */
     loginUrl: string;
     hiddenInputs: OAuthHiddenInput[];
+}
+
+export interface OAuthRedirectParams {
+    redirectUrl: string;
+    message: string;
 }
 
 // Scope descriptions mapping
@@ -509,6 +539,18 @@ export const generateOAuthErrorResponse = (
         [...messages, 'You can close this window and try again.'],
         iconType,
     );
+
+/**
+ * Generates a script-free redirect page for a previously validated OAuth URI.
+ */
+export const generateOAuthRedirectPage = (
+    params: OAuthRedirectParams,
+): string =>
+    compiledRedirectTemplate({
+        styles: oauthPageStyles,
+        logo: LIGHTDASH_LOGO_SVG,
+        ...params,
+    });
 
 const getUserInitials = (user: OAuthUser): string => {
     const initials =


### PR DESCRIPTION
## Summary

- Fix CLI OAuth login in Chromium-based browsers.
- Replace the consent POST's HTTP 302 with a script-free, escaped redirect handoff.
- Preserve success, denial, and server-error callback parameters.

## What happened

The previous OAuth redirect hardening changed the authorization response from an HTML handoff to an HTTP 302. Chromium applies the consent page's `form-action` policy to the 302 target, so it blocked CLI loopback callback URLs. Firefox handles this flow differently, which is why the regression was browser-specific.

## Why the earlier hardening remains intact

This is a fix-forward rather than a revert:

- Authentication still happens before any authorization decision.
- The `client_id` and `redirect_uri` are still checked against the registered OAuth client on every outcome.
- Invalid or unregistered callback URLs still receive a 400 response and are not included in the response body.
- The callback is rendered only in a Handlebars-escaped meta refresh attribute; there is no inline JavaScript or clickable callback link.

Only the final handoff after validation changes: from an HTTP 302 to a script-free HTML redirect that Chromium does not treat as a continued form submission.

## Verification

- Focused backend redirect tests: 7/7 passing
- Common redirect-template tests, including hostile markup: 4/4 passing
- OAuth API integration suite: 17/17 passing against the isolated local instance
- CLI OAuth login confirmed working in Chrome against the isolated local instance
- Common, backend, and API test typechecks passed
- Touched-path lint and formatting passed

Relates: SPK-1201