### PR TITLE
feat(coder): portable chart-type slug in charts-as-code viz bindings

### DIFF
--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -505,26 +505,32 @@ export class AppModel {
     async findAppsBySlugs(
         projectUuid: string,
         slugs: string[],
+        options: { dataAppVizsFilter?: DataAppVizsFilter } = {},
     ): Promise<Pick<DbApp, 'app_id' | 'slug'>[]> {
         if (slugs.length === 0) return [];
-        return this.database(AppsTableName)
+        const query = this.database(AppsTableName)
             .select('app_id', 'slug')
             .where('project_uuid', projectUuid)
             .whereIn('slug', slugs)
             .whereNull('deleted_at');
+        AppModel.applyDataAppVizsFilter(query, options.dataAppVizsFilter);
+        return query;
     }
 
     /** Batch uuid filter, for legacy content-as-code tiles that predate app slugs. */
     async findAppsByUuids(
         projectUuid: string,
         appUuids: string[],
+        options: { dataAppVizsFilter?: DataAppVizsFilter } = {},
     ): Promise<Pick<DbApp, 'app_id' | 'slug'>[]> {
         if (appUuids.length === 0) return [];
-        return this.database(AppsTableName)
+        const query = this.database(AppsTableName)
             .select('app_id', 'slug')
             .where('project_uuid', projectUuid)
             .whereIn('app_id', appUuids)
             .whereNull('deleted_at');
+        AppModel.applyDataAppVizsFilter(query, options.dataAppVizsFilter);
+        return query;
     }
 
     /**

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -1644,4 +1644,140 @@ describe('CoderService', () => {
             ]);
         });
     });
+
+    describe('withDataAppVizSlugs', () => {
+        const { withDataAppVizSlugs } = CoderService as unknown as {
+            withDataAppVizSlugs: (
+                charts: AnyType[],
+                slugByUuid: Map<string, string>,
+            ) => AnyType[];
+        };
+
+        it('stamps the viz slug into DATA_APP_VIZ chart configs', () => {
+            const charts = [
+                {
+                    slug: 'viz-chart',
+                    chartConfig: {
+                        type: ChartType.DATA_APP_VIZ,
+                        config: {
+                            dataAppVizUuid: 'viz-uuid',
+                            fieldMapping: {},
+                        },
+                    },
+                },
+                {
+                    slug: 'bar-chart',
+                    chartConfig: { type: ChartType.CARTESIAN, config: {} },
+                },
+            ];
+            const result = withDataAppVizSlugs(
+                charts,
+                new Map([['viz-uuid', 'my-chart-type']]),
+            );
+            expect(result[0].chartConfig.config.dataAppVizSlug).toBe(
+                'my-chart-type',
+            );
+            expect(result[1]).toBe(charts[1]);
+        });
+
+        it('leaves the config untouched when the viz uuid is unknown', () => {
+            const charts = [
+                {
+                    slug: 'viz-chart',
+                    chartConfig: {
+                        type: ChartType.DATA_APP_VIZ,
+                        config: {
+                            dataAppVizUuid: 'gone-uuid',
+                            fieldMapping: {},
+                        },
+                    },
+                },
+            ];
+            const result = withDataAppVizSlugs(charts, new Map());
+            expect(result[0]).toBe(charts[0]);
+        });
+    });
+
+    describe('resolveDataAppVizBinding', () => {
+        const buildResolver = (
+            findAppsBySlugs:
+                | ReturnType<typeof vi.fn>
+                | ((...args: AnyType[]) => AnyType),
+        ) => {
+            const warn = vi.fn();
+            const service = {
+                appModel: { findAppsBySlugs },
+                logger: { warn },
+                resolveDataAppVizBinding: (CoderService.prototype as AnyType)
+                    .resolveDataAppVizBinding,
+            } as AnyType;
+            return { service, warn };
+        };
+
+        it('resolves the slug to this project uuid and strips it', async () => {
+            const { service } = buildResolver(
+                vi
+                    .fn()
+                    .mockResolvedValue([
+                        { app_id: 'target-viz-uuid', slug: 'my-chart-type' },
+                    ]),
+            );
+            const result = await service.resolveDataAppVizBinding('proj', {
+                type: ChartType.DATA_APP_VIZ,
+                config: {
+                    dataAppVizUuid: 'source-viz-uuid',
+                    dataAppVizSlug: 'my-chart-type',
+                    fieldMapping: { x: 'field_x' },
+                },
+            });
+            expect(result.config).toEqual({
+                dataAppVizUuid: 'target-viz-uuid',
+                fieldMapping: { x: 'field_x' },
+            });
+            expect(service.appModel.findAppsBySlugs).toHaveBeenCalledWith(
+                'proj',
+                ['my-chart-type'],
+                { dataAppVizsFilter: 'only' },
+            );
+        });
+
+        it('keeps the original uuid (slug stripped) when the slug is missing in the project', async () => {
+            const { service, warn } = buildResolver(
+                vi.fn().mockResolvedValue([]),
+            );
+            const result = await service.resolveDataAppVizBinding('proj', {
+                type: ChartType.DATA_APP_VIZ,
+                config: {
+                    dataAppVizUuid: 'source-viz-uuid',
+                    dataAppVizSlug: 'gone-chart-type',
+                    fieldMapping: {},
+                },
+            });
+            expect(result.config).toEqual({
+                dataAppVizUuid: 'source-viz-uuid',
+                fieldMapping: {},
+            });
+            expect(warn).toHaveBeenCalled();
+        });
+
+        it('passes non-viz and slug-less configs through untouched', async () => {
+            const findAppsBySlugs = vi.fn();
+            const { service } = buildResolver(findAppsBySlugs);
+            const cartesian = {
+                type: ChartType.CARTESIAN,
+                config: {},
+            };
+            expect(
+                await service.resolveDataAppVizBinding('proj', cartesian),
+            ).toBe(cartesian);
+            const legacyViz = {
+                type: ChartType.DATA_APP_VIZ,
+                config: { dataAppVizUuid: 'viz-uuid', fieldMapping: {} },
+            };
+            expect(
+                await service.resolveDataAppVizBinding('proj', legacyViz),
+            ).toBe(legacyViz);
+            expect(findAppsBySlugs).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -21,6 +21,7 @@ import {
     ChartGoogleSheetsSyncAsCode,
     ChartScheduledDeliveryAsCode,
     ChartSummary,
+    ChartType,
     ContentAsCodeType,
     ContentSlugRenameRequest,
     ContentType,
@@ -2127,6 +2128,75 @@ export class CoderService extends BaseService {
         };
     }
 
+    /** Stamp each DATA_APP_VIZ chart's config with its viz's portable slug. */
+    private static withDataAppVizSlugs(
+        charts: ChartAsCode[],
+        dataAppVizSlugByUuid: ReadonlyMap<string, string>,
+    ): ChartAsCode[] {
+        return charts.map((chart) => {
+            if (
+                chart.chartConfig.type !== ChartType.DATA_APP_VIZ ||
+                chart.chartConfig.config === undefined
+            ) {
+                return chart;
+            }
+            const dataAppVizSlug = dataAppVizSlugByUuid.get(
+                chart.chartConfig.config.dataAppVizUuid,
+            );
+            if (dataAppVizSlug === undefined) {
+                return chart;
+            }
+            return {
+                ...chart,
+                chartConfig: {
+                    ...chart.chartConfig,
+                    config: {
+                        ...chart.chartConfig.config,
+                        dataAppVizSlug,
+                    },
+                },
+            };
+        });
+    }
+
+    /**
+     * Charts on a custom chart type carry a portable dataAppVizSlug in YAML;
+     * resolve it against the target project's chart types and rewrite the
+     * config with the resolved uuid, stripping the slug (it is content-as-code
+     * identity only, never persisted). Unresolvable references upload as-is —
+     * the chart renders the viz-not-found state until the chart type arrives.
+     */
+    private async resolveDataAppVizBinding(
+        projectUuid: string,
+        chartConfig: ChartAsCode['chartConfig'],
+    ): Promise<ChartAsCode['chartConfig']> {
+        if (
+            chartConfig.type !== ChartType.DATA_APP_VIZ ||
+            chartConfig.config === undefined
+        ) {
+            return chartConfig;
+        }
+        const { dataAppVizSlug, ...configWithoutSlug } = chartConfig.config;
+        if (dataAppVizSlug === undefined) {
+            return chartConfig;
+        }
+        const [vizRow] = await this.appModel.findAppsBySlugs(
+            projectUuid,
+            [dataAppVizSlug],
+            { dataAppVizsFilter: 'only' },
+        );
+        if (vizRow === undefined) {
+            this.logger.warn(
+                `Chart type "${dataAppVizSlug}" was not found in project ${projectUuid}; keeping the chart's existing dataAppVizUuid reference.`,
+            );
+            return { ...chartConfig, config: configWithoutSlug };
+        }
+        return {
+            ...chartConfig,
+            config: { ...configWithoutSlug, dataAppVizUuid: vizRow.app_id },
+        };
+    }
+
     async getCharts(
         user: SessionUser,
         projectUuid: string,
@@ -2219,13 +2289,37 @@ export class CoderService extends BaseService {
             this.savedChartModel.getSlugAliasesForUuids(chartUuids),
         ]);
 
-        const transformedCharts = charts.map((chart) =>
-            CoderService.transformChart(
-                chart,
-                spaces,
-                dashboards,
-                chartVerificationMap,
+        // Charts on a custom chart type reference it by uuid at runtime;
+        // stamp the viz's project-scoped slug into the YAML so the binding
+        // stays portable across projects.
+        const dataAppVizUuids = charts.reduce<string[]>((acc, chart) => {
+            if (
+                chart.chartConfig.type === ChartType.DATA_APP_VIZ &&
+                chart.chartConfig.config?.dataAppVizUuid
+            ) {
+                acc.push(chart.chartConfig.config.dataAppVizUuid);
+            }
+            return acc;
+        }, []);
+        const dataAppVizRows = await this.appModel.findAppsByUuids(
+            projectUuid,
+            [...new Set(dataAppVizUuids)],
+            { dataAppVizsFilter: 'only' },
+        );
+        const dataAppVizSlugByUuid = new Map(
+            dataAppVizRows.map((row) => [row.app_id, row.slug]),
+        );
+
+        const transformedCharts = CoderService.withDataAppVizSlugs(
+            charts.map((chart) =>
+                CoderService.transformChart(
+                    chart,
+                    spaces,
+                    dashboards,
+                    chartVerificationMap,
+                ),
             ),
+            dataAppVizSlugByUuid,
         );
 
         const missingIds = CoderService.getMissingIds(
@@ -2657,6 +2751,11 @@ export class CoderService extends BaseService {
             ...chartAsCode,
             updatedAt: chartAsCode.updatedAt ?? new Date(),
             tableConfig: chartAsCode.tableConfig ?? { columnOrder: [] },
+            // Portable chart-type slug → this project's viz uuid (slug stripped)
+            chartConfig: await this.resolveDataAppVizBinding(
+                projectUuid,
+                chartAsCode.chartConfig,
+            ),
             metricQuery: {
                 ...chartAsCode.metricQuery,
                 filters: normalizeFilterIds(chartAsCode.metricQuery.filters),

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -795,6 +795,13 @@ export type DataAppVizOptionValues = Record<string, DataAppVizOptionValue>;
 export type DataAppVizChart = {
     /** The reusable data app viz this chart renders with (by reference). */
     dataAppVizUuid: string;
+    /**
+     * Content-as-code only: the viz's project-scoped slug, emitted on chart
+     * download and resolved back to dataAppVizUuid (then stripped) on upload
+     * so chart YAML stays portable across projects. Never persisted and
+     * never used at render time — dataAppVizUuid is the runtime identity.
+     */
+    dataAppVizSlug?: string;
     fieldMapping: DataAppVizFieldMapping;
     /**
      * Only options the user explicitly changed — declared defaults are never

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
@@ -5,8 +5,16 @@ import {
 } from '@lightdash/common';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
-/** The chart's binding to a picked viz; null while it points at none. */
-export type SelectedDataAppViz = Required<DataAppVizChart>;
+/**
+ * The chart's binding to a picked viz; null while it points at none.
+ * Deliberately not Required<DataAppVizChart>: the as-code-only
+ * dataAppVizSlug never participates in runtime state.
+ */
+export type SelectedDataAppViz = Pick<
+    DataAppVizChart,
+    'dataAppVizUuid' | 'fieldMapping'
+> &
+    Required<Pick<DataAppVizChart, 'optionValues'>>;
 
 export interface DataAppVizVisualizationConfigAndData {
     validConfig: SelectedDataAppViz | null;


### PR DESCRIPTION
Charts on a custom chart type bind to it via a raw \`dataAppVizUuid\` in \`chartConfig\`, which charts-as-code serialized verbatim — so a chart YAML uploaded to another project (or instance) pointed at a viz UUID that doesn't exist there, and the chart rendered the not-found state forever.

This makes the binding portable, mirroring the dashboard data-app tile \`appSlug\` pattern:

- \`DataAppVizChart\` gains \`dataAppVizSlug\` — **content-as-code only**: emitted on chart download, resolved back to the target project's viz UUID on upload, then stripped. Never persisted and never used at render time, so a stale slug can't mislead (download always re-derives it from the runtime UUID).
- Download (\`CoderService.getCharts\`): batch-resolves viz UUIDs → slugs (template-filtered via \`dataAppVizsFilter: 'only'\`, so a data-app row can never satisfy a viz binding) and stamps them into the YAML.
- Upload (\`CoderService.upsertChart\`): resolves the slug in the target project and rewrites \`dataAppVizUuid\`. A slug missing in the target logs a warning and uploads the chart with its original UUID — the chart renders the viz-not-found state until the chart type is uploaded (pairs with the CLI chart-types-as-code split in this stack).
- \`AppModel.findAppsBySlugs\`/\`findAppsByUuids\` accept the shared \`dataAppVizsFilter\` option (existing callers unchanged).

Test plan: new unit tests for the stamping helper and the resolve/strip behavior (48 pass in \`CoderService.test.ts\`); common + backend typecheck.

Relates: PROD-10449
Relates: #27856

🤖 Generated with [Claude Code](https://claude.com/claude-code)