### PR TITLE
fix: resolve project uuid from route params across remaining slug-URL surfaces

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -36,6 +36,7 @@ import ProjectRoute from './components/ProjectRoute';
 import LegacyAppPreviewRedirect from './features/apps/LegacyAppPreviewRedirect';
 import { loadLazyRouteDefault } from './features/chunkErrorHandler';
 import { useActiveProjectUuid } from './hooks/useActiveProject';
+import { useProjectUuid } from './hooks/useProjectUuid';
 import useLogoutMutation from './hooks/user/useUserLogoutMutation';
 import classes from './MobileRoutes.module.css';
 import MantineBaseProvider from './providers/MantineBaseProvider';
@@ -51,7 +52,8 @@ const getMobileNavBarRootElement = () =>
     document.getElementById('mobile-navbar') ?? undefined;
 
 const RedirectToResource: FC = () => {
-    const { projectUuid, savedQueryUuid, dashboardUuid } = useParams();
+    const { savedQueryUuid, dashboardUuid } = useParams();
+    const projectUuid = useProjectUuid();
     if (dashboardUuid) {
         return (
             <Navigate

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -7,7 +7,6 @@ import {
 import { Stack, Text } from '@mantine/core';
 import { IconPuzzle } from '@tabler/icons-react';
 import { useEffect, useMemo, useRef, type FC } from 'react';
-import { useParams } from 'react-router';
 import useEmbed from '../../ee/providers/Embed/useEmbed';
 import AppIframePreview from '../../features/apps/AppIframePreview';
 import { useChartVersionPreview } from '../../features/apps/ChartVersionPreview/useChartVersionPreview';
@@ -20,6 +19,7 @@ import {
 import { reconcileDataAppVizFieldMapping } from '../../features/chartTypes/utils/autoMapDataAppVizFields';
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
 import { useExplore } from '../../hooks/useExplore';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import MantineIcon from '../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
@@ -54,7 +54,7 @@ const getTerminalRequestErrorMessage = (
 };
 
 const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const {
         visualizationConfig,
         resultsData,

--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -2,8 +2,8 @@ import { ChartType, FeatureFlags } from '@lightdash/common';
 import { Button, Menu } from '@mantine/core';
 import { IconChevronDown, IconCode } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
-import { useParams } from 'react-router';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -21,7 +21,7 @@ const VisualizationCardOptions: FC = memo(() => {
         selectedChartType,
     } = useChartTypeOptions();
 
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const dataAppsEnabled =
         useServerFeatureFlag(FeatureFlags.EnableDataApps).data?.enabled ===
         true;

--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
@@ -18,12 +18,12 @@ import {
 import { IconGitBranch } from '@tabler/icons-react';
 import * as yaml from 'js-yaml';
 import { memo, useMemo, useState } from 'react';
-import { useParams } from 'react-router';
 import {
     explorerActions,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import CodeBlock from '../../common/CodeBlock/CodeBlock';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
 import MantineModal from '../../common/MantineModal';
@@ -422,9 +422,7 @@ export const WriteBackModal = memo(() => {
     );
     const dispatch = useExplorerDispatch();
 
-    const { projectUuid } = useParams<{
-        projectUuid: string;
-    }>();
+    const projectUuid = useProjectUuid();
 
     const toggleModal = () => dispatch(explorerActions.toggleWriteBackModal());
 

--- a/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
@@ -22,10 +22,10 @@ import {
 import { Button } from '@mantine/core';
 import { IconArrowBarToDown, IconExternalLink } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import { v4 as uuidv4 } from 'uuid';
 import { useExplore } from '../../hooks/useExplore';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import FieldSelect from '../common/FieldSelect';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
@@ -202,7 +202,7 @@ const drillDownExploreUrl = ({
 };
 
 export const DrillDownModal: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     const [selectedDimension, setSelectedDimension] =
         useState<CompiledDimension>();

--- a/packages/frontend/src/components/RenderedSql.tsx
+++ b/packages/frontend/src/components/RenderedSql.tsx
@@ -10,7 +10,6 @@ import {
 } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
-import { useParams } from 'react-router';
 import { useMergeCompiledSql } from '../features/mergeQuery/hooks/useMergeCompiledSql';
 import {
     getLightdashMonacoTheme,
@@ -20,6 +19,7 @@ import {
 } from '../features/sqlRunner/utils/monaco';
 import { useCompiledSql } from '../hooks/useCompiledSql';
 import { useProject } from '../hooks/useProject';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import Editor, { type BeforeMount, type EditorProps } from './MonacoEditor';
 
 const MONACO_READ_ONLY: EditorProps['options'] = {
@@ -37,7 +37,7 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
     selectedView = 'query',
 }) => {
     const { colorScheme } = useMantineColorScheme();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { data: project } = useProject(projectUuid);
     const language = useMemo(
         () => getMonacoLanguage(project?.warehouseConnection?.type),

--- a/packages/frontend/src/components/Settings/CreateProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/CreateProjectSettings.tsx
@@ -1,14 +1,15 @@
 import { Stack, Text, Title } from '@mantine/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { type FC } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate } from 'react-router';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import useApp from '../../providers/App/useApp';
 import Page from '../common/Page/Page';
 import PageSpinner from '../PageSpinner';
 import ProjectTablesConfiguration from '../ProjectTablesConfiguration/ProjectTablesConfiguration';
 
 const CreateProjectSettings: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const queryClient = useQueryClient();
     const navigate = useNavigate();
     const { health } = useApp();

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -11,7 +11,6 @@ import {
     matchPath,
     Navigate,
     useLocation,
-    useParams,
     useRoutes,
     type RouteObject,
 } from 'react-router';
@@ -22,6 +21,7 @@ import PullRequestsPage from '../../features/pullRequests/components/PullRequest
 import RecentlyDeletedPage from '../../features/recentlyDeleted/components/RecentlyDeletedPage';
 import { useOrganization } from '../../hooks/organization/useOrganization';
 import { useProject } from '../../hooks/useProject';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import { DocumentTitle } from '../common/DocumentTitle';
@@ -77,9 +77,7 @@ const ProjectSettingsPage: FC<ProjectSettingsPageProps> = ({
 const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
     externalSourcesEnabled,
 }) => {
-    const { projectUuid } = useParams<{
-        projectUuid: string;
-    }>();
+    const projectUuid = useProjectUuid();
     const location = useLocation();
 
     const { health, user } = useApp();

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -12,8 +12,8 @@ import { useClipboard } from '@mantine/hooks';
 import { IconCopy, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
-import { useParams } from 'react-router';
 import useToaster from '../../hooks/toaster/useToaster';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { Can } from '../../providers/Ability';
 import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
@@ -45,7 +45,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
 
     const { track } = useTracking();
     const { user } = useApp();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const clipboard = useClipboard({ timeout: 200 });
 
     const handleCopyToClipboard = useCallback(() => {

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -15,9 +15,9 @@ import { useClipboard } from '@mantine/hooks';
 import { IconCopy, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
-import { useParams } from 'react-router';
 import { FilterDashboardTo } from '../../features/dashboardFilters/FilterDashboardTo';
 import useToaster from '../../hooks/toaster/useToaster';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { Can } from '../../providers/Ability';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
@@ -102,7 +102,7 @@ const DashboardCellContextMenu: FC<
     const filters = [...filterField, ...possiblePivotFilters];
     const { track } = useTracking();
     const { user } = useApp();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     const handleCopyToClipboard = useCallback(() => {
         clipboard.copy(value.formatted);

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingRule.tsx
@@ -9,7 +9,7 @@ import {
 } from '@lightdash/common';
 import { Group, Select, Stack, TextInput, Accordion } from '@mantine/core';
 import { useCallback, useMemo, type FC } from 'react';
-import { useParams } from 'react-router';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import FilterInputComponent from '../../common/Filters/FilterInputs';
 import {
     getFilterOperatorOptions,
@@ -39,7 +39,7 @@ const BigNumberConditionalFormattingRule: FC<Props> = ({
     onRemoveRule,
     hasRemove,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     const filterType: FilterType.NUMBER | FilterType.STRING | undefined =
         useMemo(() => {

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
@@ -20,8 +20,8 @@ import {
 } from '@mantine/core';
 import { useDebouncedCallback } from '@mantine/hooks';
 import { lazy, Suspense, useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import { useToggle } from 'react-use';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 import UnitInput from '../../../common/UnitInput';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
@@ -141,7 +141,7 @@ type Props = {
 };
 
 export const Legend: FC<Props> = ({ items }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     const { visualizationConfig } = useVisualizationContext();
 

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
@@ -19,7 +19,7 @@ import {
 import { useHover } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 import FilterInputComponent from '../../../common/Filters/FilterInputs';
 import { getFilterOperatorOptions } from '../../../common/Filters/FilterInputs/utils';
 import FiltersProvider from '../../../common/Filters/FiltersProvider';
@@ -44,7 +44,7 @@ export const ChartConditionalFormattingRule: FC<Props> = ({
     onChangeRuleOperator,
     onRemoveRule,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { ref, hovered } = useHover();
     const [isOpen, setIsOpen] = useState(ruleIndex === 0);
 

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -24,7 +24,7 @@ import {
 } from '@mantine/core';
 import differenceBy from 'lodash/differenceBy';
 import { useCallback, useMemo, type FC } from 'react';
-import { useParams } from 'react-router';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import FieldSelect from '../../common/FieldSelect';
 import FilterInputComponent from '../../common/Filters/FilterInputs';
 import {
@@ -63,7 +63,7 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
     hasRemove,
     disabled,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
 
     const comparisonType = useMemo(() => {
         if (

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -10,10 +10,11 @@ import {
 import { Menu, type MenuProps, Text } from '@mantine/core';
 import { IconArrowBarToDown, IconCopy } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
-import { useLocation, useParams } from 'react-router';
+import { useLocation } from 'react-router';
 import { FilterDashboardTo } from '../../../features/dashboardFilters/FilterDashboardTo';
 import { useContextMenuPermissions } from '../../../hooks/useContextMenuPermissions';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useAccount } from '../../../hooks/user/useAccount';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -63,7 +64,7 @@ const ValueCellMenuDropdownContent: FC<{
     const tracking = useTracking({ failSilently: true });
     const metricQueryData = useMetricQueryDataContext(true);
     const { data: account } = useAccount();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { data: project } = useProject(projectUuid);
     const location = useLocation();
     const isDashboardPage = location.pathname.includes('/dashboards');

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingRunPage.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingRunPage.tsx
@@ -27,6 +27,7 @@ import ErrorState from '../../../components/common/ErrorState';
 import MantineIcon from '../../../components/common/MantineIcon';
 import Page from '../../../components/common/Page/Page';
 import PageSpinner from '../../../components/PageSpinner';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { AgentOnboardingActivityPanel } from './AgentOnboardingActivity';
 import { AgentOnboardingDemoOffer } from './AgentOnboardingDemoOffer';
 import { AgentOnboardingFileBrowser } from './AgentOnboardingFileBrowser';
@@ -148,10 +149,8 @@ const RunActions: FC<{
 };
 
 const AgentOnboardingRunPage: FC = () => {
-    const { agentOnboardingRunUuid, projectUuid } = useParams<{
-        agentOnboardingRunUuid: string;
-        projectUuid: string;
-    }>();
+    const { agentOnboardingRunUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const navigate = useNavigate();
     const [isCancellationRequested, setIsCancellationRequested] =
         useState(false);

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.tsx
@@ -1,17 +1,18 @@
 import { FeatureFlags } from '@lightdash/common';
 import { Box, Stack, Text } from '@mantine/core';
 import { type FC } from 'react';
-import { Navigate, useParams } from 'react-router';
+import { Navigate } from 'react-router';
 import Page from '../../../components/common/Page/Page';
 import PageSpinner from '../../../components/PageSpinner';
 import { OnboardingTitle } from '../../../components/ProjectConnection/ProjectConnectFlow/common/OnboardingTitle';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import { AgentOnboardingLaunchPanel } from './AgentOnboardingLaunchPanel';
 
 const AgentOnboardingStartPage: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { health } = useApp();
     const { data: project, isInitialLoading: isLoadingProject } =
         useProject(projectUuid);

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactDetail.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactDetail.tsx
@@ -3,6 +3,7 @@ import { useEffect, type FC } from 'react';
 import { Panel, PanelGroup } from 'react-resizable-panels';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { useAiAgentArtifact } from '../../hooks/useAiAgentArtifacts';
 import { clearArtifact, setArtifact } from '../../store/aiArtifactSlice';
 import {
@@ -13,11 +14,8 @@ import { AiArtifactPanel } from '../ChatElements/AiArtifactPanel';
 
 export const VerifiedArtifactDetail: FC = () => {
     const navigate = useNavigate();
-    const { projectUuid, agentUuid, artifactUuid } = useParams<{
-        projectUuid: string;
-        agentUuid: string;
-        artifactUuid: string;
-    }>();
+    const { agentUuid, artifactUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const [searchParams] = useSearchParams();
     const dispatch = useAiAgentStoreDispatch();
     const artifact = useAiAgentStoreSelector(

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsLayout.tsx
@@ -6,6 +6,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useParams } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { clearArtifact, setArtifact } from '../../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
@@ -17,7 +18,8 @@ import { VerifiedArtifactsTable } from './VerifiedArtifactsTable';
 
 export const VerifiedArtifactsLayout: FC = () => {
     const theme = useMantineTheme();
-    const { projectUuid, agentUuid } = useParams();
+    const { agentUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const dispatch = useAiAgentStoreDispatch();
     const artifact = useAiAgentStoreSelector(
         (state) => state.aiArtifact.artifact,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsTable.tsx
@@ -22,6 +22,7 @@ import {
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { useInfiniteVerifiedArtifacts } from '../../hooks/useAiAgentAdmin';
 import { useSetArtifactVersionVerified } from '../../hooks/useAiAgentArtifacts';
 import { useAiAgentPermission } from '../../hooks/useAiAgentPermission';
@@ -36,7 +37,8 @@ export const VerifiedArtifactsTable: FC<Props> = ({
     selectedArtifactVersionUuid,
 }) => {
     const theme = useMantineTheme();
-    const { projectUuid, agentUuid } = useParams();
+    const { agentUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const navigate = useNavigate();
     const canManageAgent = useAiAgentPermission({
         action: 'manage',

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -4,6 +4,7 @@ import MDEditor from '@uiw/react-md-editor';
 import { format, parseISO } from 'date-fns';
 import { type FC } from 'react';
 import { Link, useParams } from 'react-router';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { useTimeAgo } from '../../../../../hooks/useTimeAgo';
 import useApp from '../../../../../providers/App/useApp';
 import { PinnedContextCard } from '../PinnedContextCard/PinnedContextCard';
@@ -39,7 +40,8 @@ export const UserBubble: FC<Props> = ({
     isActive = false,
     projectUuid: projectUuidProp,
 }) => {
-    const { projectUuid: paramsProjectUuid, agentUuid } = useParams();
+    const { agentUuid } = useParams();
+    const paramsProjectUuid = useProjectUuid();
     const projectUuid = projectUuidProp ?? paramsProjectUuid;
     const timeAgo = useTimeAgo(message.createdAt);
     const name = getVisibleUserName(message.user.name);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationMetricsAndDimensions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentVisualizationMetricsAndDimensions.tsx
@@ -22,11 +22,11 @@ import {
 } from '@mantine/core';
 import { IconCode } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import FieldIcon from '../../../../../components/common/Filters/FieldIcon';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { ItemDetailPreview } from '../../../../../components/Explorer/ExploreTree/TableTree/ItemDetailPreview';
 import { SingleItemModalContent } from '../../../../../components/Explorer/WriteBackModal';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -48,7 +48,7 @@ const MetricDimensionItem: FC<{
     customMetric,
     onWriteBackCustomMetric,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { user } = useApp();
     const { track } = useTracking();
     const [isCodeIconHovered, setIsCodeIconHovered] = useState(false);
@@ -236,7 +236,7 @@ const AgentVisualizationMetricsAndDimensions: FC<Props> = ({
     metricQuery,
     fieldsMap,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [writeBackModal, setWriteBackModal] = useState<{
         isOpen: boolean;
         metric: AdditionalMetric | null;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -30,7 +30,6 @@ import {
     IconExclamationCircle,
 } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC, type ReactNode } from 'react';
-import { useParams } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { SeriesContextMenu } from '../../../../../components/Explorer/VisualizationCard/SeriesContextMenu';
 import LightdashVisualization from '../../../../../components/LightdashVisualization';
@@ -43,6 +42,7 @@ import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
 import { useProjectColorPalette } from '../../../../../hooks/appearance/useProjectColorPalette';
 import useHealth from '../../../../../hooks/health/useHealth';
 import { useExplore } from '../../../../../hooks/useExplore';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { type InfiniteQueryResults } from '../../../../../hooks/useQueryResults';
 import { isEmbedAiAgentRoute } from '../../hooks/aiAgentRouting';
 import { AgentVisualizationChartTypeSwitcher } from './AgentVisualizationChartTypeSwitcher';
@@ -96,7 +96,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
     interactionMode = 'full',
 }) => {
     const { data: health } = useHealth();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const isEmbed = isEmbedAiAgentRoute();
     const { data: resolvedPalette } = useProjectColorPalette(
         projectUuid,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
@@ -13,6 +13,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { IconArrowRight } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useParams } from 'react-router';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { useAiAgentMemory } from '../../hooks/useAiAgentMemory';
 import { MemoryDetailsModal } from '../MemoryDetails/MemoryDetails';
 import styles from './MemoryCitation.module.css';
@@ -29,7 +30,8 @@ export const MemoryCitation = ({
     const [hasOpened, setHasOpened] = useState(false);
     const [detailsOpened, { open: openDetails, close: closeDetails }] =
         useDisclosure(false);
-    const { projectUuid, agentUuid } = useParams();
+    const { agentUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const slug = id?.replace(/^user-content-/, '');
     // Citations in old threads keep resolving after memories are disabled
     const memoryQuery = useAiAgentMemory({

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
@@ -16,6 +16,7 @@ import { type FC, type ReactNode } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import {
     useAiAgentEvaluation,
     useAiAgentEvaluationRuns,
@@ -33,12 +34,8 @@ export const EvalSectionLayout: FC<EvalSectionLayoutProps> = ({ children }) => {
     const theme = useMantineTheme();
     const navigate = useNavigate();
     const [searchParams, setSearchParams] = useSearchParams();
-    const { projectUuid, agentUuid, evalUuid, runUuid } = useParams<{
-        projectUuid: string;
-        agentUuid: string;
-        evalUuid?: string;
-        runUuid?: string;
-    }>();
+    const { agentUuid, evalUuid, runUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const { selectedThreadUuid, isSidebarOpen, clearThread } =
         useEvalSectionContext();
     // Fetch evaluation data if we're on an eval detail page

--- a/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiCustomDimensionInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiCustomDimensionInput.tsx
@@ -4,7 +4,6 @@ import { useHotkeys } from '@mantine/hooks';
 import { IconArrowUp } from '@tabler/icons-react';
 import { type Editor } from '@tiptap/react';
 import { useCallback, useRef, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import {
     selectMetricQuery,
@@ -13,6 +12,7 @@ import {
 } from '../../../../../../features/explorer/store';
 import { useExplore } from '../../../../../../hooks/useExplore';
 import { useGenerateCustomDimension } from '../../../../../../hooks/useGenerateCustomDimension';
+import { useProjectUuid } from '../../../../../../hooks/useProjectUuid';
 import { AiPromptEditor } from './AiPromptInput';
 import styles from './AiTableCalculationInput.module.css';
 
@@ -25,7 +25,7 @@ export const AiCustomDimensionInputBody: FC<Props> = ({
     currentSql,
     onApply,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const tableName = useExplorerSelector(selectTableName);
     const metricQuery = useExplorerSelector(selectMetricQuery);
     const { data: explore } = useExplore(tableName);

--- a/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiTableCalculationInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiTableCalculationInput.tsx
@@ -4,7 +4,6 @@ import { useHotkeys } from '@mantine/hooks';
 import { IconArrowUp } from '@tabler/icons-react';
 import { type Editor } from '@tiptap/react';
 import { useCallback, useRef, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import {
     selectMetricQuery,
@@ -13,6 +12,7 @@ import {
 } from '../../../../../../features/explorer/store';
 import { useExplore } from '../../../../../../hooks/useExplore';
 import { useGenerateTableCalculation } from '../../../../../../hooks/useGenerateTableCalculation';
+import { useProjectUuid } from '../../../../../../hooks/useProjectUuid';
 import { AiPromptEditor } from './AiPromptInput';
 import styles from './AiTableCalculationInput.module.css';
 
@@ -30,7 +30,7 @@ export const AiTableCalculationInputBody: FC<Props> = ({
     currentSql,
     onApply,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const tableName = useExplorerSelector(selectTableName);
     const metricQuery = useExplorerSelector(selectMetricQuery);
     const { data: explore } = useExplore(tableName);

--- a/packages/frontend/src/ee/features/ambientAi/components/tooltip/AiTooltipInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tooltip/AiTooltipInput.tsx
@@ -2,9 +2,9 @@ import { ActionIcon, Box, Group, Text, Textarea } from '@mantine/core';
 import { useHotkeys } from '@mantine/hooks';
 import { IconArrowUp, IconSparkles } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useGenerateTooltip } from '../../../../../hooks/useGenerateTooltip';
+import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import styles from './AiTooltipInput.module.css';
 
 type Props = {
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export const AiTooltipInput: FC<Props> = ({ fields, currentHtml, onApply }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [prompt, setPrompt] = useState('');
 
     const handleSuccess = useCallback(

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -2,12 +2,13 @@ import { subject } from '@casl/ability';
 import { type ProjectHomepage } from '@lightdash/common';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import Page from '../../../components/common/Page/Page';
 import ForbiddenPanel from '../../../components/ForbiddenPanel';
 import PageSpinner from '../../../components/PageSpinner';
 import { usePinnedItems } from '../../../hooks/pinning/usePinnedItems';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useApp from '../../../providers/App/useApp';
 import { CreateHomepageModal } from './CreateHomepageModal';
 import { HomepageEditor } from './HomepageEditor';
@@ -26,7 +27,7 @@ const MAX_STARTER_SPACES = 4;
 
 // ts-unused-exports:disable-next-line
 export const HomepageBuilderPage: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [searchParams, setSearchParams] = useSearchParams();
     const navigate = useNavigate();
     const queryClient = useQueryClient();

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -81,7 +81,6 @@ import {
     type FC,
 } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../../../api';
 import { AiMarkdown } from '../../../components/common/AiMarkdown';
 import { CategoryBadge } from '../../../components/common/CategoryBadge';
@@ -99,6 +98,7 @@ import { useDashboardQuery } from '../../../hooks/dashboard/useDashboard';
 import { useGetSlack } from '../../../hooks/slack/useSlack';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useChartVersion, useSavedQuery } from '../../../hooks/useSavedQuery';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import useApp from '../../../providers/App/useApp';
@@ -2634,7 +2634,7 @@ const FilteredActionsView: FC<{
 };
 
 const ManagedAgentActivityPage: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const queryClient = useQueryClient();
     const { user } = useApp();
     const canManageAutopilot =

--- a/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentActions.ts
+++ b/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentActions.ts
@@ -4,8 +4,8 @@ import {
     type ManagedAgentTargetType,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../../../../api';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 
 export type ManagedAgentActionQueryFilters = {
     search?: string;
@@ -43,7 +43,7 @@ export const useManagedAgentActions = (
         filters?: ManagedAgentActionQueryFilters;
     } = {},
 ) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const isEnabled = opts.enabled ?? true;
     return useQuery<ManagedAgentAction[]>({
         queryKey: [

--- a/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentLatestRun.ts
+++ b/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentLatestRun.ts
@@ -1,7 +1,7 @@
 import { ManagedAgentRunStatus, type ManagedAgentRun } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../../../../api';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 
 const POLL_INTERVAL_RUNNING_MS = 3000;
 const POLL_INTERVAL_IDLE_MS = 30000;
@@ -16,7 +16,7 @@ const getLatestRun = async (
     });
 
 export const useManagedAgentLatestRun = (opts: { enabled?: boolean } = {}) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const isEnabled = opts.enabled ?? true;
     return useQuery<ManagedAgentRun | null>({
         queryKey: ['managed-agent-latest-run', projectUuid],

--- a/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentRuns.ts
+++ b/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentRuns.ts
@@ -1,7 +1,7 @@
 import { type ManagedAgentRunsListResponse } from '@lightdash/common';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../../../../api';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 
 const PAGE_SIZE = 20;
 const FIRST_PAGE_REFETCH_MS = 30000;
@@ -20,7 +20,7 @@ const getRuns = async (
 };
 
 export const useManagedAgentRuns = (opts: { enabled?: boolean } = {}) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const isEnabled = opts.enabled ?? true;
     return useInfiniteQuery<ManagedAgentRunsListResponse>({
         queryKey: ['managed-agent-runs', projectUuid],

--- a/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentSettings.ts
+++ b/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentSettings.ts
@@ -3,8 +3,8 @@ import {
     type ManagedAgentScheduleOption,
 } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router';
 import { lightdashApi } from '../../../../api';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 
 type ManagedAgentSettings = {
     projectUuid: string;
@@ -29,7 +29,7 @@ const getSettings = async (
     });
 
 export const useManagedAgentSettings = (opts: { enabled?: boolean } = {}) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const isEnabled = opts.enabled ?? true;
     return useQuery<ManagedAgentSettings | null>({
         queryKey: ['managed-agent-settings', projectUuid],

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -13,6 +13,7 @@ import { GuidedTour } from '../../../components/common/GuidedTour';
 import MantineModal from '../../../components/common/MantineModal';
 import { ShareLinkButton } from '../../../components/common/ShareLinkButton';
 import { useOnboardingTour } from '../../../hooks/useOnboardingTour';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -47,7 +48,8 @@ type NavigateFromAgentChatOptions = {
 };
 
 const AgentPage = () => {
-    const { agentUuid, threadUuid, projectUuid } = useParams();
+    const { agentUuid, threadUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const [searchParams] = useSearchParams();
     const navigate = useNavigate();
     const isEmbed = isEmbedAiAgentRoute();

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -3,6 +3,7 @@ import { Box, Center, Flex, Loader } from '@mantine/core';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { matchesModelConfig } from '../../../components/common/ModelSelector/utils';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useApp from '../../../providers/App/useApp';
 import { ReviewVerificationPanel } from '../../features/aiCopilot/components/Admin/ReviewVerificationPanel';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
@@ -57,7 +58,8 @@ import { getDashboardNavigationUrlFromContentToolResult } from '../../features/a
 import { type AgentContext } from './AgentPage';
 
 const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
-    const { agentUuid, threadUuid, projectUuid, promptUuid } = useParams();
+    const { agentUuid, threadUuid, promptUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const [searchParams] = useSearchParams();
     const isEmbed = isEmbedAiAgentRoute();
     const { user } = useApp();

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -20,15 +20,11 @@ import {
     IconNotebook,
 } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-    useLocation,
-    useNavigate,
-    useParams,
-    useSearchParams,
-} from 'react-router';
+import { useLocation, useNavigate, useSearchParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { AgentSettingsSelector } from '../../features/aiCopilot/components/AgentSelector';
 import { AutoModeSidebar } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentSidebar';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
@@ -57,7 +53,7 @@ import { useAiAgentStoreDispatch } from '../../features/aiCopilot/store/hooks';
 import classes from './AgentsRouterPage.module.css';
 
 const AgentsRouterPage = () => {
-    const { projectUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const navigate = useNavigate();
     const location = useLocation();
     const [searchParams] = useSearchParams();

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
@@ -17,8 +17,9 @@ import {
     IconMessageChatbot,
     IconPlus,
 } from '@tabler/icons-react';
-import { Link, Navigate, useParams, useSearchParams } from 'react-router';
+import { Link, Navigate, useSearchParams } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import {
     AI_ROUTING_AUTO_VALUE,
     AI_ROUTING_SEARCH_PARAM,
@@ -83,7 +84,7 @@ const AiPageLoading = () => (
  * 5. Otherwise — open the first agent in the list.
  */
 const AgentsWelcome = () => {
-    const { projectUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const [searchParams] = useSearchParams();
     const forceRouter =
         searchParams.get(AI_ROUTING_SEARCH_PARAM) === AI_ROUTING_AUTO_VALUE;

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.tsx
@@ -3,6 +3,7 @@ import { IconArrowLeft } from '@tabler/icons-react';
 import { Link, useParams } from 'react-router';
 import ErrorState from '../../../components/common/ErrorState';
 import PageSpinner from '../../../components/PageSpinner';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { MemoryActions } from '../../features/aiCopilot/components/MemoryDetails/MemoryActions';
 import { MemoryDetails } from '../../features/aiCopilot/components/MemoryDetails/MemoryDetails';
 import {
@@ -12,7 +13,8 @@ import {
 import styles from './AiAgentMemoryPage.module.css';
 
 const AiAgentMemoryPage = () => {
-    const { projectUuid, agentUuid, slug } = useParams();
+    const { agentUuid, slug } = useParams();
+    const projectUuid = useProjectUuid();
     const agentMemoryQuery = useAiAgentMemory({
         projectUuid,
         agentUuid,

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { AiAgentNewThreadMcpConnections } from '../../features/aiCopilot/components/AiAgentNewThreadMcpConnections';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import {
@@ -48,7 +49,8 @@ import { type AgentContext } from './AgentPage';
 import styles from './AiAgentNewThreadPage.module.css';
 
 const AiAgentNewThreadPage: FC = () => {
-    const { agentUuid, projectUuid } = useParams();
+    const { agentUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const isEmbed = isEmbedAiAgentRoute();
     const [searchParams] = useSearchParams();
     const chartUuid = searchParams.get('chartUuid');

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentThreadSharePage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentThreadSharePage.tsx
@@ -3,13 +3,12 @@ import { IconLinkOff } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
 import { useParams } from 'react-router';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useCloneAgentThreadShareMutation } from '../../features/aiCopilot/hooks/useProjectAiAgents';
 
 const AiAgentThreadSharePage: FC = () => {
-    const { projectUuid, aiThreadShareUuid } = useParams<{
-        projectUuid: string;
-        aiThreadShareUuid: string;
-    }>();
+    const { aiThreadShareUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const { mutate, isLoading, error } = useCloneAgentThreadShareMutation(
         projectUuid!,
     );

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentsNotAuthorizedPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentsNotAuthorizedPage.tsx
@@ -10,13 +10,14 @@ import {
 } from '@mantine/core';
 import { IconArrowLeft, IconLock, IconRobot } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { Link, useParams } from 'react-router';
+import { Link } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
 import { isEmbedAiAgentRoute } from '../../features/aiCopilot/hooks/aiAgentRouting';
 
 const AiAgentsNotAuthorizedPage: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const isEmbed = isEmbedAiAgentRoute();
 
     return (

--- a/packages/frontend/src/ee/pages/AiAgents/DeepResearchReportPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/DeepResearchReportPage.tsx
@@ -4,11 +4,13 @@ import { useNavigate, useParams } from 'react-router';
 import ErrorState from '../../../components/common/ErrorState';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
 import PageSpinner from '../../../components/PageSpinner';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { DeepResearchReport } from '../../features/aiCopilot/components/DeepResearch/DeepResearchReport';
 import { useDeepResearchReport } from '../../features/aiCopilot/hooks/useDeepResearch';
 
 const DeepResearchReportPage = () => {
-    const { projectUuid, runUuid } = useParams();
+    const { runUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const navigate = useNavigate();
     const runQuery = useDeepResearchReport(projectUuid, runUuid);
 

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -41,6 +41,7 @@ import {
     NAVBAR_HEIGHT,
 } from '../../../components/common/Page/constants';
 import { useProjects } from '../../../hooks/useProjects';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useApp from '../../../providers/App/useApp';
 import { VerifiedArtifactDetail } from '../../features/aiCopilot/components/Admin/VerifiedArtifactDetail';
 import { VerifiedArtifactsLayout } from '../../features/aiCopilot/components/Admin/VerifiedArtifactsLayout';
@@ -126,14 +127,8 @@ type Props = {
 
 const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
     const navigate = useNavigate();
-    const { agentUuid, projectUuid, evalUuid, runUuid, artifactUuid } =
-        useParams<{
-            agentUuid: string;
-            projectUuid: string;
-            evalUuid?: string;
-            runUuid?: string;
-            artifactUuid?: string;
-        }>();
+    const { agentUuid, evalUuid, runUuid, artifactUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const location = useLocation();
     const canManageAgents = useAiAgentPermission({
         action: 'manage',

--- a/packages/frontend/src/ee/pages/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/pages/EmbedDashboard.tsx
@@ -1,8 +1,8 @@
 import { type EmbedDashboard as EmbedDashboardType } from '@lightdash/common';
 import { IconUnlink } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useParams } from 'react-router';
 import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import DashboardProvider from '../../providers/Dashboard/DashboardProvider';
 import EmbedDashboard from '../features/embed/EmbedDashboard/components/EmbedDashboard';
 import useEmbed from '../providers/Embed/useEmbed';
@@ -13,9 +13,7 @@ const EmbedDashboardPage: FC<{
     isEditMode?: boolean;
     onEditModeChange?: (isEditMode: boolean) => void;
 }> = ({ containerStyles, initialDashboard, isEditMode, onEditModeChange }) => {
-    const { projectUuid: projectUuidFromParams } = useParams<{
-        projectUuid?: string;
-    }>();
+    const projectUuidFromParams = useProjectUuid();
 
     const { embedToken, projectUuid: projectUuidFromEmbed } = useEmbed();
 

--- a/packages/frontend/src/ee/pages/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/pages/EmbedExplore.tsx
@@ -5,9 +5,10 @@ import {
 } from '@lightdash/common';
 import { IconUnlink } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
-import { useLocation, useParams, useSearchParams } from 'react-router';
+import { useLocation, useSearchParams } from 'react-router';
 import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
 import { parseChartFromExplorerSearchParams } from '../../hooks/useExplorerRoute';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { useSavedQuery } from '../../hooks/useSavedQuery';
 import EmbedExplore from '../features/embed/EmbedExplore/components/EmbedExplore';
 import useEmbed from '../providers/Embed/useEmbed';
@@ -29,9 +30,7 @@ const EmbedExplorePage: FC<{
         projectUuid: embedProjectUuid,
         savedChart: savedChartEmbed,
     } = useEmbed();
-    const { projectUuid: paramsProjectUuid } = useParams<{
-        projectUuid: string;
-    }>();
+    const paramsProjectUuid = useProjectUuid();
     const { search } = useLocation();
     const [searchParams] = useSearchParams();
     const projectUuid = embedProjectUuid ?? paramsProjectUuid;

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -51,7 +51,6 @@ import {
     type ClipboardEvent,
     type FC,
 } from 'react';
-import { useParams } from 'react-router';
 import MantineIcon from '../../components/common/MantineIcon';
 import { ModelSelector } from '../../components/common/ModelSelector/ModelSelector';
 import { ChartIcon, IconBox } from '../../components/common/ResourceIcon';
@@ -59,6 +58,7 @@ import { getChartIcon } from '../../components/common/ResourceIcon/utils';
 import { useDashboards } from '../../hooks/dashboard/useDashboards';
 import { useChartSummariesV2 } from '../../hooks/useChartSummariesV2';
 import { useProject } from '../../hooks/useProject';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import useApp from '../../providers/App/useApp';
 import { useExternalConnections } from '../externalConnections/hooks/useExternalConnections';
 import classes from './AppResourcePicker.module.css';
@@ -360,7 +360,7 @@ const QueryPickerView: FC<{
     attachFromLink,
     isResolvingLink,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearch] = useDebouncedValue(searchQuery, 300);
 
@@ -835,7 +835,7 @@ const DashboardPickerView: FC<{
     attachFromLink,
     isResolvingLink,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearch] = useDebouncedValue(searchQuery, 300);
 
@@ -953,7 +953,7 @@ const ConnectionPickerView: FC<{
     onDone: () => void;
     enabled: boolean;
 }> = ({ selectedConnections, onSelect, onDeselect, onDone, enabled }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [searchQuery, setSearchQuery] = useState('');
     const { data: connections, isInitialLoading } = useExternalConnections(
         enabled ? projectUuid : undefined,
@@ -1144,7 +1144,7 @@ export const AttachButton: FC<{
     disabled,
     filesDisabled,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [opened, setOpened] = useState(false);
     const [view, setView] = useState<AttachView>('menu');
 

--- a/packages/frontend/src/features/apps/LegacyAppPreviewRedirect.tsx
+++ b/packages/frontend/src/features/apps/LegacyAppPreviewRedirect.tsx
@@ -1,8 +1,10 @@
 import { Navigate, useLocation, useParams } from 'react-router';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 
 // The app viewer used to live at `/preview`; old bookmarked links must keep working.
 const LegacyAppPreviewRedirect = () => {
-    const { projectUuid, appUuid, version } = useParams();
+    const { appUuid, version } = useParams();
+    const projectUuid = useProjectUuid();
     const location = useLocation();
     const basePath = `/projects/${projectUuid}/apps/${appUuid}`;
 

--- a/packages/frontend/src/features/funnelBuilder/FunnelBuilderPage.tsx
+++ b/packages/frontend/src/features/funnelBuilder/FunnelBuilderPage.tsx
@@ -3,10 +3,11 @@ import { Badge, Group, Title } from '@mantine/core';
 import { IconFlask2Filled } from '@tabler/icons-react';
 import { useEffect, useMemo, useRef, type FC } from 'react';
 import { Provider } from 'react-redux';
-import { Navigate, useParams } from 'react-router';
+import { Navigate } from 'react-router';
 import Page from '../../components/common/Page/Page';
 import useHealth from '../../hooks/health/useHealth';
 import useToaster from '../../hooks/toaster/useToaster';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { store } from '../sqlRunner/store';
 import { FunnelBuilderSidebar } from './components/FunnelBuilderSidebar';
 import { FunnelMainContent } from './components/FunnelMainContent';
@@ -26,7 +27,7 @@ const isApiErrorDetail = (
 };
 
 const FunnelBuilder: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const dispatch = useAppDispatch();
     const { showToastApiError, showToastError } = useToaster();
 
@@ -126,7 +127,7 @@ const FunnelBuilder: FC = () => {
 };
 
 const FunnelBuilderPage: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const health = useHealth();
 
     // Redirect to home if feature is disabled

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -20,7 +20,8 @@ import {
     type FC,
     type PropsWithChildren,
 } from 'react';
-import { useParams, useSearchParams } from 'react-router';
+import { useSearchParams } from 'react-router';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useInfiniteQueryResults } from '../../../hooks/useQueryResults';
 import {
     DEFAULT_ADDITIONAL_SOURCE_ID,
@@ -50,7 +51,7 @@ export const MergeProvider: FC<
         readOnly?: boolean;
     }>
 > = ({ children, savedMerge, readOnly = false }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [searchParams, setSearchParams] = useSearchParams();
     // Restored once, on mount. A link wins over the chart's stored merge, so
     // that sharing a modified merge shows what was shared rather than what was

--- a/packages/frontend/src/features/parameters/components/Parameters.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameters.tsx
@@ -7,12 +7,12 @@ import {
 } from '@lightdash/common';
 import { Group, Skeleton } from '@mantine/core';
 import { useCallback, useMemo, useState, type FC, type ReactNode } from 'react';
-import { useParams } from 'react-router';
 import {
     DraggableItem,
     DroppableArea,
 } from '../../../components/common/DndHelpers';
 import { useDndSensors } from '../../../hooks/useDndSensors';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import Parameter from './Parameter';
 
 type Props = {
@@ -49,7 +49,7 @@ export const Parameters: FC<Props> = ({
     dropdownClassName,
     shadowedReservedNames = [],
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [openPopoverId, setOpenPopoverId] = useState<string | undefined>();
 
     const handlePopoverOpen = useCallback((popoverId: string) => {

--- a/packages/frontend/src/features/queryHistory/components/QueryHistoryPage.tsx
+++ b/packages/frontend/src/features/queryHistory/components/QueryHistoryPage.tsx
@@ -14,10 +14,10 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { IconChevronDown, IconSearch } from '@tabler/icons-react';
 import clsx from 'clsx';
 import { useCallback, useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import Page from '../../../components/common/Page/Page';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useInfiniteQueryHistory } from '../hooks/useQueryHistory';
 import styles from '../QueryHistory.module.css';
 import { formatWarehouseTime } from '../utils/format';
@@ -37,7 +37,7 @@ const DEFAULT_EXPANDED_WINDOWS = new Set([
 ]);
 
 export const QueryHistoryPage: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { data: project } = useProject(projectUuid);
 
     const [trigger, setTrigger] = useState<QueryTrigger | undefined>(

--- a/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
@@ -2,9 +2,10 @@ import { subject } from '@casl/ability';
 import { isGitProjectType } from '@lightdash/common';
 import { Box, Group } from '@mantine/core';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
-import { useParams, useSearchParams } from 'react-router';
+import { useSearchParams } from 'react-router';
 import ErrorState from '../../../components/common/ErrorState';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useRefreshServer } from '../../../hooks/useRefreshServer';
 import useApp from '../../../providers/App/useApp';
 import { useSourceCodeEditor } from '../context/useSourceCodeEditor';
@@ -23,9 +24,7 @@ import SourceCodeSidebar from './SourceCodeSidebar';
 import UnsavedChangesModal from './UnsavedChangesModal';
 
 const SourceCodeEditorContent: FC = () => {
-    const { projectUuid: routeProjectUuid } = useParams<{
-        projectUuid: string;
-    }>();
+    const routeProjectUuid = useProjectUuid();
     const [searchParams, setSearchParams] = useSearchParams();
     const { user } = useApp();
     const {

--- a/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaForm.tsx
@@ -13,11 +13,11 @@ import {
     useRef,
     useState,
 } from 'react';
-import { useParams } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useAmbientAiEnabled } from '../../../../ee/features/ambientAi/hooks/useAmbientAiEnabled';
 import { useGenerateFormulaTableCalculation } from '../../../../hooks/useGenerateFormulaTableCalculation';
 import { useProject } from '../../../../hooks/useProject';
+import { useProjectUuid } from '../../../../hooks/useProjectUuid';
 import useApp from '../../../../providers/App/useApp';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
@@ -63,7 +63,7 @@ export const FormulaForm = forwardRef<FormulaFormHandle, Props>(
         },
         ref,
     ) {
-        const { projectUuid } = useParams<{ projectUuid: string }>();
+        const projectUuid = useProjectUuid();
         const { data: project } = useProject(projectUuid);
         const { user } = useApp();
         const { track } = useTracking();

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -55,7 +55,6 @@ import {
     useState,
     type FC,
 } from 'react';
-import { useParams } from 'react-router';
 import { useToggle } from 'react-use';
 import { type ValueOf } from 'type-fest';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -72,6 +71,7 @@ import useToaster from '../../../hooks/toaster/useToaster';
 import { useConvertSqlToFormula } from '../../../hooks/useConvertSqlToFormula';
 import { useExplore } from '../../../hooks/useExplore';
 import { useProject } from '../../../hooks/useProject';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useCannotAuthorCustomSqlTableCalculations } from '../../../hooks/user/useCannotAuthorCustomSqlTableCalculations';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { getUniqueTableCalculationName } from '../utils';
@@ -169,7 +169,7 @@ const TableCalculationModal: FC<Props> = ({
 }) => {
     const [isExpanded, toggleExpanded] = useToggle(false);
 
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { data: project } = useProject(projectUuid);
     const { data: health } = useHealth();
 

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -26,12 +26,13 @@ import {
     useQueryClient,
     type UseQueryOptions,
 } from '@tanstack/react-query';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate } from 'react-router';
 import { lightdashApi } from '../../api';
 import { pollJobStatus } from '../../features/scheduler/hooks/useScheduler';
 import useApp from '../../providers/App/useApp';
 import useToaster from '../toaster/useToaster';
 import { invalidateContent } from '../useContent';
+import { useProjectUuid } from '../useProjectUuid';
 import useQueryError from '../useQueryError';
 import useDashboardStorage from './useDashboardStorage';
 
@@ -628,7 +629,7 @@ export const useDuplicateDashboardMutation = (
     options?: DuplicateDashboardMutationOptions,
 ) => {
     const navigate = useNavigate();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<

--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -21,6 +21,7 @@ import {
     isChunkLoadErrorObject,
     RouteChunkLoadError,
 } from '../../features/chunkErrorHandler';
+import { useProjectUuid } from '../useProjectUuid';
 
 const useSentry = (
     sentryConfig: HealthState['sentry'] | undefined,
@@ -112,10 +113,8 @@ const useSentry = (
         }
     }, [sentryConfig, user, disableDashboardTracing]);
 
-    const { projectUuid, dashboardUuid } = useParams<{
-        projectUuid?: string;
-        dashboardUuid?: string;
-    }>();
+    const { dashboardUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const location = useLocation();
     useEffect(() => {
         if (projectUuid) {

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -153,6 +153,7 @@ import { useAppExternalConnections } from '../features/externalConnections/hooks
 import { ThemePicker } from '../features/organizationDesigns/components/ThemePicker';
 import { useOrganizationDesigns } from '../features/organizationDesigns/hooks/useOrganizationDesigns';
 import useToaster from '../hooks/toaster/useToaster';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useSpaceSummaries } from '../hooks/useSpaces';
 import { useAbilityContext } from '../providers/Ability/useAbilityContext';
@@ -390,10 +391,8 @@ const AvailableConnectionsChip: FC<{ aliases: string[] }> = ({ aliases }) => (
 );
 
 const AppGenerate: FC = () => {
-    const { projectUuid, appUuid: urlAppUuid } = useParams<{
-        projectUuid: string;
-        appUuid: string;
-    }>();
+    const { appUuid: urlAppUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const navigate = useNavigate();
     const location = useLocation();
     const queryClient = useQueryClient();

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -23,21 +23,15 @@ import {
 } from '../features/apps/hooks/useTrackedAppQueries';
 import { useTrackedExternalRequests } from '../features/apps/hooks/useTrackedExternalRequests';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useNativeFullscreenToggle from '../providers/Fullscreen/useNativeFullscreenToggle';
 import classes from './AppPreviewTest.module.css';
 
 export default function AppPreviewTest() {
     const navigate = useNavigate();
-    const {
-        projectUuid,
-        appUuid,
-        version: versionParam,
-    } = useParams<{
-        projectUuid: string;
-        appUuid: string;
-        version: string;
-    }>();
+    const { appUuid, version: versionParam } = useParams();
+    const projectUuid = useProjectUuid();
 
     const explicitVersion = versionParam ? Number(versionParam) : undefined;
 

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -60,6 +60,7 @@ import {
     getExplorerUrlFromCreateSavedChartVersion,
     parseChartFromExplorerSearchParams,
 } from '../hooks/useExplorerRoute';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import classes from './ChartTypeBuilder.module.css';
 
@@ -77,10 +78,8 @@ const toVizClarifyParams = (request: VizBuildRequest): ClarifyParams => ({
 });
 
 const ChartTypeBuilder: FC = () => {
-    const { projectUuid, dataAppVizUuid: urlVizUuid } = useParams<{
-        projectUuid: string;
-        dataAppVizUuid?: string;
-    }>();
+    const { dataAppVizUuid: urlVizUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const location = useLocation();
     const navigate = useNavigate();
     const explorerChart = useMemo(() => {

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -12,7 +12,7 @@ import {
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconPlus, IconSearch } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
-import { Link, Navigate, useParams } from 'react-router';
+import { Link, Navigate } from 'react-router';
 import EmptyStateLoader from '../components/common/EmptyStateLoader';
 import InlineErrorState from '../components/common/InlineErrorState';
 import MantineIcon from '../components/common/MantineIcon';
@@ -24,12 +24,13 @@ import ChartTypeGalleryCard from '../features/chartTypes/components/ChartTypeGal
 import ChartTypeGalleryEmptyState from '../features/chartTypes/components/ChartTypeGalleryEmptyState';
 import { useDataAppVisualizations } from '../features/chartTypes/hooks/useDataAppVisualizations';
 import { chartTypeBuilderPath } from '../features/chartTypes/utils/chartTypeBuilderPath';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
 
 const ChartTypeGallery = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { user } = useApp();
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
 

--- a/packages/frontend/src/pages/LegacySqlRunner.tsx
+++ b/packages/frontend/src/pages/LegacySqlRunner.tsx
@@ -1,13 +1,14 @@
 import type { FC } from 'react';
 import { Provider } from 'react-redux';
-import { Navigate, useLocation, useParams } from 'react-router';
+import { Navigate, useLocation } from 'react-router';
 import { store } from '../features/sqlRunner/store';
 import { useAppDispatch } from '../features/sqlRunner/store/hooks';
 import { setSql } from '../features/sqlRunner/store/sqlRunnerSlice';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 
 const RedirectToSqlRunner: FC = () => {
     const dispatch = useAppDispatch();
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { search } = useLocation();
     const searchParams = new URLSearchParams(search);
     const sqlRunnerSearchParam = searchParams.get('sql_runner');

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -19,6 +19,7 @@ import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { type QueryEvent } from '../features/apps/hooks/useAppSdkBridge';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 
 /**
@@ -49,10 +50,8 @@ const SDK_ALIVE_FALLBACK_MS = 8_000;
  * that signal before triggering the screenshot.
  */
 export default function MinimalApp() {
-    const { projectUuid, appUuid } = useParams<{
-        projectUuid: string;
-        appUuid: string;
-    }>();
+    const { appUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const [searchParams] = useSearchParams();
     const captureModeParam = searchParams.get('captureMode');
     const captureMode: 'delivery' | 'preview' | null =

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -45,6 +45,7 @@ import {
 import { useScheduler } from '../features/scheduler/hooks/useScheduler';
 import { useDashboardQuery } from '../hooks/dashboard/useDashboard';
 import { useDateZoomGranularitySearch } from '../hooks/useExplorerRoute';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import useSearchParams from '../hooks/useSearchParams';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
@@ -309,11 +310,8 @@ const MinimalDashboardContent: FC<MinimalDashboardContentProps> = ({
 };
 
 const MinimalDashboard: FC = () => {
-    const { projectUuid, dashboardUuid, tabUuid } = useParams<{
-        projectUuid: string;
-        dashboardUuid: string;
-        tabUuid?: string;
-    }>();
+    const { dashboardUuid, tabUuid } = useParams();
+    const projectUuid = useProjectUuid();
 
     const schedulerUuid = useSearchParams('schedulerUuid');
 

--- a/packages/frontend/src/pages/MobileCharts.tsx
+++ b/packages/frontend/src/pages/MobileCharts.tsx
@@ -7,17 +7,17 @@ import { TextInput, Group, Stack, ActionIcon } from '@mantine/core';
 import { IconChartBar, IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import EmptyStateLoader from '../components/common/EmptyStateLoader';
 import MantineIcon from '../components/common/MantineIcon';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
 import { ResourceSortDirection } from '../components/common/ResourceView/types';
 import { useCharts } from '../hooks/useCharts';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import useApp from '../providers/App/useApp';
 
 const MobileCharts: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { isInitialLoading, data: savedQueries = [] } =
         useCharts(projectUuid);
     const { user } = useApp();

--- a/packages/frontend/src/pages/MobileDashboards.tsx
+++ b/packages/frontend/src/pages/MobileDashboards.tsx
@@ -7,16 +7,16 @@ import { TextInput, Group, Stack, ActionIcon } from '@mantine/core';
 import { IconLayoutDashboard, IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState } from 'react';
-import { useParams } from 'react-router';
 import EmptyStateLoader from '../components/common/EmptyStateLoader';
 import MantineIcon from '../components/common/MantineIcon';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import ResourceView from '../components/common/ResourceView';
 import { ResourceSortDirection } from '../components/common/ResourceView/types';
 import { useDashboards } from '../hooks/dashboard/useDashboards';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 
 const MobileDashboards = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { isInitialLoading, data: dashboards = [] } =
         useDashboards(projectUuid);
     const [search, setSearch] = useState<string>('');

--- a/packages/frontend/src/pages/MobileHome.tsx
+++ b/packages/frontend/src/pages/MobileHome.tsx
@@ -6,7 +6,6 @@ import {
 import { Stack, Title } from '@mantine/core';
 import { IconLayoutDashboard } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
-import { useParams } from 'react-router';
 import ErrorState from '../components/common/ErrorState';
 import ResourceView from '../components/common/ResourceView';
 import { ResourceSortDirection } from '../components/common/ResourceView/types';
@@ -18,11 +17,11 @@ import {
     useMostPopularAndRecentlyUpdated,
     useProject,
 } from '../hooks/useProject';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import useApp from '../providers/App/useApp';
 
 const MobileHome: FC = () => {
-    const params = useParams<{ projectUuid: string }>();
-    const selectedProjectUuid = params.projectUuid;
+    const selectedProjectUuid = useProjectUuid();
     const savedChartStatus = useProjectSavedChartStatus(selectedProjectUuid);
     const project = useProject(selectedProjectUuid);
     const pinnedItems = usePinnedItems(

--- a/packages/frontend/src/pages/MobileSpace.tsx
+++ b/packages/frontend/src/pages/MobileSpace.tsx
@@ -20,14 +20,13 @@ import { ResourceSortDirection } from '../components/common/ResourceView/types';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import { useInfiniteContent } from '../hooks/useContent';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useSpace, useSpaceSummaries } from '../hooks/useSpaces';
 import useApp from '../providers/App/useApp';
 
 const MobileSpace: FC = () => {
-    const { projectUuid, spaceUuid } = useParams<{
-        projectUuid: string;
-        spaceUuid: string;
-    }>();
+    const { spaceUuid } = useParams();
+    const projectUuid = useProjectUuid();
     const {
         data: space,
         isInitialLoading,

--- a/packages/frontend/src/pages/MobileSpaces.tsx
+++ b/packages/frontend/src/pages/MobileSpaces.tsx
@@ -9,7 +9,6 @@ import { TextInput, Group, Stack, ActionIcon } from '@mantine/core';
 import { IconFolders, IconSearch, IconX } from '@tabler/icons-react';
 import Fuse from 'fuse.js';
 import { useMemo, useState, type FC } from 'react';
-import { useParams } from 'react-router';
 import EmptyStateLoader from '../components/common/EmptyStateLoader';
 import MantineIcon from '../components/common/MantineIcon';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
@@ -17,11 +16,12 @@ import ResourceView from '../components/common/ResourceView';
 import { ResourceSortDirection } from '../components/common/ResourceView/types';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import { useProject } from '../hooks/useProject';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useSpaceSummaries } from '../hooks/useSpaces';
 import useApp from '../providers/App/useApp';
 
 const MobileSpaces: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { data: spaces = [], isInitialLoading: spaceIsLoading } =
         useSpaceSummaries(projectUuid, true);
     const project = useProject(projectUuid);

--- a/packages/frontend/src/pages/SavedApps.tsx
+++ b/packages/frontend/src/pages/SavedApps.tsx
@@ -2,17 +2,18 @@ import { subject } from '@casl/ability';
 import { ContentType, FeatureFlags } from '@lightdash/common';
 import { Group, Stack, Button } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
-import { Link, Navigate, useParams } from 'react-router';
+import { Link, Navigate } from 'react-router';
 import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import InfiniteResourceTable from '../components/common/ResourceView/InfiniteResourceTable';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
 import { FavoritesProvider } from '../providers/Favorites/FavoritesProvider';
 
 const SavedApps = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { user } = useApp();
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
 

--- a/packages/frontend/src/pages/SourceCodeEditorRedirect.tsx
+++ b/packages/frontend/src/pages/SourceCodeEditorRedirect.tsx
@@ -1,4 +1,5 @@
-import { Navigate, useParams, useSearchParams } from 'react-router';
+import { Navigate, useSearchParams } from 'react-router';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 
 /**
  * Redirects the old /projects/:projectUuid/source-code route to the project
@@ -7,7 +8,7 @@ import { Navigate, useParams, useSearchParams } from 'react-router';
  * Preserves any branch/file params from the original URL.
  */
 const SourceCodeEditorRedirect = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [searchParams] = useSearchParams();
 
     // Preserve branch and file params if they exist

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -19,7 +19,7 @@ import {
 } from '@mantine/core';
 import { IconUsers } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { Link, useParams } from 'react-router';
+import { Link } from 'react-router';
 import MantineIcon from '../components/common/MantineIcon';
 import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
@@ -32,6 +32,7 @@ import {
 } from '../hooks/analytics/useUserActivity';
 import useHealth from '../hooks/health/useHealth';
 import { useProject } from '../hooks/useProject';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import useApp from '../providers/App/useApp';
 import classes from './UserActivity.module.css';
 
@@ -205,15 +206,14 @@ const chartWeeklyAverageQueries = (
 });
 
 const UserActivity: FC = () => {
-    const params = useParams<{ projectUuid: string }>();
-    const { data: project } = useProject(params.projectUuid);
+    const projectUuid = useProjectUuid();
+    const { data: project } = useProject(projectUuid);
     const { user: sessionUser } = useApp();
     const { data: health } = useHealth();
     const { mutateAsync: downloadCsv, isLoading: isDownloadingCsv } =
         useDownloadUserActivityCsv();
 
-    const { data, isInitialLoading } = useUserActivity(params.projectUuid);
-    const projectUuid = params.projectUuid;
+    const { data, isInitialLoading } = useUserActivity(projectUuid);
     if (sessionUser.data?.ability?.cannot('view', 'Analytics')) {
         return <ForbiddenPanel />;
     }
@@ -233,7 +233,7 @@ const UserActivity: FC = () => {
                     items={[
                         {
                             title: 'Usage analytics',
-                            to: `/generalSettings/projectManagement/${params.projectUuid}/usageAnalytics`,
+                            to: `/generalSettings/projectManagement/${projectUuid}/usageAnalytics`,
                         },
                         {
                             title: (
@@ -257,8 +257,8 @@ const UserActivity: FC = () => {
                         variant="outline"
                         disabled={isDownloadingCsv}
                         onClick={() => {
-                            if (params.projectUuid)
-                                downloadCsv(params.projectUuid)
+                            if (projectUuid)
+                                downloadCsv(projectUuid)
                                     .then((url) => {
                                         if (url) {
                                             // If the file takes a while to download,

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -43,6 +43,7 @@ import {
     setSavedChartData,
     updateParameterValue,
 } from '../features/sqlRunner/store/sqlRunnerSlice';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 
 enum TabOption {
     CHART = 'chart',
@@ -51,7 +52,8 @@ enum TabOption {
 }
 
 const ViewSqlChart = () => {
-    const params = useParams<{ projectUuid: string; slug?: string }>();
+    const params = useParams<{ slug?: string }>();
+    const projectUuid = useProjectUuid();
     const dispatch = useAppDispatch();
     const [activeTab, setActiveTab] = useState<TabOption>(TabOption.CHART);
 
@@ -79,7 +81,7 @@ const ViewSqlChart = () => {
         },
         getDownloadQueryUuid,
     } = useSavedSqlChartResults({
-        projectUuid: params.projectUuid,
+        projectUuid: projectUuid,
         ...(isUuid ? { savedSqlUuid: slugParam } : { slug: slugParam }),
         parameters: parameterValues,
     });
@@ -104,19 +106,16 @@ const ViewSqlChart = () => {
         if (chartData) {
             dispatch(setSavedChartData(chartData));
         }
-        if (params.projectUuid) {
-            dispatch(setProjectUuid(params.projectUuid));
+        if (projectUuid) {
+            dispatch(setProjectUuid(projectUuid));
         }
-    }, [dispatch, chartData, params.projectUuid]);
+    }, [dispatch, chartData, projectUuid]);
 
     const {
         data: projectParameters,
         isLoading: isProjectParametersLoading,
         isError: isProjectParametersError,
-    } = useParameters(
-        params.projectUuid,
-        Array.from(parameterReferences ?? []),
-    );
+    } = useParameters(projectUuid, Array.from(parameterReferences ?? []));
 
     return (
         <Page
@@ -182,9 +181,9 @@ const ViewSqlChart = () => {
                                         isVizBigNumberConfig(
                                             chartData?.config,
                                         )))) &&
-                                params.projectUuid && (
+                                projectUuid && (
                                     <ResultsDownloadButton
-                                        projectUuid={params.projectUuid}
+                                        projectUuid={projectUuid}
                                         disabled={!chartResultsData}
                                         vizTableConfig={
                                             isVizTableConfig(chartData?.config)
@@ -209,11 +208,11 @@ const ViewSqlChart = () => {
                                 )}
                             {activeTab === TabOption.CHART &&
                                 echartsInstance &&
-                                params.projectUuid && (
+                                projectUuid && (
                                     <ChartDownload
                                         echartsInstance={echartsInstance}
                                         chartName={chartData?.name}
-                                        projectUuid={params.projectUuid}
+                                        projectUuid={projectUuid}
                                         disabled={!chartResultsData}
                                         totalResults={
                                             chartResultsData

--- a/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../ee/features/aiCopilot/store/hooks';
 import { useActiveAiAgentThreadStreamParts } from '../../ee/features/aiCopilot/streaming/useAiAgentThreadStreamQuery';
 import { getDashboard } from '../../hooks/dashboard/useDashboard';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { getSavedQuery } from '../../hooks/useSavedQuery';
 import { planDashboardAiAgentChanges } from './dashboardAiAgentChangePlanner';
 import useDashboardContext from './useDashboardContext';
@@ -44,15 +45,8 @@ const isDashboardChartReadyQueryForCharts = (
 const DashboardAiAgentContextBridge = () => {
     const queryClient = useQueryClient();
     // useDashboardQuery/saved_dashboard_query use UUID-or-slug; useDashboardChartReadyQuery/dashboard_chart_ready_query uses dashboard.uuid.
-    const {
-        projectUuid,
-        dashboardUuid: dashboardUuidOrSlug,
-        mode,
-    } = useParams<{
-        projectUuid: string;
-        dashboardUuid: string;
-        mode: string;
-    }>();
+    const { dashboardUuid: dashboardUuidOrSlug, mode } = useParams();
+    const projectUuid = useProjectUuid();
     const isEditMode = mode === 'edit';
     const dispatch = useAiAgentStoreDispatch();
     const dashboardRefreshRequest = useAiAgentStoreSelector(


### PR DESCRIPTION
## Problem

Since project slugs landed in core frontend URLs (#27826), `useParams<{ projectUuid }>` returns the slug on slug URLs. Components across the app passed that raw value into project-scoped API calls, which reject non-uuids.

#27910 fixed the surfaces that blocked the explorer chart gallery work; this PR migrates the rest.

## Fix

- Every remaining `useParams` consumer of `projectUuid` (74 files: chart-type pages, app builder surfaces, AI agents, mobile pages, settings, context menus, conditional formatting, …) now resolves the uuid via `useProjectUuid()` (ProjectRoute context first, route param fallback, embed context last).
- Deliberate exceptions that keep raw param reads: `ProjectRoute`, `useProjectUuid`, and `useEmbed`/`EmbeddedApp` — they are the resolution chain itself.

Relates: [PROD-10465](https://linear.app/lightdash/issue/PROD-10465/show-built-in-chart-types-as-a-grid-in-the-chart-gallery)
