### PR TITLE
fix(cli): lint uploadable code files before deployment

### DIFF
--- a/packages/cli/src/handlers/contentAsCode/fileDiscovery.ts
+++ b/packages/cli/src/handlers/contentAsCode/fileDiscovery.ts
@@ -1,0 +1,30 @@
+import * as path from 'path';
+
+export type ContentFileType = 'chart' | 'dashboard';
+
+export const getContentFileType = (
+    filePath: string,
+): ContentFileType | undefined => {
+    if (
+        !filePath.endsWith('.yml') ||
+        filePath.endsWith('.space.yml') ||
+        filePath.endsWith('.language.map.yml')
+    ) {
+        return undefined;
+    }
+
+    const parentFolder = path.basename(path.dirname(filePath));
+    if (parentFolder === 'charts') return 'chart';
+    if (parentFolder === 'dashboards') return 'dashboard';
+    return undefined;
+};
+
+export const isLooseContentFilePath = (filePath: string): boolean => {
+    const parentFolder = path.basename(path.dirname(filePath));
+    return (
+        filePath.endsWith('.yml') &&
+        !filePath.endsWith('.language.map.yml') &&
+        parentFolder !== 'charts' &&
+        parentFolder !== 'dashboards'
+    );
+};

--- a/packages/cli/src/handlers/contentAsCode/fileDiscovery.ts
+++ b/packages/cli/src/handlers/contentAsCode/fileDiscovery.ts
@@ -2,11 +2,34 @@ import * as path from 'path';
 
 export type ContentFileType = 'chart' | 'dashboard';
 
-export const getContentFileType = (
+export type ContentFileClassification =
+    | {
+          kind: 'content';
+          contentType: ContentFileType;
+          supportedExtension: boolean;
+      }
+    | { kind: 'loose'; supportedExtension: boolean };
+
+const isWithinRoot = (filePath: string, rootPath: string): boolean => {
+    const relativePath = path.relative(rootPath, filePath);
+    return (
+        relativePath === '' ||
+        (!relativePath.startsWith(`..${path.sep}`) &&
+            relativePath !== '..' &&
+            !path.isAbsolute(relativePath))
+    );
+};
+
+export const classifyContentFilePath = (
     filePath: string,
-): ContentFileType | undefined => {
+    rootPath?: string,
+): ContentFileClassification | undefined => {
+    if (rootPath && !isWithinRoot(filePath, rootPath)) return undefined;
+
+    const supportedExtension = filePath.endsWith('.yml');
+    if (!supportedExtension && !filePath.endsWith('.yaml')) return undefined;
+
     if (
-        !filePath.endsWith('.yml') ||
         filePath.endsWith('.space.yml') ||
         filePath.endsWith('.language.map.yml')
     ) {
@@ -14,17 +37,18 @@ export const getContentFileType = (
     }
 
     const parentFolder = path.basename(path.dirname(filePath));
-    if (parentFolder === 'charts') return 'chart';
-    if (parentFolder === 'dashboards') return 'dashboard';
-    return undefined;
+    if (parentFolder === 'charts') {
+        return { kind: 'content', contentType: 'chart', supportedExtension };
+    }
+    if (parentFolder === 'dashboards') {
+        return {
+            kind: 'content',
+            contentType: 'dashboard',
+            supportedExtension,
+        };
+    }
+    return { kind: 'loose', supportedExtension };
 };
 
-export const isLooseContentFilePath = (filePath: string): boolean => {
-    const parentFolder = path.basename(path.dirname(filePath));
-    return (
-        filePath.endsWith('.yml') &&
-        !filePath.endsWith('.language.map.yml') &&
-        parentFolder !== 'charts' &&
-        parentFolder !== 'dashboards'
-    );
-};
+export const isSqlChartContent = (item: object): boolean =>
+    'sql' in item && !('tableName' in item);

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -100,6 +100,10 @@ import {
     withBuildLimitRetry,
 } from './apps/uploadRetry';
 import {
+    getContentFileType,
+    isLooseContentFilePath,
+} from './contentAsCode/fileDiscovery';
+import {
     AI_AGENT_CODE_RESOURCE,
     ALERT_CODE_RESOURCE,
     EXTERNAL_CONNECTION_CODE_RESOURCE,
@@ -435,21 +439,19 @@ const hasUnsortedKeys = (obj: unknown): boolean => {
     return Object.values(obj).some(hasUnsortedKeys);
 };
 
-const isLightdashContentFile = (folder: string, entry: Dirent) =>
+const isLightdashContentFile = (
+    folder: 'charts' | 'dashboards',
+    entry: Dirent,
+) =>
     entry.isFile() &&
     entry.parentPath &&
-    entry.parentPath.endsWith(path.sep + folder) &&
-    entry.name.endsWith('.yml') &&
-    !entry.name.endsWith('.space.yml') &&
-    !entry.name.endsWith('.language.map.yml');
+    getContentFileType(path.join(entry.parentPath, entry.name)) ===
+        (folder === 'charts' ? 'chart' : 'dashboard');
 
 const isLooseContentFile = (entry: Dirent) =>
     entry.isFile() &&
     entry.parentPath &&
-    !entry.parentPath.endsWith(`${path.sep}charts`) &&
-    !entry.parentPath.endsWith(`${path.sep}dashboards`) &&
-    entry.name.endsWith('.yml') &&
-    !entry.name.endsWith('.language.map.yml');
+    isLooseContentFilePath(path.join(entry.parentPath, entry.name));
 
 const processYamlItem = <
     T extends ChartAsCode | DashboardAsCode | SqlChartAsCode,

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -100,8 +100,8 @@ import {
     withBuildLimitRetry,
 } from './apps/uploadRetry';
 import {
-    getContentFileType,
-    isLooseContentFilePath,
+    classifyContentFilePath,
+    isSqlChartContent,
 } from './contentAsCode/fileDiscovery';
 import {
     AI_AGENT_CODE_RESOURCE,
@@ -442,16 +442,29 @@ const hasUnsortedKeys = (obj: unknown): boolean => {
 const isLightdashContentFile = (
     folder: 'charts' | 'dashboards',
     entry: Dirent,
-) =>
-    entry.isFile() &&
-    entry.parentPath &&
-    getContentFileType(path.join(entry.parentPath, entry.name)) ===
-        (folder === 'charts' ? 'chart' : 'dashboard');
+) => {
+    if (!entry.isFile() || !entry.parentPath) return false;
 
-const isLooseContentFile = (entry: Dirent) =>
-    entry.isFile() &&
-    entry.parentPath &&
-    isLooseContentFilePath(path.join(entry.parentPath, entry.name));
+    const classification = classifyContentFilePath(
+        path.join(entry.parentPath, entry.name),
+    );
+    return (
+        classification?.kind === 'content' &&
+        classification.supportedExtension &&
+        `${classification.contentType}s` === folder
+    );
+};
+
+const isLooseContentFile = (entry: Dirent) => {
+    if (!entry.isFile() || !entry.parentPath) return false;
+
+    const classification = classifyContentFilePath(
+        path.join(entry.parentPath, entry.name),
+    );
+    return (
+        classification?.kind === 'loose' && classification.supportedExtension
+    );
+};
 
 const processYamlItem = <
     T extends ChartAsCode | DashboardAsCode | SqlChartAsCode,
@@ -2557,11 +2570,6 @@ const runUploadChangesPhase = async ({
     return updatedChanges;
 };
 
-// SQL charts have 'sql' field instead of 'tableName'/'metricQuery'
-const isSqlChart = (
-    item: ChartAsCode | DashboardAsCode | SqlChartAsCode,
-): item is SqlChartAsCode => 'sql' in item && !('tableName' in item);
-
 const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
     item: T & { needsUpdating: boolean },
     type: 'charts' | 'dashboards',
@@ -2585,7 +2593,7 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
         GlobalState.debug(`Upserting ${type} ${item.slug}`);
 
         // SQL charts use a different endpoint
-        const isSqlChartItem = type === 'charts' && isSqlChart(item);
+        const isSqlChartItem = type === 'charts' && isSqlChartContent(item);
         const endpoint = isSqlChartItem
             ? `/api/v1/projects/${projectId}/code/sqlCharts/${item.slug}`
             : `/api/v1/projects/${projectId}/code/${type}/${item.slug}`;

--- a/packages/cli/src/handlers/lint.test.ts
+++ b/packages/cli/src/handlers/lint.test.ts
@@ -97,10 +97,17 @@ describe('lintHandler', () => {
             ].join('\n'),
         );
 
-        const lintOutput = await expectLintFailure();
+        await expect(
+            lintHandler({ path: tempDir, format: 'cli' }),
+        ).rejects.toThrow('process.exit');
+        expect(process.exit).toHaveBeenCalledWith(2);
+        const lintOutput = output.join('\n');
 
         expect(lintOutput).toContain('missing-version.yml');
         expect(lintOutput).toContain("Missing required property 'version'");
+        expect(lintOutput).toContain('2 Lightdash Code files');
+        expect(lintOutput).toContain('1 valid');
+        expect(lintOutput).toContain('1 invalid');
     });
 
     test('fails when a chart upload file cannot be parsed', async () => {
@@ -108,13 +115,14 @@ describe('lintHandler', () => {
         await fs.mkdir(chartsDir);
         await fs.writeFile(
             path.join(chartsDir, 'invalid-yaml.yml'),
-            'name: [unterminated',
+            ['name: Invalid YAML', 'slug: invalid-yaml', 'sql: ]'].join('\n'),
         );
 
         const lintOutput = await expectLintFailure();
 
         expect(lintOutput).toContain('invalid-yaml.yml');
         expect(lintOutput).toContain('chart/parse');
+        expect(lintOutput).toContain('"startLine": 3');
     });
 
     test('reports empty chart upload files as invalid', async () => {
@@ -149,7 +157,11 @@ describe('lintHandler', () => {
         await fs.mkdir(dashboardsDir);
         await fs.writeFile(
             path.join(dashboardsDir, 'sql-chart.yml'),
-            'contentType: sqlChart\nname: Misplaced SQL chart',
+            [
+                'contentType: sql_chart',
+                'name: Misplaced SQL chart',
+                'sql: SELECT 1',
+            ].join('\n'),
         );
 
         const lintOutput = await expectLintFailure();
@@ -158,25 +170,161 @@ describe('lintHandler', () => {
         expect(lintOutput).toContain("Missing required property 'version'");
     });
 
-    test('ignores YAML files upload would not select and SQL charts', async () => {
+    test('accepts structurally recognized SQL charts selected for upload', async () => {
         const chartsDir = path.join(tempDir, 'charts');
         await fs.mkdir(chartsDir);
         await fs.writeFile(
-            path.join(tempDir, 'unrelated.yml'),
-            'metricQuery: {}\ntiles: []',
-        );
-        await fs.writeFile(
             path.join(tempDir, 'sql-chart.yml'),
-            'contentType: sqlChart\nname: Loose SQL chart',
+            [
+                'contentType: sql_chart',
+                'name: Loose SQL chart',
+                'sql: SELECT 1',
+            ].join('\n'),
         );
         await fs.writeFile(
             path.join(chartsDir, 'sql-chart.yml'),
-            'contentType: sqlChart\nname: Folder SQL chart',
+            ['name: Folder SQL chart', 'sql: SELECT 1'].join('\n'),
+        );
+
+        await lintHandler({ path: tempDir, format: 'cli' });
+
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(output.join('\n')).toContain(
+            'All Lightdash Code files are valid!',
+        );
+    });
+
+    test('ignores loose YAML files upload would not select', async () => {
+        await fs.writeFile(
+            path.join(tempDir, 'unrelated.yml'),
+            ['version: 1', 'metricQuery: {}', 'name: Not uploadable'].join(
+                '\n',
+            ),
         );
 
         await lintHandler({ path: tempDir, format: 'cli' });
 
         expect(process.exit).not.toHaveBeenCalled();
         expect(output.join('\n')).toContain('No Lightdash Code files found.');
+    });
+
+    test('accepts merge keys that upload resolves with js-yaml', async () => {
+        const dashboardsDir = path.join(tempDir, 'dashboards');
+        await fs.mkdir(dashboardsDir);
+        await fs.writeFile(
+            path.join(dashboardsDir, 'merged-tabs.yml'),
+            [
+                'contentType: dashboard',
+                'name: Merged tabs',
+                'slug: merged-tabs',
+                'spaceSlug: shared',
+                'version: 1',
+                'tiles: []',
+                'tabs:',
+                '  - &tab',
+                '    name: Overview',
+                '    order: 0',
+                '  - <<: *tab',
+                '    name: Details',
+                '    order: 1',
+            ].join('\n'),
+        );
+
+        await lintHandler({ path: tempDir, format: 'cli' });
+
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(output.join('\n')).toContain(
+            'All Lightdash Code files are valid!',
+        );
+    });
+
+    test('reports parse errors for loose content files and models', async () => {
+        const modelsDir = path.join(tempDir, 'models');
+        await fs.mkdir(modelsDir);
+        await fs.writeFile(
+            path.join(tempDir, 'loose-chart.yml'),
+            [
+                'contentType: chart',
+                'name: Broken chart',
+                'bad: [unterminated',
+            ].join('\n'),
+        );
+        await fs.writeFile(
+            path.join(modelsDir, 'broken-model.yml'),
+            ['type: model', 'name: Broken model', 'bad: [unterminated'].join(
+                '\n',
+            ),
+        );
+
+        const lintOutput = await expectLintFailure();
+
+        expect(lintOutput).toContain('loose-chart.yml');
+        expect(lintOutput).toContain('chart/parse');
+        expect(lintOutput).toContain('broken-model.yml');
+        expect(lintOutput).toContain('model/parse');
+    });
+
+    test('reports .yaml content files as unsupported', async () => {
+        const chartsDir = path.join(tempDir, 'charts');
+        await fs.mkdir(chartsDir);
+        await fs.writeFile(
+            path.join(chartsDir, 'unsupported.yaml'),
+            'name: Unsupported extension',
+        );
+
+        const lintOutput = await expectLintFailure();
+
+        expect(lintOutput).toContain('unsupported.yaml');
+        expect(lintOutput).toContain('chart/extension');
+        expect(lintOutput).toContain(
+            "Content files must use the '.yml' extension",
+        );
+    });
+
+    test('defaults strict content discovery to the upload root', async () => {
+        const thirdPartyChartsDir = path.join(tempDir, 'vendor', 'charts');
+        await fs.mkdir(thirdPartyChartsDir, { recursive: true });
+        await fs.writeFile(
+            path.join(thirdPartyChartsDir, 'unrelated.yml'),
+            'name: Not Lightdash content',
+        );
+        vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+
+        await lintHandler({ format: 'cli' });
+
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(output.join('\n')).toContain('No Lightdash Code files found.');
+    });
+
+    test('discovers content when run from inside the download root', async () => {
+        const chartsDir = path.join(tempDir, 'charts');
+        await fs.mkdir(chartsDir);
+        await fs.writeFile(
+            path.join(chartsDir, 'missing-version.yml'),
+            'name: Missing version',
+        );
+        vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+
+        await expect(lintHandler({ format: 'cli' })).rejects.toThrow(
+            'process.exit',
+        );
+
+        expect(output.join('\n')).toContain('missing-version.yml');
+        expect(output.join('\n')).toContain(
+            "Missing required property 'version'",
+        );
+    });
+
+    test('shows the filename when linting a single file', async () => {
+        const dashboardsDir = path.join(tempDir, 'dashboards');
+        await fs.mkdir(dashboardsDir);
+        const dashboardPath = path.join(dashboardsDir, 'single-file.yml');
+        await fs.writeFile(dashboardPath, 'name: Missing version');
+
+        await expect(
+            lintHandler({ path: dashboardPath, format: 'cli' }),
+        ).rejects.toThrow('process.exit');
+
+        expect(output.join('\n')).toContain('✗ single-file.yml');
     });
 });

--- a/packages/cli/src/handlers/lint.test.ts
+++ b/packages/cli/src/handlers/lint.test.ts
@@ -1,0 +1,182 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { lintHandler } from './lint';
+
+vi.mock('../analytics/analytics', () => ({
+    categorizeError: vi.fn(),
+    LightdashAnalytics: {
+        track: vi.fn().mockResolvedValue(undefined),
+    },
+}));
+
+describe('lintHandler', () => {
+    let tempDir: string;
+    let output: string[];
+
+    beforeEach(async () => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lightdash-lint-'));
+        output = [];
+        vi.spyOn(console, 'log').mockImplementation((...args) => {
+            output.push(args.map(String).join(' '));
+        });
+        vi.spyOn(process, 'exit').mockImplementation(() => {
+            throw new Error('process.exit');
+        });
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    const expectLintFailure = async () => {
+        await expect(
+            lintHandler({ path: tempDir, format: 'json' }),
+        ).rejects.toThrow('process.exit');
+        expect(process.exit).toHaveBeenCalledWith(2);
+        return output.join('\n');
+    };
+
+    test('fails for a dashboard upload file missing its required version', async () => {
+        const dashboardsDir = path.join(tempDir, 'dashboards');
+        await fs.mkdir(dashboardsDir);
+        await fs.writeFile(
+            path.join(dashboardsDir, 'missing-version.yml'),
+            [
+                'name: Missing version',
+                'slug: missing-version',
+                'spaceSlug: shared',
+                'tiles: []',
+                'tabs: []',
+            ].join('\n'),
+        );
+
+        const lintOutput = await expectLintFailure();
+
+        expect(lintOutput).toContain('missing-version.yml');
+        expect(lintOutput).toContain("Missing required property 'version'");
+    });
+
+    test('fails for a chart missing its required version alongside a valid sibling', async () => {
+        const chartsDir = path.join(tempDir, 'charts');
+        const dashboardsDir = path.join(tempDir, 'dashboards');
+        await fs.mkdir(chartsDir);
+        await fs.mkdir(dashboardsDir);
+        await fs.writeFile(
+            path.join(chartsDir, 'missing-version.yml'),
+            [
+                'name: Missing version',
+                'slug: missing-version',
+                'spaceSlug: shared',
+                'tableName: orders',
+                'metricQuery:',
+                '  exploreName: orders',
+                '  dimensions: []',
+                '  metrics: []',
+                '  filters: {}',
+                '  sorts: []',
+                '  limit: 500',
+                '  tableCalculations: []',
+                '  additionalMetrics: []',
+                '  customDimensions: []',
+                'chartConfig:',
+                '  type: table',
+                '  config: {}',
+            ].join('\n'),
+        );
+        await fs.writeFile(
+            path.join(dashboardsDir, 'valid.yml'),
+            [
+                'name: Valid dashboard',
+                'slug: valid-dashboard',
+                'spaceSlug: shared',
+                'tiles: []',
+                'tabs: []',
+                'version: 1',
+            ].join('\n'),
+        );
+
+        const lintOutput = await expectLintFailure();
+
+        expect(lintOutput).toContain('missing-version.yml');
+        expect(lintOutput).toContain("Missing required property 'version'");
+    });
+
+    test('fails when a chart upload file cannot be parsed', async () => {
+        const chartsDir = path.join(tempDir, 'charts');
+        await fs.mkdir(chartsDir);
+        await fs.writeFile(
+            path.join(chartsDir, 'invalid-yaml.yml'),
+            'name: [unterminated',
+        );
+
+        const lintOutput = await expectLintFailure();
+
+        expect(lintOutput).toContain('invalid-yaml.yml');
+        expect(lintOutput).toContain('chart/parse');
+    });
+
+    test('reports empty chart upload files as invalid', async () => {
+        const chartsDir = path.join(tempDir, 'charts');
+        await fs.mkdir(chartsDir);
+        await fs.writeFile(path.join(chartsDir, 'empty.yml'), '');
+
+        const lintOutput = await expectLintFailure();
+
+        expect(lintOutput).toContain('empty.yml');
+        expect(lintOutput).toContain('chart/type');
+    });
+
+    test('validates loose chart files by contentType', async () => {
+        await fs.writeFile(
+            path.join(tempDir, 'loose-chart.yml'),
+            [
+                'contentType: chart',
+                'name: Missing version',
+                'metricQuery: {}',
+            ].join('\n'),
+        );
+
+        const lintOutput = await expectLintFailure();
+
+        expect(lintOutput).toContain('loose-chart.yml');
+        expect(lintOutput).toContain("Missing required property 'version'");
+    });
+
+    test('validates SQL chart content as a dashboard when placed in dashboards', async () => {
+        const dashboardsDir = path.join(tempDir, 'dashboards');
+        await fs.mkdir(dashboardsDir);
+        await fs.writeFile(
+            path.join(dashboardsDir, 'sql-chart.yml'),
+            'contentType: sqlChart\nname: Misplaced SQL chart',
+        );
+
+        const lintOutput = await expectLintFailure();
+
+        expect(lintOutput).toContain('sql-chart.yml');
+        expect(lintOutput).toContain("Missing required property 'version'");
+    });
+
+    test('ignores YAML files upload would not select and SQL charts', async () => {
+        const chartsDir = path.join(tempDir, 'charts');
+        await fs.mkdir(chartsDir);
+        await fs.writeFile(
+            path.join(tempDir, 'unrelated.yml'),
+            'metricQuery: {}\ntiles: []',
+        );
+        await fs.writeFile(
+            path.join(tempDir, 'sql-chart.yml'),
+            'contentType: sqlChart\nname: Loose SQL chart',
+        );
+        await fs.writeFile(
+            path.join(chartsDir, 'sql-chart.yml'),
+            'contentType: sqlChart\nname: Folder SQL chart',
+        );
+
+        await lintHandler({ path: tempDir, format: 'cli' });
+
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(output.join('\n')).toContain('No Lightdash Code files found.');
+    });
+});

--- a/packages/cli/src/handlers/lint.ts
+++ b/packages/cli/src/handlers/lint.ts
@@ -1,6 +1,7 @@
 import {
     assertUnreachable,
     chartAsCodeSchema,
+    ContentAsCodeType,
     dashboardAsCodeSchema,
     getErrorMessage,
     modelAsCodeSchema,
@@ -8,15 +9,19 @@ import {
 import type { ErrorObject } from 'ajv';
 import chalk from 'chalk';
 import * as fs from 'fs';
+import * as yaml from 'js-yaml';
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import * as YAML from 'yaml';
 import { ajv } from '../ajv';
 import { categorizeError, LightdashAnalytics } from '../analytics/analytics';
 import {
-    getContentFileType,
-    isLooseContentFilePath,
+    classifyContentFilePath,
+    isSqlChartContent,
+    type ContentFileClassification,
+    type ContentFileType,
 } from './contentAsCode/fileDiscovery';
+import { getDownloadFolder } from './contentAsCodePaths';
 import { createSarifReport } from './lint/ajvToSarif';
 import { formatSarifForCli, getSarifSummary } from './lint/sarifFormatter';
 
@@ -28,7 +33,7 @@ type LintOptions = {
 
 type LocationMap = Map<string, { line: number; column: number }>;
 
-type LightdashCodeType = 'chart' | 'dashboard' | 'model';
+type LightdashCodeType = ContentFileType | 'model';
 
 type FileValidationResult = {
     filePath: string;
@@ -125,11 +130,15 @@ function buildLocationMap(
         return { data, locationMap };
     }
 
-    // Parse YAML with the 'yaml' package to access the Abstract Syntax Tree (AST)
-    const doc = YAML.parseDocument(fileContent);
-    if (doc.errors.length > 0) {
-        throw doc.errors[0];
-    }
+    // Match upload parsing, then normalize the value as it will be serialized
+    // into the upload request. Use `yaml` separately for source locations.
+    const parsedData = yaml.load(fileContent);
+    const serializedData = JSON.stringify(parsedData);
+    const data =
+        serializedData === undefined
+            ? parsedData
+            : (JSON.parse(serializedData) as unknown);
+    const doc = YAML.parseDocument(fileContent, { merge: true });
 
     function traverse(node: YAML.Node | null, jsonPath: string) {
         if (!node) return;
@@ -161,10 +170,10 @@ function buildLocationMap(
         }
     }
 
-    traverse(doc.contents, '');
+    if (doc.errors.length === 0) {
+        traverse(doc.contents, '');
+    }
 
-    // Convert to plain JS object for validation
-    const data = doc.toJS();
     return { data, locationMap };
 }
 
@@ -216,53 +225,169 @@ function validateAsCodeSchema({
 /**
  * Validate a single YAML or JSON file
  */
-function validateFile(filePath: string): FileValidationResult {
-    const uploadType = getContentFileType(filePath);
+type LintData = {
+    type?: string;
+    contentType?: string;
+};
+
+function createErrorResult({
+    error,
+    fileContent,
+    filePath,
+    locationMap,
+    type,
+}: {
+    error: ErrorObject;
+    fileContent: string;
+    filePath: string;
+    locationMap?: LocationMap;
+    type: LightdashCodeType;
+}): FileValidationResult {
+    return {
+        filePath,
+        valid: false,
+        errors: [error],
+        fileContent,
+        locationMap,
+        type,
+    };
+}
+
+function getUploadType(
+    classification: ContentFileClassification | undefined,
+    data?: LintData,
+): ContentFileType | undefined {
+    if (classification?.kind === 'content') {
+        return classification.contentType;
+    }
+    if (classification?.kind !== 'loose') return undefined;
+
+    if (
+        data?.contentType === ContentAsCodeType.CHART ||
+        data?.contentType === ContentAsCodeType.SQL_CHART
+    ) {
+        return 'chart';
+    }
+    if (data?.contentType === ContentAsCodeType.DASHBOARD) {
+        return 'dashboard';
+    }
+    return undefined;
+}
+
+function getModelCodeType(data?: LintData): 'model' | undefined {
+    if (
+        data?.type === 'model' ||
+        data?.type === 'model/v1beta' ||
+        data?.type === 'model/v1'
+    ) {
+        return 'model';
+    }
+    return undefined;
+}
+
+function getPartialYamlData(fileContent: string): LintData | undefined {
+    try {
+        const doc = YAML.parseDocument(fileContent, { merge: true });
+        const data = doc.toJS() as unknown;
+        return data && typeof data === 'object' && !Array.isArray(data)
+            ? (data as LintData)
+            : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function getParseErrorLocation(
+    error: unknown,
+): { line: number; column: number } | undefined {
+    if (!error || typeof error !== 'object') return undefined;
+
+    const linePos = Reflect.get(error, 'linePos');
+    if (Array.isArray(linePos)) {
+        const firstPosition = linePos[0] as { line?: unknown; col?: unknown };
+        if (
+            typeof firstPosition?.line === 'number' &&
+            typeof firstPosition.col === 'number'
+        ) {
+            return { line: firstPosition.line, column: firstPosition.col };
+        }
+    }
+
+    const mark = Reflect.get(error, 'mark') as
+        | { line?: unknown; column?: unknown }
+        | undefined;
+    if (typeof mark?.line === 'number' && typeof mark.column === 'number') {
+        return { line: mark.line + 1, column: mark.column + 1 };
+    }
+    return undefined;
+}
+
+function createUnsupportedExtensionResult(
+    filePath: string,
+    fileContent: string,
+    type: ContentFileType,
+): FileValidationResult {
+    return createErrorResult({
+        filePath,
+        fileContent,
+        type,
+        error: {
+            keyword: 'extension',
+            instancePath: '',
+            schemaPath: '',
+            params: { allowedExtension: '.yml' },
+            message: "Content files must use the '.yml' extension",
+        },
+    });
+}
+
+function validateFile(
+    filePath: string,
+    contentRoot: string,
+): FileValidationResult {
+    const classification = classifyContentFilePath(filePath, contentRoot);
     let fileContent: string | undefined;
 
     try {
         fileContent = fs.readFileSync(filePath, 'utf8');
         const isJson = filePath.endsWith('.json');
         const { data, locationMap } = buildLocationMap(fileContent, isJson);
+        const dataObj =
+            data && typeof data === 'object' && !Array.isArray(data)
+                ? (data as LintData)
+                : undefined;
+        const uploadType = getUploadType(classification, dataObj);
 
-        if (!data || typeof data !== 'object') {
+        if (uploadType && classification?.supportedExtension === false) {
+            return createUnsupportedExtensionResult(
+                filePath,
+                fileContent,
+                uploadType,
+            );
+        }
+
+        if (!dataObj) {
             return uploadType
-                ? {
+                ? createErrorResult({
                       filePath,
-                      valid: false,
-                      errors: [
-                          {
-                              keyword: 'type',
-                              instancePath: '',
-                              schemaPath: '#/type',
-                              params: { type: 'object' },
-                              message: 'must be object',
-                          },
-                      ],
                       fileContent,
                       locationMap,
                       type: uploadType,
-                  }
+                      error: {
+                          keyword: 'type',
+                          instancePath: '',
+                          schemaPath: '#/type',
+                          params: { type: 'object' },
+                          message: 'must be object',
+                      },
+                  })
                 : { filePath, valid: true };
         }
 
-        const dataObj = data as {
-            type?: string;
-            contentType?: string;
-            version?: number;
-            metricQuery?: unknown;
-            tiles?: unknown;
-        };
-        const isLooseFile = isLooseContentFilePath(filePath);
-
-        if (
-            dataObj.contentType === 'sqlChart' &&
-            (uploadType === 'chart' || isLooseFile)
-        ) {
-            return { filePath, valid: true };
-        }
-
         if (uploadType) {
+            if (uploadType === 'chart' && isSqlChartContent(dataObj)) {
+                return { filePath, valid: true, type: 'chart' };
+            }
             return validateAsCodeSchema({
                 data,
                 fileContent,
@@ -272,76 +397,64 @@ function validateFile(filePath: string): FileValidationResult {
             });
         }
 
-        let looseContentType: 'chart' | 'dashboard' | undefined;
-        if (isLooseFile && dataObj.contentType === 'chart') {
-            looseContentType = 'chart';
-        } else if (isLooseFile && dataObj.contentType === 'dashboard') {
-            looseContentType = 'dashboard';
-        }
-        if (looseContentType) {
+        const modelType = getModelCodeType(dataObj);
+        if (modelType) {
             return validateAsCodeSchema({
                 data,
                 fileContent,
                 filePath,
                 locationMap,
-                type: looseContentType,
-            });
-        }
-
-        if (
-            dataObj.type === 'model' ||
-            dataObj.type === 'model/v1beta' ||
-            dataObj.type === 'model/v1'
-        ) {
-            return validateAsCodeSchema({
-                data,
-                fileContent,
-                filePath,
-                locationMap,
-                type: 'model',
-            });
-        }
-
-        if (dataObj.version === 1 && dataObj.metricQuery && !dataObj.tiles) {
-            return validateAsCodeSchema({
-                data,
-                fileContent,
-                filePath,
-                locationMap,
-                type: 'chart',
-            });
-        }
-
-        if (dataObj.version === 1 && dataObj.tiles) {
-            return validateAsCodeSchema({
-                data,
-                fileContent,
-                filePath,
-                locationMap,
-                type: 'dashboard',
+                type: modelType,
             });
         }
 
         return { filePath, valid: true };
     } catch (error) {
-        if (!uploadType) return { filePath, valid: true };
+        const partialData = fileContent
+            ? getPartialYamlData(fileContent)
+            : undefined;
+        const uploadType = getUploadType(classification, partialData);
+        const type = uploadType ?? getModelCodeType(partialData);
+        if (!type) return { filePath, valid: true };
+        if (uploadType && classification?.supportedExtension === false) {
+            return createUnsupportedExtensionResult(
+                filePath,
+                fileContent ?? '',
+                uploadType,
+            );
+        }
 
-        return {
+        const parseLocation = getParseErrorLocation(error);
+        const locationMap = parseLocation
+            ? new Map([['/', parseLocation]])
+            : undefined;
+        return createErrorResult({
             filePath,
-            valid: false,
-            errors: [
-                {
-                    keyword: 'parse',
-                    instancePath: '',
-                    schemaPath: '',
-                    params: {},
-                    message: getErrorMessage(error),
-                },
-            ],
             fileContent: fileContent ?? '',
-            type: uploadType,
-        };
+            locationMap,
+            type,
+            error: {
+                keyword: 'parse',
+                instancePath: '',
+                schemaPath: '',
+                params: {},
+                message: getErrorMessage(error),
+            },
+        });
     }
+}
+
+function getDefaultContentRoot(searchPath: string): string {
+    const contentRootMarkers = [
+        '.lightdash-metadata.json',
+        'charts',
+        'dashboards',
+    ];
+    return contentRootMarkers.some((marker) =>
+        fs.existsSync(path.join(searchPath, marker)),
+    )
+        ? searchPath
+        : getDownloadFolder();
 }
 
 export async function lintHandler(options: LintOptions): Promise<void> {
@@ -356,6 +469,12 @@ export async function lintHandler(options: LintOptions): Promise<void> {
         // Check if path exists
         if (!fs.existsSync(searchPath)) {
             throw new Error(`Path does not exist: ${searchPath}`);
+        }
+        let contentRoot = getDefaultContentRoot(searchPath);
+        if (options.path) {
+            contentRoot = fs.statSync(searchPath).isFile()
+                ? path.dirname(searchPath)
+                : searchPath;
         }
 
         if (outputFormat === 'cli') {
@@ -387,7 +506,7 @@ export async function lintHandler(options: LintOptions): Promise<void> {
 
             // Validate each file
             for (const file of codeFiles) {
-                const result = validateFile(file);
+                const result = validateFile(file, contentRoot);
                 // Only track Lightdash Code files (models, charts, dashboards)
                 if (result.type) {
                     results.push(result);

--- a/packages/cli/src/handlers/lint.ts
+++ b/packages/cli/src/handlers/lint.ts
@@ -1,4 +1,5 @@
 import {
+    assertUnreachable,
     chartAsCodeSchema,
     dashboardAsCodeSchema,
     getErrorMessage,
@@ -12,6 +13,10 @@ import { v4 as uuidv4 } from 'uuid';
 import * as YAML from 'yaml';
 import { ajv } from '../ajv';
 import { categorizeError, LightdashAnalytics } from '../analytics/analytics';
+import {
+    getContentFileType,
+    isLooseContentFilePath,
+} from './contentAsCode/fileDiscovery';
 import { createSarifReport } from './lint/ajvToSarif';
 import { formatSarifForCli, getSarifSummary } from './lint/sarifFormatter';
 
@@ -23,13 +28,15 @@ type LintOptions = {
 
 type LocationMap = Map<string, { line: number; column: number }>;
 
+type LightdashCodeType = 'chart' | 'dashboard' | 'model';
+
 type FileValidationResult = {
     filePath: string;
     valid: boolean;
     errors?: ErrorObject[];
     fileContent?: string;
     locationMap?: LocationMap;
-    type?: 'chart' | 'dashboard' | 'model';
+    type?: LightdashCodeType;
 };
 
 const validateChartSchema = ajv.compile(chartAsCodeSchema);
@@ -120,6 +127,9 @@ function buildLocationMap(
 
     // Parse YAML with the 'yaml' package to access the Abstract Syntax Tree (AST)
     const doc = YAML.parseDocument(fileContent);
+    if (doc.errors.length > 0) {
+        throw doc.errors[0];
+    }
 
     function traverse(node: YAML.Node | null, jsonPath: string) {
         if (!node) return;
@@ -158,93 +168,178 @@ function buildLocationMap(
     return { data, locationMap };
 }
 
+function validateAsCodeSchema({
+    data,
+    fileContent,
+    filePath,
+    locationMap,
+    type,
+}: {
+    data: unknown;
+    fileContent: string;
+    filePath: string;
+    locationMap: LocationMap;
+    type: LightdashCodeType;
+}): FileValidationResult {
+    let validate;
+    switch (type) {
+        case 'chart':
+            validate = validateChartSchema;
+            break;
+        case 'dashboard':
+            validate = validateDashboardSchema;
+            break;
+        case 'model':
+            validate = validateModelSchema;
+            break;
+        default:
+            return assertUnreachable(
+                type,
+                `Unknown Lightdash Code type: ${type}`,
+            );
+    }
+    const valid = validate(data);
+
+    if (!valid && validate.errors) {
+        return {
+            filePath,
+            valid: false,
+            errors: validate.errors,
+            fileContent,
+            locationMap,
+            type,
+        };
+    }
+    return { filePath, valid: true, type };
+}
+
 /**
  * Validate a single YAML or JSON file
  */
 function validateFile(filePath: string): FileValidationResult {
+    const uploadType = getContentFileType(filePath);
+    let fileContent: string | undefined;
+
     try {
-        // Read and parse file
-        const fileContent = fs.readFileSync(filePath, 'utf8');
+        fileContent = fs.readFileSync(filePath, 'utf8');
         const isJson = filePath.endsWith('.json');
         const { data, locationMap } = buildLocationMap(fileContent, isJson);
 
         if (!data || typeof data !== 'object') {
-            return {
-                filePath,
-                valid: false,
-                // Skip non-object files as they're not lightdash code
-            };
+            return uploadType
+                ? {
+                      filePath,
+                      valid: false,
+                      errors: [
+                          {
+                              keyword: 'type',
+                              instancePath: '',
+                              schemaPath: '#/type',
+                              params: { type: 'object' },
+                              message: 'must be object',
+                          },
+                      ],
+                      fileContent,
+                      locationMap,
+                      type: uploadType,
+                  }
+                : { filePath, valid: true };
         }
 
         const dataObj = data as {
-            version?: number;
             type?: string;
+            contentType?: string;
+            version?: number;
             metricQuery?: unknown;
             tiles?: unknown;
         };
+        const isLooseFile = isLooseContentFilePath(filePath);
 
-        // Check if this is a model (has type: "model", "model/v1beta", or "model/v1")
+        if (
+            dataObj.contentType === 'sqlChart' &&
+            (uploadType === 'chart' || isLooseFile)
+        ) {
+            return { filePath, valid: true };
+        }
+
+        if (uploadType) {
+            return validateAsCodeSchema({
+                data,
+                fileContent,
+                filePath,
+                locationMap,
+                type: uploadType,
+            });
+        }
+
+        let looseContentType: 'chart' | 'dashboard' | undefined;
+        if (isLooseFile && dataObj.contentType === 'chart') {
+            looseContentType = 'chart';
+        } else if (isLooseFile && dataObj.contentType === 'dashboard') {
+            looseContentType = 'dashboard';
+        }
+        if (looseContentType) {
+            return validateAsCodeSchema({
+                data,
+                fileContent,
+                filePath,
+                locationMap,
+                type: looseContentType,
+            });
+        }
+
         if (
             dataObj.type === 'model' ||
             dataObj.type === 'model/v1beta' ||
             dataObj.type === 'model/v1'
         ) {
-            const valid = validateModelSchema(data);
-            if (!valid && validateModelSchema.errors) {
-                return {
-                    filePath,
-                    valid: false,
-                    errors: validateModelSchema.errors,
-                    fileContent,
-                    locationMap,
-                    type: 'model',
-                };
-            }
-            return { filePath, valid: true, type: 'model' };
+            return validateAsCodeSchema({
+                data,
+                fileContent,
+                filePath,
+                locationMap,
+                type: 'model',
+            });
         }
 
-        // Check if this is a chart (has version and metricQuery)
         if (dataObj.version === 1 && dataObj.metricQuery && !dataObj.tiles) {
-            const valid = validateChartSchema(data);
-            if (!valid && validateChartSchema.errors) {
-                return {
-                    filePath,
-                    valid: false,
-                    errors: validateChartSchema.errors,
-                    fileContent,
-                    locationMap,
-                    type: 'chart',
-                };
-            }
-            return { filePath, valid: true, type: 'chart' };
+            return validateAsCodeSchema({
+                data,
+                fileContent,
+                filePath,
+                locationMap,
+                type: 'chart',
+            });
         }
 
-        // Check if this is a dashboard (has version and tiles)
         if (dataObj.version === 1 && dataObj.tiles) {
-            const valid = validateDashboardSchema(data);
-            if (!valid && validateDashboardSchema.errors) {
-                return {
-                    filePath,
-                    valid: false,
-                    errors: validateDashboardSchema.errors,
-                    fileContent,
-                    locationMap,
-                    type: 'dashboard',
-                };
-            }
-            return { filePath, valid: true, type: 'dashboard' };
+            return validateAsCodeSchema({
+                data,
+                fileContent,
+                filePath,
+                locationMap,
+                type: 'dashboard',
+            });
         }
 
-        // Not a lightdash code file
-        return {
-            filePath,
-            valid: true, // Don't report non-lightdash files as errors
-        };
+        return { filePath, valid: true };
     } catch (error) {
-        // Parsing error - skip this file
+        if (!uploadType) return { filePath, valid: true };
+
         return {
             filePath,
             valid: false,
+            errors: [
+                {
+                    keyword: 'parse',
+                    instancePath: '',
+                    schemaPath: '',
+                    params: {},
+                    message: getErrorMessage(error),
+                },
+            ],
+            fileContent: fileContent ?? '',
+            type: uploadType,
         };
     }
 }
@@ -304,7 +399,7 @@ export async function lintHandler(options: LintOptions): Promise<void> {
                     console.log(chalk.yellow('No Lightdash Code files found.'));
                     console.log(
                         chalk.dim(
-                            'Models must have type: model (or model/v1, model/v1beta), charts must have version: 1 + metricQuery, dashboards must have version: 1 + tiles',
+                            'Models must have type: model (or model/v1, model/v1beta). Charts and dashboards must be in their matching folder or declare contentType.',
                         ),
                     );
                 }
@@ -313,7 +408,7 @@ export async function lintHandler(options: LintOptions): Promise<void> {
                 const sarifResults = results
                     .filter(
                         (r) =>
-                            r.fileContent &&
+                            r.fileContent !== undefined &&
                             r.type &&
                             r.errors &&
                             r.errors.length > 0,

--- a/packages/cli/src/handlers/lint/sarifFormatter.ts
+++ b/packages/cli/src/handlers/lint/sarifFormatter.ts
@@ -79,7 +79,8 @@ export function formatSarifForCli(
         output.push(color(`\n${sectionLabel}\n`));
 
         for (const [fileUri, fileResults] of byFile.entries()) {
-            const relativePath = path.relative(searchPath, fileUri);
+            const relativePath =
+                path.relative(searchPath, fileUri) || path.basename(fileUri);
             output.push(boldColor(`\n${marker} ${relativePath}`));
 
             for (const result of fileResults) {


### PR DESCRIPTION
## What changed

## Summary
- Align lint discovery with upload discovery for folder-based and loose chart/dashboard content.
- Report schema and YAML parsing failures instead of silently dropping invalid uploadable files.
- Preserve standalone shape-based linting and exclude SQL charts where upload treats them as SQL charts.
- Add regression coverage for missing versions, valid siblings, malformed/empty YAML, loose content, and SQL chart boundaries.

### Validation
- `pnpm -F 'cli' exec oxfmt 'src/handlers/contentAsCode/fileDiscovery.ts' 'src/handlers/download.ts' 'src/handlers/lint.test.ts' 'src/handlers/lint.ts'` — passed
- `pnpm -F 'cli' run --if-present lint` — passed
- `pnpm -F 'cli' run --if-present typecheck` — passed
- `pnpm -F 'cli' run --if-present test` — passed

## Preview

[Open the public Lightdash preview](https://ld-runner-prod-10459-90edae3f03d9.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10459

