### PR TITLE
Add live per-node status indicators for composer query execution

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -1764,6 +1764,155 @@ describe('AiAgentToolsService runComposerQueries', () => {
         });
     });
 
+    it('emits per-node status transitions while the pipeline executes', async () => {
+        vi.useFakeTimers();
+        try {
+            const executeSourceQueries = vi
+                .fn()
+                .mockResolvedValue({ queries: submissions });
+            const getAsyncQueryResults = vi
+                .fn()
+                .mockResolvedValueOnce({ status: QueryHistoryStatus.EXECUTING })
+                .mockResolvedValue(readyResults);
+            // While the terminal is still running, the upstream node has
+            // already finished.
+            const getSourceQueryStatuses = vi.fn().mockResolvedValue({
+                statuses: [
+                    {
+                        queryUuid: 'query-1',
+                        status: QueryHistoryStatus.READY,
+                        error: null,
+                    },
+                    {
+                        queryUuid: 'query-2',
+                        status: QueryHistoryStatus.EXECUTING,
+                        error: null,
+                    },
+                ],
+            });
+            const service = makeService({
+                querySourceService: {
+                    executeSourceQueries,
+                    getSourceQueryStatuses,
+                },
+                asyncQueryService: { getAsyncQueryResults },
+            });
+
+            const onNodeStatus = vi.fn();
+            const promise = service
+                .createRuntime(makeRuntimeContext())
+                .runComposerQueries({
+                    queries: composerQueries,
+                    terminalNodeId: 'joined',
+                    onNodeStatus,
+                });
+            await vi.advanceTimersByTimeAsync(2_000);
+            await promise;
+
+            expect(onNodeStatus.mock.calls.map(([update]) => update)).toEqual([
+                {
+                    nodeId: 'orders',
+                    queryUuid: 'query-1',
+                    status: 'running',
+                    errorMessage: null,
+                },
+                {
+                    nodeId: 'joined',
+                    queryUuid: 'query-2',
+                    status: 'running',
+                    errorMessage: null,
+                },
+                {
+                    nodeId: 'orders',
+                    queryUuid: 'query-1',
+                    status: 'success',
+                    errorMessage: null,
+                },
+                {
+                    nodeId: 'joined',
+                    queryUuid: 'query-2',
+                    status: 'success',
+                    errorMessage: null,
+                },
+            ]);
+            // Only the still-pending nodes are batch-polled.
+            expect(getSourceQueryStatuses).toHaveBeenCalledWith(
+                account,
+                projectUuid,
+                ['query-1', 'query-2'],
+            );
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('emits error statuses for failing nodes before throwing', async () => {
+        const executeSourceQueries = vi
+            .fn()
+            .mockResolvedValue({ queries: submissions });
+        const getAsyncQueryResults = vi.fn().mockResolvedValue({
+            status: QueryHistoryStatus.ERROR,
+            error: 'referenced query failed',
+        });
+        const getSourceQueryStatuses = vi.fn().mockResolvedValue({
+            statuses: [
+                {
+                    queryUuid: 'query-1',
+                    status: QueryHistoryStatus.ERROR,
+                    error: 'relation does not exist',
+                },
+                {
+                    queryUuid: 'query-2',
+                    status: QueryHistoryStatus.ERROR,
+                    error: 'referenced query failed',
+                },
+            ],
+        });
+        const service = makeService({
+            querySourceService: {
+                executeSourceQueries,
+                getSourceQueryStatuses,
+            },
+            asyncQueryService: { getAsyncQueryResults },
+        });
+
+        const onNodeStatus = vi.fn();
+        await expect(
+            service.createRuntime(makeRuntimeContext()).runComposerQueries({
+                queries: composerQueries,
+                terminalNodeId: 'joined',
+                onNodeStatus,
+            }),
+        ).rejects.toThrow(/"orders" \(relation does not exist\)/);
+
+        expect(onNodeStatus.mock.calls.map(([update]) => update)).toEqual([
+            {
+                nodeId: 'orders',
+                queryUuid: 'query-1',
+                status: 'running',
+                errorMessage: null,
+            },
+            {
+                nodeId: 'joined',
+                queryUuid: 'query-2',
+                status: 'running',
+                errorMessage: null,
+            },
+            {
+                nodeId: 'orders',
+                queryUuid: 'query-1',
+                status: 'error',
+                errorMessage: 'relation does not exist',
+            },
+            {
+                nodeId: 'joined',
+                queryUuid: 'query-2',
+                status: 'error',
+                errorMessage: 'referenced query failed',
+            },
+        ]);
+    });
+
     it('rejects a terminal node that was not part of the submission', async () => {
         const executeSourceQueries = vi
             .fn()

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -82,6 +82,7 @@ import { ProjectContextModel } from '../../models/ProjectContextModel';
 import type { BuiltInSkills } from '../ai/skills/builtInSkills';
 import {
     AnalyzeFieldImpactFn,
+    ComposerNodeStatusUpdate,
     CreateContentFn,
     CreateScheduledDeliveryFn,
     DescribeWarehouseTableFn,
@@ -2184,7 +2185,11 @@ export class AiAgentToolsService extends BaseService {
 
     private runComposerQueries(
         context: AiAgentToolsRuntimeContext,
-        { queries, terminalNodeId }: Parameters<RunComposerQueriesFn>[0],
+        {
+            queries,
+            terminalNodeId,
+            onNodeStatus,
+        }: Parameters<RunComposerQueriesFn>[0],
     ): ReturnType<RunComposerQueriesFn> {
         return wrapSentryTransaction(
             `${AiAgentToolsService.transactionPrefix(context)}.runComposerQueries`,
@@ -2202,6 +2207,81 @@ export class AiAgentToolsService extends BaseService {
                         queries,
                         context: context.defaultQueryExecutionContext,
                     });
+
+                // Per-node status emission is best-effort UI telemetry: only
+                // transitions are emitted, and a listener error never breaks
+                // execution.
+                const emittedNodeStatuses = new Map<
+                    string,
+                    ComposerNodeStatusUpdate['status']
+                >();
+                const emitNodeStatus = (update: ComposerNodeStatusUpdate) => {
+                    if (
+                        emittedNodeStatuses.get(update.nodeId) === update.status
+                    )
+                        return;
+                    emittedNodeStatuses.set(update.nodeId, update.status);
+                    try {
+                        onNodeStatus?.(update);
+                    } catch {
+                        // never let a status listener break the query
+                    }
+                };
+                submissions.forEach((submission) =>
+                    emitNodeStatus({
+                        nodeId: submission.nodeId,
+                        queryUuid: submission.queryUuid,
+                        status: 'running',
+                        errorMessage: null,
+                    }),
+                );
+                const pollNodeStatuses = async () => {
+                    if (!onNodeStatus) return;
+                    const pending = submissions.filter((submission) => {
+                        const emitted = emittedNodeStatuses.get(
+                            submission.nodeId,
+                        );
+                        return emitted !== 'success' && emitted !== 'error';
+                    });
+                    if (pending.length === 0) return;
+                    try {
+                        const { statuses } =
+                            await this.querySourceService.getSourceQueryStatuses(
+                                context.account,
+                                context.projectUuid,
+                                pending.map(
+                                    (submission) => submission.queryUuid,
+                                ),
+                            );
+                        statuses.forEach((status) => {
+                            const submission = pending.find(
+                                (candidate) =>
+                                    candidate.queryUuid === status.queryUuid,
+                            );
+                            if (!submission) return;
+                            if (status.status === QueryHistoryStatus.READY) {
+                                emitNodeStatus({
+                                    nodeId: submission.nodeId,
+                                    queryUuid: submission.queryUuid,
+                                    status: 'success',
+                                    errorMessage: null,
+                                });
+                            } else if (
+                                status.status === QueryHistoryStatus.ERROR ||
+                                status.status === QueryHistoryStatus.CANCELLED
+                            ) {
+                                emitNodeStatus({
+                                    nodeId: submission.nodeId,
+                                    queryUuid: submission.queryUuid,
+                                    status: 'error',
+                                    errorMessage: status.error ?? null,
+                                });
+                            }
+                        });
+                    } catch {
+                        // status polling is best-effort; keep executing
+                    }
+                };
 
                 const terminalSubmission = submissions.find(
                     (submission) => submission.nodeId === terminalNodeId,
@@ -2247,6 +2327,15 @@ export class AiAgentToolsService extends BaseService {
                         });
 
                     if (queryResults.status === QueryHistoryStatus.READY) {
+                        // Terminal ready implies every upstream node finished.
+                        submissions.forEach((submission) =>
+                            emitNodeStatus({
+                                nodeId: submission.nodeId,
+                                queryUuid: submission.queryUuid,
+                                status: 'success',
+                                errorMessage: null,
+                            }),
+                        );
                         const wrappedRows = (queryResults.rows ?? []) as Record<
                             string,
                             AnyType
@@ -2276,6 +2365,24 @@ export class AiAgentToolsService extends BaseService {
                             context,
                             submissions,
                         );
+                        failedNodes.forEach(({ nodeId, error }) => {
+                            const submission = submissions.find(
+                                (candidate) => candidate.nodeId === nodeId,
+                            );
+                            if (!submission) return;
+                            emitNodeStatus({
+                                nodeId,
+                                queryUuid: submission.queryUuid,
+                                status: 'error',
+                                errorMessage: error,
+                            });
+                        });
+                        emitNodeStatus({
+                            nodeId: terminalSubmission.nodeId,
+                            queryUuid: terminalSubmission.queryUuid,
+                            status: 'error',
+                            errorMessage: queryResults.error ?? null,
+                        });
                         throw new WarehouseQueryError(
                             `Composer query failed${
                                 failedNodes.length > 0
@@ -2291,10 +2398,22 @@ export class AiAgentToolsService extends BaseService {
                     }
 
                     if (queryResults.status === QueryHistoryStatus.CANCELLED) {
+                        emitNodeStatus({
+                            nodeId: terminalSubmission.nodeId,
+                            queryUuid: terminalSubmission.queryUuid,
+                            status: 'error',
+                            errorMessage: 'Query was cancelled',
+                        });
                         throw new WarehouseQueryError(
                             'Composer query was cancelled',
                         );
                     }
+
+                    // Terminal still running: surface upstream nodes that have
+                    // already finished so the pipeline shows live per-node
+                    // progress.
+                    // eslint-disable-next-line no-await-in-loop
+                    await pollNodeStatuses();
 
                     const localDelay = delayMs;
                     // eslint-disable-next-line no-await-in-loop

--- a/packages/backend/src/ee/services/ai/tools/runComposerQueries.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runComposerQueries.test.ts
@@ -158,6 +158,7 @@ describe('getRunComposerQueries', () => {
                 expect.objectContaining({ nodeId: 'joined' }),
             ],
             terminalNodeId: 'joined',
+            onNodeStatus: expect.any(Function),
         });
         expect(dependencies.createOrUpdateArtifact).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -273,6 +274,7 @@ describe('getRunComposerQueries', () => {
                 },
             ],
             terminalNodeId: 'targets',
+            onNodeStatus: expect.any(Function),
         });
         expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
         expect(output.metadata?.status).toBe('success');
@@ -300,6 +302,7 @@ describe('getRunComposerQueries', () => {
                 composedNode,
             ],
             terminalNodeId: 'joined',
+            onNodeStatus: expect.any(Function),
         });
         expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
         expect(output.metadata?.status).toBe('success');
@@ -361,6 +364,77 @@ describe('getRunComposerQueries', () => {
         expect(output.metadata?.status).toBe('error');
         expect(dependencies.waitForSqlApproval).not.toHaveBeenCalled();
         expect(dependencies.runComposerQueries).not.toHaveBeenCalled();
+    });
+
+    it('forwards per-node status updates as attributed step-progress events', async () => {
+        const { tool, dependencies } = makeTool({ autoApproveSql: true });
+        dependencies.runComposerQueries.mockImplementation(
+            async ({
+                onNodeStatus,
+            }: {
+                onNodeStatus?: (update: {
+                    nodeId: string;
+                    queryUuid: string;
+                    status: 'running' | 'success' | 'error';
+                    errorMessage: string | null;
+                }) => void;
+            }) => {
+                onNodeStatus?.({
+                    nodeId: 'revenue',
+                    queryUuid: 'query-1',
+                    status: 'running',
+                    errorMessage: null,
+                });
+                onNodeStatus?.({
+                    nodeId: 'revenue',
+                    queryUuid: 'query-1',
+                    status: 'success',
+                    errorMessage: null,
+                });
+                onNodeStatus?.({
+                    nodeId: 'joined',
+                    queryUuid: 'query-3',
+                    status: 'error',
+                    errorMessage: 'column not found',
+                });
+                return {
+                    submissions: [
+                        {
+                            nodeId: 'revenue',
+                            sourceType: QuerySourceType.SEMANTIC_LAYER,
+                            queryUuid: 'query-1',
+                        },
+                    ],
+                    terminal: {
+                        queryUuid: 'query-1',
+                        columns: {},
+                        rows: [],
+                        rowCount: 0,
+                    },
+                };
+            },
+        );
+
+        await executeTool(tool, makeArgs());
+
+        expect(dependencies.updateProgress).toHaveBeenCalledWith(
+            'Running query "revenue"...',
+            'runComposerQueries',
+            'tool-call-1:revenue',
+            'in_progress',
+        );
+        expect(dependencies.updateProgress).toHaveBeenCalledWith(
+            'Query "revenue" complete',
+            'runComposerQueries',
+            'tool-call-1:revenue',
+            'complete',
+        );
+        expect(dependencies.updateProgress).toHaveBeenCalledWith(
+            'Query "joined" failed: column not found',
+            'runComposerQueries',
+            'tool-call-1:joined',
+            'error',
+        );
     });
 
     it('returns only a summary when data access is disabled', async () => {

--- a/packages/backend/src/ee/services/ai/tools/runComposerQueries.ts
+++ b/packages/backend/src/ee/services/ai/tools/runComposerQueries.ts
@@ -188,6 +188,35 @@ export const getRunComposerQueries = ({
                 const { submissions, terminal } = await runComposerQueries({
                     queries,
                     terminalNodeId: resolvedTerminalNodeId,
+                    // Per-node lifecycle → transient step-progress events the
+                    // web stream renders as live statuses on the pipeline.
+                    // progressId carries `${toolCallId}:${nodeId}` so the
+                    // client can key events to the right call and node.
+                    // Fire-and-forget: status delivery must never block or
+                    // fail the query.
+                    onNodeStatus: ({ nodeId, status, errorMessage }) => {
+                        let message: string;
+                        let progressStatus:
+                            | 'in_progress'
+                            | 'complete'
+                            | 'error';
+                        if (status === 'running') {
+                            message = `Running query "${nodeId}"...`;
+                            progressStatus = 'in_progress';
+                        } else if (status === 'success') {
+                            message = `Query "${nodeId}" complete`;
+                            progressStatus = 'complete';
+                        } else {
+                            message = `Query "${nodeId}" failed${errorMessage ? `: ${errorMessage}` : ''}`;
+                            progressStatus = 'error';
+                        }
+                        void updateProgress(
+                            message,
+                            'runComposerQueries',
+                            `${toolCallId}:${nodeId}`,
+                            progressStatus,
+                        ).catch(() => {});
+                    },
                 });
 
                 const prompt = await getPrompt();

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -518,14 +518,29 @@ export type RunSqlJobFn = (args: { sql: string; limit: number }) => Promise<{
 }>;
 
 /**
+ * Per-node lifecycle event emitted while a composer pipeline executes, so the
+ * UI can show each node's status live. Best-effort: emission failures must
+ * never affect query execution.
+ */
+export type ComposerNodeStatusUpdate = {
+    nodeId: string;
+    queryUuid: string;
+    status: 'running' | 'success' | 'error';
+    errorMessage: string | null;
+};
+
+/**
  * Submits a composer query (multi-source pipeline) and waits for the terminal
  * node's results. Submissions carry the pinned nodeId → queryUuid mapping for
  * every node; the terminal snapshot is the first page of the terminal node's
- * results, capped at that node's limit.
+ * results, capped at that node's limit. `onNodeStatus` receives per-node
+ * lifecycle transitions (running on submission, then success/error) while the
+ * pipeline executes.
  */
 export type RunComposerQueriesFn = (args: {
     queries: SourceQuery[];
     terminalNodeId: string;
+    onNodeStatus?: (update: ComposerNodeStatusUpdate) => void;
 }) => Promise<{
     submissions: SourceQuerySubmission[];
     terminal: {

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolComposerQueryArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolComposerQueryArgs.test.ts
@@ -1,0 +1,107 @@
+import { QuerySourceType } from '../../../../types/querySources';
+import {
+    DEFAULT_COMPOSER_QUERY_LIMIT,
+    parsePartialToolComposerQueriesArgs,
+} from './toolComposerQueryArgs';
+
+describe('parsePartialToolComposerQueriesArgs', () => {
+    it('returns null when no node is renderable yet', () => {
+        expect(parsePartialToolComposerQueriesArgs(undefined)).toBeNull();
+        expect(parsePartialToolComposerQueriesArgs(null)).toBeNull();
+        expect(parsePartialToolComposerQueriesArgs('{"que')).toBeNull();
+        expect(parsePartialToolComposerQueriesArgs({})).toBeNull();
+        expect(parsePartialToolComposerQueriesArgs({ queries: [] })).toBeNull();
+        // A node streamed up to (but not including) its nodeId isn't
+        // identifiable yet.
+        expect(
+            parsePartialToolComposerQueriesArgs({
+                queries: [{ sourceType: QuerySourceType.SQL }],
+            }),
+        ).toBeNull();
+        // Unknown source types are skipped, not defaulted.
+        expect(
+            parsePartialToolComposerQueriesArgs({
+                queries: [{ nodeId: 'orders', sourceType: 'sem' }],
+            }),
+        ).toBeNull();
+    });
+
+    it('keeps identifiable nodes and defaults their missing fields', () => {
+        const parsed = parsePartialToolComposerQueriesArgs({
+            title: 'Revenue vs signups',
+            queries: [
+                {
+                    sourceType: QuerySourceType.SEMANTIC_LAYER,
+                    nodeId: 'revenue',
+                    exploreName: 'payments',
+                    dimensions: ['payments_month'],
+                    // metrics not streamed yet
+                },
+                {
+                    sourceType: QuerySourceType.SQL,
+                    nodeId: 'signups',
+                    sql: 'SELECT month, count(*) FROM raw.us',
+                },
+            ],
+        });
+
+        expect(parsed).toEqual({
+            title: 'Revenue vs signups',
+            description: null,
+            terminalNodeId: null,
+            queries: [
+                {
+                    sourceType: QuerySourceType.SEMANTIC_LAYER,
+                    nodeId: 'revenue',
+                    exploreName: 'payments',
+                    dimensions: ['payments_month'],
+                    metrics: [],
+                    filters: null,
+                    sorts: null,
+                    limit: DEFAULT_COMPOSER_QUERY_LIMIT,
+                },
+                {
+                    sourceType: QuerySourceType.SQL,
+                    nodeId: 'signups',
+                    // Cut-off SQL is kept as-is so it can grow with the stream
+                    sql: 'SELECT month, count(*) FROM raw.us',
+                    limit: DEFAULT_COMPOSER_QUERY_LIMIT,
+                },
+            ],
+        });
+    });
+
+    it('parses duckdb references and external tables in both shapes', () => {
+        const parsed = parsePartialToolComposerQueriesArgs({
+            queries: [
+                {
+                    sourceType: QuerySourceType.EXTERNAL,
+                    nodeId: 'targets',
+                    tables: { t: 'table-uuid', partial: 42 },
+                },
+                {
+                    sourceType: QuerySourceType.DUCKDB,
+                    nodeId: 'joined',
+                    references: ['revenue', 'targets'],
+                },
+            ],
+        });
+
+        expect(parsed?.queries).toEqual([
+            {
+                sourceType: QuerySourceType.EXTERNAL,
+                nodeId: 'targets',
+                sql: '',
+                tables: { t: 'table-uuid' },
+                limit: DEFAULT_COMPOSER_QUERY_LIMIT,
+            },
+            {
+                sourceType: QuerySourceType.DUCKDB,
+                nodeId: 'joined',
+                sql: '',
+                references: ['revenue', 'targets'],
+                limit: DEFAULT_COMPOSER_QUERY_LIMIT,
+            },
+        ]);
+    });
+});

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolComposerQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolComposerQueryArgs.ts
@@ -249,6 +249,111 @@ export const toolComposerQueryNodeToSourceQuery = (
     }
 };
 
+const asStringArray = (value: unknown): string[] =>
+    Array.isArray(value)
+        ? value.filter((item): item is string => typeof item === 'string')
+        : [];
+
+const asReferenceMapOrArray = (
+    value: unknown,
+): string[] | Record<string, string> => {
+    if (Array.isArray(value)) return asStringArray(value);
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value).filter(
+                (entry): entry is [string, string] =>
+                    typeof entry[1] === 'string',
+            ),
+        );
+    }
+    return [];
+};
+
+/**
+ * Lenient parse of partially-streamed composer args so the pipeline renders
+ * while the model is still writing it. Nodes are kept as soon as they have a
+ * nodeId and a known sourceType; every other field falls back to an empty
+ * default (e.g. a half-written SQL string renders as-is and grows with the
+ * stream). Returns null when nothing is renderable yet. Never use the result
+ * for execution — only the strict schema validates a runnable pipeline.
+ */
+export const parsePartialToolComposerQueriesArgs = (
+    input: unknown,
+): ToolComposerQueriesArgs | null => {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+        return null;
+    }
+    const raw = input as Record<string, unknown>;
+    const rawQueries = Array.isArray(raw.queries) ? raw.queries : [];
+    const queries = rawQueries.flatMap<ToolComposerQueryNode>((rawNode) => {
+        if (!rawNode || typeof rawNode !== 'object' || Array.isArray(rawNode)) {
+            return [];
+        }
+        const node = rawNode as Record<string, unknown>;
+        const { nodeId } = node;
+        if (typeof nodeId !== 'string' || nodeId.length === 0) return [];
+        const sql = typeof node.sql === 'string' ? node.sql : '';
+        switch (node.sourceType) {
+            case QuerySourceType.SEMANTIC_LAYER:
+                return [
+                    {
+                        sourceType: QuerySourceType.SEMANTIC_LAYER,
+                        nodeId,
+                        exploreName:
+                            typeof node.exploreName === 'string'
+                                ? node.exploreName
+                                : '',
+                        dimensions: asStringArray(node.dimensions),
+                        metrics: asStringArray(node.metrics),
+                        filters: null,
+                        sorts: null,
+                        limit: DEFAULT_COMPOSER_QUERY_LIMIT,
+                    },
+                ];
+            case QuerySourceType.SQL:
+                return [
+                    {
+                        sourceType: QuerySourceType.SQL,
+                        nodeId,
+                        sql,
+                        limit: DEFAULT_COMPOSER_QUERY_LIMIT,
+                    },
+                ];
+            case QuerySourceType.DUCKDB:
+                return [
+                    {
+                        sourceType: QuerySourceType.DUCKDB,
+                        nodeId,
+                        sql,
+                        references: asReferenceMapOrArray(node.references),
+                        limit: DEFAULT_COMPOSER_QUERY_LIMIT,
+                    },
+                ];
+            case QuerySourceType.EXTERNAL:
+                return [
+                    {
+                        sourceType: QuerySourceType.EXTERNAL,
+                        nodeId,
+                        sql,
+                        tables: asReferenceMapOrArray(node.tables),
+                        limit: DEFAULT_COMPOSER_QUERY_LIMIT,
+                    },
+                ];
+            default:
+                return [];
+        }
+    });
+    if (queries.length === 0) return null;
+    return {
+        title: typeof raw.title === 'string' ? raw.title : null,
+        description:
+            typeof raw.description === 'string' ? raw.description : null,
+        queries,
+        terminalNodeId:
+            typeof raw.terminalNodeId === 'string' ? raw.terminalNodeId : null,
+    };
+};
+
 export const toolComposerQueriesOutputSchema = z.object({
     result: z.string(),
     metadata: z.object({

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -161,6 +161,10 @@ const segmentStreamParts = (
         if (
             part.toolName === 'runComposerQueries' &&
             !part.toolResult &&
+            // Never build an approval card from partially-streamed args —
+            // the SQL may be cut off mid-statement and the tool hasn't
+            // started waiting for a decision yet.
+            part.isArgsPartial !== true &&
             !decidedToolCallIds.includes(part.toolCallId)
         ) {
             const approvalSql = getComposerApprovalSql(part.toolArgs);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
@@ -24,6 +24,7 @@ import { AiMarkdown } from '../../../../../../components/common/AiMarkdown';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import { type StepProgressMessage } from '../../../store/aiAgentThreadStreamSlice';
 import { AgentStepGroups } from './AgentStepGroups';
+import { type ComposerQueryNodeStatus } from './descriptions/ComposerQueriesToolCallDescription';
 import { ToolCallDescription } from './descriptions/ToolCallDescription';
 import { DiscoverFieldsTrace, type TraceEntry } from './DiscoverFieldsTrace';
 import styles from './LiveActivityCard.module.css';
@@ -544,6 +545,71 @@ const renderInlineLiveStepProgress = (params: {
 };
 
 /**
+ * Derive per-node execution statuses for a live composer pipeline from the
+ * transient step-progress events the runComposerQueries tool emits
+ * (progressId = `${toolCallId}:${nodeId}`). Nodes without an event yet show
+ * as pending while the call is in flight, and flip to success wholesale when
+ * the tool's final output lands successfully. Returns undefined for other
+ * tools so persisted pipelines render without indicators.
+ */
+const getComposerNodeStatuses = (
+    call: ToolCallSummary,
+    stepProgressMessages: StepProgressMessage[],
+): Record<string, ComposerQueryNodeStatus> | undefined => {
+    if (call.toolName !== 'runComposerQueries') return undefined;
+    const args = call.toolArgs as
+        | { queries?: { nodeId?: unknown }[] }
+        | undefined;
+    const nodeIds = (args?.queries ?? [])
+        .map((query) => query?.nodeId)
+        .filter((nodeId): nodeId is string => typeof nodeId === 'string');
+    if (nodeIds.length === 0) return undefined;
+
+    const progressIdPrefix = `${call.toolCallId}:`;
+    const eventStatuses = new Map<string, ComposerQueryNodeStatus>();
+    for (const event of stepProgressMessages) {
+        if (event.toolName !== 'runComposerQueries') continue;
+        if (
+            !event.progressId?.startsWith(progressIdPrefix) ||
+            !event.progressStatus
+        )
+            continue;
+        const nodeId = event.progressId.slice(progressIdPrefix.length);
+        if (event.progressStatus === 'in_progress') {
+            eventStatuses.set(nodeId, { status: 'running' });
+        } else if (event.progressStatus === 'complete') {
+            eventStatuses.set(nodeId, { status: 'success' });
+        } else {
+            const failurePrefix = `Query "${nodeId}" failed: `;
+            eventStatuses.set(nodeId, {
+                status: 'error',
+                errorMessage: event.message.startsWith(failurePrefix)
+                    ? event.message.slice(failurePrefix.length)
+                    : null,
+            });
+        }
+    }
+
+    const output = call.toolOutput as
+        | { metadata?: { status?: string } }
+        | undefined;
+    const outputStatus = output?.metadata?.status;
+
+    return Object.fromEntries(
+        nodeIds.flatMap((nodeId): [string, ComposerQueryNodeStatus][] => {
+            const fromEvent = eventStatuses.get(nodeId);
+            if (fromEvent) return [[nodeId, fromEvent]];
+            if (outputStatus === 'success')
+                return [[nodeId, { status: 'success' }]];
+            if (output === undefined) return [[nodeId, { status: 'pending' }]];
+            // Rejected/timed-out/unattributed failure: nothing truthful to
+            // claim about this node, so show no indicator.
+            return [];
+        }),
+    );
+};
+
+/**
  * Render the subagent's live trace outside the activity card's collapse
  * so users see findExplores / findFields rows appear under the
  * "Discovering fields" header without having to expand the card.
@@ -820,6 +886,14 @@ export const LiveActivityCard: FC<Props> = ({
                                                         result.toolCallId ===
                                                         tc.toolCallId,
                                                 )}
+                                                composerNodeStatuses={
+                                                    isLive
+                                                        ? getComposerNodeStatuses(
+                                                              tc,
+                                                              stepProgressMessages,
+                                                          )
+                                                        : undefined
+                                                }
                                             />
                                         )}
                                         {trace && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.module.css
@@ -6,6 +6,68 @@
     min-width: 0;
     padding-left: 10px;
     border-left: 2px solid var(--mantine-color-ldGray-3);
+    transition: border-color 200ms ease;
+}
+
+.node[data-status='running'] {
+    border-left-color: var(--mantine-color-indigo-4);
+}
+
+.node[data-status='success'] {
+    border-left-color: var(--mantine-color-teal-5);
+}
+
+.node[data-status='error'] {
+    border-left-color: var(--mantine-color-red-5);
+}
+
+.statusIndicator {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 12px;
+    height: 12px;
+}
+
+.statusIndicator[data-status='success'] {
+    color: var(--mantine-color-teal-6);
+}
+
+.statusIndicator[data-status='error'] {
+    color: var(--mantine-color-red-6);
+}
+
+.statusIcon {
+    flex-shrink: 0;
+}
+
+.statusDot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+}
+
+.statusDot[data-status='pending'] {
+    border: 1.5px solid var(--mantine-color-ldGray-5);
+    background: transparent;
+}
+
+.statusDot[data-status='running'] {
+    background: var(--mantine-color-indigo-5);
+    animation: composer-node-pulse 1.1s ease-in-out infinite;
+}
+
+@keyframes composer-node-pulse {
+    0%,
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    50% {
+        opacity: 0.45;
+        transform: scale(0.78);
+    }
 }
 
 .header {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.test.tsx
@@ -38,4 +38,73 @@ describe('ComposerQueriesToolCallDescription', () => {
             'select payment_method, target_revenue from targets_csv',
         );
     });
+
+    it('renders a live status indicator per node when statuses are provided', () => {
+        renderWithProviders(
+            <ComposerQueriesToolCallDescription
+                queries={[
+                    {
+                        sourceType: QuerySourceType.SQL,
+                        nodeId: 'orders',
+                        sql: 'select 1',
+                        limit: 500,
+                    },
+                    {
+                        sourceType: QuerySourceType.SQL,
+                        nodeId: 'revenue',
+                        sql: 'select 2',
+                        limit: 500,
+                    },
+                    {
+                        sourceType: QuerySourceType.DUCKDB,
+                        nodeId: 'combined',
+                        sql: 'select * from orders join revenue on true',
+                        references: ['orders', 'revenue'],
+                        limit: 500,
+                    },
+                    {
+                        sourceType: QuerySourceType.DUCKDB,
+                        nodeId: 'failed',
+                        sql: 'select broken',
+                        references: ['combined'],
+                        limit: 500,
+                    },
+                ]}
+                nodeStatuses={{
+                    orders: { status: 'success' },
+                    revenue: { status: 'running' },
+                    combined: { status: 'pending' },
+                    failed: {
+                        status: 'error',
+                        errorMessage: 'column not found',
+                    },
+                }}
+            />,
+        );
+
+        expect(screen.getByLabelText('Completed')).toBeInTheDocument();
+        expect(screen.getByLabelText('Running')).toBeInTheDocument();
+        expect(screen.getByLabelText('Queued')).toBeInTheDocument();
+        expect(
+            screen.getByLabelText('Failed: column not found'),
+        ).toBeInTheDocument();
+    });
+
+    it('renders no status indicators for the persisted view', () => {
+        renderWithProviders(
+            <ComposerQueriesToolCallDescription
+                queries={[
+                    {
+                        sourceType: QuerySourceType.SQL,
+                        nodeId: 'orders',
+                        sql: 'select 1',
+                        limit: 500,
+                    },
+                ]}
+            />,
+        );
+
+        expect(screen.queryByLabelText('Completed')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Queued')).not.toBeInTheDocument();
+    });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ComposerQueriesToolCallDescription.tsx
@@ -5,13 +5,73 @@ import {
     type ToolComposerQueryNode,
     WarehouseTypes,
 } from '@lightdash/common';
-import { Badge, Box, Group, Stack, Text } from '@mantine/core';
+import { Badge, Box, Group, Stack, Text, Tooltip } from '@mantine/core';
+import { IconCheck, IconX } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import CodeBlock from '../../../../../../../components/common/CodeBlock/CodeBlock';
+import MantineIcon from '../../../../../../../components/common/MantineIcon';
 import styles from './ComposerQueriesToolCallDescription.module.css';
+
+/**
+ * Live execution status of one pipeline node, derived from the transient
+ * step-progress events the composer tool emits while it runs. Undefined maps
+ * (the persisted, post-run view) render the pipeline without indicators.
+ */
+export type ComposerQueryNodeStatus =
+    | { status: 'pending' }
+    | { status: 'running' }
+    | { status: 'success' }
+    | { status: 'error'; errorMessage: string | null };
 
 type ComposerQueriesToolCallDescriptionProps = {
     queries: ToolComposerQueriesArgs['queries'];
+    nodeStatuses?: Record<string, ComposerQueryNodeStatus>;
+};
+
+const NODE_STATUS_LABELS = {
+    pending: 'Queued',
+    running: 'Running',
+    success: 'Completed',
+    error: 'Failed',
+} as const;
+
+const NodeStatusIndicator: FC<{ nodeStatus: ComposerQueryNodeStatus }> = ({
+    nodeStatus,
+}) => {
+    const label =
+        nodeStatus.status === 'error' && nodeStatus.errorMessage
+            ? `Failed: ${nodeStatus.errorMessage}`
+            : NODE_STATUS_LABELS[nodeStatus.status];
+    return (
+        <Tooltip label={label} position="top" withArrow>
+            <Box
+                className={styles.statusIndicator}
+                data-status={nodeStatus.status}
+                aria-label={label}
+            >
+                {nodeStatus.status === 'success' ? (
+                    <MantineIcon
+                        icon={IconCheck}
+                        size={11}
+                        stroke={2.4}
+                        className={styles.statusIcon}
+                    />
+                ) : nodeStatus.status === 'error' ? (
+                    <MantineIcon
+                        icon={IconX}
+                        size={11}
+                        stroke={2.4}
+                        className={styles.statusIcon}
+                    />
+                ) : (
+                    <Box
+                        className={styles.statusDot}
+                        data-status={nodeStatus.status}
+                    />
+                )}
+            </Box>
+        </Tooltip>
+    );
 };
 
 const referenceAliases = (items: string[] | Record<string, string>) =>
@@ -50,7 +110,10 @@ const getNodePresentation = (node: ToolComposerQueryNode) => {
     }
 };
 
-const ComposerQueryNode: FC<{ node: ToolComposerQueryNode }> = ({ node }) => {
+const ComposerQueryNode: FC<{
+    node: ToolComposerQueryNode;
+    nodeStatus?: ComposerQueryNodeStatus;
+}> = ({ node, nodeStatus }) => {
     const presentation = getNodePresentation(node);
     const formattedSql = useMemo(() => {
         if (!('sql' in node) || !node.sql) return null;
@@ -65,8 +128,11 @@ const ComposerQueryNode: FC<{ node: ToolComposerQueryNode }> = ({ node }) => {
     }, [node]);
 
     return (
-        <Box className={styles.node}>
+        <Box className={styles.node} data-status={nodeStatus?.status}>
             <Group gap={6} wrap="nowrap" className={styles.header}>
+                {nodeStatus ? (
+                    <NodeStatusIndicator nodeStatus={nodeStatus} />
+                ) : null}
                 <Text component="span" className={styles.nodeId}>
                     {node.nodeId}
                 </Text>
@@ -93,10 +159,14 @@ const ComposerQueryNode: FC<{ node: ToolComposerQueryNode }> = ({ node }) => {
 
 export const ComposerQueriesToolCallDescription: FC<
     ComposerQueriesToolCallDescriptionProps
-> = ({ queries }) => (
+> = ({ queries, nodeStatuses }) => (
     <Stack gap={10} align="stretch" w="100%" className={styles.pipeline}>
         {queries.map((node) => (
-            <ComposerQueryNode key={node.nodeId} node={node} />
+            <ComposerQueryNode
+                key={node.nodeId}
+                node={node}
+                nodeStatus={nodeStatuses?.[node.nodeId]}
+            />
         ))}
     </Stack>
 );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -39,7 +39,10 @@ import {
 import type { FC } from 'react';
 import type { ToolCallSummary } from '../utils/types';
 import { AiChartGenerationToolCallDescription } from './AiChartGenerationToolCallDescription';
-import { ComposerQueriesToolCallDescription } from './ComposerQueriesToolCallDescription';
+import {
+    ComposerQueriesToolCallDescription,
+    type ComposerQueryNodeStatus,
+} from './ComposerQueriesToolCallDescription';
 import { ContentEditorToolCallDescription } from './ContentEditorToolCallDescription';
 import { ContentSearchToolCallDescription } from './ContentSearchToolCallDescription';
 import { DashboardChartsToolCallDescription } from './DashboardChartsToolCallDescription';
@@ -81,7 +84,13 @@ export const ToolCallDescription: FC<{
     toolName: ToolName;
     toolCall: ToolCallSummary;
     toolResult?: AiAgentToolResult;
-}> = ({ toolName, toolCall, toolResult }) => {
+    /**
+     * Live per-node execution statuses for a running composer pipeline,
+     * keyed by nodeId. Only meaningful for runComposerQueries; omitted for
+     * persisted views, which render the pipeline without indicators.
+     */
+    composerNodeStatuses?: Record<string, ComposerQueryNodeStatus>;
+}> = ({ toolName, toolCall, toolResult, composerNodeStatuses }) => {
     // Mid-stream the toolArgs payload can arrive before any input chunks have
     // been parsed. Casting an undefined value and reading fields throws, so
     // bail until args exist.
@@ -237,6 +246,7 @@ export const ToolCallDescription: FC<{
             return (
                 <ComposerQueriesToolCallDescription
                     queries={composerToolArgs.queries ?? []}
+                    nodeStatuses={composerNodeStatuses}
                 />
             );
         case 'readContent':

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.test.ts
@@ -139,8 +139,18 @@ describe('aiAgentThreadStreamSlice', () => {
             }),
         );
         expect(afterSecond['thread-1']?.stepProgressMessages).toEqual([
-            { message: 'Starting sandbox...', toolName: 'editDbtProject' },
-            { message: 'Cloning project...', toolName: 'editDbtProject' },
+            {
+                message: 'Starting sandbox...',
+                toolName: 'editDbtProject',
+                progressId: null,
+                progressStatus: null,
+            },
+            {
+                message: 'Cloning project...',
+                toolName: 'editDbtProject',
+                progressId: null,
+                progressStatus: null,
+            },
         ]);
     });
 
@@ -168,7 +178,12 @@ describe('aiAgentThreadStreamSlice', () => {
             }),
         );
         expect(afterDuplicate['thread-1']?.stepProgressMessages).toEqual([
-            { message: 'Running your query...', toolName: 'runQuery' },
+            {
+                message: 'Running your query...',
+                toolName: 'runQuery',
+                progressId: null,
+                progressStatus: null,
+            },
         ]);
     });
 
@@ -193,8 +208,18 @@ describe('aiAgentThreadStreamSlice', () => {
             );
         }
         expect(state['thread-1']?.stepProgressMessages).toEqual([
-            { message: 'Discovering models', toolName: 'editDbtProject' },
-            { message: 'Discovering models', toolName: 'findExplores' },
+            {
+                message: 'Discovering models',
+                toolName: 'editDbtProject',
+                progressId: null,
+                progressStatus: null,
+            },
+            {
+                message: 'Discovering models',
+                toolName: 'findExplores',
+                progressId: null,
+                progressStatus: null,
+            },
         ]);
     });
 
@@ -221,9 +246,71 @@ describe('aiAgentThreadStreamSlice', () => {
             );
         }
         expect(state['thread-1']?.stepProgressMessages).toEqual([
-            { message: 'Running your query...', toolName: 'runQuery' },
-            { message: 'Editing models', toolName: 'runQuery' },
-            { message: 'Running your query...', toolName: 'runQuery' },
+            {
+                message: 'Running your query...',
+                toolName: 'runQuery',
+                progressId: null,
+                progressStatus: null,
+            },
+            {
+                message: 'Editing models',
+                toolName: 'runQuery',
+                progressId: null,
+                progressStatus: null,
+            },
+            {
+                message: 'Running your query...',
+                toolName: 'runQuery',
+                progressId: null,
+                progressStatus: null,
+            },
+        ]);
+    });
+
+    it('keeps per-node composer status transitions with the same progressId', () => {
+        // A node's running → complete transition reuses the progressId; the
+        // status change makes it a distinct event, so both entries survive
+        // and the UI can take the latest per node.
+        let state = aiAgentThreadStreamSlice.reducer(
+            undefined,
+            startStreaming({
+                threadUuid: 'thread-1',
+                messageUuid: 'message-1',
+            }),
+        );
+        for (const event of [
+            {
+                message: 'Running query "orders"...',
+                progressStatus: 'in_progress' as const,
+            },
+            {
+                message: 'Query "orders" complete',
+                progressStatus: 'complete' as const,
+            },
+        ]) {
+            state = aiAgentThreadStreamSlice.reducer(
+                state,
+                appendStepProgress({
+                    threadUuid: 'thread-1',
+                    toolName: 'runComposerQueries',
+                    progressId: 'call-1:orders',
+                    ...event,
+                }),
+            );
+        }
+        expect(state['thread-1']?.stepProgressMessages).toEqual([
+            {
+                message: 'Running query "orders"...',
+                toolName: 'runComposerQueries',
+                progressId: 'call-1:orders',
+                progressStatus: 'in_progress',
+            },
+            {
+                message: 'Query "orders" complete',
+                toolName: 'runComposerQueries',
+                progressId: 'call-1:orders',
+                progressStatus: 'complete',
+            },
         ]);
     });
 
@@ -252,7 +339,12 @@ describe('aiAgentThreadStreamSlice', () => {
             }),
         );
         expect(afterText['thread-1']?.stepProgressMessages).toEqual([
-            { message: 'Committing changes', toolName: 'editDbtProject' },
+            {
+                message: 'Committing changes',
+                toolName: 'editDbtProject',
+                progressId: null,
+                progressStatus: null,
+            },
         ]);
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
@@ -20,6 +20,13 @@ export type StepProgressMessage = {
     // The tool the event belongs to, or null when the emitting tool didn't
     // attribute it. Used to scope the inline progress row to the active tool.
     toolName: string | null;
+    // Correlates repeated events about the same unit of work (composer
+    // pipeline nodes use `${toolCallId}:${nodeId}`), or null for one-off
+    // progress strings.
+    progressId: string | null;
+    // Lifecycle of the unit identified by progressId, or null when the event
+    // is a plain progress string.
+    progressStatus: 'in_progress' | 'complete' | 'error' | null;
 };
 
 export type StreamPart =
@@ -319,9 +326,21 @@ export const aiAgentThreadStreamSlice = createSlice({
                     threadUuid: string;
                     message: string;
                     toolName: string | null;
+                    progressId?: string | null;
+                    progressStatus?:
+                        | 'in_progress'
+                        | 'complete'
+                        | 'error'
+                        | null;
                 }>,
             ) => {
-                const { threadUuid, message, toolName } = action.payload;
+                const {
+                    threadUuid,
+                    message,
+                    toolName,
+                    progressId = null,
+                    progressStatus = null,
+                } = action.payload;
                 const streamingThread = state[threadUuid];
                 if (!streamingThread) return;
                 // Drop adjacent-duplicate step events — `runQuery` fires
@@ -329,7 +348,9 @@ export const aiAgentThreadStreamSlice = createSlice({
                 // don't want a stuttering list. Non-adjacent repeats are
                 // fine (different cycle, different context) so we only
                 // check the most recent entry. A repeat from a different
-                // tool is kept (different toolName → not a true duplicate).
+                // tool is kept (different toolName → not a true duplicate),
+                // as is a repeat about a different unit of work or a status
+                // transition (different progressId/progressStatus).
                 const last =
                     streamingThread.stepProgressMessages[
                         streamingThread.stepProgressMessages.length - 1
@@ -337,18 +358,24 @@ export const aiAgentThreadStreamSlice = createSlice({
                 if (
                     last &&
                     last.message === message &&
-                    last.toolName === toolName
+                    last.toolName === toolName &&
+                    last.progressId === progressId &&
+                    last.progressStatus === progressStatus
                 )
                     return;
                 streamingThread.stepProgressMessages.push({
                     message,
                     toolName,
+                    progressId,
+                    progressStatus,
                 });
             },
             prepare: prepareAutoBatched<{
                 threadUuid: string;
                 message: string;
                 toolName: string | null;
+                progressId?: string | null;
+                progressStatus?: 'in_progress' | 'complete' | 'error' | null;
             }>(),
         },
     },

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/parseStreamRawToolResult.ts
@@ -1,6 +1,7 @@
 import {
     agentToolDefinitionsByName,
     isAiAgentMcpToolName,
+    parsePartialToolComposerQueriesArgs,
     toolDashboardV2ArgsSchemaPersisted,
     toolRunQueryArgsSchemaPersisted,
     type ToolDefinition,
@@ -47,6 +48,12 @@ type BuiltInToolCall = {
         toolArgs: ToolArgs<K>;
         toolResult?: ToolResult<K> | null;
         isPreliminary?: boolean;
+        /**
+         * True while the model is still streaming this call's input: toolArgs
+         * is a lenient reconstruction of the partial JSON, good for live
+         * rendering but not final (e.g. SQL strings may be cut off).
+         */
+        isArgsPartial?: boolean;
     };
 }[ParsedToolName];
 
@@ -64,6 +71,7 @@ type McpToolCall = {
     toolArgs: object;
     toolResult?: unknown;
     isPreliminary?: boolean;
+    isArgsPartial?: boolean;
 };
 
 type McpToolResult = {
@@ -137,6 +145,31 @@ export const parseStreamRawToolCall = (
         toolArgs: toolArgs.data,
         isPreliminary: toolCall.isPreliminary,
     } as AiAgentToolCall;
+};
+
+/**
+ * Parse a tool call whose input is still streaming. Strict parsing usually
+ * fails on partial JSON, so tools with a lenient partial parser (today only
+ * runComposerQueries) fall back to it — letting the pipeline render node by
+ * node while the model writes it. Returns null for tools without partial
+ * support whose partial args don't yet satisfy the strict schema.
+ */
+export const parseStreamRawPartialToolCall = (
+    toolCall: StreamRawToolCall,
+): AiAgentToolCall | null => {
+    if (toolCall.toolName !== 'runComposerQueries') return null;
+
+    const strict = parseStreamRawToolCall(toolCall);
+    if (strict) return { ...strict, isArgsPartial: true };
+
+    const partialArgs = parsePartialToolComposerQueriesArgs(toolCall.toolArgs);
+    if (!partialArgs) return null;
+    return {
+        toolName: 'runComposerQueries',
+        toolArgs: partialArgs,
+        isPreliminary: toolCall.isPreliminary,
+        isArgsPartial: true,
+    };
 };
 
 export const parseStreamRawToolResult = (

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -27,6 +27,7 @@ import { useAiAgentStoreDispatch } from '../store/hooks';
 import { type AiAgentToolCall, type AiAgentToolResult } from '../types';
 import { useAiAgentThreadStreamAbortController } from './AiAgentThreadStreamAbortControllerContext';
 import {
+    parseStreamRawPartialToolCall,
     parseStreamRawToolCall,
     parseStreamRawToolResult,
 } from './parseStreamRawToolResult';
@@ -65,6 +66,10 @@ type StepProgressChunk = UIMessageChunk & {
         message: string;
         // The tool the event belongs to, or null/absent when unattributed.
         toolName?: string | null;
+        // Correlates repeated events about the same unit of work (e.g. a
+        // composer pipeline node, keyed `${toolCallId}:${nodeId}`).
+        progressId?: string | null;
+        progressStatus?: 'in_progress' | 'complete' | 'error' | null;
     };
     transient?: boolean;
 };
@@ -145,10 +150,32 @@ export const getStreamToolCallPart = (
     if (
         !toolPart ||
         !toolPart.toolName ||
-        !isAiAgentToolName(toolPart.toolName) ||
-        (toolPart.state !== 'input-available' &&
-            toolPart.state !== 'output-available' &&
-            toolPart.state !== 'output-error')
+        !isAiAgentToolName(toolPart.toolName)
+    ) {
+        return null;
+    }
+
+    // While the model is still writing the call's input, tools with a lenient
+    // partial parser (runComposerQueries) render progressively instead of
+    // waiting for input-available.
+    if (toolPart.state === 'input-streaming') {
+        const partialToolCall = parseStreamRawPartialToolCall({
+            toolName: toolPart.toolName,
+            toolArgs: toolPart.input,
+        });
+        if (!partialToolCall) return null;
+        return {
+            type: 'toolCall',
+            toolCallId: toolPart.toolCallId,
+            ...partialToolCall,
+            toolResult: null,
+        } as StreamToolCallPart;
+    }
+
+    if (
+        toolPart.state !== 'input-available' &&
+        toolPart.state !== 'output-available' &&
+        toolPart.state !== 'output-error'
     ) {
         return null;
     }
@@ -174,6 +201,9 @@ export const getStreamToolCallPart = (
             toolArgs: toolResult.toolArgs,
             toolResult: toolResult.toolResult,
             isPreliminary: toolResult.isPreliminary,
+            // Explicit false so merge-by-toolCallId in the stream slice
+            // clears the flag once the full input has arrived.
+            isArgsPartial: false,
         } as StreamToolCallPart;
     }
 
@@ -191,6 +221,7 @@ export const getStreamToolCallPart = (
         toolCallId: toolPart.toolCallId,
         ...toolCall,
         toolResult: null,
+        isArgsPartial: false,
     } as StreamToolCallPart;
 };
 
@@ -208,9 +239,19 @@ export const readStreamResult = async <T>(
     }
 };
 
+const isStepProgressStatus = (
+    value: unknown,
+): value is 'in_progress' | 'complete' | 'error' =>
+    value === 'in_progress' || value === 'complete' || value === 'error';
+
 export const getStepProgressFromChunk = (
     chunk: UIMessageChunk,
-): { message: string; toolName: string | null } | null => {
+): {
+    message: string;
+    toolName: string | null;
+    progressId: string | null;
+    progressStatus: 'in_progress' | 'complete' | 'error' | null;
+} | null => {
     if (
         chunk.type === 'data-step-progress' &&
         'data' in chunk &&
@@ -223,6 +264,13 @@ export const getStepProgressFromChunk = (
                 message: data.message,
                 toolName:
                     typeof data.toolName === 'string' ? data.toolName : null,
+                progressId:
+                    typeof data.progressId === 'string'
+                        ? data.progressId
+                        : null,
+                progressStatus: isStepProgressStatus(data.progressStatus)
+                    ? data.progressStatus
+                    : null,
             };
         }
     }
@@ -335,6 +383,8 @@ export function useAiAgentThreadStreamMutation() {
                                     threadUuid,
                                     message: stepProgress.message,
                                     toolName: stepProgress.toolName,
+                                    progressId: stepProgress.progressId,
+                                    progressStatus: stepProgress.progressStatus,
                                 }),
                             );
                             continue;


### PR DESCRIPTION
Closes: <!-- reference the related issue -->

### Description:

This PR adds real-time execution status tracking for individual nodes in the AI Composer query pipeline. As queries execute, the UI now displays live status indicators (pending → running → success/error) for each node, with error messages shown on failure.

**Key changes:**

**Backend:**
- Added `ComposerNodeStatusUpdate` type to track per-node lifecycle events (running, success, error)
- Implemented `onNodeStatus` callback in `runComposerQueries` that emits status transitions while the pipeline executes
- Status polling deduplicates transitions and gracefully handles failures (best-effort telemetry)
- Integrated status callbacks into the `runComposerQueries` tool to emit step-progress events with `progressId` = `${toolCallId}:${nodeId}` for client-side correlation

**Frontend:**
- Added lenient partial parser `parsePartialToolComposerQueriesArgs` to render composer pipelines progressively while the model is still streaming the input
- Implemented `getComposerNodeStatuses` to derive per-node execution statuses from transient step-progress events
- Added visual status indicators (checkmark for success, X for error, pulsing dot for running) with tooltips showing error messages
- Updated `ComposerQueriesToolCallDescription` to render live status badges per node
- Enhanced `aiAgentThreadStreamSlice` to track `progressId` and `progressStatus` on step-progress messages, allowing repeated events about the same unit of work (e.g., a node's running → complete transition)

**Tests:**
- Added comprehensive test coverage for per-node status emission during pipeline execution
- Added tests for error status emission before throwing
- Added tests for partial composer args parsing with various source types
- Updated existing tests to account for new `progressId` and `progressStatus` fields

The implementation is best-effort: status delivery failures never block or fail query execution, and the UI gracefully handles missing or incomplete status events.

### Risk assessment:

- [ ] This is a high-risk change

This is a low-risk change. It adds new optional telemetry callbacks and UI rendering without modifying core query execution logic. All changes are backwards-compatible, and status delivery failures are explicitly caught and ignored to prevent impact on query execution.

https://claude.ai/code/session_01RZFYSft8kU6qHXiNUENmHU