### PR TITLE
fix(apps): exclude custom chart types from the project data apps listing

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -109,7 +109,9 @@ export class AppGenerateController extends BaseController {
     }
 
     /**
-     * List the project's data apps (for the embed config allowlist picker).
+     * List the project's data apps (for the embed config allowlist picker
+     * and the CLI's project-wide listing). Custom chart types are never
+     * included — they have their own listing at /chart-types.
      * @summary List project data apps
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
@@ -125,6 +127,34 @@ export class AppGenerateController extends BaseController {
         const results = await this.getAppGenerateService().listAppsForProject(
             toSessionUser(req.account),
             projectUuid,
+            'exclude',
+        );
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * List the project's custom chart types (for the CLI's
+     * chart-types-as-code listing). Same shape as the data apps listing;
+     * a 404 tells older CLIs the server predates the split.
+     * @summary List project custom chart types
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/chart-types')
+    @OperationId('listProjectChartTypes')
+    async listProjectChartTypes(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiEmbedProjectAppsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results = await this.getAppGenerateService().listAppsForProject(
+            toSessionUser(req.account),
+            projectUuid,
+            'only',
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -109,8 +109,12 @@ export class AppGenerateController extends BaseController {
     }
 
     /**
-     * List the project's data apps (for the embed config allowlist picker).
+     * List the project's data apps (for the embed config allowlist picker
+     * and the CLI's project-wide listing). Custom chart types are excluded
+     * unless requested with dataAppVizsFilter=only.
      * @summary List project data apps
+     * @param dataAppVizsFilter 'only' lists custom chart types instead of
+     * data apps; omitted or 'exclude' lists data apps only
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -119,12 +123,14 @@ export class AppGenerateController extends BaseController {
     async listProjectApps(
         @Request() req: express.Request,
         @Path() projectUuid: string,
+        @Query() dataAppVizsFilter?: 'exclude' | 'only',
     ): Promise<ApiEmbedProjectAppsResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
         const results = await this.getAppGenerateService().listAppsForProject(
             toSessionUser(req.account),
             projectUuid,
+            dataAppVizsFilter,
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -95,6 +95,7 @@ import {
     type DataAppViz,
     type DataAppVizRenderMetadata,
     type DataAppVizSchema,
+    type DataAppVizsFilter,
     type EmbedProjectApp,
     type Explore,
     type ExternalConnectionMethod,
@@ -8165,12 +8166,16 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
-     * List all (non-deleted) data apps in a project — used by the embed config
-     * UI to populate the standalone-app allowlist picker.
+     * List the project's (non-deleted) apps of one kind. Serves both listing
+     * endpoints: GET /apps ('exclude' — data apps for the embed config
+     * allowlist picker and the CLI) and GET /apps/chart-types ('only' —
+     * custom chart types for the CLI). Defaults to excluding chart types:
+     * they are not data apps.
      */
     async listAppsForProject(
         user: SessionUser,
         projectUuid: string,
+        dataAppVizsFilter: DataAppVizsFilter = 'exclude',
     ): Promise<EmbedProjectApp[]> {
         await this.assertDataAppsEnabled(user);
         const projectContext = await this.getDataAppProjectContext(projectUuid);
@@ -8178,11 +8183,14 @@ export class AppGenerateService extends BaseService {
         if (auditedAbility.cannot('view', subject('DataApp', projectContext))) {
             throw new ForbiddenError('Insufficient permissions');
         }
-        const apps = await this.appModel.listAppsByProject(projectUuid);
+        const apps = await this.appModel.listAppsByProject(projectUuid, {
+            dataAppVizsFilter,
+        });
         return apps.map((app) => ({
             appUuid: app.app_id,
             name: app.name,
             slug: app.slug,
+            template: app.template,
         }));
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -95,6 +95,7 @@ import {
     type DataAppViz,
     type DataAppVizRenderMetadata,
     type DataAppVizSchema,
+    type DataAppVizsFilter,
     type EmbedProjectApp,
     type Explore,
     type ExternalConnectionMethod,
@@ -8163,12 +8164,16 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
-     * List all (non-deleted) data apps in a project — used by the embed config
-     * UI to populate the standalone-app allowlist picker.
+     * List the project's (non-deleted) data apps — used by the embed config
+     * UI to populate the standalone-app allowlist picker, and by the CLI's
+     * project-wide app listing. Defaults to excluding custom chart types:
+     * they are not data apps, so every consumer that wants them must ask
+     * with 'only'.
      */
     async listAppsForProject(
         user: SessionUser,
         projectUuid: string,
+        dataAppVizsFilter: DataAppVizsFilter = 'exclude',
     ): Promise<EmbedProjectApp[]> {
         await this.assertDataAppsEnabled(user);
         const projectContext = await this.getDataAppProjectContext(projectUuid);
@@ -8176,11 +8181,14 @@ export class AppGenerateService extends BaseService {
         if (auditedAbility.cannot('view', subject('DataApp', projectContext))) {
             throw new ForbiddenError('Insufficient permissions');
         }
-        const apps = await this.appModel.listAppsByProject(projectUuid);
+        const apps = await this.appModel.listAppsByProject(projectUuid, {
+            dataAppVizsFilter,
+        });
         return apps.map((app) => ({
             appUuid: app.app_id,
             name: app.name,
             slug: app.slug,
+            template: app.template,
         }));
     }
 

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -12,6 +12,7 @@ import {
     type DataAppActivityFilters,
     type DataAppGenerationUsage,
     type DataAppVizSchema,
+    type DataAppVizsFilter,
     type KnexPaginateArgs,
     type KnexPaginatedData,
     type MyAppsSortBy,
@@ -903,14 +904,46 @@ export class AppModel {
     }
 
     /**
-     * List every non-deleted app in a project. Used by preview duplication to
-     * mirror the upstream project's apps into a freshly created preview.
+     * Narrows an apps query by template: 'exclude' drops custom chart types
+     * (data_app_viz), 'only' keeps just them. NULL templates ("Custom" and
+     * pre-template apps) count as data apps.
      */
-    async listAppsByProject(projectUuid: string): Promise<DbApp[]> {
-        return this.database(AppsTableName)
+    private static applyDataAppVizsFilter(
+        query: Knex.QueryBuilder,
+        dataAppVizsFilter: DataAppVizsFilter | undefined,
+    ): void {
+        if (dataAppVizsFilter === 'exclude') {
+            void query.where((templateFilter) => {
+                void templateFilter
+                    .whereNot(
+                        `${AppsTableName}.template`,
+                        DATA_APP_VIZ_TEMPLATE,
+                    )
+                    .orWhereNull(`${AppsTableName}.template`);
+            });
+        } else if (dataAppVizsFilter === 'only') {
+            void query.where(
+                `${AppsTableName}.template`,
+                DATA_APP_VIZ_TEMPLATE,
+            );
+        }
+    }
+
+    /**
+     * List every non-deleted app in a project. Used by preview duplication to
+     * mirror the upstream project's apps into a freshly created preview
+     * (unfiltered), and by the project apps listing endpoint (filtered).
+     */
+    async listAppsByProject(
+        projectUuid: string,
+        options: { dataAppVizsFilter?: DataAppVizsFilter } = {},
+    ): Promise<DbApp[]> {
+        const query = this.database(AppsTableName)
             .where({ project_uuid: projectUuid })
             .whereNull('deleted_at')
             .select('*');
+        AppModel.applyDataAppVizsFilter(query, options.dataAppVizsFilter);
+        return query;
     }
 
     // Derived table of each app's latest ready version number, for joining the
@@ -1259,13 +1292,8 @@ export class AppModel {
             .where(`${AppsTableName}.created_by_user_uuid`, userUuid)
             .whereNull(`${AppsTableName}.deleted_at`)
             // Vizs (custom chart types) are not offered on app surfaces.
-            .where((templateFilter) => {
-                void templateFilter
-                    .whereNot(
-                        `${AppsTableName}.template`,
-                        DATA_APP_VIZ_TEMPLATE,
-                    )
-                    .orWhereNull(`${AppsTableName}.template`);
+            .modify((queryBuilder) => {
+                AppModel.applyDataAppVizsFilter(queryBuilder, 'exclude');
             })
             .modify((queryBuilder) => {
                 if (options.excludePreviewProjects ?? true) {

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -12,6 +12,7 @@ import {
     type DataAppActivityFilters,
     type DataAppGenerationUsage,
     type DataAppVizSchema,
+    type DataAppVizsFilter,
     type KnexPaginateArgs,
     type KnexPaginatedData,
     type MyAppsSortBy,
@@ -903,14 +904,46 @@ export class AppModel {
     }
 
     /**
-     * List every non-deleted app in a project. Used by preview duplication to
-     * mirror the upstream project's apps into a freshly created preview.
+     * Narrows an apps query by template: 'exclude' drops custom chart types
+     * (data_app_viz), 'only' keeps just them. NULL templates ("Custom" and
+     * pre-template apps) count as data apps.
      */
-    async listAppsByProject(projectUuid: string): Promise<DbApp[]> {
-        return this.database(AppsTableName)
+    private static applyDataAppVizsFilter(
+        query: Knex.QueryBuilder,
+        dataAppVizsFilter: DataAppVizsFilter | undefined,
+    ): void {
+        if (dataAppVizsFilter === 'exclude') {
+            void query.where((templateFilter) => {
+                void templateFilter
+                    .whereNot(
+                        `${AppsTableName}.template`,
+                        DATA_APP_VIZ_TEMPLATE,
+                    )
+                    .orWhereNull(`${AppsTableName}.template`);
+            });
+        } else if (dataAppVizsFilter === 'only') {
+            void query.where(
+                `${AppsTableName}.template`,
+                DATA_APP_VIZ_TEMPLATE,
+            );
+        }
+    }
+
+    /**
+     * List every non-deleted app in a project. Used by preview duplication to
+     * mirror the upstream project's apps into a freshly created preview
+     * (unfiltered), and by the project apps listing endpoint (filtered).
+     */
+    async listAppsByProject(
+        projectUuid: string,
+        options: { dataAppVizsFilter?: DataAppVizsFilter } = {},
+    ): Promise<DbApp[]> {
+        const query = this.database(AppsTableName)
             .where({ project_uuid: projectUuid })
             .whereNull('deleted_at')
             .select('*');
+        AppModel.applyDataAppVizsFilter(query, options.dataAppVizsFilter);
+        return query;
     }
 
     // Derived table of each app's latest ready version number, for joining the
@@ -1282,13 +1315,8 @@ export class AppModel {
             .where(`${AppsTableName}.created_by_user_uuid`, userUuid)
             .whereNull(`${AppsTableName}.deleted_at`)
             // Vizs (custom chart types) are not offered on app surfaces.
-            .where((templateFilter) => {
-                void templateFilter
-                    .whereNot(
-                        `${AppsTableName}.template`,
-                        DATA_APP_VIZ_TEMPLATE,
-                    )
-                    .orWhereNull(`${AppsTableName}.template`);
+            .modify((queryBuilder) => {
+                AppModel.applyDataAppVizsFilter(queryBuilder, 'exclude');
             })
             .modify((queryBuilder) => {
                 if (options.excludePreviewProjects ?? true) {

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -632,6 +632,13 @@ export type ApiAppSummary = {
 
 export type MyAppsSortBy = 'createdAt' | 'latestActivity';
 
+/**
+ * Narrows an app listing to real data apps ('exclude' drops custom chart
+ * types) or to custom chart types only ('only'). Same vocabulary as the
+ * content API's dataAppVizsFilter query param.
+ */
+export type DataAppVizsFilter = 'exclude' | 'only';
+
 /** Minimal app shape for the embed config's standalone-app allowlist picker. */
 export type EmbedProjectApp = {
     appUuid: string;
@@ -639,6 +646,9 @@ export type EmbedProjectApp = {
     // Project-scoped identity, used by the CLI to tell whether a dashboard's
     // app already exists in an upload target.
     slug: string;
+    // The stored template flavor; distinguishes custom chart types
+    // (data_app_viz) from data apps. Null for "Custom" or pre-template apps.
+    template: Exclude<DataAppTemplate, 'custom'> | null;
 };
 
 export type ApiEmbedProjectAppsResponse = ApiSuccess<EmbedProjectApp[]>;

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -632,6 +632,13 @@ export type ApiAppSummary = {
 
 export type MyAppsSortBy = 'createdAt' | 'latestActivity';
 
+/**
+ * Narrows an app listing to real data apps ('exclude' drops custom chart
+ * types) or to custom chart types only ('only'). Same vocabulary as the
+ * content API's dataAppVizsFilter query param.
+ */
+export type DataAppVizsFilter = 'exclude' | 'only';
+
 /** Minimal app shape for the embed config's standalone-app allowlist picker. */
 export type EmbedProjectApp = {
     appUuid: string;
@@ -639,6 +646,11 @@ export type EmbedProjectApp = {
     // Project-scoped identity, used by the CLI to tell whether a dashboard's
     // app already exists in an upload target.
     slug: string;
+    // The stored template flavor; distinguishes custom chart types
+    // (data_app_viz) from data apps. Null for "Custom" or pre-template apps.
+    // Optional because servers predating the apps/chart-types split omit it —
+    // consumers must treat an absent field as "unknown", not "data app".
+    template?: Exclude<DataAppTemplate, 'custom'> | null;
 };
 
 export type ApiEmbedProjectAppsResponse = ApiSuccess<EmbedProjectApp[]>;


### PR DESCRIPTION
Custom chart types (apps with \`template = 'data_app_viz'\`) were returned by \`GET /api/v1/ee/projects/:id/apps\` alongside real data apps, so they showed up in the embed config's allowlist picker, the embed preview app picker, and the CLI's \`--include-apps\` download listing.

This splits the listing into two endpoints with disjoint, fixed contracts:

- \`GET /apps\` — **data apps only** (custom chart types are never included). Intentional behavior change: chart types appearing here was the bug.
- \`GET /apps/chart-types\` (new, \`listProjectChartTypes\`) — custom chart types only, same response shape. A 404 tells CLIs the server predates the split — a crisp signal for graceful degradation.

The response type gains an **optional** \`template\` field (\`template?: … | null\`) so consumers can distinguish app flavors; optional because servers predating the split omit it, so a required field would lie on the wire and break type-level construction — consumers must treat an absent field as "unknown".

Internals: \`AppModel.listAppsByProject\` accepts a \`dataAppVizsFilter\` via a shared \`applyDataAppVizsFilter\` helper (also now used by \`listMyApps\`); unfiltered callers (preview duplication, validation) are unchanged. Both routes call one service method with a fixed filter value.

Test plan: backend + common typecheck; AppGenerateService/EmbedService suites pass; both endpoints verified against a live dev server (chart types with template on \`/chart-types\`, data apps only on \`/\`).

Relates: PROD-10448
Relates: #27855

🤖 Generated with [Claude Code](https://claude.com/claude-code)