### PR TITLE
feat(query-sdk): viz drill-down capability

### DIFF
--- a/packages/common/src/ee/apps/sdkFeatures.ts
+++ b/packages/common/src/ee/apps/sdkFeatures.ts
@@ -122,6 +122,13 @@ export const SDK_FEATURES: SdkFeature[] = [
             'Open the raw result rows behind a clicked data point in a reusable visualization, with CSV/XLSX download.',
         wiring: 'In the viz, keep the untransformed source row on each interactive datum, show a data-point action menu only when useVizContext().underlyingData.enabled and the mark maps to exactly one source row, render underlyingData.get({ row, metric }) in a themed dialog, and wire its Download button to underlyingData.download.',
     },
+    {
+        key: 'viz-drill-down',
+        label: 'Drill into data points',
+        description:
+            'Drill into a clicked data point in a reusable visualization — pick a dimension in Lightdash and open the drilled view in explore.',
+        wiring: 'Show a "Drill into …" item in the data-point action menu only when useVizContext().drillDown.enabled and the mark maps to exactly one source row, and call drillDown.open({ row: datum.sourceRow, metric: "<field name>" }) on selection. The host opens its drill dialog — render no dialog in the viz and never render a disabled item.',
+    },
 ];
 
 export const SDK_FEATURE_KEYS: string[] = SDK_FEATURES.map((f) => f.key);

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -1112,13 +1112,26 @@ export type DataAppVizUnderlyingDataIntent = {
     limit?: number | null;
 };
 
+// Bridge-only virtual route: the viz posts a drill click intent here and the
+// host resolves it and opens its drill dialog. Never forwarded to the API —
+// `useAppSdkBridge` answers it before allowlist matching.
+export const APP_SDK_VIZ_DRILL_DOWN_PATH = '/__sdk/viz/drill-down';
+
+// Drill click intent a viz sends to the virtual route: the untransformed
+// source row (as pushed in the viz context) and the declared field NAME bound
+// to the clicked metric slot. The host resolves everything else.
+export type DataAppVizDrillDownIntent = {
+    row: ResultRow;
+    metric: string;
+};
+
 // Host-owned render context pushed into a data app viz: field name → bound query
 // field id, the host-fetched result rows the renderer reads, the effective
 // config option values (stored value ?? declared default), and the palette
 // resolved for this chart (org → project → space → dashboard → chart, dark-mode
 // corrected). `colorPalette` is pushed whether or not the viz declared one, so a
-// viz that colours series never has to check first. `underlyingData.enabled` is
-// required so every push site decides availability explicitly.
+// viz that colours series never has to check first. `underlyingData.enabled` and
+// `drillDown.enabled` are required so every push site decides availability explicitly.
 export type DataAppVizContext = {
     fieldMapping: Record<string, string>;
     rows: ResultRow[];
@@ -1126,4 +1139,5 @@ export type DataAppVizContext = {
     colorPalette: string[];
     pivotDetails: ReadyQueryResultsPage['pivotDetails'];
     underlyingData: { enabled: boolean };
+    drillDown: { enabled: boolean };
 };

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -213,6 +213,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
             colorPalette,
             pivotDetails,
             underlyingData: { enabled: underlyingDataEnabled },
+            drillDown: { enabled: false },
         };
     }, [
         reconciledFieldMapping,

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1181,6 +1181,7 @@ describe('data-app-viz-context push', () => {
         colorPalette: ['#7162FF', '#1A1B1E'],
         pivotDetails: null,
         underlyingData: { enabled: false },
+        drillDown: { enabled: false },
     };
 
     function renderWithDataAppVizContext(ctx: DataAppVizContext | undefined) {

--- a/packages/frontend/src/features/chartTypes/components/DataAppVizTestPanel.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/DataAppVizTestPanel.test.tsx
@@ -376,6 +376,7 @@ describe('DataAppVizTestPanel', () => {
                 colorPalette: ['#111111'],
                 pivotDetails: null,
                 underlyingData: { enabled: false },
+                drillDown: { enabled: false },
             }),
         );
 
@@ -390,6 +391,7 @@ describe('DataAppVizTestPanel', () => {
                 colorPalette: ['#111111'],
                 pivotDetails: null,
                 underlyingData: { enabled: false },
+                drillDown: { enabled: false },
             }),
         );
     });
@@ -413,6 +415,7 @@ describe('DataAppVizTestPanel', () => {
                 colorPalette: ['#111111'],
                 pivotDetails: null,
                 underlyingData: { enabled: false },
+                drillDown: { enabled: false },
             }),
         );
 
@@ -427,6 +430,7 @@ describe('DataAppVizTestPanel', () => {
                 colorPalette: ['#123456', '#abcdef'],
                 pivotDetails: null,
                 underlyingData: { enabled: false },
+                drillDown: { enabled: false },
             }),
         );
     });

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVizTestContext.ts
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVizTestContext.ts
@@ -142,6 +142,7 @@ export const useDataAppVizTestContext = ({
                 colorPalette,
                 pivotDetails: queryResults.pivotDetails ?? null,
                 underlyingData: { enabled: false },
+                drillDown: { enabled: false },
             });
         }
     }, [

--- a/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
+++ b/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
@@ -82,5 +82,6 @@ export const buildSampleVizContext = (
         pivotDetails: null,
         // Sample rows come from no query — there is nothing to drill into.
         underlyingData: { enabled: false },
+        drillDown: { enabled: false },
     };
 };

--- a/packages/query-sdk/src/apiTransport.ts
+++ b/packages/query-sdk/src/apiTransport.ts
@@ -28,9 +28,10 @@ import type {
     Transport,
     UnderlyingDataOptions,
     UnderlyingDataResult,
+    VizDrillDownIntent,
     VizUnderlyingDataIntent,
 } from './types';
-import { VIZ_UNDERLYING_DATA_PATH } from './types';
+import { VIZ_DRILL_DOWN_PATH, VIZ_UNDERLYING_DATA_PATH } from './types';
 
 // Mirrors the explorer's `useInfiniteQueryResults` polling rhythm so the
 // SDK behaves like a normal Lightdash chart: 500-row pages, exponential
@@ -1223,6 +1224,14 @@ export function createApiTransport(
                 queryUuid: execResult.queryUuid,
                 options,
             });
+        },
+
+        async openVizDrillDown(intent: VizDrillDownIntent): Promise<void> {
+            await fetchFn<Record<string, never>>(
+                'POST',
+                VIZ_DRILL_DOWN_PATH,
+                intent,
+            );
         },
     };
 }

--- a/packages/query-sdk/src/features.ts
+++ b/packages/query-sdk/src/features.ts
@@ -122,6 +122,13 @@ export const SDK_FEATURES: SdkFeature[] = [
             'Open the raw result rows behind a clicked data point in a reusable visualization, with CSV/XLSX download.',
         wiring: 'In the viz, keep the untransformed source row on each interactive datum, show a data-point action menu only when useVizContext().underlyingData.enabled and the mark maps to exactly one source row, render underlyingData.get({ row, metric }) in a themed dialog, and wire its Download button to underlyingData.download.',
     },
+    {
+        key: 'viz-drill-down',
+        label: 'Drill into data points',
+        description:
+            'Drill into a clicked data point in a reusable visualization — pick a dimension in Lightdash and open the drilled view in explore.',
+        wiring: 'Show a "Drill into …" item in the data-point action menu only when useVizContext().drillDown.enabled and the mark maps to exactly one source row, and call drillDown.open({ row: datum.sourceRow, metric: "<field name>" }) on selection. The host opens its drill dialog — render no dialog in the viz and never render a disabled item.',
+    },
 ];
 
 export const SDK_FEATURE_KEYS: string[] = SDK_FEATURES.map((f) => f.key);

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -107,6 +107,7 @@ export type {
     VizContextPivotDetails,
     VizContextRow,
     VizUnderlyingData,
+    VizDrillDown,
     DataAppVizContextMessage,
     VizContextRequestMessage,
 } from './vizContext';

--- a/packages/query-sdk/src/types.ts
+++ b/packages/query-sdk/src/types.ts
@@ -261,6 +261,29 @@ export type VizUnderlyingDataIntent = {
     limit?: number | null;
 };
 
+/**
+ * Bridge-only virtual route for viz drill-down click intents. Duplicated from
+ * `@lightdash/common` (`APP_SDK_VIZ_DRILL_DOWN_PATH`) — this package must not
+ * depend on common. The host answers it directly (opens its drill dialog);
+ * nothing is forwarded to the API. On a direct-API transport it fails with a
+ * plain HTTP error.
+ */
+export const VIZ_DRILL_DOWN_PATH = '/__sdk/viz/drill-down';
+
+/**
+ * Drill click intent a viz sends to the host: the untransformed source row
+ * (as received from `useVizContext().rows`) and the declared field NAME bound
+ * to the clicked metric slot. The host resolves everything else and owns all
+ * subsequent UI.
+ */
+export type VizDrillDownIntent = {
+    row: Record<
+        string,
+        { value?: { raw?: unknown; formatted?: string } } | undefined
+    >;
+    metric: string;
+};
+
 // --- Client config ---
 
 export type LightdashClientConfig = {
@@ -351,4 +374,11 @@ export type Transport = {
         intent: Omit<VizUnderlyingDataIntent, 'limit'>,
         options?: DownloadResultsOptions,
     ) => Promise<DownloadResultsResult>;
+    /**
+     * Fire the drill-down intent for a viz data point via the host bridge.
+     * One-way: the host opens its drill dialog; the resolved promise is only
+     * an ack. Optional so custom transports predating the capability stay
+     * valid — `useVizContext().drillDown.enabled` is false when absent.
+     */
+    openVizDrillDown?: (intent: VizDrillDownIntent) => Promise<void>;
 };

--- a/packages/query-sdk/src/vizContext.test.ts
+++ b/packages/query-sdk/src/vizContext.test.ts
@@ -6,6 +6,7 @@ import {
 import { describe, expect, it, vi } from 'vitest';
 import type { Transport } from './types';
 import {
+    buildVizDrillDown,
     buildVizUnderlyingData,
     getFormatted,
     getRaw,
@@ -203,6 +204,7 @@ describe('toVizContextState', () => {
             colorPalette: [],
             pivotDetails: null,
             underlyingDataEnabled: false,
+            drillDownEnabled: false,
         });
     });
 
@@ -362,5 +364,74 @@ describe('buildVizUnderlyingData', () => {
                 metric: 'value',
             }),
         ).rejects.toThrow(/rebuild the app/i);
+    });
+});
+
+const drillMessage = (
+    drillDown?: Record<string, unknown>,
+): DataAppVizContextMessage =>
+    ({
+        type: 'lightdash:sdk:data-app-viz-context',
+        fieldMapping: {},
+        rows: [],
+        ...(drillDown !== undefined ? { drillDown } : {}),
+    }) as DataAppVizContextMessage;
+
+describe('toVizContextState drill-down flag', () => {
+    it('reads drillDown.enabled strictly', () => {
+        expect(
+            toVizContextState(drillMessage({ enabled: true })).drillDownEnabled,
+        ).toBe(true);
+        expect(toVizContextState(drillMessage()).drillDownEnabled).toBe(false);
+        expect(
+            toVizContextState(drillMessage({ enabled: 'yes' }))
+                .drillDownEnabled,
+        ).toBe(false);
+    });
+});
+
+describe('buildVizDrillDown', () => {
+    const transportWith = (open?: Transport['openVizDrillDown']) =>
+        ({ openVizDrillDown: open }) as unknown as Transport;
+
+    it('is enabled only when the host flag and transport method are both present', () => {
+        const open = vi.fn().mockResolvedValue(undefined);
+        expect(buildVizDrillDown(true, transportWith(open)).enabled).toBe(true);
+        expect(buildVizDrillDown(false, transportWith(open)).enabled).toBe(
+            false,
+        );
+        expect(buildVizDrillDown(true, transportWith(undefined)).enabled).toBe(
+            false,
+        );
+        expect(buildVizDrillDown(true, null).enabled).toBe(false);
+    });
+
+    it('open() forwards the intent through the transport', async () => {
+        const open = vi.fn().mockResolvedValue(undefined);
+        const row = { m: { value: { raw: 1, formatted: '1' } } };
+        await buildVizDrillDown(true, transportWith(open)).open({
+            row,
+            metric: 'value',
+        });
+        expect(open).toHaveBeenCalledWith({ row, metric: 'value' });
+    });
+
+    it('open() rejects with clear messages when disabled or unsupported', async () => {
+        await expect(
+            buildVizDrillDown(false, transportWith(vi.fn())).open({
+                row: {},
+                metric: 'value',
+            }),
+        ).rejects.toThrow(
+            'Drill-down is not enabled for this visualization.',
+        );
+        await expect(
+            buildVizDrillDown(true, transportWith(undefined)).open({
+                row: {},
+                metric: 'value',
+            }),
+        ).rejects.toThrow(
+            'This SDK build predates drill-down. Rebuild the app on the current template.',
+        );
     });
 });

--- a/packages/query-sdk/src/vizContext.ts
+++ b/packages/query-sdk/src/vizContext.ts
@@ -105,6 +105,8 @@ export type DataAppVizContextMessage = {
     pivotDetails?: VizContextPivotDetails | null;
     /** Absent when the installed host predates underlying-data delivery. */
     underlyingData?: { enabled?: boolean };
+    /** Absent when the installed host predates drill-down delivery. */
+    drillDown?: { enabled?: boolean };
 };
 
 /** Posted by the iframe on mount so the host pushes the current context. */
@@ -172,6 +174,8 @@ export type VizContext = {
     ready: boolean;
     /** Fetch/export the raw rows behind a clicked data point via the host. */
     underlyingData: VizUnderlyingData;
+    /** Fire a drill-down on a clicked data point; the host opens its drill dialog. */
+    drillDown: VizDrillDown;
 };
 
 type VizContextValue = {
@@ -181,6 +185,7 @@ type VizContextValue = {
     colorPalette: string[];
     pivotDetails: VizContextPivotDetails | null;
     underlyingDataEnabled: boolean;
+    drillDownEnabled: boolean;
 };
 
 type VizContextState = VizContextValue | null;
@@ -229,6 +234,7 @@ export function toVizContextState(
         pivotDetails: message.pivotDetails ?? null,
         // Strict boolean check — non-boolean payloads read as disabled.
         underlyingDataEnabled: message.underlyingData?.enabled === true,
+        drillDownEnabled: message.drillDown?.enabled === true,
     };
 }
 
@@ -276,6 +282,42 @@ export function buildVizUnderlyingData(
                 { row, metric },
                 options,
             );
+        },
+    };
+}
+
+/**
+ * Host-mediated drill-down for a clicked data point. `enabled` is false when
+ * the host predates the capability, the viewer lacks permission, results are
+ * pivoted, or no transport is mounted — render no menu item in that case
+ * (never a disabled one). `open` fires the intent; the HOST shows the drill
+ * dialog, nothing renders in the viz.
+ */
+export type VizDrillDown = {
+    enabled: boolean;
+    open: (opts: { row: VizContextRow; metric: string }) => Promise<void>;
+};
+
+/** Builds the `drillDown` surface. Exported for tests. */
+export function buildVizDrillDown(
+    hostEnabled: boolean,
+    transport: Transport | null,
+): VizDrillDown {
+    const supported = typeof transport?.openVizDrillDown === 'function';
+    return {
+        enabled: hostEnabled && supported,
+        open: async ({ row, metric }) => {
+            if (!hostEnabled) {
+                throw new Error(
+                    'Drill-down is not enabled for this visualization.',
+                );
+            }
+            if (!transport?.openVizDrillDown) {
+                throw new Error(
+                    'This SDK build predates drill-down. Rebuild the app on the current template.',
+                );
+            }
+            return transport.openVizDrillDown({ row, metric });
         },
     };
 }
@@ -365,6 +407,12 @@ export function useVizContext(): VizContext {
         [hostEnabled, transport],
     );
 
+    const drillHostEnabled = context?.drillDownEnabled === true;
+    const drillDown = useMemo<VizDrillDown>(
+        () => buildVizDrillDown(drillHostEnabled, transport),
+        [drillHostEnabled, transport],
+    );
+
     return {
         fieldMapping: context?.fieldMapping ?? {},
         rows: context?.rows ?? [],
@@ -373,5 +421,6 @@ export function useVizContext(): VizContext {
         pivotDetails: context?.pivotDetails ?? null,
         ready: context !== null,
         underlyingData,
+        drillDown,
     };
 }

--- a/packages/query-sdk/src/vizUnderlyingData.test.ts
+++ b/packages/query-sdk/src/vizUnderlyingData.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createApiTransport, type FetchAdapter } from './apiTransport';
-import { VIZ_UNDERLYING_DATA_PATH } from './types';
+import { VIZ_DRILL_DOWN_PATH, VIZ_UNDERLYING_DATA_PATH } from './types';
 
 const CONFIG = { baseUrl: '', projectUuid: 'p1', apiKey: 'key' };
 
@@ -83,6 +83,40 @@ describe('getVizUnderlyingData', () => {
         const transport = createApiTransport(CONFIG, fetchFn);
         await expect(transport.getVizUnderlyingData!(INTENT)).rejects.toThrow(
             'Underlying data is not available for this visualization.',
+        );
+    });
+});
+
+describe('openVizDrillDown', () => {
+    it('POSTs the intent to the drill virtual path and resolves void', async () => {
+        const fetchFn = vi.fn(async (method: string, path: string) => {
+            if (method === 'POST' && path === VIZ_DRILL_DOWN_PATH) {
+                return {};
+            }
+            throw new Error(`Unexpected request: ${method} ${path}`);
+        }) as FetchAdapter;
+
+        const transport = createApiTransport(CONFIG, fetchFn);
+        const result = await transport.openVizDrillDown!(INTENT);
+
+        expect(fetchFn).toHaveBeenCalledWith(
+            'POST',
+            VIZ_DRILL_DOWN_PATH,
+            INTENT,
+        );
+        expect(result).toBeUndefined();
+    });
+
+    it('surfaces the bridge error message when the virtual route rejects', async () => {
+        const fetchFn = vi.fn(async () => {
+            throw new Error(
+                'Drill-down is not available for this visualization.',
+            );
+        }) as FetchAdapter;
+
+        const transport = createApiTransport(CONFIG, fetchFn);
+        await expect(transport.openVizDrillDown!(INTENT)).rejects.toThrow(
+            'Drill-down is not available for this visualization.',
         );
     });
 });


### PR DESCRIPTION
## Summary

Adds the SDK + shared-type layer for drill-down on data app vizes (reusable visualizations), mirroring the shipped `viz-underlying-data` capability:

- `useVizContext()` gains a `drillDown: { enabled, open({ row, metric }) }` surface. `enabled` is pushed by the host (`drillDown?: { enabled?: boolean }` on the context message, strict `=== true`, absent-on-old-hosts ⇒ disabled).
- New optional transport method `openVizDrillDown(intent)` POSTs the one-way click intent to a bridge-only virtual route (`/__sdk/viz/drill-down`). Nothing returns to the iframe — the host owns all subsequent UI (its existing DrillDownModal → explore).
- Common gains `APP_SDK_VIZ_DRILL_DOWN_PATH`, `DataAppVizDrillDownIntent`, and the required `DataAppVizContext.drillDown` field; the `viz-drill-down` feature entry is registered in both `SDK_FEATURES` registries (sync test enforces byte-identical mirrors), so deployed bundles missing it are flagged for upgrade.

Host-side handling of the intent lands in the next PR of this stack; the sandbox skill-doc mandate for generated vizes in the one after.

## Testing

- query-sdk: 141 tests incl. new `openVizDrillDown` transport tests and `buildVizDrillDown` enabled-matrix/error-message tests; typecheck green (incl. the SDK↔common drift guard).
- All `DataAppVizContext` constructor sites updated for the new required field (4 sites, verified exhaustively).

Relates: GLITCH-588

🤖 Generated with [Claude Code](https://claude.com/claude-code)
