### PR TITLE
fix(embed): never authorize custom chart types as standalone data app embeds

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -17,6 +17,7 @@ import {
     DashboardAvailableFilters,
     DashboardDAO,
     DashboardFilters,
+    DATA_APP_VIZ_TEMPLATE,
     DateGranularity,
     DateZoom,
     DecodedEmbed,
@@ -2640,6 +2641,20 @@ export class EmbedService extends BaseService {
                         throw new ForbiddenError(
                             'This data app is not authorized for standalone embedding',
                         );
+                    }
+                    // Custom chart types are chart-rendering content, not
+                    // standalone apps — `allowAllApps` and stale allowlist
+                    // entries must not make them embeddable as apps. Chart
+                    // embeds render vizs through the viz-specific endpoints.
+                    if (content.appUuid !== undefined) {
+                        const app = await this.appModel.findAppByUuid(
+                            content.appUuid,
+                        );
+                        if (app?.template === DATA_APP_VIZ_TEMPLATE) {
+                            throw new ForbiddenError(
+                                'Custom chart types cannot be embedded as standalone data apps',
+                            );
+                        }
                     }
                 }
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -17,6 +17,7 @@ import {
     DashboardAvailableFilters,
     DashboardDAO,
     DashboardFilters,
+    DATA_APP_VIZ_TEMPLATE,
     DateGranularity,
     DateZoom,
     DecodedEmbed,
@@ -2578,6 +2579,20 @@ export class EmbedService extends BaseService {
                         throw new ForbiddenError(
                             'This data app is not authorized for standalone embedding',
                         );
+                    }
+                    // Custom chart types are chart-rendering content, not
+                    // standalone apps — `allowAllApps` and stale allowlist
+                    // entries must not make them embeddable as apps. Chart
+                    // embeds render vizs through the viz-specific endpoints.
+                    if (content.appUuid !== undefined) {
+                        const app = await this.appModel.findAppByUuid(
+                            content.appUuid,
+                        );
+                        if (app?.template === DATA_APP_VIZ_TEMPLATE) {
+                            throw new ForbiddenError(
+                                'Custom chart types cannot be embedded as standalone data apps',
+                            );
+                        }
                     }
                 }
 


### PR DESCRIPTION
The standalone data-app embed authorization treated custom chart types like any other app: the "Allow all data apps" toggle silently authorized every custom chart type for standalone embedding, and a viz UUID in the \`app_uuids\` allowlist was honoured.

Chart types are chart-rendering content, not standalone apps — chart/dashboard embeds render them through the viz-specific endpoints with their own authorization. This adds a template guard at the fail-closed JWT check: a \`dataApp\` embed of an app with \`template = 'data_app_viz'\` is rejected even when \`allowAllApps\` is on or a stale allowlist entry exists.

Test plan: backend typecheck; EmbedService suites pass. (No existing harness covers the standalone-dataApp JWT path; the guard sits inside the existing fail-closed block.)

Relates: PROD-10448
Relates: #27855

🤖 Generated with [Claude Code](https://claude.com/claude-code)