### PR TITLE
feat: Learn player — lesson styles, citations and click-through demos (CS-139)

### DIFF
--- a/packages/common/src/types/learn.ts
+++ b/packages/common/src/types/learn.ts
@@ -55,6 +55,28 @@ export type LearnLesson = {
     html: string;
 };
 
+/** A clickable region on a demo step, as fractions of the image. */
+export type LearnDemoHotspot = {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+};
+
+export type LearnDemoStep = {
+    image: string;
+    caption: string;
+    hotspot: LearnDemoHotspot | null;
+};
+
+/** An interactive click-through demo a lesson mounts with `data-demo`. */
+export type LearnDemo = {
+    id: string;
+    title: string;
+    viewport: { width: number; height: number };
+    steps: LearnDemoStep[];
+};
+
 export type LearnCourse = {
     id: string;
     title: string;
@@ -62,6 +84,7 @@ export type LearnCourse = {
     logo?: string;
     lessons: LearnLesson[];
     quiz: { questions: LearnQuizQuestion[] };
+    demos: Record<string, LearnDemo>;
     version: number;
     contentHash: string;
     publishedAt: string;
@@ -69,12 +92,38 @@ export type LearnCourse = {
     assetBaseUrl: string;
 };
 
+const LearnDemoSchema = z
+    .object({
+        id: z.string().min(1),
+        title: z.string(),
+        viewport: z.object({ width: z.number(), height: z.number() }),
+        steps: z.array(
+            z
+                .object({
+                    image: z.string().min(1),
+                    caption: z.string(),
+                    hotspot: z
+                        .object({
+                            x: z.number(),
+                            y: z.number(),
+                            width: z.number(),
+                            height: z.number(),
+                        })
+                        .nullish()
+                        .transform((value) => value ?? null),
+                })
+                .passthrough(),
+        ),
+    })
+    .passthrough();
+
 export const LearnCourseSchema = z
     .object({
         id: z.string().min(1),
         title: z.string().min(1),
         passingScore: z.number(),
         logo: z.string().optional(),
+        demos: z.record(LearnDemoSchema).default({}),
         lessons: z.array(
             z
                 .object({

--- a/packages/common/src/utils/sanitizeHtml.test.ts
+++ b/packages/common/src/utils/sanitizeHtml.test.ts
@@ -1,5 +1,6 @@
 import {
     HTML_SANITIZE_DEFAULT_RULES,
+    HTML_SANITIZE_LEARN_LESSON_RULES,
     HTML_SANITIZE_MARKDOWN_TILE_RULES,
     sanitizeHtml,
 } from './sanitizeHtml';
@@ -327,5 +328,59 @@ describe('sanitizeHtml', () => {
                 input,
             );
         });
+    });
+});
+
+describe('HTML_SANITIZE_LEARN_LESSON_RULES', () => {
+    const lesson =
+        '<p>Open Browse<a class="cit" href="#fig-1" data-hl="r1">1</a>.</p>' +
+        '<span class="figwrap" id="fig-1"><img src="https://x/y.png" alt="Spaces">' +
+        '<span class="hlbox below pl-l" data-r="r1" data-label="1 · Browse" style="left:10.5%;top:1.2%;width:7.5%;height:4%"></span></span>' +
+        '<figure class="shot" id="fig-2"><img src="https://x/z.png" alt=""><figcaption>Cap</figcaption></figure>';
+
+    test('keeps citation pins, figure ids and positioned highlight boxes', () => {
+        const out = sanitizeHtml(lesson, HTML_SANITIZE_LEARN_LESSON_RULES);
+        expect(out).toContain(
+            '<a class="cit" href="#fig-1" data-hl="r1">1</a>',
+        );
+        expect(out).toContain('<span class="figwrap" id="fig-1">');
+        expect(out).toContain('data-r="r1"');
+        expect(out).toContain('data-label="1 · Browse"');
+        expect(out).toContain('left:10.5%');
+        expect(out).toContain('height:4%');
+        expect(out).toContain('<figure class="shot" id="fig-2">');
+    });
+
+    test('still drops scripts, stylesheets and unsafe styles', () => {
+        const out = sanitizeHtml(
+            '<style>a{}</style><script>x()</script>' +
+                '<span class="hlbox" style="position:fixed;left:10%;background:url(x)"></span>',
+            HTML_SANITIZE_LEARN_LESSON_RULES,
+        );
+        expect(out).not.toContain('<style');
+        expect(out).not.toContain('<script');
+        expect(out).not.toContain('position');
+        expect(out).not.toContain('url(');
+        expect(out).toContain('left:10%');
+    });
+});
+
+describe('HTML_SANITIZE_LEARN_LESSON_RULES demo placeholders', () => {
+    test('keeps the data-demo mount point and nothing else on it', () => {
+        const out = sanitizeHtml(
+            '<div data-demo="save-chart" onclick="x()"></div>',
+            HTML_SANITIZE_LEARN_LESSON_RULES,
+        );
+        expect(out).toBe('<div data-demo="save-chart"></div>');
+    });
+});
+
+describe('HTML_SANITIZE_LEARN_LESSON_RULES frames', () => {
+    test('drops iframes even though markdown tiles allow them', () => {
+        const out = sanitizeHtml(
+            '<p>Before</p><iframe src="https://example.com/login" width="600" height="400"></iframe><p>After</p>',
+            HTML_SANITIZE_LEARN_LESSON_RULES,
+        );
+        expect(out).toBe('<p>Before</p><p>After</p>');
     });
 });

--- a/packages/common/src/utils/sanitizeHtml.ts
+++ b/packages/common/src/utils/sanitizeHtml.ts
@@ -127,6 +127,49 @@ export const HTML_SANITIZE_MARKDOWN_TILE_RULES: sanitize.IOptions = {
     ),
 };
 
+const percentRegex = /^\d+(?:\.\d+)?%$/;
+const tileAttributes =
+    HTML_SANITIZE_MARKDOWN_TILE_RULES.allowedAttributes || {};
+
+/**
+ * Rules for lesson HTML published by Lightdash University. Lessons carry
+ * citation pins (`a.cit` → `#fig-…`) and highlight boxes positioned by
+ * percentage over a figure; scripts and stylesheets are still dropped.
+ */
+export const HTML_SANITIZE_LEARN_LESSON_RULES: sanitize.IOptions = {
+    ...HTML_SANITIZE_MARKDOWN_TILE_RULES,
+    // Lessons never embed frames; a compromised content host must not either.
+    allowedTags: (HTML_SANITIZE_MARKDOWN_TILE_RULES.allowedTags || []).filter(
+        (tag) => tag !== 'iframe',
+    ),
+    allowedAttributes: {
+        ...Object.fromEntries(
+            Object.entries(tileAttributes).filter(([tag]) => tag !== 'iframe'),
+        ),
+        a: [...(tileAttributes.a ?? []), 'class', 'data-hl'],
+        span: [
+            ...(tileAttributes.span ?? []),
+            'class',
+            'id',
+            'data-r',
+            'data-label',
+        ],
+        figure: ['class', 'id'],
+        img: [...(tileAttributes.img ?? []), 'class'],
+        div: [...(tileAttributes.div ?? []), 'data-demo'],
+    },
+    allowedStyles: {
+        ...HTML_SANITIZE_MARKDOWN_TILE_RULES.allowedStyles,
+        span: {
+            ...allowedTextStylingProperties,
+            left: [percentRegex],
+            top: [percentRegex],
+            width: [...allowedTextStylingProperties.width, percentRegex],
+            height: [...allowedTextStylingProperties.height, percentRegex],
+        },
+    },
+};
+
 export const sanitizeHtml = (
     input: string,
     ruleSet: sanitize.IOptions = HTML_SANITIZE_DEFAULT_RULES,

--- a/packages/frontend/src/features/learn/citations.test.ts
+++ b/packages/frontend/src/features/learn/citations.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { wireCitations } from './citations';
+
+const LESSON = `
+<p>Reach a space from Browse<a class="cit" href="#fig-1" data-hl="r1">1</a>.</p>
+<span class="figwrap" id="fig-1">
+  <img src="x.png" alt="">
+  <span class="hlbox" data-r="r1" data-label="1 · Browse" style="left:10.5%;top:1.2%;width:7.5%;height:4%"></span>
+  <span class="hlbox" data-r="r2" data-label="2 · Other" style="left:50%;top:1.2%;width:7.5%;height:4%"></span>
+</span>
+<p>Another<a class="cit" href="#fig-1" data-hl="r2">2</a>.</p>
+`;
+
+describe('wireCitations', () => {
+    let scope: HTMLElement;
+    let dispose: () => void;
+
+    beforeEach(() => {
+        scope = document.createElement('div');
+        scope.innerHTML = LESSON;
+        document.body.appendChild(scope);
+        Element.prototype.scrollIntoView = vi.fn();
+        dispose = wireCitations(scope);
+    });
+
+    afterEach(() => {
+        dispose();
+        scope.remove();
+    });
+
+    const pin = (n: number) =>
+        scope.querySelectorAll('a.cit')[n] as HTMLElement;
+    const box = (r: string) => scope.querySelector(`.hlbox[data-r="${r}"]`)!;
+
+    it('lights the matching box on hover and clears on mouseout', () => {
+        pin(0).dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+        expect(pin(0).classList.contains('active')).toBe(true);
+        expect(box('r1').classList.contains('active')).toBe(true);
+        expect(box('r2').classList.contains('active')).toBe(false);
+
+        pin(0).dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+        expect(pin(0).classList.contains('active')).toBe(false);
+        expect(box('r1').classList.contains('active')).toBe(false);
+    });
+
+    it('moves the highlight between pins and follows focus', () => {
+        pin(0).dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        expect(box('r1').classList.contains('active')).toBe(true);
+        pin(1).dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        expect(box('r1').classList.contains('active')).toBe(false);
+        expect(box('r2').classList.contains('active')).toBe(true);
+    });
+
+    it('click keeps the highlight, scrolls to the figure and does not navigate', () => {
+        const event = new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+        });
+        pin(1).dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(true);
+        expect(box('r2').classList.contains('active')).toBe(true);
+        expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+
+        box('r2').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(box('r2').classList.contains('active')).toBe(false);
+    });
+
+    it('disposer removes the listeners and any active state', () => {
+        pin(0).dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+        dispose();
+        expect(box('r1').classList.contains('active')).toBe(false);
+        pin(0).dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+        expect(box('r1').classList.contains('active')).toBe(false);
+        dispose = () => {};
+    });
+});

--- a/packages/frontend/src/features/learn/citations.ts
+++ b/packages/frontend/src/features/learn/citations.ts
@@ -1,0 +1,83 @@
+// Citation pins in published lesson HTML (`a.cit` with `href="#fig-…"` and
+// `data-hl`) light the matching `.hlbox` on their figure. The lesson ships
+// this behaviour as an inline script, which never runs once the HTML is
+// injected, so the player wires it here with delegated listeners.
+
+const CLEAR_EVENTS = ['mouseout', 'focusout'] as const;
+const ACTIVATE_EVENTS = ['mouseover', 'focusin'] as const;
+
+const clearActive = (scope: HTMLElement): void => {
+    scope
+        .querySelectorAll('a.cit.active, .hlbox.active')
+        .forEach((el) => el.classList.remove('active'));
+};
+
+const activate = (scope: HTMLElement, pin: HTMLAnchorElement): void => {
+    clearActive(scope);
+    pin.classList.add('active');
+    const href = pin.getAttribute('href');
+    const region = pin.getAttribute('data-hl');
+    if (!href || !href.startsWith('#') || !region) return;
+    const figure = scope.querySelector(`[id="${CSS.escape(href.slice(1))}"]`);
+    const box = figure?.querySelector(`.hlbox[data-r="${CSS.escape(region)}"]`);
+    if (box) box.classList.add('active');
+};
+
+const pinFrom = (event: Event): HTMLAnchorElement | null => {
+    const target = event.target;
+    if (!(target instanceof Element)) return null;
+    return target.closest<HTMLAnchorElement>('a.cit');
+};
+
+/**
+ * Wire citation pins inside `scope`. Returns a disposer that removes the
+ * listeners; call it before the scope's HTML is replaced.
+ */
+export const wireCitations = (scope: HTMLElement): (() => void) => {
+    const onActivate = (event: Event) => {
+        const pin = pinFrom(event);
+        if (pin) activate(scope, pin);
+    };
+    const onClear = (event: Event) => {
+        if (pinFrom(event)) clearActive(scope);
+    };
+    const onClick = (event: Event) => {
+        const pin = pinFrom(event);
+        if (pin) {
+            event.preventDefault();
+            activate(scope, pin);
+            const href = pin.getAttribute('href');
+            const figure =
+                href && href.startsWith('#')
+                    ? scope.querySelector(`[id="${CSS.escape(href.slice(1))}"]`)
+                    : null;
+            const reduced = window.matchMedia?.(
+                '(prefers-reduced-motion: reduce)',
+            ).matches;
+            figure?.scrollIntoView({
+                behavior: reduced ? 'auto' : 'smooth',
+                block: 'center',
+            });
+            return;
+        }
+        const target = event.target;
+        if (target instanceof Element && target.closest('.figwrap')) {
+            clearActive(scope);
+        }
+    };
+
+    ACTIVATE_EVENTS.forEach((name) => scope.addEventListener(name, onActivate));
+    CLEAR_EVENTS.forEach((name) => scope.addEventListener(name, onClear));
+    scope.addEventListener('click', onClick);
+
+    return () => {
+        ACTIVATE_EVENTS.forEach((name) =>
+            scope.removeEventListener(name, onActivate),
+        );
+        CLEAR_EVENTS.forEach((name) =>
+            scope.removeEventListener(name, onClear),
+        );
+        scope.removeEventListener('click', onClick);
+        clearActive(scope);
+    };
+};

--- a/packages/frontend/src/features/learn/components/LearnCoursePlayer.test.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCoursePlayer.test.tsx
@@ -1,0 +1,99 @@
+import { type LearnCourse } from '@lightdash/common';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import type * as ReactRouter from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { emptyRollup } from '../model';
+import { LearnCoursePlayer } from './LearnCoursePlayer';
+
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual<typeof ReactRouter>('react-router');
+    return {
+        ...actual,
+        useNavigate: () => vi.fn(),
+        useParams: () => ({
+            projectUuid: 'project-1',
+            courseId: 'saving-charts',
+        }),
+    };
+});
+
+const course: LearnCourse = {
+    id: 'saving-charts',
+    title: 'Saving charts',
+    passingScore: 80,
+    lessons: [
+        {
+            id: 'l1',
+            title: 'Save a chart',
+            html:
+                '<p>Open the chart<a class="cit" href="#fig-1" data-hl="r1">1</a>.</p>' +
+                '<div data-demo="save-chart"></div>' +
+                '<span class="figwrap" id="fig-1"><img src="assets/a.png" alt="">' +
+                '<span class="hlbox" data-r="r1" data-label="1 · Save" style="left:1%;top:2%;width:3%;height:4%"></span></span>',
+        },
+    ],
+    quiz: { questions: [] },
+    demos: {
+        'save-chart': {
+            id: 'save-chart',
+            title: 'Save a chart',
+            viewport: { width: 1440, height: 900 },
+            steps: [
+                {
+                    image: 'save-1.png',
+                    caption: 'Click Save.',
+                    hotspot: { x: 0.5, y: 0.5, width: 0.1, height: 0.1 },
+                },
+                { image: 'save-2.png', caption: 'Done.', hotspot: null },
+            ],
+        },
+    },
+    version: 1,
+    contentHash: 'abc',
+    publishedAt: '2026-08-01T00:00:00.000Z',
+    assetBaseUrl: 'https://cdn/courses/saving-charts/abc',
+};
+
+vi.mock('../hooks', () => ({
+    useLearnCourse: () => ({
+        data: course,
+        isInitialLoading: false,
+        isError: false,
+    }),
+    useLearnRollups: () => ({
+        rollups: new Map([['saving-charts', emptyRollup()]]),
+        isLoading: false,
+        serverSynced: false,
+    }),
+    useRecordLearnEvent: () => ({ record: vi.fn() }),
+    getLessonBookmark: () => null,
+    setLessonBookmark: vi.fn(),
+    setLastCourseId: vi.fn(),
+}));
+
+describe('LearnCoursePlayer', () => {
+    it('mounts a click-through demo where the lesson left its placeholder', async () => {
+        renderWithProviders(<LearnCoursePlayer />);
+        await waitFor(() =>
+            expect(screen.getByText('Click Save.')).toBeInTheDocument(),
+        );
+        const placeholder = document.querySelector(
+            'div[data-demo="save-chart"]',
+        );
+        expect(placeholder?.textContent).toContain('1/2');
+        fireEvent.click(screen.getByRole('button', { name: 'Next step' }));
+        expect(screen.getByText('2/2')).toBeInTheDocument();
+    });
+
+    it('keeps the citation markup and resolves asset paths', async () => {
+        renderWithProviders(<LearnCoursePlayer />);
+        await waitFor(() =>
+            expect(document.querySelector('a.cit')).toBeInTheDocument(),
+        );
+        expect(document.querySelector('.hlbox[data-r="r1"]')).not.toBeNull();
+        expect(
+            document.querySelector('.figwrap img')?.getAttribute('src'),
+        ).toBe('https://cdn/courses/saving-charts/abc/assets/a.png');
+    });
+});

--- a/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
@@ -1,5 +1,5 @@
 import {
-    HTML_SANITIZE_MARKDOWN_TILE_RULES,
+    HTML_SANITIZE_LEARN_LESSON_RULES,
     sanitizeHtml,
     type LearnCourse,
 } from '@lightdash/common';
@@ -15,10 +15,12 @@ import {
     Title,
 } from '@mantine/core';
 import { IconArrowLeft } from '@tabler/icons-react';
-import { useEffect, useMemo, useState, type FC } from 'react';
+import { useEffect, useMemo, useRef, useState, type FC } from 'react';
+import { createPortal } from 'react-dom';
 import { useNavigate, useParams } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import { wireCitations } from '../citations';
 import {
     getLessonBookmark,
     setLastCourseId,
@@ -28,6 +30,10 @@ import {
     useRecordLearnEvent,
 } from '../hooks';
 import { cardState, emptyRollup } from '../model';
+import { LearnDemo } from './LearnDemo';
+import styles from './LearnLesson.module.css';
+
+type DemoMount = { id: string; element: HTMLElement };
 
 function scoreQuiz(
     questions: LearnCourse['quiz']['questions'],
@@ -42,7 +48,7 @@ function lessonHtml(course: LearnCourse, index: number): string {
         /src="assets\//g,
         `src="${course.assetBaseUrl}/assets/`,
     );
-    return sanitizeHtml(raw, HTML_SANITIZE_MARKDOWN_TILE_RULES);
+    return sanitizeHtml(raw, HTML_SANITIZE_LEARN_LESSON_RULES);
 }
 
 export const LearnCoursePlayer: FC = () => {
@@ -98,6 +104,41 @@ export const LearnCoursePlayer: FC = () => {
             object: { type: 'course', ...eventObject },
         });
     }, [data, started, state, eventObject, record]);
+
+    // One object per lesson: a fresh `{ __html }` each render would make React
+    // reset the injected HTML and wipe the demo portals mounted inside it.
+    const lessonHtmlString = useMemo(
+        () =>
+            data && page !== null && page < data.lessons.length
+                ? lessonHtml(data, page)
+                : null,
+        [data, page],
+    );
+    const lessonMarkup = useMemo(
+        () => (lessonHtmlString === null ? null : { __html: lessonHtmlString }),
+        [lessonHtmlString],
+    );
+
+    // Re-wire after every lesson change: React replaces the injected HTML.
+    // Demo placeholders left by the lesson become portal targets.
+    const lessonRef = useRef<HTMLDivElement>(null);
+    const [demoMounts, setDemoMounts] = useState<DemoMount[]>([]);
+    useEffect(() => {
+        const el = lessonRef.current;
+        if (!el) {
+            setDemoMounts([]);
+            return undefined;
+        }
+        setDemoMounts(
+            Array.from(el.querySelectorAll<HTMLElement>('div[data-demo]')).map(
+                (element) => ({
+                    id: element.getAttribute('data-demo') ?? '',
+                    element,
+                }),
+            ),
+        );
+        return wireCitations(el);
+    }, [data, page]);
 
     if (course.isInitialLoading || (data && page === null)) {
         return <SuboptimalState title="Loading course…" loading />;
@@ -156,7 +197,7 @@ export const LearnCoursePlayer: FC = () => {
     };
 
     return (
-        <Stack gap="md" py="lg" maw={760} mx="auto">
+        <Stack gap="md" py="lg" maw={760} w="100%" mx="auto">
             <Anchor
                 size="sm"
                 onClick={() => navigate(`/projects/${projectUuid}/learn`)}
@@ -189,15 +230,32 @@ export const LearnCoursePlayer: FC = () => {
                 </Group>
                 <Progress value={progressPct} size="xs" radius={0} />
                 <Stack p="lg" gap="md">
-                    {!onQuiz && (
+                    {!onQuiz && lessonMarkup && (
                         <div
                             // eslint-disable-next-line react/no-danger
-                            dangerouslySetInnerHTML={{
-                                __html: lessonHtml(data, page),
-                            }}
-                            style={{ lineHeight: 1.6 }}
+                            ref={lessonRef}
+                            className={styles.lesson}
+                            dangerouslySetInnerHTML={lessonMarkup}
                         />
                     )}
+                    {!onQuiz &&
+                        demoMounts.map(({ id, element }, index) => {
+                            const demo = Object.prototype.hasOwnProperty.call(
+                                data.demos,
+                                id,
+                            )
+                                ? data.demos[id]
+                                : undefined;
+                            if (!demo || !element.isConnected) return null;
+                            return createPortal(
+                                <LearnDemo
+                                    demo={demo}
+                                    assetBaseUrl={data.assetBaseUrl}
+                                />,
+                                element,
+                                `${page}-${index}-${id}`,
+                            );
+                        })}
                     {onQuiz && quizResult === null && (
                         <Stack gap="md">
                             <Title order={3}>Quiz</Title>

--- a/packages/frontend/src/features/learn/components/LearnDemo.test.tsx
+++ b/packages/frontend/src/features/learn/components/LearnDemo.test.tsx
@@ -1,0 +1,43 @@
+import { type LearnDemo as LearnDemoManifest } from '@lightdash/common';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LearnDemo } from './LearnDemo';
+
+const demo: LearnDemoManifest = {
+    id: 'save-chart',
+    title: 'Save a chart',
+    viewport: { width: 1440, height: 900 },
+    steps: [
+        {
+            image: 'save-1.png',
+            caption: 'Click Save.',
+            hotspot: { x: 0.8, y: 0.1, width: 0.1, height: 0.05 },
+        },
+        { image: 'save-2.png', caption: 'Name it.', hotspot: null },
+        { image: 'save-3.png', caption: 'Saved.', hotspot: null },
+    ],
+};
+
+describe('LearnDemo', () => {
+    it('walks the steps by hotspot, then Next, then Replay', () => {
+        render(<LearnDemo demo={demo} assetBaseUrl="https://cdn/x" />);
+        expect(screen.getByText('1/3')).toBeInTheDocument();
+        expect(screen.getByRole('img')).toHaveAttribute(
+            'src',
+            'https://cdn/x/assets/save-1.png',
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Next step' }));
+        expect(screen.getByText('2/3')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Next step' }),
+        ).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+        expect(screen.getByText('3/3')).toBeInTheDocument();
+        expect(screen.getByText('Saved.')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Replay' }));
+        expect(screen.getByText('1/3')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/learn/components/LearnDemo.tsx
+++ b/packages/frontend/src/features/learn/components/LearnDemo.tsx
@@ -1,0 +1,72 @@
+import { type LearnDemo as LearnDemoManifest } from '@lightdash/common';
+import { useState, type FC } from 'react';
+import styles from './LearnLesson.module.css';
+
+type Props = {
+    demo: LearnDemoManifest;
+    assetBaseUrl: string;
+};
+
+const pct = (value: number): string => `${(value * 100).toFixed(2)}%`;
+
+/** Click-through demo: one screenshot per step, the hotspot advances it. */
+export const LearnDemo: FC<Props> = ({ demo, assetBaseUrl }) => {
+    const [step, setStep] = useState(0);
+    const current = demo.steps[step];
+    if (!current) return null;
+    const last = step === demo.steps.length - 1;
+
+    return (
+        <div className={styles.demo}>
+            <div
+                className={styles.demoStage}
+                style={{
+                    aspectRatio: `${demo.viewport.width} / ${demo.viewport.height}`,
+                }}
+            >
+                <img
+                    src={`${assetBaseUrl}/assets/${current.image}`}
+                    alt={`${demo.title}, step ${step + 1}`}
+                />
+                {current.hotspot && !last && (
+                    <button
+                        type="button"
+                        className={styles.demoHotspot}
+                        aria-label="Next step"
+                        style={{
+                            left: pct(current.hotspot.x),
+                            top: pct(current.hotspot.y),
+                            width: pct(current.hotspot.width),
+                            height: pct(current.hotspot.height),
+                        }}
+                        onClick={() => setStep(step + 1)}
+                    />
+                )}
+            </div>
+            <div className={styles.demoCaption}>
+                <span className={styles.demoStepCount}>
+                    {step + 1}/{demo.steps.length}
+                </span>
+                {current.caption}
+                {!current.hotspot && !last && (
+                    <button
+                        type="button"
+                        className={styles.demoButton}
+                        onClick={() => setStep(step + 1)}
+                    >
+                        Next
+                    </button>
+                )}
+                {last && (
+                    <button
+                        type="button"
+                        className={styles.demoButton}
+                        onClick={() => setStep(0)}
+                    >
+                        Replay
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/packages/frontend/src/features/learn/components/LearnLesson.module.css
+++ b/packages/frontend/src/features/learn/components/LearnLesson.module.css
@@ -1,0 +1,241 @@
+/* Styles for the lesson HTML published by Lightdash University, which is
+   injected verbatim (sanitised) and carries no stylesheet of its own. The
+   citation and highlight rules mirror the lesson's own inline CSS, which the
+   sanitiser drops; their classes come from the lesson, hence :global(). */
+.lesson {
+    line-height: 1.6;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.lesson h1 {
+    font-size: 24px;
+    line-height: 1.2;
+    margin: 0 0 12px;
+}
+
+.lesson h2 {
+    font-size: 17px;
+    line-height: 1.3;
+    margin: 24px 0 8px;
+}
+
+.lesson p {
+    margin: 0 0 12px;
+}
+
+.lesson ul,
+.lesson ol {
+    margin: 0 0 12px;
+    padding-left: 22px;
+}
+
+.lesson img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+    box-shadow: 0 0 0 1px #eceff3;
+}
+
+.lesson figure {
+    margin: 16px 0 20px;
+}
+
+.lesson figcaption {
+    margin-top: 8px;
+    font-size: 13px;
+    color: #818898;
+}
+
+.lesson a {
+    color: var(--mantine-color-ldBrandViolet-6);
+}
+
+/* Citation pins: a numbered dot after the sentence that describes a region of
+   the figure below it. */
+.lesson :global(a.cit) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    background: var(--mantine-color-ldBrandViolet-6);
+    color: #ffffff;
+    font-size: 9px;
+    font-weight: 700;
+    line-height: 1;
+    vertical-align: super;
+    margin: 0 1px 0 3px;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+        background 0.15s ease,
+        transform 0.15s ease;
+}
+
+.lesson :global(a.cit:hover),
+.lesson :global(a.cit:focus) {
+    background: #4536d6;
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.lesson :global(a.cit.active) {
+    background: #1a1b25;
+}
+
+/* A figure that carries highlight regions. */
+.lesson :global(.figwrap) {
+    position: relative;
+    display: block;
+    overflow: hidden;
+    border: 1px solid #eceff3;
+    border-radius: 10px;
+    margin: 8px 0 20px;
+    line-height: 0;
+    scroll-margin-top: 28px;
+}
+
+.lesson :global(.figwrap) img {
+    width: 100%;
+    border-radius: 0;
+    box-shadow: none;
+    margin: 0;
+}
+
+/* Positioned by inline percentages from the lesson; the rest is here. The
+   huge spread shadow dims everything outside the box. */
+.lesson :global(.hlbox) {
+    position: absolute;
+    border-radius: 8px;
+    pointer-events: none;
+    opacity: 0;
+    box-shadow:
+        0 0 0 2px var(--mantine-color-ldBrandViolet-6),
+        0 0 0 9999px rgba(39, 40, 53, 0.58);
+    transition: opacity 0.18s ease;
+}
+
+.lesson :global(.hlbox.active) {
+    opacity: 1;
+}
+
+.lesson :global(.hlbox)::after {
+    content: attr(data-label);
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 100%;
+    margin-bottom: 6px;
+    background: var(--mantine-color-ldBrandViolet-6);
+    color: #ffffff;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+    padding: 6px 9px;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+
+.lesson :global(.hlbox.below)::after {
+    bottom: auto;
+    top: 100%;
+    margin-bottom: 0;
+    margin-top: 6px;
+}
+
+.lesson :global(.hlbox.pl-r)::after {
+    left: auto;
+    right: 0;
+    transform: none;
+}
+
+.lesson :global(.hlbox.pl-l)::after {
+    left: 0;
+    right: auto;
+    transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .lesson :global(a.cit),
+    .lesson :global(.hlbox) {
+        transition: none;
+    }
+}
+
+/* Click-through demos mounted where the lesson left a `data-demo` div. */
+.demo {
+    margin: 8px 0 20px;
+}
+
+.demoStage {
+    position: relative;
+    border: 1px solid #eceff3;
+    border-radius: 10px;
+    overflow: hidden;
+    line-height: 0;
+}
+
+.demoStage img {
+    display: block;
+    width: 100%;
+    border-radius: 0;
+    box-shadow: none;
+    margin: 0;
+}
+
+.demoHotspot {
+    position: absolute;
+    background: transparent;
+    border: 2px solid var(--mantine-color-ldBrandViolet-6);
+    border-radius: 6px;
+    padding: 0;
+    cursor: pointer;
+    animation: demoPulse 1.6s ease-in-out infinite;
+}
+
+.demoHotspot:hover,
+.demoHotspot:focus-visible {
+    background: rgba(94, 76, 255, 0.12);
+}
+
+@keyframes demoPulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 rgba(94, 76, 255, 0.45);
+    }
+    50% {
+        box-shadow: 0 0 0 8px rgba(94, 76, 255, 0);
+    }
+}
+
+.demoCaption {
+    margin-top: 8px;
+    font-size: 14px;
+    color: #818898;
+}
+
+.demoStepCount {
+    font-weight: 600;
+    color: var(--mantine-color-ldBrandViolet-6);
+    margin-right: 6px;
+}
+
+.demoButton {
+    margin-left: 8px;
+    padding: 3px 10px;
+    font: inherit;
+    font-size: 13px;
+    border-radius: 999px;
+    border: 1px solid #dfe1e7;
+    background: #ffffff;
+    cursor: pointer;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .demoHotspot {
+        animation: none;
+    }
+}


### PR DESCRIPTION
Course player follow-ups split out of the board PR so each reviews on its own: lesson styling, interactive citations, and click-through demos. No board code here; the branch sits between `learn-4-progress` and `learn-5-board` on the CS-73 Learn stack.

## What changed

- The published lesson HTML now has a stylesheet (`LearnLesson.module.css`) and the player column fills the page, so lesson screenshots fit the column instead of overflowing it.
- Click-through demos play. `LearnCourse.demos` is typed (zod defaults keep older catalogues parsing), the `data-demo` placeholder survives sanitising, and `LearnDemo` renders each demo (screenshot per step, hotspot advances, Replay) through a portal into its placeholder.
- Citation pins work. A lesson-specific sanitiser rule set (`HTML_SANITIZE_LEARN_LESSON_RULES` in common) keeps the pin and highlight markup (scripts and stylesheets still drop), and `citations.ts` wires hover, focus and click so a pin lights its region on the figure.

## Behaviour worth knowing

- The lesson markup object is memoised per lesson: a fresh `{ __html }` each render would make React reset the injected HTML and wipe the demo portals mounted inside it.
- Demo mounts re-wire after every lesson change, since React replaces the injected HTML.

## Verification

Unit: `citations.test.ts`, `LearnDemo.test.tsx`, `LearnCoursePlayer.test.tsx`, `sanitizeHtml.test.ts`. Full common suite, frontend learn suite, and typecheck clean.

Relates: CS-139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAD1wSdyo6Mewb2PMFA1GD
