### PR TITLE
feat: Learn Ask bar — library search lights the board (CS-142)

### DIFF
--- a/packages/backend/src/controllers/learnController.ts
+++ b/packages/backend/src/controllers/learnController.ts
@@ -1,10 +1,12 @@
 import {
     assertRegisteredAccount,
     type ApiErrorPayload,
+    type ApiLearnAskResponse,
     type ApiLearnCatalogueResponse,
     type ApiLearnCourseResponse,
     type ApiLearnEventsResponse,
     type ApiLearnProgressResponse,
+    type LearnAskRequest,
     type LearnEventInput,
 } from '@lightdash/common';
 import {
@@ -115,6 +117,28 @@ export class LearnController extends BaseController {
             results: await this.services
                 .getLearnService()
                 .recordEvents(req.account, body),
+        };
+    }
+
+    /**
+     * Search the Lightdash University library for lessons matching a question.
+     * @summary Search Learn content
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/ask')
+    @OperationId('askLearn')
+    async askLearn(
+        @Request() req: express.Request,
+        @Body() body: LearnAskRequest,
+    ): Promise<ApiLearnAskResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getLearnService()
+                .ask(req.account, body),
         };
     }
 }

--- a/packages/backend/src/services/LearnService/LearnService.test.ts
+++ b/packages/backend/src/services/LearnService/LearnService.test.ts
@@ -1,5 +1,6 @@
 import {
     ForbiddenError,
+    LEARN_ASK_QUERY_MAX_LENGTH,
     NotFoundError,
     ParameterError,
     UnexpectedServerError,
@@ -60,9 +61,15 @@ const catalogueEntry = {
     publishedAt: '2026-08-01T00:00:00.000Z',
 };
 
+const suggestion = {
+    query: 'How do I get a dashboard emailed to me every Monday?',
+    courseId: 'viewer-fundamentals',
+};
+
 const cataloguePayload = {
     generatedAt: '2026-08-01T00:00:00.000Z',
     courses: [catalogueEntry],
+    suggestions: [suggestion],
 };
 
 const coursePayload = {
@@ -118,6 +125,14 @@ describe('LearnService', () => {
             await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
                 ForbiddenError,
             );
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('gates the ask proxy on the flag', async () => {
+            const { service } = buildService({ flagEnabled: false });
+            await expect(
+                service.ask(buildAccount(), { query: 'anything' }),
+            ).rejects.toThrow(ForbiddenError);
             expect(fetchMock).not.toHaveBeenCalled();
         });
     });
@@ -184,6 +199,21 @@ describe('LearnService', () => {
             await expect(service.getCatalogue(buildAccount())).rejects.toThrow(
                 UnexpectedServerError,
             );
+        });
+
+        it('returns the curated ask suggestions', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse(cataloguePayload));
+            const catalogue = await service.getCatalogue(buildAccount());
+            expect(catalogue.suggestions).toEqual([suggestion]);
+        });
+
+        it('defaults suggestions for a catalogue published before them', async () => {
+            const { service } = buildService();
+            const { suggestions, ...legacy } = cataloguePayload;
+            fetchMock.mockResolvedValue(jsonResponse(legacy));
+            const catalogue = await service.getCatalogue(buildAccount());
+            expect(catalogue.suggestions).toEqual([]);
         });
     });
 
@@ -296,6 +326,105 @@ describe('LearnService', () => {
             fetchMock.mockResolvedValue(jsonResponse({}, 500));
             await expect(
                 service.recordEvents(buildAccount(), [validEvent]),
+            ).rejects.toThrow(UnexpectedServerError);
+        });
+    });
+
+    describe('ask', () => {
+        it('rejects an invalid payload with ParameterError', async () => {
+            const { service } = buildService();
+            await expect(
+                service.ask(buildAccount(), { query: '' }),
+            ).rejects.toThrow(ParameterError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('rejects a query over the published length cap', async () => {
+            const { service } = buildService();
+            await expect(
+                service.ask(buildAccount(), {
+                    query: 'x'.repeat(LEARN_ASK_QUERY_MAX_LENGTH + 1),
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('searches on an instance with no service token', async () => {
+            const { service } = buildService({ withToken: false });
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    results: [
+                        {
+                            courseId: 'viewer-fundamentals',
+                            lessonId: 'l1',
+                            title: 'Lesson One',
+                            score: 0.72,
+                        },
+                    ],
+                }),
+            );
+            const result = await service.ask(buildAccount(), {
+                query: 'deliveries',
+            });
+            expect(result.matches).toHaveLength(1);
+            const [url, init] = fetchMock.mock.calls[0];
+            expect(url).toBe('https://progress.test/api/v1/ask');
+            expect(
+                (init.headers as Record<string, string>).authorization,
+            ).toBeUndefined();
+        });
+
+        it('forwards the query, normalises a missing lessonId and drops unknown per-match fields', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(
+                jsonResponse({
+                    results: [
+                        {
+                            courseId: 'viewer-fundamentals',
+                            lessonId: 'l1',
+                            title: 'Lesson One',
+                            score: 0.72,
+                            snippet: 'internal debugging text',
+                        },
+                        {
+                            courseId: 'deliveries',
+                            title: 'Deliveries',
+                            score: 0.51,
+                        },
+                    ],
+                }),
+            );
+            const result = await service.ask(buildAccount(), {
+                query: 'email me a dashboard',
+            });
+            expect(result.matches).toEqual([
+                {
+                    courseId: 'viewer-fundamentals',
+                    lessonId: 'l1',
+                    title: 'Lesson One',
+                    score: 0.72,
+                },
+                {
+                    courseId: 'deliveries',
+                    lessonId: null,
+                    title: 'Deliveries',
+                    score: 0.51,
+                },
+            ]);
+            const [url, init] = fetchMock.mock.calls[0];
+            // Upstream ask never reads the learner: no email in the URL or body.
+            expect(url).toBe('https://progress.test/api/v1/ask');
+            expect(init.method).toBe('POST');
+            expect(JSON.parse(init.body as string)).toEqual({
+                query: 'email me a dashboard',
+            });
+        });
+
+        it('maps a search outage to UnexpectedServerError', async () => {
+            const { service } = buildService();
+            fetchMock.mockResolvedValue(jsonResponse({}, 503));
+            await expect(
+                service.ask(buildAccount(), { query: 'anything' }),
             ).rejects.toThrow(UnexpectedServerError);
         });
     });

--- a/packages/backend/src/services/LearnService/LearnService.ts
+++ b/packages/backend/src/services/LearnService/LearnService.ts
@@ -2,6 +2,8 @@ import {
     assertRegisteredAccount,
     FeatureFlags,
     ForbiddenError,
+    LearnAskRequestSchema,
+    LearnAskResponseSchema,
     LearnCatalogueSchema,
     LearnCourseSchema,
     LearnEventInputSchema,
@@ -11,6 +13,7 @@ import {
     UnexpectedServerError,
     type Account,
     type ApiLearnEventsResponse,
+    type LearnAskResults,
     type LearnCatalogue,
     type LearnCourse,
     type LearnEventInput,
@@ -177,6 +180,41 @@ export class LearnService extends BaseService {
             throw new UnexpectedServerError('Could not load Learn progress');
         }
         return { courses: parsed.data.courses, serverSynced: true };
+    }
+
+    async ask(account: Account, body: unknown): Promise<LearnAskResults> {
+        await this.assertLearnEnabled(account);
+        const request = LearnAskRequestSchema.safeParse(body);
+        if (!request.success) {
+            throw new ParameterError('Invalid Learn ask payload');
+        }
+        // Upstream search is unauthenticated and never reads the learner, so it
+        // carries neither the service token nor the email: it works unconfigured.
+        const { progressApiUrl } = this.lightdashConfig.learn;
+        const response = await this.fetchUpstream(
+            `${progressApiUrl}/api/v1/ask`,
+            {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify(request.data),
+            },
+        );
+        if (!response.ok) {
+            this.logger.warn('Learn ask service returned an error', {
+                statusCode: response.status,
+            });
+            throw new UnexpectedServerError('Could not search Learn content');
+        }
+        const parsed = LearnAskResponseSchema.safeParse(
+            await LearnService.parseJson(response),
+        );
+        if (!parsed.success) {
+            this.logger.warn('Learn ask results failed validation', {
+                issueCount: parsed.error.issues.length,
+            });
+            throw new UnexpectedServerError('Could not search Learn content');
+        }
+        return { matches: parsed.data.results };
     }
 
     async recordEvents(

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -223,6 +223,7 @@ import type {
 } from './groups';
 import { type ApiImpersonationOrganizationSettingsResponse } from './impersonationOrganizationSettings';
 import {
+    type ApiLearnAskResponse,
     type ApiLearnCatalogueResponse,
     type ApiLearnCourseResponse,
     type ApiLearnEventsResponse,
@@ -1315,6 +1316,7 @@ type ApiResults =
     | ApiLearnCourseResponse['results']
     | ApiLearnProgressResponse['results']
     | ApiLearnEventsResponse['results']
+    | ApiLearnAskResponse['results']
     | ChartHistory
     | ChartVersion
     | DashboardHistory

--- a/packages/common/src/types/learn.ts
+++ b/packages/common/src/types/learn.ts
@@ -23,9 +23,16 @@ export type LearnCatalogueEntry = {
     publishedAt: string;
 };
 
+/** A curated Ask chip: the question, and the module that answers it. */
+export type LearnAskSuggestion = {
+    query: string;
+    courseId: string;
+};
+
 export type LearnCatalogue = {
     generatedAt: string;
     courses: LearnCatalogueEntry[];
+    suggestions: LearnAskSuggestion[];
 };
 
 const LearnFeatureRequirementSchema = z.object({
@@ -52,10 +59,16 @@ export const LearnCatalogueEntrySchema: z.ZodType<LearnCatalogueEntry> = z
     })
     .passthrough() as unknown as z.ZodType<LearnCatalogueEntry>;
 
+const LearnAskSuggestionSchema = z.object({
+    query: z.string().min(1),
+    courseId: z.string().min(1),
+});
+
 export const LearnCatalogueSchema: z.ZodType<LearnCatalogue> = z
     .object({
         generatedAt: z.string(),
         courses: z.array(LearnCatalogueEntrySchema),
+        suggestions: z.array(LearnAskSuggestionSchema).default([]),
     })
     .passthrough() as unknown as z.ZodType<LearnCatalogue>;
 
@@ -290,4 +303,49 @@ export type ApiLearnProgressResponse = {
 export type ApiLearnEventsResponse = {
     status: 'ok';
     results: { accepted: number };
+};
+
+export type LearnAskRequest = {
+    query: string;
+};
+
+/** The longest question the search accepts: shared by the schema and the input. */
+export const LEARN_ASK_QUERY_MAX_LENGTH = 500;
+
+export const LearnAskRequestSchema: z.ZodType<LearnAskRequest> = z
+    .object({
+        query: z.string().min(1).max(LEARN_ASK_QUERY_MAX_LENGTH),
+    })
+    .strict() as unknown as z.ZodType<LearnAskRequest>;
+
+export type LearnAskMatch = {
+    courseId: string;
+    lessonId: string | null;
+    title: string;
+    score: number;
+};
+
+export type LearnAskResults = {
+    matches: LearnAskMatch[];
+};
+
+export const LearnAskResponseSchema = z
+    .object({
+        results: z.array(
+            z.object({
+                courseId: z.string().min(1),
+                lessonId: z
+                    .string()
+                    .nullish()
+                    .transform((value) => value ?? null),
+                title: z.string(),
+                score: z.number(),
+            }),
+        ),
+    })
+    .passthrough();
+
+export type ApiLearnAskResponse = {
+    status: 'ok';
+    results: LearnAskResults;
 };

--- a/packages/frontend/src/features/learn/board/CLAUDE.md
+++ b/packages/frontend/src/features/learn/board/CLAUDE.md
@@ -1,0 +1,45 @@
+<summary>
+The scope-driven course board that is the Learn section's landing page: role tabs, one ring of module nodes per permission group lit by the selected role's scopes, an Ask bar that searches the library and lights the answer, and a rail with overall progress, a resume queue and a module detail pane. Everything derivable is a pure function; the components only render.
+</summary>
+
+<howToUse>
+`components/LearnBoardPanel.tsx` is the only entry point. It owns the selected role, the selected module, and the submitted ask query, and feeds three pure layers:
+
+- `model.ts`: scope tags (`holds`, `parseScopeTag`), grouping (`groupOf`, `GROUP_ORDER`), role scope sets (`roleScopes`, `heldBy`), the held course (`courseFor`) and the rail numbers (`railModel`).
+- `layout.ts`: `buildLayout(modules)` returns seats, connectors and captions in a fixed 1120px board space; `seatMap` gives the previous seats for a role change.
+- `motion.ts`: `resolveMotion(input)` turns a seat change into the per-node fly-in or collapse.
+
+Ask adds a copied layer plus its lightdash-only view layer:
+
+- `ask.ts` (copied): `askHighlights(matches, entries, held)` splits held matches from locked ones, `suggestionsFor(suggestions, entries, held)` filters the curated chips down to `SUGGESTION_LIMIT`, `lockedLabel(entry)` names the lowest role that holds a module or null when every role does.
+- `askView.ts` (lightdash only): `resolveMatches` drops results the catalogue lost and caps at `ASK_RESULT_LIMIT`, `boardHighlights` adapts the published match type, `nodeAskState`/`askOpacity`/`askScale` drive the per-node treatment, `groupMatches` groups the results list, `lockedNote` is `lockedLabel` with a fallback.
+</howToUse>
+
+<codeExample>
+
+```tsx
+// An answer lights the modules it matched and dims everything else.
+const matches = resolveMatches(ask.data.matches, entries);
+const highlights = boardHighlights(matches, entries, roleScopes(role));
+<ClusterBoard entries={entries} held={held} highlights={highlights} ... />;
+```
+
+</codeExample>
+
+<importantToKnow>
+- **Copied files, one sync rule.** Four modules, `model.ts`, `layout.ts`, `motion.ts` and `ask.ts`, plus `testFixtures.ts` and the tests `model.test.ts`, `layout.test.ts`, `motion.test.ts`, `ask.test.ts` are byte-identical twins of lightdash-university's `academy/board/` and `test/academy-board-*.test.ts`. A change to any of them lands in **both** repositories in the same piece of work, tests included, and both sides must survive `oxfmt` unchanged. The one permitted difference is the leading comment and import block: LU's `academy/board/scopeSource.ts` stands in for `@lightdash/common`. `npm run board:sync-check -- --lightdash <path>` in LU diffs the pairs.
+- **`askView.ts` is lightdash only.** Anything the components need that the copied files do not export lives there, built on top of them. Nothing lightdash-specific may go into a copied file.
+- **The Ask bar sits above the role tabs**, so the tabs are next to the rings the nodes fly out of. Switching role keeps the answer and re-derives which of its matches are locked; only the query changing replaces it. Asking does not close an open module pane, which is the academy's behaviour too.
+- **One search at a time.** Every submit costs an upstream embedding, so a submit while a request is in flight is ignored, re-asking the question already answered is a no-op, and the panel tags each request with a sequence id so a late response never overwrites a newer answer. The previous answer and its highlights stay on screen while the next request runs.
+- **Progress is never revoked by a role change.** `railModel` scores every module but filters the board, queue and totals by the held course, so a completed module stays completed after a role switch.
+- **Ask never blocks the board.** It fails inline: a failed request shows "Couldn't search right now", nothing left after `resolveMatches` shows "Nothing in the library matches that yet", and the board is left untouched in both cases. Results are resolved against the catalogue and capped once, before both the list and the highlights, so the two light the same set.
+- **A locked match is visible, not openable.** Locked modules have no ring seat, so a locked match is parked at its cluster centre and takes no part in the role-switch flight. Its group in the results list names the lowest holding role instead of an Open link; the node stays disabled and out of the accessibility tree, so the results list is the accessible route to that answer. A matched glow beats the next-up pulse: two highlights at once read as two answers.
+- **Suggestion chips are content.** They come from `catalogue.suggestions`, curated in lightdash-university and validated against promoted modules there. The field defaults to `[]`, so an older catalogue simply shows no chips.
+- **The board geometry is fixed at 1120px** and scaled down with a transform to fit the column. Seats are in board space, so anything converting client coordinates must divide by the same scale.
+</importantToKnow>
+
+<links>
+- @/packages/frontend/src/features/learn/hooks.ts (catalogue, course, rollups, ask)
+- @/packages/backend/src/services/LearnService/LearnService.ts (the proxies these hooks call)
+- @/packages/common/src/types/learn.ts (the published contract and its zod schemas)
+</links>

--- a/packages/frontend/src/features/learn/board/ask.test.ts
+++ b/packages/frontend/src/features/learn/board/ask.test.ts
@@ -1,0 +1,135 @@
+// Ask derivation tests. Twin: lightdash-university test/academy-board-ask.test.ts.
+// A change here lands in both repositories in the same piece of work.
+
+import { ProjectMemberRole } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { askHighlights, lockedLabel, suggestionsFor } from './ask';
+import { roleScopes } from './model';
+import { entry } from './testFixtures';
+
+const library = [
+    entry({ id: 'foundation', scope: 'view:Project' }),
+    entry({ id: 'dashboards', scope: 'manage:Dashboard' }),
+    entry({ id: 'org', scope: 'manage:Organization' }),
+];
+const viewer = roleScopes(ProjectMemberRole.VIEWER);
+const admin = roleScopes(ProjectMemberRole.ADMIN);
+
+const match = (courseId: string, score = 0.9) => ({
+    courseId,
+    title: courseId,
+    score,
+});
+
+describe('askHighlights', () => {
+    it('splits matches into the ones the role holds and the ones it does not', () => {
+        const { matched, locked } = askHighlights(
+            [match('foundation'), match('org')],
+            library,
+            viewer,
+        );
+        expect([...matched]).toEqual(['foundation']);
+        expect([...locked]).toEqual(['org']);
+    });
+
+    it('locks nothing for a role that holds everything', () => {
+        const { matched, locked } = askHighlights(
+            [match('foundation'), match('org')],
+            library,
+            admin,
+        );
+        expect([...matched].sort()).toEqual(['foundation', 'org']);
+        expect(locked.size).toBe(0);
+    });
+
+    it('drops results naming a module the catalogue does not have', () => {
+        const { matched, locked } = askHighlights(
+            [match('ghost')],
+            library,
+            admin,
+        );
+        expect(matched.size).toBe(0);
+        expect(locked.size).toBe(0);
+    });
+
+    it('de-duplicates lesson-level matches within one module', () => {
+        const { matched } = askHighlights(
+            [
+                {
+                    courseId: 'foundation',
+                    lessonId: '01',
+                    title: 'One',
+                    score: 0.9,
+                },
+                {
+                    courseId: 'foundation',
+                    lessonId: '02',
+                    title: 'Two',
+                    score: 0.8,
+                },
+            ],
+            library,
+            viewer,
+        );
+        expect([...matched]).toEqual(['foundation']);
+    });
+
+    it('highlights nothing for an empty result list', () => {
+        const { matched, locked } = askHighlights([], library, viewer);
+        expect(matched.size).toBe(0);
+        expect(locked.size).toBe(0);
+    });
+});
+
+describe('suggestionsFor', () => {
+    const suggestions = [
+        { query: 'Where do I find things?', courseId: 'foundation' },
+        { query: 'How do I run the org?', courseId: 'org' },
+        { query: 'Ghost', courseId: 'not-in-catalogue' },
+    ];
+
+    it('keeps only suggestions whose module the role holds', () => {
+        expect(
+            suggestionsFor(suggestions, library, viewer).map((s) => s.courseId),
+        ).toEqual(['foundation']);
+    });
+
+    it('keeps authored order for a role that holds more', () => {
+        expect(
+            suggestionsFor(suggestions, library, admin).map((s) => s.courseId),
+        ).toEqual(['foundation', 'org']);
+    });
+
+    it('caps the chips at one row of three, in authored order', () => {
+        const many = [1, 2, 3, 4, 5].map((n) => ({
+            query: `Question ${n}`,
+            courseId: 'foundation',
+        }));
+        expect(
+            suggestionsFor(many, library, viewer).map((s) => s.query),
+        ).toEqual(['Question 1', 'Question 2', 'Question 3']);
+    });
+
+    it('drops a suggestion naming a module the catalogue does not have', () => {
+        expect(
+            suggestionsFor(suggestions, library, admin).some(
+                (s) => s.courseId === 'not-in-catalogue',
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('lockedLabel', () => {
+    it('names the lowest role that can open the module', () => {
+        expect(
+            lockedLabel(entry({ id: 'org', scope: 'manage:Organization' })),
+        ).toBe('admin and above');
+    });
+
+    it('is null when every system role holds it, so there is nothing to explain', () => {
+        expect(
+            lockedLabel(entry({ id: 'foundation', scope: 'view:Project' })),
+        ).toBeNull();
+        expect(lockedLabel(entry({ id: 'untagged', scope: null }))).toBeNull();
+    });
+});

--- a/packages/frontend/src/features/learn/board/ask.ts
+++ b/packages/frontend/src/features/learn/board/ask.ts
@@ -1,0 +1,82 @@
+// Ask derivations. Twin: lightdash-university academy/board/ask.ts.
+// A change here lands in both repositories in the same piece of work.
+
+import { type LearnCatalogueEntry } from '@lightdash/common';
+import {
+    courseFor,
+    heldBy,
+    isUnlocked,
+    ROLE_LABEL,
+    SYSTEM_ROLES,
+} from './model';
+
+/** One lesson match from the ask API. */
+export type AskMatch = {
+    courseId: string;
+    lessonId?: string;
+    title: string;
+    score: number;
+};
+
+/** A curated chip, as published on the catalogue. */
+export type AskSuggestion = { query: string; courseId: string };
+
+export type AskHighlights = {
+    /** Modules the role holds that the query hit: these glow. */
+    matched: Set<string>;
+    /** Modules the query hit that the role cannot open: outlined, not hidden. */
+    locked: Set<string>;
+};
+
+/**
+ * A locked match is shown rather than filtered out: the answer existing is
+ * useful even when the learner cannot open it yet, and hiding it would make the
+ * board look like the library has no answer at all.
+ */
+export const askHighlights = (
+    results: AskMatch[],
+    entries: LearnCatalogueEntry[],
+    held: Iterable<string>,
+): AskHighlights => {
+    const heldList = Array.from(held);
+    const byId = new Map(entries.map((entry) => [entry.id, entry]));
+    const matched = new Set<string>();
+    const locked = new Set<string>();
+    for (const result of results) {
+        const entry = byId.get(result.courseId);
+        if (!entry) continue;
+        if (isUnlocked(entry, heldList)) matched.add(entry.id);
+        else locked.add(entry.id);
+    }
+    return { matched, locked };
+};
+
+/**
+ * Chips are offers, not answers, so an offer the role cannot take is worse than
+ * one fewer chip. Authored order is kept: the library curates which reads first.
+ */
+/** Chips stay on one row: the first few authored suggestions the role can use. */
+export const SUGGESTION_LIMIT = 3;
+
+export const suggestionsFor = (
+    suggestions: AskSuggestion[],
+    entries: LearnCatalogueEntry[],
+    held: Iterable<string>,
+): AskSuggestion[] => {
+    const holdable = new Set(courseFor(entries, held).map((entry) => entry.id));
+    return suggestions
+        .filter((s) => holdable.has(s.courseId))
+        .slice(0, SUGGESTION_LIMIT);
+};
+
+/**
+ * What to say beside a locked match. Null when every system role holds the
+ * module, because then the lock is not about the role and naming one would
+ * mislead.
+ */
+export const lockedLabel = (entry: LearnCatalogueEntry): string | null => {
+    const holders = heldBy(entry);
+    if (holders.length === 0 || holders.length === SYSTEM_ROLES.length)
+        return null;
+    return `${ROLE_LABEL[holders[0]]} and above`;
+};

--- a/packages/frontend/src/features/learn/board/askView.test.ts
+++ b/packages/frontend/src/features/learn/board/askView.test.ts
@@ -1,0 +1,138 @@
+import {
+    getAllScopesForRole,
+    ProjectMemberRole,
+    type LearnAskMatch,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    ASK_RESULT_LIMIT,
+    askOpacity,
+    askScale,
+    boardHighlights,
+    groupMatches,
+    lockedNote,
+    nodeAskState,
+    resolveMatches,
+} from './askView';
+import { entry } from './testFixtures';
+
+const entries = [
+    entry({ id: 'foundation', scope: 'view:Project' }),
+    entry({ id: 'dashboards', scope: 'manage:Dashboard' }),
+    entry({ id: 'spaces', scope: 'manage:Space' }),
+];
+
+const viewerScopes = getAllScopesForRole(ProjectMemberRole.VIEWER);
+
+const match = (courseId: string, score: number): LearnAskMatch => ({
+    courseId,
+    lessonId: 'l1',
+    title: `${courseId} lesson`,
+    score,
+});
+
+describe('resolveMatches', () => {
+    it('drops matches naming a module this catalogue does not carry', () => {
+        expect(
+            resolveMatches(
+                [match('retired-module', 0.9), match('foundation', 0.8)],
+                entries,
+            ),
+        ).toEqual([match('foundation', 0.8)]);
+    });
+
+    it('caps the list once, so the board and the list light the same set', () => {
+        const many = Array.from({ length: 8 }, (_, i) =>
+            match('foundation', 1 - i / 10),
+        );
+        expect(resolveMatches(many, entries)).toHaveLength(ASK_RESULT_LIMIT);
+    });
+});
+
+describe('boardHighlights', () => {
+    it('splits held matches from locked ones', () => {
+        const highlights = boardHighlights(
+            [match('foundation', 0.8), match('dashboards', 0.6)],
+            entries,
+            viewerScopes,
+        );
+        expect([...highlights.matched]).toEqual(['foundation']);
+        expect([...highlights.locked]).toEqual(['dashboards']);
+    });
+});
+
+describe('nodeAskState', () => {
+    const highlights = {
+        matched: new Set(['foundation']),
+        locked: new Set(['dashboards']),
+    };
+
+    it('is none when nothing is highlighted', () => {
+        expect(nodeAskState('foundation', null)).toBe('none');
+    });
+
+    it('marks matched, locked and dimmed nodes', () => {
+        expect(nodeAskState('foundation', highlights)).toBe('matched');
+        expect(nodeAskState('dashboards', highlights)).toBe('locked-match');
+        expect(nodeAskState('spaces', highlights)).toBe('dimmed');
+    });
+});
+
+describe('askOpacity / askScale', () => {
+    it('leaves untouched and matched nodes on their motion values', () => {
+        expect(askOpacity('none', 1)).toBe(1);
+        expect(askOpacity('matched', 1)).toBe(1);
+        expect(askScale('matched', 1)).toBe(1);
+    });
+
+    it('dims everything else to 40 percent of its motion opacity', () => {
+        expect(askOpacity('dimmed', 1)).toBe(0.4);
+        expect(askOpacity('dimmed', 0)).toBe(0);
+    });
+
+    it('surfaces a locked match that motion would have hidden', () => {
+        expect(askOpacity('locked-match', 0)).toBe(0.4);
+        expect(askScale('locked-match', 0.3)).toBe(1);
+    });
+});
+
+describe('groupMatches', () => {
+    it('groups by module and keeps first-seen order', () => {
+        expect(
+            groupMatches([
+                match('dashboards', 0.9),
+                match('foundation', 0.8),
+                { ...match('dashboards', 0.7), lessonId: 'l2' },
+            ]),
+        ).toEqual([
+            {
+                courseId: 'dashboards',
+                matches: [
+                    match('dashboards', 0.9),
+                    { ...match('dashboards', 0.7), lessonId: 'l2' },
+                ],
+            },
+            { courseId: 'foundation', matches: [match('foundation', 0.8)] },
+        ]);
+    });
+});
+
+describe('lockedNote', () => {
+    it('names the lowest role that holds the module', () => {
+        // 'manage:Dashboard' is held from interactive viewer up (the
+        // '@space' variant satisfies it, see model.test.ts), so this uses
+        // 'manage:Tags', which has no scoped lower-tier variant and is
+        // genuinely editor-and-above.
+        expect(lockedNote(entry({ id: 'tags', scope: 'manage:Tags' }))).toBe(
+            'editor and above',
+        );
+    });
+
+    it('says custom roles only when there is no system role to name', () => {
+        // An untagged module is held by every system role, so lockedLabel has
+        // nothing to name and the pane still needs a line.
+        expect(lockedNote(entry({ id: 'x', scope: null }))).toBe(
+            'custom roles only',
+        );
+    });
+});

--- a/packages/frontend/src/features/learn/board/askView.ts
+++ b/packages/frontend/src/features/learn/board/askView.ts
@@ -1,0 +1,118 @@
+// Board-only view helpers over the copied ask.ts. Lightdash side only: nothing
+// here has a twin in lightdash-university.
+
+import {
+    assertUnreachable,
+    type LearnAskMatch,
+    type LearnCatalogueEntry,
+} from '@lightdash/common';
+import {
+    askHighlights,
+    lockedLabel,
+    type AskHighlights,
+    type AskMatch,
+} from './ask';
+
+/** The results list stops at five: past that it stops reading as an answer. */
+export const ASK_RESULT_LIMIT = 5;
+
+const DIM_OPACITY = 0.4;
+
+export type NodeAskState = 'none' | 'matched' | 'locked-match' | 'dimmed';
+
+/**
+ * The search ranks embeddings and can name a module this catalogue does not
+ * carry. Resolve against the library and cap once, so the list and the lit
+ * nodes are the same set.
+ */
+export const resolveMatches = (
+    matches: LearnAskMatch[],
+    entries: LearnCatalogueEntry[],
+): LearnAskMatch[] => {
+    const known = new Set(entries.map((entry) => entry.id));
+    return matches
+        .filter((match) => known.has(match.courseId))
+        .slice(0, ASK_RESULT_LIMIT);
+};
+
+// The published match carries `lessonId: string | null` where the copied
+// AskMatch declares it optional; only the course id is read either way.
+const asAskMatch = ({ courseId, title, score }: LearnAskMatch): AskMatch => ({
+    courseId,
+    title,
+    score,
+});
+
+export const boardHighlights = (
+    matches: LearnAskMatch[],
+    entries: LearnCatalogueEntry[],
+    held: string[],
+): AskHighlights => askHighlights(matches.map(asAskMatch), entries, held);
+
+export const nodeAskState = (
+    id: string,
+    highlights: AskHighlights | null,
+): NodeAskState => {
+    if (highlights === null) return 'none';
+    if (highlights.matched.has(id)) return 'matched';
+    if (highlights.locked.has(id)) return 'locked-match';
+    return 'dimmed';
+};
+
+export const askOpacity = (
+    state: NodeAskState,
+    motionOpacity: number,
+): number => {
+    switch (state) {
+        case 'none':
+        case 'matched':
+            return motionOpacity;
+        case 'dimmed':
+            return motionOpacity * DIM_OPACITY;
+        case 'locked-match':
+            return DIM_OPACITY;
+        default:
+            return assertUnreachable(state, 'Unknown ask state');
+    }
+};
+
+export const askScale = (state: NodeAskState, motionScale: number): number => {
+    switch (state) {
+        case 'none':
+        case 'matched':
+        case 'dimmed':
+            return motionScale;
+        case 'locked-match':
+            return 1;
+        default:
+            return assertUnreachable(state, 'Unknown ask state');
+    }
+};
+
+export type AskGroup = {
+    courseId: string;
+    matches: LearnAskMatch[];
+};
+
+export const groupMatches = (matches: LearnAskMatch[]): AskGroup[] => {
+    const groups: AskGroup[] = [];
+    const byCourse = new Map<string, AskGroup>();
+    for (const result of matches) {
+        const existing = byCourse.get(result.courseId);
+        if (existing) {
+            existing.matches.push(result);
+            continue;
+        }
+        const group: AskGroup = {
+            courseId: result.courseId,
+            matches: [result],
+        };
+        byCourse.set(result.courseId, group);
+        groups.push(group);
+    }
+    return groups;
+};
+
+/** Who can reach a module the selected role cannot, for a locked match. */
+export const lockedNote = (entry: LearnCatalogueEntry): string =>
+    lockedLabel(entry) ?? 'custom roles only';

--- a/packages/frontend/src/features/learn/board/components/AskBar.test.tsx
+++ b/packages/frontend/src/features/learn/board/components/AskBar.test.tsx
@@ -1,0 +1,171 @@
+import { type LearnAskMatch } from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import { entry } from '../testFixtures';
+import { AskBar, type AskBarProps } from './AskBar';
+
+const entries = [
+    entry({ id: 'foundation', title: 'Getting around', scope: 'view:Project' }),
+    entry({
+        id: 'dashboards',
+        title: 'Building dashboards',
+        scope: 'manage:Dashboard',
+    }),
+];
+
+const match = (courseId: string, lessonId: string | null): LearnAskMatch => ({
+    courseId,
+    lessonId,
+    title: `${courseId} lesson`,
+    score: 0.7,
+});
+
+const renderBar = (overrides: Partial<AskBarProps> = {}) => {
+    const props: AskBarProps = {
+        entries,
+        suggestions: [
+            { query: 'Where do I find a chart?', courseId: 'foundation' },
+        ],
+        matches: null,
+        lockedIds: new Set<string>(),
+        isSearching: false,
+        isError: false,
+        onSubmit: vi.fn(),
+        onClear: vi.fn(),
+        onOpen: vi.fn(),
+        ...overrides,
+    };
+    renderWithProviders(<AskBar {...props} />);
+    return props;
+};
+
+describe('AskBar', () => {
+    it('submits the typed question', () => {
+        const props = renderBar();
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'email me a dashboard' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).toHaveBeenCalledWith('email me a dashboard');
+    });
+
+    it('clears instead of searching when the box is empty', () => {
+        const props = renderBar();
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).not.toHaveBeenCalled();
+        expect(props.onClear).toHaveBeenCalled();
+    });
+
+    it('treats a whitespace-only question as a clear, box included', () => {
+        const props = renderBar();
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: '   ' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).not.toHaveBeenCalled();
+        expect(props.onClear).toHaveBeenCalled();
+        expect(screen.getByRole('searchbox')).toHaveValue('');
+    });
+
+    it('caps the box at the length the request schema accepts', () => {
+        renderBar();
+        expect(screen.getByRole('searchbox')).toHaveAttribute(
+            'maxlength',
+            '500',
+        );
+    });
+
+    it('sends one request for a double submit of the same question', () => {
+        const props = renderBar({ matches: [match('foundation', 'l1')] });
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'where are my charts' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends nothing while a search is already in flight', () => {
+        const props = renderBar({ isSearching: true });
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'anything' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('re-runs a question that failed', () => {
+        const props = renderBar({ isError: true });
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'anything' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        fireEvent.submit(screen.getByRole('search'));
+        expect(props.onSubmit).toHaveBeenCalledTimes(2);
+    });
+
+    it('runs a suggestion chip as a query', () => {
+        const props = renderBar();
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Where do I find a chart?' }),
+        );
+        expect(props.onSubmit).toHaveBeenCalledWith('Where do I find a chart?');
+    });
+
+    it('groups results by module and opens the matched lesson', () => {
+        const props = renderBar({ matches: [match('foundation', 'l2')] });
+        expect(screen.getByText('Getting around')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+        expect(props.onOpen).toHaveBeenCalledWith('foundation', 'l2');
+    });
+
+    it('names the lowest holding role for a locked match instead of opening it', () => {
+        renderBar({
+            matches: [match('dashboards', 'l1')],
+            lockedIds: new Set(['dashboards']),
+        });
+        // manage:Dashboard is held from interactive viewer up via space access.
+        expect(
+            screen.getByText('interactive viewer and above'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Open' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows the empty copy when nothing matched', () => {
+        renderBar({ matches: [] });
+        expect(
+            screen.getByText('Nothing in the library matches that yet'),
+        ).toBeInTheDocument();
+    });
+
+    it('shows the failure copy when the search request failed', () => {
+        renderBar({ isError: true });
+        expect(
+            screen.getByText("Couldn't search right now"),
+        ).toBeInTheDocument();
+    });
+
+    it('clears the box and the board with the clear button', () => {
+        const props = renderBar({ matches: [match('foundation', 'l1')] });
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'anything' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+        expect(screen.getByRole('searchbox')).toHaveValue('');
+        expect(props.onClear).toHaveBeenCalled();
+    });
+
+    it('leaves focus on the input when the clear button unmounts itself', () => {
+        renderBar({ matches: [match('foundation', 'l1')] });
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'anything' },
+        });
+        const clear = screen.getByRole('button', { name: 'Clear search' });
+        clear.focus();
+        fireEvent.click(clear);
+        expect(screen.getByRole('searchbox')).toHaveFocus();
+    });
+});

--- a/packages/frontend/src/features/learn/board/components/AskBar.tsx
+++ b/packages/frontend/src/features/learn/board/components/AskBar.tsx
@@ -1,0 +1,193 @@
+import {
+    LEARN_ASK_QUERY_MAX_LENGTH,
+    type LearnAskMatch,
+    type LearnAskSuggestion,
+    type LearnCatalogueEntry,
+} from '@lightdash/common';
+import { Text } from '@mantine/core';
+import { useRef, useState, type FC, type FormEvent } from 'react';
+import { groupMatches, lockedNote } from '../askView';
+import styles from './LearnBoard.module.css';
+
+export type AskBarProps = {
+    entries: LearnCatalogueEntry[];
+    suggestions: LearnAskSuggestion[];
+    matches: LearnAskMatch[] | null;
+    lockedIds: Set<string>;
+    isSearching: boolean;
+    isError: boolean;
+    onSubmit: (query: string) => void;
+    onClear: () => void;
+    onOpen: (courseId: string, lessonId: string | null) => void;
+};
+
+export const AskBar: FC<AskBarProps> = ({
+    entries,
+    suggestions,
+    matches,
+    lockedIds,
+    isSearching,
+    isError,
+    onSubmit,
+    onClear,
+    onOpen,
+}) => {
+    const [value, setValue] = useState('');
+    const [submitted, setSubmitted] = useState<string | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const byId = new Map(entries.map((e) => [e.id, e]));
+
+    const clear = () => {
+        // Focus first: the × unmounts with the last character, and a focused
+        // button removed in the same commit drops focus to the body.
+        inputRef.current?.focus();
+        setValue('');
+        setSubmitted(null);
+        onClear();
+    };
+
+    // A request in flight, or the question already answered on screen, means
+    // there is nothing to send.
+    const run = (query: string) => {
+        if (isSearching) return;
+        if (query === submitted && matches !== null && !isError) return;
+        setSubmitted(query);
+        onSubmit(query);
+    };
+
+    const submit = (event: FormEvent) => {
+        event.preventDefault();
+        const query = value.trim();
+        if (query === '') {
+            clear();
+            return;
+        }
+        run(query);
+    };
+
+    const runSuggestion = (query: string) => {
+        setValue(query);
+        run(query);
+    };
+
+    return (
+        <div className={styles.ask}>
+            <form className={styles.askForm} role="search" onSubmit={submit}>
+                <input
+                    ref={inputRef}
+                    type="search"
+                    className={styles.askInput}
+                    aria-label="Ask the library"
+                    placeholder="Ask a question about Lightdash"
+                    maxLength={LEARN_ASK_QUERY_MAX_LENGTH}
+                    value={value}
+                    onChange={(event) => setValue(event.target.value)}
+                />
+                {value !== '' && (
+                    <button
+                        type="button"
+                        className={styles.askClear}
+                        aria-label="Clear search"
+                        onClick={clear}
+                    >
+                        ×
+                    </button>
+                )}
+                <button
+                    type="submit"
+                    className={styles.askSubmit}
+                    disabled={isSearching}
+                >
+                    Ask
+                </button>
+            </form>
+
+            {suggestions.length > 0 && (
+                <div className={styles.askChips} data-testid="ask-chips">
+                    {suggestions.map((suggestion, index) => (
+                        <button
+                            key={`${suggestion.courseId}:${index}`}
+                            type="button"
+                            className={styles.askChip}
+                            disabled={isSearching}
+                            onClick={() => runSuggestion(suggestion.query)}
+                        >
+                            {suggestion.query}
+                        </button>
+                    ))}
+                </div>
+            )}
+
+            {isSearching && (
+                <Text size="sm" className={styles.muted}>
+                    Searching…
+                </Text>
+            )}
+            {isError && (
+                <Text size="sm" className={styles.muted}>
+                    Couldn&apos;t search right now
+                </Text>
+            )}
+            {!isError && matches !== null && matches.length === 0 && (
+                <Text size="sm" className={styles.muted}>
+                    Nothing in the library matches that yet
+                </Text>
+            )}
+
+            {!isError && matches !== null && matches.length > 0 && (
+                <ul className={styles.askResults}>
+                    {groupMatches(matches).map((group) => {
+                        const entry = byId.get(group.courseId);
+                        if (!entry) return null;
+                        const locked = lockedIds.has(group.courseId);
+                        return (
+                            <li
+                                key={group.courseId}
+                                className={styles.askGroup}
+                            >
+                                <span className={styles.askModule}>
+                                    {entry.title}
+                                </span>
+                                {/* A locked group names the role that holds it
+                                    once, in place of every row's Open. */}
+                                {locked && (
+                                    <Text
+                                        size="xs"
+                                        className={styles.muted}
+                                        data-testid="ask-locked-note"
+                                    >
+                                        {lockedNote(entry)}
+                                    </Text>
+                                )}
+                                {group.matches.map((result, index) => (
+                                    <span
+                                        key={`${group.courseId}:${index}`}
+                                        className={styles.askRow}
+                                    >
+                                        <span className={styles.askLesson}>
+                                            {result.title}
+                                        </span>
+                                        {!locked && (
+                                            <button
+                                                type="button"
+                                                className={styles.askOpen}
+                                                onClick={() =>
+                                                    onOpen(
+                                                        result.courseId,
+                                                        result.lessonId,
+                                                    )
+                                                }
+                                            >
+                                                Open
+                                            </button>
+                                        )}
+                                    </span>
+                                ))}
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </div>
+    );
+};

--- a/packages/frontend/src/features/learn/board/components/BoardNode.tsx
+++ b/packages/frontend/src/features/learn/board/components/BoardNode.tsx
@@ -1,4 +1,5 @@
 import { type FC } from 'react';
+import { askOpacity, askScale, type NodeAskState } from '../askView';
 import { NODE_SIZE } from '../layout';
 import { plural } from '../model';
 import { NODE_TRANSITION, staggerMs, type NodeMotion } from '../motion';
@@ -16,6 +17,7 @@ export type BoardNodeProps = {
     nextUp: boolean;
     index: number;
     motion: NodeMotion;
+    askState: NodeAskState;
     onSelect: (id: string) => void;
 };
 
@@ -30,9 +32,10 @@ export const BoardNode: FC<BoardNodeProps> = ({
     nextUp,
     index,
     motion,
+    askState,
     onSelect,
 }) => {
-    const showPulse = nextUp && unlocked && !selected;
+    const showPulse = nextUp && unlocked && !selected && askState === 'none';
     // Ring/glow/label colour are enumerable states, so they live as CSS
     // modifier classes; only continuous per-node values stay inline.
     const className = [
@@ -41,6 +44,8 @@ export const BoardNode: FC<BoardNodeProps> = ({
         unlocked && done && styles.nodeDone,
         selected && styles.nodeSelected,
         showPulse && styles.nodeNextUp,
+        askState === 'matched' && styles.nodeMatched,
+        askState === 'locked-match' && styles.nodeLockedMatch,
     ]
         .filter(Boolean)
         .join(' ');
@@ -59,8 +64,8 @@ export const BoardNode: FC<BoardNodeProps> = ({
                 left: motion.x - NODE_SIZE / 2,
                 top: motion.y - NODE_SIZE / 2,
                 background: unlocked ? progressFill(progress) : undefined,
-                opacity: motion.opacity,
-                transform: `scale(${motion.scale})`,
+                opacity: askOpacity(askState, motion.opacity),
+                transform: `scale(${askScale(askState, motion.scale)})`,
                 transition: motion.animate ? NODE_TRANSITION : 'none',
                 transitionDelay: motion.animate
                     ? `${staggerMs(index)}ms`

--- a/packages/frontend/src/features/learn/board/components/ClusterBoard.test.tsx
+++ b/packages/frontend/src/features/learn/board/components/ClusterBoard.test.tsx
@@ -1,0 +1,124 @@
+import { getAllScopesForRole, ProjectMemberRole } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { createRef, type ComponentProps } from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import { type Rollup } from '../../model';
+import { entry } from '../testFixtures';
+import { ClusterBoard } from './ClusterBoard';
+
+const entries = [
+    entry({ id: 'foundation', title: 'Getting around', scope: 'view:Project' }),
+    // Untagged, so every role holds it: a second lit node with no scope guesswork.
+    entry({ id: 'sharing', title: 'Sharing your work', scope: null }),
+    entry({
+        id: 'dashboards',
+        title: 'Building dashboards',
+        scope: 'manage:Dashboard',
+    }),
+];
+
+type BoardOverrides = Partial<
+    Pick<
+        ComponentProps<typeof ClusterBoard>,
+        'prevHeld' | 'origin' | 'reducedMotion'
+    >
+>;
+
+const renderBoard = (
+    highlights: { matched: Set<string>; locked: Set<string> } | null,
+    nextUpId: string | null = null,
+    overrides: BoardOverrides = {},
+) =>
+    renderWithProviders(
+        <ClusterBoard
+            entries={entries}
+            held={getAllScopesForRole(ProjectMemberRole.VIEWER)}
+            prevHeld={null}
+            rollups={new Map<string, Rollup>()}
+            selectedId={null}
+            nextUpId={nextUpId}
+            origin={null}
+            burst={false}
+            reducedMotion
+            highlights={highlights}
+            onSelect={() => {}}
+            boardRef={createRef<HTMLDivElement>()}
+            {...overrides}
+        />,
+    );
+
+const nodeFor = (title: string): HTMLElement => {
+    const node = screen
+        .getByTestId('learn-board')
+        .querySelector<HTMLElement>(`[aria-label^="${title}"]`);
+    if (!node) throw new Error(`no node for ${title}`);
+    return node;
+};
+
+describe('ClusterBoard ask states', () => {
+    it('leaves every node at full opacity with no highlights', () => {
+        renderBoard(null);
+        expect(nodeFor('Getting around').style.opacity).toBe('1');
+        expect(nodeFor('Sharing your work').style.opacity).toBe('1');
+    });
+
+    it('dims the modules an answer did not match', () => {
+        renderBoard({
+            matched: new Set(['foundation']),
+            locked: new Set<string>(),
+        });
+        expect(nodeFor('Getting around').style.opacity).toBe('1');
+        expect(nodeFor('Sharing your work').style.opacity).toBe('0.4');
+    });
+
+    it('pulses the next-up module while nothing is lit', () => {
+        renderBoard(null, 'sharing');
+        expect(nodeFor('Sharing your work').className).toMatch(/nodeNextUp/);
+    });
+
+    it('drops the next-up pulse while an answer is lit', () => {
+        // Two highlights at once read as two answers, so the glow wins.
+        renderBoard(
+            { matched: new Set(['foundation']), locked: new Set<string>() },
+            'sharing',
+        );
+        expect(nodeFor('Sharing your work').className).not.toMatch(
+            /nodeNextUp/,
+        );
+    });
+
+    it('surfaces a locked match that would otherwise be invisible', () => {
+        renderBoard({
+            matched: new Set<string>(),
+            locked: new Set(['dashboards']),
+        });
+        const locked = nodeFor('Building dashboards');
+        expect(locked.style.opacity).toBe('0.4');
+        expect(locked.style.transform).toBe('scale(1)');
+    });
+
+    it('keeps a locked match at its seat through a role switch', () => {
+        const highlights = {
+            matched: new Set<string>(),
+            locked: new Set(['dashboards']),
+        };
+        const { unmount } = renderBoard(highlights);
+        const settled = nodeFor('Building dashboards');
+        const seat = { left: settled.style.left, top: settled.style.top };
+        unmount();
+
+        // Editor to viewer: dashboards flies out to the tab above the board,
+        // which is where the answer would otherwise paint its ring.
+        renderBoard(highlights, null, {
+            prevHeld: getAllScopesForRole(ProjectMemberRole.EDITOR),
+            origin: { x: 540, y: -60 },
+            reducedMotion: false,
+        });
+        const locked = nodeFor('Building dashboards');
+        expect(locked.style.left).toBe(seat.left);
+        expect(locked.style.top).toBe(seat.top);
+        expect(locked.style.transform).toBe('scale(1)');
+        expect(locked.style.opacity).toBe('0.4');
+    });
+});

--- a/packages/frontend/src/features/learn/board/components/ClusterBoard.tsx
+++ b/packages/frontend/src/features/learn/board/components/ClusterBoard.tsx
@@ -2,6 +2,8 @@ import { type LearnCatalogueEntry } from '@lightdash/common';
 import { useElementSize } from '@mantine/hooks';
 import { useMemo, type FC, type RefObject } from 'react';
 import { type Rollup } from '../../model';
+import { type AskHighlights } from '../ask';
+import { nodeAskState } from '../askView';
 import {
     BOARD_WIDTH,
     buildLayout,
@@ -30,6 +32,7 @@ export type ClusterBoardProps = {
     origin: Seat | null;
     burst: boolean;
     reducedMotion: boolean;
+    highlights: AskHighlights | null;
     onSelect: (id: string) => void;
     boardRef: RefObject<HTMLDivElement | null>;
 };
@@ -54,6 +57,7 @@ export const ClusterBoard: FC<ClusterBoardProps> = ({
     origin,
     burst,
     reducedMotion,
+    highlights,
     onSelect,
     boardRef,
 }) => {
@@ -151,7 +155,8 @@ export const ClusterBoard: FC<ClusterBoardProps> = ({
                 {layout.nodes.map((node) => {
                     const entry = byId.get(node.id);
                     if (!entry) return null;
-                    const motion = resolveMotion({
+                    const askState = nodeAskState(node.id, highlights);
+                    const flight = resolveMotion({
                         unlocked: node.unlocked,
                         wasUnlocked: prevHeld
                             ? isUnlocked(entry, prevHeld)
@@ -162,6 +167,17 @@ export const ClusterBoard: FC<ClusterBoardProps> = ({
                         burst,
                         reducedMotion,
                     });
+                    // A locked match is parked at its cluster centre: it shows
+                    // an answer, so it takes no part in the role-switch flight.
+                    const motion =
+                        askState === 'locked-match'
+                            ? {
+                                  ...flight,
+                                  x: node.x,
+                                  y: node.y,
+                                  animate: false,
+                              }
+                            : flight;
                     return (
                         <BoardNode
                             key={node.id}
@@ -178,6 +194,7 @@ export const ClusterBoard: FC<ClusterBoardProps> = ({
                             nextUp={nextUpId === node.id}
                             index={node.index}
                             motion={motion}
+                            askState={askState}
                             onSelect={onSelect}
                         />
                     );

--- a/packages/frontend/src/features/learn/board/components/LearnBoard.module.css
+++ b/packages/frontend/src/features/learn/board/components/LearnBoard.module.css
@@ -57,10 +57,14 @@
     color: #818898;
 }
 
+.tabsRow {
+    padding: 4px 28px 10px;
+}
+
 .tabs {
     display: flex;
+    flex-wrap: wrap;
     gap: 6px;
-    margin-top: 8px;
 }
 
 .tab {
@@ -189,6 +193,20 @@
             inset 0 0 0 2px var(--mantine-color-ldBrandViolet-6),
             0 0 0 10px rgba(94, 76, 255, 0);
     }
+}
+
+/* Ask states. Dimming is the inline opacity from askOpacity(); these classes
+   carry only the ring treatment. */
+.nodeMatched {
+    box-shadow:
+        inset 0 0 0 2px var(--mantine-color-ldBrandViolet-6),
+        0 0 0 8px rgba(94, 76, 255, 0.18);
+}
+
+.nodeLockedMatch {
+    background: #ffffff;
+    color: #818898;
+    box-shadow: inset 0 0 0 1.5px #818898;
 }
 
 .rail {
@@ -375,6 +393,132 @@
 .cta:hover {
     /* No ldBrandViolet shade matches this hover tone; kept as a literal. */
     background: #1200b2;
+}
+
+.ask {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 12px;
+}
+
+.askForm {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    background: #ffffff;
+    border-radius: 999px;
+    padding: 4px 4px 4px 16px;
+    box-shadow: inset 0 0 0 1px #e5e7eb;
+}
+
+.askInput {
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 36px;
+    border: 0;
+    outline: none;
+    font: inherit;
+    font-size: 14px;
+    background: transparent;
+    color: #272835;
+}
+
+.askInput::placeholder {
+    color: #818898;
+}
+
+.askClear {
+    width: 24px;
+    height: 24px;
+    flex: none;
+    border: 0;
+    border-radius: 50%;
+    background: transparent;
+    color: #818898;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.askSubmit {
+    height: 36px;
+    flex: none;
+    padding: 0 18px;
+    border: 0;
+    border-radius: 999px;
+    background: var(--mantine-color-ldBrandViolet-6);
+    color: #ffffff;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+/* One row: the chip list is capped, so it never needs to wrap. */
+.askChips {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 6px;
+}
+
+.askChip {
+    height: 28px;
+    padding: 0 12px;
+    border: 0;
+    border-radius: 999px;
+    background: #ffffff;
+    color: #818898;
+    font: inherit;
+    font-size: 12px;
+    cursor: pointer;
+    box-shadow: inset 0 0 0 1px #eceff3;
+}
+
+.askResults {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.askGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.askModule {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #818898;
+}
+
+.askRow {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+}
+
+.askLesson {
+    color: #272835;
+}
+
+.askOpen {
+    border: 0;
+    background: transparent;
+    padding: 0;
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--mantine-color-ldBrandViolet-6);
+    cursor: pointer;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/frontend/src/features/learn/board/components/LearnBoardPanel.test.tsx
+++ b/packages/frontend/src/features/learn/board/components/LearnBoardPanel.test.tsx
@@ -1,9 +1,16 @@
-import { OrganizationMemberRole } from '@lightdash/common';
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { OrganizationMemberRole, type LearnAskMatch } from '@lightdash/common';
+import {
+    act,
+    fireEvent,
+    screen,
+    waitFor,
+    within,
+} from '@testing-library/react';
 import type * as ReactRouter from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../testing/testUtils';
 import { emptyRollup } from '../../model';
+import { SUGGESTION_LIMIT } from '../ask';
 import { entry } from '../testFixtures';
 import { LearnBoardPanel } from './LearnBoardPanel';
 
@@ -24,6 +31,13 @@ const catalogue = [
         scope: 'view:Project',
         lessonCount: 2,
     }),
+    // Untagged, so every role holds it.
+    entry({
+        id: 'sharing',
+        title: 'Sharing your work',
+        scope: null,
+        lessonCount: 2,
+    }),
     entry({
         id: 'dashboards',
         title: 'Building dashboards',
@@ -32,9 +46,46 @@ const catalogue = [
     }),
 ];
 
+type AskCallbacks = {
+    onSuccess?: (data: { matches: LearnAskMatch[] }) => void;
+    onError?: () => void;
+    onSettled?: () => void;
+};
+const askCalls: Array<{ query: string } & AskCallbacks> = [];
+const askMutate = vi.fn(
+    (variables: { query: string }, options: AskCallbacks = {}) => {
+        askCalls.push({ query: variables.query, ...options });
+    },
+);
+// Answers arrive through the mutation callbacks, so a test can settle two
+// requests in whichever order it likes.
+const answerWith = (matches: LearnAskMatch[], index = askCalls.length - 1) => {
+    const call = askCalls[index];
+    act(() => {
+        call.onSuccess?.({ matches });
+        call.onSettled?.();
+    });
+};
+const askState: { isLoading: boolean; isError: boolean } = {
+    isLoading: false,
+    isError: false,
+};
+// Hoisted: the mock factory reads this one eagerly, not from inside a closure.
+const setLessonBookmarkMock = vi.hoisted(() => vi.fn());
+
 vi.mock('../../hooks', () => ({
     useLearnCatalogue: () => ({
-        data: { generatedAt: '2026-08-01T00:00:00.000Z', courses: catalogue },
+        data: {
+            generatedAt: '2026-08-01T00:00:00.000Z',
+            courses: catalogue,
+            suggestions: [
+                { query: 'Where do I find a chart?', courseId: 'foundation' },
+                { query: 'How do I build one?', courseId: 'dashboards' },
+                { query: 'How do I share it?', courseId: 'sharing' },
+                { query: 'Where does progress live?', courseId: 'foundation' },
+                { query: 'What is a space?', courseId: 'sharing' },
+            ],
+        },
         isLoading: false,
         isError: false,
     }),
@@ -62,10 +113,26 @@ vi.mock('../../hooks', () => ({
         },
         isError: false,
     }),
+    useLearnAsk: () => ({
+        mutate: askMutate,
+        reset: () => {
+            askState.isError = false;
+        },
+        isLoading: askState.isLoading,
+        isError: askState.isError,
+    }),
+    setLessonBookmark: setLessonBookmarkMock,
 }));
 
 describe('LearnBoardPanel', () => {
-    beforeEach(() => navigate.mockClear());
+    beforeEach(() => {
+        navigate.mockClear();
+        askMutate.mockClear();
+        askCalls.length = 0;
+        setLessonBookmarkMock.mockClear();
+        askState.isLoading = false;
+        askState.isError = false;
+    });
 
     it('defaults to the org role and lights only the held modules', async () => {
         renderWithProviders(<LearnBoardPanel />, {
@@ -126,6 +193,19 @@ describe('LearnBoardPanel', () => {
         );
     });
 
+    it('hands focus back to the node when the pane closes', async () => {
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        const node = within(await screen.findByTestId('learn-board')).getByRole(
+            'button',
+            { name: /Getting around/ },
+        );
+        fireEvent.click(node);
+        fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+        await waitFor(() => expect(node).toHaveFocus());
+    });
+
     it('switching role clears the open module pane', async () => {
         renderWithProviders(<LearnBoardPanel />, {
             user: { role: OrganizationMemberRole.VIEWER },
@@ -149,5 +229,248 @@ describe('LearnBoardPanel', () => {
         expect(
             screen.getByText('Pick up where you left off'),
         ).toBeInTheDocument();
+    });
+
+    it('shows only the chips the selected role holds, capped at one row', async () => {
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        expect(
+            await screen.findByRole('button', {
+                name: 'Where do I find a chart?',
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'How do I build one?' }),
+        ).not.toBeInTheDocument();
+        // 'What is a space?' is held too, but it is the fourth offer.
+        const chips = within(screen.getByTestId('ask-chips')).getAllByRole(
+            'button',
+        );
+        expect(chips).toHaveLength(SUGGESTION_LIMIT);
+        expect(chips.map((chip) => chip.textContent)).toEqual([
+            'Where do I find a chart?',
+            'How do I share it?',
+            'Where does progress live?',
+        ]);
+    });
+
+    it('puts the Ask bar above the role tabs', async () => {
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        const search = await screen.findByRole('search');
+        const tabs = screen.getByRole('tablist');
+        expect(
+            search.compareDocumentPosition(tabs) &
+                Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+    });
+
+    it('treats an answer naming modules the catalogue lost as no answer', async () => {
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'anything' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        answerWith([
+            {
+                courseId: 'retired',
+                lessonId: 'l1',
+                title: 'Gone from the library',
+                score: 0.9,
+            },
+        ]);
+        expect(
+            await screen.findByText('Nothing in the library matches that yet'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Gone from the library'),
+        ).not.toBeInTheDocument();
+        const untouched = screen
+            .getByTestId('learn-board')
+            .querySelector<HTMLElement>('[aria-label^="Sharing your work"]');
+        expect(untouched?.style.opacity).not.toBe('0.4');
+    });
+
+    it('keeps the answer across a role change and re-derives the locked matches', async () => {
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'filters' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        answerWith([
+            {
+                courseId: 'dashboards',
+                lessonId: 'l1',
+                title: 'Filter a dashboard',
+                score: 0.9,
+            },
+        ]);
+        expect(
+            await screen.findByTestId('ask-locked-note'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Open' }),
+        ).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('tab', { name: 'editor' }));
+        await waitFor(() =>
+            expect(
+                screen.queryByTestId('ask-locked-note'),
+            ).not.toBeInTheDocument(),
+        );
+        expect(screen.getByText('Filter a dashboard')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Open' }),
+        ).toBeInTheDocument();
+    });
+
+    it('submitting a question searches and lights the matched module, and clearing restores the board', async () => {
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'where are my charts' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        expect(askMutate).toHaveBeenCalledWith(
+            { query: 'where are my charts' },
+            expect.anything(),
+        );
+
+        answerWith([
+            {
+                courseId: 'foundation',
+                lessonId: 'l2',
+                title: 'Finding saved charts',
+                score: 0.8,
+            },
+        ]);
+        expect(
+            await screen.findByText('Finding saved charts'),
+        ).toBeInTheDocument();
+        const dimmed = screen
+            .getByTestId('learn-board')
+            .querySelector<HTMLElement>('[aria-label^="Sharing your work"]');
+        expect(dimmed?.style.opacity).toBe('0.4');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+        await waitFor(() => expect(dimmed?.style.opacity).toBe('1'));
+        expect(
+            screen.queryByText('Finding saved charts'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('sends one request for a double submit and keeps the answer on a resubmit', async () => {
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'where are my charts' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        fireEvent.submit(screen.getByRole('search'));
+        expect(askMutate).toHaveBeenCalledTimes(1);
+
+        answerWith([
+            {
+                courseId: 'foundation',
+                lessonId: 'l2',
+                title: 'Finding saved charts',
+                score: 0.8,
+            },
+        ]);
+        expect(
+            await screen.findByText('Finding saved charts'),
+        ).toBeInTheDocument();
+        fireEvent.submit(screen.getByRole('search'));
+        expect(askMutate).toHaveBeenCalledTimes(1);
+    });
+
+    it('holds the answer while the next question runs and ignores the stale response', async () => {
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'where are my charts' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        answerWith([
+            {
+                courseId: 'foundation',
+                lessonId: 'l2',
+                title: 'Finding saved charts',
+                score: 0.8,
+            },
+        ]);
+        expect(
+            await screen.findByText('Finding saved charts'),
+        ).toBeInTheDocument();
+
+        fireEvent.change(screen.getByRole('searchbox'), {
+            target: { value: 'how do I share' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        // The board must not flash back to undimmed while the answer reloads.
+        expect(screen.getByText('Finding saved charts')).toBeInTheDocument();
+        const dimmed = screen
+            .getByTestId('learn-board')
+            .querySelector<HTMLElement>('[aria-label^="Sharing your work"]');
+        expect(dimmed?.style.opacity).toBe('0.4');
+
+        answerWith([
+            {
+                courseId: 'sharing',
+                lessonId: 'l1',
+                title: 'Sharing basics',
+                score: 0.9,
+            },
+        ]);
+        expect(await screen.findByText('Sharing basics')).toBeInTheDocument();
+
+        // The first request answers late: the newer answer stands.
+        answerWith(
+            [
+                {
+                    courseId: 'foundation',
+                    lessonId: 'l2',
+                    title: 'Finding saved charts',
+                    score: 0.8,
+                },
+            ],
+            0,
+        );
+        expect(screen.getByText('Sharing basics')).toBeInTheDocument();
+        expect(
+            screen.queryByText('Finding saved charts'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('opening a match bookmarks the lesson then navigates to the course', async () => {
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        fireEvent.change(await screen.findByRole('searchbox'), {
+            target: { value: 'charts' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+        answerWith([
+            {
+                courseId: 'foundation',
+                lessonId: 'l2',
+                title: 'Finding saved charts',
+                score: 0.8,
+            },
+        ]);
+        fireEvent.click(await screen.findByRole('button', { name: 'Open' }));
+        expect(setLessonBookmarkMock).toHaveBeenCalledWith('foundation', 'l2');
+        expect(navigate).toHaveBeenCalledWith(
+            '/projects/project-1/learn/courses/foundation',
+        );
     });
 });

--- a/packages/frontend/src/features/learn/board/components/LearnBoardPanel.tsx
+++ b/packages/frontend/src/features/learn/board/components/LearnBoardPanel.tsx
@@ -1,4 +1,4 @@
-import { type ProjectMemberRole } from '@lightdash/common';
+import { type LearnAskMatch, type ProjectMemberRole } from '@lightdash/common';
 import { useReducedMotion } from '@mantine/hooks';
 import { IconSchool } from '@tabler/icons-react';
 import {
@@ -12,7 +12,14 @@ import {
 import { useNavigate, useParams } from 'react-router';
 import SuboptimalState from '../../../../components/common/SuboptimalState/SuboptimalState';
 import useApp from '../../../../providers/App/useApp';
-import { useLearnCatalogue, useLearnRollups } from '../../hooks';
+import {
+    setLessonBookmark,
+    useLearnAsk,
+    useLearnCatalogue,
+    useLearnRollups,
+} from '../../hooks';
+import { suggestionsFor } from '../ask';
+import { boardHighlights, resolveMatches } from '../askView';
 import { BOARD_WIDTH, type Seat } from '../layout';
 import {
     defaultRoleFor,
@@ -21,10 +28,14 @@ import {
     ROLE_LABEL,
     roleScopes,
 } from '../model';
+import { AskBar } from './AskBar';
 import { BoardRail } from './BoardRail';
 import { ClusterBoard } from './ClusterBoard';
 import styles from './LearnBoard.module.css';
 import { RoleTabs } from './RoleTabs';
+
+/** The answer on screen, kept while the next request is in flight. */
+type AskAnswer = { query: string; matches: LearnAskMatch[] };
 
 export const LearnBoardPanel: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -32,10 +43,14 @@ export const LearnBoardPanel: FC = () => {
     const { user } = useApp();
     const catalogue = useLearnCatalogue();
     const { rollups } = useLearnRollups();
+    const ask = useLearnAsk();
+    const [answer, setAnswer] = useState<AskAnswer | null>(null);
     const reducedMotion = useReducedMotion() ?? false;
     const boardRef = useRef<HTMLDivElement>(null);
-    const headerRef = useRef<HTMLDivElement>(null);
+    const tabsRef = useRef<HTMLDivElement>(null);
     const frameRef = useRef<number | null>(null);
+    const askSeqRef = useRef(0);
+    const askInFlightRef = useRef(false);
 
     // Not initialised from the org role: that query is still async at mount,
     // so `picked` stays null until the learner overrides the derived default.
@@ -53,6 +68,43 @@ export const LearnBoardPanel: FC = () => {
         },
         [],
     );
+
+    const { reset: resetAsk, mutate: runAsk } = ask;
+    // One request at a time, and re-asking the answer on screen is a no-op:
+    // every submit costs an upstream embedding. The pane is left open.
+    const submitAsk = useCallback(
+        (query: string) => {
+            if (askInFlightRef.current) return;
+            if (answer !== null && answer.query === query) return;
+            askSeqRef.current += 1;
+            askInFlightRef.current = true;
+            const seq = askSeqRef.current;
+            const current = () => seq === askSeqRef.current;
+            runAsk(
+                { query },
+                {
+                    onSuccess: (data) => {
+                        if (current())
+                            setAnswer({ query, matches: data.matches });
+                    },
+                    onError: () => {
+                        if (current()) setAnswer(null);
+                    },
+                    onSettled: () => {
+                        if (current()) askInFlightRef.current = false;
+                    },
+                },
+            );
+        },
+        [runAsk, answer],
+    );
+    const clearAsk = useCallback(() => {
+        // A response still in flight belongs to a question the learner dropped.
+        askSeqRef.current += 1;
+        askInFlightRef.current = false;
+        setAnswer(null);
+        resetAsk();
+    }, [resetAsk]);
 
     const pickRole = useCallback(
         (next: ProjectMemberRole, element: HTMLElement) => {
@@ -78,6 +130,8 @@ export const LearnBoardPanel: FC = () => {
             setPrevRole(role);
             setPicked(next);
             setSelectedId(null);
+            // The answer is kept: the query has not changed, only which of its
+            // matches the new role can open, so the highlights re-derive.
             setBurst(true);
             frameRef.current = requestAnimationFrame(() => {
                 frameRef.current = requestAnimationFrame(() => setBurst(false));
@@ -92,7 +146,7 @@ export const LearnBoardPanel: FC = () => {
         const node = boardRef.current?.querySelector<HTMLElement>(
             'button[aria-pressed="true"]:not(:disabled)',
         );
-        const tab = headerRef.current?.querySelector<HTMLElement>(
+        const tab = tabsRef.current?.querySelector<HTMLElement>(
             '[role="tab"][aria-selected="true"]',
         );
         setSelectedId(null);
@@ -112,11 +166,34 @@ export const LearnBoardPanel: FC = () => {
         () => railModel(entries, held, rollups),
         [entries, held, rollups],
     );
+    const suggestions = useMemo(
+        () =>
+            catalogue.data
+                ? suggestionsFor(catalogue.data.suggestions, entries, held)
+                : [],
+        [catalogue.data, entries, held],
+    );
+    const matches = useMemo(
+        () =>
+            answer === null ? null : resolveMatches(answer.matches, entries),
+        [answer, entries],
+    );
+    const highlights = useMemo(
+        () =>
+            matches === null || matches.length === 0
+                ? null
+                : boardHighlights(matches, entries, held),
+        [matches, entries, held],
+    );
 
     const openCourse = (courseId: string) =>
         navigate(
             `/projects/${projectUuid}/learn/courses/${encodeURIComponent(courseId)}`,
         );
+    const openMatch = (courseId: string, lessonId: string | null) => {
+        if (lessonId !== null) setLessonBookmark(courseId, lessonId);
+        void openCourse(courseId);
+    };
 
     if (catalogue.isError) {
         return (
@@ -135,13 +212,27 @@ export const LearnBoardPanel: FC = () => {
         <div className={styles.scroller}>
             <div className={styles.card}>
                 <div className={styles.boardColumn}>
-                    <div className={styles.header} ref={headerRef}>
+                    <div className={styles.header}>
                         <h2 className={styles.title}>Your course</h2>
                         <span className={styles.sub}>
                             Everything your {ROLE_LABEL[role]} role unlocks:{' '}
                             {plural(rail.mine.length, 'module')},{' '}
                             {rail.overall.modulesComplete} finished.
                         </span>
+                        <AskBar
+                            entries={entries}
+                            suggestions={suggestions}
+                            matches={matches}
+                            lockedIds={highlights?.locked ?? new Set<string>()}
+                            isSearching={ask.isLoading}
+                            isError={ask.isError}
+                            onSubmit={submitAsk}
+                            onClear={clearAsk}
+                            onOpen={openMatch}
+                        />
+                    </div>
+                    {/* The tabs sit next to the rings the nodes fly out of. */}
+                    <div className={styles.tabsRow} ref={tabsRef}>
                         <RoleTabs role={role} onPick={pickRole} />
                     </div>
                     {rail.mine.length === 0 ? (
@@ -161,6 +252,7 @@ export const LearnBoardPanel: FC = () => {
                             origin={origin}
                             burst={burst}
                             reducedMotion={reducedMotion}
+                            highlights={highlights}
                             onSelect={setSelectedId}
                             boardRef={boardRef}
                         />

--- a/packages/frontend/src/features/learn/board/layout.ts
+++ b/packages/frontend/src/features/learn/board/layout.ts
@@ -1,3 +1,6 @@
+// Board geometry. Twin: lightdash-university academy/board/layout.ts.
+// A change here lands in both repositories in the same piece of work.
+
 import { GROUP_ORDER, type BoardGroup } from './model';
 
 export const BOARD_WIDTH = 1120;

--- a/packages/frontend/src/features/learn/board/model.ts
+++ b/packages/frontend/src/features/learn/board/model.ts
@@ -1,3 +1,6 @@
+// Board model. Twin: lightdash-university academy/board/model.ts.
+// A change here lands in both repositories in the same piece of work.
+
 import {
     getAllScopeMap,
     getAllScopesForRole,

--- a/packages/frontend/src/features/learn/board/motion.ts
+++ b/packages/frontend/src/features/learn/board/motion.ts
@@ -1,3 +1,6 @@
+// Board motion. Twin: lightdash-university academy/board/motion.ts.
+// A change here lands in both repositories in the same piece of work.
+
 import type { Seat } from './layout';
 
 export const NODE_TRANSITION =

--- a/packages/frontend/src/features/learn/hooks.ts
+++ b/packages/frontend/src/features/learn/hooks.ts
@@ -1,5 +1,7 @@
 import {
     type ApiError,
+    type LearnAskRequest,
+    type LearnAskResults,
     type LearnCatalogue,
     type LearnCourse,
     type LearnEventInput,
@@ -47,6 +49,13 @@ const postLearnEvents = async (events: LearnEventInput[]) =>
         body: JSON.stringify(events),
     });
 
+const postLearnAsk = async (body: LearnAskRequest) =>
+    lightdashApi<LearnAskResults>({
+        url: '/learn/ask',
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+
 export const useLearnCatalogue = () =>
     useQuery<LearnCatalogue, ApiError>({
         queryKey: ['learn-catalogue'],
@@ -62,6 +71,11 @@ export const useLearnCourse = (courseId: string | undefined) =>
         enabled: courseId !== undefined,
         staleTime: 5 * 60 * 1000,
         retry: false,
+    });
+
+export const useLearnAsk = () =>
+    useMutation<LearnAskResults, ApiError, LearnAskRequest>({
+        mutationFn: postLearnAsk,
     });
 
 const useLearnServerProgress = () =>


### PR DESCRIPTION
Adds Ask to the in-app course board, mirroring the academy at learn.lightdash.com so both surfaces teach the same way. Split from the original board-rail PR so Ask and role badges review separately; role badges follow in the next PR on the stack (`learn-6-rail`).

## What changed

- **Ask bar** above the role tabs: searches the library through a new `POST /learn/ask` proxy to lu-progress, lists up to five matches grouped by module with an Open link that sets the lesson bookmark, lights the matched modules on the rings and dims the rest; a match the selected role cannot open is labelled with the lowest role that holds it instead of Open. Suggestion chips come from the catalogue's `suggestions` (curated in Lightdash University, filtered to the selected role, capped at three).
- **Common types**: `LearnCatalogue.suggestions` (defaults to `[]` for older catalogues), ask request/response types, `LEARN_ASK_QUERY_MAX_LENGTH` shared between the schema and the input.
- **Pure module** `board/ask.ts` (and its tests) is a byte-identical copy of the academy's below the import seam; lightdash-only helpers live in `askView.ts`. `board/CLAUDE.md` carries the sync rule; the university repo's `npm run board:sync-check` reports the pairs in step.

## Behaviour worth knowing

- The Ask proxy calls lu-progress without the service token or the learner's email: the upstream route is unauthenticated and never reads them, so search also works on instances running Learn in client-local mode.
- Submits are guarded (no double-fire, no stale response overwriting a newer one) and the previous answer stays on screen while a new one loads. Asking does not close an open module pane.
- Locked matches stay parked at their cluster centre, outlined, and never open a pane. A matched glow beats the next-up pulse: two highlights at once read as two answers.

## Verification

Unit: AskBar, ClusterBoard ask states, panel guards (double-submit, stale response, role-change re-derivation), pure modules, and `LearnService` including the flag-off path for the proxy. Typecheck clean across common, backend and frontend.

Relates: CS-142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAD1wSdyo6Mewb2PMFA1GD
