### PR TITLE
fix(pgwire): ignore scheduler pauses in catalog timeouts

### DIFF
--- a/packages/backend/src/ee/postgresWire/pgCatalog/catalogEvaluator.test.ts
+++ b/packages/backend/src/ee/postgresWire/pgCatalog/catalogEvaluator.test.ts
@@ -1,7 +1,8 @@
 import { parse, type SelectStatement } from 'pgsql-ast-parser';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { type PgWireTable } from '../types';
 import { evaluateCatalogSelect, toCatalogText } from './catalogEvaluator';
+import { MAX_STATEMENT_CPU_MS } from './catalogLimits';
 import { buildCatalogRelations } from './catalogRelations';
 
 const catalog: PgWireTable[] = [
@@ -163,6 +164,42 @@ describe('catalog evaluator: FROM and joins', () => {
                 'select count(*) from generate_series(1, 300) a(x) join generate_series(1, 300) b(y) on a.x - a.x = b.y - b.y',
             ),
         ).toEqual([['90000']]);
+    });
+
+    it('cancels statements that exceed the thread CPU budget', () => {
+        const [statement] = parse('select * from generate_series(1, 3000)');
+        const getThreadCpuUsage = vi
+            .fn()
+            .mockReturnValueOnce({ user: 0, system: 0 })
+            .mockReturnValue({
+                user: MAX_STATEMENT_CPU_MS * 1_000 + 1,
+                system: 0,
+            });
+
+        expect(() =>
+            evaluateCatalogSelect(
+                context,
+                statement as SelectStatement,
+                getThreadCpuUsage,
+            ),
+        ).toThrow(expect.objectContaining({ code: '57014' }));
+    });
+
+    it('does not charge descheduled wall time to the CPU budget', () => {
+        const dateNow = vi
+            .spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValue(10_000);
+
+        const result = (() => {
+            try {
+                return rows('select * from generate_series(1, 3000)');
+            } finally {
+                dateNow.mockRestore();
+            }
+        })();
+
+        expect(result).toHaveLength(3_000);
     });
 
     it('caps value and result sizes and pattern subjects with 54000', () => {

--- a/packages/backend/src/ee/postgresWire/pgCatalog/catalogEvaluator.ts
+++ b/packages/backend/src/ee/postgresWire/pgCatalog/catalogEvaluator.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define -- expressions, subqueries and FROM items evaluate each other recursively */
 import { assertUnreachable } from '@lightdash/common';
+import { threadCpuUsage } from 'node:process';
 import {
     type DataTypeDef,
     type Expr,
@@ -19,7 +20,7 @@ import {
     MAX_INTERMEDIATE_TUPLES,
     MAX_PATTERN_LENGTH,
     MAX_PATTERN_SUBJECT_LENGTH,
-    MAX_STATEMENT_MS,
+    MAX_STATEMENT_CPU_MS,
     MAX_WORK_UNITS,
     tooExpensive,
     unitsForLength,
@@ -328,13 +329,16 @@ const readRef = (resolved: ResolvedRef): CatalogValue =>
 
 type Evaluator = {
     context: EvaluatorContext;
-    /** remaining work units and the wall-clock deadline for this statement */
-    budget: { remaining: number; deadline: number; sinceClock: number };
+    budget: {
+        remaining: number;
+        cpuStartedAt: ReturnType<typeof threadCpuUsage>;
+        sinceCpuSample: number;
+        threadCpuUsage: typeof threadCpuUsage;
+    };
     regexCache: Map<string, RE2JS>;
 };
 
-/** Units between wall-clock checks: cheap enough to run often, rare enough not to matter */
-const CLOCK_SAMPLE_UNITS = 2_048;
+const CPU_SAMPLE_UNITS = 2_048;
 
 const spend = (evaluator: Evaluator, units: number): void => {
     const { budget } = evaluator;
@@ -342,10 +346,11 @@ const spend = (evaluator: Evaluator, units: number): void => {
     if (budget.remaining < 0) {
         throw tooExpensive('is too expensive');
     }
-    budget.sinceClock += units;
-    if (budget.sinceClock >= CLOCK_SAMPLE_UNITS) {
-        budget.sinceClock = 0;
-        if (Date.now() > budget.deadline) {
+    budget.sinceCpuSample += units;
+    if (budget.sinceCpuSample >= CPU_SAMPLE_UNITS) {
+        budget.sinceCpuSample = 0;
+        const cpuUsage = budget.threadCpuUsage(budget.cpuStartedAt);
+        if (cpuUsage.user + cpuUsage.system > MAX_STATEMENT_CPU_MS * 1_000) {
             throw new PgWireServerError(
                 'canceling statement due to statement timeout',
                 '57014',
@@ -1816,15 +1821,18 @@ function evaluateSelect(
 export const evaluateCatalogSelect = (
     context: EvaluatorContext,
     statement: SelectStatement,
+    getThreadCpuUsage: typeof threadCpuUsage = threadCpuUsage,
 ): EvaluatedRelation => {
     try {
+        const cpuStartedAt = getThreadCpuUsage();
         return evaluateSelect(
             {
                 context,
                 budget: {
                     remaining: MAX_WORK_UNITS,
-                    deadline: Date.now() + MAX_STATEMENT_MS,
-                    sinceClock: 0,
+                    cpuStartedAt,
+                    sinceCpuSample: 0,
+                    threadCpuUsage: getThreadCpuUsage,
                 },
                 regexCache: new Map(),
             },

--- a/packages/backend/src/ee/postgresWire/pgCatalog/catalogLimits.ts
+++ b/packages/backend/src/ee/postgresWire/pgCatalog/catalogLimits.ts
@@ -10,7 +10,7 @@ import { PgWireServerError } from '../PgWireServerError';
 export const MAX_INTERMEDIATE_TUPLES = 100_000;
 /** Work units: roughly one per row per pass, plus bytes/64 for every string built or keyed */
 export const MAX_WORK_UNITS = 10_000_000;
-export const MAX_STATEMENT_MS = 2_000;
+export const MAX_STATEMENT_CPU_MS = 2_000;
 export const MAX_VALUE_LENGTH = 64 * 1024;
 export const MAX_RESULT_LENGTH = 16 * 1024 * 1024;
 export const MAX_PATTERN_LENGTH = 1_000;

--- a/packages/backend/src/ee/postgresWire/pgCatalog/catalogQuery.test.ts
+++ b/packages/backend/src/ee/postgresWire/pgCatalog/catalogQuery.test.ts
@@ -414,7 +414,7 @@ describe('information_schema and constant selects (behaviour carried over)', () 
 });
 
 describe('large projects', () => {
-    it('answers pgjdbc wildcard getColumns over 45k columns within the budget', () => {
+    it('answers pgjdbc wildcard getColumns over 45k columns within resource budgets', () => {
         const bigCatalog: PgWireTable[] = Array.from(
             { length: 300 },
             (_, t) => ({
@@ -436,11 +436,9 @@ describe('large projects', () => {
         const sql = (
             pgjdbcFixtures().get('getColumns(null,public,orders,%)')?.[0] ?? ''
         ).replace("c.relname LIKE 'orders'", "c.relname LIKE '%'");
-        const started = Date.now();
         const result = tryHandleCatalogQuery(sql, bigInput);
         expect(result).toMatchObject({ type: 'rows' });
         expect((result as { rows: unknown[] }).rows).toHaveLength(45_000);
-        expect(Date.now() - started).toBeLessThan(5_000);
     });
 });
 


### PR DESCRIPTION
Relates: #27868

## Summary

Large pgwire catalog queries no longer fail when the API process is temporarily descheduled. The evaluator still cancels statements after two seconds of actual thread CPU consumption.

## Root cause

The catalog evaluator used elapsed wall time as a resource budget:

```ts
if (Date.now() > budget.deadline) {
    throw statementTimeout();
}
```

A busy CI runner paused the process while evaluating pgjdbc metadata for 45,000 columns. The pause counted against the two-second deadline even though the evaluator was not consuming CPU, producing a nondeterministic `57014` timeout.

## Fix

The evaluator now samples `process.threadCpuUsage()`. This preserves the two-second CPU guard and all deterministic work, tuple, value, pattern, and result limits while excluding scheduler pauses.

- `catalogEvaluator.ts` — accounts current-thread CPU instead of elapsed wall time.
- `catalogEvaluator.test.ts` — covers CPU overruns and simulated wall-clock jumps independently.
- `catalogQuery.test.ts` — keeps the 45,000-column resource-budget assertion without a contradictory five-second wall-clock threshold.

## Before and after

    Before: evaluator CPU + scheduler pause ──> 2 s wall deadline ──> 57014
    After:  evaluator thread CPU only       ──> 2 s CPU budget  ──> result

## Test plan

- [x] `pnpm -F backend exec vitest run src/ee/postgresWire` — 220 tests pass
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] Regression: simulated 10-second wall-clock jump does not consume CPU budget
- [x] Failure path: simulated CPU overrun returns `57014`

### Risk assessment

- [ ] This is a high-risk change
