### PR TITLE
fix(search): exclude custom chart types from data app search results

### DIFF
--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -908,7 +908,7 @@ export class AppModel {
      * (data_app_viz), 'only' keeps just them. NULL templates ("Custom" and
      * pre-template apps) count as data apps.
      */
-    private static applyDataAppVizsFilter(
+    static applyDataAppVizsFilter(
         query: Knex.QueryBuilder,
         dataAppVizsFilter: DataAppVizsFilter | undefined,
     ): void {

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -45,6 +45,7 @@ import { SavedSqlTableName } from '../../database/entities/savedSql';
 import { SpaceTableName } from '../../database/entities/spaces';
 import { UserTableName } from '../../database/entities/users';
 import KnexPaginate from '../../database/pagination';
+import { AppModel } from '../AppModel';
 import { ContentVerificationModel } from '../ContentVerificationModel';
 import {
     filterByCreatedAt,
@@ -1158,6 +1159,10 @@ export class SearchModel {
             .whereRaw(hasReadyVersionSql)
             .whereRaw(searchFilterSql)
             .orderBy('search_rank', 'desc');
+
+        // Custom chart types are not data apps — they have their own gallery
+        // and must not surface as "Data app" search results.
+        AppModel.applyDataAppVizsFilter(subquery, 'exclude');
 
         subquery = filterByCreatedAt(AppsTableName, subquery, filters);
         subquery = filterByCreatedByUuid(


### PR DESCRIPTION
Global search indexed custom chart types as data apps: \`SearchModel.searchApps\` had no template filter, so vizs surfaced as "Data app" results (for their creator and project admins) linking to the full data-app viewer, which has no chart-type redirect.

This reuses \`AppModel.applyDataAppVizsFilter\` (made public) to exclude \`template = 'data_app_viz'\` rows from app search results. Chart types have their own gallery; if we later want them searchable it should be a distinct category with correct routing.

Test plan: backend typecheck; search + app suites pass.

Relates: PROD-10448
Relates: #27855

🤖 Generated with [Claude Code](https://claude.com/claude-code)