### PR TITLE
fix: scope scheduler run child counts to the parent jobs in range

### DIFF
--- a/packages/backend/src/database/migrations/20260824100000_index_scheduler_log_scheduler_uuid_scheduled_time.ts
+++ b/packages/backend/src/database/migrations/20260824100000_index_scheduler_log_scheduler_uuid_scheduled_time.ts
@@ -1,0 +1,41 @@
+import { Knex } from 'knex';
+
+export const config = { transaction: false };
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Builds a secondary index on scheduler_log concurrently; no lock that blocks reads or writes, no table rewrite, and older app versions keep working.',
+};
+
+const TableName = 'scheduler_log';
+const IndexName = 'scheduler_log_scheduler_uuid_scheduled_time_index';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    await knex.raw("SET lock_timeout = '5s'");
+    try {
+        const invalidIndex = await knex.raw<{ rowCount: number }>(
+            `SELECT 1
+             FROM pg_class
+             JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+             WHERE pg_class.relname = ?
+               AND pg_index.indrelid = ?::regclass
+               AND NOT pg_index.indisvalid`,
+            [IndexName, TableName],
+        );
+        if ((invalidIndex.rowCount ?? 0) > 0) {
+            await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${IndexName}`);
+        }
+        await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${IndexName}
+             ON ${TableName} (scheduler_uuid, scheduled_time)`,
+        );
+    } finally {
+        await knex.raw('RESET statement_timeout');
+        await knex.raw('RESET lock_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${IndexName}`);
+}

--- a/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
+++ b/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
@@ -1,7 +1,10 @@
 import { AnyType, SchedulerJobStatus, SchedulerLog } from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
-import { SchedulerTableName } from '../../database/entities/scheduler';
+import {
+    SchedulerLogTableName,
+    SchedulerTableName,
+} from '../../database/entities/scheduler';
 import { SchedulerModel } from './index';
 
 describe('Scheduler model test', () => {
@@ -204,6 +207,45 @@ describe('Scheduler model test', () => {
             const sql = schedulerSelectSql();
             expect(sql).toContain('"users"."is_active"');
             expect(sql).not.toContain('service_accounts');
+        });
+    });
+
+    describe('getRunsForSchedulers', () => {
+        const database = knex({ client: MockClient, dialect: 'pg' });
+        const model = new SchedulerModel({ database });
+        let tracker: Tracker;
+
+        beforeAll(() => {
+            tracker = getTracker();
+        });
+
+        afterEach(() => {
+            tracker.reset();
+        });
+
+        it('scopes the child job counts to the parent jobs in scope', async () => {
+            tracker.on.select(SchedulerLogTableName).response([]);
+
+            await model.getRunsForSchedulers({
+                schedulers: [
+                    {
+                        schedulerUuid: 'scheduler-1',
+                        name: 'My delivery',
+                        targets: [],
+                    } as AnyType,
+                ],
+                latestOnly: true,
+            });
+
+            const sql = tracker.history.select.find((query) =>
+                query.sql.includes('ranked_children'),
+            )?.sql;
+
+            // Without this restriction the child ranking window scans every
+            // child row in scheduler_log
+            expect(sql).toContain(
+                'where job_id != job_group and "job_group" in (select distinct "job_id" from "scheduler_log" where job_id = job_group and "scheduler_uuid" in (',
+            );
         });
     });
 

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -2203,9 +2203,19 @@ export class SchedulerModel {
         const schedulerUuids = filteredSchedulers.map((s) => s.schedulerUuid);
 
         // Query parent jobs (where job_id = job_group) with aggregated child counts
+        const now: Date = new Date();
         const sevenDaysAgo: Date = new Date(
-            Date.now() - 7 * 24 * 60 * 60 * 1000,
+            now.getTime() - 7 * 24 * 60 * 60 * 1000,
         );
+
+        // Parent job ids in scope. Used to restrict the child count subquery so
+        // it doesn't rank every child row in scheduler_log.
+        const parentJobIdsSubquery = this.database(SchedulerLogTableName)
+            .distinct('job_id')
+            .whereRaw('job_id = job_group')
+            .whereIn('scheduler_uuid', schedulerUuids)
+            .where('scheduled_time', '>', sevenDaysAgo)
+            .where('scheduled_time', '<', now);
 
         // Build subquery for child job counts - only count most recent status per child
         // First, get the most recent entry for each child job
@@ -2220,6 +2230,7 @@ export class SchedulerModel {
                 ),
             )
             .whereRaw('job_id != job_group') // Only child jobs
+            .whereIn('job_group', parentJobIdsSubquery)
             .as('ranked_children');
 
         // Then count only the most recent status of each child (rn = 1)
@@ -2279,7 +2290,7 @@ export class SchedulerModel {
             .whereRaw('job_id = job_group') // Only parent jobs
             .whereIn('scheduler_uuid', schedulerUuids)
             .where('scheduled_time', '>', sevenDaysAgo)
-            .where('scheduled_time', '<', new Date())
+            .where('scheduled_time', '<', now)
             .as('ranked_runs');
 
         const distinctRunsSubquery = this.database


### PR DESCRIPTION
Closes: lightdash/lightdash#27892

### Description:

The scheduled deliveries panel fetches schedulers with `includeLatestRun=true`, which goes through `getRunsForSchedulers`. Its child-job count subquery ranked **every** child row in `scheduler_log` (`ROW_NUMBER() OVER (PARTITION BY job_id)` with only `job_id != job_group` as a filter) before the outer `LEFT JOIN` threw almost all of it away. On Cloud that log table is huge, so the panel paid a full scan every time — 150s+ in production. A dashboard with no deliveries returns early before that query runs, which is why it felt instant.

Two changes:

* Restrict the child ranking to parent jobs already in scope (same scheduler uuids + 7-day window). Every row of a `job_id` shares one `job_group`, so no partition changes — the result set is identical, just without the table-wide scan.
* Add a concurrent `(scheduler_uuid, scheduled_time)` index on `scheduler_log` so the parent lookup doesn't read a scheduler's whole history.

Saving/editing a delivery refetches the same list, so it should get the same speedup.

Verified by unit test on the emitted SQL and package lint/typecheck; I had no Postgres available here, so the plan improvement hasn't been measured against real data.

### Risk assessment:

- [ ] This is a high-risk change