### PR TITLE
fix: resolve project uuid in chart config components under slug URLs

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -13,10 +13,11 @@ import {
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconChevronRight, IconPlus, IconSearch } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useDataAppVisualizations } from '../../../features/chartTypes/hooks/useDataAppVisualizations';
 import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
@@ -201,7 +202,8 @@ type ExplorerChartTypeGalleryProps = {
 const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
     onSelected,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    // Resolves the project uuid even when the URL carries the project slug.
+    const projectUuid = useProjectUuid();
     const location = useLocation();
     const navigate = useNavigate();
     const [search, setSearch] = useState('');

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -202,7 +202,6 @@ type ExplorerChartTypeGalleryProps = {
 const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
     onSelected,
 }) => {
-    // Resolves the project uuid even when the URL carries the project slug.
     const projectUuid = useProjectUuid();
     const location = useLocation();
     const navigate = useNavigate();

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -12,10 +12,11 @@ import {
 } from '@mantine/core';
 import { IconArrowLeft, IconSettings, IconX } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
-import { Link, useLocation, useParams } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
 import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { ChartGalleryContext } from '../../common/ChartGallery/ChartGalleryContext';
 import MantineIcon from '../../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
@@ -39,7 +40,8 @@ const isMode = (value: string): value is Mode =>
 
 const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
     const [mode, setMode] = useState<Mode>('configure');
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    // Resolves the project uuid even when the URL carries the project slug.
+    const projectUuid = useProjectUuid();
     const location = useLocation();
     const { visualizationConfig } = useVisualizationContext();
     const { getSelectedChartTypeItem } = useChartTypeOptions();

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -40,7 +40,6 @@ const isMode = (value: string): value is Mode =>
 
 const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
     const [mode, setMode] = useState<Mode>('configure');
-    // Resolves the project uuid even when the URL carries the project slug.
     const projectUuid = useProjectUuid();
     const location = useLocation();
     const { visualizationConfig } = useVisualizationContext();

--- a/packages/frontend/src/components/ProjectRoute.tsx
+++ b/packages/frontend/src/components/ProjectRoute.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import React, { type FC } from 'react';
+import React, { useMemo, type FC } from 'react';
 import { Navigate, useParams } from 'react-router';
 import { validate as isUuidString } from 'uuid';
 import ErrorState from '../components/common/ErrorState';
@@ -25,6 +25,21 @@ const ResolvedProjectRoute: FC<
     });
 
     const { data: project, isError, error } = useProject(projectUuid);
+
+    // Stable identity: useProjectRoute/useProjectUuid consumers would
+    // otherwise re-render whenever this provider re-renders.
+    const projectRouteContext: ProjectRouteContextValue | null = useMemo(
+        () =>
+            project
+                ? {
+                      project,
+                      projectUuid,
+                      projectUrlIdentifier: getProjectUrlIdentifier(project),
+                  }
+                : null,
+        [project, projectUuid],
+    );
+
     if (isInitialLoading) {
         return <PageSpinner />;
     }
@@ -33,15 +48,9 @@ const ResolvedProjectRoute: FC<
         return <ErrorState error={error.error} />;
     }
 
-    if (!project) {
+    if (projectRouteContext === null) {
         return <Navigate to="/no-access" />;
     }
-
-    const projectRouteContext: ProjectRouteContextValue = {
-        project,
-        projectUuid,
-        projectUrlIdentifier: getProjectUrlIdentifier(project),
-    };
 
     return (
         <Can

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -10,10 +10,11 @@ import {
 import { useDebouncedValue } from '@mantine/hooks';
 import { type IDisposable, type languages } from 'monaco-editor';
 import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { useDeepCompareEffect } from 'react-use';
 import { useCanCreateDataApp } from '../../../../features/apps/hooks/useCanCreateDataApp';
 import { chartTypeBuilderPath } from '../../../../features/chartTypes/utils/chartTypeBuilderPath';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import { useIsInsideChartGallery } from '../../../common/ChartGallery/ChartGalleryContext';
 import DocumentationHelpButton from '../../../DocumentationHelpButton';
@@ -127,7 +128,8 @@ const registerCustomCompletionProvider = (
 export const ConfigTabs: React.FC = memo(() => {
     const { visualizationConfig } = useVisualizationContext();
     const colorScheme = useComputedColorScheme();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    // Resolves the project uuid even when the URL carries the project slug.
+    const projectUuid = useProjectUuid();
     const location = useLocation();
     const navigate = useNavigate();
 

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -128,7 +128,6 @@ const registerCustomCompletionProvider = (
 export const ConfigTabs: React.FC = memo(() => {
     const { visualizationConfig } = useVisualizationContext();
     const colorScheme = useComputedColorScheme();
-    // Resolves the project uuid even when the URL carries the project slug.
     const projectUuid = useProjectUuid();
     const location = useLocation();
     const navigate = useNavigate();

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisAi.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisAi.tsx
@@ -19,7 +19,6 @@ export const GenerateVizWithAi = ({
     editorConfig: string;
     setEditorConfig: (config: string) => void;
 }) => {
-    // Resolves the project uuid even when the URL carries the project slug.
     const projectUuid = useProjectUuid();
     const [prompt, setPrompt] = useState('');
 

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisAi.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/components/CustomVisAi.tsx
@@ -2,7 +2,7 @@ import { type ItemsMap } from '@lightdash/common';
 import { Button, Textarea, Popover } from '@mantine/core';
 import { IconSparkles } from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import MantineIcon from '../../../../common/MantineIcon';
 import { useCustomVis } from '../hooks/useCustomVisAi';
 
@@ -19,9 +19,8 @@ export const GenerateVizWithAi = ({
     editorConfig: string;
     setEditorConfig: (config: string) => void;
 }) => {
-    const { projectUuid } = useParams<{
-        projectUuid: string;
-    }>();
+    // Resolves the project uuid even when the URL carries the project slug.
+    const projectUuid = useProjectUuid();
     const [prompt, setPrompt] = useState('');
 
     const { mutate: getCustomVis, data, isLoading } = useCustomVis(projectUuid);

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -30,7 +30,6 @@ import DataAppVizSettings from './DataAppVizSettings';
 const NO_COLUMNS: ItemsMap = {};
 
 export const ConfigTabs: FC = memo(() => {
-    // Resolves the project uuid even when the URL carries the project slug.
     const projectUuid = useProjectUuid();
     const location = useLocation();
     const navigate = useNavigate();

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -7,13 +7,14 @@ import {
 } from '@lightdash/common';
 import { Anchor, Box, Stack, Text } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
-import { Link, useLocation, useNavigate, useParams } from 'react-router';
+import { Link, useLocation, useNavigate } from 'react-router';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
 import { reconcileDataAppVizFieldMapping } from '../../../features/chartTypes/utils/autoMapDataAppVizFields';
 import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
 import { getDataAppVizFieldItems } from '../../../features/chartTypes/utils/getDataAppVizFieldItems';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useIsInsideChartGallery } from '../../common/ChartGallery/ChartGalleryContext';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -29,7 +30,8 @@ import DataAppVizSettings from './DataAppVizSettings';
 const NO_COLUMNS: ItemsMap = {};
 
 export const ConfigTabs: FC = memo(() => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    // Resolves the project uuid even when the URL carries the project slug.
+    const projectUuid = useProjectUuid();
     const location = useLocation();
     const navigate = useNavigate();
     const { visualizationConfig, itemsMap, setChartType, setPivotDimensions } =


### PR DESCRIPTION
## Problem

Since project slugs landed in core frontend URLs (#27826), `useParams<{ projectUuid }>` returns the slug on slug URLs. Components passed that raw value into project-scoped API calls, which reject non-uuids — e.g. the chart gallery's project section failed with a 500, and the CustomVis/data-app-viz config panels made broken calls.

## Fix

Scoped to the surfaces that blocked the explorer chart gallery work; #27914 migrates the remaining `useParams` consumers.

- Chart gallery (`ChartTypeGallery`, `ExplorerChartSidebar`) and chart config panel surfaces (`CustomVisConfig`, `CustomVisAi`, `DataAppVizConfigTabs`) resolve the uuid via `useProjectUuid()` (ProjectRoute context first, route param fallback, embed context last).
- `ProjectRoute`'s context value is memoized so the subscribers don't re-render on every provider render.

Relates: [PROD-10465](https://linear.app/lightdash/issue/PROD-10465/show-built-in-chart-types-as-a-grid-in-the-chart-gallery)
