### PR TITLE
feat(ai): save custom chart type answers as saved charts

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    ChartType,
     type AiAgentMessageAssistant,
     type AiArtifact,
     type ApiError,
@@ -59,7 +58,10 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
-import { buildAiSavedChartData } from '../../utils/aiSavedChartData';
+import {
+    buildAiSavedChartData,
+    getCustomChartTypeConfig,
+} from '../../utils/aiSavedChartData';
 import {
     canonicalizeAiMerge,
     remapFieldIdsDeep,
@@ -203,10 +205,7 @@ export const AiChartQuickOptions = ({
 
     // Custom-chart-type answers derive their saved pivot from the type's
     // schema, fetched with the same query key as the thread renderer.
-    const customChartTypeConfig =
-        chartConfig.type === ChartType.DATA_APP_VIZ
-            ? chartConfig.config
-            : undefined;
+    const customChartTypeConfig = getCustomChartTypeConfig(chartConfig);
     const chartVersionUuid = useChartVersionPreview();
     const customChartTypeRenderTarget = useMemo(
         () => ({ isEmbedded: !!embedToken, savedChartUuid, chartVersionUuid }),
@@ -376,13 +375,15 @@ export const AiChartQuickOptions = ({
             );
             return { pathname: url.pathname, search: search.toString() };
         }
+        // Custom-chart-type answers carry the schema-derived pivot so the
+        // explorer opens pivoted exactly like the thread render; until the
+        // schema loads there is no pivot to carry, so no URL.
+        if (customChartTypeConfig && !savedData) return undefined;
         return getOpenInExploreUrl({
             metricQuery,
             projectUuid,
             columnOrder,
             chartConfig,
-            // Custom-chart-type answers carry the schema-derived pivot so the
-            // explorer opens pivoted exactly like the thread render.
             pivotColumns: customChartTypeConfig
                 ? savedData?.pivotConfig?.columns
                 : pivotDimensions,
@@ -397,7 +398,7 @@ export const AiChartQuickOptions = ({
         chartConfig,
         pivotDimensions,
         customChartTypeConfig,
-        savedData?.pivotConfig?.columns,
+        savedData,
     ]);
 
     const { mutateAsync: createShareUrl } = useCreateShareMutation();
@@ -633,7 +634,7 @@ export const AiChartQuickOptions = ({
                                 leftSection={
                                     <MantineIcon icon={IconExternalLink} />
                                 }
-                                disabled={isDisabled}
+                                disabled={isDisabled || !openInExploreUrl}
                                 onClick={handleExploreFromHere}
                             >
                                 Explore from here

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    ChartType,
     type AiAgentMessageAssistant,
     type AiArtifact,
     type ApiError,
@@ -32,11 +33,12 @@ import MantineModal from '../../../../../components/common/MantineModal';
 import { SaveToSpaceOrDashboard } from '../../../../../components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard';
 import { useVisualizationContext } from '../../../../../components/LightdashVisualization/useVisualizationContext';
 import useEmbed from '../../../../../ee/providers/Embed/useEmbed';
+import { useChartVersionPreview } from '../../../../../features/apps/ChartVersionPreview/useChartVersionPreview';
+import { useDataAppVizRenderMetadata } from '../../../../../features/chartTypes/hooks/useDataAppVizRender';
 import {
     MERGE_URL_PARAM,
     serializeMergeState,
 } from '../../../../../features/mergeQuery/context/mergeUrlState';
-import { toSavedMerge } from '../../../../../features/mergeQuery/hooks/useSavedMerge';
 import useToaster from '../../../../../hooks/toaster/useToaster';
 import useCreateInAnySpaceAccess from '../../../../../hooks/user/useCreateInAnySpaceAccess';
 import { useCreateShareMutation } from '../../../../../hooks/useShare';
@@ -57,6 +59,7 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
+import { buildAiSavedChartData } from '../../utils/aiSavedChartData';
 import {
     canonicalizeAiMerge,
     remapFieldIdsDeep,
@@ -99,7 +102,7 @@ export const AiChartQuickOptions = ({
 }: Props) => {
     const { track } = useTracking();
     const { user } = useApp();
-    const { content, writeActions } = useEmbed();
+    const { content, writeActions, embedToken } = useEmbed();
     const isEmbed = isEmbedAiAgentRoute();
     const location = useLocation();
     const navigate = useNavigate();
@@ -162,6 +165,7 @@ export const AiChartQuickOptions = ({
         chartConfig,
         pivotDimensions,
         chartRef,
+        savedChartUuid,
     } = useVisualizationContext();
     const { mutate: savePromptQuery } = useSavePromptQuery(
         projectUuid,
@@ -197,53 +201,44 @@ export const AiChartQuickOptions = ({
         [merge],
     );
 
-    const savedData = useMemo(() => {
-        if (!metricQuery) return undefined;
-        // A merged result's own metricQuery is synthetic; the chart persists
-        // the primary source's query (always first) plus the stored merge.
-        if (merge) {
-            if (!canonicalMerge) return undefined;
-            const { fieldIdByAiFieldId } = canonicalMerge;
-            const [primary] = canonicalMerge.mergeQuery.sources;
-            return {
-                metricQuery: primary.metricQuery,
-                tableName: primary.metricQuery.exploreName,
-                chartConfig: remapFieldIdsDeep(chartConfig, fieldIdByAiFieldId),
-                tableConfig: {
-                    columnOrder: remapFieldIdsDeep(
-                        columnOrder,
-                        fieldIdByAiFieldId,
-                    ),
-                },
-                pivotConfig: pivotDimensions?.length
-                    ? {
-                          columns: remapFieldIdsDeep(
-                              pivotDimensions,
-                              fieldIdByAiFieldId,
-                          ),
-                      }
-                    : undefined,
-                merge: toSavedMerge(canonicalMerge.mergeQuery),
-                parameters: merge.parameters,
-            };
-        }
-        return {
+    // Custom-chart-type answers derive their saved pivot from the type's
+    // schema, fetched with the same query key as the thread renderer.
+    const customChartTypeConfig =
+        chartConfig.type === ChartType.DATA_APP_VIZ
+            ? chartConfig.config
+            : undefined;
+    const chartVersionUuid = useChartVersionPreview();
+    const customChartTypeRenderTarget = useMemo(
+        () => ({ isEmbedded: !!embedToken, savedChartUuid, chartVersionUuid }),
+        [embedToken, savedChartUuid, chartVersionUuid],
+    );
+    const { data: customChartTypeMetadata } = useDataAppVizRenderMetadata(
+        projectUuid,
+        customChartTypeConfig?.dataAppVizUuid,
+        customChartTypeRenderTarget,
+    );
+
+    const savedData = useMemo(
+        () =>
+            buildAiSavedChartData({
+                metricQuery,
+                chartConfig,
+                columnOrder,
+                pivotDimensions,
+                merge,
+                canonicalMerge,
+                customChartTypeMetadata,
+            }),
+        [
             metricQuery,
-            tableName: metricQuery.exploreName,
             chartConfig,
-            tableConfig: { columnOrder },
-            pivotConfig: pivotDimensions?.length
-                ? { columns: pivotDimensions }
-                : undefined,
-        };
-    }, [
-        metricQuery,
-        chartConfig,
-        columnOrder,
-        pivotDimensions,
-        merge,
-        canonicalMerge,
-    ]);
+            columnOrder,
+            pivotDimensions,
+            merge,
+            canonicalMerge,
+            customChartTypeMetadata,
+        ],
+    );
 
     const trackChartCreated = useCallback(() => {
         if (
@@ -386,7 +381,11 @@ export const AiChartQuickOptions = ({
             projectUuid,
             columnOrder,
             chartConfig,
-            pivotColumns: pivotDimensions,
+            // Custom-chart-type answers carry the schema-derived pivot so the
+            // explorer opens pivoted exactly like the thread render.
+            pivotColumns: customChartTypeConfig
+                ? savedData?.pivotConfig?.columns
+                : pivotDimensions,
         });
     }, [
         isDisabled,
@@ -397,6 +396,8 @@ export const AiChartQuickOptions = ({
         columnOrder,
         chartConfig,
         pivotDimensions,
+        customChartTypeConfig,
+        savedData?.pivotConfig?.columns,
     ]);
 
     const { mutateAsync: createShareUrl } = useCreateShareMutation();
@@ -596,7 +597,9 @@ export const AiChartQuickOptions = ({
                                             void handleSaveToCurrentDashboard()
                                         }
                                         disabled={
-                                            isDisabled || isSavingToDashboard
+                                            isDisabled ||
+                                            !savedData ||
+                                            isSavingToDashboard
                                         }
                                         leftSection={
                                             <MantineIcon
@@ -610,6 +613,7 @@ export const AiChartQuickOptions = ({
                                 {canSaveChart && (
                                     <Menu.Item
                                         onClick={() => open()}
+                                        disabled={isDisabled || !savedData}
                                         leftSection={
                                             <MantineIcon
                                                 icon={IconDeviceFloppy}

--- a/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.test.ts
@@ -1,5 +1,6 @@
 import {
     ChartType,
+    MergeJoinType,
     type ChartConfig,
     type DataAppVizRenderMetadata,
     type MetricQuery,
@@ -185,7 +186,7 @@ describe('buildAiSavedChartData', () => {
                         },
                     },
                 ],
-                joinType: 'full' as CanonicalAiMerge['mergeQuery']['joinType'],
+                joinType: MergeJoinType.FULL,
                 tableCalculations: [],
                 limit: 500,
             },

--- a/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.test.ts
@@ -1,0 +1,232 @@
+import {
+    ChartType,
+    type ChartConfig,
+    type DataAppVizRenderMetadata,
+    type MetricQuery,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    DEFAULT_ADDITIONAL_SOURCE_ID,
+    PRIMARY_SOURCE_ID,
+} from '../../../../features/mergeQuery/constants';
+import { buildAiSavedChartData } from './aiSavedChartData';
+import { type CanonicalAiMerge } from './canonicalizeAiMerge';
+
+const metricQuery: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_status', 'orders_region'],
+    metrics: ['orders_total'],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const tableChartConfig: ChartConfig = {
+    type: ChartType.TABLE,
+    config: undefined,
+};
+
+const customChartConfig: ChartConfig = {
+    type: ChartType.DATA_APP_VIZ,
+    config: {
+        dataAppVizUuid: 'viz-uuid',
+        fieldMapping: {
+            x: 'orders_status',
+            y: 'orders_total',
+            split: 'orders_region',
+        },
+    },
+};
+
+const readyMetadata: DataAppVizRenderMetadata = {
+    state: 'ready',
+    version: 3,
+    schema: {
+        fields: [
+            { name: 'x', label: 'X', type: 'dimension', required: true },
+            { name: 'y', label: 'Y', type: 'metric', required: true },
+            { name: 'split', label: 'Split', type: 'series', required: false },
+        ],
+        configOptions: [],
+        colorPalette: null,
+    },
+    latestBuildInProgress: false,
+};
+
+const baseArgs = {
+    metricQuery,
+    columnOrder: ['orders_status', 'orders_region', 'orders_total'],
+    pivotDimensions: undefined,
+    merge: null,
+    canonicalMerge: null,
+    customChartTypeMetadata: undefined,
+};
+
+describe('buildAiSavedChartData', () => {
+    it('returns undefined without a metric query', () => {
+        expect(
+            buildAiSavedChartData({
+                ...baseArgs,
+                metricQuery: undefined,
+                chartConfig: tableChartConfig,
+            }),
+        ).toBeUndefined();
+    });
+
+    it('passes builtin answers through with the live pivot dimensions', () => {
+        const result = buildAiSavedChartData({
+            ...baseArgs,
+            chartConfig: tableChartConfig,
+            pivotDimensions: ['orders_region'],
+        });
+        expect(result).toEqual({
+            metricQuery,
+            tableName: 'orders',
+            chartConfig: tableChartConfig,
+            tableConfig: { columnOrder: baseArgs.columnOrder },
+            pivotConfig: { columns: ['orders_region'] },
+        });
+    });
+
+    it('omits pivotConfig for builtin answers without pivot dimensions', () => {
+        const result = buildAiSavedChartData({
+            ...baseArgs,
+            chartConfig: tableChartConfig,
+        });
+        expect(result?.pivotConfig).toBeUndefined();
+    });
+
+    describe('custom chart type answers', () => {
+        it('derives pivotConfig from the series slots of the schema', () => {
+            const result = buildAiSavedChartData({
+                ...baseArgs,
+                chartConfig: customChartConfig,
+                customChartTypeMetadata: readyMetadata,
+            });
+            expect(result).toEqual({
+                metricQuery,
+                tableName: 'orders',
+                chartConfig: customChartConfig,
+                tableConfig: { columnOrder: baseArgs.columnOrder },
+                pivotConfig: { columns: ['orders_region'] },
+            });
+        });
+
+        it('ignores live pivot dimensions in favour of the schema derivation', () => {
+            const result = buildAiSavedChartData({
+                ...baseArgs,
+                chartConfig: customChartConfig,
+                pivotDimensions: ['orders_status'],
+                customChartTypeMetadata: readyMetadata,
+            });
+            expect(result?.pivotConfig).toEqual({
+                columns: ['orders_region'],
+            });
+        });
+
+        it('omits pivotConfig when the schema has no series slots', () => {
+            const result = buildAiSavedChartData({
+                ...baseArgs,
+                chartConfig: customChartConfig,
+                customChartTypeMetadata: {
+                    ...readyMetadata,
+                    schema: {
+                        ...readyMetadata.schema,
+                        fields: readyMetadata.schema.fields.filter(
+                            (field) => field.type !== 'series',
+                        ),
+                    },
+                },
+            });
+            expect(result).toBeDefined();
+            expect(result?.pivotConfig).toBeUndefined();
+        });
+
+        it('returns undefined until the schema metadata is ready', () => {
+            expect(
+                buildAiSavedChartData({
+                    ...baseArgs,
+                    chartConfig: customChartConfig,
+                }),
+            ).toBeUndefined();
+            expect(
+                buildAiSavedChartData({
+                    ...baseArgs,
+                    chartConfig: customChartConfig,
+                    customChartTypeMetadata: {
+                        state: 'building',
+                        latestBuildInProgress: true,
+                    },
+                }),
+            ).toBeUndefined();
+        });
+    });
+
+    describe('merge answers', () => {
+        const canonicalMerge: CanonicalAiMerge = {
+            mergeQuery: {
+                sources: [
+                    { id: PRIMARY_SOURCE_ID, metricQuery },
+                    {
+                        id: DEFAULT_ADDITIONAL_SOURCE_ID,
+                        metricQuery: {
+                            ...metricQuery,
+                            exploreName: 'payments',
+                        },
+                    },
+                ],
+                joinKey: [
+                    {
+                        name: 'join_key_0',
+                        fieldIdBySourceId: {
+                            [PRIMARY_SOURCE_ID]: 'orders_status',
+                            [DEFAULT_ADDITIONAL_SOURCE_ID]: 'payments_status',
+                        },
+                    },
+                ],
+                joinType: 'full' as CanonicalAiMerge['mergeQuery']['joinType'],
+                tableCalculations: [],
+                limit: 500,
+            },
+            fieldIdByAiFieldId: { source_1_total: 'a_total' },
+        };
+
+        it('saves the primary source query with remapped config', () => {
+            const chartConfig: ChartConfig = {
+                type: ChartType.BIG_NUMBER,
+                config: { selectedField: 'source_1_total' },
+            };
+            const result = buildAiSavedChartData({
+                ...baseArgs,
+                chartConfig,
+                columnOrder: ['source_1_total'],
+                pivotDimensions: ['source_1_total'],
+                merge: { parameters: undefined },
+                canonicalMerge,
+            });
+            expect(result?.metricQuery).toEqual(metricQuery);
+            expect(result?.tableName).toBe('orders');
+            expect(result?.chartConfig).toEqual({
+                type: ChartType.BIG_NUMBER,
+                config: { selectedField: 'a_total' },
+            });
+            expect(result?.tableConfig).toEqual({
+                columnOrder: ['a_total'],
+            });
+            expect(result?.pivotConfig).toEqual({ columns: ['a_total'] });
+            expect(result?.merge?.primarySourceId).toBe(PRIMARY_SOURCE_ID);
+        });
+
+        it('returns undefined for a merge that could not be canonicalized', () => {
+            expect(
+                buildAiSavedChartData({
+                    ...baseArgs,
+                    chartConfig: tableChartConfig,
+                    merge: { parameters: undefined },
+                    canonicalMerge: null,
+                }),
+            ).toBeUndefined();
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.ts
@@ -3,6 +3,7 @@ import {
     deriveDataAppVizPivotConfig,
     type ChartConfig,
     type CreateSavedChartVersion,
+    type DataAppVizChart,
     type DataAppVizRenderMetadata,
     type MetricQuery,
     type ParametersValuesMap,
@@ -24,6 +25,13 @@ type BuildAiSavedChartDataArgs = {
     /** Fetched for custom-chart-type answers; undefined for builtin answers. */
     customChartTypeMetadata: DataAppVizRenderMetadata | undefined;
 };
+
+export const getCustomChartTypeConfig = (
+    chartConfig: ChartConfig,
+): DataAppVizChart | undefined =>
+    chartConfig.type === ChartType.DATA_APP_VIZ
+        ? chartConfig.config
+        : undefined;
 
 /** The saved-chart version an AI answer persists through the save flows. */
 export const buildAiSavedChartData = ({
@@ -61,10 +69,7 @@ export const buildAiSavedChartData = ({
             parameters: merge.parameters,
         };
     }
-    const customChartTypeConfig =
-        chartConfig.type === ChartType.DATA_APP_VIZ
-            ? chartConfig.config
-            : undefined;
+    const customChartTypeConfig = getCustomChartTypeConfig(chartConfig);
     // The thread pivots custom answers server-side from the type's schema;
     // persisting the same derivation makes the saved chart round-trip.
     if (customChartTypeConfig) {

--- a/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.ts
@@ -1,0 +1,92 @@
+import {
+    ChartType,
+    deriveDataAppVizPivotConfig,
+    type ChartConfig,
+    type CreateSavedChartVersion,
+    type DataAppVizRenderMetadata,
+    type MetricQuery,
+    type ParametersValuesMap,
+} from '@lightdash/common';
+import { toSavedMerge } from '../../../../features/mergeQuery/hooks/useSavedMerge';
+import {
+    remapFieldIdsDeep,
+    type CanonicalAiMerge,
+} from './canonicalizeAiMerge';
+
+type BuildAiSavedChartDataArgs = {
+    metricQuery: MetricQuery | undefined;
+    chartConfig: ChartConfig;
+    columnOrder: string[];
+    pivotDimensions: string[] | undefined;
+    /** Set for merge artifacts. */
+    merge: { parameters: ParametersValuesMap | undefined } | null;
+    canonicalMerge: CanonicalAiMerge | null;
+    /** Fetched for custom-chart-type answers; undefined for builtin answers. */
+    customChartTypeMetadata: DataAppVizRenderMetadata | undefined;
+};
+
+/** The saved-chart version an AI answer persists through the save flows. */
+export const buildAiSavedChartData = ({
+    metricQuery,
+    chartConfig,
+    columnOrder,
+    pivotDimensions,
+    merge,
+    canonicalMerge,
+    customChartTypeMetadata,
+}: BuildAiSavedChartDataArgs): CreateSavedChartVersion | undefined => {
+    if (!metricQuery) return undefined;
+    // A merged result's own metricQuery is synthetic; the chart persists
+    // the primary source's query (always first) plus the stored merge.
+    if (merge) {
+        if (!canonicalMerge) return undefined;
+        const { fieldIdByAiFieldId } = canonicalMerge;
+        const [primary] = canonicalMerge.mergeQuery.sources;
+        return {
+            metricQuery: primary.metricQuery,
+            tableName: primary.metricQuery.exploreName,
+            chartConfig: remapFieldIdsDeep(chartConfig, fieldIdByAiFieldId),
+            tableConfig: {
+                columnOrder: remapFieldIdsDeep(columnOrder, fieldIdByAiFieldId),
+            },
+            pivotConfig: pivotDimensions?.length
+                ? {
+                      columns: remapFieldIdsDeep(
+                          pivotDimensions,
+                          fieldIdByAiFieldId,
+                      ),
+                  }
+                : undefined,
+            merge: toSavedMerge(canonicalMerge.mergeQuery),
+            parameters: merge.parameters,
+        };
+    }
+    const customChartTypeConfig =
+        chartConfig.type === ChartType.DATA_APP_VIZ
+            ? chartConfig.config
+            : undefined;
+    // The thread pivots custom answers server-side from the type's schema;
+    // persisting the same derivation makes the saved chart round-trip.
+    if (customChartTypeConfig) {
+        if (customChartTypeMetadata?.state !== 'ready') return undefined;
+        return {
+            metricQuery,
+            tableName: metricQuery.exploreName,
+            chartConfig,
+            tableConfig: { columnOrder },
+            pivotConfig: deriveDataAppVizPivotConfig(
+                customChartTypeMetadata.schema.fields,
+                customChartTypeConfig.fieldMapping,
+            ),
+        };
+    }
+    return {
+        metricQuery,
+        tableName: metricQuery.exploreName,
+        chartConfig,
+        tableConfig: { columnOrder },
+        pivotConfig: pivotDimensions?.length
+            ? { columns: pivotDimensions }
+            : undefined,
+    };
+};


### PR DESCRIPTION
Saving a custom-chart-type answer from a web thread now produces a `DATA_APP_VIZ` saved chart that round-trips — opening it in a space or dashboard renders the identical viz.

- **Schema-derived pivot**: the quick options' save payload was built from the live `pivotDimensions`, which are always empty for custom answers (their pivot is derived server-side) — so saves would have persisted no `pivotConfig` and rendered flat. `buildAiSavedChartData` now derives it with `deriveDataAppVizPivotConfig(schema.fields, fieldMapping)`, the same derivation the thread's server-side pivot and the saved-chart read path use, so the chart round-trips by construction.
- **Schema fetch**: reuses `useDataAppVizRenderMetadata` with the same query key as the thread renderer, so the schema is already cached when saving. Save actions and explore-from-here stay disabled until metadata is `ready` (an un-ready save would persist the wrong pivot).
- **Explore from here** carries the schema-derived pivot for custom answers, matching the thread render.
- **Extraction**: the `savedData` construction moved out of `AiChartQuickOptions` into pure `buildAiSavedChartData`; the builtin and merge branches are verbatim moves, pinned by unit tests.

Tests: 9 pure-function units (builtin passthrough, merge remap, custom derivation, no-series-slots, not-ready gating). Full frontend suite green.

Same PoC limitation as ZAP-928: the schema fetch uses the chart-less render-metadata route (`manage Explore`), so only users who can see the thread viz can save it.

Closes: ZAP-930

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MDtcEEDhT6tcXPTSk4t6a
