### PR TITLE
fix(apps): read iframe color scheme from ColorSchemeContext instead of Mantine

### DIFF
--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -4,7 +4,6 @@ import {
     type DashboardFilters,
     type QueryExecutionContext,
 } from '@lightdash/common';
-import { useComputedColorScheme } from '@mantine/core';
 import {
     forwardRef,
     useCallback,
@@ -14,6 +13,7 @@ import {
     useRef,
     useState,
 } from 'react';
+import { useAppColorScheme } from '../../providers/ColorSchemeContext';
 import { type DeliveryCaptureAccumulator } from './deliveryCapture/deliveryCaptureAccumulator';
 import {
     useAppSdkBridge,
@@ -192,9 +192,9 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
         ref,
     ) => {
         const iframeRef = useRef<HTMLIFrameElement>(null);
-        // Resolves to an exact light/dark (embed routes force it from
-        // `?theme=`), so this is the scheme the surrounding page renders in.
-        const hostColorScheme = useComputedColorScheme('light');
+        // Reads from ColorSchemeContext — the same source of truth the host
+        // UI uses — so the iframe always matches the visible appearance.
+        const { colorScheme: hostColorScheme } = useAppColorScheme();
         const colorScheme: AppColorScheme = forceColorScheme ?? hostColorScheme;
         const { applySeed, handleUrlStateChange } = useAppUrlStateSync({
             appUuid,


### PR DESCRIPTION
## Problem

Data app tiles can render in a different color scheme from the surrounding Lightdash UI. For example, the Lightdash UI may render in light mode while the data app tile renders in dark mode, with no visible setting explaining or resolving the mismatch.

The root cause is that `AppIframePreview` and the host UI use different sources of truth for the color scheme:

- The host UI uses `ColorSchemeContext`, which resolves the scheme from `forceColorScheme ?? storedColorScheme`.
- `AppIframePreview` uses Mantine's `useComputedColorScheme('light')`, which reads Mantine's internal computed color scheme.

These values can diverge, particularly when `forceColorScheme` or nested Mantine providers are involved. When they do, the iframe can render in a different theme from the host UI.

This was observed after migrating a dashboard containing a data app tile to a second instance using Content as Code. The same app rendered light on the source instance and dark on the target instance, while the surrounding Lightdash UI remained light on both instances.

## Fix

Replaced `useComputedColorScheme('light')` with `useAppColorScheme()` in `AppIframePreview`.

`useAppColorScheme()` reads from `ColorSchemeContext`, the same source of truth used by the host application. This ensures that the data app iframe always uses the same color scheme as the surrounding Lightdash UI.

## Changes

- Updated `packages/frontend/src/features/apps/AppIframePreview.tsx`
- Replaced `useComputedColorScheme` from `@mantine/core` with `useAppColorScheme` from `../../providers/ColorSchemeContext`
- Removed the unused `useComputedColorScheme` import

## Steps to Reproduce

Before the fix:

1. Open the Lightdash instance in a browser.
2. Open DevTools (`F12`) → **Console**.
3. Run:
   ```js
   localStorage.setItem('color-scheme', 'dark')

## Close : #27038 