### PR TITLE
fix(data-apps): resolve project slug URLs before calling apps endpoints

### DIFF
--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -52,10 +52,14 @@ const mocks = vi.hoisted(() => ({
     exploreHook: vi.fn(),
     // Extra keys merged into the useVisualizationContext mock return value.
     vizContextOverrides: { current: {} as Record<string, unknown> },
+    // Simulates useProjectUuid()'s frontend-resolved project uuid — the
+    // project-route provider always resolves any slug URL to this value
+    // before it reaches the component.
+    projectUuid: { current: 'project-uuid' as string | undefined },
 }));
 
-vi.mock('react-router', () => ({
-    useParams: () => ({ projectUuid: 'project-uuid' }),
+vi.mock('../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => mocks.projectUuid.current,
 }));
 vi.mock('../../ee/providers/Embed/useEmbed', () => ({
     default: () => ({ embedToken: mocks.embedToken.current }),
@@ -169,6 +173,34 @@ describe('DataAppVizRenderer', () => {
         mocks.explore.current = undefined;
         mocks.exploreHook.mockClear();
         mocks.vizContextOverrides.current = {};
+        mocks.projectUuid.current = 'project-uuid';
+    });
+
+    it('sends the resolved project uuid, not a raw slug, to the render metadata and preview token requests', () => {
+        mocks.projectUuid.current = 'resolved-project-uuid';
+
+        renderRenderer();
+
+        expect(mocks.renderMetadataHook).toHaveBeenCalledWith(
+            'resolved-project-uuid',
+            'viz-uuid',
+            { isEmbedded: false, savedChartUuid: 'saved-chart-uuid' },
+        );
+        expect(mocks.previewTokenHook).toHaveBeenCalledWith(
+            'resolved-project-uuid',
+            'viz-uuid',
+            7,
+            { isEmbedded: false, savedChartUuid: 'saved-chart-uuid' },
+        );
+        expect(mocks.iframePreview).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                src: expect.stringContaining(
+                    'projectUuid=resolved-project-uuid',
+                ),
+                projectUuid: 'resolved-project-uuid',
+            }),
+            undefined,
+        );
     });
 
     it('prompts for a visualization when none is selected', () => {
@@ -410,6 +442,7 @@ describe('DataAppVizRenderer underlying-data gating', () => {
         mocks.canViewUnderlyingData.current = true;
         mocks.explore.current = { name: 'orders' };
         mocks.vizContextOverrides.current = { resultsData: happyResultsData() };
+        mocks.projectUuid.current = 'project-uuid';
     });
 
     it('happy path: pushes enabled and installs the rewrite callback', () => {

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -7,7 +7,6 @@ import {
 import { Stack, Text } from '@mantine/core';
 import { IconPuzzle } from '@tabler/icons-react';
 import { useEffect, useMemo, useRef, type FC } from 'react';
-import { useParams } from 'react-router';
 import useEmbed from '../../ee/providers/Embed/useEmbed';
 import AppIframePreview from '../../features/apps/AppIframePreview';
 import { useChartVersionPreview } from '../../features/apps/ChartVersionPreview/useChartVersionPreview';
@@ -20,6 +19,7 @@ import {
 import { reconcileDataAppVizFieldMapping } from '../../features/chartTypes/utils/autoMapDataAppVizFields';
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
 import { useExplore } from '../../hooks/useExplore';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import MantineIcon from '../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
@@ -54,7 +54,7 @@ const getTerminalRequestErrorMessage = (
 };
 
 const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const {
         visualizationConfig,
         resultsData,

--- a/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
@@ -1,7 +1,18 @@
+import { type Project } from '@lightdash/common';
 import { MantineProvider } from '@mantine/core';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { vi } from 'vitest';
-import { SelectedQuerySection } from './AppResourcePicker';
+import { ProjectRouteContext } from '../../hooks/useProjectRoute';
+import { AttachButton, SelectedQuerySection } from './AppResourcePicker';
+import { useAttachResourceLink } from './hooks/useAttachResourceLink';
+
+vi.mock('./hooks/useAttachResourceLink', () => ({
+    useAttachResourceLink: vi.fn(() => ({
+        attachFromLink: vi.fn(),
+        isResolvingLink: false,
+    })),
+}));
 
 const baseChart = {
     uuid: 'c1',
@@ -57,4 +68,46 @@ it('hides the sample-data controls when the instance disables sample data', () =
     );
     expect(screen.queryByLabelText('Include sample data')).toBeNull();
     expect(screen.getByLabelText('Link live')).toBeInTheDocument();
+});
+
+it('resolves a project slug URL to the canonical uuid before wiring the attach-link resolver', () => {
+    render(
+        <MantineProvider env="test">
+            <MemoryRouter initialEntries={['/projects/jaffle-shop/generate']}>
+                <Routes>
+                    <Route
+                        path="/projects/:projectUuid/generate"
+                        element={
+                            <ProjectRouteContext.Provider
+                                value={{
+                                    project: {} as Project,
+                                    projectUuid: 'resolved-project-uuid',
+                                    projectUrlIdentifier: 'jaffle-shop',
+                                }}
+                            >
+                                <AttachButton
+                                    selectedCharts={[]}
+                                    onSelectChart={() => {}}
+                                    onDeselectChart={() => {}}
+                                    selectedDashboard={null}
+                                    onSelectDashboard={() => {}}
+                                    onDeselectDashboard={() => {}}
+                                    selectedConnections={[]}
+                                    onSelectConnection={() => {}}
+                                    onDeselectConnection={() => {}}
+                                    onAddFiles={() => {}}
+                                    disabled={false}
+                                    filesDisabled={false}
+                                />
+                            </ProjectRouteContext.Provider>
+                        }
+                    />
+                </Routes>
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+    expect(useAttachResourceLink).toHaveBeenCalledWith(
+        expect.objectContaining({ projectUuid: 'resolved-project-uuid' }),
+    );
 });

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -51,7 +51,6 @@ import {
     type ClipboardEvent,
     type FC,
 } from 'react';
-import { useParams } from 'react-router';
 import MantineIcon from '../../components/common/MantineIcon';
 import { ModelSelector } from '../../components/common/ModelSelector/ModelSelector';
 import { ChartIcon, IconBox } from '../../components/common/ResourceIcon';
@@ -59,6 +58,7 @@ import { getChartIcon } from '../../components/common/ResourceIcon/utils';
 import { useDashboards } from '../../hooks/dashboard/useDashboards';
 import { useChartSummariesV2 } from '../../hooks/useChartSummariesV2';
 import { useProject } from '../../hooks/useProject';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
 import useApp from '../../providers/App/useApp';
 import { useExternalConnections } from '../externalConnections/hooks/useExternalConnections';
 import classes from './AppResourcePicker.module.css';
@@ -360,7 +360,7 @@ const QueryPickerView: FC<{
     attachFromLink,
     isResolvingLink,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearch] = useDebouncedValue(searchQuery, 300);
 
@@ -835,7 +835,7 @@ const DashboardPickerView: FC<{
     attachFromLink,
     isResolvingLink,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearch] = useDebouncedValue(searchQuery, 300);
 
@@ -953,7 +953,7 @@ const ConnectionPickerView: FC<{
     onDone: () => void;
     enabled: boolean;
 }> = ({ selectedConnections, onSelect, onDeselect, onDone, enabled }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [searchQuery, setSearchQuery] = useState('');
     const { data: connections, isInitialLoading } = useExternalConnections(
         enabled ? projectUuid : undefined,
@@ -1144,7 +1144,7 @@ export const AttachButton: FC<{
     disabled,
     filesDisabled,
 }) => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const [opened, setOpened] = useState(false);
     const [view, setView] = useState<AttachView>('menu');
 

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlags, type DataAppViz } from '@lightdash/common';
+import { FeatureFlags, type DataAppViz, type Project } from '@lightdash/common';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -6,6 +6,7 @@ import { useAppVersionHistory } from '../features/apps/hooks/useAppVersionHistor
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
 import { useDeleteApp } from '../features/apps/hooks/useDeleteApp';
 import { useDataAppVisualizations } from '../features/chartTypes/hooks/useDataAppVisualizations';
+import { ProjectRouteContext } from '../hooks/useProjectRoute';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { renderWithProviders } from '../testing/testUtils';
 import ChartTypeGallery from './ChartTypeGallery';
@@ -98,6 +99,30 @@ const renderPage = () =>
                 <Route
                     path="/projects/:projectUuid/home"
                     element={<div>home</div>}
+                />
+            </Routes>
+        </MemoryRouter>,
+    );
+
+// Mirrors ProjectRoute: a slug URL resolves through the project-route
+// provider to the canonical project uuid before the page ever sees it.
+const renderPageWithSlugRoute = (resolvedProjectUuid: string) =>
+    renderWithProviders(
+        <MemoryRouter initialEntries={['/projects/jaffle-shop/gallery']}>
+            <Routes>
+                <Route
+                    path="/projects/:projectUuid/gallery"
+                    element={
+                        <ProjectRouteContext.Provider
+                            value={{
+                                project: {} as Project,
+                                projectUuid: resolvedProjectUuid,
+                                projectUrlIdentifier: 'jaffle-shop',
+                            }}
+                        >
+                            <ChartTypeGallery />
+                        </ProjectRouteContext.Provider>
+                    }
                 />
             </Routes>
         </MemoryRouter>,
@@ -287,6 +312,16 @@ describe('ChartTypeGallery', () => {
             expect(
                 screen.getByText(/No chart types match/),
             ).toBeInTheDocument(),
+        );
+    });
+
+    it('resolves a project slug URL to the canonical project uuid before fetching chart types', () => {
+        setData([]);
+        renderPageWithSlugRoute('project-uuid-canonical');
+
+        expect(mockedUseDataAppVisualizations).toHaveBeenCalledWith(
+            'project-uuid-canonical',
+            '',
         );
     });
 

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -12,7 +12,7 @@ import {
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconPlus, IconSearch } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
-import { Link, Navigate, useParams } from 'react-router';
+import { Link, Navigate } from 'react-router';
 import EmptyStateLoader from '../components/common/EmptyStateLoader';
 import InlineErrorState from '../components/common/InlineErrorState';
 import MantineIcon from '../components/common/MantineIcon';
@@ -24,12 +24,13 @@ import ChartTypeGalleryCard from '../features/chartTypes/components/ChartTypeGal
 import ChartTypeGalleryEmptyState from '../features/chartTypes/components/ChartTypeGalleryEmptyState';
 import { useDataAppVisualizations } from '../features/chartTypes/hooks/useDataAppVisualizations';
 import { chartTypeBuilderPath } from '../features/chartTypes/utils/chartTypeBuilderPath';
+import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
 
 const ChartTypeGallery = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const projectUuid = useProjectUuid();
     const { user } = useApp();
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
 


### PR DESCRIPTION
## Description

Since project slugs landed in core frontend URLs (#27826), the Gallery page (`/projects/{slug}/gallery`) 500'd for any project accessed by slug: `Failed to load chart types`. The EE endpoint `/api/v1/ee/projects/{slug}/apps/visualizations` received the raw slug instead of a project UUID and Postgres rejected it with `invalid input syntax for type uuid`.

#27826's design is frontend-resolves: `useProjectUuid()` (`packages/frontend/src/hooks/useProjectUuid.ts`) prefers the project-route provider's resolved UUID and falls back to raw route params or the embed context. Several data-app surfaces predated that hook and still read the raw `:projectUuid` route param directly via `useParams`, bypassing the resolution and forwarding whatever the URL contained (a slug) straight into EE endpoints that require a canonical UUID.

This PR is a mechanical swap of `useParams<{ projectUuid: string }>()` to `useProjectUuid()` at the six call sites that still read the raw param, keeping the variable name `projectUuid` so downstream code is untouched:

1. `packages/frontend/src/pages/ChartTypeGallery.tsx`
2. `packages/frontend/src/components/DataAppVizRenderer/index.tsx`
3. `packages/frontend/src/features/apps/AppResourcePicker.tsx` — four sites: `QueryPickerView`, `DashboardPickerView`, `ConnectionPickerView`, and `AttachButton`

`useEmbed`'s own `useParams` fallback is untouched — it's not one of the affected data-app-endpoint call sites and is out of scope here.

## Testing

- `pnpm -F frontend test AppResourcePicker DataAppVizRenderer ChartTypeGallery` — 55 tests pass (5 files).
- `pnpm -F frontend typecheck` — green.
- `pnpm -F frontend lint` — green.
- Regression coverage added (one test per component with an existing test file, per the touched sites):
  - `pages/ChartTypeGallery.test.tsx`: new test mounts the page under a slug route (`/projects/jaffle-shop/gallery`) with a `ProjectRouteContext.Provider` resolving a different canonical UUID, and asserts `useDataAppVisualizations` is called with the resolved UUID, not the slug.
  - `components/DataAppVizRenderer/index.test.tsx`: swapped the `react-router` `useParams` mock for a `useProjectUuid` mock (mock churn expected, proves the swap), and added a test asserting the render-metadata/preview-token hooks and the iframe `src`/`projectUuid` prop all receive the resolved UUID.
  - `features/apps/AppResourcePicker.test.tsx`: added a test mounting the exported `AttachButton` (the `useParams` call site at line ~1147) under a slug route with `ProjectRouteContext.Provider` resolving a UUID, asserting `useAttachResourceLink` is called with the resolved UUID.
- Skipped: `QueryPickerView`, `DashboardPickerView`, and `ConnectionPickerView` inside `AppResourcePicker.tsx` are internal, unexported components reachable only by driving the full `AttachButton` popover flow, which would require newly mocking `useChartSummariesV2`, `useDashboards`, `useExternalConnections`, `useProject`, and ability checks that this test file doesn't currently set up. That harness would be disproportionate to the mechanical fix and largely duplicate the `AttachButton` assertion already added, so it was skipped.

Closes: GLITCH-689

🤖 Generated with [Claude Code](https://claude.com/claude-code)
