### PR TITLE
fix(data-apps): make app clarification provider agnostic

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
@@ -17,12 +17,6 @@ vi.mock('ai', () => ({
     generateObject: vi.fn(),
 }));
 vi.mock('../ai/models', () => ({
-    getModel: vi.fn(() => ({
-        model: { provider: 'anthropic', modelId: 'claude-sonnet-4-5' },
-        callOptions: {},
-        providerOptions: {},
-        keyManagement: 'lightdash',
-    })),
     resolveKeyManagement: vi.fn(() => 'lightdash'),
 }));
 vi.mock('../ai/utils/aiCallTelemetry', () => ({
@@ -58,8 +52,16 @@ const CATALOG_ITEMS = [
     },
 ];
 
+const FAST_MODEL_OPTIONS = {
+    model: { provider: 'openai.responses', modelId: 'gpt-5.6-luna' },
+    callOptions: {},
+    providerOptions: {},
+    keyManagement: 'lightdash-managed',
+};
+
 function buildService() {
     const getCatalogItemsSummary = vi.fn().mockResolvedValue(CATALOG_ITEMS);
+    const resolveFastModel = vi.fn().mockResolvedValue(FAST_MODEL_OPTIONS);
     const service = new AppGenerateService({
         lightdashConfig: {
             appRuntime: { sampleDataEnabled: true },
@@ -98,14 +100,15 @@ function buildService() {
         orgAiCopilotConfigResolver: {
             getCopilotConfig: vi
                 .fn()
-                .mockResolvedValue({ defaultProvider: 'anthropic' }),
+                .mockResolvedValue({ defaultProvider: 'openai' }),
+            resolveFastModel,
         } as never,
     });
     // Bypass real CASL — the prompt/context selection is what these tests cover.
     (
         service as unknown as { createAuditedAbility: () => unknown }
     ).createAuditedAbility = () => ({ cannot: () => false });
-    return { service, getCatalogItemsSummary };
+    return { service, getCatalogItemsSummary, resolveFastModel };
 }
 
 const generateObjectMock = vi.mocked(generateObject);
@@ -141,6 +144,32 @@ async function clarify(template: DataAppTemplate | undefined) {
 beforeEach(() => {
     generateObjectMock.mockReset();
     mockQuestions([]);
+});
+
+describe('AppGenerateService.clarifyApp model resolution', () => {
+    it('uses the org-resolved fast model for the LLM call', async () => {
+        const { service, resolveFastModel } = buildService();
+
+        await service.clarifyApp(USER, 'project-1', 'a radial gauge');
+
+        expect(resolveFastModel).toHaveBeenCalledWith(
+            { defaultProvider: 'openai' },
+            { enableReasoning: false },
+        );
+        expect(generateObjectMock).toHaveBeenCalledWith(
+            expect.objectContaining({ model: FAST_MODEL_OPTIONS.model }),
+        );
+    });
+
+    it('falls through to no questions when no fast model resolves', async () => {
+        const { service, resolveFastModel } = buildService();
+        resolveFastModel.mockRejectedValueOnce(new Error('not configured'));
+
+        await expect(
+            service.clarifyApp(USER, 'project-1', 'a radial gauge'),
+        ).resolves.toEqual({ questions: [] });
+        expect(generateObjectMock).not.toHaveBeenCalled();
+    });
 });
 
 describe('AppGenerateService.clarifyApp for the data app viz template', () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -175,7 +175,7 @@ import {
 import { type ExternalConnectionModel } from '../../models/ExternalConnectionModel';
 import type { SandboxRegistryModel } from '../../models/SandboxRegistryModel';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
-import { getModel, resolveKeyManagement } from '../ai/models';
+import { resolveKeyManagement } from '../ai/models';
 import {
     OrgAiCopilotConfigResolver,
     type CopilotConfig,
@@ -5603,13 +5603,12 @@ export class AppGenerateService extends BaseService {
      * LLM errors — the build flow should proceed without clarification
      * rather than fail. Returns an empty array when:
      * - the prompt is already specific enough (model judgment),
-     * - neither Anthropic nor Bedrock is configured,
+     * - no LLM provider is configured,
      * - the LLM call times out or errors.
      *
-     * Routes through Bedrock when `AI_DEFAULT_PROVIDER=bedrock`, otherwise
-     * Anthropic — mirroring the data-apps sandbox provider switch in
-     * `claudeCodeEnv.ts` so the clarifier and code generation use the same
-     * provider.
+     * Uses the org-resolved, BYO-key-aware fast model so clarification follows
+     * the same provider resolution as other lightweight AI tasks such as app
+     * naming.
      *
      * Branches on template: a data app viz gets a component-scoped prompt and
      * no catalog context, because it never runs a query. Everything else shares
@@ -5641,22 +5640,25 @@ export class AppGenerateService extends BaseService {
             await this.orgAiCopilotConfigResolver.getCopilotConfig(
                 organizationUuid,
             );
-        const llmProvider: 'anthropic' | 'bedrock' =
-            copilot.defaultProvider === 'bedrock' ? 'bedrock' : 'anthropic';
 
         let modelOptions;
         try {
-            modelOptions = getModel(copilot, {
-                provider: llmProvider,
-                modelName: 'claude-sonnet-4-5',
-                enableReasoning: false,
-            });
+            modelOptions =
+                await this.orgAiCopilotConfigResolver.resolveFastModel(
+                    copilot,
+                    { enableReasoning: false },
+                );
         } catch (err) {
             this.logger.info(
-                `Skipping app clarification: ${llmProvider} not configured (${getErrorMessage(err)})`,
+                `Skipping app clarification: no LLM provider configured (${getErrorMessage(err)})`,
             );
             return { questions: [] };
         }
+
+        const modelAttribution = getLanguageModelAttribution(
+            modelOptions.model,
+        );
+        const llmProvider = modelAttribution.provider ?? 'unknown';
 
         // A data app viz never runs a query — it renders whatever rows the host
         // explore hands it — so catalog context would only invite questions
@@ -5701,7 +5703,7 @@ export class AppGenerateService extends BaseService {
             organizationUuid,
             projectUuid,
             userUuid: user.userUuid,
-            ...getLanguageModelAttribution(modelOptions.model),
+            ...modelAttribution,
             keyManagement: modelOptions.keyManagement,
             // Which prompt variant ran — the two ask for very different things,
             // so spend and question counts are only comparable within a variant.


### PR DESCRIPTION
### Description

- Resolve pre-build clarifying questions through the org-aware fast-model resolver instead of hard-coding Claude Sonnet through Anthropic or Bedrock
- Reuse the same provider and BYO-key resolution as other lightweight AI tasks while preserving the no-questions fallback on configuration or provider errors
- Add focused coverage for a generically resolved model and model-resolution failure

### Validation

- `pnpm exec vitest run src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts` (12 tests)
- `pnpm typecheck`
- Scoped `oxlint`
- Scoped `oxfmt --check`
- `git diff --check`

### Risk assessment

- [ ] This is a high-risk change

Low risk: this changes only the model-selection path for a non-blocking clarification call. Failures continue to fall through to app generation with no clarifying questions.