### PR TITLE
feat(data-app-viz): host-side drill-down intent handling

### DIFF
--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -2,6 +2,9 @@ import { MantineProvider } from '@mantine/core';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Mirrors the real hook's failSilently contract: TrackingContextType | undefined.
+type TrackingMockContext = { track: (...args: unknown[]) => void } | undefined;
+
 const mocks = vi.hoisted(() => ({
     metadata: {
         current: undefined as
@@ -52,6 +55,12 @@ const mocks = vi.hoisted(() => ({
     exploreHook: vi.fn(),
     // Extra keys merged into the useVisualizationContext mock return value.
     vizContextOverrides: { current: {} as Record<string, unknown> },
+    track: vi.fn(),
+    // undefined models no TrackingProvider mounted (e.g. /minimal routes at
+    // desktop viewports) — the real fail-silent hook returns undefined there.
+    trackingContext: {
+        current: undefined as TrackingMockContext,
+    },
 }));
 
 vi.mock('react-router', () => ({
@@ -89,6 +98,19 @@ vi.mock('../../hooks/useExplore', () => ({
         mocks.exploreHook(...args);
         return { data: mocks.explore.current };
     },
+}));
+vi.mock('../../providers/App/useApp', () => ({
+    default: () => ({
+        user: {
+            data: {
+                organizationUuid: 'organization-uuid',
+                userUuid: 'user-uuid',
+            },
+        },
+    }),
+}));
+vi.mock('../../providers/Tracking/useTracking', () => ({
+    default: (): TrackingMockContext => mocks.trackingContext.current,
 }));
 vi.mock('../LightdashVisualization/types', () => ({
     isDataAppVizVisualizationConfig: () => true,
@@ -169,6 +191,8 @@ describe('DataAppVizRenderer', () => {
         mocks.explore.current = undefined;
         mocks.exploreHook.mockClear();
         mocks.vizContextOverrides.current = {};
+        mocks.track.mockClear();
+        mocks.trackingContext.current = { track: mocks.track };
     });
 
     it('prompts for a visualization when none is selected', () => {
@@ -410,6 +434,8 @@ describe('DataAppVizRenderer underlying-data gating', () => {
         mocks.canViewUnderlyingData.current = true;
         mocks.explore.current = { name: 'orders' };
         mocks.vizContextOverrides.current = { resultsData: happyResultsData() };
+        mocks.track.mockClear();
+        mocks.trackingContext.current = { track: mocks.track };
     });
 
     it('happy path: pushes enabled and installs the rewrite callback', () => {
@@ -461,6 +487,10 @@ describe('DataAppVizRenderer underlying-data gating', () => {
                     resultsData: happyResultsData(),
                     minimal: true,
                 };
+                // /minimal routes at desktop viewports mount no
+                // TrackingProvider — exercise the real fail-silent path
+                // rather than masking it with a working mock.
+                mocks.trackingContext.current = undefined;
             },
         ],
         [

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -17,12 +17,18 @@ import {
     useDataAppVizRenderMetadata,
 } from '../../features/chartTypes/hooks/useDataAppVizRender';
 import { reconcileDataAppVizFieldMapping } from '../../features/chartTypes/utils/autoMapDataAppVizFields';
+import useToaster from '../../hooks/toaster/useToaster';
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
 import { useExplore } from '../../hooks/useExplore';
 import { useProjectUuid } from '../../hooks/useProjectUuid';
+import useApp from '../../providers/App/useApp';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
 import MantineIcon from '../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
+import { useMetricQueryDataContext } from '../MetricQueryData/useMetricQueryDataContext';
+import { resolveVizDrillDownConfig } from './vizDrillDownConfig';
 import { buildVizUnderlyingDataRequest } from './vizUnderlyingDataRequest';
 
 type Props = {
@@ -67,8 +73,13 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         resolvedTimezone,
     } = useVisualizationContext();
     const { embedToken } = useEmbed();
-    const { canViewUnderlyingData } = useContextMenuPermissions();
+    const { canViewUnderlyingData, canDrillInto } = useContextMenuPermissions();
     const previewOrigin = usePreviewOrigin();
+    const { user } = useApp();
+    // Fail-silent: /minimal routes at desktop viewports mount no
+    // TrackingProvider (App.tsx `enabled={isMobile || !isMinimalPage}`), so
+    // screenshot/export/unfurl renders simply skip the drill-by event.
+    const trackingContext = useTracking({ failSilently: true });
     const hasSignaledScreenshotReady = useRef(false);
 
     // Signal screenshot readiness on mount so dashboard capture isn't blocked
@@ -157,6 +168,65 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         [fields, itemsMap, fieldMapping],
     );
 
+    // Fail-silent: surfaces without MetricQueryDataProvider (no drill modal
+    // mounted) simply report drill-down as unavailable.
+    const metricQueryData = useMetricQueryDataContext(true);
+    const openDrillDownModal = metricQueryData?.openDrillDownModal;
+    const { showToastError } = useToaster();
+
+    // Same shape as underlyingDataPreconditions plus the drill permission and
+    // dialog; no explore fetch needed — DrillDownModal reads it from its provider.
+    const drillDownEnabled =
+        !!sourceQueryUuid &&
+        !!metricQuery &&
+        canDrillInto &&
+        !hasCustomBinDimension(metricQuery) &&
+        !embedToken &&
+        !minimal &&
+        !pivotDetails &&
+        !!openDrillDownModal &&
+        !!reconciledFieldMapping;
+
+    // undefined ⇒ the bridge answers the virtual route with an error —
+    // enforcement is structural, matching the underlying-data rewrite.
+    const onVizDrillDownIntent = useMemo(() => {
+        if (!drillDownEnabled || !openDrillDownModal || !reconciledFieldMapping)
+            return undefined;
+        return (intentBody: unknown) => {
+            try {
+                openDrillDownModal(
+                    resolveVizDrillDownConfig(intentBody, {
+                        fieldMapping: reconciledFieldMapping,
+                        itemsMap: itemsMap ?? {},
+                    }),
+                );
+                trackingContext?.track({
+                    name: EventName.DRILL_BY_CLICKED,
+                    properties: {
+                        organizationId: user?.data?.organizationUuid,
+                        userId: user?.data?.userUuid,
+                        projectId: projectUuid,
+                    },
+                });
+            } catch (err) {
+                showToastError({
+                    title: 'Could not drill into this data point',
+                    subtitle: err instanceof Error ? err.message : undefined,
+                });
+                throw err; // bridge relays the message as the route's error response
+            }
+        };
+    }, [
+        drillDownEnabled,
+        openDrillDownModal,
+        reconciledFieldMapping,
+        itemsMap,
+        showToastError,
+        trackingContext,
+        user,
+        projectUuid,
+    ]);
+
     const underlyingDataEnabled =
         underlyingDataPreconditions && !!explore && !!reconciledFieldMapping;
 
@@ -213,7 +283,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
             colorPalette,
             pivotDetails,
             underlyingData: { enabled: underlyingDataEnabled },
-            drillDown: { enabled: false },
+            drillDown: { enabled: drillDownEnabled },
         };
     }, [
         reconciledFieldMapping,
@@ -223,6 +293,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         colorPalette,
         pivotDetails,
         underlyingDataEnabled,
+        drillDownEnabled,
     ]);
 
     if (!projectUuid || !dataAppVizUuid) {
@@ -293,6 +364,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
             identityKey={dataAppVizUuid}
             dataAppVizContext={dataAppVizContext}
             rewriteVizUnderlyingDataRequest={rewriteVizUnderlyingDataRequest}
+            onVizDrillDownIntent={onVizDrillDownIntent}
         />
     );
 };

--- a/packages/frontend/src/components/DataAppVizRenderer/vizDrillDownConfig.test.ts
+++ b/packages/frontend/src/components/DataAppVizRenderer/vizDrillDownConfig.test.ts
@@ -1,0 +1,75 @@
+import { type ItemsMap } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { resolveVizDrillDownConfig } from './vizDrillDownConfig';
+
+// Minimal metric/dimension shaped like ItemsMap entries — only the fields
+// isField/isMetric discriminate on.
+const metricItem = {
+    fieldType: 'metric',
+    type: 'count',
+    name: 'revenue',
+    table: 'orders',
+    label: 'Revenue',
+    hidden: false,
+} as unknown as ItemsMap[string];
+const dimensionItem = {
+    fieldType: 'dimension',
+    type: 'string',
+    name: 'status',
+    table: 'orders',
+    label: 'Status',
+    hidden: false,
+} as unknown as ItemsMap[string];
+
+const itemsMap = {
+    orders_revenue: metricItem,
+    orders_status: dimensionItem,
+} as ItemsMap;
+const fieldMapping = { value: 'orders_revenue', category: 'orders_status' };
+
+const row = {
+    orders_revenue: { value: { raw: 42, formatted: '42' } },
+    orders_status: { value: { raw: 'done', formatted: 'Done' } },
+    junk: { nope: true },
+};
+
+describe('resolveVizDrillDownConfig', () => {
+    it('resolves a valid intent to a DrillDownConfig', () => {
+        const config = resolveVizDrillDownConfig(
+            { row, metric: 'value' },
+            { fieldMapping, itemsMap },
+        );
+        expect(config.item).toBe(metricItem);
+        expect(config.fieldValues).toEqual({
+            orders_revenue: { raw: 42, formatted: '42' },
+            orders_status: { raw: 'done', formatted: 'Done' },
+        });
+    });
+
+    it('rejects a malformed intent', () => {
+        expect(() =>
+            resolveVizDrillDownConfig(
+                { metric: 42 },
+                { fieldMapping, itemsMap },
+            ),
+        ).toThrow('Invalid drill-down request.');
+    });
+
+    it('rejects a metric name not bound on this chart', () => {
+        expect(() =>
+            resolveVizDrillDownConfig(
+                { row, metric: 'ghost' },
+                { fieldMapping, itemsMap },
+            ),
+        ).toThrow('"ghost" is not bound to a query field on this chart.');
+    });
+
+    it('rejects a slot bound to a non-metric', () => {
+        expect(() =>
+            resolveVizDrillDownConfig(
+                { row, metric: 'category' },
+                { fieldMapping, itemsMap },
+            ),
+        ).toThrow('"category" is not a metric on this chart.');
+    });
+});

--- a/packages/frontend/src/components/DataAppVizRenderer/vizDrillDownConfig.ts
+++ b/packages/frontend/src/components/DataAppVizRenderer/vizDrillDownConfig.ts
@@ -1,0 +1,26 @@
+import { isField, isMetric, type ItemsMap } from '@lightdash/common';
+import { type DrillDownConfig } from '../MetricQueryData/types';
+import { isVizIntent, toVizFieldValues } from './vizIntent';
+
+// Resolves a viz's drill click intent (untrusted iframe input) into the
+// config DrillDownModal consumes. metricQuery/explore come from the
+// MetricQueryDataProvider already mounted on the surface.
+export const resolveVizDrillDownConfig = (
+    intent: unknown,
+    args: { fieldMapping: Record<string, string>; itemsMap: ItemsMap },
+): DrillDownConfig => {
+    if (!isVizIntent(intent)) {
+        throw new Error('Invalid drill-down request.');
+    }
+    const fieldId = args.fieldMapping[intent.metric];
+    const item = fieldId ? args.itemsMap[fieldId] : undefined;
+    if (!fieldId || !item) {
+        throw new Error(
+            `"${intent.metric}" is not bound to a query field on this chart.`,
+        );
+    }
+    if (!isField(item) || !isMetric(item)) {
+        throw new Error(`"${intent.metric}" is not a metric on this chart.`);
+    }
+    return { item, fieldValues: toVizFieldValues(intent.row) };
+};

--- a/packages/frontend/src/components/DataAppVizRenderer/vizIntent.ts
+++ b/packages/frontend/src/components/DataAppVizRenderer/vizIntent.ts
@@ -1,0 +1,25 @@
+import { isResultValue, type ResultValue } from '@lightdash/common';
+
+/** A viz click intent as it crosses the untrusted iframe boundary. */
+export type VizIntent = {
+    row: Record<string, unknown>;
+    metric: string;
+};
+
+export const isVizIntent = (input: unknown): input is VizIntent =>
+    typeof input === 'object' &&
+    input !== null &&
+    typeof (input as { metric?: unknown }).metric === 'string' &&
+    typeof (input as { row?: unknown }).row === 'object' &&
+    (input as { row?: unknown }).row !== null;
+
+// ResultRow cells → the { raw, formatted } fieldValues the shared builders
+// consume; cells failing strict ResultValue validation are skipped (untrusted iframe boundary).
+export const toVizFieldValues = (
+    row: Record<string, unknown>,
+): Record<string, ResultValue> =>
+    Object.fromEntries(
+        Object.entries(row).flatMap(([id, cell]) =>
+            isResultValue(cell) ? [[id, cell.value]] : [],
+        ),
+    );

--- a/packages/frontend/src/components/DataAppVizRenderer/vizUnderlyingDataRequest.ts
+++ b/packages/frontend/src/components/DataAppVizRenderer/vizUnderlyingDataRequest.ts
@@ -4,7 +4,6 @@ import {
     getItemId,
     isCustomBinDimension,
     isField,
-    isResultValue,
     QueryExecutionContext,
     type DataAppVizUnderlyingDataIntent,
     type DateZoom,
@@ -13,13 +12,13 @@ import {
     type ItemsMap,
     type MetricQuery,
     type ParametersValuesMap,
-    type ResultValue,
 } from '@lightdash/common';
 import { convertDateFilters } from '../../utils/dateFilter';
 import {
     combineUnderlyingDataFilters,
     getUnderlyingDataFilterParts,
 } from '../MetricQueryData/underlyingDataFilters';
+import { isVizIntent, toVizFieldValues } from './vizIntent';
 
 export type VizUnderlyingDataRewriteArgs = {
     projectUuid: string;
@@ -43,13 +42,6 @@ export type VizUnderlyingDataRequest = {
     };
 };
 
-const isIntent = (input: unknown): input is DataAppVizUnderlyingDataIntent =>
-    typeof input === 'object' &&
-    input !== null &&
-    typeof (input as { metric?: unknown }).metric === 'string' &&
-    typeof (input as { row?: unknown }).row === 'object' &&
-    (input as { row?: unknown }).row !== null;
-
 // Rewrites a viz's semantic click intent (untrusted iframe input) into the
 // real underlying-data request, using the same point-filter construction as
 // UnderlyingDataModal.
@@ -57,9 +49,10 @@ export const buildVizUnderlyingDataRequest = (
     intent: unknown,
     args: VizUnderlyingDataRewriteArgs,
 ): VizUnderlyingDataRequest => {
-    if (!isIntent(intent)) {
+    if (!isVizIntent(intent)) {
         throw new Error('Invalid underlying-data request.');
     }
+    const { limit } = intent as DataAppVizUnderlyingDataIntent;
 
     const fieldId = args.fieldMapping[intent.metric];
     const item = fieldId ? args.itemsMap[fieldId] : undefined;
@@ -79,14 +72,7 @@ export const buildVizUnderlyingDataRequest = (
         ...getDimensions(args.explore),
     ];
 
-    // ResultRow cells → the { raw, formatted } fieldValues the shared builder
-    // consumes; cells that fail strict ResultValue validation are skipped —
-    // the payload crosses an untrusted iframe boundary.
-    const fieldValues: Record<string, ResultValue> = Object.fromEntries(
-        Object.entries(intent.row).flatMap(([id, cell]) =>
-            isResultValue(cell) ? [[id, cell.value]] : [],
-        ),
-    );
+    const fieldValues = toVizFieldValues(intent.row);
 
     const filterParts = getUnderlyingDataFilterParts({
         item,
@@ -116,7 +102,7 @@ export const buildVizUnderlyingDataRequest = (
             ...(isField(item) ? { underlyingDataItemId: getItemId(item) } : {}),
             filters: convertDateFilters(filters),
             ...(args.dateZoom ? { dateZoom: args.dateZoom } : {}),
-            ...(intent.limit !== undefined ? { limit: intent.limit } : {}),
+            ...(limit !== undefined ? { limit } : {}),
             ...(args.parameters && Object.keys(args.parameters).length > 0
                 ? { parameters: args.parameters }
                 : {}),

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -124,6 +124,9 @@ type Props = {
         path: string;
         body: unknown;
     };
+    /** Handles the viz drill-down virtual route. Only set by
+     *  DataAppVizRenderer when the capability is on. */
+    onVizDrillDownIntent?: (intentBody: unknown) => void;
     // Round-trip the app's `useUrlState` controls through the page's `?state=`
     // param. Leave unset where the page URL isn't the app's share surface
     // (dashboard tiles, screenshots).
@@ -185,6 +188,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             capabilities,
             dataAppVizContext,
             rewriteVizUnderlyingDataRequest,
+            onVizDrillDownIntent,
             urlStateSync,
             onSdkManifest,
             forceColorScheme,
@@ -283,6 +287,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onExternalRequestEvent,
             dataAppVizContext,
             rewriteVizUnderlyingDataRequest,
+            onVizDrillDownIntent,
             onUrlStateChange: urlStateSync ? handleUrlStateChange : undefined,
             onSdkManifest,
             colorScheme,

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1826,3 +1826,104 @@ describe('viz underlying-data virtual route', () => {
         expect(fetch).not.toHaveBeenCalled();
     });
 });
+
+describe('viz drill-down virtual route', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    const VIRTUAL_PATH = '/__sdk/viz/drill-down';
+    const INTENT = { row: {}, metric: 'x' };
+
+    function renderBridgeWithDrillDown(
+        onVizDrillDownIntent?: (intentBody: unknown) => void,
+    ) {
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        renderHook(() =>
+            useAppSdkBridge({
+                colorScheme: 'light',
+                iframeRef,
+                expectedPreviewOrigin: window.location.origin,
+                projectUuid: PROJECT_UUID,
+                appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
+                onVizDrillDownIntent,
+            }),
+        );
+    }
+
+    function postVirtualRoute() {
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:fetch',
+            id: POST_ID,
+            method: 'POST',
+            path: VIRTUAL_PATH,
+            body: INTENT,
+        });
+    }
+
+    it('answers with an error when no handler is mounted', async () => {
+        renderBridgeWithDrillDown(undefined);
+        const postMessageSpy = vi.spyOn(window, 'postMessage');
+        postVirtualRoute();
+
+        await vi.waitFor(() =>
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'lightdash:sdk:fetch-response',
+                    id: POST_ID,
+                    error: 'Drill-down is not available for this visualization.',
+                }),
+                '*',
+            ),
+        );
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('invokes the handler and acks without forwarding to the API', async () => {
+        const handler = vi.fn();
+        renderBridgeWithDrillDown(handler);
+        const postMessageSpy = vi.spyOn(window, 'postMessage');
+        postVirtualRoute();
+
+        await vi.waitFor(() =>
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'lightdash:sdk:fetch-response',
+                    id: POST_ID,
+                    result: {},
+                }),
+                '*',
+            ),
+        );
+        expect(handler).toHaveBeenCalledWith(INTENT);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('answers with the thrown message when the handler rejects the intent', async () => {
+        renderBridgeWithDrillDown(() => {
+            throw new Error('"x" is not a metric on this chart.');
+        });
+        const postMessageSpy = vi.spyOn(window, 'postMessage');
+        postVirtualRoute();
+
+        await vi.waitFor(() =>
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'lightdash:sdk:fetch-response',
+                    id: POST_ID,
+                    error: '"x" is not a metric on this chart.',
+                }),
+                '*',
+            ),
+        );
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -3,6 +3,7 @@ import {
     APP_SDK_COLOR_SCHEME_REQUEST_MESSAGE,
     APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
     APP_SDK_VIZ_CONTEXT_REQUEST_MESSAGE,
+    APP_SDK_VIZ_DRILL_DOWN_PATH,
     APP_SDK_VIZ_UNDERLYING_DATA_PATH,
     extractAppSdkRouteProjectUuid,
     isAllowedAppSdkRoute,
@@ -274,6 +275,15 @@ export type UseAppSdkBridgeParams = {
         path: string;
         body: unknown;
     };
+    /**
+     * Handles the viz drill-down virtual route
+     * (`APP_SDK_VIZ_DRILL_DOWN_PATH`): resolves the click intent and opens the
+     * host drill dialog. Never forwarded to the API. Absent = the capability
+     * is off and the route answers with an error — availability is enforced
+     * here, not in the iframe's menu. Throws on invalid intent (untrusted
+     * iframe input).
+     */
+    onVizDrillDownIntent?: (intentBody: unknown) => void;
     // When set, `lightdash:sdk:url-state-change` messages from the iframe SDK
     // are validated and forwarded. Left undefined, they're ignored.
     onUrlStateChange?: (state: Record<string, unknown>) => void;
@@ -315,6 +325,7 @@ export function useAppSdkBridge({
     onExternalRequestEvent,
     dataAppVizContext,
     rewriteVizUnderlyingDataRequest,
+    onVizDrillDownIntent,
     onUrlStateChange,
     onSdkManifest,
     deliveryCapture,
@@ -725,6 +736,30 @@ export function useAppSdkBridge({
                 }
             }
 
+            // Bridge-only virtual route: the viz posts a drill click intent;
+            // the host resolves it and opens its drill dialog. Answered here —
+            // nothing is forwarded to the API.
+            if (path === APP_SDK_VIZ_DRILL_DOWN_PATH) {
+                if (!onVizDrillDownIntent) {
+                    respond({
+                        error: 'Drill-down is not available for this visualization.',
+                    });
+                    return;
+                }
+                try {
+                    onVizDrillDownIntent(body);
+                    respond({ result: {} });
+                } catch (err) {
+                    respond({
+                        error:
+                            err instanceof Error
+                                ? err.message
+                                : 'Invalid drill-down request.',
+                    });
+                }
+                return;
+            }
+
             if (!isAllowedAppSdkRoute(method, path)) {
                 respond({ error: `Blocked: ${method} ${path}` });
                 return;
@@ -1073,6 +1108,7 @@ export function useAppSdkBridge({
             onExternalRequestEvent,
             pushDataAppVizContext,
             rewriteVizUnderlyingDataRequest,
+            onVizDrillDownIntent,
             pushColorScheme,
             onUrlStateChange,
             onSdkManifest,


### PR DESCRIPTION
## Summary

Host-side half of drill-down for data app vizes, on top of the SDK PR below this one in the stack:

- **Bridge**: `useAppSdkBridge` answers the `/__sdk/viz/drill-down` virtual route in place — it never forwards to the API. No handler mounted ⇒ error response (enforcement is structural, matching the underlying-data rewrite); handler throw ⇒ the message is relayed as the route's error.
- **Resolution**: shared intent parsers extracted to `vizIntent.ts` (behavior-neutral refactor of `vizUnderlyingDataRequest.ts`, its tests untouched); new `resolveVizDrillDownConfig` validates the untrusted iframe intent (shape, bound metric slot, metric-only) and builds the `DrillDownConfig` the existing `DrillDownModal` consumes.
- **Renderer**: `DataAppVizRenderer` computes `drillDownEnabled` (live query + `canDrillInto` + no custom bins/embed/minimal/pivot + drill dialog reachable via fail-silent `useMetricQueryDataContext(true)`), pushes the flag with the viz context, opens the modal on intent, fires `DRILL_BY_CLICKED` (fail-silent `useTracking` so `/minimal` screenshot renders can't crash), and toasts + relays resolution failures.

Backend-pivoted results keep drill disabled in v1 (same one-source-row provenance rule as underlying data); `pivotReference` drill is a follow-up.

## Testing

- New: bridge route tests (error without handler / ack + no fetch / thrown-message relay), resolver tests (valid, malformed, unbound, non-metric, junk-cell filtering).
- Full frontend suite green apart from 3 pre-existing machine-timezone DST flakes in an untouched file; typecheck + lint clean.
- Not yet exercised end-to-end against a generated viz (none exist in local dev data) — validate on an instance with data app vizes before un-drafting.

Relates: GLITCH-588

🤖 Generated with [Claude Code](https://claude.com/claude-code)
