### PR TITLE
feat(permissions): control PAT access from project roles

### DIFF
--- a/packages/common/src/authorization/AGENTS.md
+++ b/packages/common/src/authorization/AGENTS.md
@@ -29,6 +29,8 @@ A user's ability is the union of two independent layers:
 
 CASL rules are additive. Project permissions cannot revoke organization permissions. If the org layer grants a permission, a narrower project custom role cannot remove it.
 
+Personal access token management is the deliberate exception because it is a user-global setting authored in either role builder. A primary project custom role suppresses the organization system role's PAT default; `manage:PersonalAccessToken` in any assigned custom role grants it back when deployment PAT policy allows it. Extra custom roles remain additive.
+
 Org-level custom roles are a supported human-user surface. Assigning one (`upsertOrganizationUserRoleAssignment` with a custom `roleId`) sets `organization_memberships.role_uuid` and stores `role = 'member'`; the role's `level` must be `'organization'` (validated at assign time, alongside an org-ownership check). At runtime, when `role_uuid` is set and custom roles are enabled, the org layer is built from that role's scopes and the stored `member` is a **placeholder** that grants nothing — a custom role in the primary slot does not add on top of a system role. So a custom-only set must be self-contained: it has to list every org scope its users need (including basic `view:*`), because no system-role defaults apply underneath it. This mirrors project custom roles in the primary slot. Custom roles held as _extras_ (see role sets below) behave differently: they are unioned on top of whatever sits in the slot, so they can only widen a system base, never narrow it. SCIM and users-as-code write full role sets (`setUserOrgAndProjectRoleSets` / `additionalRoles`); a single-role write from any surface replaces the whole set.
 
 ## Role Sets (Multiple Roles Per Level)

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -83,7 +83,7 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
             );
         });
 
-        it('falls through to the system role path when customRolesEnabled=true but the role has no scopes loaded', () => {
+        it('fails closed when an assigned organization custom role is missing', () => {
             const { builder } = getUserAbilityBuilder({
                 user: {
                     role: OrganizationMemberRole.ADMIN,
@@ -92,14 +92,19 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
                     roleUuid: CUSTOM_ROLE_UUID,
                 },
                 projectProfiles: [],
-                permissionsConfig: PERMISSIONS_CONFIG,
-                customRoleScopes: {}, // no scopes for this role
+                permissionsConfig: {
+                    pat: {
+                        enabled: true,
+                        allowedOrgRoles: [OrganizationMemberRole.ADMIN],
+                    },
+                },
+                customRoleScopes: {},
                 customRolesEnabled: true,
             });
-            ruleSetEqual(
-                builder.build().rules,
-                buildExpected(OrganizationMemberRole.ADMIN),
-            );
+            const ability = builder.build();
+
+            expect(ability.rules).toEqual([]);
+            expect(ability.can('manage', 'PersonalAccessToken')).toBe(false);
         });
     });
 
@@ -433,6 +438,97 @@ describe('getUserAbilityBuilder — role sets (extra custom roles)', () => {
     const EXTRA_ROLE_UUID = '22222222-2222-4222-a222-222222222222';
     const PROJECT_UUID = 'project-uuid';
     const PROJECT_EXTRA_ROLE_UUID = '33333333-3333-4333-a333-333333333333';
+    const patPermissionsConfig = {
+        pat: {
+            enabled: true,
+            allowedOrgRoles: [OrganizationMemberRole.MEMBER],
+        },
+    };
+
+    const buildProjectCustomRoleAbility = ({
+        scopes,
+        extraRoleUuids = [],
+        extraRoleScopes = {},
+    }: {
+        scopes?: string[];
+        extraRoleUuids?: string[];
+        extraRoleScopes?: Record<string, string[]>;
+    }) => {
+        const customRoleScopes = {
+            ...(scopes === undefined ? {} : { [CUSTOM_ROLE_UUID]: scopes }),
+            ...extraRoleScopes,
+        };
+        const { builder } = getUserAbilityBuilder({
+            user: {
+                role: OrganizationMemberRole.MEMBER,
+                organizationUuid: ORG_UUID,
+                userUuid: USER_UUID,
+                roleUuid: undefined,
+            },
+            projectProfiles: [
+                {
+                    projectUuid: PROJECT_UUID,
+                    role: ProjectMemberRole.VIEWER,
+                    userUuid: USER_UUID,
+                    roleUuid: CUSTOM_ROLE_UUID,
+                    extraRoleUuids,
+                },
+            ],
+            permissionsConfig: patPermissionsConfig,
+            customRoleScopes,
+            customRolesEnabled: true,
+            isEnterprise: true,
+        });
+        return builder.build();
+    };
+
+    const expectCanManagePat = (
+        ability: ReturnType<typeof buildProjectCustomRoleAbility>,
+        expected: boolean,
+    ) => {
+        expect(ability.can('manage', 'PersonalAccessToken')).toBe(expected);
+        expect(
+            ability.can(
+                'manage',
+                subject('PersonalAccessToken', {
+                    organizationUuid: ORG_UUID,
+                }),
+            ),
+        ).toBe(expected);
+    };
+
+    it('lets a primary project custom role restrict personal access tokens', () => {
+        const ability = buildProjectCustomRoleAbility({
+            scopes: ['view:Dashboard'],
+        });
+
+        expectCanManagePat(ability, false);
+    });
+
+    it('restricts personal access tokens when a primary project custom role is missing', () => {
+        const ability = buildProjectCustomRoleAbility({});
+
+        expectCanManagePat(ability, false);
+    });
+
+    it('applies an extra PAT role when the primary project custom role is missing', () => {
+        const ability = buildProjectCustomRoleAbility({
+            extraRoleUuids: [PROJECT_EXTRA_ROLE_UUID],
+            extraRoleScopes: {
+                [PROJECT_EXTRA_ROLE_UUID]: ['manage:PersonalAccessToken'],
+            },
+        });
+
+        expectCanManagePat(ability, true);
+    });
+
+    it('lets a primary project custom role grant personal access tokens', () => {
+        const ability = buildProjectCustomRoleAbility({
+            scopes: ['manage:PersonalAccessToken'],
+        });
+
+        expectCanManagePat(ability, true);
+    });
 
     it('unions an extra org custom role on top of a system role', () => {
         const { builder } = getUserAbilityBuilder({

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -61,6 +61,28 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
                 ruleSetEqual(builder.build().rules, buildExpected(role));
             },
         );
+
+        // UserModel passes organization_memberships.role_uuid straight through,
+        // so a user with no org custom role arrives as null, never undefined.
+        it.each([OrganizationMemberRole.MEMBER, OrganizationMemberRole.ADMIN])(
+            '%s user with a null roleUuid uses the system role path when customRolesEnabled=true',
+            (role) => {
+                const { builder } = getUserAbilityBuilder({
+                    user: {
+                        role,
+                        organizationUuid: ORG_UUID,
+                        userUuid: USER_UUID,
+                        roleUuid: null,
+                    },
+                    projectProfiles: [],
+                    permissionsConfig: PERMISSIONS_CONFIG,
+                    customRoleScopes: {},
+                    customRolesEnabled: true,
+                });
+                ruleSetEqual(builder.build().rules, buildExpected(role));
+                expect(builder.build().rules.length).toBeGreaterThan(0);
+            },
+        );
     });
 
     describe('Custom-roles feature flag', () => {

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -58,6 +58,17 @@ export const getUserAbilityBuilder = ({
 }: UserAbilityBuilderArgs): UserAbilityBuilderResult => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
     const invalidScopes: string[] = [];
+    const hasPrimaryProjectCustomRole =
+        customRolesEnabled &&
+        projectProfiles.some(({ roleUuid }) => roleUuid !== undefined);
+    // A primary project custom role owns the user-global PAT decision; unlike
+    // normal project permissions, omitting this scope restricts the org default.
+    const organizationSystemPermissionsConfig = hasPrimaryProjectCustomRole
+        ? {
+              ...permissionsConfig,
+              pat: { ...permissionsConfig.pat, allowedOrgRoles: [] },
+          }
+        : permissionsConfig;
     // Extra custom roles are unioned on top of the slot; unknown uuids are
     // skipped (logged) rather than granting anything.
     const applyExtraRoles = (
@@ -80,30 +91,32 @@ export const getUserAbilityBuilder = ({
         });
     };
     if (user.role && user.organizationUuid) {
-        // Org-level custom role: if the user's organization_memberships row
-        // points at a role_uuid AND custom roles are enabled AND we have the
-        // role's scopes, build CASL from those scopes (same path as
-        // project-level custom roles below). Falls back to the system role
-        // path otherwise.
-        const orgCustomRoleScopes =
-            customRolesEnabled && user.roleUuid
-                ? customRoleScopes?.[user.roleUuid]
-                : undefined;
-
-        if (orgCustomRoleScopes) {
-            invalidScopes.push(
-                ...buildAbilityFromScopes(
-                    {
-                        organizationUuid: user.organizationUuid,
-                        userUuid: user.userUuid,
-                        scopes: orgCustomRoleScopes,
-                        isEnterprise,
-                        organizationRole: user.role,
-                        permissionsConfig,
-                    },
-                    builder,
-                ),
-            );
+        const primaryOrgCustomRoleUuid = customRolesEnabled
+            ? user.roleUuid
+            : undefined;
+        if (primaryOrgCustomRoleUuid !== undefined) {
+            const orgCustomRoleScopes =
+                customRoleScopes?.[primaryOrgCustomRoleUuid];
+            if (orgCustomRoleScopes === undefined) {
+                // eslint-disable-next-line no-console
+                console.error(
+                    `Custom role with uuid ${primaryOrgCustomRoleUuid} was not found`,
+                );
+            } else {
+                invalidScopes.push(
+                    ...buildAbilityFromScopes(
+                        {
+                            organizationUuid: user.organizationUuid,
+                            userUuid: user.userUuid,
+                            scopes: orgCustomRoleScopes,
+                            isEnterprise,
+                            organizationRole: user.role,
+                            permissionsConfig,
+                        },
+                        builder,
+                    ),
+                );
+            }
         } else {
             applyOrganizationMemberAbilities({
                 role: user.role,
@@ -112,7 +125,7 @@ export const getUserAbilityBuilder = ({
                     userUuid: user.userUuid,
                 },
                 builder,
-                permissionsConfig,
+                permissionsConfig: organizationSystemPermissionsConfig,
             });
         }
         applyExtraRoles(orgExtraRoleUuids, (scopes) =>
@@ -138,30 +151,29 @@ export const getUserAbilityBuilder = ({
                 }
 
                 const scopes = customRoleScopes?.[projectProfile.roleUuid];
-                if (!scopes) {
+                if (scopes === undefined) {
                     // eslint-disable-next-line no-console
                     console.error(
                         `Custom role with uuid ${projectProfile.roleUuid} was not found`,
                     );
-                    return;
+                } else {
+                    invalidScopes.push(
+                        ...buildAbilityFromScopes(
+                            {
+                                projectUuid: projectProfile.projectUuid,
+                                projectType: projectProfile.projectType,
+                                projectCreatedByUserUuid:
+                                    projectProfile.projectCreatedByUserUuid,
+                                userUuid: user.userUuid,
+                                scopes,
+                                isEnterprise,
+                                organizationRole: user.role,
+                                permissionsConfig,
+                            },
+                            builder,
+                        ),
+                    );
                 }
-
-                invalidScopes.push(
-                    ...buildAbilityFromScopes(
-                        {
-                            projectUuid: projectProfile.projectUuid,
-                            projectType: projectProfile.projectType,
-                            projectCreatedByUserUuid:
-                                projectProfile.projectCreatedByUserUuid,
-                            userUuid: user.userUuid,
-                            scopes,
-                            isEnterprise,
-                            organizationRole: user.role,
-                            permissionsConfig,
-                        },
-                        builder,
-                    ),
-                );
             } else {
                 projectMemberAbilities[projectProfile.role](
                     projectProfile,

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -27,10 +27,10 @@ export type ProjectAbilityProfile = Pick<
 };
 
 type UserAbilityBuilderArgs = {
-    user: Pick<
-        LightdashUser,
-        'role' | 'organizationUuid' | 'userUuid' | 'roleUuid'
-    >;
+    user: Pick<LightdashUser, 'role' | 'organizationUuid' | 'userUuid'> & {
+        /** Read straight from the DB column: `null` when there is no org custom role. */
+        roleUuid?: string | null;
+    };
     /** Additional organization custom roles unioned on top of the user's slot. */
     orgExtraRoleUuids?: string[];
     projectProfiles: ProjectAbilityProfile[];
@@ -60,7 +60,7 @@ export const getUserAbilityBuilder = ({
     const invalidScopes: string[] = [];
     const hasPrimaryProjectCustomRole =
         customRolesEnabled &&
-        projectProfiles.some(({ roleUuid }) => roleUuid !== undefined);
+        projectProfiles.some(({ roleUuid }) => !!roleUuid);
     // A primary project custom role owns the user-global PAT decision; unlike
     // normal project permissions, omitting this scope restricts the org default.
     const organizationSystemPermissionsConfig = hasPrimaryProjectCustomRole
@@ -91,9 +91,11 @@ export const getUserAbilityBuilder = ({
         });
     };
     if (user.role && user.organizationUuid) {
-        const primaryOrgCustomRoleUuid = customRolesEnabled
-            ? user.roleUuid
-            : undefined;
+        // `roleUuid` arrives as `null` for users with no org custom role, so
+        // this stays a truthiness check — `!== undefined` would send every
+        // system-role user down the fail-closed path below.
+        const primaryOrgCustomRoleUuid =
+            customRolesEnabled && user.roleUuid ? user.roleUuid : undefined;
         if (primaryOrgCustomRoleUuid !== undefined) {
             const orgCustomRoleScopes =
                 customRoleScopes?.[primaryOrgCustomRoleUuid];

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -194,17 +194,8 @@ const BASE_ROLE_SCOPES = {
         'view:Roadmap',
         'impersonate:User',
 
-        // PAT management. Granted dynamically at runtime via
-        // `applyOrganizationMemberDynamicAbilities` based on the
-        // deployment-wide `PAT_ALLOWED_ORG_ROLES` env var — that path
-        // remains the source of truth for system roles. Listing it
-        // here lets admin-clone custom roles surface the toggle in the
-        // role builder. **Caveat:** toggling it in a custom role
-        // *bypasses* the dynamic gate, since CASL is additive (the
-        // static scope-built rule wins regardless of deployment
-        // config). Operators who clone admin into a lower-privilege
-        // role should untick it manually if their deployment intends
-        // to restrict PAT to specific tiers.
+        // PAT management remains subject to the deployment-wide PAT policy.
+        // Listing it here lets admin-clone custom roles surface the toggle.
         'manage:PersonalAccessToken',
     ],
 } as const;

--- a/packages/common/src/authorization/scopeAbilityBuilder.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.ts
@@ -5,26 +5,6 @@ import { parseScope, parseScopes } from './parseScopes';
 import { getAllScopeMap } from './scopes';
 import { type MemberAbility } from './types';
 
-const handlePatConfigApplication = (
-    context: ScopeContext,
-    builder: AbilityBuilder<MemberAbility>,
-) => {
-    const { pat } = context?.permissionsConfig || {};
-    const hasPatRule = builder.rules.find(
-        (rule) =>
-            rule.action === 'manage' && rule.subject === 'PersonalAccessToken',
-    );
-
-    if (
-        !hasPatRule &&
-        pat?.enabled &&
-        context.organizationRole &&
-        pat?.allowedOrgRoles?.includes(context.organizationRole)
-    ) {
-        builder.can('manage', 'PersonalAccessToken');
-    }
-};
-
 /**
  * Apply scope-based abilities to a CASL ability builder
  * @param scopeNames - Array of scope names to apply
@@ -59,8 +39,6 @@ const applyScopeAbilities = (
             });
         }
     });
-
-    handlePatConfigApplication(context, builder);
 };
 
 type OptionalIdContext =

--- a/packages/common/src/authorization/scopes.level.test.ts
+++ b/packages/common/src/authorization/scopes.level.test.ts
@@ -19,7 +19,6 @@ const ORG_ONLY_SCOPE_NAMES = [
     'manage:GitIntegration',
     'view:OrganizationWarehouseCredentials',
     'manage:OrganizationWarehouseCredentials',
-    'manage:PersonalAccessToken',
     'manage:OrganizationColorPalette',
     'impersonate:User',
     'view:OrganizationDesign',
@@ -76,6 +75,9 @@ describe('scope levels', () => {
         expect(isScopeAssignableAtLevel('view:Dashboard', 'project')).toBe(
             true,
         );
+        expect(
+            isScopeAssignableAtLevel('manage:PersonalAccessToken', 'project'),
+        ).toBe(true);
         expect(isScopeAssignableAtLevel('view:Organization', 'project')).toBe(
             false,
         );

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -44,6 +44,19 @@ const addAccessCondition = (context: ScopeContext, role?: SpaceMemberRole) => ({
 /** Applies the UUID condition as the only condition for a scope. */
 const addDefaultUuidCondition = flow(addUuidCondition, Array.of);
 
+const personalAccessTokenConditions = (context: ScopeContext) => {
+    const { pat } = context.permissionsConfig ?? {};
+    if (
+        !pat?.enabled ||
+        !context.organizationRole ||
+        !pat.allowedOrgRoles.includes(context.organizationRole)
+    ) {
+        return null;
+    }
+
+    return context.organizationUuid ? addDefaultUuidCondition(context) : [];
+};
+
 /**
  * True only inside a preview the current user created. Shared by the @self
  * preview scopes; returns false for org-level assignments (no project context).
@@ -1024,8 +1037,7 @@ const scopes: Scope[] = [
         isEnterprise: true,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
         dependencies: [],
-        level: 'organization',
-        getConditions: addDefaultUuidCondition,
+        getConditions: personalAccessTokenConditions,
     },
     {
         name: 'impersonate:User',


### PR DESCRIPTION
## What changed

Project custom roles now expose the Personal Access Token permission and treat omission from a primary custom role as a restriction of the organization Member default. Explicit PAT grants work for both UI and API authorization checks only when deployment policy allows them; missing primary roles fail closed while additional roles continue to add permissions.

### Validation

- `pnpm -F 'common' exec oxfmt 'src/authorization/getUserAbilityBuilder.test.ts' 'src/authorization/index.ts' 'src/authorization/roleToScopeMapping.ts' 'src/authorization/scopeAbilityBuilder.ts' 'src/authorization/scopes.level.test.ts' 'src/authorization/scopes.ts'` — passed
- `pnpm -F 'common' run --if-present lint` — passed
- `pnpm -F 'common' run --if-present typecheck` — passed
- `pnpm -F 'common' run --if-present test` — passed

### Review notes

- Implemented PAT management as a deliberate exception to normal additive project/organization permissions: any primary project custom role suppresses the organization system-role PAT default, while an explicit PAT scope in any assigned custom role grants it back when deployment policy allows. The alternative is to keep PAT organization-only and add documentation or a builder hint; reviewer input is useful because the chosen behavior makes a project assignment control a user-global capability when users have multiple project roles.

## Preview

[Open the public Lightdash preview](https://ld-runner-prod-8879-c40a2d6e2b4b.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-8879

