### PR TITLE
fix: condense the chart gallery sidebar into a drill-in flow

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
@@ -13,12 +13,39 @@
     min-width: 0;
 }
 
+.rowWrapper {
+    position: relative;
+}
+
 .row {
     width: 100%;
     padding: var(--mantine-spacing-sm);
     border: 1px solid transparent;
     border-radius: var(--mantine-radius-md);
     text-align: left;
+}
+
+/* Reserve space for the hover-revealed Edit so text never runs under it. */
+.row[data-has-edit='true'] {
+    padding-right: calc(var(--mantine-spacing-sm) * 2 + 24px);
+}
+
+/* Edit fades in on hover/focus so resting rows stay clean. */
+.rowEdit {
+    position: absolute;
+    top: 50%;
+    right: var(--mantine-spacing-sm);
+    translate: 0 -50%;
+    font-family: inherit;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 100ms ease-out;
+}
+
+.rowWrapper:hover .rowEdit,
+.rowWrapper:focus-within .rowEdit {
+    opacity: 1;
+    pointer-events: auto;
 }
 
 .row:hover:not(:disabled) {
@@ -47,6 +74,12 @@
         var(--mantine-color-white),
         var(--mantine-color-ldDark-7)
     );
+}
+
+.thumbnail[data-small='true'] {
+    width: 46px;
+    height: 30px;
+    flex: 0 0 46px;
 }
 
 .icon {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -1,5 +1,6 @@
 import { FeatureFlags, type DataAppViz } from '@lightdash/common';
 import {
+    Anchor,
     Box,
     Button,
     Group,
@@ -11,10 +12,11 @@ import {
     UnstyledButton,
 } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
-import { IconChevronRight, IconPlus, IconSearch } from '@tabler/icons-react';
+import { IconPlus, IconSearch } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
+import { useCanEditDataAppChecker } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualizations } from '../../../features/chartTypes/hooks/useDataAppVisualizations';
 import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
@@ -33,20 +35,25 @@ import classes from './ChartTypeGallery.module.css';
 export type ChartTypeGalleryItem = Omit<ChartTypeOption, 'id'> & {
     key: string;
     disabled: boolean;
+    /** Opens the chart type builder for this item; null hides the action. */
+    onEdit: (() => void) | null;
 };
 
-type ThumbnailProps = Pick<ChartTypeOption, 'icon' | 'rotatedIcon'>;
+type ThumbnailProps = Pick<ChartTypeOption, 'icon' | 'rotatedIcon'> & {
+    small?: boolean;
+};
 
 export const ChartTypeThumbnail: FC<ThumbnailProps> = ({
     icon,
     rotatedIcon,
+    small,
 }) => (
-    <Box className={classes.thumbnail}>
+    <Box className={classes.thumbnail} data-small={small}>
         <MantineIcon
             className={classes.icon}
             data-rotated={rotatedIcon}
             icon={icon}
-            size="xl"
+            size={small ? 'md' : 'xl'}
             color="blue"
         />
     </Box>
@@ -129,37 +136,49 @@ const ChartTypeGallery: FC<GalleryProps> = ({
                             </Text>
                         ) : (
                             section.items.map((item) => (
-                                <UnstyledButton
+                                <Box
                                     key={item.key}
-                                    className={classes.row}
-                                    data-selected={item.selected}
-                                    disabled={item.disabled}
-                                    onClick={item.select}
+                                    className={classes.rowWrapper}
                                 >
-                                    <Group wrap="nowrap" gap="sm">
-                                        <ChartTypeThumbnail
-                                            icon={item.icon}
-                                            rotatedIcon={item.rotatedIcon}
-                                        />
-                                        <Stack gap={2} flex={1}>
-                                            <Text size="sm" fw={500}>
-                                                {item.label}
-                                            </Text>
-                                            <Text
-                                                fz="xs"
-                                                c="dimmed"
-                                                lineClamp={2}
-                                            >
-                                                {item.description}
-                                            </Text>
-                                        </Stack>
-                                        <MantineIcon
-                                            icon={IconChevronRight}
-                                            color="ldGray"
-                                            size="sm"
-                                        />
-                                    </Group>
-                                </UnstyledButton>
+                                    <UnstyledButton
+                                        className={classes.row}
+                                        data-selected={item.selected}
+                                        data-has-edit={item.onEdit !== null}
+                                        disabled={item.disabled}
+                                        onClick={item.select}
+                                    >
+                                        <Group wrap="nowrap" gap="sm">
+                                            <ChartTypeThumbnail
+                                                icon={item.icon}
+                                                rotatedIcon={item.rotatedIcon}
+                                            />
+                                            <Stack gap={2} flex={1}>
+                                                <Text size="sm" fw={500}>
+                                                    {item.label}
+                                                </Text>
+                                                <Text
+                                                    fz="xs"
+                                                    c="dimmed"
+                                                    lineClamp={2}
+                                                >
+                                                    {item.description}
+                                                </Text>
+                                            </Stack>
+                                        </Group>
+                                    </UnstyledButton>
+                                    {item.onEdit !== null ? (
+                                        <Anchor
+                                            component="button"
+                                            type="button"
+                                            className={classes.rowEdit}
+                                            fz="xs"
+                                            fw={500}
+                                            onClick={item.onEdit}
+                                        >
+                                            Edit
+                                        </Anchor>
+                                    ) : null}
+                                </Box>
                             ))
                         )}
 
@@ -223,6 +242,7 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
         debouncedSearch,
     );
     const canCreateChartType = useCanCreateDataApp(projectUuid);
+    const canEditChartType = useCanEditDataAppChecker(projectUuid);
     const { visualizationConfig, itemsMap } = useVisualizationContext();
     const selectProjectChartType = useSelectProjectChartType();
     const { disabled, options, vegaOption } = useChartTypeOptions();
@@ -249,6 +269,7 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
                 option.select();
                 onSelected();
             },
+            onEdit: null,
         }));
     const projectItems = projectTypes.map(
         (dataAppViz: DataAppViz): ChartTypeGalleryItem => {
@@ -268,6 +289,16 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
                     selectProjectChartType(dataAppViz, itemsMap ?? {});
                     onSelected();
                 },
+                onEdit: canEditChartType(dataAppViz)
+                    ? () =>
+                          void navigate({
+                              pathname: chartTypeBuilderPath(
+                                  projectUuid ?? '',
+                                  dataAppViz.dataAppVizUuid,
+                              ),
+                              search: location.search,
+                          })
+                    : null,
             };
         },
     );

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.module.css
@@ -25,10 +25,6 @@
     overflow: hidden;
 }
 
-.selectedChart {
-    flex: 0 0 auto;
-}
-
 .buttonAnchor {
     font-family: inherit;
 }

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.module.css
@@ -28,3 +28,7 @@
 .selectedChart {
     flex: 0 0 auto;
 }
+
+.buttonAnchor {
+    font-family: inherit;
+}

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
@@ -75,9 +75,29 @@ describe('ExplorerChartSidebar', () => {
             ChartType.TABLE,
             null,
         );
-        await userEvent.click(screen.getByText('Choose type'));
+        await userEvent.click(screen.getByRole('button', { name: 'Change' }));
         await userEvent.click(
             screen.getByRole('button', { name: 'Select chart' }),
+        );
+
+        expect(screen.getByText('Configure controls')).toBeInTheDocument();
+    });
+
+    it('returns to Configure from Choose without selecting', async () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <ExplorerChartSidebar
+                    chartType={ChartType.TABLE}
+                    onClose={vi.fn()}
+                />
+            </MemoryRouter>,
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: 'Change' }));
+        expect(screen.getByText('Choose chart type')).toBeInTheDocument();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Back to configuration' }),
         );
 
         expect(screen.getByText('Configure controls')).toBeInTheDocument();
@@ -90,7 +110,7 @@ describe('ExplorerChartSidebar', () => {
             </MemoryRouter>,
         );
 
-        await userEvent.click(screen.getByText('Choose type'));
+        await userEvent.click(screen.getByRole('button', { name: 'Change' }));
         await userEvent.click(
             screen.getByRole('button', {
                 name: 'Close visualization config',

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -1,20 +1,8 @@
-import { ChartType } from '@lightdash/common';
-import {
-    ActionIcon,
-    Anchor,
-    Group,
-    Paper,
-    SegmentedControl,
-    Stack,
-    Text,
-    Tooltip,
-} from '@mantine/core';
-import { IconSettings, IconX } from '@tabler/icons-react';
+import { type ChartType } from '@lightdash/common';
+import { ActionIcon, Anchor, Group, Stack, Text, Tooltip } from '@mantine/core';
+import { IconArrowLeft, IconSettings, IconX } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
-import { Link, useLocation } from 'react-router';
-import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
-import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { ChartGalleryContext } from '../../common/ChartGallery/ChartGalleryContext';
 import MantineIcon from '../../common/MantineIcon';
@@ -34,13 +22,9 @@ type Props = {
 
 type Mode = 'choose' | 'configure';
 
-const isMode = (value: string): value is Mode =>
-    value === 'choose' || value === 'configure';
-
 const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
     const [mode, setMode] = useState<Mode>('configure');
     const projectUuid = useProjectUuid();
-    const location = useLocation();
     const { visualizationConfig } = useVisualizationContext();
     const { getSelectedChartTypeItem } = useChartTypeOptions();
     const dataAppVizUuid = isDataAppVizVisualizationConfig(visualizationConfig)
@@ -52,12 +36,6 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
         null,
     );
 
-    const canEditSelectedType = useCanEditDataApp(projectUuid, {
-        spaceUuid: selectedProjectType?.spaceUuid ?? null,
-        createdByUserUuid: selectedProjectType?.createdByUserUuid ?? null,
-    });
-
-    const isProjectType = chartType === ChartType.DATA_APP_VIZ;
     const selectedItem = getSelectedChartTypeItem(
         chartType,
         selectedProjectType ?? null,
@@ -92,77 +70,48 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
                 </Group>
 
                 <Stack className={classes.body} gap="md">
-                    <SegmentedControl
-                        fullWidth
-                        value={mode}
-                        onChange={(value) => {
-                            if (isMode(value)) setMode(value);
-                        }}
-                        data={[
-                            { value: 'choose', label: 'Choose type' },
-                            { value: 'configure', label: 'Configure' },
-                        ]}
-                    />
-
                     {mode === 'choose' ? (
-                        <ExplorerChartTypeGallery
-                            onSelected={() => setMode('configure')}
-                        />
+                        <>
+                            <Group gap="xs" wrap="nowrap">
+                                <ActionIcon
+                                    variant="subtle"
+                                    color="gray"
+                                    size="sm"
+                                    aria-label="Back to configuration"
+                                    onClick={() => setMode('configure')}
+                                >
+                                    <MantineIcon icon={IconArrowLeft} />
+                                </ActionIcon>
+                                <Text fw={600} fz="sm">
+                                    Choose chart type
+                                </Text>
+                            </Group>
+                            <ExplorerChartTypeGallery
+                                onSelected={() => setMode('configure')}
+                            />
+                        </>
                     ) : (
                         <Stack className={classes.configure} gap="md">
-                            <Paper
-                                className={classes.selectedChart}
-                                withBorder
-                                radius="md"
-                                p="sm"
-                            >
-                                <Group wrap="nowrap">
-                                    <ChartTypeThumbnail
-                                        icon={selectedItem.icon}
-                                        rotatedIcon={selectedItem.rotatedIcon}
-                                    />
-                                    <Text fw={600} truncate flex={1}>
-                                        {selectedItem.label}
-                                    </Text>
-                                    <Group gap="xs" wrap="nowrap">
-                                        {isProjectType &&
-                                        selectedProjectType &&
-                                        canEditSelectedType ? (
-                                            <Anchor
-                                                component={Link}
-                                                to={{
-                                                    pathname:
-                                                        chartTypeBuilderPath(
-                                                            projectUuid ?? '',
-                                                            selectedProjectType.dataAppVizUuid,
-                                                        ),
-                                                    search: location.search,
-                                                }}
-                                                fz="xs"
-                                                fw={500}
-                                            >
-                                                Edit ↗
-                                            </Anchor>
-                                        ) : null}
-                                        <Anchor
-                                            component="button"
-                                            type="button"
-                                            className={classes.buttonAnchor}
-                                            fz="xs"
-                                            fw={500}
-                                            onClick={() => setMode('choose')}
-                                        >
-                                            Change
-                                        </Anchor>
-                                    </Group>
-                                </Group>
-                                {isProjectType &&
-                                selectedProjectType?.description ? (
-                                    <Text fz="xs" c="dimmed" lh={1.5} mt="xs">
-                                        {selectedProjectType.description}
-                                    </Text>
-                                ) : null}
-                            </Paper>
+                            <Group wrap="nowrap" gap="sm">
+                                <ChartTypeThumbnail
+                                    small
+                                    icon={selectedItem.icon}
+                                    rotatedIcon={selectedItem.rotatedIcon}
+                                />
+                                <Text fw={600} fz="sm" truncate flex={1}>
+                                    {selectedItem.label}
+                                </Text>
+                                <Anchor
+                                    component="button"
+                                    type="button"
+                                    className={classes.buttonAnchor}
+                                    fz="xs"
+                                    fw={500}
+                                    onClick={() => setMode('choose')}
+                                >
+                                    Change
+                                </Anchor>
+                            </Group>
 
                             <VisualizationConfig
                                 chartType={chartType}

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -2,7 +2,6 @@ import { ChartType } from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
-    Button,
     Group,
     Paper,
     SegmentedControl,
@@ -10,7 +9,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine/core';
-import { IconArrowLeft, IconSettings, IconX } from '@tabler/icons-react';
+import { IconSettings, IconX } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Link, useLocation } from 'react-router';
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
@@ -111,18 +110,6 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
                         />
                     ) : (
                         <Stack className={classes.configure} gap="md">
-                            <Button
-                                variant="subtle"
-                                size="xs"
-                                px={0}
-                                leftSection={
-                                    <MantineIcon icon={IconArrowLeft} />
-                                }
-                                onClick={() => setMode('choose')}
-                            >
-                                Change chart type
-                            </Button>
-
                             <Paper
                                 className={classes.selectedChart}
                                 withBorder
@@ -134,33 +121,40 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
                                         icon={selectedItem.icon}
                                         rotatedIcon={selectedItem.rotatedIcon}
                                     />
-                                    <Stack gap={3}>
-                                        <Text fw={600}>
-                                            {selectedItem.label}
-                                        </Text>
-                                        <Group gap="xs">
-                                            {isProjectType &&
-                                            selectedProjectType &&
-                                            canEditSelectedType ? (
-                                                <Anchor
-                                                    component={Link}
-                                                    to={{
-                                                        pathname:
-                                                            chartTypeBuilderPath(
-                                                                projectUuid ??
-                                                                    '',
-                                                                selectedProjectType.dataAppVizUuid,
-                                                            ),
-                                                        search: location.search,
-                                                    }}
-                                                    fz="xs"
-                                                    fw={500}
-                                                >
-                                                    Edit ↗
-                                                </Anchor>
-                                            ) : null}
-                                        </Group>
-                                    </Stack>
+                                    <Text fw={600} truncate flex={1}>
+                                        {selectedItem.label}
+                                    </Text>
+                                    <Group gap="xs" wrap="nowrap">
+                                        {isProjectType &&
+                                        selectedProjectType &&
+                                        canEditSelectedType ? (
+                                            <Anchor
+                                                component={Link}
+                                                to={{
+                                                    pathname:
+                                                        chartTypeBuilderPath(
+                                                            projectUuid ?? '',
+                                                            selectedProjectType.dataAppVizUuid,
+                                                        ),
+                                                    search: location.search,
+                                                }}
+                                                fz="xs"
+                                                fw={500}
+                                            >
+                                                Edit ↗
+                                            </Anchor>
+                                        ) : null}
+                                        <Anchor
+                                            component="button"
+                                            type="button"
+                                            className={classes.buttonAnchor}
+                                            fz="xs"
+                                            fw={500}
+                                            onClick={() => setMode('choose')}
+                                        >
+                                            Change
+                                        </Anchor>
+                                    </Group>
                                 </Group>
                                 {isProjectType &&
                                 selectedProjectType?.description ? (

--- a/packages/frontend/src/features/apps/hooks/useCanEditDataApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useCanEditDataApp.ts
@@ -1,8 +1,36 @@
 import { subject } from '@casl/ability';
-import { useMemo } from 'react';
+import { type SpaceSummary } from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
 import useApp from '../../../providers/App/useApp';
+
+type DataAppAccess = {
+    spaceUuid: string | null;
+    createdByUserUuid: string | null;
+};
+
+const canManageDataApp = (
+    ability: ReturnType<typeof useAbilityContext>,
+    organizationUuid: string | undefined,
+    projectUuid: string | undefined,
+    spaces: Pick<SpaceSummary, 'uuid' | 'userAccess'>[],
+    app: DataAppAccess,
+): boolean => {
+    if (!projectUuid) return false;
+    const userSpaceAccess = app.spaceUuid
+        ? spaces.find((s) => s.uuid === app.spaceUuid)?.userAccess
+        : undefined;
+    return ability.can(
+        'manage',
+        subject('DataApp', {
+            organizationUuid,
+            projectUuid,
+            access: userSpaceAccess ? [userSpaceAccess] : [],
+            createdByUserUuid: app.createdByUserUuid,
+        }),
+    );
+};
 
 /**
  * Whether the current user can manage (edit) a given data app. Space
@@ -13,32 +41,53 @@ import useApp from '../../../providers/App/useApp';
  */
 export const useCanEditDataApp = (
     projectUuid: string | undefined,
-    app: { spaceUuid: string | null; createdByUserUuid: string | null },
+    app: DataAppAccess,
 ): boolean => {
     const ability = useAbilityContext();
     const { user } = useApp();
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
+    const { spaceUuid, createdByUserUuid } = app;
 
-    return useMemo(() => {
-        if (!projectUuid) return false;
-        const userSpaceAccess = app.spaceUuid
-            ? spaces.find((s) => s.uuid === app.spaceUuid)?.userAccess
-            : undefined;
-        return ability.can(
-            'manage',
-            subject('DataApp', {
-                organizationUuid: user.data?.organizationUuid,
+    return useMemo(
+        () =>
+            canManageDataApp(
+                ability,
+                user.data?.organizationUuid,
                 projectUuid,
-                access: userSpaceAccess ? [userSpaceAccess] : [],
-                createdByUserUuid: app.createdByUserUuid,
-            }),
-        );
-    }, [
-        ability,
-        user.data?.organizationUuid,
-        projectUuid,
-        spaces,
-        app.spaceUuid,
-        app.createdByUserUuid,
-    ]);
+                spaces,
+                { spaceUuid, createdByUserUuid },
+            ),
+        [
+            ability,
+            user.data?.organizationUuid,
+            projectUuid,
+            spaces,
+            spaceUuid,
+            createdByUserUuid,
+        ],
+    );
+};
+
+/**
+ * List variant of `useCanEditDataApp`: returns a checker so callers rendering
+ * many apps resolve edit rights per item without a hook call per row.
+ */
+export const useCanEditDataAppChecker = (
+    projectUuid: string | undefined,
+): ((app: DataAppAccess) => boolean) => {
+    const ability = useAbilityContext();
+    const { user } = useApp();
+    const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
+
+    return useCallback(
+        (app: DataAppAccess) =>
+            canManageDataApp(
+                ability,
+                user.data?.organizationUuid,
+                projectUuid,
+                spaces,
+                app,
+            ),
+        [ability, user.data?.organizationUuid, projectUuid, spaces],
+    );
 };


### PR DESCRIPTION
## Summary

In the explorer chart gallery sidebar (behind the `explorer-chart-gallery` flag), the area above the config tabs stacked three layers: the panel title, a Choose type / Configure segmented control, and a card showing the current chart type with its own change affordance. Two of those controls did the same thing.

This condenses it to a drill-in flow:

- The segmented control and the current-type card are gone. A compact row (small thumbnail, type name, a single `Change` link) sits above the tabs and is the only way into the gallery.
- Choosing a type is now a drill-in: the body swaps to the gallery under a `← Choose chart type` row, and selecting (or going back) returns to the config controls.
- Editing a project chart type moves onto its gallery row as an `Edit` link (permission-gated per row via the shared data app ability check), so the selected-type row reads the same for built-in and project types. The link is revealed on hover/keyboard focus so rows rest clean however many project types there are, with space reserved so it never overlaps the description.
- Gallery rows drop the chevron: rows select in place, so it implied a navigation that doesn't happen.
- `ChartTypeThumbnail` gains a small variant for the compact row.

## How to test

1. Enable the `explorer-chart-gallery` feature flag
2. Open an explore and open the chart Configure sidebar
3. Above the tabs there is a single compact row with the current type and `Change`
4. `Change` drills into the gallery; the back arrow or picking a type returns to Configure
5. With data apps enabled, hovering (or tabbing to) a project row you can manage reveals its `Edit` link

Sidebar and gallery unit tests updated and passing, plus frontend lint and typecheck.


https://github.com/user-attachments/assets/08cc6db7-ddbb-4156-b874-3acc9c45104f

Closes: PROD-10493
