### PR TITLE
fix: prevent scroll-to-top button from covering table footer results count

### DIFF
--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -1378,7 +1378,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
 
             <ScrollToTop
                 show={isHeaderStuck}
-                bottom={isLauncherMounted ? 52 : 24}
+                bottom={isLauncherMounted ? 72 : 24}
             />
         </DragDropContext>
     );


### PR DESCRIPTION
## Problem

When the AI agents launcher is enabled, the scroll-to-top button is positioned `52px` from the bottom to avoid overlapping the launcher orb.

However, this puts the button at the same height as the table footer's **"N results"** text. Since the button has a `z-index` of `50`, it overlaps and obscures the results count when scrolling to the bottom of a dashboard.

## Fix

Increased the bottom offset from `52px` to `72px` when the AI launcher is mounted, providing enough clearance from the table footer.

```diff
- bottom={isLauncherMounted ? 52 : 24}
+ bottom={isLauncherMounted ? 72 : 24}
```

### File changed

* `packages/frontend/src/features/dashboardTabs/index.tsx`

## How to reproduce

1. Enable AI agents for a project.
2. Open a dashboard containing a table chart tile at the bottom.
3. Ensure **"Show results total"** is enabled.
4. Scroll to the bottom of the dashboard.
5. Observe the scroll-to-top button overlapping the **"N results"** label.

With this fix, the button remains clear of the table footer.

## close : #27881
