### PR TITLE
fix(frontend): explicitly exclude custom chart types in data app pickers

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileForms/DataAppTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/DataAppTileForm.tsx
@@ -23,7 +23,7 @@ const fetchDataAppContent = (projectUuid: string, search: string) => {
     const searchParam = search ? `&search=${encodeURIComponent(search)}` : '';
     return lightdashApi<ApiContentResponse['results']>({
         version: 'v2',
-        url: `/content?projectUuids=${projectUuid}&contentTypes=${ContentType.DATA_APP}&pageSize=${DATA_APP_PICKER_PAGE_SIZE}&page=1${searchParam}`,
+        url: `/content?projectUuids=${projectUuid}&contentTypes=${ContentType.DATA_APP}&dataAppVizsFilter=exclude&pageSize=${DATA_APP_PICKER_PAGE_SIZE}&page=1${searchParam}`,
         method: 'GET',
         body: undefined,
     });

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -293,6 +293,7 @@ const SearchContentList: FC<{
             {
                 projectUuids: [projectUuid],
                 contentTypes: [contentType],
+                dataAppVizsFilter: 'exclude',
                 pageSize: PAGE_SIZE,
                 search: debouncedSearch || undefined,
             },

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
@@ -99,6 +99,7 @@ const DataAppPicker: FC<{
         {
             projectUuids: [projectUuid],
             contentTypes: [ContentType.DATA_APP],
+            dataAppVizsFilter: 'exclude',
             pageSize: PAGE_SIZE,
             search: debouncedSearch || undefined,
         },

--- a/packages/frontend/src/pages/MobileSpace.tsx
+++ b/packages/frontend/src/pages/MobileSpace.tsx
@@ -39,6 +39,9 @@ const MobileSpace: FC = () => {
             projectUuids: projectUuid ? [projectUuid] : [],
             spaceUuids: spaceUuid ? [spaceUuid] : [],
             contentTypes: [ContentType.DATA_APP],
+            // Vizs are spaceless today, but declare the exclusion rather
+            // than rely on that invariant.
+            dataAppVizsFilter: 'exclude',
             pageSize: 100,
         },
         { enabled: !!projectUuid && !!spaceUuid },

--- a/packages/frontend/src/pages/MobileSpace.tsx
+++ b/packages/frontend/src/pages/MobileSpace.tsx
@@ -38,6 +38,9 @@ const MobileSpace: FC = () => {
             projectUuids: projectUuid ? [projectUuid] : [],
             spaceUuids: spaceUuid ? [spaceUuid] : [],
             contentTypes: [ContentType.DATA_APP],
+            // Vizs are spaceless today, but declare the exclusion rather
+            // than rely on that invariant.
+            dataAppVizsFilter: 'exclude',
             pageSize: 100,
         },
         { enabled: !!projectUuid && !!spaceUuid },

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -434,6 +434,9 @@ const Space: FC = () => {
                                 ContentType.SPACE,
                                 ContentType.DATA_APP,
                             ],
+                            // Vizs are spaceless today, but declare the
+                            // exclusion rather than rely on that invariant.
+                            dataAppVizsFilter: 'exclude',
                         }}
                         contentTypeFilter={{
                             defaultValue: undefined,

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -436,6 +436,9 @@ const Space: FC = () => {
                                 ContentType.SPACE,
                                 ContentType.DATA_APP,
                             ],
+                            // Vizs are spaceless today, but declare the
+                            // exclusion rather than rely on that invariant.
+                            dataAppVizsFilter: 'exclude',
                         }}
                         contentTypeFilter={{
                             defaultValue: undefined,


### PR DESCRIPTION
Several data-app content pickers exclude custom chart types only *implicitly* — vizs are spaceless, and these queries happen to be space-scoped or rely on the content API's spaceless guard. Nothing declared the intent, so any viz that acquired a \`space_uuid\` (see #27859) would have leaked straight into them.

This passes \`dataAppVizsFilter: 'exclude'\` explicitly at each call site:
- dashboard data-app tile picker (\`DataAppTileForm\`)
- homepage builder pickers (\`DataAppPickerModal\`, \`CollectionBlock\` apps tab)
- space content views (\`Space\`, \`MobileSpace\`)

No behavior change today; the exclusion is now declared rather than an accident of spacelessness.

Test plan: frontend typecheck.

Closes: PROD-10448
Closes: #27855

🤖 Generated with [Claude Code](https://claude.com/claude-code)