### PR TITLE
fix: support pre-aggregate SQL custom dimensions

### DIFF
--- a/docs/pre-aggregates/CONTEXT.md
+++ b/docs/pre-aggregates/CONTEXT.md
@@ -84,7 +84,9 @@ _Avoid_: routing, resolution
 **SQL custom dimension**:
 A query-defined dimension computed by a SQL expression. During matching, every
 semantic dimension referenced by the expression must be covered at a safely
-derivable grain.
+derivable grain. Expressions with no `${...}` references or with raw
+`${TABLE}.column` references can't be verified against materialized columns and
+never match.
 _Avoid_: custom SQL field, calculated dimension
 
 **Hit**:

--- a/docs/pre-aggregates/CONTEXT.md
+++ b/docs/pre-aggregates/CONTEXT.md
@@ -81,6 +81,12 @@ granularity are all covered by a pre-aggregate. When several match, the
 smallest pre-aggregate wins.
 _Avoid_: routing, resolution
 
+**SQL custom dimension**:
+A query-defined dimension computed by a SQL expression. During matching, every
+semantic dimension referenced by the expression must be covered at a safely
+derivable grain.
+_Avoid_: custom SQL field, calculated dimension
+
 **Hit**:
 A query (or dashboard tile) served from a pre-aggregate instead of the source
 tables.
@@ -125,8 +131,9 @@ granularity — so each result row is served from a single materialization row
 and no re-aggregation occurs. The only kind of match that can serve
 non-additive metrics. Fields that group identically are interchangeable: a
 date-type base field counts as day grain, and the day alias of a date-type
-dimension counts as its stored raw values. A definition dimension referenced only by a query
-filter, or reached through a custom bin, does not count as selected.
+dimension counts as its stored raw values. A definition dimension referenced
+only by a query filter, or reached through a custom dimension, does not count
+as selected.
 
 **Audit**:
 A per-dashboard coverage report classifying each tile as hit, miss (with

--- a/examples/full-jaffle-shop-demo/dbt/charts/pre-aggregate-custom-sql-dimension.yml
+++ b/examples/full-jaffle-shop-demo/dbt/charts/pre-aggregate-custom-sql-dimension.yml
@@ -1,0 +1,46 @@
+name: Pre-aggregate custom SQL dimension
+description: Monthly order totals grouped by a SQL custom dimension
+tableName: orders
+metricQuery:
+  exploreName: orders
+  dimensions:
+    - orders_order_date_month
+    - status_present
+  metrics:
+    - orders_total_order_amount
+  filters: {}
+  sorts:
+    - fieldId: orders_order_date_month
+      descending: true
+  limit: 500
+  metricOverrides: {}
+  dimensionOverrides: {}
+  tableCalculations: []
+  additionalMetrics: []
+  customDimensions:
+    - id: status_present
+      name: Status present
+      table: orders
+      type: sql
+      sql: ${orders.status} IS NOT NULL
+      dimensionType: boolean
+chartConfig:
+  type: table
+  config:
+    columns: {}
+    metricsAsRows: false
+    showSubtotals: false
+    hideRowNumbers: false
+    showTableNames: false
+    showResultsTotal: false
+    showRowCalculation: false
+    showColumnCalculation: false
+    conditionalFormattings: []
+tableConfig:
+  columnOrder:
+    - orders_order_date_month
+    - status_present
+    - orders_total_order_amount
+slug: pre-aggregate-custom-sql-dimension
+spaceSlug: jaffle-shop
+version: 1

--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -350,6 +350,25 @@ const makeCustomBinDimension = (binType: BinType) => {
     }
 };
 
+const makeCustomSqlDimension = (
+    sql: string,
+    dimensionType: DimensionType = DimensionType.STRING,
+) => ({
+    id: 'custom_1',
+    type: CustomDimensionType.SQL as const,
+    name: 'Custom',
+    table: 'orders',
+    sql,
+    dimensionType,
+});
+
+const makeExploreWithPreAggregate = (
+    preAggregate: PreAggregateDef,
+): Explore => ({
+    ...baseExplore(),
+    preAggregates: [preAggregate],
+});
+
 describe('findMatch', () => {
     it('returns no_pre_aggregates_defined when explore has no pre-aggregates', () => {
         const result = preAggregateUtils.findMatch(
@@ -1419,6 +1438,24 @@ describe('findMatch', () => {
             });
         });
 
+        it('misses when a definition dimension is reached only through a SQL custom dimension', () => {
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: ['custom_1'],
+                    metrics: ['orders_unique_customers'],
+                    customDimensions: [
+                        makeCustomSqlDimension('${orders.status}'),
+                    ],
+                }),
+                exploreWithUniqueCustomersDef(),
+            );
+
+            expect(result.miss).toStrictEqual({
+                reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH,
+                fieldId: 'orders_unique_customers',
+            });
+        });
+
         it('keeps the exact match for a subset of the pre-aggregate metrics', () => {
             const result = preAggregateUtils.findMatch(
                 makeMetricQuery({
@@ -2300,38 +2337,273 @@ describe('findMatch', () => {
         });
     });
 
-    it('returns custom_dimension_present when a custom SQL dimension exists', () => {
-        const explore = {
-            ...baseExplore(),
-            preAggregates: [
-                {
-                    name: 'orders_summary',
-                    dimensions: ['status'],
-                    metrics: ['order_count'],
-                },
-            ],
-        };
+    it('matches a SQL custom dimension derived from a covered dimension', () => {
+        const explore = makeExploreWithPreAggregate({
+            name: 'orders_summary',
+            dimensions: ['status'],
+            metrics: ['order_count'],
+        });
 
         const result = preAggregateUtils.findMatch(
             makeMetricQuery({
-                dimensions: ['orders_status'],
+                dimensions: ['custom_1'],
                 metrics: ['orders_order_count'],
                 customDimensions: [
-                    {
-                        id: 'custom_1',
-                        type: CustomDimensionType.SQL,
-                        name: 'Custom',
-                        table: 'orders',
-                        sql: '1',
-                        dimensionType: DimensionType.NUMBER,
-                    },
+                    makeCustomSqlDimension(
+                        '${orders.status} IS NOT NULL',
+                        DimensionType.BOOLEAN,
+                    ),
+                ],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+
+    it('matches an opaque SQL custom dimension', () => {
+        const explore = makeExploreWithPreAggregate({
+            name: 'orders_summary',
+            dimensions: ['status'],
+            metrics: ['order_count'],
+        });
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['custom_1'],
+                metrics: ['orders_order_count'],
+                customDimensions: [
+                    makeCustomSqlDimension(
+                        'orders.status IS NOT NULL',
+                        DimensionType.BOOLEAN,
+                    ),
+                ],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+
+    it('matches a SQL custom dimension derived from a covered joined dimension', () => {
+        const explore = makeExploreWithPreAggregate({
+            name: 'orders_summary',
+            dimensions: ['customers.first_name'],
+            metrics: ['order_count'],
+        });
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['custom_1'],
+                metrics: ['orders_order_count'],
+                customDimensions: [
+                    makeCustomSqlDimension('LOWER(${customers.first_name})'),
+                ],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+
+    it('matches a SQL custom dimension derived at a coarser time grain', () => {
+        const explore = makeExploreWithPreAggregate({
+            name: 'orders_daily',
+            dimensions: [],
+            metrics: ['order_count'],
+            timeDimension: 'order_date',
+            granularity: TimeFrames.DAY,
+        });
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['custom_1'],
+                metrics: ['orders_order_count'],
+                customDimensions: [
+                    makeCustomSqlDimension(
+                        '${orders.order_date_month}',
+                        DimensionType.DATE,
+                    ),
+                ],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_daily',
+            miss: null,
+        });
+    });
+
+    it('misses when a SQL custom dimension references an uncovered dimension', () => {
+        const explore = makeExploreWithPreAggregate({
+            name: 'orders_summary',
+            dimensions: ['status'],
+            metrics: ['order_count'],
+        });
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['custom_1'],
+                metrics: ['orders_order_count'],
+                customDimensions: [
+                    makeCustomSqlDimension(
+                        '${orders.status} || ${orders.amount}',
+                    ),
                 ],
             }),
             explore,
         );
 
         expect(result.miss).toStrictEqual({
-            reason: PreAggregateMissReason.CUSTOM_DIMENSION_PRESENT,
+            reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
+            fieldId: 'custom_1',
+        });
+    });
+
+    it('ignores unused SQL custom dimensions', () => {
+        const explore = makeExploreWithPreAggregate({
+            name: 'orders_summary',
+            dimensions: ['status'],
+            metrics: ['order_count'],
+        });
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+                customDimensions: [
+                    makeCustomSqlDimension(
+                        '${orders.amount}',
+                        DimensionType.NUMBER,
+                    ),
+                ],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+
+    it('matches a filter on a SQL custom dimension derived from a covered dimension', () => {
+        const explore = makeExploreWithPreAggregate({
+            name: 'orders_summary',
+            dimensions: ['status'],
+            metrics: ['order_count'],
+        });
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: [],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'custom-filter',
+                                target: { fieldId: 'custom_1' },
+                                operator: FilterOperator.EQUALS,
+                                values: [true],
+                            },
+                        ],
+                    },
+                },
+                customDimensions: [
+                    makeCustomSqlDimension(
+                        '${orders.status} IS NOT NULL',
+                        DimensionType.BOOLEAN,
+                    ),
+                ],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+
+    it('returns granularity_too_fine for a SQL custom dimension dependency', () => {
+        const explore = makeExploreWithPreAggregate({
+            name: 'orders_daily',
+            dimensions: [],
+            metrics: ['order_count'],
+            timeDimension: 'created_at',
+            granularity: TimeFrames.DAY,
+        });
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['custom_1'],
+                metrics: ['orders_order_count'],
+                customDimensions: [
+                    makeCustomSqlDimension(
+                        '${orders.created_at}',
+                        DimensionType.TIMESTAMP,
+                    ),
+                ],
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.GRANULARITY_TOO_FINE,
+            fieldId: 'orders_created_at',
+            queryGranularity: TimeFrames.RAW,
+            preAggregateGranularity: TimeFrames.DAY,
+            preAggregateTimeDimension: 'created_at',
+        });
+    });
+
+    it('returns time_frame_not_derivable for a SQL custom dimension dependency', () => {
+        const explore = makeExploreWithPreAggregate({
+            name: 'orders_weekly',
+            dimensions: [],
+            metrics: ['order_count'],
+            timeDimension: 'order_date',
+            granularity: TimeFrames.WEEK,
+        });
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['custom_1'],
+                metrics: ['orders_order_count'],
+                customDimensions: [
+                    makeCustomSqlDimension(
+                        '${orders.order_date_month}',
+                        DimensionType.DATE,
+                    ),
+                ],
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.TIME_FRAME_NOT_DERIVABLE,
+            fieldId: 'orders_order_date_month',
+            queryGranularity: TimeFrames.MONTH,
+            preAggregateGranularity: TimeFrames.WEEK,
+            preAggregateTimeDimension: 'order_date',
         });
     });
 

--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -2365,7 +2365,7 @@ describe('findMatch', () => {
         });
     });
 
-    it('matches an opaque SQL custom dimension', () => {
+    it('misses an opaque SQL custom dimension with no ${} references', () => {
         const explore = makeExploreWithPreAggregate({
             name: 'orders_summary',
             dimensions: ['status'],
@@ -2387,9 +2387,43 @@ describe('findMatch', () => {
         );
 
         expect(result).toStrictEqual({
-            hit: true,
-            preAggregateName: 'orders_summary',
-            miss: null,
+            hit: false,
+            preAggregateName: null,
+            miss: {
+                reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
+                fieldId: 'custom_1',
+            },
+        });
+    });
+
+    it('misses a SQL custom dimension using ${TABLE} references', () => {
+        const explore = makeExploreWithPreAggregate({
+            name: 'orders_summary',
+            dimensions: ['status'],
+            metrics: ['order_count'],
+        });
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['custom_1'],
+                metrics: ['orders_order_count'],
+                customDimensions: [
+                    makeCustomSqlDimension(
+                        '${TABLE}.status IS NOT NULL',
+                        DimensionType.BOOLEAN,
+                    ),
+                ],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: false,
+            preAggregateName: null,
+            miss: {
+                reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
+                fieldId: 'custom_1',
+            },
         });
     });
 

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.resolveExecution.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.resolveExecution.test.ts
@@ -1,4 +1,6 @@
 import {
+    CustomDimensionType,
+    DimensionType,
     ExploreType,
     QueryExecutionContext,
     type Explore,
@@ -48,7 +50,15 @@ const resolveExecutionParams = (externalTable?: string) => ({
         ...(externalTable ? { externalTable } : {}),
     },
     resolveArgs: {
-        metricQuery: {} as MetricQuery,
+        metricQuery: {
+            exploreName: 'orders',
+            dimensions: [],
+            metrics: [],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+        } as MetricQuery,
         timezone: 'UTC',
         dateZoom: undefined,
         parameters: undefined,
@@ -94,6 +104,49 @@ describe('PreAggregateStrategy.resolveExecution', () => {
         });
         expect(externalResolver.resolve).toHaveBeenCalledTimes(1);
         expect(duckDbClient.resolve).not.toHaveBeenCalled();
+    });
+
+    test('resolves with only active custom dimensions', async () => {
+        const { strategy, duckDbClient } = makeStrategy();
+        const params = resolveExecutionParams();
+        const activeCustomDimension = {
+            id: 'status_present',
+            type: CustomDimensionType.SQL,
+            name: 'Status present',
+            table: 'orders',
+            sql: '${orders.status} IS NOT NULL',
+            dimensionType: DimensionType.BOOLEAN,
+        } as const;
+        params.resolveArgs.metricQuery = {
+            exploreName: 'orders',
+            dimensions: [activeCustomDimension.id],
+            metrics: [],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+            customDimensions: [
+                activeCustomDimension,
+                {
+                    id: 'unused_amount',
+                    type: CustomDimensionType.SQL,
+                    name: 'Unused amount',
+                    table: 'orders',
+                    sql: '${orders.amount}',
+                    dimensionType: DimensionType.NUMBER,
+                },
+            ],
+        };
+
+        await strategy.resolveExecution(params);
+
+        expect(duckDbClient.resolve).toHaveBeenCalledWith(
+            expect.objectContaining({
+                metricQuery: expect.objectContaining({
+                    customDimensions: [activeCustomDimension],
+                }),
+            }),
+        );
     });
 });
 

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -191,7 +191,12 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
         const resolverArgs = {
             projectUuid,
             queryUuid,
-            metricQuery: resolveArgs.metricQuery,
+            metricQuery: {
+                ...resolveArgs.metricQuery,
+                customDimensions: preAggregateUtils.getActiveCustomDimensions(
+                    resolveArgs.metricQuery,
+                ),
+            },
             timezone: resolveArgs.timezone,
             dateZoom: resolveArgs.dateZoom,
             parameters: resolveArgs.parameters,

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationExternalResolver.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationExternalResolver.test.ts
@@ -1,7 +1,9 @@
 import {
+    CustomDimensionType,
     DimensionType,
     ExploreType,
     FieldType,
+    FilterOperator,
     MetricType,
     SupportedDbtAdapter,
     type Explore,
@@ -142,6 +144,75 @@ describe('PreAggregationExternalResolver', () => {
             'projectUuid',
             '__preagg__orders__orders_rollup',
         );
+    });
+
+    test('recompiles SQL custom dimensions against materialized columns', async () => {
+        const { resolver } = getResolver();
+
+        const result = await resolver.resolve({
+            ...baseResolveArgs,
+            metricQuery: {
+                ...metricQuery,
+                dimensions: ['status_present'],
+                customDimensions: [
+                    {
+                        id: 'status_present',
+                        type: CustomDimensionType.SQL,
+                        name: 'Status present',
+                        table: 'orders',
+                        sql: '${orders.status} IS NOT NULL',
+                        dimensionType: DimensionType.BOOLEAN,
+                    },
+                ],
+            },
+        });
+
+        expect(result.resolved).toBe(true);
+        if (!result.resolved) throw new Error('unreachable');
+        expect(result.query).toContain(
+            '((orders.orders_status) IS NOT NULL) AS "status_present"',
+        );
+        expect(result.query).toContain(`FROM ${EXTERNAL_TABLE} AS "orders"`);
+    });
+
+    test('recompiles SQL custom dimension filters against materialized columns', async () => {
+        const { resolver } = getResolver();
+
+        const result = await resolver.resolve({
+            ...baseResolveArgs,
+            metricQuery: {
+                ...metricQuery,
+                dimensions: [],
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'custom-filter',
+                                target: { fieldId: 'status_present' },
+                                operator: FilterOperator.EQUALS,
+                                values: [true],
+                            },
+                        ],
+                    },
+                },
+                customDimensions: [
+                    {
+                        id: 'status_present',
+                        type: CustomDimensionType.SQL,
+                        name: 'Status present',
+                        table: 'orders',
+                        sql: '${orders.status} IS NOT NULL',
+                        dimensionType: DimensionType.BOOLEAN,
+                    },
+                ],
+            },
+        });
+
+        expect(result.resolved).toBe(true);
+        if (!result.resolved) throw new Error('unreachable');
+        expect(result.query).toContain('WHERE');
+        expect(result.query).toContain('(orders.orders_status) IS NOT NULL');
     });
 
     test('returns unresolved when pre-aggregates are disabled', async () => {

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -1,4 +1,5 @@
 import { parseAllReferences } from '../../compiler/exploreCompiler';
+import { getReferencedDimension } from '../../compiler/referenceLookup';
 import type { Explore } from '../../types/explore';
 import {
     convertFieldRefToFieldId,
@@ -6,6 +7,8 @@ import {
     isCustomSqlDimension,
     isSqlTableCalculation,
     MetricType,
+    type CustomDimension,
+    type CustomSqlDimension,
     type FieldId,
 } from '../../types/field';
 import {
@@ -153,6 +156,19 @@ const extractDimensionFilterFieldIds = (
                 typeof target.fieldId === 'string',
         )
         .map((target) => target.fieldId);
+};
+
+export const getActiveCustomDimensions = (
+    metricQuery: MetricQuery,
+): CustomDimension[] => {
+    const activeFieldIds = new Set([
+        ...metricQuery.dimensions,
+        ...extractDimensionFilterFieldIds(metricQuery),
+    ]);
+
+    return (metricQuery.customDimensions || []).filter((customDimension) =>
+        activeFieldIds.has(getItemId(customDimension)),
+    );
 };
 
 // Field ids referenced by the base model's sql_filter. ${TABLE}.col raw
@@ -952,7 +968,7 @@ const isExactDimensionSetMatch = ({
 };
 
 const getGranularityMissForDef = (
-    metricQuery: MetricQuery,
+    dimensionFieldIds: readonly FieldId[],
     explore: Explore,
     preAggregateDef: PreAggregateDef,
     dimensionsByFieldId: Map<
@@ -971,7 +987,7 @@ const getGranularityMissForDef = (
         return null;
     }
 
-    for (const dimensionFieldId of metricQuery.dimensions) {
+    for (const dimensionFieldId of dimensionFieldIds) {
         const dimension = dimensionsByFieldId.get(dimensionFieldId);
         const queryGranularity = dimension
             ? getEffectiveDimensionTimeFrame(dimension)
@@ -1017,6 +1033,66 @@ const getGranularityMissForDef = (
     return null;
 };
 
+const getSqlCustomDimensionMissForDef = ({
+    customDimension,
+    explore,
+    preAggregateDef,
+    defDimensions,
+    dimensionsByFieldId,
+}: {
+    customDimension: CustomSqlDimension;
+    explore: Explore;
+    preAggregateDef: PreAggregateDef;
+    defDimensions: Set<string>;
+    dimensionsByFieldId: Map<
+        FieldId,
+        Explore['tables'][string]['dimensions'][string]
+    >;
+}): PreAggregateMatchMiss | null => {
+    for (const { refTable, refName } of parseAllReferences(
+        customDimension.sql,
+        customDimension.table,
+    )) {
+        if (refName === 'TABLE') {
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+
+        const dimension = getReferencedDimension(
+            refTable,
+            refName,
+            explore.tables,
+        );
+        const fieldId = dimension ? getItemId(dimension) : null;
+        if (
+            !fieldId ||
+            !dimensionFieldIdMatchesDef(
+                fieldId,
+                explore,
+                defDimensions,
+                dimensionsByFieldId,
+            )
+        ) {
+            return {
+                reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
+                fieldId: getItemId(customDimension),
+            };
+        }
+
+        const granularityMiss = getGranularityMissForDef(
+            [fieldId],
+            explore,
+            preAggregateDef,
+            dimensionsByFieldId,
+        );
+        if (granularityMiss) {
+            return granularityMiss;
+        }
+    }
+
+    return null;
+};
+
 const getMissForDef = ({
     metricQuery,
     explore,
@@ -1047,8 +1123,10 @@ const getMissForDef = ({
     ) {
         defDimensions.add(preAggregateDef.timeDimension);
     }
-    const customDimensionIds = new Set(
-        (metricQuery.customDimensions || []).map(getItemId),
+    const activeCustomDimensions = getActiveCustomDimensions(metricQuery);
+    const customDimensionIds = new Set(activeCustomDimensions.map(getItemId));
+    const sqlCustomDimensionIds = new Set(
+        activeCustomDimensions.filter(isCustomSqlDimension).map(getItemId),
     );
 
     let exactDimensionSetMatch: boolean | null = null;
@@ -1117,34 +1195,32 @@ const getMissForDef = ({
         }
     }
 
-    const missingCustomDimension = (metricQuery.customDimensions || []).find(
-        (customDimension) => {
-            if (isCustomSqlDimension(customDimension)) {
-                return true;
+    for (const customDimension of activeCustomDimensions) {
+        if (isCustomSqlDimension(customDimension)) {
+            const miss = getSqlCustomDimensionMissForDef({
+                customDimension,
+                explore,
+                preAggregateDef,
+                defDimensions,
+                dimensionsByFieldId,
+            });
+            if (miss) {
+                return miss;
             }
-
-            return (
-                isCustomBinDimension(customDimension) &&
-                !dimensionFieldIdMatchesDef(
-                    customDimension.dimensionId,
-                    explore,
-                    defDimensions,
-                    dimensionsByFieldId,
-                )
-            );
-        },
-    );
-    if (missingCustomDimension) {
-        if (isCustomSqlDimension(missingCustomDimension)) {
+        } else if (
+            isCustomBinDimension(customDimension) &&
+            !dimensionFieldIdMatchesDef(
+                customDimension.dimensionId,
+                explore,
+                defDimensions,
+                dimensionsByFieldId,
+            )
+        ) {
             return {
-                reason: PreAggregateMissReason.CUSTOM_DIMENSION_PRESENT,
+                reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
+                fieldId: getItemId(customDimension),
             };
         }
-
-        return {
-            reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
-            fieldId: getItemId(missingCustomDimension),
-        };
     }
 
     const missingQueryDimensionFieldId = metricQuery.dimensions.find(
@@ -1170,6 +1246,7 @@ const getMissForDef = ({
     ];
     const missingFilterDimensionFieldId = filterDimensionFieldIds.find(
         (dimensionFieldId) =>
+            !sqlCustomDimensionIds.has(dimensionFieldId) &&
             !filterDimensionFieldIdMatchesDef(
                 dimensionFieldId,
                 explore,
@@ -1239,7 +1316,7 @@ const getMissForDef = ({
     }
 
     const granularityMiss = getGranularityMissForDef(
-        metricQuery,
+        metricQuery.dimensions,
         explore,
         preAggregateDef,
         dimensionsByFieldId,

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -1049,15 +1049,17 @@ const getSqlCustomDimensionMissForDef = ({
         Explore['tables'][string]['dimensions'][string]
     >;
 }): PreAggregateMatchMiss | null => {
-    for (const { refTable, refName } of parseAllReferences(
-        customDimension.sql,
-        customDimension.table,
-    )) {
-        if (refName === 'TABLE') {
-            // eslint-disable-next-line no-continue
-            continue;
-        }
+    const refs = parseAllReferences(customDimension.sql, customDimension.table);
+    // Opaque SQL (no ${refs}) and ${TABLE}.col reference raw columns that don't
+    // exist in the materialized table, so coverage can't be verified
+    if (refs.length === 0 || refs.some(({ refName }) => refName === 'TABLE')) {
+        return {
+            reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
+            fieldId: getItemId(customDimension),
+        };
+    }
 
+    for (const { refTable, refName } of refs) {
         const dimension = getReferencedDimension(
             refTable,
             refName,

--- a/packages/common/src/ee/preAggregates/utils.ts
+++ b/packages/common/src/ee/preAggregates/utils.ts
@@ -14,7 +14,11 @@ export {
     PreAggregateNumberMetricDependencyIneligibilityReason,
     type PreAggregateNumberMetricDependencies,
 } from './numberMetricDependencies';
-export { applyUserBypass, findMatch } from './matcher';
+export {
+    applyUserBypass,
+    findMatch,
+    getActiveCustomDimensions,
+} from './matcher';
 export {
     getMetricRepresentation,
     isSupportedMetricType,


### PR DESCRIPTION
## Summary

- match SQL custom dimensions when every semantic dependency is covered
- miss when references can't be verified: opaque SQL (no `${}` refs) and `${TABLE}.col` can't be recompiled onto materialized columns and would binder-error at execution
- ignore unused definitions during pre-aggregate compilation
- preserve granularity and exact-match safety rules
- add focused managed/external compilation coverage and a Jaffle example

## Verification

- local Jaffle chart routed through the DuckDB pre-aggregate and matched all 26 warehouse rows
- verified end-to-end that opaque/`${TABLE}` custom dims previously hit and failed in DuckDB (binder error + warehouse fallback); they now miss at match time
- 91 matcher + focused backend tests passed
- 3,659 common tests passed

Closes: https://linear.app/lightdash/issue/ZAP-931/pre-aggregates-miss-for-sql-custom-dimensions-derived-from-covered
Closes: #27889