### PR TITLE
feat(pgwire): treat aggregates over metric columns as the metric

### DIFF
--- a/packages/backend/src/ee/postgresWire/sqlToMetricQuery.test.ts
+++ b/packages/backend/src/ee/postgresWire/sqlToMetricQuery.test.ts
@@ -1405,6 +1405,57 @@ describe('compileSqlToMetricQuery', () => {
     });
 });
 
+describe('aggregate passthrough', () => {
+    it('treats SUM over a metric column as the metric at the query grain', () => {
+        const compiled = compileSqlToMetricQuery(
+            'SELECT orders_status, SUM(orders_total_order_amount) AS orders_total_order_amount FROM orders GROUP BY orders_status ORDER BY orders_total_order_amount DESC',
+            CATALOG,
+        );
+        expect(compiled.metricQuery.dimensions).toEqual(['orders_status']);
+        expect(compiled.metricQuery.metrics).toEqual([
+            'orders_total_order_amount',
+        ]);
+        expect(compiled.metricQuery.tableCalculations).toEqual([]);
+        expect(compiled.columns.map((c) => c.name)).toEqual([
+            'orders_status',
+            'orders_total_order_amount',
+        ]);
+        expect(compiled.metricQuery.sorts).toEqual([
+            { fieldId: 'orders_total_order_amount', descending: true },
+        ]);
+    });
+
+    it('passes min/max/avg through and keeps dimension aggregates rejected', () => {
+        expect(
+            compileSqlToMetricQuery(
+                'SELECT max(orders_total_order_amount) AS m FROM orders',
+                CATALOG,
+            ).metricQuery.metrics,
+        ).toEqual(['orders_total_order_amount']);
+        expect(() =>
+            compileSqlToMetricQuery(
+                'SELECT orders_status, sum(orders_amount) FROM orders GROUP BY 1',
+                CATALOG,
+            ),
+        ).toThrow(/not supported/);
+        expect(() =>
+            compileSqlToMetricQuery(
+                'SELECT sum(distinct orders_total_order_amount) AS s FROM orders',
+                CATALOG,
+            ),
+        ).toThrow(/not supported/);
+    });
+
+    it('explains aggregation instead of an alias conflict for dimension aggregates', () => {
+        expect(() =>
+            compileSqlToMetricQuery(
+                'SELECT orders_amount, sum(orders_amount) AS orders_amount FROM orders GROUP BY orders_amount',
+                CATALOG,
+            ),
+        ).toThrow(/Aggregate function "sum" is not supported here/);
+    });
+});
+
 describe('row counts', () => {
     it('compiles count(*) to a system COUNT metric', () => {
         const compiled = compileSqlToMetricQuery(

--- a/packages/backend/src/ee/postgresWire/sqlToMetricQuery.ts
+++ b/packages/backend/src/ee/postgresWire/sqlToMetricQuery.ts
@@ -770,6 +770,35 @@ function compileSelect(
 
     const ROW_COUNT_METRIC_NAME = 'pgwire_row_count';
 
+    /**
+     * BI tools re-aggregate every measure they chart (`SUM(metric) AS metric`).
+     * Metrics are already aggregated at the query's grain, so an aggregate over a
+     * metric column means "this metric": the outer aggregate is dropped, the way
+     * semantic-layer SQL APIs conventionally treat measures.
+     */
+    const AGGREGATE_PASSTHROUGH_FUNCTIONS = new Set([
+        'sum',
+        'min',
+        'max',
+        'avg',
+    ]);
+
+    const passthroughMetricRef = (expr: Expr): ExprRef | null => {
+        if (
+            expr.type !== 'call' ||
+            !AGGREGATE_PASSTHROUGH_FUNCTIONS.has(
+                expr.function.name.toLowerCase(),
+            ) ||
+            expr.distinct === 'distinct' ||
+            expr.over ||
+            expr.args.length !== 1
+        ) {
+            return null;
+        }
+        const [arg] = expr.args;
+        return arg.type === 'ref' && arg.name !== '*' ? arg : null;
+    };
+
     /** Postgres-style default output name for an unaliased expression, unique within the statement */
     const autoName = (ctx: CompilerContext, expr: Expr): string => {
         const base =
@@ -924,6 +953,20 @@ function compileSelect(
             }
             return;
         }
+        // SUM(metric) and friends: the metric itself, at this query's grain
+        const aggregatedRef = passthroughMetricRef(expr);
+        if (aggregatedRef) {
+            const resolved = resolveRefOrThrow(ctx, aggregatedRef);
+            if (resolved.kind === 'metric') {
+                const outputName = col.alias?.name ?? resolved.source;
+                addField(resolved, outputName);
+                if (col.alias) {
+                    ctx.aliasMap.set(col.alias.name, resolved);
+                }
+                return;
+            }
+            // aggregates over dimensions still point at pre-defined metrics
+        }
         if (expr.type === 'ref') {
             const resolved = resolveRefOrThrow(ctx, expr);
             if (resolved.kind === 'table_calculation') {
@@ -937,6 +980,18 @@ function compileSelect(
                 ctx.aliasMap.set(col.alias.name, resolved);
             }
             return;
+        }
+        // a bare aggregate that did not pass through gets the aggregation
+        // explanation, not a confusing alias-conflict or table-calc error
+        if (
+            expr.type === 'call' &&
+            AGGREGATE_FUNCTIONS.has(expr.function.name.toLowerCase()) &&
+            !expr.over
+        ) {
+            throw new SqlCompileError(
+                `Aggregate function "${expr.function.name.toLowerCase()}" is not supported here`,
+                'Metrics are already aggregated at the query grain. SUM, MIN, MAX and AVG directly over a metric column are treated as the metric itself; other aggregates are not supported.',
+            );
         }
         // any other expression becomes a table calculation; name it like
         // Postgres when no alias is given (function name, else ?column?)


### PR DESCRIPTION
Part of #27624

## Summary

BI tools re-aggregate every measure they chart: a chart over the Metrics SQL API arrives as `SELECT dim, SUM(metric) AS metric ... GROUP BY dim`. Metrics are already aggregated at the query grain, so the compiler rejected the aggregate and the query died with a misleading `Alias "metric" conflicts with an existing column name` error, blocking chart creation in downstream BI tools.

## Root cause

`SUM(metric) AS metric` fell into the table-calculation path: the aggregate was turned into a calculation whose alias collided with the metric column, so the user saw an alias-conflict error instead of anything about aggregation.

## How it works

`SUM`, `MIN`, `MAX`, and `AVG` directly over a single metric column now resolve to the metric itself at the query's grain — the convention semantic-layer SQL APIs use for measures. Guarded strictly: no `DISTINCT`, no `OVER`, exactly one plain column argument, and the column must resolve to a metric.

```
Before:  SELECT status, SUM(total) AS total GROUP BY status
         → ERROR: Alias "total" conflicts with an existing column name

After:   SELECT status, SUM(total) AS total GROUP BY status
         → dimensions: [status], metrics: [total]   (aggregate dropped)

Still rejected (now with a clear message):
         SUM(dimension), SUM(DISTINCT metric), MEDIAN(anything)
         → Aggregate function "sum" is not supported here
           HINT: Metrics are already aggregated at the query grain. SUM, MIN,
           MAX and AVG directly over a metric column are treated as the metric
           itself; other aggregates are not supported.
```

Aggregates that cannot pass through now throw the aggregation explanation *before* the alias/table-calc checks, so the alias-conflict error can no longer mask the real problem.

## Test plan

- 3 new unit tests: passthrough with alias/sort, min/max/avg + rejected `DISTINCT`/dimension aggregates, and the improved error taking precedence over an alias conflict; all 223 postgresWire tests pass.
- Verified against a running instance over the wire (psql, simple + extended protocol `\bind`): `SUM(metric) ... GROUP BY` returns values identical to the plain metric query, and the dimension-aggregate case returns the new error + hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)