### PR TITLE
feat: show accepted visualization fields

### DIFF
--- a/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.module.css
+++ b/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.module.css
@@ -32,6 +32,24 @@
     white-space: nowrap;
 }
 
+.acceptedFields {
+    padding: var(--mantine-spacing-sm);
+}
+
+.fieldRow {
+    padding-block: var(--mantine-spacing-xs);
+    border-bottom: 1px solid var(--mantine-color-ldGray-1);
+}
+
+.fieldRow:last-child {
+    border-bottom: 0;
+}
+
+.fieldDetails {
+    min-width: 0;
+    flex: 1;
+}
+
 .tabs {
     display: flex;
     flex-direction: column;

--- a/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.test.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.test.tsx
@@ -45,12 +45,53 @@ describe('ConfigurePanel', () => {
         expect(screen.getByText('Generated options')).toBeInTheDocument();
     });
 
+    it('shows every accepted field with its type and requirement', () => {
+        renderPanel({
+            schema: {
+                fields: [
+                    {
+                        name: 'category',
+                        label: 'Category',
+                        type: 'dimension',
+                        required: true,
+                    },
+                    {
+                        name: 'value',
+                        label: 'Value',
+                        type: 'metric',
+                        required: true,
+                    },
+                    {
+                        name: 'series',
+                        label: 'Group by',
+                        type: 'series',
+                        required: false,
+                    },
+                ],
+                configOptions: schema.configOptions,
+                colorPalette: null,
+            },
+        });
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Fields' }));
+
+        expect(screen.getByText('Accepted fields')).toBeInTheDocument();
+        expect(screen.getByText('Category')).toBeInTheDocument();
+        expect(screen.getByText('Value')).toBeInTheDocument();
+        expect(screen.getByText('Group by')).toBeInTheDocument();
+        expect(screen.getAllByText('Required')).toHaveLength(2);
+        expect(screen.getByText('Optional')).toBeInTheDocument();
+        expect(screen.getAllByText('dimension')).toHaveLength(2);
+        expect(screen.getByText('metric')).toBeInTheDocument();
+        expect(screen.queryByText('series')).not.toBeInTheDocument();
+    });
+
     it('splits the declared options into one tab per group', () => {
         renderPanel();
 
         expect(
             screen.getAllByRole('tab').map((tab) => tab.textContent),
-        ).toEqual(['Display', 'Style']);
+        ).toEqual(['Display', 'Style', 'Fields']);
         expect(screen.getByLabelText('Show grid')).toBeInTheDocument();
         expect(screen.queryByLabelText('Show markers')).not.toBeInTheDocument();
     });
@@ -79,14 +120,17 @@ describe('ConfigurePanel', () => {
         expect(screen.getByLabelText('Show grid')).toBeChecked();
     });
 
-    it('says so when a chart type declares nothing to configure', () => {
+    it('keeps an empty fields tab when no options are declared', () => {
         renderPanel({
             schema: { fields: [], configOptions: [], colorPalette: null },
         });
 
-        expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Fields' })).toHaveAttribute(
+            'aria-selected',
+            'true',
+        );
         expect(
-            screen.getByText('This chart type declares no display options.'),
+            screen.getByText('This chart type accepts no data fields.'),
         ).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.test.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.test.tsx
@@ -45,47 +45,6 @@ describe('ConfigurePanel', () => {
         expect(screen.getByText('Generated options')).toBeInTheDocument();
     });
 
-    it('shows every accepted field with its type and requirement', () => {
-        renderPanel({
-            schema: {
-                fields: [
-                    {
-                        name: 'category',
-                        label: 'Category',
-                        type: 'dimension',
-                        required: true,
-                    },
-                    {
-                        name: 'value',
-                        label: 'Value',
-                        type: 'metric',
-                        required: true,
-                    },
-                    {
-                        name: 'series',
-                        label: 'Group by',
-                        type: 'series',
-                        required: false,
-                    },
-                ],
-                configOptions: schema.configOptions,
-                colorPalette: null,
-            },
-        });
-
-        fireEvent.click(screen.getByRole('tab', { name: 'Fields' }));
-
-        expect(screen.getByText('Accepted fields')).toBeInTheDocument();
-        expect(screen.getByText('Category')).toBeInTheDocument();
-        expect(screen.getByText('Value')).toBeInTheDocument();
-        expect(screen.getByText('Group by')).toBeInTheDocument();
-        expect(screen.getAllByText('Required')).toHaveLength(2);
-        expect(screen.getByText('Optional')).toBeInTheDocument();
-        expect(screen.getAllByText('dimension')).toHaveLength(2);
-        expect(screen.getByText('metric')).toBeInTheDocument();
-        expect(screen.queryByText('series')).not.toBeInTheDocument();
-    });
-
     it('splits the declared options into one tab per group', () => {
         renderPanel();
 
@@ -120,7 +79,7 @@ describe('ConfigurePanel', () => {
         expect(screen.getByLabelText('Show grid')).toBeChecked();
     });
 
-    it('keeps an empty fields tab when no options are declared', () => {
+    it('says so when a chart type declares nothing to configure', () => {
         renderPanel({
             schema: { fields: [], configOptions: [], colorPalette: null },
         });

--- a/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.tsx
@@ -1,17 +1,23 @@
 import {
     getEffectiveOptionValues,
+    type DataAppVizField,
     type DataAppVizOptionValue,
     type DataAppVizOptionValues,
     type DataAppVizSchema,
 } from '@lightdash/common';
-import { Box, Stack, Tabs, Text } from '@mantine/core';
+import { Box, Group, Stack, Tabs, Text } from '@mantine/core';
 import { useMemo, useState, type FC } from 'react';
 import OverflowTabsList from '../../../components/common/OverflowTabsList/OverflowTabsList';
 import { PalettePicker } from '../../../components/common/PalettePicker/PalettePicker';
+import TruncatedText from '../../../components/common/TruncatedText';
 import DataAppVizOptionControl from '../../../components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionControl';
 import { groupDataAppVizOptions } from '../../../components/VisualizationConfigs/DataAppVizConfig/dataAppVizOptionGroups';
 import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
+import DataAppVizFieldTypeBadge from '../components/DataAppVizFieldTypeBadge';
+import { poolKeyForSlot } from '../utils/autoMapDataAppVizFields';
 import classes from './ConfigurePanel.module.css';
+
+const FIELDS_TAB_ID = 'fields';
 
 type Props = {
     schema: DataAppVizSchema;
@@ -25,6 +31,44 @@ type Props = {
      *  held legible but inert until the one being previewed arrives. */
     isStale: boolean;
 };
+
+const AcceptedFields: FC<{ fields: DataAppVizField[] }> = ({ fields }) => (
+    <Stack gap="xs" className={classes.acceptedFields}>
+        <Text fz="xs" fw={600}>
+            Accepted fields
+        </Text>
+
+        {fields.length === 0 ? (
+            <Text fz="xs" c="dimmed" lh={1.5}>
+                This chart type accepts no data fields.
+            </Text>
+        ) : (
+            <Stack gap={0}>
+                {fields.map((field) => (
+                    <Group
+                        key={field.name}
+                        justify="space-between"
+                        gap="xs"
+                        wrap="nowrap"
+                        className={classes.fieldRow}
+                    >
+                        <Stack gap={1} className={classes.fieldDetails}>
+                            <TruncatedText maxWidth="100%" fw={500} fz="xs">
+                                {field.label}
+                            </TruncatedText>
+                            <Text fz="xs" c="dimmed">
+                                {field.required ? 'Required' : 'Optional'}
+                            </Text>
+                        </Stack>
+                        <DataAppVizFieldTypeBadge
+                            type={poolKeyForSlot(field)}
+                        />
+                    </Group>
+                ))}
+            </Stack>
+        )}
+    </Stack>
+);
 
 /**
  * The builder's configuration column: the options the current version declares,
@@ -53,12 +97,14 @@ const ConfigurePanel: FC<Props> = ({
     );
 
     const [selectedTab, setSelectedTab] = useState<string | null>(
-        optionGroups[0]?.id ?? null,
+        optionGroups[0]?.id ?? FIELDS_TAB_ID,
     );
     // A tab a rebuild stopped declaring must not leave the panel blank.
-    const activeTab = optionGroups.some((group) => group.id === selectedTab)
-        ? selectedTab
-        : (optionGroups[0]?.id ?? null);
+    const activeTab =
+        selectedTab === FIELDS_TAB_ID ||
+        optionGroups.some((group) => group.id === selectedTab)
+            ? selectedTab
+            : (optionGroups[0]?.id ?? FIELDS_TAB_ID);
 
     return (
         <Box className={classes.panel} data-stale={isStale} inert={isStale}>
@@ -66,57 +112,58 @@ const ConfigurePanel: FC<Props> = ({
                 config, and the chip says so. */}
             <Text className={classes.generatedChip}>Generated options</Text>
 
-            {optionGroups.length === 0 ? (
-                <Text fz="xs" c="dimmed" lh={1.5} px="sm" pb="sm">
-                    This chart type declares no display options.
-                </Text>
-            ) : (
-                <Tabs
-                    value={activeTab}
-                    onChange={setSelectedTab}
-                    keepMounted={false}
-                    className={classes.tabs}
-                >
-                    <OverflowTabsList className={classes.tabsList}>
-                        {optionGroups.map((group) => (
-                            <Tabs.Tab key={group.id} value={group.id} px="xs">
-                                {group.label}
-                            </Tabs.Tab>
-                        ))}
-                    </OverflowTabsList>
-
+            <Tabs
+                value={activeTab}
+                onChange={setSelectedTab}
+                keepMounted={false}
+                className={classes.tabs}
+            >
+                <OverflowTabsList className={classes.tabsList}>
                     {optionGroups.map((group) => (
-                        <Tabs.Panel
-                            key={group.id}
-                            value={group.id}
-                            className={classes.tabPanel}
-                        >
-                            <Stack gap="sm" px="sm" pt="sm" pb="sm">
-                                {group.options.map((option) => (
-                                    <DataAppVizOptionControl
-                                        key={option.name}
-                                        option={option}
-                                        value={effectiveValues[option.name]}
-                                        onChange={(value) =>
-                                            onOptionChange(option.name, value)
-                                        }
-                                    />
-                                ))}
-                                {group.hasPalette && (
-                                    <PalettePicker
-                                        label="Color palette"
-                                        value={colorPaletteUuid}
-                                        onChange={onPaletteChange}
-                                        palettes={palettes}
-                                        parentLabel="Project default"
-                                        showPreview={false}
-                                    />
-                                )}
-                            </Stack>
-                        </Tabs.Panel>
+                        <Tabs.Tab key={group.id} value={group.id} px="xs">
+                            {group.label}
+                        </Tabs.Tab>
                     ))}
-                </Tabs>
-            )}
+                    <Tabs.Tab value={FIELDS_TAB_ID} px="xs">
+                        Fields
+                    </Tabs.Tab>
+                </OverflowTabsList>
+
+                {optionGroups.map((group) => (
+                    <Tabs.Panel
+                        key={group.id}
+                        value={group.id}
+                        className={classes.tabPanel}
+                    >
+                        <Stack gap="sm" px="sm" pt="sm" pb="sm">
+                            {group.options.map((option) => (
+                                <DataAppVizOptionControl
+                                    key={option.name}
+                                    option={option}
+                                    value={effectiveValues[option.name]}
+                                    onChange={(value) =>
+                                        onOptionChange(option.name, value)
+                                    }
+                                />
+                            ))}
+                            {group.hasPalette && (
+                                <PalettePicker
+                                    label="Color palette"
+                                    value={colorPaletteUuid}
+                                    onChange={onPaletteChange}
+                                    palettes={palettes}
+                                    parentLabel="Project default"
+                                    showPreview={false}
+                                />
+                            )}
+                        </Stack>
+                    </Tabs.Panel>
+                ))}
+
+                <Tabs.Panel value={FIELDS_TAB_ID} className={classes.tabPanel}>
+                    <AcceptedFields fields={schema.fields} />
+                </Tabs.Panel>
+            </Tabs>
         </Box>
     );
 };

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -365,8 +365,12 @@ describe('ChartTypeBuilder', () => {
 
         // No toggle to find: the panel sits beside the preview from the start.
         expect(screen.getByText('Generated options')).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Fields' })).toHaveAttribute(
+            'aria-selected',
+            'true',
+        );
         expect(
-            screen.getByText('This chart type declares no display options.'),
+            screen.getByText('This chart type accepts no data fields.'),
         ).toBeInTheDocument();
     });
 


### PR DESCRIPTION
### Description

- add a final `Fields` tab to generated visualization options
- show each accepted field role, required state, and public dimension/metric type
- reuse Explorer field colors and present series-backed slots as dimensions

### Verification

- live builder and Explorer comparison: PASS
- `ConfigurePanel.test.tsx`: 7/7
- frontend typecheck
- focused lint and formatting

### Risk assessment

- [ ] This is a high-risk change