### PR TITLE
fix: create preview modal crash due to Mantine v8 group format mismatch

### DIFF
--- a/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
+++ b/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
@@ -246,7 +246,7 @@ const CreatePreviewModal: FC<Props> = ({
     const regularProjectList = useMemo(() => {
         if (isLoadingProjects || !projects || !user.data) return [];
 
-        return projects
+        const items = projects
             .filter((p) => p.type === ProjectType.DEFAULT)
             .map((project) => {
                 const userCannotCreatePreview = user.data.ability.cannot(
@@ -258,26 +258,32 @@ const CreatePreviewModal: FC<Props> = ({
                     }),
                 );
 
-                const item: {
-                    value: string;
-                    label: string;
-                    disabled: boolean;
-                    group?: string;
-                } = {
+                return {
                     value: project.projectUuid,
                     label: project.name,
                     disabled: userCannotCreatePreview,
                 };
-
-                if (userCannotCreatePreview) {
-                    item.group = 'Requires Developer Access';
-                }
-
-                return item;
             })
             .sort((a, b) =>
                 a.disabled === b.disabled ? 0 : a.disabled ? 1 : -1,
             );
+
+        const accessible = items.filter((item) => !item.disabled);
+        const restricted = items.filter((item) => item.disabled);
+
+        const groups: { group: string; items: typeof accessible }[] = [];
+
+        if (accessible.length > 0) {
+            groups.push({ group: 'Accessible', items: accessible });
+        }
+        if (restricted.length > 0) {
+            groups.push({
+                group: 'Requires Developer Access',
+                items: restricted,
+            });
+        }
+
+        return groups;
     }, [isLoadingProjects, projects, user.data]);
 
     const { data: projectDetails } = useProject(
@@ -297,9 +303,9 @@ const CreatePreviewModal: FC<Props> = ({
             !selectedProjectUuid &&
             projects
         ) {
-            const initialProjectValue = regularProjectList.find(
-                (project) => project.value === initialProjectUuid,
-            );
+            const initialProjectValue = regularProjectList
+                .flatMap((group) => group.items)
+                .find((project) => project.value === initialProjectUuid);
 
             if (initialProjectValue && !initialProjectValue.disabled) {
                 setSelectedProjectUuid(initialProjectUuid);


### PR DESCRIPTION
## Problem

The "Create preview" modal (CreatePreviewModal) crashes the entire page with:
TypeError: Cannot read properties of undefined (reading 'map')
This happens for any user who lacks preview-creation permission on at least one project in the organization. The React ErrorBoundary catches the crash and shows "Something went wrong", making the modal completely unusable.
Users who can create previews on every project (e.g. org admins) are unaffected — which makes the bug appear intermittent and user-specific at first glance.

## Root Cause
In packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx, the regularProjectList builds dropdown items using the Mantine v6 flat-item format:
{ value: 'uuid', label: 'Project A', disabled: true, group: 'Requires Developer Access' }
The code was migrated to Mantine v8 (@mantine-8/core) in #19134 (https://github.com/lightdash/lightdash/pull/19134), but the data shape was never updated. Mantine v8's Select component interprets any object with a group key as a group container and expects a nested items array:
{ group: 'Requires Developer Access', items: [{ value: 'uuid', label: 'Project A' }] }
Since items doesn't exist on the flat item, parseItem crashes when it tries to call item.items.map(...).

## Fix
- Restructured regularProjectList to return Mantine v8's expected grouped format ({ group: string, items: ComboboxItem[] }[]) instead of flat items with a group property.
- Updated the useEffect that searches regularProjectList to use .flatMap((group) => group.items) before calling .find(), since the array now contains group objects instead of flat items.

## Steps to Reproduce
1. Log in as a user with Viewer (or any non-developer) org role
2. Ensure the user has Developer access on one project but not on at least one other project
3. Click the project switcher in the navbar → "Create Preview"
4. The modal never renders — the page shows "Something went wrong"

## Files Changed
- packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx

## Close: #26669