### PR TITLE
feat(cli): download custom chart types as code separately from data apps

### DIFF
--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -678,8 +678,42 @@ describe('downloadAppsToDir', () => {
         expect(outcome).toEqual({
             successCount: 1,
             skippedNotBuiltCount: 0,
+            skippedWrongKindCount: 0,
             failures: [],
         });
+        expect(
+            fs.existsSync(
+                path.join(appsDir, 'revenue-explorer', 'lightdash-app.yml'),
+            ),
+        ).toBe(true);
+    });
+
+    it('skips bundles the skipBundle guard rejects without writing them', async () => {
+        const appsDir = tmpDir();
+        const vizCode = codeFor('my-chart-type');
+        vizCode.manifest.template = 'data_app_viz';
+
+        const outcome = await downloadAppsToDir({
+            appRefs: ['my-chart-type', 'revenue-explorer'],
+            projectId: 'project-uuid',
+            appsDir,
+            takenFolders: new Set(),
+            cliVersion: '0.0.0-test',
+            fetchApp: async (_p, ref) =>
+                ref === 'my-chart-type' ? vizCode : codeFor(ref),
+            skipBundle: (manifest) =>
+                manifest.template === 'data_app_viz'
+                    ? 'this is a custom chart type'
+                    : null,
+        });
+
+        expect(outcome).toEqual({
+            successCount: 1,
+            skippedNotBuiltCount: 0,
+            skippedWrongKindCount: 1,
+            failures: [],
+        });
+        expect(fs.existsSync(path.join(appsDir, 'my-chart-type'))).toBe(false);
         expect(
             fs.existsSync(
                 path.join(appsDir, 'revenue-explorer', 'lightdash-app.yml'),

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -140,28 +140,37 @@ export const preSlugServerHint = (folder: string): string =>
     `This server predates slug-based app identity, so "${folder}" was matched by uuid only. If you expected to update an existing app, verify no duplicate was created, and upgrade the server (or use a matching CLI version).`;
 
 /**
- * Resolves the --apps-limit flag. Commander passes the raw string (or
- * undefined when the flag was not given, so an explicit flag is
- * distinguishable from the default). Throws ParameterError on anything
- * that is not a positive integer.
+ * Resolves a listing-cap flag (--apps-limit / --chart-types-limit).
+ * Commander passes the raw string (or undefined when the flag was not
+ * given, so an explicit flag is distinguishable from the default). Throws
+ * ParameterError on anything that is not a positive integer.
  */
 export const resolveAppsLimit = (
     rawLimit: string | undefined,
     includeApps: boolean,
+    flagNames: {
+        limitFlag: string;
+        includeFlag: string;
+        refsFlag: string;
+    } = {
+        limitFlag: '--apps-limit',
+        includeFlag: '--include-apps',
+        refsFlag: '--apps',
+    },
 ): { limit: number; noEffectWarning: string | null } => {
     if (rawLimit === undefined) {
         return { limit: DEFAULT_APPS_LIMIT, noEffectWarning: null };
     }
     if (!/^\d+$/.test(rawLimit) || parseInt(rawLimit, 10) < 1) {
         throw new ParameterError(
-            `--apps-limit must be a positive integer, got "${rawLimit}".`,
+            `${flagNames.limitFlag} must be a positive integer, got "${rawLimit}".`,
         );
     }
     return {
         limit: parseInt(rawLimit, 10),
         noEffectWarning: includeApps
             ? null
-            : '--apps-limit only applies to --include-apps; explicit --apps references are never capped.',
+            : `${flagNames.limitFlag} only applies to ${flagNames.includeFlag}; explicit ${flagNames.refsFlag} references are never capped.`,
     };
 };
 
@@ -320,13 +329,14 @@ export const appsDownloadSummary = (
     failures: AppDownloadFailure[],
     appsDir: string,
     skippedNotBuiltCount: number,
+    noun: string = 'data app',
 ): { ok: boolean; message: string; failureLines: string[] } => {
     const attempted = total - skippedNotBuiltCount;
     const skippedSuffix =
         skippedNotBuiltCount > 0
             ? ` (${skippedNotBuiltCount} skipped: no built version)`
             : '';
-    const base = `Downloaded ${successCount} of ${attempted} data app(s) to ${appsDir}${skippedSuffix}`;
+    const base = `Downloaded ${successCount} of ${attempted} ${noun}(s) to ${appsDir}${skippedSuffix}`;
     if (failures.length === 0) {
         return { ok: true, message: base, failureLines: [] };
     }
@@ -342,6 +352,7 @@ export const appsDownloadSummary = (
 export type AppsDownloadOutcome = {
     successCount: number;
     skippedNotBuiltCount: number;
+    skippedWrongKindCount: number;
     failures: AppDownloadFailure[];
 };
 
@@ -361,6 +372,10 @@ export const downloadAppsToDir = async (args: {
         projectId: string,
         appRef: string,
     ) => Promise<DataAppCodeDownload>;
+    // Post-fetch kind guard: return a reason to skip writing this bundle
+    // (e.g. a custom chart type fetched through a data-app flag), or null
+    // to accept it. Skips are reported, not failed.
+    skipBundle?: (manifest: DataAppManifest) => string | null;
     onProgress?: (processed: number, total: number) => void;
 }): Promise<AppsDownloadOutcome> => {
     const {
@@ -370,11 +385,13 @@ export const downloadAppsToDir = async (args: {
         takenFolders,
         cliVersion,
         fetchApp,
+        skipBundle,
         onProgress,
     } = args;
 
     let successCount = 0;
     let skippedNotBuiltCount = 0;
+    let skippedWrongKindCount = 0;
     const failures: AppDownloadFailure[] = [];
 
     for (const appRef of appRefs) {
@@ -384,6 +401,23 @@ export const downloadAppsToDir = async (args: {
                 // eslint-disable-next-line no-await-in-loop
                 await fetchApp(projectId, appRef),
             );
+
+            const skipReason = skipBundle?.(code.manifest) ?? null;
+            if (skipReason !== null) {
+                skippedWrongKindCount += 1;
+                GlobalState.log(
+                    styles.warning(`Skipped ${appRef}: ${skipReason}`),
+                );
+                onProgress?.(
+                    successCount +
+                        skippedNotBuiltCount +
+                        skippedWrongKindCount +
+                        failures.length,
+                    appRefs.length,
+                );
+                // eslint-disable-next-line no-continue
+                continue;
+            }
 
             const folder = resolveAppFolderName(code.manifest, takenFolders);
             takenFolders.add(folder);
@@ -429,10 +463,18 @@ export const downloadAppsToDir = async (args: {
             }
         }
         onProgress?.(
-            successCount + skippedNotBuiltCount + failures.length,
+            successCount +
+                skippedNotBuiltCount +
+                skippedWrongKindCount +
+                failures.length,
             appRefs.length,
         );
     }
 
-    return { successCount, skippedNotBuiltCount, failures };
+    return {
+        successCount,
+        skippedNotBuiltCount,
+        skippedWrongKindCount,
+        failures,
+    };
 };

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -32,6 +32,7 @@ import {
     ContentAsCodeType as ContentAsCodeTypeEnum,
     DashboardAsCode,
     DashboardTileTypes,
+    DATA_APP_VIZ_TEMPLATE,
     ExternalConnectionAsCode,
     generateSlug,
     getErrorMessage,
@@ -169,9 +170,12 @@ export type DownloadHandlerOptions = {
     virtualViews: string[];
     externalConnections: string[]; // external connection slugs (enterprise)
     apps?: string[]; // specific app UUIDs or URLs (enterprise); absent = no explicit selection
+    chartTypes?: string[]; // specific custom chart type UUIDs or URLs (enterprise); absent = no explicit selection
     includeAgents?: boolean;
     includeApps?: boolean; // download: all of the project's apps, capped at --apps-limit; upload: all app folders on disk
+    includeChartTypes?: boolean; // download: all custom chart types, capped at --chart-types-limit; upload: all chart-type folders on disk
     appsLimit?: string; // download only: cap for the --include-apps listing (default 50); raw string from commander
+    chartTypesLimit?: string; // download only: cap for the --include-chart-types listing (default 50); raw string from commander
     createNew?: boolean; // upload only: always create a new app instead of updating the manifest's app
     allowCustomDependencies?: boolean; // upload only: approve custom-dependency uploads without prompting
     appSpace?: string; // upload only: space (slug or uuid) for data apps this run creates
@@ -202,6 +206,7 @@ export type DownloadHandlerOptions = {
     includeExternalConnections: boolean;
     includeAll: boolean;
     appsOnly?: boolean; // download: implies skipCharts + skipDashboards + skipSpaces; upload: apps-only filtered run
+    chartTypesOnly?: boolean; // download: implies skipCharts + skipDashboards + skipSpaces; upload: chart-types-only filtered run
     stripPivotSeries: boolean; // Strip per-value pivot series config for portable chart YAML
     validate?: boolean; // Validate charts and dashboards after upload
     concurrency: number;
@@ -235,6 +240,7 @@ const hasContentFilters = ({
     virtualViews,
     externalConnections,
     apps,
+    chartTypes,
 }: Pick<
     DownloadHandlerOptions,
     | 'spacesOnly'
@@ -247,6 +253,7 @@ const hasContentFilters = ({
     | 'virtualViews'
     | 'externalConnections'
     | 'apps'
+    | 'chartTypes'
 >): boolean =>
     !spacesOnly &&
     [
@@ -259,6 +266,7 @@ const hasContentFilters = ({
         virtualViews,
         externalConnections,
         apps ?? [],
+        chartTypes ?? [],
     ].some((filters) => filters.length > 0);
 
 /*
@@ -1746,6 +1754,12 @@ export const downloadHandler = async (
 
     const isOrganizationDownload = options.organization === true;
 
+    if (options.appsOnly && options.chartTypesOnly) {
+        throw new ParameterError(
+            '--apps-only cannot be combined with --chart-types-only.',
+        );
+    }
+
     // Bare --apps-only means "all apps": imply --include-apps.
     if (
         options.appsOnly &&
@@ -1755,16 +1769,43 @@ export const downloadHandler = async (
     ) {
         options.includeApps = true;
     }
+    // Bare --chart-types-only means "all chart types" likewise.
+    if (
+        options.chartTypesOnly &&
+        options.chartTypes === undefined &&
+        options.includeChartTypes !== true &&
+        options.includeAll !== true
+    ) {
+        options.includeChartTypes = true;
+    }
 
     const includeAll = options.includeAll === true;
     const includeApps =
-        !options.spacesOnly && (options.includeApps === true || includeAll);
+        !options.spacesOnly &&
+        !options.chartTypesOnly &&
+        (options.includeApps === true || includeAll);
+    const includeChartTypes =
+        !options.spacesOnly &&
+        !options.appsOnly &&
+        (options.includeChartTypes === true || includeAll);
     const includeAllOptionalContent =
-        includeAll && !options.appsOnly && !options.spacesOnly;
+        includeAll &&
+        !options.appsOnly &&
+        !options.chartTypesOnly &&
+        !options.spacesOnly;
     const { limit: appsLimit, noEffectWarning: appsLimitWarning } =
         resolveAppsLimit(options.appsLimit, includeApps);
     if (appsLimitWarning) {
         GlobalState.log(styles.warning(appsLimitWarning));
+    }
+    const { limit: chartTypesLimit, noEffectWarning: chartTypesLimitWarning } =
+        resolveAppsLimit(options.chartTypesLimit, includeChartTypes, {
+            limitFlag: '--chart-types-limit',
+            includeFlag: '--include-chart-types',
+            refsFlag: '--chart-types',
+        });
+    if (chartTypesLimitWarning) {
+        GlobalState.log(styles.warning(chartTypesLimitWarning));
     }
 
     if (options.appsOnly) {
@@ -1777,6 +1818,31 @@ export const downloadHandler = async (
                 'Nothing to download: --apps-only requires --apps <appReferences...>, --include-apps, or --include-all.',
             );
         }
+        options.chartTypes = undefined;
+        options.skipCharts = true;
+        options.skipDashboards = true;
+        options.skipSpaces = true;
+        options.includeAgents = false;
+        options.includeAlerts = false;
+        options.includeGoogleSheets = false;
+        options.includeScheduledDeliveries = false;
+        options.includeVirtualViews = false;
+        options.includeExternalConnections = false;
+    }
+
+    if (options.chartTypesOnly) {
+        const chartTypesOnlySelection = selectAppsToDownload({
+            apps: Array.isArray(options.chartTypes)
+                ? options.chartTypes
+                : undefined,
+            includeApps: includeChartTypes,
+        });
+        if (chartTypesOnlySelection.mode === 'none') {
+            throw new ParameterError(
+                'Nothing to download: --chart-types-only requires --chart-types <chartTypeReferences...>, --include-chart-types, or --include-all.',
+            );
+        }
+        options.apps = undefined;
         options.skipCharts = true;
         options.skipDashboards = true;
         options.skipSpaces = true;
@@ -1799,6 +1865,7 @@ export const downloadHandler = async (
         options.agents = [];
         options.alerts = [];
         options.apps = [];
+        options.chartTypes = [];
         options.googleSheets = [];
         options.scheduledDeliveries = [];
         options.virtualViews = [];
@@ -1891,6 +1958,8 @@ export const downloadHandler = async (
         // Shared across both apps-download steps so two different apps whose
         // names collide under the pre-slug fallback naming don't clobber each other.
         const downloadedAppFolders = new Set<string>();
+        // Chart types live in their own folder, so they track their own names.
+        const downloadedChartTypeFolders = new Set<string>();
         // App slugs referenced by downloaded dashboards' tiles, populated by
         // the Dashboards step and consumed by the Linked data apps step.
         let dashboardAppSlugs: string[] = [];
@@ -2342,39 +2411,49 @@ export const downloadHandler = async (
                 const baseDir = getDownloadFolder(options.path);
                 const appsDir = path.join(baseDir, 'apps');
 
-                const { successCount, skippedNotBuiltCount, failures } =
-                    await downloadAppsToDir({
-                        appRefs: appRefsToDownload,
-                        projectId,
-                        appsDir,
-                        takenFolders: downloadedAppFolders,
-                        cliVersion: CLI_VERSION,
-                        fetchApp: (fetchProjectId, appRef) =>
-                            lightdashApi<DataAppCodeDownload>({
-                                method: 'GET',
-                                url: `/api/v1/ee/projects/${fetchProjectId}/apps/${encodeURIComponent(
-                                    appRef,
-                                )}/download`,
-                                body: undefined,
-                            }),
-                        onProgress: (processed, total) =>
-                            output.updateActive(
-                                `${processed} of ${total} processed`,
-                            ),
-                    });
+                const {
+                    successCount,
+                    skippedNotBuiltCount,
+                    skippedWrongKindCount,
+                    failures,
+                } = await downloadAppsToDir({
+                    appRefs: appRefsToDownload,
+                    projectId,
+                    appsDir,
+                    takenFolders: downloadedAppFolders,
+                    cliVersion: CLI_VERSION,
+                    fetchApp: (fetchProjectId, appRef) =>
+                        lightdashApi<DataAppCodeDownload>({
+                            method: 'GET',
+                            url: `/api/v1/ee/projects/${fetchProjectId}/apps/${encodeURIComponent(
+                                appRef,
+                            )}/download`,
+                            body: undefined,
+                        }),
+                    skipBundle: (manifest) =>
+                        manifest.template === DATA_APP_VIZ_TEMPLATE
+                            ? 'this is a custom chart type — download it with --chart-types or --include-chart-types'
+                            : null,
+                    onProgress: (processed, total) =>
+                        output.updateActive(
+                            `${processed} of ${total} processed`,
+                        ),
+                });
 
                 const summary = appsDownloadSummary(
                     successCount,
                     appRefsToDownload.length,
                     failures,
                     appsDir,
-                    skippedNotBuiltCount,
+                    skippedNotBuiltCount + skippedWrongKindCount,
                 );
                 counts.appsNum = successCount;
                 output.completeItem(
                     `${successCount} downloaded${
-                        skippedNotBuiltCount > 0
-                            ? `, ${skippedNotBuiltCount} skipped`
+                        skippedNotBuiltCount + skippedWrongKindCount > 0
+                            ? `, ${
+                                  skippedNotBuiltCount + skippedWrongKindCount
+                              } skipped`
                             : ''
                     }${
                         failures.length > 0 ? `, ${failures.length} failed` : ''
@@ -2383,6 +2462,151 @@ export const downloadHandler = async (
                 );
                 if (!summary.ok) {
                     summary.failureLines.forEach((line) =>
+                        GlobalState.log(styles.warning(line)),
+                    );
+                }
+            }
+        }
+
+        // Download custom chart types (enterprise, opt-in via --chart-types /
+        // --include-chart-types / --include-all) into chart-types/, kept
+        // separate from data apps.
+        const chartTypesSelection = selectAppsToDownload({
+            apps: Array.isArray(options.chartTypes)
+                ? options.chartTypes
+                : undefined,
+            includeApps: includeChartTypes,
+        });
+        if (chartTypesSelection.mode !== 'none') {
+            output.startItem('Custom chart types');
+            let chartTypeRefsToDownload: string[];
+            let chartTypeListingError: string | null = null;
+
+            if (chartTypesSelection.mode === 'explicit') {
+                chartTypeRefsToDownload = chartTypesSelection.appRefs;
+            } else {
+                output.updateActive('listing project chart types…');
+                let listedChartTypes: ListedApp[] = [];
+                try {
+                    const projectChartTypes = await lightdashApi<
+                        ApiEmbedProjectAppsResponse['results']
+                    >({
+                        method: 'GET',
+                        url: `/api/v1/ee/projects/${projectId}/apps/chart-types`,
+                        body: undefined,
+                    });
+                    listedChartTypes = projectChartTypes.map((chartType) => ({
+                        appUuid: chartType.appUuid,
+                        slug: chartType.slug,
+                    }));
+                } catch (listErr) {
+                    if (shouldFallBackToSpaceScopedListing(listErr)) {
+                        // 404: the server predates the chart-types listing
+                        // (or chart types entirely) — nothing to list.
+                        GlobalState.log(
+                            styles.warning(
+                                'This server does not support listing custom chart types; pass explicit --chart-types references or upgrade the server.',
+                            ),
+                        );
+                        listedChartTypes = [];
+                    } else if (includeAllOptionalContent) {
+                        chartTypeListingError = getErrorMessage(listErr);
+                        listedChartTypes = [];
+                    } else {
+                        throw listErr;
+                    }
+                }
+
+                const {
+                    appUuids: cappedChartTypeUuids,
+                    truncatedCount: chartTypesTruncated,
+                } = capListedApps(
+                    listedChartTypes.map((chartType) => chartType.appUuid),
+                    chartTypesLimit,
+                );
+                if (chartTypesTruncated > 0) {
+                    GlobalState.log(
+                        styles.warning(
+                            `Found ${listedChartTypes.length} custom chart types, downloading the first ${chartTypesLimit}. Pass --chart-types-limit <n> to raise the cap.`,
+                        ),
+                    );
+                }
+                chartTypeRefsToDownload = [
+                    ...new Set([
+                        ...cappedChartTypeUuids,
+                        ...chartTypesSelection.extraAppRefs,
+                    ]),
+                ];
+            }
+
+            if (chartTypeRefsToDownload.length === 0) {
+                if (chartTypeListingError === null) {
+                    output.completeItem('0 found');
+                } else {
+                    output.completeItem(
+                        `listing failed: ${chartTypeListingError}`,
+                        'warning',
+                    );
+                }
+            } else {
+                output.updateActive(
+                    `0 of ${chartTypeRefsToDownload.length} downloaded`,
+                );
+                const chartTypesDir = path.join(
+                    getDownloadFolder(options.path),
+                    'chart-types',
+                );
+
+                const chartTypesOutcome = await downloadAppsToDir({
+                    appRefs: chartTypeRefsToDownload,
+                    projectId,
+                    appsDir: chartTypesDir,
+                    takenFolders: downloadedChartTypeFolders,
+                    cliVersion: CLI_VERSION,
+                    fetchApp: (fetchProjectId, appRef) =>
+                        lightdashApi<DataAppCodeDownload>({
+                            method: 'GET',
+                            url: `/api/v1/ee/projects/${fetchProjectId}/apps/${encodeURIComponent(
+                                appRef,
+                            )}/download`,
+                            body: undefined,
+                        }),
+                    skipBundle: (manifest) =>
+                        manifest.template !== DATA_APP_VIZ_TEMPLATE
+                            ? 'this is a data app — download it with --apps or --include-apps'
+                            : null,
+                    onProgress: (processed, total) =>
+                        output.updateActive(
+                            `${processed} of ${total} processed`,
+                        ),
+                });
+
+                const chartTypesSummary = appsDownloadSummary(
+                    chartTypesOutcome.successCount,
+                    chartTypeRefsToDownload.length,
+                    chartTypesOutcome.failures,
+                    chartTypesDir,
+                    chartTypesOutcome.skippedNotBuiltCount +
+                        chartTypesOutcome.skippedWrongKindCount,
+                    'custom chart type',
+                );
+                const chartTypesSkipped =
+                    chartTypesOutcome.skippedNotBuiltCount +
+                    chartTypesOutcome.skippedWrongKindCount;
+                output.completeItem(
+                    `${chartTypesOutcome.successCount} downloaded${
+                        chartTypesSkipped > 0
+                            ? `, ${chartTypesSkipped} skipped`
+                            : ''
+                    }${
+                        chartTypesOutcome.failures.length > 0
+                            ? `, ${chartTypesOutcome.failures.length} failed`
+                            : ''
+                    }`,
+                    chartTypesSummary.ok ? undefined : 'warning',
+                );
+                if (!chartTypesSummary.ok) {
+                    chartTypesSummary.failureLines.forEach((line) =>
                         GlobalState.log(styles.warning(line)),
                     );
                 }
@@ -2414,22 +2638,27 @@ export const downloadHandler = async (
                         )}/download`,
                         body: undefined,
                     }),
+                // Dashboard data-app tiles reference apps, never chart types.
+                skipBundle: (manifest) =>
+                    manifest.template === DATA_APP_VIZ_TEMPLATE
+                        ? 'this is a custom chart type — dashboard app tiles cannot reference it'
+                        : null,
                 onProgress: (processed, total) =>
                     output.updateActive(`${processed} of ${total} processed`),
             });
+            const linkedSkipped =
+                outcome.skippedNotBuiltCount + outcome.skippedWrongKindCount;
             const linkedSummary = appsDownloadSummary(
                 outcome.successCount,
                 linkedAppSlugs.length,
                 outcome.failures,
                 appsDir,
-                outcome.skippedNotBuiltCount,
+                linkedSkipped,
             );
             counts.appsNum = (counts.appsNum ?? 0) + outcome.successCount;
             output.completeItem(
                 `${outcome.successCount} downloaded${
-                    outcome.skippedNotBuiltCount > 0
-                        ? `, ${outcome.skippedNotBuiltCount} skipped`
-                        : ''
+                    linkedSkipped > 0 ? `, ${linkedSkipped} skipped` : ''
                 }${
                     outcome.failures.length > 0
                         ? `, ${outcome.failures.length} failed`

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -32,6 +32,7 @@ import {
     ContentAsCodeType as ContentAsCodeTypeEnum,
     DashboardAsCode,
     DashboardTileTypes,
+    DATA_APP_VIZ_TEMPLATE,
     ExternalConnectionAsCode,
     generateSlug,
     getErrorMessage,
@@ -162,9 +163,12 @@ export type DownloadHandlerOptions = {
     virtualViews: string[];
     externalConnections: string[]; // external connection slugs (enterprise)
     apps?: string[]; // specific app UUIDs or URLs (enterprise); absent = no explicit selection
+    chartTypes?: string[]; // specific custom chart type UUIDs or URLs (enterprise); absent = no explicit selection
     includeAgents?: boolean;
     includeApps?: boolean; // download: all of the project's apps, capped at --apps-limit; upload: all app folders on disk
+    includeChartTypes?: boolean; // download: all custom chart types, capped at --chart-types-limit; upload: all chart-type folders on disk
     appsLimit?: string; // download only: cap for the --include-apps listing (default 50); raw string from commander
+    chartTypesLimit?: string; // download only: cap for the --include-chart-types listing (default 50); raw string from commander
     createNew?: boolean; // upload only: always create a new app instead of updating the manifest's app
     allowCustomDependencies?: boolean; // upload only: approve custom-dependency uploads without prompting
     appSpace?: string; // upload only: space (slug or uuid) for data apps this run creates
@@ -195,6 +199,7 @@ export type DownloadHandlerOptions = {
     includeExternalConnections: boolean;
     includeAll: boolean;
     appsOnly?: boolean; // download: implies skipCharts + skipDashboards + skipSpaces; upload: apps-only filtered run
+    chartTypesOnly?: boolean; // download: implies skipCharts + skipDashboards + skipSpaces; upload: chart-types-only filtered run
     stripPivotSeries: boolean; // Strip per-value pivot series config for portable chart YAML
     validate?: boolean; // Validate charts and dashboards after upload
     concurrency: number;
@@ -228,6 +233,7 @@ const hasContentFilters = ({
     virtualViews,
     externalConnections,
     apps,
+    chartTypes,
 }: Pick<
     DownloadHandlerOptions,
     | 'spacesOnly'
@@ -240,6 +246,7 @@ const hasContentFilters = ({
     | 'virtualViews'
     | 'externalConnections'
     | 'apps'
+    | 'chartTypes'
 >): boolean =>
     !spacesOnly &&
     [
@@ -252,6 +259,7 @@ const hasContentFilters = ({
         virtualViews,
         externalConnections,
         apps ?? [],
+        chartTypes ?? [],
     ].some((filters) => filters.length > 0);
 
 /*
@@ -1728,6 +1736,12 @@ export const downloadHandler = async (
 
     const isOrganizationDownload = options.organization === true;
 
+    if (options.appsOnly && options.chartTypesOnly) {
+        throw new ParameterError(
+            '--apps-only cannot be combined with --chart-types-only.',
+        );
+    }
+
     // Bare --apps-only means "all apps": imply --include-apps.
     if (
         options.appsOnly &&
@@ -1737,16 +1751,43 @@ export const downloadHandler = async (
     ) {
         options.includeApps = true;
     }
+    // Bare --chart-types-only means "all chart types" likewise.
+    if (
+        options.chartTypesOnly &&
+        options.chartTypes === undefined &&
+        options.includeChartTypes !== true &&
+        options.includeAll !== true
+    ) {
+        options.includeChartTypes = true;
+    }
 
     const includeAll = options.includeAll === true;
     const includeApps =
-        !options.spacesOnly && (options.includeApps === true || includeAll);
+        !options.spacesOnly &&
+        !options.chartTypesOnly &&
+        (options.includeApps === true || includeAll);
+    const includeChartTypes =
+        !options.spacesOnly &&
+        !options.appsOnly &&
+        (options.includeChartTypes === true || includeAll);
     const includeAllOptionalContent =
-        includeAll && !options.appsOnly && !options.spacesOnly;
+        includeAll &&
+        !options.appsOnly &&
+        !options.chartTypesOnly &&
+        !options.spacesOnly;
     const { limit: appsLimit, noEffectWarning: appsLimitWarning } =
         resolveAppsLimit(options.appsLimit, includeApps);
     if (appsLimitWarning) {
         GlobalState.log(styles.warning(appsLimitWarning));
+    }
+    const { limit: chartTypesLimit, noEffectWarning: chartTypesLimitWarning } =
+        resolveAppsLimit(options.chartTypesLimit, includeChartTypes, {
+            limitFlag: '--chart-types-limit',
+            includeFlag: '--include-chart-types',
+            refsFlag: '--chart-types',
+        });
+    if (chartTypesLimitWarning) {
+        GlobalState.log(styles.warning(chartTypesLimitWarning));
     }
 
     if (options.appsOnly) {
@@ -1759,6 +1800,31 @@ export const downloadHandler = async (
                 'Nothing to download: --apps-only requires --apps <appReferences...>, --include-apps, or --include-all.',
             );
         }
+        options.chartTypes = undefined;
+        options.skipCharts = true;
+        options.skipDashboards = true;
+        options.skipSpaces = true;
+        options.includeAgents = false;
+        options.includeAlerts = false;
+        options.includeGoogleSheets = false;
+        options.includeScheduledDeliveries = false;
+        options.includeVirtualViews = false;
+        options.includeExternalConnections = false;
+    }
+
+    if (options.chartTypesOnly) {
+        const chartTypesOnlySelection = selectAppsToDownload({
+            apps: Array.isArray(options.chartTypes)
+                ? options.chartTypes
+                : undefined,
+            includeApps: includeChartTypes,
+        });
+        if (chartTypesOnlySelection.mode === 'none') {
+            throw new ParameterError(
+                'Nothing to download: --chart-types-only requires --chart-types <chartTypeReferences...>, --include-chart-types, or --include-all.',
+            );
+        }
+        options.apps = undefined;
         options.skipCharts = true;
         options.skipDashboards = true;
         options.skipSpaces = true;
@@ -1781,6 +1847,7 @@ export const downloadHandler = async (
         options.agents = [];
         options.alerts = [];
         options.apps = [];
+        options.chartTypes = [];
         options.googleSheets = [];
         options.scheduledDeliveries = [];
         options.virtualViews = [];
@@ -1875,6 +1942,8 @@ export const downloadHandler = async (
         // Shared across both apps-download steps so two different apps whose
         // names collide under the pre-slug fallback naming don't clobber each other.
         const downloadedAppFolders = new Set<string>();
+        // Chart types live in their own folder, so they track their own names.
+        const downloadedChartTypeFolders = new Set<string>();
         // App slugs referenced by downloaded dashboards' tiles, populated by
         // the Dashboards step and consumed by the Linked data apps step.
         let dashboardAppSlugs: string[] = [];
@@ -2303,38 +2372,48 @@ export const downloadHandler = async (
                 const baseDir = getDownloadFolder(options.path);
                 const appsDir = path.join(baseDir, 'apps');
 
-                const { successCount, skippedNotBuiltCount, failures } =
-                    await downloadAppsToDir({
-                        appRefs: appRefsToDownload,
-                        projectId,
-                        appsDir,
-                        takenFolders: downloadedAppFolders,
-                        cliVersion: CLI_VERSION,
-                        fetchApp: (fetchProjectId, appRef) =>
-                            lightdashApi<DataAppCodeDownload>({
-                                method: 'GET',
-                                url: `/api/v1/ee/projects/${fetchProjectId}/apps/${encodeURIComponent(
-                                    appRef,
-                                )}/download`,
-                                body: undefined,
-                            }),
-                        onProgress: (processed, total) =>
-                            output.updateActive(
-                                `${processed} of ${total} processed`,
-                            ),
-                    });
+                const {
+                    successCount,
+                    skippedNotBuiltCount,
+                    skippedWrongKindCount,
+                    failures,
+                } = await downloadAppsToDir({
+                    appRefs: appRefsToDownload,
+                    projectId,
+                    appsDir,
+                    takenFolders: downloadedAppFolders,
+                    cliVersion: CLI_VERSION,
+                    fetchApp: (fetchProjectId, appRef) =>
+                        lightdashApi<DataAppCodeDownload>({
+                            method: 'GET',
+                            url: `/api/v1/ee/projects/${fetchProjectId}/apps/${encodeURIComponent(
+                                appRef,
+                            )}/download`,
+                            body: undefined,
+                        }),
+                    skipBundle: (manifest) =>
+                        manifest.template === DATA_APP_VIZ_TEMPLATE
+                            ? 'this is a custom chart type — download it with --chart-types or --include-chart-types'
+                            : null,
+                    onProgress: (processed, total) =>
+                        output.updateActive(
+                            `${processed} of ${total} processed`,
+                        ),
+                });
 
                 const summary = appsDownloadSummary(
                     successCount,
                     appRefsToDownload.length,
                     failures,
                     appsDir,
-                    skippedNotBuiltCount,
+                    skippedNotBuiltCount + skippedWrongKindCount,
                 );
                 output.completeItem(
                     `${successCount} downloaded${
-                        skippedNotBuiltCount > 0
-                            ? `, ${skippedNotBuiltCount} skipped`
+                        skippedNotBuiltCount + skippedWrongKindCount > 0
+                            ? `, ${
+                                  skippedNotBuiltCount + skippedWrongKindCount
+                              } skipped`
                             : ''
                     }${
                         failures.length > 0 ? `, ${failures.length} failed` : ''
@@ -2343,6 +2422,162 @@ export const downloadHandler = async (
                 );
                 if (!summary.ok) {
                     summary.failureLines.forEach((line) =>
+                        GlobalState.log(styles.warning(line)),
+                    );
+                }
+            }
+        }
+
+        // Download custom chart types (enterprise, opt-in via --chart-types /
+        // --include-chart-types / --include-all) into chart-types/, kept
+        // separate from data apps.
+        const chartTypesSelection = selectAppsToDownload({
+            apps: Array.isArray(options.chartTypes)
+                ? options.chartTypes
+                : undefined,
+            includeApps: includeChartTypes,
+        });
+        if (chartTypesSelection.mode !== 'none') {
+            output.startItem('Custom chart types');
+            let chartTypeRefsToDownload: string[];
+            let chartTypeListingError: string | null = null;
+
+            if (chartTypesSelection.mode === 'explicit') {
+                chartTypeRefsToDownload = chartTypesSelection.appRefs;
+            } else {
+                output.updateActive('listing project chart types…');
+                let listedChartTypes: ListedApp[] = [];
+                try {
+                    const projectChartTypes = await lightdashApi<
+                        ApiEmbedProjectAppsResponse['results']
+                    >({
+                        method: 'GET',
+                        url: `/api/v1/ee/projects/${projectId}/apps?dataAppVizsFilter=only`,
+                        body: undefined,
+                    });
+                    // Old servers ignore the filter and return every app
+                    // without a template field — there is no way to tell
+                    // chart types apart, so list nothing rather than filing
+                    // data apps under chart-types/.
+                    listedChartTypes = projectChartTypes
+                        .filter((app) => app.template === DATA_APP_VIZ_TEMPLATE)
+                        .map((app) => ({
+                            appUuid: app.appUuid,
+                            slug: app.slug,
+                        }));
+                    if (
+                        listedChartTypes.length === 0 &&
+                        projectChartTypes.length > 0
+                    ) {
+                        GlobalState.log(
+                            styles.warning(
+                                'This server does not support listing custom chart types; pass explicit --chart-types references or upgrade the server.',
+                            ),
+                        );
+                    }
+                } catch (listErr) {
+                    if (shouldFallBackToSpaceScopedListing(listErr)) {
+                        // Servers without the project-wide apps endpoint
+                        // predate custom chart types entirely.
+                        listedChartTypes = [];
+                    } else if (includeAllOptionalContent) {
+                        chartTypeListingError = getErrorMessage(listErr);
+                        listedChartTypes = [];
+                    } else {
+                        throw listErr;
+                    }
+                }
+
+                const {
+                    appUuids: cappedChartTypeUuids,
+                    truncatedCount: chartTypesTruncated,
+                } = capListedApps(
+                    listedChartTypes.map((chartType) => chartType.appUuid),
+                    chartTypesLimit,
+                );
+                if (chartTypesTruncated > 0) {
+                    GlobalState.log(
+                        styles.warning(
+                            `Found ${listedChartTypes.length} custom chart types, downloading the first ${chartTypesLimit}. Pass --chart-types-limit <n> to raise the cap.`,
+                        ),
+                    );
+                }
+                chartTypeRefsToDownload = [
+                    ...new Set([
+                        ...cappedChartTypeUuids,
+                        ...chartTypesSelection.extraAppRefs,
+                    ]),
+                ];
+            }
+
+            if (chartTypeRefsToDownload.length === 0) {
+                if (chartTypeListingError === null) {
+                    output.completeItem('0 found');
+                } else {
+                    output.completeItem(
+                        `listing failed: ${chartTypeListingError}`,
+                        'warning',
+                    );
+                }
+            } else {
+                output.updateActive(
+                    `0 of ${chartTypeRefsToDownload.length} downloaded`,
+                );
+                const chartTypesDir = path.join(
+                    getDownloadFolder(options.path),
+                    'chart-types',
+                );
+
+                const chartTypesOutcome = await downloadAppsToDir({
+                    appRefs: chartTypeRefsToDownload,
+                    projectId,
+                    appsDir: chartTypesDir,
+                    takenFolders: downloadedChartTypeFolders,
+                    cliVersion: CLI_VERSION,
+                    fetchApp: (fetchProjectId, appRef) =>
+                        lightdashApi<DataAppCodeDownload>({
+                            method: 'GET',
+                            url: `/api/v1/ee/projects/${fetchProjectId}/apps/${encodeURIComponent(
+                                appRef,
+                            )}/download`,
+                            body: undefined,
+                        }),
+                    skipBundle: (manifest) =>
+                        manifest.template !== DATA_APP_VIZ_TEMPLATE
+                            ? 'this is a data app — download it with --apps or --include-apps'
+                            : null,
+                    onProgress: (processed, total) =>
+                        output.updateActive(
+                            `${processed} of ${total} processed`,
+                        ),
+                });
+
+                const chartTypesSummary = appsDownloadSummary(
+                    chartTypesOutcome.successCount,
+                    chartTypeRefsToDownload.length,
+                    chartTypesOutcome.failures,
+                    chartTypesDir,
+                    chartTypesOutcome.skippedNotBuiltCount +
+                        chartTypesOutcome.skippedWrongKindCount,
+                    'custom chart type',
+                );
+                const chartTypesSkipped =
+                    chartTypesOutcome.skippedNotBuiltCount +
+                    chartTypesOutcome.skippedWrongKindCount;
+                output.completeItem(
+                    `${chartTypesOutcome.successCount} downloaded${
+                        chartTypesSkipped > 0
+                            ? `, ${chartTypesSkipped} skipped`
+                            : ''
+                    }${
+                        chartTypesOutcome.failures.length > 0
+                            ? `, ${chartTypesOutcome.failures.length} failed`
+                            : ''
+                    }`,
+                    chartTypesSummary.ok ? undefined : 'warning',
+                );
+                if (!chartTypesSummary.ok) {
+                    chartTypesSummary.failureLines.forEach((line) =>
                         GlobalState.log(styles.warning(line)),
                     );
                 }
@@ -2374,21 +2609,26 @@ export const downloadHandler = async (
                         )}/download`,
                         body: undefined,
                     }),
+                // Dashboard data-app tiles reference apps, never chart types.
+                skipBundle: (manifest) =>
+                    manifest.template === DATA_APP_VIZ_TEMPLATE
+                        ? 'this is a custom chart type — dashboard app tiles cannot reference it'
+                        : null,
                 onProgress: (processed, total) =>
                     output.updateActive(`${processed} of ${total} processed`),
             });
+            const linkedSkipped =
+                outcome.skippedNotBuiltCount + outcome.skippedWrongKindCount;
             const linkedSummary = appsDownloadSummary(
                 outcome.successCount,
                 linkedAppSlugs.length,
                 outcome.failures,
                 appsDir,
-                outcome.skippedNotBuiltCount,
+                linkedSkipped,
             );
             output.completeItem(
                 `${outcome.successCount} downloaded${
-                    outcome.skippedNotBuiltCount > 0
-                        ? `, ${outcome.skippedNotBuiltCount} skipped`
-                        : ''
+                    linkedSkipped > 0 ? `, ${linkedSkipped} skipped` : ''
                 }${
                     outcome.failures.length > 0
                         ? `, ${outcome.failures.length} failed`

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -954,6 +954,25 @@ const downloadCommand = program
         false,
     )
     .option(
+        '--chart-types <chartTypeReferences...>',
+        'Download only the specified custom chart types, by slug, URL, or UUID (enterprise).',
+    )
+    .option(
+        '--include-chart-types',
+        "Include all of the project's custom chart types (enterprise), capped at --chart-types-limit (default: 50)",
+        false,
+    )
+    .option(
+        '--chart-types-limit <number>',
+        'Maximum number of custom chart types downloaded by --include-chart-types or --include-all (default: 50)',
+        undefined,
+    )
+    .option(
+        '--chart-types-only',
+        "Download only custom chart types (implies --skip-charts --skip-dashboards --skip-spaces). Bare --chart-types-only downloads all the project's chart types; pass --chart-types <chartTypeReferences...> to select.",
+        false,
+    )
+    .option(
         '--organization',
         'download all organization-scoped resources, including Data App themes, without selecting a project',
         false,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -962,6 +962,25 @@ const downloadCommand = program
         false,
     )
     .option(
+        '--chart-types <chartTypeReferences...>',
+        'Download only the specified custom chart types, by slug, URL, or UUID (enterprise).',
+    )
+    .option(
+        '--include-chart-types',
+        "Include all of the project's custom chart types (enterprise), capped at --chart-types-limit (default: 50)",
+        false,
+    )
+    .option(
+        '--chart-types-limit <number>',
+        'Maximum number of custom chart types downloaded by --include-chart-types or --include-all (default: 50)',
+        undefined,
+    )
+    .option(
+        '--chart-types-only',
+        "Download only custom chart types (implies --skip-charts --skip-dashboards --skip-spaces). Bare --chart-types-only downloads all the project's chart types; pass --chart-types <chartTypeReferences...> to select.",
+        false,
+    )
+    .option(
         '--organization',
         'download all organization-scoped resources, including Data App themes, without selecting a project',
         false,


### PR DESCRIPTION
First half of the chart-types-as-code split (GLITCH-684): \`lightdash download\` now treats custom chart types as their own entity, never bundled with data apps.

- New flags: \`--chart-types <refs...>\`, \`--include-chart-types\`, \`--chart-types-limit\` (default 50), \`--chart-types-only\` — mirroring the \`--apps\` family. \`--include-all\` covers both kinds.
- Chart types download into \`lightdash/chart-types/<slug>/\` (same bundle format — manifest already round-trips \`template\` + \`vizSchema\`).
- The chart-types listing calls the dedicated \`GET /apps/chart-types\` endpoint (added in #27857); a 404 means the server predates the split — the CLI warns and only explicit references work. \`--include-apps\` no longer picks up chart types (the apps listing excludes them server-side).
- Post-fetch kind guard (\`skipBundle\`): a bundle fetched through the wrong flag family is skipped with a pointer to the right one, instead of silently filed into the wrong folder. Applies to the apps, chart types, and linked-apps phases.

Upload-side split lands in the next PR of the stack.

Test plan: CLI typecheck; \`appsDownload\`/\`download\` suites pass (604 tests) incl. a \`skipBundle\` test; live smoke test against local dev (download into \`chart-types/\`, \`--apps-only\` unaffected, upload round-trip \`unchanged\`).

Relates: GLITCH-684
Relates: #27855

🤖 Generated with [Claude Code](https://claude.com/claude-code)