### PR TITLE
feat: Learn role badges in the board rail (CS-142)

### DIFF
--- a/packages/backend/src/controllers/learnController.ts
+++ b/packages/backend/src/controllers/learnController.ts
@@ -2,6 +2,7 @@ import {
     assertRegisteredAccount,
     type ApiErrorPayload,
     type ApiLearnAskResponse,
+    type ApiLearnBadgesResponse,
     type ApiLearnCatalogueResponse,
     type ApiLearnCourseResponse,
     type ApiLearnEventsResponse,
@@ -117,6 +118,28 @@ export class LearnController extends BaseController {
             results: await this.services
                 .getLearnService()
                 .recordEvents(req.account, body),
+        };
+    }
+
+    /**
+     * Get the signed-in user's per-module badge tiers. `badges` is null when
+     * the instance has no Learn service token configured.
+     * @summary Get Learn badges
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/badges')
+    @OperationId('getLearnBadges')
+    async getLearnBadges(
+        @Request() req: express.Request,
+    ): Promise<ApiLearnBadgesResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .getBadges(req.account),
         };
     }
 

--- a/packages/backend/src/services/LearnService/LearnService.test.ts
+++ b/packages/backend/src/services/LearnService/LearnService.test.ts
@@ -128,6 +128,14 @@ describe('LearnService', () => {
             expect(fetchMock).not.toHaveBeenCalled();
         });
 
+        it('gates the badges proxy on the flag', async () => {
+            const { service } = buildService({ flagEnabled: false });
+            await expect(service.getBadges(buildAccount())).rejects.toThrow(
+                ForbiddenError,
+            );
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
         it('gates the ask proxy on the flag', async () => {
             const { service } = buildService({ flagEnabled: false });
             await expect(
@@ -327,6 +335,77 @@ describe('LearnService', () => {
             await expect(
                 service.recordEvents(buildAccount(), [validEvent]),
             ).rejects.toThrow(UnexpectedServerError);
+        });
+    });
+
+    describe('getBadges', () => {
+        it('reports badges: null without a service token and never calls upstream', async () => {
+            const { service } = buildService({ withToken: false });
+            const result = await service.getBadges(buildAccount());
+            expect(result).toEqual({ badges: null });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('proxies with the server-held token and the session email', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    badges: [
+                        { courseId: 'viewer-fundamentals', tier: 'silver' },
+                    ],
+                    unacknowledged: [],
+                }),
+            );
+            const result = await service.getBadges(buildAccount());
+            expect(result).toEqual({
+                badges: [{ courseId: 'viewer-fundamentals', tier: 'silver' }],
+            });
+            const [url, init] = fetchMock.mock.calls[0];
+            expect(url).toBe(
+                'https://progress.test/api/v1/badges?email=learner%2Btest%40example.com',
+            );
+            expect((init.headers as Record<string, string>).authorization).toBe(
+                'Bearer service-token-1',
+            );
+        });
+
+        it('maps upstream failures to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({}, 500));
+            await expect(service.getBadges(buildAccount())).rejects.toThrow(
+                UnexpectedServerError,
+            );
+        });
+
+        it('drops per-badge fields the contract does not name', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    badges: [
+                        {
+                            courseId: 'viewer-fundamentals',
+                            tier: 'silver',
+                            earnedByEmail: 'learner+test@example.com',
+                        },
+                    ],
+                }),
+            );
+            const result = await service.getBadges(buildAccount());
+            expect(result.badges).toEqual([
+                { courseId: 'viewer-fundamentals', tier: 'silver' },
+            ]);
+        });
+
+        it('maps an unknown tier to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    badges: [{ courseId: 'viewer-fundamentals', tier: 'ruby' }],
+                }),
+            );
+            await expect(service.getBadges(buildAccount())).rejects.toThrow(
+                UnexpectedServerError,
+            );
         });
     });
 

--- a/packages/backend/src/services/LearnService/LearnService.ts
+++ b/packages/backend/src/services/LearnService/LearnService.ts
@@ -4,6 +4,7 @@ import {
     ForbiddenError,
     LearnAskRequestSchema,
     LearnAskResponseSchema,
+    LearnBadgesResponseSchema,
     LearnCatalogueSchema,
     LearnCourseSchema,
     LearnEventInputSchema,
@@ -14,6 +15,7 @@ import {
     type Account,
     type ApiLearnEventsResponse,
     type LearnAskResults,
+    type LearnBadgesResults,
     type LearnCatalogue,
     type LearnCourse,
     type LearnEventInput,
@@ -180,6 +182,30 @@ export class LearnService extends BaseService {
             throw new UnexpectedServerError('Could not load Learn progress');
         }
         return { courses: parsed.data.courses, serverSynced: true };
+    }
+
+    async getBadges(account: Account): Promise<LearnBadgesResults> {
+        await this.assertLearnEnabled(account);
+        if (!this.lightdashConfig.learn.serviceToken) {
+            return { badges: null };
+        }
+        const response = await this.progressRequest(account, '/api/v1/badges');
+        if (!response.ok) {
+            this.logger.warn('Learn badges service returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not load Learn badges');
+        }
+        const parsed = LearnBadgesResponseSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn badges failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not load Learn badges');
+        }
+        return { badges: parsed.data.badges };
     }
 
     async ask(account: Account, body: unknown): Promise<LearnAskResults> {

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -224,6 +224,7 @@ import type {
 import { type ApiImpersonationOrganizationSettingsResponse } from './impersonationOrganizationSettings';
 import {
     type ApiLearnAskResponse,
+    type ApiLearnBadgesResponse,
     type ApiLearnCatalogueResponse,
     type ApiLearnCourseResponse,
     type ApiLearnEventsResponse,
@@ -1316,6 +1317,7 @@ type ApiResults =
     | ApiLearnCourseResponse['results']
     | ApiLearnProgressResponse['results']
     | ApiLearnEventsResponse['results']
+    | ApiLearnBadgesResponse['results']
     | ApiLearnAskResponse['results']
     | ChartHistory
     | ChartVersion

--- a/packages/common/src/types/learn.ts
+++ b/packages/common/src/types/learn.ts
@@ -305,6 +305,31 @@ export type ApiLearnEventsResponse = {
     results: { accepted: number };
 };
 
+export type LearnBadgeTier = 'bronze' | 'silver' | 'gold' | 'violet';
+
+export type LearnCourseBadge = {
+    courseId: string;
+    tier: LearnBadgeTier;
+};
+
+export type LearnBadgesResults = {
+    /** Null when the instance has no Learn service token: tiers are server-derived only. */
+    badges: LearnCourseBadge[] | null;
+};
+
+// The envelope passes unknown fields through for forward compatibility; each
+// badge is stripped to the contract, so a new upstream field never reaches a browser.
+export const LearnBadgesResponseSchema = z
+    .object({
+        badges: z.array(
+            z.object({
+                courseId: z.string().min(1),
+                tier: z.enum(['bronze', 'silver', 'gold', 'violet']),
+            }),
+        ),
+    })
+    .passthrough();
+
 export type LearnAskRequest = {
     query: string;
 };
@@ -344,6 +369,11 @@ export const LearnAskResponseSchema = z
         ),
     })
     .passthrough();
+
+export type ApiLearnBadgesResponse = {
+    status: 'ok';
+    results: LearnBadgesResults;
+};
 
 export type ApiLearnAskResponse = {
     status: 'ok';

--- a/packages/frontend/src/features/learn/board/CLAUDE.md
+++ b/packages/frontend/src/features/learn/board/CLAUDE.md
@@ -1,5 +1,5 @@
 <summary>
-The scope-driven course board that is the Learn section's landing page: role tabs, one ring of module nodes per permission group lit by the selected role's scopes, an Ask bar that searches the library and lights the answer, and a rail with overall progress, a resume queue and a module detail pane. Everything derivable is a pure function; the components only render.
+The scope-driven course board that is the Learn section's landing page: role tabs, one ring of module nodes per permission group lit by the selected role's scopes, an Ask bar that searches the library and lights the answer, and a rail with overall progress, one badge per role, a resume queue and a module detail pane. Everything derivable is a pure function; the components only render.
 </summary>
 
 <howToUse>
@@ -9,15 +9,21 @@ The scope-driven course board that is the Learn section's landing page: role tab
 - `layout.ts`: `buildLayout(modules)` returns seats, connectors and captions in a fixed 1120px board space; `seatMap` gives the previous seats for a role change.
 - `motion.ts`: `resolveMotion(input)` turns a seat change into the per-node fly-in or collapse.
 
-Ask adds a copied layer plus its lightdash-only view layer:
+Ask and badges add two copied layers plus their lightdash-only view layers:
 
 - `ask.ts` (copied): `askHighlights(matches, entries, held)` splits held matches from locked ones, `suggestionsFor(suggestions, entries, held)` filters the curated chips down to `SUGGESTION_LIMIT`, `lockedLabel(entry)` names the lowest role that holds a module or null when every role does.
 - `askView.ts` (lightdash only): `resolveMatches` drops results the catalogue lost and caps at `ASK_RESULT_LIMIT`, `boardHighlights` adapts the published match type, `nodeAskState`/`askOpacity`/`askScale` drive the per-node treatment, `groupMatches` groups the results list, `lockedNote` is `lockedLabel` with a fallback.
+- `badges.ts` (copied): `roleBadge(held, tiers)` rolls per-module tiers up to one rung for the role.
+- `badgesView.ts` (lightdash only): `BadgeRung` against the published tier union, the rung words and requirements, and `badgeDetail(badge, available)`; `badgeArt.ts` renders the emblem.
 </howToUse>
 
 <codeExample>
 
 ```tsx
+// One badge per role: the role sits at its weakest held module.
+const badge = roleBadge(courseFor(entries, roleScopes(role)), tiers);
+// { rung: 'bronze', nextRung: 'silver', at: 2, of: 5 }
+
 // An answer lights the modules it matched and dims everything else.
 const matches = resolveMatches(ask.data.matches, entries);
 const highlights = boardHighlights(matches, entries, roleScopes(role));
@@ -27,8 +33,9 @@ const highlights = boardHighlights(matches, entries, roleScopes(role));
 </codeExample>
 
 <importantToKnow>
-- **Copied files, one sync rule.** Four modules, `model.ts`, `layout.ts`, `motion.ts` and `ask.ts`, plus `testFixtures.ts` and the tests `model.test.ts`, `layout.test.ts`, `motion.test.ts`, `ask.test.ts` are byte-identical twins of lightdash-university's `academy/board/` and `test/academy-board-*.test.ts`. A change to any of them lands in **both** repositories in the same piece of work, tests included, and both sides must survive `oxfmt` unchanged. The one permitted difference is the leading comment and import block: LU's `academy/board/scopeSource.ts` stands in for `@lightdash/common`. `npm run board:sync-check -- --lightdash <path>` in LU diffs the pairs.
-- **`askView.ts` is lightdash only.** Anything the components need that the copied files do not export lives there, built on top of them. Nothing lightdash-specific may go into a copied file.
+- **Copied files, one sync rule.** Five modules, `model.ts`, `layout.ts`, `motion.ts`, `ask.ts` and `badges.ts`, plus `testFixtures.ts` and the tests `model.test.ts`, `layout.test.ts`, `motion.test.ts`, `ask.test.ts`, `badges.test.ts` are byte-identical twins of lightdash-university's `academy/board/` and `test/academy-board-*.test.ts`. A change to any of them lands in **both** repositories in the same piece of work, tests included, and both sides must survive `oxfmt` unchanged. The one permitted difference is the leading comment and import block: LU's `academy/board/scopeSource.ts` stands in for `@lightdash/common`. `npm run board:sync-check -- --lightdash <path>` in LU diffs all eleven pairs. `badgeArt.ts` is a copy of the academy's `badges.ts` art (`PALETTES` and `TIER_MOTIFS`) under the same rule, but it sits outside the automated check, so a palette or motif edit has to be carried across by hand.
+- **`askView.ts` and `badgesView.ts` are lightdash only.** Anything the components need that the copied files do not export lives there, built on top of them. Nothing lightdash-specific may go into a copied file.
+- **Tiers are server derived, never computed here.** `useLearnBadges()` returns `badges: null` when the instance has no Learn service token; the badge card then says "Badges unavailable right now", because saying Locked to a learner who holds gold reads as a revoked badge. A query still in flight is neither: the card says "Loading badges" and names no rung until it settles. Recording an event invalidates `['learn-badges']` with `['learn-progress']`, since the server derives tiers at read time. Contract: `docs/badges-contract.md` in lightdash-university.
 - **The Ask bar sits above the role tabs**, so the tabs are next to the rings the nodes fly out of. Switching role keeps the answer and re-derives which of its matches are locked; only the query changing replaces it. Asking does not close an open module pane, which is the academy's behaviour too.
 - **One search at a time.** Every submit costs an upstream embedding, so a submit while a request is in flight is ignored, re-asking the question already answered is a no-op, and the panel tags each request with a sequence id so a late response never overwrites a newer answer. The previous answer and its highlights stay on screen while the next request runs.
 - **Progress is never revoked by a role change.** `railModel` scores every module but filters the board, queue and totals by the held course, so a completed module stays completed after a role switch.
@@ -39,7 +46,7 @@ const highlights = boardHighlights(matches, entries, roleScopes(role));
 </importantToKnow>
 
 <links>
-- @/packages/frontend/src/features/learn/hooks.ts (catalogue, course, rollups, ask)
+- @/packages/frontend/src/features/learn/hooks.ts (catalogue, course, rollups, badges, ask)
 - @/packages/backend/src/services/LearnService/LearnService.ts (the proxies these hooks call)
 - @/packages/common/src/types/learn.ts (the published contract and its zod schemas)
 </links>

--- a/packages/frontend/src/features/learn/board/badgeArt.ts
+++ b/packages/frontend/src/features/learn/board/badgeArt.ts
@@ -1,0 +1,129 @@
+// Badge art copied from lightdash-university academy/badges.ts (PALETTES,
+// TIER_MOTIFS, badgeSvg, tierBadgeSvg): no sync check covers it, so keep both by hand.
+
+import { type BadgeRung } from './badgesView';
+
+// Slots read outline, body, highlight, inner mark. Slot 4 is near white so the
+// emblem's inner mark reads as a white counter; `locked` is deepened off near
+// white so it still shows on a light rail.
+const PALETTES: Record<BadgeRung, [string, string, string, string]> = {
+    violet: ['#3d22b8', '#6b46f0', '#9b83ff', '#f5f1ff'],
+    locked: ['#8e8e9a', '#a8a8b4', '#c4c4ce', '#ecedf0'],
+    bronze: ['#8c5a2b', '#b6763a', '#d6994f', '#fff7ec'],
+    silver: ['#5f6672', '#878e9b', '#b6bcc6', '#ffffff'],
+    gold: ['#8a6d1a', '#c9a02c', '#eac545', '#fffbe9'],
+};
+
+// Tier reads from the silhouette (orb, shield, diamond, gem, rosette), not from
+// the palette alone, so a badge stays legible at 16px and in monochrome.
+const TIER_MOTIFS: Record<BadgeRung, string[]> = {
+    locked: [
+        '................',
+        '................',
+        '................',
+        '................',
+        '......4444......',
+        '.....422224.....',
+        '....42144124....',
+        '...4214444124...',
+        '...4214444124...',
+        '...4214444124...',
+        '...1214444121...',
+        '....12144121....',
+        '.....122221.....',
+        '......1111......',
+        '................',
+        '................',
+    ],
+    bronze: [
+        '................',
+        '................',
+        '...1111111111...',
+        '...4333333334...',
+        '...4222222224...',
+        '...4212222124...',
+        '...4214444124...',
+        '...4214444124...',
+        '...3213443123...',
+        '...1221331221...',
+        '....12211221....',
+        '.....122221.....',
+        '......1221......',
+        '.......11.......',
+        '................',
+        '................',
+    ],
+    silver: [
+        '................',
+        '................',
+        '................',
+        '.......44.......',
+        '......4334......',
+        '.....431134.....',
+        '....43144134....',
+        '...4214444124...',
+        '...4214444124...',
+        '....22144122....',
+        '.....221122.....',
+        '......2222......',
+        '.......22.......',
+        '................',
+        '................',
+        '................',
+    ],
+    gold: [
+        '................',
+        '................',
+        '................',
+        '....44444444....',
+        '...4222222224...',
+        '..422111111224..',
+        '..421444444124..',
+        '..421444444124..',
+        '...2214444122...',
+        '....22144122....',
+        '.....221122.....',
+        '......2222......',
+        '.......22.......',
+        '................',
+        '................',
+        '................',
+    ],
+    violet: [
+        '................',
+        '................',
+        '................',
+        '.......44.......',
+        '.....442244.....',
+        '....42211224....',
+        '...4221441224...',
+        '...4214444124...',
+        '...4214444124...',
+        '...2221441222...',
+        '....22211222....',
+        '.....222222.....',
+        '......2222......',
+        '................',
+        '................',
+        '................',
+    ],
+};
+
+const badgeSvg = (motif: string[], rung: BadgeRung, cell: number): string => {
+    const rects: string[] = [];
+    motif.forEach((row, r) => {
+        for (let c = 0; c < row.length; c += 1) {
+            const ch = row[c];
+            if (ch === '.') continue;
+            const fill = PALETTES[rung][Number(ch) - 1];
+            rects.push(
+                `<rect x="${c * cell}" y="${r * cell}" width="${cell}" height="${cell}" fill="${fill}"/>`,
+            );
+        }
+    });
+    const size = 16 * cell;
+    return `<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" shape-rendering="crispEdges" aria-hidden="true">${rects.join('')}</svg>`;
+};
+
+export const tierBadgeSvg = (rung: BadgeRung, cell: number): string =>
+    badgeSvg(TIER_MOTIFS[rung], rung, cell);

--- a/packages/frontend/src/features/learn/board/badges.test.ts
+++ b/packages/frontend/src/features/learn/board/badges.test.ts
@@ -1,0 +1,107 @@
+// Role badge tests. Twin: lightdash-university test/academy-board-badges.test.ts.
+// A change here lands in both repositories in the same piece of work.
+
+import { describe, expect, it } from 'vitest';
+import { roleBadge, type Rung } from './badges';
+import { entry } from './testFixtures';
+
+const held = [entry({ id: 'a' }), entry({ id: 'b' }), entry({ id: 'c' })];
+const tiers = (pairs: [string, Rung][]): Map<string, Rung> => new Map(pairs);
+
+describe('roleBadge', () => {
+    it('sits at the lowest rung across the held modules', () => {
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'gold'],
+                    ['b', 'gold'],
+                    ['c', 'gold'],
+                ]),
+            ),
+        ).toMatchObject({ rung: 'gold', nextRung: 'violet' });
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'violet'],
+                    ['b', 'gold'],
+                    ['c', 'silver'],
+                ]),
+            ),
+        ).toMatchObject({ rung: 'silver', nextRung: 'gold' });
+    });
+
+    it('a module with no row pins the badge to locked', () => {
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'violet'],
+                    ['b', 'violet'],
+                ]),
+            ),
+        ).toMatchObject({ rung: 'locked', nextRung: 'bronze' });
+    });
+
+    it('counts how many held modules already cleared the next rung', () => {
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'gold'],
+                    ['b', 'bronze'],
+                ]),
+            ),
+        ).toEqual({
+            rung: 'locked',
+            nextRung: 'bronze',
+            at: 2,
+            of: 3,
+        });
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'gold'],
+                    ['b', 'silver'],
+                    ['c', 'silver'],
+                ]),
+            ),
+        ).toEqual({ rung: 'silver', nextRung: 'gold', at: 1, of: 3 });
+    });
+
+    it('tops out with no next rung once everything is violet', () => {
+        expect(
+            roleBadge(
+                held,
+                tiers([
+                    ['a', 'violet'],
+                    ['b', 'violet'],
+                    ['c', 'violet'],
+                ]),
+            ),
+        ).toEqual({ rung: 'violet', nextRung: null, at: 3, of: 3 });
+    });
+
+    it('a role holding nothing is locked with nothing to count', () => {
+        expect(roleBadge([], new Map())).toEqual({
+            rung: 'locked',
+            nextRung: 'bronze',
+            at: 0,
+            of: 0,
+        });
+    });
+
+    it('ignores tiers for modules the role does not hold', () => {
+        expect(
+            roleBadge(
+                [entry({ id: 'a' })],
+                tiers([
+                    ['a', 'bronze'],
+                    ['elsewhere', 'locked'],
+                ]),
+            ),
+        ).toMatchObject({ rung: 'bronze', of: 1 });
+    });
+});

--- a/packages/frontend/src/features/learn/board/badges.ts
+++ b/packages/frontend/src/features/learn/board/badges.ts
@@ -1,0 +1,59 @@
+// Role badge rollup. Twin: lightdash-university academy/board/badges.ts.
+// A change here lands in both repositories in the same piece of work.
+
+import { type LearnCatalogueEntry } from '@lightdash/common';
+
+/**
+ * One badge per role, not per module: a role badge is the honest summary of a
+ * course, and a shelf of per-module tiles only repeated the board underneath it.
+ *
+ * The badge sits at the WEAKEST held module, which is what makes it worth more
+ * than the modules it contains: gold means every module the role holds is gold.
+ * Per-module tiers are server-derived (docs/badges-contract.md); this is a
+ * client-side rollup over them, and it never invents a rung the server did not
+ * grant. A module the role does not hold is not in `held` at all, so role growth
+ * can lower the badge but never revokes a module's own tier.
+ */
+export type Rung = 'locked' | 'bronze' | 'silver' | 'gold' | 'violet';
+
+export const RUNG_LADDER: Rung[] = [
+    'locked',
+    'bronze',
+    'silver',
+    'gold',
+    'violet',
+];
+
+const rank = (rung: Rung): number => RUNG_LADDER.indexOf(rung);
+
+export type RoleBadge = {
+    /** Where the role stands now. */
+    rung: Rung;
+    /** The rung being worked toward, null once everything is violet. */
+    nextRung: Rung | null;
+    /** Held modules already at or above `nextRung`. */
+    at: number;
+    /** Held modules in total. */
+    of: number;
+};
+
+export const roleBadge = (
+    held: LearnCatalogueEntry[],
+    tiers: Map<string, Rung>,
+): RoleBadge => {
+    const of = held.length;
+    const earned = held.map((entry) => tiers.get(entry.id) ?? 'locked');
+    // A role with no modules is locked rather than violet: nothing was earned.
+    const rung =
+        earned.length === 0
+            ? 'locked'
+            : RUNG_LADDER[Math.min(...earned.map(rank))];
+    const nextRung = rung === 'violet' ? null : RUNG_LADDER[rank(rung) + 1];
+    if (nextRung === null) return { rung, nextRung: null, at: of, of };
+    return {
+        rung,
+        nextRung,
+        at: earned.filter((tier) => rank(tier) >= rank(nextRung)).length,
+        of,
+    };
+};

--- a/packages/frontend/src/features/learn/board/badgesView.test.ts
+++ b/packages/frontend/src/features/learn/board/badgesView.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { type RoleBadge } from './badges';
+import { badgeDetail } from './badgesView';
+
+const badge = (overrides: Partial<RoleBadge>): RoleBadge => ({
+    rung: 'bronze',
+    nextRung: 'silver',
+    at: 1,
+    of: 3,
+    ...overrides,
+});
+
+describe('badgeDetail', () => {
+    it('names what earns the next rung and how far along the role is', () => {
+        expect(badgeDetail(badge({}), true)).toBe(
+            'Pass every quiz for silver · 1 of 3 there',
+        );
+    });
+
+    it('says the role topped out, in the singular for one module', () => {
+        expect(
+            badgeDetail(
+                badge({ rung: 'violet', nextRung: null, at: 1, of: 1 }),
+                true,
+            ),
+        ).toBe('All 1 module at violet');
+        expect(
+            badgeDetail(
+                badge({ rung: 'violet', nextRung: null, at: 4, of: 4 }),
+                true,
+            ),
+        ).toBe('All 4 modules at violet');
+    });
+
+    it('says it cannot tell rather than Locked when badges did not load', () => {
+        expect(badgeDetail(badge({ rung: 'locked' }), false)).toBe(
+            'Badges unavailable right now',
+        );
+    });
+});

--- a/packages/frontend/src/features/learn/board/badgesView.ts
+++ b/packages/frontend/src/features/learn/board/badgesView.ts
@@ -1,0 +1,56 @@
+// Badge card copy over the copied badges.ts. Lightdash side only: nothing here
+// has a twin in lightdash-university.
+
+import { type LearnBadgeTier } from '@lightdash/common';
+import { RUNG_LADDER, type RoleBadge } from './badges';
+import { plural } from './model';
+
+/** The copied ladder, named against the published tier union. */
+export type BadgeRung = 'locked' | LearnBadgeTier;
+
+export const RUNG_WORD: Record<BadgeRung, string> = {
+    locked: 'Locked',
+    bronze: 'Bronze',
+    silver: 'Silver',
+    gold: 'Gold',
+    violet: 'Violet',
+};
+
+// What earns the next rung, so a locked badge is a goal rather than a blank.
+const RUNG_HINT: Record<BadgeRung, string> = {
+    locked: '',
+    bronze: 'Finish every module for bronze',
+    silver: 'Pass every quiz for silver',
+    gold: 'Score 90%+ on every quiz for gold',
+    violet: 'Ace every quiz for violet',
+};
+
+/** The full ladder, so a learner can read what each rung takes. */
+export const RUNG_REQ: Record<LearnBadgeTier, string> = {
+    bronze: 'Finish every module',
+    silver: 'Pass every quiz',
+    gold: 'Score 90% or more on every quiz',
+    violet: 'Ace every quiz (100%)',
+};
+
+/** The rungs a learner can earn, in ladder order: the copy owns the order. */
+export const EARNABLE: LearnBadgeTier[] = RUNG_LADDER.filter(
+    (rung): rung is LearnBadgeTier => rung !== 'locked',
+);
+
+/** Pending is not unavailable: an in-flight fetch says so and names no rung. */
+export const BADGE_PENDING_DETAIL = 'Loading badges';
+
+/**
+ * The line under the rung word. A failed badges fetch is not "nothing earned":
+ * saying Locked to a learner who holds gold reads as a revoked badge.
+ */
+export const badgeDetail = (badge: RoleBadge, available: boolean): string => {
+    if (!available) return 'Badges unavailable right now';
+    if (badge.nextRung === null) {
+        return `All ${plural(badge.of, 'module')} at ${RUNG_WORD[
+            badge.rung
+        ].toLowerCase()}`;
+    }
+    return `${RUNG_HINT[badge.nextRung]} · ${badge.at} of ${badge.of} there`;
+};

--- a/packages/frontend/src/features/learn/board/components/BoardRail.tsx
+++ b/packages/frontend/src/features/learn/board/components/BoardRail.tsx
@@ -1,13 +1,23 @@
+import {
+    type LearnBadgeTier,
+    type LearnCatalogueEntry,
+    type ProjectMemberRole,
+} from '@lightdash/common';
 import { Stack, Text } from '@mantine/core';
 import { type FC } from 'react';
 import { type Rollup } from '../../model';
 import { GROUP_LABEL, plural, type RailModel } from '../model';
 import styles from './LearnBoard.module.css';
 import { ModulePane } from './ModulePane';
+import { RoleBadgeCard } from './RoleBadgeCard';
 
 type Props = {
     rail: RailModel;
     rollups: Map<string, Rollup>;
+    role: ProjectMemberRole;
+    heldEntries: LearnCatalogueEntry[];
+    tiers: Map<string, LearnBadgeTier> | null;
+    tiersLoading: boolean;
     selectedId: string | null;
     onSelect: (id: string) => void;
     onClearSelection: () => void;
@@ -17,6 +27,10 @@ type Props = {
 export const BoardRail: FC<Props> = ({
     rail,
     rollups,
+    role,
+    heldEntries,
+    tiers,
+    tiersLoading,
     selectedId,
     onSelect,
     onClearSelection,
@@ -47,6 +61,13 @@ export const BoardRail: FC<Props> = ({
                     {plural(rail.overall.modulesComplete, 'module')} complete
                 </Text>
             </Stack>
+
+            <RoleBadgeCard
+                role={role}
+                held={heldEntries}
+                tiers={tiers}
+                isLoading={tiersLoading}
+            />
 
             {selected ? (
                 <ModulePane

--- a/packages/frontend/src/features/learn/board/components/LearnBoard.module.css
+++ b/packages/frontend/src/features/learn/board/components/LearnBoard.module.css
@@ -521,6 +521,60 @@
     cursor: pointer;
 }
 
+.badgeHero {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.badgeEmblem {
+    display: inline-flex;
+    flex: none;
+    line-height: 0;
+}
+
+.badgeRung {
+    font-size: 20px;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+    font-weight: 500;
+}
+
+.badgeHowto {
+    font-size: 12px;
+}
+
+.badgeHowtoSummary {
+    cursor: pointer;
+    color: #818898;
+}
+
+.badgeHowtoList {
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.badgeHowtoRung {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: #818898;
+}
+
+.badgeHowtoEmblem {
+    display: inline-flex;
+    flex: none;
+    line-height: 0;
+}
+
+.badgeHowtoReq {
+    color: #818898;
+}
+
 @media (prefers-reduced-motion: reduce) {
     .nodeNextUp {
         animation: none;

--- a/packages/frontend/src/features/learn/board/components/LearnBoardPanel.test.tsx
+++ b/packages/frontend/src/features/learn/board/components/LearnBoardPanel.test.tsx
@@ -1,4 +1,8 @@
-import { OrganizationMemberRole, type LearnAskMatch } from '@lightdash/common';
+import {
+    OrganizationMemberRole,
+    type LearnAskMatch,
+    type LearnBadgesResults,
+} from '@lightdash/common';
 import {
     act,
     fireEvent,
@@ -70,6 +74,19 @@ const askState: { isLoading: boolean; isError: boolean } = {
     isLoading: false,
     isError: false,
 };
+const bronzeEverywhere: LearnBadgesResults = {
+    badges: [
+        { courseId: 'foundation', tier: 'bronze' },
+        { courseId: 'sharing', tier: 'bronze' },
+    ],
+};
+const badgesState: {
+    data: LearnBadgesResults | undefined;
+    isInitialLoading: boolean;
+} = {
+    data: bronzeEverywhere,
+    isInitialLoading: false,
+};
 // Hoisted: the mock factory reads this one eagerly, not from inside a closure.
 const setLessonBookmarkMock = vi.hoisted(() => vi.fn());
 
@@ -113,6 +130,7 @@ vi.mock('../../hooks', () => ({
         },
         isError: false,
     }),
+    useLearnBadges: () => badgesState,
     useLearnAsk: () => ({
         mutate: askMutate,
         reset: () => {
@@ -132,6 +150,8 @@ describe('LearnBoardPanel', () => {
         setLessonBookmarkMock.mockClear();
         askState.isLoading = false;
         askState.isError = false;
+        badgesState.data = bronzeEverywhere;
+        badgesState.isInitialLoading = false;
     });
 
     it('defaults to the org role and lights only the held modules', async () => {
@@ -472,5 +492,54 @@ describe('LearnBoardPanel', () => {
         expect(navigate).toHaveBeenCalledWith(
             '/projects/project-1/learn/courses/foundation',
         );
+    });
+
+    it('renders the role badge card from the badge tiers', async () => {
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        expect(await screen.findByText('viewer badge')).toBeInTheDocument();
+        // The rung word also appears in the disclosure, so pin the hero span.
+        expect(
+            screen.getByText('Bronze', { selector: 'span' }),
+        ).toBeInTheDocument();
+    });
+
+    it('switches the badge when the role tab changes', async () => {
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        expect(await screen.findByText('viewer badge')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('tab', { name: 'editor' }));
+        expect(await screen.findByText('editor badge')).toBeInTheDocument();
+        // Editor also holds the untiered dashboards module, so the role drops
+        // back to the lowest rung.
+        expect(
+            screen.getByText('Locked', { selector: 'span' }),
+        ).toBeInTheDocument();
+    });
+
+    it('waits for the badges query rather than calling it unavailable', async () => {
+        badgesState.data = undefined;
+        badgesState.isInitialLoading = true;
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        expect(await screen.findByText('Loading badges')).toBeInTheDocument();
+        expect(
+            screen.queryByText('Badges unavailable right now'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('says badges are unavailable rather than showing them as locked', async () => {
+        badgesState.data = { badges: null };
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        expect(await screen.findByText('Overall')).toBeInTheDocument();
+        expect(screen.getByText('viewer badge')).toBeInTheDocument();
+        expect(
+            screen.getByText('Badges unavailable right now'),
+        ).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/features/learn/board/components/LearnBoardPanel.tsx
+++ b/packages/frontend/src/features/learn/board/components/LearnBoardPanel.tsx
@@ -1,4 +1,8 @@
-import { type LearnAskMatch, type ProjectMemberRole } from '@lightdash/common';
+import {
+    type LearnAskMatch,
+    type LearnBadgeTier,
+    type ProjectMemberRole,
+} from '@lightdash/common';
 import { useReducedMotion } from '@mantine/hooks';
 import { IconSchool } from '@tabler/icons-react';
 import {
@@ -15,6 +19,7 @@ import useApp from '../../../../providers/App/useApp';
 import {
     setLessonBookmark,
     useLearnAsk,
+    useLearnBadges,
     useLearnCatalogue,
     useLearnRollups,
 } from '../../hooks';
@@ -22,6 +27,7 @@ import { suggestionsFor } from '../ask';
 import { boardHighlights, resolveMatches } from '../askView';
 import { BOARD_WIDTH, type Seat } from '../layout';
 import {
+    courseFor,
     defaultRoleFor,
     plural,
     railModel,
@@ -43,6 +49,7 @@ export const LearnBoardPanel: FC = () => {
     const { user } = useApp();
     const catalogue = useLearnCatalogue();
     const { rollups } = useLearnRollups();
+    const badges = useLearnBadges();
     const ask = useLearnAsk();
     const [answer, setAnswer] = useState<AskAnswer | null>(null);
     const reducedMotion = useReducedMotion() ?? false;
@@ -166,6 +173,15 @@ export const LearnBoardPanel: FC = () => {
         () => railModel(entries, held, rollups),
         [entries, held, rollups],
     );
+    const heldEntries = useMemo(
+        () => courseFor(entries, held),
+        [entries, held],
+    );
+    const tiers = useMemo((): Map<string, LearnBadgeTier> | null => {
+        const rows = badges.data?.badges;
+        if (!rows) return null;
+        return new Map(rows.map((badge) => [badge.courseId, badge.tier]));
+    }, [badges.data]);
     const suggestions = useMemo(
         () =>
             catalogue.data
@@ -261,6 +277,10 @@ export const LearnBoardPanel: FC = () => {
                 <BoardRail
                     rail={rail}
                     rollups={rollups}
+                    role={role}
+                    heldEntries={heldEntries}
+                    tiers={tiers}
+                    tiersLoading={badges.isInitialLoading}
                     selectedId={selectedId}
                     onSelect={setSelectedId}
                     onClearSelection={clearSelection}

--- a/packages/frontend/src/features/learn/board/components/RoleBadgeCard.test.tsx
+++ b/packages/frontend/src/features/learn/board/components/RoleBadgeCard.test.tsx
@@ -1,0 +1,111 @@
+import { ProjectMemberRole, type LearnBadgeTier } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import { entry } from '../testFixtures';
+import { RoleBadgeCard } from './RoleBadgeCard';
+
+const held = [entry({ id: 'a' }), entry({ id: 'b' })];
+
+const tiers = (map: Record<string, LearnBadgeTier>) =>
+    new Map(Object.entries(map));
+
+describe('RoleBadgeCard', () => {
+    it('sits at the weakest held module and counts towards the next rung', () => {
+        renderWithProviders(
+            <RoleBadgeCard
+                role={ProjectMemberRole.VIEWER}
+                held={held}
+                tiers={tiers({ a: 'bronze', b: 'silver' })}
+                isLoading={false}
+            />,
+        );
+        expect(screen.getByText('viewer badge')).toBeInTheDocument();
+        // The rung word also appears in the disclosure, so pin the hero span.
+        expect(
+            screen.getByText('Bronze', { selector: 'span' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/Pass every quiz for silver/),
+        ).toBeInTheDocument();
+        expect(screen.getByText(/1 of 2 there/)).toBeInTheDocument();
+    });
+
+    it('says so when every held module is at the top rung', () => {
+        renderWithProviders(
+            <RoleBadgeCard
+                role={ProjectMemberRole.EDITOR}
+                held={held}
+                tiers={tiers({ a: 'violet', b: 'violet' })}
+                isLoading={false}
+            />,
+        );
+        expect(screen.getByText('editor badge')).toBeInTheDocument();
+        expect(screen.getByText('All 2 modules at violet')).toBeInTheDocument();
+    });
+
+    it('lists the four rungs in the How badges work disclosure', () => {
+        renderWithProviders(
+            <RoleBadgeCard
+                role={ProjectMemberRole.VIEWER}
+                held={held}
+                tiers={tiers({})}
+                isLoading={false}
+            />,
+        );
+        expect(screen.getByText('How badges work')).toBeInTheDocument();
+        expect(screen.getByText('Finish every module')).toBeInTheDocument();
+        expect(screen.getByText('Pass every quiz')).toBeInTheDocument();
+        expect(
+            screen.getByText('Score 90% or more on every quiz'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Ace every quiz (100%)')).toBeInTheDocument();
+    });
+
+    it('waits rather than calling a pending fetch unavailable', () => {
+        renderWithProviders(
+            <RoleBadgeCard
+                role={ProjectMemberRole.VIEWER}
+                held={held}
+                tiers={null}
+                isLoading
+            />,
+        );
+        expect(screen.getByText('Loading badges')).toBeInTheDocument();
+        expect(
+            screen.queryByText('Badges unavailable right now'),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText('Locked', { selector: 'span' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('says badges could not be loaded rather than reading as revoked', () => {
+        renderWithProviders(
+            <RoleBadgeCard
+                role={ProjectMemberRole.VIEWER}
+                held={held}
+                tiers={null}
+                isLoading={false}
+            />,
+        );
+        expect(
+            screen.getByText('Badges unavailable right now'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('viewer badge')).toBeInTheDocument();
+    });
+
+    it('renders nothing when the role holds no modules', () => {
+        renderWithProviders(
+            <div data-testid="mount">
+                <RoleBadgeCard
+                    role={ProjectMemberRole.VIEWER}
+                    held={[]}
+                    tiers={tiers({})}
+                    isLoading={false}
+                />
+            </div>,
+        );
+        expect(screen.getByTestId('mount')).toBeEmptyDOMElement();
+    });
+});

--- a/packages/frontend/src/features/learn/board/components/RoleBadgeCard.tsx
+++ b/packages/frontend/src/features/learn/board/components/RoleBadgeCard.tsx
@@ -1,0 +1,91 @@
+import {
+    type LearnBadgeTier,
+    type LearnCatalogueEntry,
+    type ProjectMemberRole,
+} from '@lightdash/common';
+import { Stack, Text } from '@mantine/core';
+import { type FC } from 'react';
+import { tierBadgeSvg } from '../badgeArt';
+import { roleBadge } from '../badges';
+import {
+    BADGE_PENDING_DETAIL,
+    badgeDetail,
+    EARNABLE,
+    RUNG_REQ,
+    RUNG_WORD,
+} from '../badgesView';
+import { ROLE_LABEL } from '../model';
+import styles from './LearnBoard.module.css';
+
+export type RoleBadgeCardProps = {
+    role: ProjectMemberRole;
+    held: LearnCatalogueEntry[];
+    /** Null when badges could not be loaded, which is not the same as none earned. */
+    tiers: Map<string, LearnBadgeTier> | null;
+    /** True while the badges query is in flight, which is not unavailable either. */
+    isLoading: boolean;
+};
+
+export const RoleBadgeCard: FC<RoleBadgeCardProps> = ({
+    role,
+    held,
+    tiers,
+    isLoading,
+}) => {
+    // A role with nothing to learn has nothing to earn: no card rather than a
+    // badge reading "0 of 0 there" beside the empty state.
+    if (held.length === 0) return null;
+    const badge = roleBadge(held, tiers ?? new Map());
+    const detail = isLoading
+        ? BADGE_PENDING_DETAIL
+        : badgeDetail(badge, tiers !== null);
+
+    return (
+        <Stack gap={10}>
+            <span className={styles.overline}>{ROLE_LABEL[role]} badge</span>
+            <div className={styles.badgeHero}>
+                {/* Local constant markup from badgeArt, never remote content. */}
+                <span
+                    className={styles.badgeEmblem}
+                    dangerouslySetInnerHTML={{
+                        __html: tierBadgeSvg(
+                            isLoading ? 'locked' : badge.rung,
+                            4,
+                        ),
+                    }}
+                />
+                <Stack gap={2}>
+                    {!isLoading && (
+                        <span className={styles.badgeRung}>
+                            {RUNG_WORD[badge.rung]}
+                        </span>
+                    )}
+                    <Text size="xs" className={styles.muted}>
+                        {detail}
+                    </Text>
+                </Stack>
+            </div>
+            <details className={styles.badgeHowto}>
+                <summary className={styles.badgeHowtoSummary}>
+                    How badges work
+                </summary>
+                <ul className={styles.badgeHowtoList}>
+                    {EARNABLE.map((rung) => (
+                        <li key={rung} className={styles.badgeHowtoRung}>
+                            <span
+                                className={styles.badgeHowtoEmblem}
+                                dangerouslySetInnerHTML={{
+                                    __html: tierBadgeSvg(rung, 2),
+                                }}
+                            />
+                            <b>{RUNG_WORD[rung]}</b>
+                            <span className={styles.badgeHowtoReq}>
+                                {RUNG_REQ[rung]}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+            </details>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/learn/hooks.test.tsx
+++ b/packages/frontend/src/features/learn/hooks.test.tsx
@@ -1,0 +1,51 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { useRecordLearnEvent } from './hooks';
+
+const lightdashApi = vi.hoisted(() => vi.fn());
+
+vi.mock('../../api', () => ({ lightdashApi }));
+
+const renderWithClient = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+
+    return {
+        queryClient,
+        ...renderHook(() => useRecordLearnEvent(), { wrapper }),
+    };
+};
+
+describe('useRecordLearnEvent', () => {
+    beforeEach(() => {
+        lightdashApi.mockReset();
+        localStorage.clear();
+    });
+
+    it('invalidates the badges as well as the progress once an event settles', async () => {
+        lightdashApi.mockResolvedValue({ accepted: 1 });
+        const { queryClient, result } = renderWithClient();
+        const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+        act(() =>
+            result.current.record({
+                verb: 'completed',
+                object: { type: 'course', course: 'viewer-fundamentals' },
+            }),
+        );
+
+        await waitFor(() => {
+            expect(invalidateQueries).toHaveBeenCalledWith(['learn-progress']);
+            // Tiers are read-time on the server: a stale badge contradicts the
+            // rail sitting beside it.
+            expect(invalidateQueries).toHaveBeenCalledWith(['learn-badges']);
+        });
+    });
+});

--- a/packages/frontend/src/features/learn/hooks.ts
+++ b/packages/frontend/src/features/learn/hooks.ts
@@ -2,6 +2,7 @@ import {
     type ApiError,
     type LearnAskRequest,
     type LearnAskResults,
+    type LearnBadgesResults,
     type LearnCatalogue,
     type LearnCourse,
     type LearnEventInput,
@@ -49,6 +50,13 @@ const postLearnEvents = async (events: LearnEventInput[]) =>
         body: JSON.stringify(events),
     });
 
+const getLearnBadges = async () =>
+    lightdashApi<LearnBadgesResults>({
+        url: '/learn/badges',
+        method: 'GET',
+        body: undefined,
+    });
+
 const postLearnAsk = async (body: LearnAskRequest) =>
     lightdashApi<LearnAskResults>({
         url: '/learn/ask',
@@ -69,6 +77,15 @@ export const useLearnCourse = (courseId: string | undefined) =>
         queryKey: ['learn-course', courseId],
         queryFn: () => getLearnCourse(courseId!),
         enabled: courseId !== undefined,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+/** Per-module tiers. `badges` is null when the instance has no service token. */
+export const useLearnBadges = () =>
+    useQuery<LearnBadgesResults, ApiError>({
+        queryKey: ['learn-badges'],
+        queryFn: getLearnBadges,
         staleTime: 5 * 60 * 1000,
         retry: false,
     });
@@ -134,7 +151,14 @@ export const useRecordLearnEvent = () => {
         LearnEventInput[]
     >({
         mutationFn: postLearnEvents,
-        onSettled: () => queryClient.invalidateQueries(['learn-progress']),
+        // Tiers are derived server side at read time, so a finished module
+        // changes the badge as well as the progress the rail reads.
+        onSettled: async () => {
+            await Promise.all([
+                queryClient.invalidateQueries(['learn-progress']),
+                queryClient.invalidateQueries(['learn-badges']),
+            ]);
+        },
     });
     const { mutate } = mutation;
     const record = useCallback(


### PR DESCRIPTION
Adds one role badge to the course-board rail, mirroring the academy at learn.lightdash.com. Split from the original board-rail PR so Ask (`learn-6-ask`, the PR below this one) and role badges review separately.

## What changed

- **Role badge** card in the rail: one badge per role tab, the lowest rung across every module that role holds (bronze, silver, gold, violet), from a new `GET /learn/badges` proxy that carries the server-held service token; a loading state while the query settles and an "unavailable" line if it fails; refreshed whenever the learner records an event.
- **Common types**: badge response types and the `LearnBadgesResponseSchema` envelope (unknown per-badge fields are stripped so a new upstream field never reaches a browser).
- **Pure module** `board/badges.ts` (and its tests) is a byte-identical copy of the academy's below the import seam; lightdash-only helpers live in `badgesView.ts`, and `badgeArt.ts` renders the emblem (a hand-carried copy of the academy's palettes and motifs). `board/CLAUDE.md` picks up the badge rules.

## Behaviour worth knowing

- Tiers are server derived, never computed here. `useLearnBadges()` returns `badges: null` when the instance has no Learn service token; the card then says "Badges unavailable right now", because saying Locked to a learner who holds gold reads as a revoked badge. A query still in flight names no rung until it settles.
- Recording an event invalidates `['learn-badges']` with `['learn-progress']`, since the server derives tiers at read time. Contract: `docs/badges-contract.md` in lightdash-university.
- Badges are per role only (the role sits at its weakest held module); there are no per-module rungs.

## Verification

- Unit: RoleBadgeCard states (tiers, switch on role change, loading, unavailable), `badges.ts`/`badgesView.ts` pure modules, hooks invalidation, and `LearnService` including the flag-off path for the proxy. Typecheck clean across common, backend and frontend.
- The local dev instance has no `LEARN_SERVICE_TOKEN`, so the badges proxy (which needs it) was exercised through tests; the card states were checked in the browser.

## Out of scope

Per-module rung display on nodes; the earn-moment modal in-app; the reach page; custom-role resolution; guided tracks (CS-136); role promotion (CS-141); entitlement suppression (CS-51).

Relates: CS-142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAD1wSdyo6Mewb2PMFA1GD
