### PR TITLE
fix: accept project slugs in Slack unfurls

### DIFF
--- a/packages/backend/src/ee/models/CommercialSlackAuthenticationModel.ts
+++ b/packages/backend/src/ee/models/CommercialSlackAuthenticationModel.ts
@@ -9,24 +9,6 @@ import { AiRouterTableName } from '../database/entities/aiRouter';
 import { SlackChannelProjectMappingsTableName } from '../database/entities/slackChannelProjectMappings';
 
 export class CommercialSlackAuthenticationModel extends SlackAuthenticationModel {
-    async getOrganizationUuidFromTeamId(teamId: string) {
-        const row = await this.database(SlackAuthTokensTableName)
-            .leftJoin(
-                'organizations',
-                'slack_auth_tokens.organization_id',
-                'organizations.organization_id',
-            )
-            .select('organization_uuid')
-            .where('slack_team_id', teamId)
-            .first();
-
-        if (!row) {
-            throw new Error('Could not find organization');
-        }
-
-        return row.organization_uuid;
-    }
-
     async getInstallationFromOrganizationUuid(
         organizationUuid: string,
     ): Promise<Omit<SlackSettings, 'hasRequiredScopes'> | undefined> {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1278,6 +1278,33 @@ export class ProjectModel {
         };
     }
 
+    async getUuidBySlug(
+        organizationUuid: string,
+        projectSlug: string,
+    ): Promise<string> {
+        const project = await this.database(ProjectTableName)
+            .innerJoin(
+                OrganizationTableName,
+                `${ProjectTableName}.organization_id`,
+                `${OrganizationTableName}.organization_id`,
+            )
+            .select(`${ProjectTableName}.project_uuid`)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(`${ProjectTableName}.slug`, projectSlug)
+            .first();
+
+        if (!project) {
+            throw new NotFoundError(
+                `Cannot find project with slug: ${projectSlug}`,
+            );
+        }
+
+        return project.project_uuid;
+    }
+
     /*
     This method will load default values for backwards compatibility
     For example, when we introduce a new authentication type, we need to set the default value for the existing projects

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -111,6 +111,26 @@ export class SlackAuthenticationModel {
         return row.slack_team_id;
     }
 
+    async getOrganizationUuidFromTeamId(teamId: string) {
+        const row = await this.database(SlackAuthTokensTableName)
+            .leftJoin(
+                'organizations',
+                'slack_auth_tokens.organization_id',
+                'organizations.organization_id',
+            )
+            .select('organization_uuid')
+            .where('slack_team_id', teamId)
+            .first();
+
+        if (!row) {
+            throw new NotFoundError(
+                `Could not find organization for Slack team ${teamId}`,
+            );
+        }
+
+        return row.organization_uuid;
+    }
+
     async getUserUuid(teamId: string) {
         const [row] = await this.database(SlackAuthTokensTableName)
             .leftJoin(

--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -81,6 +81,8 @@ function createService(
         savedSqlModel: Partial<SavedSqlModel>;
         savedChartModel: Partial<SavedChartModel>;
         dashboardModel: Partial<DashboardModel>;
+        projectModel: Partial<ProjectModel>;
+        slackAuthenticationModel: Partial<SlackAuthenticationModel>;
         headlessBrowser: Record<string, unknown>;
     }> = {},
 ) {
@@ -104,13 +106,14 @@ function createService(
         fileStorageClient:
             mockFileStorageClient as unknown as FileStorageClient,
         slackClient: {} as unknown as SlackClient,
-        projectModel: {} as unknown as ProjectModel,
+        projectModel: (overrides.projectModel ?? {}) as unknown as ProjectModel,
         downloadFileModel:
             mockDownloadFileModel as unknown as DownloadFileModel,
         slackUnfurlImageModel:
             mockSlackUnfurlImageModel as unknown as SlackUnfurlImageModel,
         analytics: {} as unknown as LightdashAnalytics,
-        slackAuthenticationModel: {} as unknown as SlackAuthenticationModel,
+        slackAuthenticationModel: (overrides.slackAuthenticationModel ??
+            {}) as unknown as SlackAuthenticationModel,
         spacePermissionService: {} as unknown as SpacePermissionService,
         headlessBrowserLoginGrantModel:
             {} as unknown as HeadlessBrowserLoginGrantModel,
@@ -477,6 +480,163 @@ describe('UnfurlService', () => {
             );
 
             expect(result.isValid).toBe(false);
+        });
+    });
+
+    describe('parseUrl - project slugs', () => {
+        const ORGANIZATION_UUID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+        const PROJECT_UUID = '21eef0b9-5bae-40f3-851e-9554588e71a6';
+        const PROJECT_SLUG = 'analytics-project';
+        const CHART_UUID = '11111111-2222-4333-8444-555555555555';
+        const DASHBOARD_UUID = '66666666-7777-4888-8999-000000000000';
+
+        const projectModel = () => ({
+            getUuidBySlug: vi.fn().mockResolvedValue(PROJECT_UUID),
+        });
+
+        it('resolves a chart beneath an organization-scoped project slug', async () => {
+            const project = projectModel();
+            const get = vi.fn().mockResolvedValue({ uuid: CHART_UUID });
+            const service = createService({
+                projectModel: project,
+                savedChartModel: { get },
+            });
+
+            const result = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_SLUG}/saved/retired-chart-alias`,
+                ORGANIZATION_UUID,
+            );
+
+            expect(project.getUuidBySlug).toHaveBeenCalledWith(
+                ORGANIZATION_UUID,
+                PROJECT_SLUG,
+            );
+            expect(get).toHaveBeenCalledWith('retired-chart-alias', undefined, {
+                projectUuid: PROJECT_UUID,
+            });
+            expect(result).toMatchObject({
+                isValid: true,
+                projectUuid: PROJECT_UUID,
+                chartUuid: CHART_UUID,
+                minimalUrl: `http://headless-browser:8080/minimal/projects/${PROJECT_UUID}/saved/${CHART_UUID}`,
+            });
+        });
+
+        it('keeps UUID project URLs on the existing lookup-free path', async () => {
+            const project = projectModel();
+            const service = createService({ projectModel: project });
+
+            const result = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_UUID}/saved/${CHART_UUID}`,
+                ORGANIZATION_UUID,
+            );
+
+            expect(project.getUuidBySlug).not.toHaveBeenCalled();
+            expect(result).toMatchObject({
+                isValid: true,
+                projectUuid: PROJECT_UUID,
+                chartUuid: CHART_UUID,
+                minimalUrl: `http://headless-browser:8080/minimal/projects/${PROJECT_UUID}/saved/${CHART_UUID}`,
+            });
+        });
+
+        it('resolves a dashboard beneath an organization-scoped project slug', async () => {
+            const project = projectModel();
+            const getByIdOrSlug = vi
+                .fn()
+                .mockResolvedValue({ uuid: DASHBOARD_UUID });
+            const service = createService({
+                projectModel: project,
+                dashboardModel: { getByIdOrSlug },
+            });
+
+            const result = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_SLUG}/dashboards/sales-dashboard/view`,
+                ORGANIZATION_UUID,
+            );
+
+            expect(getByIdOrSlug).toHaveBeenCalledWith('sales-dashboard', {
+                projectUuid: PROJECT_UUID,
+            });
+            expect(result).toMatchObject({
+                isValid: true,
+                projectUuid: PROJECT_UUID,
+                dashboardUuid: DASHBOARD_UUID,
+                minimalUrl: `http://headless-browser:8080/minimal/projects/${PROJECT_UUID}/dashboards/${DASHBOARD_UUID}?`,
+            });
+        });
+
+        it('canonicalizes project slugs for SQL charts and explores', async () => {
+            const project = projectModel();
+            const getBySlug = vi.fn().mockResolvedValue({
+                savedSqlUuid: CHART_UUID,
+            });
+            const service = createService({
+                projectModel: project,
+                savedSqlModel: { getBySlug },
+            });
+
+            const sqlResult = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_SLUG}/sql-runner/saved-query`,
+                ORGANIZATION_UUID,
+            );
+            const exploreResult = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_SLUG}/tables/orders?foo=bar`,
+                ORGANIZATION_UUID,
+            );
+
+            expect(sqlResult).toMatchObject({
+                isValid: true,
+                projectUuid: PROJECT_UUID,
+                savedSqlUuid: CHART_UUID,
+                minimalUrl: `http://headless-browser:8080/minimal/projects/${PROJECT_UUID}/sql-runner/${CHART_UUID}`,
+            });
+            expect(exploreResult).toMatchObject({
+                isValid: true,
+                projectUuid: PROJECT_UUID,
+                exploreModel: 'orders',
+                minimalUrl: `http://headless-browser:8080/projects/${PROJECT_UUID}/tables/orders?foo=bar`,
+            });
+        });
+
+        it('fails safely when a project slug has no organization context', async () => {
+            const project = projectModel();
+            const get = vi.fn();
+            const service = createService({
+                projectModel: project,
+                savedChartModel: { get },
+            });
+
+            const result = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_SLUG}/saved/chart`,
+            );
+
+            expect(result.isValid).toBe(false);
+            expect(project.getUuidBySlug).not.toHaveBeenCalled();
+            expect(get).not.toHaveBeenCalled();
+        });
+
+        it('does not fall back to another organization', async () => {
+            const getUuidBySlug = vi
+                .fn()
+                .mockRejectedValue(new NotFoundError('not found'));
+            const get = vi.fn();
+            const service = createService({
+                projectModel: { getUuidBySlug },
+                savedChartModel: { get },
+            });
+
+            const result = await service.parseUrl(
+                `https://app.lightdash.cloud/projects/${PROJECT_SLUG}/saved/chart`,
+                ORGANIZATION_UUID,
+            );
+
+            expect(getUuidBySlug).toHaveBeenCalledWith(
+                ORGANIZATION_UUID,
+                PROJECT_SLUG,
+            );
+            expect(result.isValid).toBe(false);
+            expect(get).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -587,8 +587,12 @@ export class UnfurlService extends BaseService {
     async unfurlDetails(
         originUrl: string,
         selectedTabs: string[] | null,
+        organizationUuidContext?: string,
     ): Promise<Unfurl | undefined> {
-        const parsedUrl = await this.parseUrl(originUrl);
+        const parsedUrl = await this.parseUrl(
+            originUrl,
+            organizationUuidContext,
+        );
 
         if (
             !parsedUrl.isValid ||
@@ -2545,10 +2549,60 @@ export class UnfurlService extends BaseService {
         return fullUrl;
     }
 
-    async parseUrl(linkUrl: string): Promise<ParsedUrl> {
+    private async resolveProjectUuid(
+        projectIdentifier: string,
+        organizationUuid?: string,
+    ): Promise<string> {
+        const decodedIdentifier = decodeURIComponent(projectIdentifier);
+        if (uuidExactRegex.test(decodedIdentifier)) {
+            return decodedIdentifier;
+        }
+        if (!organizationUuid) {
+            throw new NotFoundError(
+                `Cannot resolve project slug without an organization`,
+            );
+        }
+
+        return this.projectModel.getUuidBySlug(
+            organizationUuid,
+            decodedIdentifier,
+        );
+    }
+
+    async parseUrl(
+        linkUrl: string,
+        organizationUuid?: string,
+    ): Promise<ParsedUrl> {
         const url = matchShareUrlNanoid(linkUrl)
             ? await this.getSharedUrl(linkUrl)
             : linkUrl;
+
+        const projectMatch = url.match(/\/projects\/([^/?#]+)/);
+        let resolvedUrl = url;
+        if (projectMatch) {
+            const [, projectIdentifier] = projectMatch;
+            try {
+                const projectUuid = await this.resolveProjectUuid(
+                    projectIdentifier,
+                    organizationUuid,
+                );
+                resolvedUrl = url.replace(
+                    `/projects/${projectIdentifier}`,
+                    `/projects/${projectUuid}`,
+                );
+            } catch (e) {
+                this.logger.debug(
+                    `Project ${projectIdentifier} did not resolve: ${getErrorMessage(
+                        e,
+                    )}`,
+                );
+                return {
+                    isValid: false,
+                    url,
+                    minimalUrl: url,
+                };
+            }
+        }
 
         const dashboardUrl = new RegExp(
             `/projects/(${uuid})/dashboards/([^/?#]+)`,
@@ -2560,8 +2614,8 @@ export class UnfurlService extends BaseService {
         );
         const appUrl = new RegExp(`/projects/${uuid}/apps/${uuid}`);
 
-        if (url.match(appUrl) !== null) {
-            const [projectUuid, appUuid] = url.match(uuidRegex) || [];
+        if (resolvedUrl.match(appUrl) !== null) {
+            const [projectUuid, appUuid] = resolvedUrl.match(uuidRegex) || [];
             return {
                 isValid: true,
                 lightdashPage: LightdashPage.APP,
@@ -2574,7 +2628,7 @@ export class UnfurlService extends BaseService {
                 appUuid,
             };
         }
-        const dashboardMatch = url.match(dashboardUrl);
+        const dashboardMatch = resolvedUrl.match(dashboardUrl);
         if (dashboardMatch !== null) {
             const [, projectUuid, encodedIdentifier] = dashboardMatch;
             try {
@@ -2609,7 +2663,7 @@ export class UnfurlService extends BaseService {
                 );
             }
         }
-        const chartMatch = url.match(chartUrl);
+        const chartMatch = resolvedUrl.match(chartUrl);
         if (chartMatch !== null) {
             const [, projectUuid, encodedIdentifier] = chartMatch;
             try {
@@ -2644,12 +2698,12 @@ export class UnfurlService extends BaseService {
                 );
             }
         }
-        if (url.match(exploreUrl) !== null) {
-            const [projectUuid] = url.match(uuidRegex) || [];
+        if (resolvedUrl.match(exploreUrl) !== null) {
+            const [projectUuid] = resolvedUrl.match(uuidRegex) || [];
 
-            const urlWithoutParams = url.split('?')[0];
+            const urlWithoutParams = resolvedUrl.split('?')[0];
             const exploreModel = urlWithoutParams.split('/tables/')[1];
-            const internalUrl = url.replace(
+            const internalUrl = resolvedUrl.replace(
                 this.lightdashConfig.siteUrl,
                 this.lightdashConfig.headlessBrowser.internalLightdashHost,
             );
@@ -2662,7 +2716,7 @@ export class UnfurlService extends BaseService {
                 exploreModel,
             };
         }
-        const sqlChartMatch = url.match(sqlChartUrl);
+        const sqlChartMatch = resolvedUrl.match(sqlChartUrl);
         if (sqlChartMatch !== null) {
             const [, projectUuid, slug] = sqlChartMatch;
             try {
@@ -2797,11 +2851,20 @@ export class UnfurlService extends BaseService {
             return;
         }
 
+        const organizationUuid =
+            await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(
+                teamId,
+            );
+
         void event.links.map(async (l) => {
             const eventUserId = context.botUserId;
 
             try {
-                const details = await this.unfurlDetails(l.url, null);
+                const details = await this.unfurlDetails(
+                    l.url,
+                    null,
+                    organizationUuid,
+                );
 
                 if (details) {
                     this.analytics.track({


### PR DESCRIPTION
Part of: [SPK-1208](https://linear.app/lightdash/issue/SPK-1208/accept-project-slug-urls-in-backend-url-parsers)

### Description

Allows Slack unfurls to accept project slugs while preserving the existing UUID-based downstream and headless-browser flow. Project slug resolution is scoped to the Slack installation organization; legacy UUID URLs bypass the new lookup entirely.

The project identifier is resolved once and canonicalized to a UUID before the existing chart, dashboard, Explore, SQL chart, and app URL parsing logic runs. Authenticated support-report parsing will follow in the next stacked PR so this PR stays focused on Slack.

### Validation

- Focused `UnfurlService` suite: 40 passing
- Backend typecheck and focused lint pass
- Live scheduled delivery/headless screenshot completed successfully
- Legacy UUID parsing explicitly verified to remain lookup-free
- Cross-organization and missing-context project slug cases fail closed

### Risk assessment

- [ ] This is a high-risk change

Low risk: the existing parsers and canonical UUID headless URLs remain in place; only organization-scoped project slug resolution is added ahead of them.