### PR TITLE
docs(data-apps): mandate drill-down in reusable viz template

### DIFF
--- a/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
+++ b/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
@@ -35,6 +35,7 @@ const {
   pivotDetails,
   ready,
   underlyingData,
+  drillDown,
 } = useVizContext();
 ```
 
@@ -51,6 +52,8 @@ const {
 - `ready` — false until the first context arrives.
 - `underlyingData` — host-mediated access to the raw rows behind a clicked data point.
   See "Data-point actions" below.
+- `drillDown` — host-mediated drill on a clicked data point. See "Data-point
+  actions" below.
 
 Read all of them. Ignoring `options` and `colorPalette` is the most common way to build a
 viz nobody can configure.
@@ -153,9 +156,14 @@ declared series fields builds its label from each matching `pivotValues` entry i
 field order. Backend-pivoted rows do not have safe one-source-row provenance, so the host
 sets `underlyingData.enabled` to false for them.
 
-## Data-point actions: underlying data
+## Data-point actions: underlying data and drill-down
 
-When `underlyingData.enabled` is true, viewers expect the standard Lightdash action on
+Every chart whose marks satisfy the provenance rule below MUST wire the data-point
+action menu. This is part of the component contract, not an optional nicety — a
+"keep it minimal" prompt does not waive it. The flags decide at RUNTIME whether each
+item shows; you always write the wiring, and it costs nothing visually when disabled.
+
+When `underlyingData.enabled` is true, viewers get the standard Lightdash action on
 chart marks: click a data point → small action menu → "View underlying data" → a dialog
 listing the raw rows behind that point, with a Download button. When it is false (host
 too old, viewer lacks permission, embed), render no menu item — never a disabled one.
@@ -202,6 +210,24 @@ max-content`). A wrapper that sizes to the table's intrinsic width makes the
 overflow container's horizontal scroll dead — the table looks clipped and viewers
 cannot reach the right-hand columns. Verify by scrolling right in the rendered
 dialog with more columns than fit.
+
+### Drill into a data point
+
+When `drillDown.enabled` is true, the same data-point action menu also offers
+"Drill into *{formatted metric value}*" (e.g. "Drill into $1,234"). On
+selection, fire the intent and render nothing else — Lightdash opens its own
+drill dialog outside the viz:
+
+```tsx
+drillDown.open({ row: datum.sourceRow, metric: 'value' }).catch(() => {});
+```
+
+`metric` is the declared field NAME, exactly as for `underlyingData`. The same
+provenance contract applies: the item appears only where one mark maps to
+exactly ONE source row and ONE metric-slot field, and only when
+`drillDown.enabled` — never a disabled item. The two flags are independent:
+show each action on its own flag (a viewer may have one permission but not
+the other).
 
 ## The declaration
 
@@ -334,5 +360,8 @@ Then check both directions: every key you read from `options` is declared, and e
 you declared is read somewhere. `colorPalette` is declared when you colour from
 `colorPalette` — it is never read from `options`.
 
-Finally, if the chart has clickable marks: each interactive datum carries `sourceRow`,
-and the data-point action menu is gated on `underlyingData.enabled`.
+Finally, if any mark maps to exactly one source row, the data-point action
+menu is wired: each interactive datum carries `sourceRow`, the underlying-data
+action is gated on `underlyingData.enabled`, and the drill action is gated on
+`drillDown.enabled`. Omitting the menu on a chart whose marks satisfy
+provenance is a defect, not a simplification.

--- a/sandboxes/data-apps/template/.claude/skills/sdk-features/SKILL.md
+++ b/sandboxes/data-apps/template/.claude/skills/sdk-features/SKILL.md
@@ -20,6 +20,7 @@ Users describe features by what they see in the Lightdash editor. Translate:
 | "select an element", editor element picker | `inspect` | none (automatic) |
 | thumbnails / screenshots / scheduled deliveries | `screenshot` | required — see below |
 | drill down, click into a chart | `drill-down` | app code opt-in |
+| drill into a viz data point (reusable visualization) | `viz-drill-down` | app code opt-in |
 | "share this view", URL that restores state | `url-state` | app code opt-in |
 | Google Sheets export | `gsheet-export` | app code opt-in |
 | "delivery has all tabs", full data in scheduled deliveries | `delivery-render` | app code opt-in |
@@ -102,6 +103,10 @@ order, `sortBy` describes result ordering, `totalColumnCount` exposes truncation
 
 - `drill-down`: `drillDown(...)` derives a more detailed query from a clicked
   result row — wire it to click handlers on charts/rows.
+- `viz-drill-down`: in a reusable visualization, the data-point action menu
+  offers "Drill into …" when `useVizContext().drillDown.enabled`; selection
+  calls `drillDown.open({ row, metric })` and Lightdash opens its drill
+  dialog. Distinct from `drill-down`, which is the full-app query helper.
 - `url-state`: `useUrlState(...)` syncs a piece of app state into the page URL
   so views can be shared and restored.
 - `gsheet-export`: `exportToSheets(...)` sends tabular results to a new


### PR DESCRIPTION
## Summary

The generation-time mandate for viz drill-down, completing the stack:

- `reusable-visualization/SKILL.md`: the data-point actions section now covers drill-down — the action menu must offer "Drill into *{formatted metric value}*" when `drillDown.enabled` (never a disabled item; the two action flags are independent), firing `drillDown.open(...).catch(() => {})` and rendering nothing else — Lightdash opens its own drill dialog. Final-pass checklist updated to gate both actions.
- `sdk-features/SKILL.md`: `viz-drill-down` feature row + a note disambiguating it from the full-app `drill-down` query helper, so the upgrade agent can offer it by name.

With this, newly generated vizes wire the menu item automatically, and existing bundles are detected as missing the feature via the SDK manifest and offered the standard upgrade.

Closes: GLITCH-588

🤖 Generated with [Claude Code](https://claude.com/claude-code)
