### PR TITLE
fix(apps): keep custom chart types spaceless on as-code upload

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -556,6 +556,73 @@ describe('AppGenerateService.importAppCode', () => {
         expect(appModel.moveToSpace).not.toHaveBeenCalled();
     });
 
+    it('create mode: a custom chart type is created spaceless and warns when a space was requested', async () => {
+        const { service, appModel, coderService } = buildService();
+        appModel.findApp.mockResolvedValue(undefined);
+
+        const result = await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: makeCode(undefined, {
+                template: 'data_app_viz',
+                vizSchema: VIZ_SCHEMA,
+                spaceSlug: 'sales/q3-reports',
+            }),
+            spaceUuid: 'explicit-space-uuid',
+        } as ImportAppCodeRequestBody);
+
+        expect(coderService.getOrCreateSpace).not.toHaveBeenCalled();
+        expect(appModel.createWithVersion).toHaveBeenCalledWith(
+            expect.objectContaining({ space_uuid: null }),
+            expect.anything(),
+            'pending',
+            expect.any(Object),
+            undefined,
+            expect.anything(),
+            { forceSlug: true },
+        );
+        expect(result.warnings).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining(
+                    'Custom chart types cannot be placed in spaces',
+                ),
+            ]),
+        );
+    });
+
+    it('append mode: a custom chart type ignores the manifest spaceSlug and warns', async () => {
+        const { service, appModel, coderService } = buildService();
+        appModel.findApp.mockResolvedValue({
+            app_id: EXISTING_APP_UUID,
+            project_uuid: PROJECT_UUID,
+            space_uuid: null,
+            created_by_user_uuid: USER_UUID,
+            organization_uuid: PROJECT_ORG_UUID,
+            name: 'Test Viz',
+            description: 'A test viz',
+            slug: EXISTING_APP_SLUG,
+            template: 'data_app_viz',
+        });
+        appModel.getLatestVersion.mockResolvedValue({ version: 4 });
+
+        const result = await service.importAppCode(makeUser(), PROJECT_UUID, {
+            code: makeCode(undefined, {
+                template: 'data_app_viz',
+                vizSchema: VIZ_SCHEMA,
+                spaceSlug: 'sales/q3-reports',
+            }),
+            targetAppUuid: EXISTING_APP_UUID,
+        } as ImportAppCodeRequestBody);
+
+        expect(coderService.getOrCreateSpace).not.toHaveBeenCalled();
+        expect(appModel.moveToSpace).not.toHaveBeenCalled();
+        expect(result.warnings).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining(
+                    'Custom chart types cannot be placed in spaces',
+                ),
+            ]),
+        );
+    });
+
     it('throws ParameterError when targetAppUuid is given but app is not found', async () => {
         const { service, appModel, schedulerClient } = buildService();
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -10631,6 +10631,7 @@ export class AppGenerateService extends BaseService {
                 organizationUuid,
                 manifestLinks,
             );
+        const warnings = [...linkWarnings];
 
         // Validate the round-tripped viz schema up front and fail loud: the
         // build-from-source pipeline has no generation run to re-emit it, so
@@ -10926,7 +10927,7 @@ export class AppGenerateService extends BaseService {
                     version: latestVersion.version,
                     action: 'unchanged',
                     slug: existingApp.slug,
-                    warnings: linkWarnings,
+                    warnings,
                 };
             }
         }
@@ -10954,34 +10955,46 @@ export class AppGenerateService extends BaseService {
                 code.manifest,
                 projectUuid,
             );
-            // spaceSlug present → reconcile placement; absent → untouched
-            // (mirrors the externalConnections manifest semantics).
-            const manifestSpaceUuid = await this.resolveManifestSpace(
-                user,
-                projectUuid,
-                code.manifest.spaceSlug,
-            );
-            if (
-                manifestSpaceUuid !== undefined &&
-                manifestSpaceUuid !== existingApp.space_uuid
-            ) {
-                const spaceContext =
-                    await this.spacePermissionService.getSpaceAccessContext(
-                        user.userUuid,
-                        manifestSpaceUuid,
+            // Vizs are project-global chart content — space semantics don't
+            // apply, and a spaced viz would leak into every space-scoped
+            // data-app surface. Skip placement (guarded before
+            // resolveManifestSpace so a viz upload can't create the space).
+            if (existingApp.template === DATA_APP_VIZ_TEMPLATE) {
+                if (code.manifest.spaceSlug !== undefined) {
+                    warnings.push(
+                        'Custom chart types cannot be placed in spaces — the manifest spaceSlug was ignored.',
                     );
-                await this.assertDataAppAbility(
+                }
+            } else {
+                // spaceSlug present → reconcile placement; absent → untouched
+                // (mirrors the externalConnections manifest semantics).
+                const manifestSpaceUuid = await this.resolveManifestSpace(
                     user,
-                    'manage',
                     projectUuid,
-                    'Insufficient permissions to move this data app into the manifest space',
-                    spaceContext,
+                    code.manifest.spaceSlug,
                 );
-                await this.appModel.moveToSpace({
-                    appId: existingApp.app_id,
-                    projectUuid,
-                    targetSpaceUuid: manifestSpaceUuid,
-                });
+                if (
+                    manifestSpaceUuid !== undefined &&
+                    manifestSpaceUuid !== existingApp.space_uuid
+                ) {
+                    const spaceContext =
+                        await this.spacePermissionService.getSpaceAccessContext(
+                            user.userUuid,
+                            manifestSpaceUuid,
+                        );
+                    await this.assertDataAppAbility(
+                        user,
+                        'manage',
+                        projectUuid,
+                        'Insufficient permissions to move this data app into the manifest space',
+                        spaceContext,
+                    );
+                    await this.appModel.moveToSpace({
+                        appId: existingApp.app_id,
+                        projectUuid,
+                        targetSpaceUuid: manifestSpaceUuid,
+                    });
+                }
             }
             newAppUuid = existingApp.app_id;
             newAppSlug = existingApp.slug;
@@ -11008,16 +11021,31 @@ export class AppGenerateService extends BaseService {
                 projectUuid,
                 'Insufficient permissions to create data apps',
             );
-            // Explicit --app-space wins over the manifest's spaceSlug; both
-            // absent → personal app.
-            const targetSpaceUuid =
-                body.spaceUuid ??
-                (await this.resolveManifestSpace(
-                    user,
-                    projectUuid,
-                    code.manifest.spaceSlug,
-                )) ??
-                null;
+            // Vizs are project-global chart content — created spaceless
+            // regardless of --app-space or manifest spaceSlug (a spaced viz
+            // would leak into every space-scoped data-app surface).
+            let targetSpaceUuid: string | null = null;
+            if (code.manifest.template === DATA_APP_VIZ_TEMPLATE) {
+                if (
+                    body.spaceUuid !== undefined ||
+                    code.manifest.spaceSlug !== undefined
+                ) {
+                    warnings.push(
+                        'Custom chart types cannot be placed in spaces — created without a space.',
+                    );
+                }
+            } else {
+                // Explicit --app-space wins over the manifest's spaceSlug;
+                // both absent → personal app.
+                targetSpaceUuid =
+                    body.spaceUuid ??
+                    (await this.resolveManifestSpace(
+                        user,
+                        projectUuid,
+                        code.manifest.spaceSlug,
+                    )) ??
+                    null;
+            }
             if (targetSpaceUuid) {
                 const spaceContext =
                     await this.spacePermissionService.getSpaceAccessContext(
@@ -11182,7 +11210,7 @@ export class AppGenerateService extends BaseService {
             version: newVersion,
             action,
             slug: newAppSlug,
-            warnings: linkWarnings,
+            warnings,
         };
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -10629,6 +10629,7 @@ export class AppGenerateService extends BaseService {
                 organizationUuid,
                 manifestLinks,
             );
+        const warnings = [...linkWarnings];
 
         // Validate the round-tripped viz schema up front and fail loud: the
         // build-from-source pipeline has no generation run to re-emit it, so
@@ -10924,7 +10925,7 @@ export class AppGenerateService extends BaseService {
                     version: latestVersion.version,
                     action: 'unchanged',
                     slug: existingApp.slug,
-                    warnings: linkWarnings,
+                    warnings,
                 };
             }
         }
@@ -10952,34 +10953,46 @@ export class AppGenerateService extends BaseService {
                 code.manifest,
                 projectUuid,
             );
-            // spaceSlug present → reconcile placement; absent → untouched
-            // (mirrors the externalConnections manifest semantics).
-            const manifestSpaceUuid = await this.resolveManifestSpace(
-                user,
-                projectUuid,
-                code.manifest.spaceSlug,
-            );
-            if (
-                manifestSpaceUuid !== undefined &&
-                manifestSpaceUuid !== existingApp.space_uuid
-            ) {
-                const spaceContext =
-                    await this.spacePermissionService.getSpaceAccessContext(
-                        user.userUuid,
-                        manifestSpaceUuid,
+            // Vizs are project-global chart content — space semantics don't
+            // apply, and a spaced viz would leak into every space-scoped
+            // data-app surface. Skip placement (guarded before
+            // resolveManifestSpace so a viz upload can't create the space).
+            if (existingApp.template === DATA_APP_VIZ_TEMPLATE) {
+                if (code.manifest.spaceSlug !== undefined) {
+                    warnings.push(
+                        'Custom chart types cannot be placed in spaces — the manifest spaceSlug was ignored.',
                     );
-                await this.assertDataAppAbility(
+                }
+            } else {
+                // spaceSlug present → reconcile placement; absent → untouched
+                // (mirrors the externalConnections manifest semantics).
+                const manifestSpaceUuid = await this.resolveManifestSpace(
                     user,
-                    'manage',
                     projectUuid,
-                    'Insufficient permissions to move this data app into the manifest space',
-                    spaceContext,
+                    code.manifest.spaceSlug,
                 );
-                await this.appModel.moveToSpace({
-                    appId: existingApp.app_id,
-                    projectUuid,
-                    targetSpaceUuid: manifestSpaceUuid,
-                });
+                if (
+                    manifestSpaceUuid !== undefined &&
+                    manifestSpaceUuid !== existingApp.space_uuid
+                ) {
+                    const spaceContext =
+                        await this.spacePermissionService.getSpaceAccessContext(
+                            user.userUuid,
+                            manifestSpaceUuid,
+                        );
+                    await this.assertDataAppAbility(
+                        user,
+                        'manage',
+                        projectUuid,
+                        'Insufficient permissions to move this data app into the manifest space',
+                        spaceContext,
+                    );
+                    await this.appModel.moveToSpace({
+                        appId: existingApp.app_id,
+                        projectUuid,
+                        targetSpaceUuid: manifestSpaceUuid,
+                    });
+                }
             }
             newAppUuid = existingApp.app_id;
             newAppSlug = existingApp.slug;
@@ -11006,16 +11019,31 @@ export class AppGenerateService extends BaseService {
                 projectUuid,
                 'Insufficient permissions to create data apps',
             );
-            // Explicit --app-space wins over the manifest's spaceSlug; both
-            // absent → personal app.
-            const targetSpaceUuid =
-                body.spaceUuid ??
-                (await this.resolveManifestSpace(
-                    user,
-                    projectUuid,
-                    code.manifest.spaceSlug,
-                )) ??
-                null;
+            // Vizs are project-global chart content — created spaceless
+            // regardless of --app-space or manifest spaceSlug (a spaced viz
+            // would leak into every space-scoped data-app surface).
+            let targetSpaceUuid: string | null = null;
+            if (code.manifest.template === DATA_APP_VIZ_TEMPLATE) {
+                if (
+                    body.spaceUuid !== undefined ||
+                    code.manifest.spaceSlug !== undefined
+                ) {
+                    warnings.push(
+                        'Custom chart types cannot be placed in spaces — created without a space.',
+                    );
+                }
+            } else {
+                // Explicit --app-space wins over the manifest's spaceSlug;
+                // both absent → personal app.
+                targetSpaceUuid =
+                    body.spaceUuid ??
+                    (await this.resolveManifestSpace(
+                        user,
+                        projectUuid,
+                        code.manifest.spaceSlug,
+                    )) ??
+                    null;
+            }
             if (targetSpaceUuid) {
                 const spaceContext =
                     await this.spacePermissionService.getSpaceAccessContext(
@@ -11180,7 +11208,7 @@ export class AppGenerateService extends BaseService {
             version: newVersion,
             action,
             slug: newAppSlug,
-            warnings: linkWarnings,
+            warnings,
         };
     }
 


### PR DESCRIPTION
Custom chart types are created spaceless, and most data-app surfaces (space pages, tile pickers, pinning, favorites) rely on that invariant to exclude them. But \`importAppCode\` could break it: \`--app-space\` / a manifest \`spaceSlug\` placed a viz bundle into a space on create, and the append path called \`moveToSpace\` directly, bypassing the service-level guard ("Custom chart types cannot be moved into spaces"). A spaced viz then leaks into every space-scoped data-app surface.

This keeps viz bundles spaceless on upload, on both paths:
- **create**: a viz manifest ignores \`body.spaceUuid\` and \`spaceSlug\` and is created with \`space_uuid: null\`
- **append**: a viz target skips space reconciliation (and never auto-creates the manifest space)

Both cases surface a warning in the upload response (\`warnings\`) instead of failing the upload — an \`--app-space\` sweep that includes viz bundles still succeeds for the real apps it was aimed at.

Test plan: two new tests in \`AppGenerateService.appCode.test.ts\` (create + append guard, warning assertion); full suite passes (64 tests in file, 352 across the service suites).

Relates: PROD-10448
Relates: #27855

🤖 Generated with [Claude Code](https://claude.com/claude-code)