### PR TITLE
fix: resolve project slugs in support reports

### DIFF
--- a/packages/backend/src/ee/services/SupportService/SupportService.test.ts
+++ b/packages/backend/src/ee/services/SupportService/SupportService.test.ts
@@ -1,0 +1,110 @@
+import { SessionUser } from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SupportService } from './SupportService';
+
+const ORGANIZATION_UUID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+const PROJECT_UUID = '21eef0b9-5bae-40f3-851e-9554588e71a6';
+const PROJECT_SLUG = 'analytics-project';
+
+const user = {
+    userUuid: '11111111-2222-4333-8444-555555555555',
+    organizationUuid: ORGANIZATION_UUID,
+    firstName: 'Test',
+    lastName: 'User',
+    role: 'admin',
+} as SessionUser;
+
+const createService = () => {
+    const projectModel = {
+        getUuidBySlug: vi.fn().mockResolvedValue(PROJECT_UUID),
+        get: vi.fn().mockResolvedValue({
+            projectUuid: PROJECT_UUID,
+            name: 'Analytics project',
+        }),
+    };
+    const unfurlService = {
+        parseUrl: vi.fn().mockImplementation((url: string) => ({
+            isValid: false,
+            url,
+            minimalUrl: url,
+        })),
+    };
+
+    const service = new SupportService({
+        dashboardModel: {} as never,
+        savedChartModel: {} as never,
+        spaceModel: {} as never,
+        projectModel: projectModel as never,
+        fileStorageClient: {} as never,
+        organizationModel: {
+            get: vi.fn().mockResolvedValue({
+                organizationUuid: ORGANIZATION_UUID,
+                name: 'Test organization',
+            }),
+        } as never,
+        unfurlService: unfurlService as never,
+        projectService: {} as never,
+        lightdashConfig: {
+            slack: { supportUrl: 'https://support.example' },
+            k8s: { podNamespace: 'test' },
+        } as never,
+        analytics: { track: vi.fn() } as never,
+    });
+
+    return { projectModel, service, unfurlService };
+};
+
+describe('SupportService project URL parsing', () => {
+    beforeEach(() => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            status: 200,
+        } as Response);
+    });
+
+    it('resolves a project slug within the authenticated organization', async () => {
+        const { projectModel, service, unfurlService } = createService();
+        const referer = `https://app.lightdash.cloud/projects/${PROJECT_SLUG}/home`;
+
+        await service.shareWithSupport(
+            user,
+            {
+                canImpersonate: false,
+                logs: [],
+                network: [],
+            },
+            { referer, origin: 'https://app.lightdash.cloud' },
+        );
+
+        expect(projectModel.getUuidBySlug).toHaveBeenCalledWith(
+            ORGANIZATION_UUID,
+            PROJECT_SLUG,
+        );
+        expect(projectModel.get).toHaveBeenCalledWith(PROJECT_UUID);
+        expect(unfurlService.parseUrl).toHaveBeenCalledWith(
+            referer,
+            ORGANIZATION_UUID,
+        );
+    });
+
+    it('keeps project UUID URLs on the existing path', async () => {
+        const { projectModel, service, unfurlService } = createService();
+        const referer = `https://app.lightdash.cloud/projects/${PROJECT_UUID}/home`;
+
+        await service.shareWithSupport(
+            user,
+            {
+                canImpersonate: false,
+                logs: [],
+                network: [],
+            },
+            { referer, origin: 'https://app.lightdash.cloud' },
+        );
+
+        expect(projectModel.getUuidBySlug).not.toHaveBeenCalled();
+        expect(projectModel.get).toHaveBeenCalledWith(PROJECT_UUID);
+        expect(unfurlService.parseUrl).toHaveBeenCalledWith(
+            referer,
+            ORGANIZATION_UUID,
+        );
+    });
+});

--- a/packages/backend/src/ee/services/SupportService/SupportService.ts
+++ b/packages/backend/src/ee/services/SupportService/SupportService.ts
@@ -7,6 +7,7 @@ import {
 import { KnownBlock } from '@slack/web-api';
 import { IncomingHttpHeaders } from 'http';
 import { nanoid } from 'nanoid';
+import { validate as isUuid } from 'uuid';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
 import { type FileStorageClient } from '../../../clients/FileStorage/FileStorageClient';
@@ -197,17 +198,25 @@ export class SupportService extends BaseService {
         const organization = await this.organizationModel.get(
             user.organizationUuid!,
         );
-        // Extract /project/<uuid> from referer
-        const projectUuid = headers.referer
+        const projectIdentifier = headers.referer
             ?.split('/projects/')[1]
             ?.split('/')[0];
+        let projectUuid: string | undefined;
+        if (projectIdentifier) {
+            projectUuid = isUuid(projectIdentifier)
+                ? projectIdentifier
+                : await this.projectModel.getUuidBySlug(
+                      user.organizationUuid!,
+                      decodeURIComponent(projectIdentifier),
+                  );
+        }
         const project = projectUuid
             ? await this.projectModel.get(projectUuid)
             : undefined;
 
         const url = headers.referer;
         const parsedUrl = url
-            ? await this.unfurlService.parseUrl(url)
+            ? await this.unfurlService.parseUrl(url, user.organizationUuid)
             : undefined;
 
         const namespace = this.lightdashConfig.k8s.podNamespace || 'unknown';


### PR DESCRIPTION
Closes: [SPK-1208](https://linear.app/lightdash/issue/SPK-1208/accept-project-slug-urls-in-backend-url-parsers)

### Description

Completes project-slug compatibility for authenticated support/error reports. A project slug from the browser referrer is resolved within the signed-in user's organization before project metadata, analytics links, chart diagnostics, or downstream parsing use it.

Existing project UUID referrers retain their previous lookup path. The organization context is also passed into the unfurl parser introduced by the parent PR.

### Validation

- Focused `SupportService` suite: 2 passing
- Backend typecheck and focused lint pass
- Project-slug referrer resolves with the authenticated organization
- Legacy UUID referrer bypasses slug lookup

### Risk assessment

- [ ] This is a high-risk change

Low risk: two focused service lines plus regression coverage; API routes and UUID-based downstream identity remain unchanged.