### PR TITLE
feat: allow disabling AI thread deletion via feature flag

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3041,7 +3041,9 @@ export class AiAgentService extends BaseService {
      * cleanup. Owners can delete their own threads (`manage:AiAgentThread`
      * conditioned on their user uuid); agent admins can delete any thread.
      * Deliberately not gated on copilot being enabled so conversations remain
-     * deletable after the feature is turned off.
+     * deletable after the feature is turned off. The `ai-disable-thread-deletion`
+     * feature flag blocks this endpoint entirely; the admin threads view uses a
+     * separate path and keeps working.
      */
     async deleteAgentThread(
         user: SessionUser,
@@ -3051,6 +3053,18 @@ export class AiAgentService extends BaseService {
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
+        }
+
+        const { enabled: deletionDisabled } = await this.featureFlagService.get(
+            {
+                user,
+                featureFlagId: FeatureFlags.AiDisableThreadDeletion,
+            },
+        );
+        if (deletionDisabled) {
+            throw new ForbiddenError(
+                'Thread deletion is disabled for this organization',
+            );
         }
 
         const agent = await this.aiAgentModel.getAgent({

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -363,6 +363,12 @@ export enum FeatureFlags {
      * engine and its S3 configuration. Off by default.
      */
     ExternalSources = 'external-sources',
+
+    /**
+     * Prevent users from deleting their own AI agent threads. Admins can
+     * still delete threads from the agent admin threads view. Off by default.
+     */
+    AiDisableThreadDeletion = 'ai-disable-thread-deletion',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     type AiAgent,
     type AiAgentProjectThreadSummary,
 } from '@lightdash/common';
@@ -27,6 +28,7 @@ import { useState, type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
+import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import { useCanManageAiAgentThread } from '../../hooks/useAiAgentPermission';
 import { useAiOrganizationSettings } from '../../hooks/useAiOrganizationSettings';
 import {
@@ -43,6 +45,7 @@ type ThreadNavLinkProps = {
     isActive: boolean;
     projectUuid: string;
     showAgentName?: boolean;
+    deletionDisabled: boolean;
     onDelete: (thread: AiAgentProjectThreadSummary) => void;
 };
 
@@ -51,6 +54,7 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
     isActive,
     projectUuid,
     showAgentName = false,
+    deletionDisabled,
     onDelete,
 }) => {
     const threadTitle = (thread.title || thread.firstMessage.message).trim();
@@ -60,7 +64,8 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
         threadUserUuid: thread.user.uuid,
     });
     // Deleting a Slack thread here would not remove it from Slack itself
-    const canDelete = canManageThread && thread.createdFrom !== 'slack';
+    const canDelete =
+        !deletionDisabled && canManageThread && thread.createdFrom !== 'slack';
 
     return (
         <NavLink
@@ -144,6 +149,11 @@ const ThreadList: FC<ThreadListProps> = ({
 
     const threads = data?.pages.flatMap((page) => page.data) ?? [];
 
+    const deletionDisabledFlag = useServerFeatureFlag(
+        FeatureFlags.AiDisableThreadDeletion,
+    );
+    const deletionDisabled = deletionDisabledFlag.data?.enabled === true;
+
     const [threadToDelete, setThreadToDelete] =
         useState<AiAgentProjectThreadSummary | null>(null);
     const { mutateAsync: deleteThread, isLoading: isDeletingThread } =
@@ -184,6 +194,7 @@ const ThreadList: FC<ThreadListProps> = ({
                             isActive={thread.uuid === threadUuid}
                             projectUuid={projectUuid}
                             showAgentName={showAgentName}
+                            deletionDisabled={deletionDisabled}
                             onDelete={setThreadToDelete}
                         />
                     ))}


### PR DESCRIPTION
Adds a new `ai-disable-thread-deletion` feature flag. When enabled, users can no longer delete their own AI agent threads: the delete action is hidden in the thread sidebar and the endpoint rejects deletion requests. Admins can still delete threads from the agent admin threads view.
