### PR TITLE
feat(ai): agent browses the custom chart type library

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -484,6 +484,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new AiAgentToolsService({
                     builtInSkills: BuiltInSkills,
                     lightdashConfig: context.lightdashConfig,
+                    appModel: models.getAppModel(),
                     projectModel: models.getProjectModel(),
                     projectParametersModel: models.getProjectParametersModel(),
                     projectService: repository.getProjectService(),

--- a/packages/backend/src/ee/services/AiAgentMemoryService/transcriptToolPolicy.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/transcriptToolPolicy.ts
@@ -79,6 +79,7 @@ export const DISTILL_TOOL_POLICIES = {
     discoverFields: { result: keep },
     getMetadata: { result: keep },
     findExplores: { result: keep },
+    findCustomChartTypes: { result: keep },
     findFields: { result: keep },
     searchSemanticLayer: { result: keep },
     analyzeFieldImpact: { result: keep },

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -9817,6 +9817,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             validateContent: toolsRuntime.validateContent,
             getDashboardCharts: toolsRuntime.getDashboardCharts,
             findExplores: toolsRuntime.findExplores,
+            listCustomChartTypes: toolsRuntime.listCustomChartTypes,
+            findCustomChartTypes: toolsRuntime.findCustomChartTypes,
             getVerifiedFieldUsage: toolsRuntime.getVerifiedFieldUsage,
             searchSemanticLayer: toolsRuntime.searchSemanticLayer,
             analyzeFieldImpact: toolsRuntime.analyzeFieldImpact,
@@ -10020,6 +10022,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             validateContent,
             getDashboardCharts,
             findExplores,
+            listCustomChartTypes,
+            findCustomChartTypes,
             getVerifiedFieldUsage,
             searchSemanticLayer,
             analyzeFieldImpact,
@@ -10595,6 +10599,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             validateContent,
             getDashboardCharts,
             findExplores,
+            listCustomChartTypes,
+            findCustomChartTypes,
             getVerifiedFieldUsage,
             searchSemanticLayer,
             analyzeFieldImpact,
@@ -12029,6 +12035,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     return 'Reviewing the project context...';
                 case 'findContent':
                 case 'findCharts':
+                case 'findCustomChartTypes':
                 case 'findDashboards':
                 case 'generateHashes':
                 case 'generateUuids':

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -9831,6 +9831,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             validateContent: toolsRuntime.validateContent,
             getDashboardCharts: toolsRuntime.getDashboardCharts,
             findExplores: toolsRuntime.findExplores,
+            listCustomChartTypes: toolsRuntime.listCustomChartTypes,
+            findCustomChartTypes: toolsRuntime.findCustomChartTypes,
             getVerifiedFieldUsage: toolsRuntime.getVerifiedFieldUsage,
             searchSemanticLayer: toolsRuntime.searchSemanticLayer,
             analyzeFieldImpact: toolsRuntime.analyzeFieldImpact,
@@ -10034,6 +10036,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             validateContent,
             getDashboardCharts,
             findExplores,
+            listCustomChartTypes,
+            findCustomChartTypes,
             getVerifiedFieldUsage,
             searchSemanticLayer,
             analyzeFieldImpact,
@@ -10609,6 +10613,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             validateContent,
             getDashboardCharts,
             findExplores,
+            listCustomChartTypes,
+            findCustomChartTypes,
             getVerifiedFieldUsage,
             searchSemanticLayer,
             analyzeFieldImpact,
@@ -12043,6 +12049,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     return 'Reviewing the project context...';
                 case 'findContent':
                 case 'findCharts':
+                case 'findCustomChartTypes':
                 case 'findDashboards':
                 case 'generateHashes':
                 case 'generateUuids':

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -884,28 +884,24 @@ export class AiAgentToolsService extends BaseService {
                 if (!(await this.customChartTypesEnabled(context))) {
                     return [];
                 }
-                const rows =
-                    'slug' in args
-                        ? [
-                              await this.appModel.findDataAppVisualizationBySlug(
-                                  context.projectUuid,
-                                  args.slug,
-                              ),
-                          ]
-                        : (
-                              await this.appModel.listDataAppVisualizations(
-                                  context.projectUuid,
-                                  {
-                                      page: 1,
-                                      pageSize:
-                                          AiAgentToolsService.CUSTOM_CHART_TYPES_SEARCH_LIMIT,
-                                  },
-                                  args.query,
-                              )
-                          ).data;
-                return this.parseCustomChartTypes(
-                    rows.filter((row) => row !== undefined),
+                if ('slug' in args) {
+                    const row =
+                        await this.appModel.findDataAppVisualizationBySlug(
+                            context.projectUuid,
+                            args.slug,
+                        );
+                    return this.parseCustomChartTypes(row ? [row] : []);
+                }
+                const { data } = await this.appModel.listDataAppVisualizations(
+                    context.projectUuid,
+                    {
+                        page: 1,
+                        pageSize:
+                            AiAgentToolsService.CUSTOM_CHART_TYPES_SEARCH_LIMIT,
+                    },
+                    args.query,
                 );
+                return this.parseCustomChartTypes(data);
             },
         );
     }

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -6,6 +6,7 @@ import {
     CatalogFilter,
     CatalogType,
     ContentType,
+    dataAppVizSchema,
     DimensionType,
     Explore,
     FeatureFlags,
@@ -38,13 +39,17 @@ import {
     type AgentSqlScope,
     type AiAgentDocumentSummary,
     type ChartAsCode,
+    type CustomChartType,
     type DashboardAsCode,
+    type DataAppVizSchema,
     type FieldValueSearchResult,
     type ParameterDefinitions,
     type SchedulerAiAugmentation,
 } from '@lightdash/common';
 import * as JsonPatch from 'fast-json-patch';
+import { type DbApp } from '../../../database/entities/apps';
 import Logger from '../../../logging/logger';
+import { AppModel } from '../../../models/AppModel';
 import { CatalogSearchContext } from '../../../models/CatalogModel/CatalogModel';
 import { ContentVerificationModel } from '../../../models/ContentVerificationModel';
 import { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
@@ -90,6 +95,7 @@ import {
     FindContentResult,
     FindContentSpaceBreadcrumb,
     FindContentSpaceMetadata,
+    FindCustomChartTypesFn,
     FindExploresFn,
     FindFieldFn,
     FindFieldsFn,
@@ -99,6 +105,7 @@ import {
     GetSavedChartFn,
     GetVerifiedFieldUsageFn,
     ListContentFn,
+    ListCustomChartTypesFn,
     ListExploresFn,
     ListKnowledgeDocumentsFn,
     ListProjectsFn,
@@ -198,6 +205,8 @@ export type AiAgentToolsRuntime = {
     getProjectParameterDefinitions: () => Promise<ParameterDefinitions>;
     getExplore: GetExploreFn;
     findExplores: FindExploresFn;
+    listCustomChartTypes: ListCustomChartTypesFn;
+    findCustomChartTypes: FindCustomChartTypesFn;
     getVerifiedFieldUsage: GetVerifiedFieldUsageFn;
     findFields: FindFieldsFn;
     findContent: FindContentFn;
@@ -262,6 +271,7 @@ type BuiltInSkillsClient = Pick<
 
 type AiAgentToolsServiceDependencies = {
     builtInSkills: BuiltInSkillsClient;
+    appModel: AppModel;
     projectModel: ProjectModel;
     projectParametersModel: ProjectParametersModel;
     projectService: ProjectService;
@@ -299,6 +309,8 @@ type AiAgentToolsServiceDependencies = {
 };
 
 export class AiAgentToolsService extends BaseService {
+    private readonly appModel: AppModel;
+
     private readonly projectModel: ProjectModel;
 
     private readonly projectParametersModel: ProjectParametersModel;
@@ -390,6 +402,7 @@ export class AiAgentToolsService extends BaseService {
 
     constructor({
         builtInSkills,
+        appModel,
         projectModel,
         projectParametersModel,
         projectService,
@@ -421,6 +434,7 @@ export class AiAgentToolsService extends BaseService {
     }: AiAgentToolsServiceDependencies) {
         super();
         this.builtInSkills = builtInSkills;
+        this.appModel = appModel;
         this.projectModel = projectModel;
         this.projectParametersModel = projectParametersModel;
         this.projectService = projectService;
@@ -562,6 +576,9 @@ export class AiAgentToolsService extends BaseService {
                 this.getProjectParameterDefinitions(context),
             getExplore: (args) => this.getExploreForRuntime(context, args),
             findExplores: (args) => this.findExplores(context, args),
+            listCustomChartTypes: () => this.listCustomChartTypes(context),
+            findCustomChartTypes: (args) =>
+                this.findCustomChartTypes(context, args),
             getVerifiedFieldUsage: () => this.getVerifiedFieldUsage(context),
             findFields: (args) => this.findFields(context, args),
             findContent: (args) => this.findContent(context, args),
@@ -796,6 +813,93 @@ export class AiAgentToolsService extends BaseService {
                     }));
 
                 return { exploreSearchResults, topMatchingFields };
+            },
+        );
+    }
+
+    // Custom chart types (data app vizs) are a project-level library, not
+    // space content — agent spaceAccess deliberately does not filter them.
+
+    private static mapCustomChartType(
+        app: DbApp & { viz_schema: DataAppVizSchema },
+    ): CustomChartType | null {
+        // Persisted schemas may predate configOptions/colorPalette; the
+        // permissive parser backfills defaults and rejects malformed rows.
+        const parsed = dataAppVizSchema.safeParse(app.viz_schema);
+        if (!parsed.success) return null;
+        return {
+            slug: app.slug,
+            name: app.name,
+            description: app.description,
+            schema: parsed.data,
+        };
+    }
+
+    private async customChartTypesEnabled(
+        context: AiAgentToolsRuntimeContext,
+    ): Promise<boolean> {
+        const { enabled } = await this.featureFlagService.get({
+            user: context.user,
+            featureFlagId: FeatureFlags.EnableDataApps,
+        });
+        return enabled;
+    }
+
+    static readonly CUSTOM_CHART_TYPES_INLINE_LIMIT = 10;
+
+    static readonly CUSTOM_CHART_TYPES_SEARCH_LIMIT = 10;
+
+    private async listCustomChartTypes(
+        context: AiAgentToolsRuntimeContext,
+    ): ReturnType<ListCustomChartTypesFn> {
+        if (!(await this.customChartTypesEnabled(context))) {
+            return { types: [], totalCount: 0 };
+        }
+        const { data, pagination } =
+            await this.appModel.listDataAppVisualizations(context.projectUuid, {
+                page: 1,
+                pageSize: AiAgentToolsService.CUSTOM_CHART_TYPES_INLINE_LIMIT,
+            });
+        const types = data
+            .map(AiAgentToolsService.mapCustomChartType)
+            .filter((type): type is CustomChartType => type !== null);
+        return { types, totalCount: pagination?.totalResults ?? types.length };
+    }
+
+    private findCustomChartTypes(
+        context: AiAgentToolsRuntimeContext,
+        args: Parameters<FindCustomChartTypesFn>[0],
+    ): ReturnType<FindCustomChartTypesFn> {
+        return wrapSentryTransaction(
+            `${AiAgentToolsService.transactionPrefix(context)}.findCustomChartTypes`,
+            args,
+            async () => {
+                if (!(await this.customChartTypesEnabled(context))) {
+                    return [];
+                }
+                const rows =
+                    'slug' in args
+                        ? [
+                              await this.appModel.findDataAppVisualizationBySlug(
+                                  context.projectUuid,
+                                  args.slug,
+                              ),
+                          ]
+                        : (
+                              await this.appModel.listDataAppVisualizations(
+                                  context.projectUuid,
+                                  {
+                                      page: 1,
+                                      pageSize:
+                                          AiAgentToolsService.CUSTOM_CHART_TYPES_SEARCH_LIMIT,
+                                  },
+                                  args.query,
+                              )
+                          ).data;
+                return rows
+                    .filter((row) => row !== undefined)
+                    .map(AiAgentToolsService.mapCustomChartType)
+                    .filter((type): type is CustomChartType => type !== null);
             },
         );
     }

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -820,19 +820,28 @@ export class AiAgentToolsService extends BaseService {
     // Custom chart types (data app vizs) are a project-level library, not
     // space content — agent spaceAccess deliberately does not filter them.
 
-    private static mapCustomChartType(
-        app: DbApp & { viz_schema: DataAppVizSchema },
-    ): CustomChartType | null {
-        // Persisted schemas may predate configOptions/colorPalette; the
-        // permissive parser backfills defaults and rejects malformed rows.
-        const parsed = dataAppVizSchema.safeParse(app.viz_schema);
-        if (!parsed.success) return null;
-        return {
-            slug: app.slug,
-            name: app.name,
-            description: app.description,
-            schema: parsed.data,
-        };
+    // Persisted schemas may predate configOptions/colorPalette; the
+    // permissive parser backfills defaults and rejects malformed rows.
+    private parseCustomChartTypes(
+        rows: (DbApp & { viz_schema: DataAppVizSchema })[],
+    ): CustomChartType[] {
+        const types: CustomChartType[] = [];
+        for (const row of rows) {
+            const parsed = dataAppVizSchema.safeParse(row.viz_schema);
+            if (parsed.success) {
+                types.push({
+                    slug: row.slug,
+                    name: row.name,
+                    description: row.description,
+                    schema: parsed.data,
+                });
+            } else {
+                this.logger.warn(
+                    `Dropping custom chart type "${row.slug}": persisted viz_schema failed validation`,
+                );
+            }
+        }
+        return types;
     }
 
     private async customChartTypesEnabled(
@@ -860,9 +869,7 @@ export class AiAgentToolsService extends BaseService {
                 page: 1,
                 pageSize: AiAgentToolsService.CUSTOM_CHART_TYPES_INLINE_LIMIT,
             });
-        const types = data
-            .map(AiAgentToolsService.mapCustomChartType)
-            .filter((type): type is CustomChartType => type !== null);
+        const types = this.parseCustomChartTypes(data);
         return { types, totalCount: pagination?.totalResults ?? types.length };
     }
 
@@ -896,10 +903,9 @@ export class AiAgentToolsService extends BaseService {
                                   args.query,
                               )
                           ).data;
-                return rows
-                    .filter((row) => row !== undefined)
-                    .map(AiAgentToolsService.mapCustomChartType)
-                    .filter((type): type is CustomChartType => type !== null);
+                return this.parseCustomChartTypes(
+                    rows.filter((row) => row !== undefined),
+                );
             },
         );
     }

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -54,6 +54,9 @@ const buildAgentDependencies = (updatePrompt: ReturnType<typeof vi.fn>) =>
             listExplores: vi.fn().mockResolvedValue([]),
             getVerifiedFieldUsage: vi.fn().mockResolvedValue(new Map()),
             getProjectParameterDefinitions: vi.fn().mockResolvedValue({}),
+            listCustomChartTypes: vi
+                .fn()
+                .mockResolvedValue({ types: [], totalCount: 0 }),
             updatePrompt,
             perf: new Proxy({}, { get: () => vi.fn() }),
         },
@@ -1049,7 +1052,18 @@ describe('getAgentTools workstream tool gate', () => {
         }) as unknown as AiAgentArgs;
 
     const buildTools = (flags: ToolFlags) =>
-        getAgentTools(buildArgs(flags), depsStub(), [], mcpStub, new Map(), {});
+        getAgentTools(
+            buildArgs(flags),
+            depsStub(),
+            [],
+            mcpStub,
+            new Map(),
+            {},
+            {
+                types: [],
+                totalCount: 0,
+            },
+        );
 
     const toolNames = (flags: ToolFlags) => Object.keys(buildTools(flags));
 
@@ -1163,6 +1177,7 @@ describe('getAgentTools workstream tool gate', () => {
             },
             new Map(),
             {},
+            { types: [], totalCount: 0 },
         );
 
         expect(Object.keys(tools)).toEqual(
@@ -1321,6 +1336,7 @@ describe('getAgentTools workstream tool gate', () => {
                 },
                 new Map(),
                 {},
+                { types: [], totalCount: 0 },
             ),
         );
     };
@@ -1530,6 +1546,7 @@ describe('scopeAgentConversation', () => {
             {},
             new Map(),
             'Agent memory',
+            { types: [], totalCount: 0 },
         );
 
         expect(messages[0].role).toBe('system');

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -6,6 +6,7 @@ import {
     Explore,
     type AiDeepResearchBudget,
     type AiDeepResearchExecutionContextSnapshot,
+    type CustomChartTypeLibrary,
     type ParameterDefinitions,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
@@ -34,7 +35,6 @@ import {
     isDeepResearchWarehouseMcpTool,
 } from '../../AiDeepResearchService/toolClassification';
 import { Compaction } from '../compaction';
-import { type CustomChartTypeLibrary } from '../prompts/availableCustomChartTypes';
 import { AI_DEEP_RESEARCH_INSTRUCTIONS } from '../prompts/deepResearch';
 import { getSystemPromptV2 } from '../prompts/systemV2';
 import {

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -34,6 +34,7 @@ import {
     isDeepResearchWarehouseMcpTool,
 } from '../../AiDeepResearchService/toolClassification';
 import { Compaction } from '../compaction';
+import { type CustomChartTypeLibrary } from '../prompts/availableCustomChartTypes';
 import { AI_DEEP_RESEARCH_INSTRUCTIONS } from '../prompts/deepResearch';
 import { getSystemPromptV2 } from '../prompts/systemV2';
 import {
@@ -54,6 +55,7 @@ import { getEditProjectContext } from '../tools/editProjectContext';
 import { getEditRepo } from '../tools/editRepo';
 import { getExploreRepo } from '../tools/exploreRepo';
 import { getFindContent } from '../tools/findContent';
+import { getFindCustomChartTypes } from '../tools/findCustomChartTypes';
 import { getGenerateDashboardV2 } from '../tools/generateDashboardV2';
 import { getGenerateHashes } from '../tools/generateHashes';
 import { getGenerateUuids } from '../tools/generateUuids';
@@ -770,6 +772,7 @@ export const getAgentTools = (
     mcpToolSetup: AgentMcpToolSetup,
     verifiedFieldUsage: Map<string, number>,
     projectParameterDefinitions: ParameterDefinitions,
+    customChartTypeLibrary: CustomChartTypeLibrary,
 ): ToolSet => {
     const logger = createAiAgentLogger(args.debugLoggingEnabled);
     logger(
@@ -819,6 +822,16 @@ export const getAgentTools = (
     const listContent = getListContent({
         listContent: dependencies.listContent,
     });
+
+    // Only offered when the project has a custom chart type library — an
+    // empty library keeps zero prompt and tool overhead.
+    const findCustomChartTypes =
+        customChartTypeLibrary.totalCount > 0
+            ? getFindCustomChartTypes({
+                  findCustomChartTypes: dependencies.findCustomChartTypes,
+                  updateProgress: dependencies.updateProgress,
+              })
+            : null;
 
     const getDashboardCharts = getGetDashboardCharts({
         getDashboardCharts: dependencies.getDashboardCharts,
@@ -1143,6 +1156,7 @@ export const getAgentTools = (
         ...(closePullRequest ? { closePullRequest } : {}),
         ...(getPullRequestDiff ? { getPullRequestDiff } : {}),
         ...(args.enableDataAccess ? { searchFieldValues } : {}),
+        ...(findCustomChartTypes ? { findCustomChartTypes } : {}),
         ...(runSql ? { runSql } : {}),
         ...(runComposerQueries ? { runComposerQueries } : {}),
         ...(listWarehouseTables ? { listWarehouseTables } : {}),
@@ -1364,6 +1378,7 @@ export const getAgentMessages = (
     tools: ToolSet,
     verifiedFieldUsage: Map<string, number>,
     memoryBlock: string | null,
+    customChartTypeLibrary: CustomChartTypeLibrary,
 ) => {
     const logger = createAiAgentLogger(args.debugLoggingEnabled);
     logger('Agent Messages', 'Getting agent messages.');
@@ -1435,6 +1450,7 @@ export const getAgentMessages = (
             instructions.length > 0 ? instructions.join('\n\n') : undefined,
         requestingUser: args.requestingUser,
         availableExplores,
+        availableCustomChartTypes: customChartTypeLibrary,
         availableSkills: args.availableSkills,
         knowledgeDocuments: args.knowledgeDocuments,
         deepResearchRuns: args.deepResearchRuns,
@@ -1536,12 +1552,17 @@ export const generateAgentResponse = async ({
     );
 
     try {
-        const [availableExplores, memoryBlock, projectParameterDefinitions] =
-            await Promise.all([
-                dependencies.listExplores(),
-                getMemoryBlock(args, dependencies),
-                dependencies.getProjectParameterDefinitions(),
-            ]);
+        const [
+            availableExplores,
+            memoryBlock,
+            projectParameterDefinitions,
+            customChartTypeLibrary,
+        ] = await Promise.all([
+            dependencies.listExplores(),
+            getMemoryBlock(args, dependencies),
+            dependencies.getProjectParameterDefinitions(),
+            dependencies.listCustomChartTypes(),
+        ]);
         // Verified-chart usage powers verified-first ranking in grep discovery;
         // degrade to an empty map if it can't be fetched.
         const verifiedFieldUsage = await dependencies
@@ -1555,6 +1576,7 @@ export const generateAgentResponse = async ({
                 mcpToolSetup,
                 verifiedFieldUsage,
                 projectParameterDefinitions,
+                customChartTypeLibrary,
             ),
             dependencies.updateProgress,
             args.execution.mode === 'deep_research',
@@ -1567,6 +1589,7 @@ export const generateAgentResponse = async ({
             tools,
             verifiedFieldUsage,
             memoryBlock,
+            customChartTypeLibrary,
         );
         logger(
             'Generate Agent Response',
@@ -1895,12 +1918,17 @@ export const streamAgentResponse = async ({
     };
 
     try {
-        const [availableExplores, memoryBlock, projectParameterDefinitions] =
-            await Promise.all([
-                dependencies.listExplores(),
-                getMemoryBlock(args, dependencies),
-                dependencies.getProjectParameterDefinitions(),
-            ]);
+        const [
+            availableExplores,
+            memoryBlock,
+            projectParameterDefinitions,
+            customChartTypeLibrary,
+        ] = await Promise.all([
+            dependencies.listExplores(),
+            getMemoryBlock(args, dependencies),
+            dependencies.getProjectParameterDefinitions(),
+            dependencies.listCustomChartTypes(),
+        ]);
         const verifiedFieldUsage = await dependencies
             .getVerifiedFieldUsage()
             .catch(() => new Map<string, number>());
@@ -1911,6 +1939,7 @@ export const streamAgentResponse = async ({
             mcpToolSetup,
             verifiedFieldUsage,
             projectParameterDefinitions,
+            customChartTypeLibrary,
         );
         await persistDeepResearchExecutionContext(args, tools, mcpToolSetup);
         const messages = getAgentMessages(
@@ -1920,6 +1949,7 @@ export const streamAgentResponse = async ({
             tools,
             verifiedFieldUsage,
             memoryBlock,
+            customChartTypeLibrary,
         );
         logger(
             'Stream Agent Response',

--- a/packages/backend/src/ee/services/ai/prompts/availableCustomChartTypes.ts
+++ b/packages/backend/src/ee/services/ai/prompts/availableCustomChartTypes.ts
@@ -1,14 +1,7 @@
 import {
     serializeCustomChartTypeForPrompt,
-    type CustomChartType,
+    type CustomChartTypeLibrary,
 } from '@lightdash/common';
-
-export type CustomChartTypeLibrary = {
-    // Newest first, capped at the inline limit; totalCount is the whole
-    // library's size so the block can point past the cap.
-    types: CustomChartType[];
-    totalCount: number;
-};
 
 /**
  * The `availableCustomChartTypes` system prompt block. Empty string for an
@@ -19,18 +12,18 @@ export const renderAvailableCustomChartTypes = ({
     totalCount,
 }: CustomChartTypeLibrary): string => {
     if (types.length === 0) return '';
+    const remainder = totalCount - types.length;
     const lines = [
         '## Available custom chart types',
         "This project has custom chart types — the team's own reusable visualizations, identified by slug. When the user asks about one, answer from the list below; call `findCustomChartTypes` with a slug to read a type's full schema (field slots and config options), or with a query to search the library.",
         '<availableCustomChartTypes>',
         ...types.map(serializeCustomChartTypeForPrompt),
+        ...(remainder > 0
+            ? [
+                  `${remainder} more types exist — use findCustomChartTypes to search the whole library.`,
+              ]
+            : []),
         '</availableCustomChartTypes>',
     ];
-    const remainder = totalCount - types.length;
-    if (remainder > 0) {
-        lines.push(
-            `${remainder} more types exist — use findCustomChartTypes to search the whole library.`,
-        );
-    }
     return lines.join('\n');
 };

--- a/packages/backend/src/ee/services/ai/prompts/availableCustomChartTypes.ts
+++ b/packages/backend/src/ee/services/ai/prompts/availableCustomChartTypes.ts
@@ -1,0 +1,36 @@
+import {
+    serializeCustomChartTypeForPrompt,
+    type CustomChartType,
+} from '@lightdash/common';
+
+export type CustomChartTypeLibrary = {
+    // Newest first, capped at the inline limit; totalCount is the whole
+    // library's size so the block can point past the cap.
+    types: CustomChartType[];
+    totalCount: number;
+};
+
+/**
+ * The `availableCustomChartTypes` system prompt block. Empty string for an
+ * empty library — the section (including its header) disappears entirely.
+ */
+export const renderAvailableCustomChartTypes = ({
+    types,
+    totalCount,
+}: CustomChartTypeLibrary): string => {
+    if (types.length === 0) return '';
+    const lines = [
+        '## Available custom chart types',
+        "This project has custom chart types — the team's own reusable visualizations, identified by slug. When the user asks about one, answer from the list below; call `findCustomChartTypes` with a slug to read a type's full schema (field slots and config options), or with a query to search the library.",
+        '<availableCustomChartTypes>',
+        ...types.map(serializeCustomChartTypeForPrompt),
+        '</availableCustomChartTypes>',
+    ];
+    const remainder = totalCount - types.length;
+    if (remainder > 0) {
+        lines.push(
+            `${remainder} more types exist — use findCustomChartTypes to search the whole library.`,
+        );
+    }
+    return lines.join('\n');
+};

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
@@ -41,6 +41,62 @@ describe('getSystemPromptV2 project context', () => {
     });
 });
 
+describe('getSystemPromptV2 custom chart types', () => {
+    const chartType = (slug: string, name: string) => ({
+        slug,
+        name,
+        description: '',
+        schema: {
+            fields: [
+                {
+                    name: 'status',
+                    label: 'Status',
+                    type: 'dimension' as const,
+                    required: true,
+                },
+            ],
+            configOptions: [],
+            colorPalette: null,
+        },
+    });
+
+    test('inlines the library as an availableCustomChartTypes block', () => {
+        const content = promptText({
+            availableExplores: [],
+            availableCustomChartTypes: {
+                types: [chartType('cohort-waterfall', 'Cohort Waterfall')],
+                totalCount: 1,
+            },
+        });
+        expect(content).toContain('## Available custom chart types');
+        expect(content).toContain('<availableCustomChartTypes>');
+        expect(content).toContain(
+            '<customChartType slug="cohort-waterfall" name="Cohort Waterfall">',
+        );
+        expect(content).not.toContain('more types exist');
+    });
+
+    test('omits the whole section for an empty library', () => {
+        const content = promptText({ availableExplores: [] });
+        expect(content).not.toContain('## Available custom chart types');
+        expect(content).not.toContain('{{available_custom_chart_types}}');
+        expect(content).not.toContain('availableCustomChartTypes');
+    });
+
+    test('points past the inline cap when more types exist', () => {
+        const content = promptText({
+            availableExplores: [],
+            availableCustomChartTypes: {
+                types: [chartType('cohort-waterfall', 'Cohort Waterfall')],
+                totalCount: 12,
+            },
+        });
+        expect(content).toContain(
+            '11 more types exist — use findCustomChartTypes',
+        );
+    });
+});
+
 describe('getSystemPromptV2 merge queries', () => {
     test('directs cross-explore questions to generateVisualization when enabled', () => {
         const content = promptText({

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -13,6 +13,10 @@ import {
     AiAgentRequestingUser,
 } from '../types/aiAgent';
 import { escapeXmlText, xmlBuilder } from '../xmlBuilder';
+import {
+    renderAvailableCustomChartTypes,
+    type CustomChartTypeLibrary,
+} from './availableCustomChartTypes';
 import { renderAvailableExplores } from './availableExplores';
 import { getAiWritebackSection } from './systemV2AiWriteback';
 import { getCodingAgentSection } from './systemV2CodingAgent';
@@ -34,6 +38,7 @@ import { SYSTEM_PROMPT_TEMPLATE } from './systemV2Template';
 
 export const getSystemPromptV2 = (args: {
     availableExplores: Explore[];
+    availableCustomChartTypes?: CustomChartTypeLibrary;
     availableSkills?: AiAgentSkillReference[];
     knowledgeDocuments?: AiAgentDocumentContext[];
     deepResearchRuns?: AiAgentDeepResearchRunContext[];
@@ -307,6 +312,12 @@ export const getSystemPromptV2 = (args: {
         )
         .replace('{{date}}', date)
         .replace('{{available_explores}}', availableExploresContent)
+        .replace(
+            '{{available_custom_chart_types}}',
+            renderAvailableCustomChartTypes(
+                args.availableCustomChartTypes ?? { types: [], totalCount: 0 },
+            ),
+        )
         .replace('{{knowledge_documents}}', knowledgeDocumentsContent)
         .replace('{{project_context}}', projectContextContent);
 

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -4,6 +4,7 @@ import {
     Explore,
     WarehouseTypes,
     type AgentSqlScope,
+    type CustomChartTypeLibrary,
 } from '@lightdash/common';
 import { SystemModelMessage } from 'ai';
 import moment from 'moment';
@@ -13,10 +14,7 @@ import {
     AiAgentRequestingUser,
 } from '../types/aiAgent';
 import { escapeXmlText, xmlBuilder } from '../xmlBuilder';
-import {
-    renderAvailableCustomChartTypes,
-    type CustomChartTypeLibrary,
-} from './availableCustomChartTypes';
+import { renderAvailableCustomChartTypes } from './availableCustomChartTypes';
 import { renderAvailableExplores } from './availableExplores';
 import { getAiWritebackSection } from './systemV2AiWriteback';
 import { getCodingAgentSection } from './systemV2CodingAgent';

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -153,6 +153,8 @@ See the CRITICAL section at the top of this prompt: reasoning is user-visible. D
 ## Available explores
 {{available_explores}}
 
+{{available_custom_chart_types}}
+
 ## Available knowledge documents
 {{knowledge_documents}}
 

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -1209,6 +1209,78 @@ Usage tips:
     },
   },
   {
+    "description": "Tool: findCustomChartTypes
+
+Purpose:
+Browse the project's custom chart type library. Set \`query\` to keyword-search types by name and description, or set \`slug\` to fetch one exact type — set exactly one of the two. Each match returns the type's slug plus its full schema: the field slots to bind query fields to (name, label, type, required) and the config options it accepts.
+
+Use it to look beyond the types inlined in availableCustomChartTypes, or to read a type's full schema before rendering through it.
+
+Parameters:
+- query: keyword terms matched against custom chart type names and descriptions
+- slug: exact slug of one custom chart type, from availableCustomChartTypes or a previous search
+
+Output:
+- Matching custom chart types, each with slug, name, description and full serialized schema (field slots and config option details)
+",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "description": "Keyword terms matched against custom chart type names and descriptions. Set exactly one of query or slug.",
+          "type": [
+            "string",
+            "null",
+          ],
+        },
+        "slug": {
+          "description": "Exact slug of one custom chart type. Set exactly one of query or slug.",
+          "type": [
+            "string",
+            "null",
+          ],
+        },
+      },
+      "required": [
+        "query",
+        "slug",
+      ],
+      "type": "object",
+    },
+    "name": "findCustomChartTypes",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "enum": [
+                "success",
+                "error",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "status",
+          ],
+          "type": "object",
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
     "description": "Tool: findExplores
 
 Purpose:
@@ -7851,6 +7923,7 @@ Usage Tips:
 exports[`AI agent tool contracts > matches the shared agent tool definition names snapshot 1`] = `
 [
   "findExplores",
+  "findCustomChartTypes",
   "findFields",
   "searchSemanticLayer",
   "analyzeFieldImpact",

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -1209,9 +1209,7 @@ Usage tips:
     },
   },
   {
-    "description": "Tool: findCustomChartTypes
-
-Purpose:
+    "description": "Purpose:
 Browse the project's custom chart type library. Set \`query\` to keyword-search types by name and description, or set \`slug\` to fetch one exact type — set exactly one of the two. Each match returns the type's slug plus its full schema: the field slots to bind query fields to (name, label, type, required) and the config options it accepts.
 
 Use it to look beyond the types inlined in availableCustomChartTypes, or to read a type's full schema before rendering through it.
@@ -1242,10 +1240,6 @@ Output:
           ],
         },
       },
-      "required": [
-        "query",
-        "slug",
-      ],
       "type": "object",
     },
     "name": "findCustomChartTypes",

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -15,6 +15,7 @@ import { getEditProjectContext } from './editProjectContext';
 import { getEditRepo } from './editRepo';
 import { getExploreRepo } from './exploreRepo';
 import { getFindContent } from './findContent';
+import { getFindCustomChartTypes } from './findCustomChartTypes';
 import { getFindExplores } from './findExplores';
 import { getFindFields } from './findFields';
 import { getGenerateDashboardV2 } from './generateDashboardV2';
@@ -91,6 +92,10 @@ const makeAgentTools = () => {
             toolDescriptionMaxChars: 600,
             dashboardDetailsToolName: 'readContent',
             trackCoverage: noop,
+        }),
+        findCustomChartTypes: getFindCustomChartTypes({
+            findCustomChartTypes: noop,
+            updateProgress: noopAsync,
         }),
         findExplores: getFindExplores({
             fieldSearchSize: 25,

--- a/packages/backend/src/ee/services/ai/tools/findCustomChartTypes.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/findCustomChartTypes.test.ts
@@ -1,0 +1,84 @@
+import { type CustomChartType } from '@lightdash/common';
+import {
+    buildFindCustomChartTypesStructuredContent,
+    parseFindCustomChartTypesArgs,
+} from './findCustomChartTypes';
+
+describe('parseFindCustomChartTypesArgs', () => {
+    test('accepts exactly one of query or slug', () => {
+        expect(
+            parseFindCustomChartTypesArgs({ query: 'waterfall', slug: null }),
+        ).toEqual({ query: 'waterfall' });
+        expect(
+            parseFindCustomChartTypesArgs({
+                query: null,
+                slug: 'cohort-waterfall',
+            }),
+        ).toEqual({ slug: 'cohort-waterfall' });
+    });
+
+    test('rejects both, neither, and blank values', () => {
+        expect(
+            parseFindCustomChartTypesArgs({ query: 'a', slug: 'b' }),
+        ).toBeNull();
+        expect(
+            parseFindCustomChartTypesArgs({ query: null, slug: null }),
+        ).toBeNull();
+        expect(
+            parseFindCustomChartTypesArgs({ query: '  ', slug: null }),
+        ).toBeNull();
+    });
+});
+
+describe('buildFindCustomChartTypesStructuredContent', () => {
+    const match: CustomChartType = {
+        slug: 'cohort-waterfall',
+        name: 'Cohort Waterfall',
+        description: 'Retention by cohort',
+        schema: {
+            fields: [
+                {
+                    name: 'cohort',
+                    label: 'Cohort',
+                    type: 'dimension',
+                    required: true,
+                },
+            ],
+            configOptions: [],
+            colorPalette: null,
+        },
+    };
+
+    test('returns matches with slug and full serialized schema', () => {
+        const content = buildFindCustomChartTypesStructuredContent(
+            { query: 'waterfall' },
+            [match],
+        );
+        expect(content.matches.count).toBe(1);
+        expect(content.matches.results[0].slug).toBe('cohort-waterfall');
+        expect(content.matches.results[0].schema).toContain(
+            'slug: cohort-waterfall',
+        );
+        expect(content.matches.results[0].schema).toContain(
+            '- cohort "Cohort" (dimension, required)',
+        );
+    });
+
+    test('explains an unknown slug', () => {
+        const content = buildFindCustomChartTypesStructuredContent(
+            { slug: 'nope' },
+            [],
+        );
+        expect(content.matches.note).toContain(
+            'No custom chart type with slug "nope"',
+        );
+    });
+
+    test('suggests retrying an empty query search', () => {
+        const content = buildFindCustomChartTypesStructuredContent(
+            { query: 'zzz' },
+            [],
+        );
+        expect(content.matches.note).toContain('No custom chart type matched');
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/findCustomChartTypes.ts
+++ b/packages/backend/src/ee/services/ai/tools/findCustomChartTypes.ts
@@ -20,7 +20,7 @@ type Dependencies = {
 
 const toolDefinition = findCustomChartTypesToolDefinition.for('agent');
 
-// The args schema keeps both fields nullable (LLM tool inputs are flat
+// The args schema keeps both fields nullish (LLM tool inputs are flat
 // objects); exactly-one is enforced here with a retryable tool error.
 export const parseFindCustomChartTypesArgs = (
     args: ToolFindCustomChartTypesArgs,

--- a/packages/backend/src/ee/services/ai/tools/findCustomChartTypes.ts
+++ b/packages/backend/src/ee/services/ai/tools/findCustomChartTypes.ts
@@ -1,0 +1,105 @@
+import {
+    findCustomChartTypesToolDefinition,
+    serializeCustomChartTypeSchema,
+    type CustomChartType,
+    type ToolFindCustomChartTypesArgs,
+} from '@lightdash/common';
+import { tool } from 'ai';
+import type {
+    FindCustomChartTypesFn,
+    UpdateProgressFn,
+} from '../types/aiAgentDependencies';
+import { toModelOutput } from '../utils/toModelOutput';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+import { formatToolJsonOutput } from './toolOutputFormat';
+
+type Dependencies = {
+    findCustomChartTypes: FindCustomChartTypesFn;
+    updateProgress: UpdateProgressFn;
+};
+
+const toolDefinition = findCustomChartTypesToolDefinition.for('agent');
+
+// The args schema keeps both fields nullable (LLM tool inputs are flat
+// objects); exactly-one is enforced here with a retryable tool error.
+export const parseFindCustomChartTypesArgs = (
+    args: ToolFindCustomChartTypesArgs,
+): { query: string } | { slug: string } | null => {
+    const query = args.query?.trim() || null;
+    const slug = args.slug?.trim() || null;
+    if (query !== null && slug === null) return { query };
+    if (slug !== null && query === null) return { slug };
+    return null;
+};
+
+export const buildFindCustomChartTypesStructuredContent = (
+    request: { query: string } | { slug: string },
+    matches: CustomChartType[],
+) => {
+    const note = (() => {
+        if (matches.length === 0) {
+            return 'slug' in request
+                ? `No custom chart type with slug "${request.slug}" exists in this project. Search by query to discover the available slugs.`
+                : 'No custom chart type matched your query. Try different terms, or fetch a specific type by slug.';
+        }
+        return 'Bind the required field slots to fields from your query when rendering through a type; the slug identifies the type.';
+    })();
+
+    return {
+        request,
+        matches: {
+            count: matches.length,
+            note,
+            results: matches.map((match) => ({
+                slug: match.slug,
+                name: match.name,
+                description: match.description,
+                schema: serializeCustomChartTypeSchema(match),
+            })),
+        },
+    };
+};
+
+export const getFindCustomChartTypes = ({
+    findCustomChartTypes,
+    updateProgress,
+}: Dependencies) =>
+    tool({
+        ...toolDefinition,
+        execute: async (args) => {
+            try {
+                const request = parseFindCustomChartTypesArgs(args);
+                if (request === null) {
+                    return {
+                        result: 'Set exactly one of `query` (keyword search) or `slug` (exact fetch), not both and not neither.',
+                        metadata: { status: 'error' as const },
+                    };
+                }
+                await updateProgress(
+                    'query' in request
+                        ? `Searching custom chart types matching "${request.query}"...`
+                        : `Fetching custom chart type "${request.slug}"...`,
+                );
+
+                const matches = await findCustomChartTypes(request);
+                return {
+                    result: formatToolJsonOutput(
+                        buildFindCustomChartTypesStructuredContent(
+                            request,
+                            matches,
+                        ),
+                    ),
+                    metadata: { status: 'success' as const },
+                };
+            } catch (error) {
+                return {
+                    result: toolErrorHandler(
+                        error,
+                        'Error finding custom chart types.',
+                    ),
+                    metadata: { status: 'error' as const },
+                };
+            }
+        },
+        toModelOutput: ({ output }) => toModelOutput(output),
+    });

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -46,6 +46,7 @@ import {
     EditRepoFn,
     ExploreRepoFn,
     FindContentFn,
+    FindCustomChartTypesFn,
     FindExploresFn,
     GetDashboardChartsFn,
     GetKnowledgeDocumentContentFn,
@@ -58,6 +59,7 @@ import {
     IsPromptInterruptedFn,
     IsThreadSqlAutoApprovedFn,
     ListContentFn,
+    ListCustomChartTypesFn,
     ListExploresFn,
     ListKnowledgeDocumentsFn,
     ListProjectsFn,
@@ -304,6 +306,8 @@ export type AiAgentDependencies = {
     validateContent: ValidateContentFn;
     getDashboardCharts: GetDashboardChartsFn;
     findExplores: FindExploresFn;
+    listCustomChartTypes: ListCustomChartTypesFn;
+    findCustomChartTypes: FindCustomChartTypesFn;
     getVerifiedFieldUsage: GetVerifiedFieldUsageFn;
     searchSemanticLayer: SearchSemanticLayerFn;
     analyzeFieldImpact: AnalyzeFieldImpactFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -16,6 +16,7 @@ import {
     ChartAsCode,
     CreateSchedulerAndTargetsWithoutIds,
     CustomChartType,
+    CustomChartTypeLibrary,
     DashboardAsCode,
     DashboardSearchResult,
     DbtProjectType,
@@ -103,12 +104,7 @@ export type FindExploresFn = (args: {
 // Used to rank verified/governed fields first in grep discovery.
 export type GetVerifiedFieldUsageFn = () => Promise<Map<string, number>>;
 
-// The project's custom chart type library, newest first, capped at the
-// system-prompt inline limit; totalCount is the whole library's size.
-export type ListCustomChartTypesFn = () => Promise<{
-    types: CustomChartType[];
-    totalCount: number;
-}>;
+export type ListCustomChartTypesFn = () => Promise<CustomChartTypeLibrary>;
 
 export type FindCustomChartTypesFn = (
     args: { query: string } | { slug: string },

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -15,6 +15,7 @@ import {
     CatalogField,
     ChartAsCode,
     CreateSchedulerAndTargetsWithoutIds,
+    CustomChartType,
     DashboardAsCode,
     DashboardSearchResult,
     DbtProjectType,
@@ -101,6 +102,17 @@ export type FindExploresFn = (args: {
 // Project-wide verified-chart usage per field, keyed `table_field::fieldType`.
 // Used to rank verified/governed fields first in grep discovery.
 export type GetVerifiedFieldUsageFn = () => Promise<Map<string, number>>;
+
+// The project's custom chart type library, newest first, capped at the
+// system-prompt inline limit; totalCount is the whole library's size.
+export type ListCustomChartTypesFn = () => Promise<{
+    types: CustomChartType[];
+    totalCount: number;
+}>;
+
+export type FindCustomChartTypesFn = (
+    args: { query: string } | { slug: string },
+) => Promise<CustomChartType[]>;
 
 export type FindFieldResult = {
     fields: CatalogField[];

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -21,6 +21,7 @@ import {
 
 const TOOL_NAME_TO_DB_TOOL_NAME = {
     findExplores: 'find_explores',
+    findCustomChartTypes: 'find_custom_chart_types',
     findFields: 'find_fields',
     searchSemanticLayer: 'search_semantic_layer',
     analyzeFieldImpact: 'analyze_field_impact',

--- a/packages/backend/src/ee/services/ai/utils/threadDumpSanitizer.ts
+++ b/packages/backend/src/ee/services/ai/utils/threadDumpSanitizer.ts
@@ -12,6 +12,7 @@ const DUMP_TOOL_RESULT_POLICIES = {
     discoverFields: 'keep',
     getMetadata: 'keep',
     findExplores: 'keep',
+    findCustomChartTypes: 'keep',
     findFields: 'keep',
     searchSemanticLayer: 'keep',
     analyzeFieldImpact: 'keep',

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -996,6 +996,29 @@ export class AppModel {
     }
 
     /**
+     * A single data app viz by its project-scoped slug, with its latest ready
+     * schema. Undefined when the slug is not a schema-bearing data app viz.
+     */
+    async findDataAppVisualizationBySlug(
+        projectUuid: string,
+        slug: string,
+    ): Promise<(DbApp & { viz_schema: DataAppVizSchema }) | undefined> {
+        return this.joinLatestReadyVersion(this.database(AppsTableName))
+            .where({
+                [`${AppsTableName}.project_uuid`]: projectUuid,
+                [`${AppsTableName}.template`]: DATA_APP_VIZ_TEMPLATE,
+                [`${AppsTableName}.slug`]: slug,
+            })
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .whereNotNull(`${AppVersionsTableName}.viz_schema`)
+            .select<(DbApp & { viz_schema: DataAppVizSchema })[]>(
+                `${AppsTableName}.*`,
+                `${AppVersionsTableName}.viz_schema`,
+            )
+            .first();
+    }
+
+    /**
      * Fetch a single data app viz by id, with its organization uuid (for the
      * view permission check) and latest schema. Undefined when the id is not a
      * data app viz in this project.

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -42,6 +42,7 @@ export * from './toolFindDashboardsArgs';
 export * from './toolGetDashboardChartsArgs';
 export * from './toolGetQueryResultArgs';
 export * from './toolGetProjectInfoArgs';
+export * from './toolFindCustomChartTypesArgs';
 export * from './toolFindExploresArgs';
 export * from './toolFindFieldsArgs';
 export * from './toolListProjectsArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -124,6 +124,11 @@ import {
     toolFindContentOutputSchema,
 } from './toolFindContentArgs';
 import {
+    TOOL_FIND_CUSTOM_CHART_TYPES_DESCRIPTION,
+    toolFindCustomChartTypesArgsSchema,
+    toolFindCustomChartTypesOutputSchema,
+} from './toolFindCustomChartTypesArgs';
+import {
     TOOL_FIND_DASHBOARDS_DESCRIPTION,
     toolFindDashboardsArgsSchema,
     toolFindDashboardsOutputSchema,
@@ -439,6 +444,20 @@ export const findExploresToolDefinition: ToolDefinitionWithoutMcpOutput<
     availability: ['agent'],
     inputSchema: toolFindExploresArgsSchemaV3,
     agent: { outputSchema: toolFindExploresOutputSchema },
+});
+
+export const findCustomChartTypesToolDefinition: ToolDefinitionWithoutMcpOutput<
+    'findCustomChartTypes',
+    typeof toolFindCustomChartTypesArgsSchema,
+    typeof toolFindCustomChartTypesArgsSchema,
+    typeof toolFindCustomChartTypesOutputSchema
+> = defineTool({
+    name: 'findCustomChartTypes',
+    title: 'Find custom chart types',
+    description: TOOL_FIND_CUSTOM_CHART_TYPES_DESCRIPTION,
+    availability: ['agent'],
+    inputSchema: toolFindCustomChartTypesArgsSchema,
+    agent: { outputSchema: toolFindCustomChartTypesOutputSchema },
 });
 
 export const findFieldsToolDefinition: ToolDefinitionWithoutMcpOutput<
@@ -1632,6 +1651,7 @@ export const getAiWritebackStatusToolDefinition: ToolDefinitionWithMcpOutput<
 
 type AgentToolDefinitionsByName = {
     findExplores: typeof findExploresToolDefinition;
+    findCustomChartTypes: typeof findCustomChartTypesToolDefinition;
     findFields: typeof findFieldsToolDefinition;
     searchSemanticLayer: typeof searchSemanticLayerToolDefinition;
     analyzeFieldImpact: typeof analyzeFieldImpactToolDefinition;
@@ -1689,6 +1709,7 @@ type AgentToolDefinitionsByName = {
 
 export const agentToolDefinitionsByName: AgentToolDefinitionsByName = {
     findExplores: findExploresToolDefinition,
+    findCustomChartTypes: findCustomChartTypesToolDefinition,
     findFields: findFieldsToolDefinition,
     searchSemanticLayer: searchSemanticLayerToolDefinition,
     analyzeFieldImpact: analyzeFieldImpactToolDefinition,
@@ -1751,6 +1772,7 @@ export const isAgentToolName = (toolName: string): toolName is AgentToolName =>
 
 export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     findExploresToolDefinition,
+    findCustomChartTypesToolDefinition,
     findFieldsToolDefinition,
     searchSemanticLayerToolDefinition,
     analyzeFieldImpactToolDefinition,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindCustomChartTypesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindCustomChartTypesArgs.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+import { type ToolDescriptionContext } from '../defineTool';
+import { baseOutputMetadataSchema } from '../outputMetadata';
+import { createToolSchema } from '../toolSchemaBuilder';
+
+export const TOOL_FIND_CUSTOM_CHART_TYPES_DESCRIPTION = ({
+    toolName,
+}: ToolDescriptionContext): string => `Tool: ${toolName}
+
+Purpose:
+Browse the project's custom chart type library. Set \`query\` to keyword-search types by name and description, or set \`slug\` to fetch one exact type — set exactly one of the two. Each match returns the type's slug plus its full schema: the field slots to bind query fields to (name, label, type, required) and the config options it accepts.
+
+Use it to look beyond the types inlined in availableCustomChartTypes, or to read a type's full schema before rendering through it.
+
+Parameters:
+- query: keyword terms matched against custom chart type names and descriptions
+- slug: exact slug of one custom chart type, from availableCustomChartTypes or a previous search
+
+Output:
+- Matching custom chart types, each with slug, name, description and full serialized schema (field slots and config option details)
+`;
+
+export const toolFindCustomChartTypesArgsSchema = createToolSchema()
+    .extend({
+        query: z
+            .string()
+            .nullable()
+            .describe(
+                'Keyword terms matched against custom chart type names and descriptions. Set exactly one of query or slug.',
+            ),
+        slug: z
+            .string()
+            .nullable()
+            .describe(
+                'Exact slug of one custom chart type. Set exactly one of query or slug.',
+            ),
+    })
+    .build();
+
+export const toolFindCustomChartTypesOutputSchema = z.object({
+    result: z.string(),
+    metadata: baseOutputMetadataSchema,
+});
+
+export type ToolFindCustomChartTypesArgs = z.infer<
+    typeof toolFindCustomChartTypesArgsSchema
+>;
+export type ToolFindCustomChartTypesOutput = z.infer<
+    typeof toolFindCustomChartTypesOutputSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindCustomChartTypesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindCustomChartTypesArgs.ts
@@ -1,13 +1,8 @@
 import { z } from 'zod';
-import { type ToolDescriptionContext } from '../defineTool';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { createToolSchema } from '../toolSchemaBuilder';
 
-export const TOOL_FIND_CUSTOM_CHART_TYPES_DESCRIPTION = ({
-    toolName,
-}: ToolDescriptionContext): string => `Tool: ${toolName}
-
-Purpose:
+export const TOOL_FIND_CUSTOM_CHART_TYPES_DESCRIPTION = `Purpose:
 Browse the project's custom chart type library. Set \`query\` to keyword-search types by name and description, or set \`slug\` to fetch one exact type — set exactly one of the two. Each match returns the type's slug plus its full schema: the field slots to bind query fields to (name, label, type, required) and the config options it accepts.
 
 Use it to look beyond the types inlined in availableCustomChartTypes, or to read a type's full schema before rendering through it.
@@ -24,13 +19,13 @@ export const toolFindCustomChartTypesArgsSchema = createToolSchema()
     .extend({
         query: z
             .string()
-            .nullable()
+            .nullish()
             .describe(
                 'Keyword terms matched against custom chart type names and descriptions. Set exactly one of query or slug.',
             ),
         slug: z
             .string()
-            .nullable()
+            .nullish()
             .describe(
                 'Exact slug of one custom chart type. Set exactly one of query or slug.',
             ),

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -19,6 +19,7 @@ export const ToolNameSchema = z.enum([
     'findContent',
     'listContent',
     'findExplores',
+    'findCustomChartTypes',
     'findFields',
     'searchSemanticLayer',
     'analyzeFieldImpact',
@@ -76,6 +77,7 @@ export const ToolDisplayMessagesSchema = z.record(ToolNameSchema, z.string());
 
 export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
     findExplores: 'Finding relevant explores',
+    findCustomChartTypes: 'Browsing custom chart types',
     findDashboards: 'Finding relevant dashboards',
     findContent: 'Finding relevant content',
     listContent: 'Listing content',
@@ -134,6 +136,7 @@ export const TOOL_DISPLAY_MESSAGES = ToolDisplayMessagesSchema.parse({
 export const TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL =
     ToolDisplayMessagesSchema.parse({
         findExplores: 'Found relevant explores',
+        findCustomChartTypes: 'Browsed custom chart types',
         findDashboards: 'Found relevant dashboards',
         findFields: 'Found relevant fields',
         searchSemanticLayer: 'Searched the semantic layer',

--- a/packages/common/src/ee/apps/customChartTypeSerializer.test.ts
+++ b/packages/common/src/ee/apps/customChartTypeSerializer.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+    serializeCustomChartTypeForPrompt,
+    serializeCustomChartTypeSchema,
+    type CustomChartType,
+} from './customChartTypeSerializer';
+
+const cohortWaterfall: CustomChartType = {
+    slug: 'cohort-waterfall',
+    name: 'Cohort Waterfall',
+    description: 'Retention by signup cohort',
+    schema: {
+        fields: [
+            {
+                name: 'cohort_period',
+                label: 'Cohort period',
+                type: 'dimension',
+                required: true,
+            },
+            {
+                name: 'revenue',
+                label: 'Revenue',
+                type: 'metric',
+                required: true,
+            },
+            {
+                name: 'segment',
+                label: 'Segment',
+                type: 'series',
+                required: false,
+            },
+        ],
+        configOptions: [
+            {
+                type: 'boolean',
+                name: 'show_labels',
+                label: 'Show labels',
+                default: true,
+            },
+            {
+                type: 'select',
+                name: 'scale',
+                label: 'Scale',
+                group: 'Axis',
+                choices: [
+                    { value: 'linear', label: 'Linear' },
+                    { value: 'log', label: 'Log' },
+                ],
+                default: 'linear',
+            },
+            {
+                type: 'number',
+                name: 'max_bars',
+                label: 'Max bars',
+                group: 'Axis',
+                default: 10,
+                min: 1,
+                max: 50,
+            },
+            {
+                type: 'text',
+                name: 'subtitle',
+                label: 'Subtitle',
+                default: '',
+            },
+            {
+                type: 'color',
+                name: 'highlight',
+                label: 'Highlight color',
+                group: 'Style',
+                default: '#ff0000',
+            },
+        ],
+        colorPalette: null,
+    },
+};
+
+const minimal: CustomChartType = {
+    slug: 'status-donut',
+    name: 'Status Donut',
+    description: '',
+    schema: {
+        fields: [
+            {
+                name: 'status',
+                label: 'Status',
+                type: 'dimension',
+                required: true,
+            },
+        ],
+        configOptions: [],
+        colorPalette: null,
+    },
+};
+
+describe('serializeCustomChartTypeForPrompt', () => {
+    it('serializes name, description, field labels and grouped option labels', () => {
+        expect(serializeCustomChartTypeForPrompt(cohortWaterfall)).toBe(
+            [
+                '<customChartType slug="cohort-waterfall" name="Cohort Waterfall">',
+                '<description>Retention by signup cohort</description>',
+                '<fields>Cohort period; Revenue; Segment</fields>',
+                '<configOptions>Show labels; Axis: Scale; Axis: Max bars; Subtitle; Style: Highlight color</configOptions>',
+                '</customChartType>',
+            ].join('\n'),
+        );
+    });
+
+    it('omits empty description and empty configOptions', () => {
+        expect(serializeCustomChartTypeForPrompt(minimal)).toBe(
+            [
+                '<customChartType slug="status-donut" name="Status Donut">',
+                '<fields>Status</fields>',
+                '</customChartType>',
+            ].join('\n'),
+        );
+    });
+
+    it('escapes XML-significant characters', () => {
+        const nasty: CustomChartType = {
+            ...minimal,
+            name: 'A <b> & "c"',
+            description: 'x < y & z',
+        };
+        const output = serializeCustomChartTypeForPrompt(nasty);
+        expect(output).toContain('name="A &lt;b&gt; &amp; &quot;c&quot;"');
+        expect(output).toContain('<description>x &lt; y &amp; z</description>');
+    });
+});
+
+describe('serializeCustomChartTypeSchema', () => {
+    it('serializes the full schema with slot names, types, required and option details', () => {
+        expect(serializeCustomChartTypeSchema(cohortWaterfall)).toBe(
+            [
+                'name: Cohort Waterfall',
+                'slug: cohort-waterfall',
+                'description: Retention by signup cohort',
+                'fields:',
+                '- cohort_period "Cohort period" (dimension, required)',
+                '- revenue "Revenue" (metric, required)',
+                '- segment "Segment" (series, optional)',
+                'configOptions:',
+                '- show_labels "Show labels" [boolean] default: true',
+                '- scale "Scale" [select] group: Axis, choices: linear | log, default: linear',
+                '- max_bars "Max bars" [number] group: Axis, min: 1, max: 50, default: 10',
+                '- subtitle "Subtitle" [text] default: ""',
+                '- highlight "Highlight color" [color] group: Style, default: "#ff0000"',
+            ].join('\n'),
+        );
+    });
+
+    it('serializes a schema without options or description', () => {
+        expect(serializeCustomChartTypeSchema(minimal)).toBe(
+            [
+                'name: Status Donut',
+                'slug: status-donut',
+                'fields:',
+                '- status "Status" (dimension, required)',
+                'configOptions: none',
+            ].join('\n'),
+        );
+    });
+});

--- a/packages/common/src/ee/apps/customChartTypeSerializer.ts
+++ b/packages/common/src/ee/apps/customChartTypeSerializer.ts
@@ -13,6 +13,15 @@ export type CustomChartType = {
     schema: DataAppVizSchema;
 };
 
+/**
+ * The slice of the library the agent sees inline: newest first, capped at the
+ * system-prompt inline limit; totalCount is the whole library's size.
+ */
+export type CustomChartTypeLibrary = {
+    types: CustomChartType[];
+    totalCount: number;
+};
+
 const escapeXml = (value: string): string =>
     value
         .replace(/&/g, '&amp;')

--- a/packages/common/src/ee/apps/customChartTypeSerializer.ts
+++ b/packages/common/src/ee/apps/customChartTypeSerializer.ts
@@ -1,0 +1,120 @@
+import assertUnreachable from '../../utils/assertUnreachable';
+import { type DataAppVizConfigOption } from './dataAppVizConfigOptions';
+import { type DataAppVizSchema } from './types';
+
+/**
+ * A custom chart type as the AI agent sees it: a project-level library entry
+ * identified by slug (never uuid), backed by a data app viz schema.
+ */
+export type CustomChartType = {
+    slug: string;
+    name: string;
+    description: string;
+    schema: DataAppVizSchema;
+};
+
+const escapeXml = (value: string): string =>
+    value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+
+const optionPromptLabel = (option: DataAppVizConfigOption): string =>
+    option.group ? `${option.group}: ${option.label}` : option.label;
+
+/**
+ * Compact per-type surface for the agent system prompt: name, description,
+ * field labels, config options as `group: label`. Full detail (slot names,
+ * types, defaults) is fetched on demand via the findCustomChartTypes tool.
+ */
+export const serializeCustomChartTypeForPrompt = (
+    type: CustomChartType,
+): string => {
+    const lines = [
+        `<customChartType slug="${escapeXml(type.slug)}" name="${escapeXml(
+            type.name,
+        )}">`,
+    ];
+    if (type.description) {
+        lines.push(`<description>${escapeXml(type.description)}</description>`);
+    }
+    lines.push(
+        `<fields>${escapeXml(
+            type.schema.fields.map((field) => field.label).join('; '),
+        )}</fields>`,
+    );
+    if (type.schema.configOptions.length > 0) {
+        lines.push(
+            `<configOptions>${escapeXml(
+                type.schema.configOptions.map(optionPromptLabel).join('; '),
+            )}</configOptions>`,
+        );
+    }
+    lines.push('</customChartType>');
+    return lines.join('\n');
+};
+
+const serializeOptionDetail = (option: DataAppVizConfigOption): string => {
+    const parts: string[] = [];
+    if (option.group) {
+        parts.push(`group: ${option.group}`);
+    }
+    switch (option.type) {
+        case 'boolean':
+            parts.push(`default: ${option.default}`);
+            break;
+        case 'select':
+            parts.push(
+                `choices: ${option.choices
+                    .map((choice) => choice.value)
+                    .join(' | ')}`,
+                `default: ${option.default}`,
+            );
+            break;
+        case 'number':
+            if (option.min !== undefined) parts.push(`min: ${option.min}`);
+            if (option.max !== undefined) parts.push(`max: ${option.max}`);
+            parts.push(`default: ${option.default}`);
+            break;
+        case 'text':
+        case 'color':
+            parts.push(`default: ${JSON.stringify(option.default)}`);
+            break;
+        default:
+            return assertUnreachable(option, 'Unknown config option type');
+    }
+    return `- ${option.name} "${option.label}" [${option.type}] ${parts.join(
+        ', ',
+    )}`;
+};
+
+/**
+ * Full schema detail returned by the findCustomChartTypes tool: everything
+ * needed to author a field mapping and option values for this type.
+ */
+export const serializeCustomChartTypeSchema = (
+    type: CustomChartType,
+): string => {
+    const lines = [`name: ${type.name}`, `slug: ${type.slug}`];
+    if (type.description) {
+        lines.push(`description: ${type.description}`);
+    }
+    lines.push('fields:');
+    for (const field of type.schema.fields) {
+        lines.push(
+            `- ${field.name} "${field.label}" (${field.type}, ${
+                field.required ? 'required' : 'optional'
+            })`,
+        );
+    }
+    if (type.schema.configOptions.length === 0) {
+        lines.push('configOptions: none');
+    } else {
+        lines.push('configOptions:');
+        for (const option of type.schema.configOptions) {
+            lines.push(serializeOptionDetail(option));
+        }
+    }
+    return lines.join('\n');
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -10,6 +10,7 @@ export * from './mcp/tasks';
 export * from './externalConnections/coder';
 export * from './externalConnections/types';
 export * from './AiRouter';
+export * from './apps/customChartTypeSerializer';
 export * from './apps/deliveryCapture';
 export * from './apps/sdkFeatures';
 export * from './apps/types';

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -388,6 +388,7 @@ export const ToolCallDescription: FC<{
         case 'submitWorkerFindings':
         case 'loadMcpTools':
         case 'resolveUrl':
+        case 'findCustomChartTypes':
             return <> </>;
         default:
             return assertUnreachable(toolName, `Unknown tool name ${toolName}`);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getActivityTitle.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getActivityTitle.ts
@@ -15,6 +15,7 @@ type ActivityTitle = {
 
 const SEARCH_TOOLS = new Set([
     'findExplores',
+    'findCustomChartTypes',
     'findFields',
     'discoverFields',
     'grepFields',

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallChipLabel.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallChipLabel.ts
@@ -6,6 +6,7 @@ import type {
     ToolDescribeWarehouseTableArgs,
     ToolFindChartsArgs,
     ToolFindContentArgs,
+    ToolFindCustomChartTypesArgs,
     ToolFindDashboardsArgs,
     ToolFindExploresArgsV1,
     ToolFindExploresArgsV2,
@@ -84,6 +85,10 @@ export const getToolCallChipLabel = (
         case 'findFields': {
             const args = toolArgs as ToolFindFieldsArgs;
             return args.fieldSearchQueries?.[0]?.label ?? null;
+        }
+        case 'findCustomChartTypes': {
+            const args = toolArgs as ToolFindCustomChartTypesArgs;
+            return args.query ?? args.slug ?? null;
         }
         case 'discoverFields': {
             const args = toolArgs as DiscoverFieldsInput;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
@@ -40,6 +40,7 @@ export const getToolIcon = (toolName: AiAgentToolName) => {
     const iconMap: Record<ToolName, (props: TablerIconsProps) => JSX.Element> =
         {
             findExplores: IconDatabase,
+            findCustomChartTypes: IconChartDots3,
             findFields: IconSearch,
             searchSemanticLayer: IconBooks,
             analyzeFieldImpact: IconChartDots3,

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -436,6 +436,7 @@ export function useAiAgentThreadStreamMutation() {
                             case 'tool-generateTableVizConfig':
                             case 'tool-generateTimeSeriesVizConfig':
                             case 'tool-findExplores':
+                            case 'tool-findCustomChartTypes':
                             case 'tool-findFields':
                             case 'tool-grepFields':
                             case 'tool-getMetadata':


### PR DESCRIPTION
Closes: ZAP-926

### Description:

- expose newest custom chart types in the agent system prompt
- add `findCustomChartTypes` search and detail tool
- add pure schema serializers and focused contract tests

### Risk assessment:

- [ ] This is a high-risk change
