### PR TITLE
fix: downgrade NotFoundError log level from error to info

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -8,6 +8,7 @@ import {
     LightdashMode,
     LightdashVersionHeader,
     MissingConfigError,
+    NotFoundError,
     OauthAuthenticationError,
     UnexpectedServerError,
     UPLOAD_GSHEET_FROM_ROWS_MAX_BYTES,
@@ -932,11 +933,17 @@ export default class App {
                     // This intentionally uses console vs. winston because of problems from some error/JSON payloads.
                     console.error(error);
                 }
-                Logger.error(
-                    `Handled error of type ${errorResponse.name} on [${req.method}] ${req.path}`,
-                    errorResponse,
-                );
-
+                if (error instanceof NotFoundError) {
+                    Logger.info(
+                        `Handled error of type ${errorResponse.name} on [${req.method}] ${req.path}`,
+                        errorResponse,
+                    );
+                } else {
+                    Logger.error(
+                        `Handled error of type ${errorResponse.name} on [${req.method}] ${req.path}`,
+                        errorResponse,
+                    );
+                }
                 if (process.env.NODE_ENV === 'development') {
                     Logger.error(error.stack);
                 }


### PR DESCRIPTION
## Problem

Organizations with AI Agents enabled see repeated error-level log entries for GET /api/v1/org/aiRouter even when no AI Router has been configured. The frontend polls this endpoint on every page that renders AI UI components to discover whether the router is enabled. When no router exists, the backend correctly returns a 404 — which the frontend already handles gracefully by treating it as "router disabled". However, the global error handler logs every NotFoundError at Logger.error() level, generating false-alarm noise in container logs.
This is the normal first-use state and should not produce error-level output.

## Solution
In packages/backend/src/App.ts, the global Express error handler now checks for NotFoundError and logs it at info level instead of error level. This is consistent with:
- The Sentry IGNORE_ERRORS list, which already excludes NotFoundError (sentry.ts:87)
- The fact that 404 is a standard HTTP response, not a server error

## Changes
- packages/backend/src/App.ts: Added instanceof NotFoundError check in the global error handler to log 404s at info level instead of error level. All other errors continue to log at error level as before.
What this does NOT change
- No frontend changes — the frontend already handles the 404 gracefully
- No API behavior changes — 404 responses are still returned as before
- No impact on other NotFoundError use cases — they still return 404, just at a quieter log level

## Testing
- Verify with AI Agents enabled but no router configured: the endpoint should return 404 with no error-level log entry
- Verify real errors still log at error level
- Run existing tests to ensure no regressions

## Steps to Reproduce
1. Start Lightdash with AI Agents enabled (but no AI Router configured)
2. Open the browser and navigate to any page that renders AI UI components (e.g., the home page with the AI search box, or the AI agent panel)
3. Open the application logs (e.g., docker logs <container> or PM2 logs)
4. Observe repeated error-level log entries like:
Handled error of type NotFoundError on [GET] /api/v1/org/aiRouter AI router not configured.
5. Notice that these error logs appear every time the page loads or the frontend polls the endpoint — even though no router was ever configured and the frontend handles the 404 gracefully
6. Expected (before fix): Error-level log entries flood the logs for a normal first-use state
7. Expected (after fix): The same 404 is logged at info level — no more false-alarm noise in error logs

## Close : #26297 