### PR TITLE
fix(ai): preserve MCP tool schema wrapper during input-schema hardening

### DIFF
--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.test.ts
@@ -1,6 +1,6 @@
 import * as mcpSdk from '@ai-sdk/mcp';
 import type { MCPClient } from '@ai-sdk/mcp';
-import { jsonSchema } from 'ai';
+import { asSchema, jsonSchema } from 'ai';
 import dns from 'node:dns';
 import type { LightdashConfig } from '../../../config/parseConfig';
 import type { AiAgentModel, AiMcpCredential } from '../../models/AiAgentModel';
@@ -111,6 +111,24 @@ describe('hardenMcpToolDefinition', () => {
             value: expect.arrayContaining([
                 expect.objectContaining({ type: 'image-data' }),
             ]),
+        });
+    });
+
+    it('keeps the hardened input schema recognizable by the AI SDK', () => {
+        // MCP clients build inputSchema via jsonSchema() without a validate
+        // function; hardening must preserve the wrapper's Schema contract or
+        // asSchema() treats it as a lazy-schema function and throws.
+        const hardened = hardenMcpToolDefinition({
+            inputSchema: jsonSchema({
+                type: 'object',
+                properties: { query: { type: 'string' } },
+            }),
+        } as never);
+
+        const schema = asSchema(hardened.inputSchema as never);
+        expect(schema.jsonSchema).toMatchObject({
+            type: 'object',
+            properties: { query: { type: 'string' } },
         });
     });
 

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
@@ -213,9 +213,21 @@ const hardenMcpInputSchema = (inputSchema: unknown): unknown => {
                         ) {
                             throw new McpPayloadTooLargeError();
                         }
-                        return [childKey, visit(child, childKey, depth + 1)];
+                        return [
+                            childKey,
+                            visit(child, childKey, depth + 1),
+                            child,
+                        ];
                     })
-                    .filter(([, child]) => child !== undefined),
+                    // Drop only keys the sanitizer removed; keys that were
+                    // undefined to begin with must survive — the AI SDK Schema
+                    // wrapper is only recognized by asSchema() when its
+                    // `validate` key is present, even if undefined.
+                    .filter(
+                        ([, sanitized, original]) =>
+                            sanitized !== undefined || original === undefined,
+                    )
+                    .map(([childKey, sanitized]) => [childKey, sanitized]),
             );
             for (const symbol of Object.getOwnPropertySymbols(value)) {
                 Object.defineProperty(


### PR DESCRIPTION
Since v1.237, asking an AI agent anything that used a remote MCP tool crashed the response stream with "schema is not a function": the input-schema hardening dropped a key the AI SDK requires to recognize a tool schema. Once a thread had loaded an MCP tool it stayed permanently broken, failing on every follow-up message — this affected every org with MCP servers attached to agents.

Closes: #27896

🤖 Generated with [Claude Code](https://claude.com/claude-code)
