### PR TITLE
fix(ai): allow Deep Research in Demo mode

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearchAccess.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearchAccess.test.ts
@@ -4,41 +4,52 @@ import { canStartDeepResearch } from './useDeepResearchAccess';
 describe('canStartDeepResearch', () => {
     it.each([
         {
-            canCreate: true,
-            isEnvironmentReady: true,
-            isDemo: false,
-            isImpersonating: false,
+            name: 'allows authorized sessions',
+            access: {
+                canCreate: true,
+                isEnvironmentReady: true,
+                isImpersonating: false,
+            },
             result: true,
         },
         {
-            canCreate: false,
-            isEnvironmentReady: true,
-            isDemo: false,
-            isImpersonating: false,
+            name: 'blocks sessions without permission',
+            access: {
+                canCreate: false,
+                isEnvironmentReady: true,
+                isImpersonating: false,
+            },
             result: false,
         },
         {
-            canCreate: true,
-            isEnvironmentReady: true,
-            isDemo: true,
-            isImpersonating: false,
+            name: 'allows authorized Demo sessions',
+            access: {
+                canCreate: true,
+                isEnvironmentReady: true,
+                isDemo: true,
+                isImpersonating: false,
+            },
+            result: true,
+        },
+        {
+            name: 'blocks impersonated sessions',
+            access: {
+                canCreate: true,
+                isEnvironmentReady: true,
+                isImpersonating: true,
+            },
             result: false,
         },
         {
-            canCreate: true,
-            isEnvironmentReady: true,
-            isDemo: false,
-            isImpersonating: true,
+            name: 'blocks sessions before the environment is ready',
+            access: {
+                canCreate: true,
+                isEnvironmentReady: false,
+                isImpersonating: false,
+            },
             result: false,
         },
-        {
-            canCreate: true,
-            isEnvironmentReady: false,
-            isDemo: false,
-            isImpersonating: false,
-            result: false,
-        },
-    ])('returns $result for %#', ({ result, ...access }) => {
+    ])('$name', ({ access, result }) => {
         expect(canStartDeepResearch(access)).toBe(result);
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearchAccess.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearchAccess.ts
@@ -1,5 +1,4 @@
 import { subject } from '@casl/ability';
-import { LightdashMode } from '@lightdash/common';
 import useHealth from '../../../../hooks/health/useHealth';
 import { useImpersonation } from '../../../../hooks/user/useImpersonation';
 import useApp from '../../../../providers/App/useApp';
@@ -7,14 +6,12 @@ import useApp from '../../../../providers/App/useApp';
 export const canStartDeepResearch = ({
     canCreate,
     isEnvironmentReady,
-    isDemo,
     isImpersonating,
 }: {
     canCreate: boolean;
     isEnvironmentReady: boolean;
-    isDemo: boolean;
     isImpersonating: boolean;
-}): boolean => isEnvironmentReady && canCreate && !isDemo && !isImpersonating;
+}): boolean => isEnvironmentReady && canCreate && !isImpersonating;
 
 export const useDeepResearchAccess = (projectUuid: string | undefined) => {
     const { user } = useApp();
@@ -33,7 +30,6 @@ export const useDeepResearchAccess = (projectUuid: string | undefined) => {
     return canStartDeepResearch({
         canCreate,
         isEnvironmentReady: health.data !== undefined,
-        isDemo: health.data?.mode === LightdashMode.DEMO,
         isImpersonating,
     });
 };


### PR DESCRIPTION
## Description

Allows authorized users to start and retry Deep Research on Demo instances. Scoped `create:AiDeepResearch` authorization, health readiness, and the impersonation restriction remain unchanged.

```text
Before: Demo mode ────────────────────────────────> blocked
After:  Demo mode + permission + ready + direct session ─> available
```

## Test plan

- Updated the focused access matrix; the authorized Demo case fails before the implementation and passes afterward.
- Verified missing permission, impersonation, and unavailable health data still block access.
- Ran the focused frontend Vitest file, frontend lint, frontend typecheck, and `git diff --check`.