### PR TITLE
fix(previews): remap chart viz bindings when duplicating chart types into previews

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7732,6 +7732,13 @@ export class AppGenerateService extends BaseService {
             previewProjectUuid,
             mappings,
         );
+        // Same for charts on a custom chart type — their copied chart_config
+        // still references the upstream viz uuid, which is invisible to the
+        // preview's project-scoped viz render endpoints.
+        await this.appModel.remapPreviewChartVizBindings(
+            previewProjectUuid,
+            mappings,
+        );
 
         this.logger.info(
             `Preview duplication: copied ${mappings.length}/${sourceApps.length} data app(s) from project ${sourceProjectUuid} into preview ${previewProjectUuid}`,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7734,6 +7734,13 @@ export class AppGenerateService extends BaseService {
             previewProjectUuid,
             mappings,
         );
+        // Same for charts on a custom chart type — their copied chart_config
+        // still references the upstream viz uuid, which is invisible to the
+        // preview's project-scoped viz render endpoints.
+        await this.appModel.remapPreviewChartVizBindings(
+            previewProjectUuid,
+            mappings,
+        );
 
         this.logger.info(
             `Preview duplication: copied ${mappings.length}/${sourceApps.length} data app(s) from project ${sourceProjectUuid} into preview ${previewProjectUuid}`,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -111,6 +111,7 @@ function buildService() {
         recordBuildNarration: vi.fn().mockResolvedValue(undefined),
         listAppsByProject: vi.fn().mockResolvedValue([sourceApp]),
         remapPreviewDashboardTileApps: vi.fn().mockResolvedValue(undefined),
+        remapPreviewChartVizBindings: vi.fn().mockResolvedValue(undefined),
     };
 
     const externalConnectionModel = {

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1,6 +1,7 @@
 import {
     AlreadyExistsError,
     APP_VERSION_CANCELLED_BY_USER,
+    ChartType,
     DATA_APP_VIZ_TEMPLATE,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
     generateSlug,
@@ -9,6 +10,7 @@ import {
     type AppVersionDependencies,
     type AppVersionResources,
     type AppVersionStatusHistoryEntryKind,
+    type ChartConfig,
     type DataAppActivityFilters,
     type DataAppGenerationUsage,
     type DataAppVizSchema,
@@ -39,6 +41,10 @@ import {
 import { OrganizationTableName } from '../database/entities/organizations';
 import { PinnedAppTableName } from '../database/entities/pinnedList';
 import { ProjectTableName } from '../database/entities/projects';
+import {
+    SavedChartsTableName,
+    SavedChartVersionsTableName,
+} from '../database/entities/savedCharts';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
@@ -1131,6 +1137,76 @@ export class AppModel {
                 .where('app_uuid', sourceAppUuid)
                 .whereIn('dashboard_version_id', previewVersionIds.clone())
                 .update({ app_uuid: previewAppUuid });
+        }
+        /* eslint-enable no-await-in-loop */
+    }
+
+    /**
+     * Repoint a preview project's DATA_APP_VIZ chart configs from the source
+     * (upstream) chart types they were copied with onto the preview's own
+     * duplicated ones. Covers both space charts and dashboard-scoped charts;
+     * scoped to the preview project so upstream charts — which carry the same
+     * dataAppVizUuid — are never touched.
+     */
+    async remapPreviewChartVizBindings(
+        previewProjectUuid: string,
+        mappings: { sourceAppUuid: string; previewAppUuid: string }[],
+    ): Promise<void> {
+        if (mappings.length === 0) {
+            return;
+        }
+        const spaceChartIds = this.database(SavedChartsTableName)
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${SavedChartsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, previewProjectUuid)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .select(`${SavedChartsTableName}.saved_query_id`);
+        const dashboardChartIds = this.database(SavedChartsTableName)
+            .innerJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${SavedChartsTableName}.dashboard_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${DashboardsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, previewProjectUuid)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .select(`${SavedChartsTableName}.saved_query_id`);
+
+        /* eslint-disable no-await-in-loop */
+        for (const { sourceAppUuid, previewAppUuid } of mappings) {
+            await this.database(SavedChartVersionsTableName)
+                .where('chart_type', ChartType.DATA_APP_VIZ)
+                .whereRaw(`chart_config->>'dataAppVizUuid' = ?`, [
+                    sourceAppUuid,
+                ])
+                .where((chartScope) => {
+                    void chartScope
+                        .whereIn('saved_query_id', spaceChartIds.clone())
+                        .orWhereIn('saved_query_id', dashboardChartIds.clone());
+                })
+                .update({
+                    chart_config: this.database.raw(
+                        `jsonb_set(chart_config, '{dataAppVizUuid}', to_jsonb(?::text))`,
+                        [previewAppUuid],
+                    ) as unknown as ChartConfig['config'],
+                });
         }
         /* eslint-enable no-await-in-loop */
     }

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1,6 +1,7 @@
 import {
     AlreadyExistsError,
     APP_VERSION_CANCELLED_BY_USER,
+    ChartType,
     DATA_APP_VIZ_TEMPLATE,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
     generateSlug,
@@ -9,6 +10,7 @@ import {
     type AppVersionDependencies,
     type AppVersionResources,
     type AppVersionStatusHistoryEntryKind,
+    type ChartConfig,
     type DataAppActivityFilters,
     type DataAppGenerationUsage,
     type DataAppVizSchema,
@@ -39,6 +41,10 @@ import {
 import { OrganizationTableName } from '../database/entities/organizations';
 import { PinnedAppTableName } from '../database/entities/pinnedList';
 import { ProjectTableName } from '../database/entities/projects';
+import {
+    SavedChartsTableName,
+    SavedChartVersionsTableName,
+} from '../database/entities/savedCharts';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
@@ -1154,6 +1160,76 @@ export class AppModel {
                 .where('app_uuid', sourceAppUuid)
                 .whereIn('dashboard_version_id', previewVersionIds.clone())
                 .update({ app_uuid: previewAppUuid });
+        }
+        /* eslint-enable no-await-in-loop */
+    }
+
+    /**
+     * Repoint a preview project's DATA_APP_VIZ chart configs from the source
+     * (upstream) chart types they were copied with onto the preview's own
+     * duplicated ones. Covers both space charts and dashboard-scoped charts;
+     * scoped to the preview project so upstream charts — which carry the same
+     * dataAppVizUuid — are never touched.
+     */
+    async remapPreviewChartVizBindings(
+        previewProjectUuid: string,
+        mappings: { sourceAppUuid: string; previewAppUuid: string }[],
+    ): Promise<void> {
+        if (mappings.length === 0) {
+            return;
+        }
+        const spaceChartIds = this.database(SavedChartsTableName)
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${SavedChartsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, previewProjectUuid)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .select(`${SavedChartsTableName}.saved_query_id`);
+        const dashboardChartIds = this.database(SavedChartsTableName)
+            .innerJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${SavedChartsTableName}.dashboard_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${DashboardsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, previewProjectUuid)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .select(`${SavedChartsTableName}.saved_query_id`);
+
+        /* eslint-disable no-await-in-loop */
+        for (const { sourceAppUuid, previewAppUuid } of mappings) {
+            await this.database(SavedChartVersionsTableName)
+                .where('chart_type', ChartType.DATA_APP_VIZ)
+                .whereRaw(`chart_config->>'dataAppVizUuid' = ?`, [
+                    sourceAppUuid,
+                ])
+                .where((chartScope) => {
+                    void chartScope
+                        .whereIn('saved_query_id', spaceChartIds.clone())
+                        .orWhereIn('saved_query_id', dashboardChartIds.clone());
+                })
+                .update({
+                    chart_config: this.database.raw(
+                        `jsonb_set(chart_config, '{dataAppVizUuid}', to_jsonb(?::text))`,
+                        [previewAppUuid],
+                    ) as unknown as ChartConfig['config'],
+                });
         }
         /* eslint-enable no-await-in-loop */
     }


### PR DESCRIPTION
Preview project duplication copies custom chart types into the preview and remaps dashboard *data-app tiles* onto the copies — but charts using a custom chart type kept their copied \`chartConfig.dataAppVizUuid\` pointing at the **upstream** viz. The preview's viz render endpoints are project-scoped and template-filtered, so those charts 404'd in the preview.

Adds \`AppModel.remapPreviewChartVizBindings\`, called from \`duplicateAppsForPreview\` right after the existing tile remap: rewrites \`chart_config.dataAppVizUuid\` (JSONB) on the preview project's \`saved_queries_versions\` rows — covering both space charts and dashboard-scoped charts — using the same source→preview app UUID mappings. Scoped to the preview project so upstream charts, which carry the same UUIDs, are never touched.

Test plan: \`vizSchemaCopy\` suite covers the duplication flow (154 tests pass across the affected suites); backend typecheck.

Closes: PROD-10449
Closes: #27856

🤖 Generated with [Claude Code](https://claude.com/claude-code)