### PR TITLE
fix(dbt): compile each dbt source against its own warehouse location

### DIFF
--- a/packages/backend/src/database/entities/projectDbtSources.ts
+++ b/packages/backend/src/database/entities/projectDbtSources.ts
@@ -11,6 +11,8 @@ export type DbProjectDbtSource = {
     precedence: number;
     dbt_connection_type: DbtProjectType | null;
     dbt_connection: Buffer | null;
+    warehouse_database: string | null;
+    warehouse_schema: string | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -23,6 +25,8 @@ type CreateDbProjectDbtSource = Pick<
     | 'precedence'
     | 'dbt_connection_type'
     | 'dbt_connection'
+    | 'warehouse_database'
+    | 'warehouse_schema'
 >;
 
 type UpdateDbProjectDbtSource = Partial<
@@ -32,6 +36,8 @@ type UpdateDbProjectDbtSource = Partial<
         | 'precedence'
         | 'dbt_connection_type'
         | 'dbt_connection'
+        | 'warehouse_database'
+        | 'warehouse_schema'
         | 'updated_at'
     >
 >;

--- a/packages/backend/src/database/migrations/20260824120000_add_dbt_source_warehouse_location.ts
+++ b/packages/backend/src/database/migrations/20260824120000_add_dbt_source_warehouse_location.ts
@@ -5,9 +5,7 @@ const tableName = 'project_dbt_sources';
 export async function up(knex: Knex): Promise<void> {
     await knex.raw("SET LOCAL lock_timeout = '5s'");
     await knex.schema.alterTable(tableName, (tableBuilder) => {
-        // Where this source's models live in the project's warehouse. Null on
-        // both columns means the source inherits the project's location, which
-        // is the behaviour every existing row had.
+        // Null on both columns means the source inherits the project's location.
         tableBuilder.text('warehouse_database').nullable();
         tableBuilder.text('warehouse_schema').nullable();
     });

--- a/packages/backend/src/database/migrations/20260824120000_add_dbt_source_warehouse_location.ts
+++ b/packages/backend/src/database/migrations/20260824120000_add_dbt_source_warehouse_location.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+
+const tableName = 'project_dbt_sources';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(tableName, (tableBuilder) => {
+        // Where this source's models live in the project's warehouse. Null on
+        // both columns means the source inherits the project's location, which
+        // is the behaviour every existing row had.
+        tableBuilder.text('warehouse_database').nullable();
+        tableBuilder.text('warehouse_schema').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(tableName, (tableBuilder) => {
+        tableBuilder.dropColumn('warehouse_database');
+        tableBuilder.dropColumn('warehouse_schema');
+    });
+}

--- a/packages/backend/src/dbt/profiles.test.ts
+++ b/packages/backend/src/dbt/profiles.test.ts
@@ -1,0 +1,103 @@
+import {
+    applyWarehouseLocation,
+    BigqueryAuthenticationType,
+    WarehouseTypes,
+    type CreateWarehouseCredentials,
+    type WarehouseLocation,
+} from '@lightdash/common';
+import * as yaml from 'js-yaml';
+import {
+    LIGHTDASH_PROFILE_NAME,
+    LIGHTDASH_TARGET_NAME,
+    profileFromCredentials,
+} from './profiles';
+
+const sourceLocation: WarehouseLocation = {
+    database: 'source-database',
+    schema: 'source_schema',
+};
+
+const targetFor = (credentials: CreateWarehouseCredentials) => {
+    const { profile } = profileFromCredentials(
+        applyWarehouseLocation(credentials, sourceLocation),
+        '/tmp/profiles',
+    );
+    const parsed = yaml.load(profile) as Record<
+        string,
+        { outputs: Record<string, Record<string, unknown>> }
+    >;
+    return parsed[LIGHTDASH_PROFILE_NAME].outputs[LIGHTDASH_TARGET_NAME];
+};
+
+describe('a dbt source compiles against its own warehouse location', () => {
+    it('writes the location into a BigQuery profile', () => {
+        expect(
+            targetFor({
+                type: WarehouseTypes.BIGQUERY,
+                project: 'primary-gcp-project',
+                dataset: 'prod',
+                authenticationType: BigqueryAuthenticationType.PRIVATE_KEY,
+                keyfileContents: { project_id: 'primary-gcp-project' },
+                timeoutSeconds: undefined,
+                priority: undefined,
+                retries: undefined,
+                location: undefined,
+                maximumBytesBilled: undefined,
+            }),
+        ).toMatchObject({
+            project: 'source-database',
+            dataset: 'source_schema',
+        });
+    });
+
+    it('writes the location into a Snowflake profile', () => {
+        expect(
+            targetFor({
+                type: WarehouseTypes.SNOWFLAKE,
+                account: 'account',
+                user: 'user',
+                password: 'password',
+                role: 'role',
+                database: 'primary_database',
+                warehouse: 'warehouse',
+                schema: 'primary_schema',
+            }),
+        ).toMatchObject({
+            database: 'source-database',
+            schema: 'source_schema',
+        });
+    });
+
+    it('writes the location into a Databricks profile, where the schema is stored as `database`', () => {
+        expect(
+            targetFor({
+                type: WarehouseTypes.DATABRICKS,
+                catalog: 'primary_catalog',
+                database: 'primary_schema',
+                serverHostName: 'host',
+                httpPath: 'path',
+                personalAccessToken: 'token',
+            }),
+        ).toMatchObject({
+            catalog: 'source-database',
+            schema: 'source_schema',
+        });
+    });
+
+    it('writes the location into a Postgres profile', () => {
+        expect(
+            targetFor({
+                type: WarehouseTypes.POSTGRES,
+                host: 'host',
+                user: 'user',
+                password: 'password',
+                port: 5432,
+                dbname: 'primary_database',
+                schema: 'primary_schema',
+            }),
+        ).toMatchObject({
+            dbname: 'source-database',
+            schema: 'source_schema',
+        });
+    });
+});

--- a/packages/backend/src/models/ProjectDbtSourcesModel.ts
+++ b/packages/backend/src/models/ProjectDbtSourcesModel.ts
@@ -92,6 +92,10 @@ export class ProjectDbtSourcesModel {
             isPrimary: row.is_primary,
             precedence: row.precedence,
             dbtConnection,
+            warehouseLocation: {
+                database: row.warehouse_database,
+                schema: row.warehouse_schema,
+            },
             hasCredentialError,
             createdAt: row.created_at,
             updatedAt: row.updated_at,
@@ -146,6 +150,8 @@ export class ProjectDbtSourcesModel {
                     precedence: data.precedence,
                     dbt_connection_type: data.dbtConnection?.type ?? null,
                     dbt_connection: this.encryptConnection(data.dbtConnection),
+                    warehouse_database: data.warehouseLocation.database,
+                    warehouse_schema: data.warehouseLocation.schema,
                 })
                 .returning('*');
             return this.convertRow(row);
@@ -182,6 +188,13 @@ export class ProjectDbtSourcesModel {
                               dbt_connection: this.encryptConnection(
                                   data.dbtConnection,
                               ),
+                          }
+                        : {}),
+                    ...(data.warehouseLocation !== undefined
+                        ? {
+                              warehouse_database:
+                                  data.warehouseLocation.database,
+                              warehouse_schema: data.warehouseLocation.schema,
                           }
                         : {}),
                     updated_at: new Date(),

--- a/packages/backend/src/services/ProjectDbtSourcesService.test.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.test.ts
@@ -1,11 +1,13 @@
 import { Ability } from '@casl/ability';
 import {
     DbtProjectType,
+    EMPTY_WAREHOUSE_LOCATION,
     ForbiddenError,
     ParameterError,
     PossibleAbilities,
     SessionUser,
     UnexpectedServerError,
+    WarehouseTypes,
 } from '@lightdash/common';
 import { fromSession } from '../auth/account/account';
 import { buildAccount, defaultSessionUser } from '../auth/account/account.mock';
@@ -113,6 +115,29 @@ describe('ProjectDbtSourcesService', () => {
                 precedence: 0,
                 type: DbtProjectType.GITHUB,
                 repository: 'acme/primary',
+            });
+        });
+
+        it("reports the primary source's location from the project warehouse", async () => {
+            projectModel.get.mockResolvedValue({
+                projectUuid,
+                dbtConnection: primaryDbtConnection,
+                warehouseConnection: {
+                    type: WarehouseTypes.BIGQUERY,
+                    project: 'primary-gcp-project',
+                    dataset: 'prod',
+                },
+            } as never);
+            const service = getService();
+
+            const sources = await service.getProjectDbtSources(
+                adminAccount,
+                projectUuid,
+            );
+
+            expect(sources[0].warehouseLocation).toEqual({
+                database: 'primary-gcp-project',
+                schema: 'prod',
             });
         });
 
@@ -227,6 +252,89 @@ describe('ProjectDbtSourcesService', () => {
             expect(created.precedence).toBe(4);
         });
 
+        it("saves the source's own warehouse location", async () => {
+            projectDbtSourcesModel.createSource.mockResolvedValue({
+                projectDbtSourceUuid: sourceUuid,
+                name: 'jaffle-2',
+                isPrimary: false,
+                precedence: 1,
+                dbtConnection: githubConnection,
+                warehouseLocation: {
+                    database: 'source-gcp-project',
+                    schema: 'source_dataset',
+                },
+            } as never);
+            const service = getService();
+
+            await service.createProjectDbtSource(adminAccount, projectUuid, {
+                name: 'jaffle-2',
+                dbtConnection: githubConnection as never,
+                warehouseLocation: {
+                    database: 'source-gcp-project',
+                    schema: 'source_dataset',
+                },
+            });
+
+            expect(projectDbtSourcesModel.createSource).toHaveBeenCalledWith(
+                projectUuid,
+                expect.objectContaining({
+                    warehouseLocation: {
+                        database: 'source-gcp-project',
+                        schema: 'source_dataset',
+                    },
+                }),
+            );
+        });
+
+        it('inherits the project location when the source sets none', async () => {
+            projectDbtSourcesModel.createSource.mockResolvedValue({
+                projectDbtSourceUuid: sourceUuid,
+                name: 'jaffle-2',
+                isPrimary: false,
+                precedence: 1,
+                dbtConnection: githubConnection,
+                warehouseLocation: EMPTY_WAREHOUSE_LOCATION,
+            } as never);
+            const service = getService();
+
+            await service.createProjectDbtSource(adminAccount, projectUuid, {
+                name: 'jaffle-2',
+                dbtConnection: githubConnection as never,
+            });
+
+            expect(projectDbtSourcesModel.createSource).toHaveBeenCalledWith(
+                projectUuid,
+                expect.objectContaining({
+                    warehouseLocation: EMPTY_WAREHOUSE_LOCATION,
+                }),
+            );
+        });
+
+        it('rejects a database on a warehouse whose tables have none', async () => {
+            projectModel.get.mockResolvedValue({
+                projectUuid,
+                dbtConnection: primaryDbtConnection,
+                warehouseConnection: {
+                    type: WarehouseTypes.CLICKHOUSE,
+                    schema: 'primary_schema',
+                },
+            } as never);
+            const service = getService();
+
+            await expect(
+                service.createProjectDbtSource(adminAccount, projectUuid, {
+                    name: 'jaffle-2',
+                    dbtConnection: githubConnection as never,
+                    warehouseLocation: {
+                        database: 'source-database',
+                        schema: null,
+                    },
+                }),
+            ).rejects.toThrow(ParameterError);
+
+            expect(projectDbtSourcesModel.createSource).not.toHaveBeenCalled();
+        });
+
         it('rejects a developer (no manage permission) with ForbiddenError', async () => {
             const service = getService();
 
@@ -290,6 +398,49 @@ describe('ProjectDbtSourcesService', () => {
             ).rejects.toThrow(ParameterError);
 
             expect(projectDbtSourcesModel.updateSource).not.toHaveBeenCalled();
+        });
+
+        it("updates the source's warehouse location", async () => {
+            projectDbtSourcesModel.getSource.mockResolvedValue({
+                projectDbtSourceUuid: sourceUuid,
+                projectUuid,
+                dbtConnection: githubConnection,
+                warehouseLocation: EMPTY_WAREHOUSE_LOCATION,
+            } as never);
+            projectDbtSourcesModel.updateSource.mockResolvedValue({
+                projectDbtSourceUuid: sourceUuid,
+                name: 'jaffle-2',
+                isPrimary: false,
+                precedence: 1,
+                dbtConnection: githubConnection,
+                warehouseLocation: {
+                    database: null,
+                    schema: 'source_dataset',
+                },
+            } as never);
+            const service = getService();
+
+            await service.updateProjectDbtSource(
+                adminAccount,
+                projectUuid,
+                sourceUuid,
+                {
+                    warehouseLocation: {
+                        database: null,
+                        schema: 'source_dataset',
+                    },
+                },
+            );
+
+            expect(projectDbtSourcesModel.updateSource).toHaveBeenCalledWith(
+                sourceUuid,
+                expect.objectContaining({
+                    warehouseLocation: {
+                        database: null,
+                        schema: 'source_dataset',
+                    },
+                }),
+            );
         });
 
         it('rejects a source uuid that belongs to a different project', async () => {

--- a/packages/backend/src/services/ProjectDbtSourcesService.test.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.test.ts
@@ -310,6 +310,31 @@ describe('ProjectDbtSourcesService', () => {
             );
         });
 
+        it('stores a blank location as inherit rather than as an override', async () => {
+            projectDbtSourcesModel.createSource.mockResolvedValue({
+                projectDbtSourceUuid: sourceUuid,
+                name: 'jaffle-2',
+                isPrimary: false,
+                precedence: 1,
+                dbtConnection: githubConnection,
+                warehouseLocation: EMPTY_WAREHOUSE_LOCATION,
+            } as never);
+            const service = getService();
+
+            await service.createProjectDbtSource(adminAccount, projectUuid, {
+                name: 'jaffle-2',
+                dbtConnection: githubConnection as never,
+                warehouseLocation: { database: '', schema: '  ' },
+            });
+
+            expect(projectDbtSourcesModel.createSource).toHaveBeenCalledWith(
+                projectUuid,
+                expect.objectContaining({
+                    warehouseLocation: EMPTY_WAREHOUSE_LOCATION,
+                }),
+            );
+        });
+
         it('rejects a database on a warehouse whose tables have none', async () => {
             projectModel.get.mockResolvedValue({
                 projectUuid,

--- a/packages/backend/src/services/ProjectDbtSourcesService.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.ts
@@ -4,15 +4,19 @@ import {
     ApiUpdateProjectDbtSource,
     DbtProjectConfig,
     DbtProjectType,
+    EMPTY_WAREHOUSE_LOCATION,
     ForbiddenError,
     getDbtEnvironmentVariableKeyError,
+    getWarehouseLocation,
     ParameterError,
     ProjectDbtSource,
     ProjectDbtSourceSummary,
     ProjectDbtSourceWithConnection,
     sensitiveDbtCredentialsFieldNames,
     UnexpectedServerError,
+    validateWarehouseLocation,
     type Account,
+    type WarehouseLocation,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../config/parseConfig';
@@ -103,6 +107,7 @@ export class ProjectDbtSourcesService extends BaseService {
             isPrimary: source.isPrimary,
             precedence: source.precedence,
             type: source.dbtConnection?.type ?? null,
+            warehouseLocation: source.warehouseLocation,
             hasCredentialError: source.hasCredentialError,
             ...ProjectDbtSourcesService.gitIdentity(source.dbtConnection),
         };
@@ -121,6 +126,27 @@ export class ProjectDbtSourcesService extends BaseService {
                 throw new ParameterError(error);
             }
         });
+    }
+
+    /**
+     * Reject a location the project's warehouse cannot express (e.g. a database
+     * on a warehouse whose tables are only schema-qualified) while the user is
+     * still looking at the form, rather than at the next deploy.
+     */
+    private async validateWarehouseLocationForProject(
+        projectUuid: string,
+        warehouseLocation: WarehouseLocation | undefined,
+    ): Promise<void> {
+        if (!warehouseLocation) {
+            return;
+        }
+        const project = await this.projectModel.get(projectUuid);
+        if (project.warehouseConnection) {
+            validateWarehouseLocation(
+                project.warehouseConnection.type,
+                warehouseLocation,
+            );
+        }
     }
 
     private async checkProjectAccess(
@@ -162,6 +188,11 @@ export class ProjectDbtSourcesService extends BaseService {
             isPrimary: true,
             precedence: 0,
             type: project.dbtConnection.type,
+            // The primary source always compiles against the project's own
+            // warehouse connection, so its location is that connection's.
+            warehouseLocation: project.warehouseConnection
+                ? getWarehouseLocation(project.warehouseConnection)
+                : EMPTY_WAREHOUSE_LOCATION,
             hasCredentialError: false,
             ...ProjectDbtSourcesService.gitIdentity(project.dbtConnection),
         };
@@ -188,6 +219,10 @@ export class ProjectDbtSourcesService extends BaseService {
         ProjectDbtSourcesService.validateDbtEnvironmentVariables(
             data.dbtConnection,
         );
+        await this.validateWarehouseLocationForProject(
+            projectUuid,
+            data.warehouseLocation,
+        );
         const existing =
             await this.projectDbtSourcesModel.getSources(projectUuid);
         // Append after the highest existing precedence (primary is 0).
@@ -203,6 +238,8 @@ export class ProjectDbtSourcesService extends BaseService {
                 isPrimary: false,
                 precedence,
                 dbtConnection: data.dbtConnection,
+                warehouseLocation:
+                    data.warehouseLocation ?? EMPTY_WAREHOUSE_LOCATION,
             },
         );
         this.analytics.track({
@@ -287,6 +324,10 @@ export class ProjectDbtSourcesService extends BaseService {
                 data.dbtConnection,
             );
         }
+        await this.validateWarehouseLocationForProject(
+            projectUuid,
+            data.warehouseLocation,
+        );
         // The edit form receives the connection with secrets stripped; restore
         // any the user did not re-enter from the stored connection.
         const dbtConnection =
@@ -301,6 +342,7 @@ export class ProjectDbtSourcesService extends BaseService {
             {
                 name: data.name,
                 dbtConnection,
+                warehouseLocation: data.warehouseLocation,
             },
         );
         return ProjectDbtSourcesService.toSummary(updated);

--- a/packages/backend/src/services/ProjectDbtSourcesService.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.ts
@@ -8,6 +8,7 @@ import {
     ForbiddenError,
     getDbtEnvironmentVariableKeyError,
     getWarehouseLocation,
+    normalizeWarehouseLocation,
     ParameterError,
     ProjectDbtSource,
     ProjectDbtSourceSummary,
@@ -129,24 +130,22 @@ export class ProjectDbtSourcesService extends BaseService {
     }
 
     /**
-     * Reject a location the project's warehouse cannot express (e.g. a database
-     * on a warehouse whose tables are only schema-qualified) while the user is
+     * Reject a location the project's warehouse cannot express while the user is
      * still looking at the form, rather than at the next deploy.
      */
-    private async validateWarehouseLocationForProject(
+    private async resolveWarehouseLocation(
         projectUuid: string,
         warehouseLocation: WarehouseLocation | undefined,
-    ): Promise<void> {
+    ): Promise<WarehouseLocation | undefined> {
         if (!warehouseLocation) {
-            return;
+            return undefined;
         }
+        const location = normalizeWarehouseLocation(warehouseLocation);
         const project = await this.projectModel.get(projectUuid);
         if (project.warehouseConnection) {
-            validateWarehouseLocation(
-                project.warehouseConnection.type,
-                warehouseLocation,
-            );
+            validateWarehouseLocation(project.warehouseConnection, location);
         }
+        return location;
     }
 
     private async checkProjectAccess(
@@ -188,8 +187,6 @@ export class ProjectDbtSourcesService extends BaseService {
             isPrimary: true,
             precedence: 0,
             type: project.dbtConnection.type,
-            // The primary source always compiles against the project's own
-            // warehouse connection, so its location is that connection's.
             warehouseLocation: project.warehouseConnection
                 ? getWarehouseLocation(project.warehouseConnection)
                 : EMPTY_WAREHOUSE_LOCATION,
@@ -219,7 +216,7 @@ export class ProjectDbtSourcesService extends BaseService {
         ProjectDbtSourcesService.validateDbtEnvironmentVariables(
             data.dbtConnection,
         );
-        await this.validateWarehouseLocationForProject(
+        const warehouseLocation = await this.resolveWarehouseLocation(
             projectUuid,
             data.warehouseLocation,
         );
@@ -239,7 +236,7 @@ export class ProjectDbtSourcesService extends BaseService {
                 precedence,
                 dbtConnection: data.dbtConnection,
                 warehouseLocation:
-                    data.warehouseLocation ?? EMPTY_WAREHOUSE_LOCATION,
+                    warehouseLocation ?? EMPTY_WAREHOUSE_LOCATION,
             },
         );
         this.analytics.track({
@@ -324,7 +321,7 @@ export class ProjectDbtSourcesService extends BaseService {
                 data.dbtConnection,
             );
         }
-        await this.validateWarehouseLocationForProject(
+        const warehouseLocation = await this.resolveWarehouseLocation(
             projectUuid,
             data.warehouseLocation,
         );
@@ -342,7 +339,7 @@ export class ProjectDbtSourcesService extends BaseService {
             {
                 name: data.name,
                 dbtConnection,
-                warehouseLocation: data.warehouseLocation,
+                warehouseLocation,
             },
         );
         return ProjectDbtSourcesService.toSummary(updated);

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -10,6 +10,7 @@ import {
     DimensionType,
     DownloadFileType,
     DuckdbConnectionType,
+    EMPTY_WAREHOUSE_LOCATION,
     FeatureFlags,
     FilterOperator,
     ForbiddenError,
@@ -42,7 +43,9 @@ import {
     type RegisteredAccount,
     type UpdateProject,
     type UserWarehouseCredentialsWithSecrets,
+    type WarehouseLocation,
 } from '@lightdash/common';
+import { warehouseClientFromCredentials } from '@lightdash/warehouses';
 import { Readable } from 'stream';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { S3CacheClient } from '../../clients/Aws/S3CacheClient';
@@ -4674,13 +4677,17 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
             })),
         }) as unknown as ProjectAdapter;
 
-    const buildSource = (name: string): ProjectDbtSource => ({
+    const buildSource = (
+        name: string,
+        warehouseLocation: WarehouseLocation = EMPTY_WAREHOUSE_LOCATION,
+    ): ProjectDbtSource => ({
         projectDbtSourceUuid: `${name}-uuid`,
         projectUuid: 'project-uuid',
         name,
         isPrimary: false,
         precedence: 1,
         dbtConnection: { type: DbtProjectType.NONE },
+        warehouseLocation,
         hasCredentialError: false,
         createdAt: new Date('2026-08-16T00:00:00.000Z'),
         updatedAt: new Date('2026-08-16T00:00:00.000Z'),
@@ -4958,6 +4965,75 @@ describe('ProjectService.resolveCompileAdapter (MultiDbtSources regression firew
         await expect(
             buildMergedAdapter(primaryManifest, sourceManifest),
         ).resolves.toBeDefined();
+    });
+
+    it('compiles a source with its own warehouse location', async () => {
+        const projectService = getMockedProjectService(
+            lightdashConfigMock,
+        ) as unknown as ProjectServiceInternals;
+        const buildSourceAdapter = vi
+            .spyOn(projectService, 'buildSourceAdapter')
+            .mockResolvedValue(
+                buildAdapterWithManifest(
+                    buildManifest([
+                        {
+                            uniqueId: 'model.pkg_b.customers',
+                            name: 'customers',
+                            packageName: 'pkg_b',
+                        },
+                    ]),
+                ),
+            );
+        const warehouseLocation: WarehouseLocation = {
+            database: 'source-database',
+            schema: 'source_schema',
+        };
+
+        await projectService.buildMergedManifestAdapter({
+            projectUuid: 'project-uuid',
+            organizationUuid: 'org-uuid',
+            primary: {
+                ...primary,
+                adapter: buildAdapterWithManifest(
+                    buildManifest([
+                        {
+                            uniqueId: 'model.pkg_a.orders',
+                            name: 'orders',
+                            packageName: 'pkg_a',
+                        },
+                    ]),
+                ),
+            },
+            sources: [buildSource('source-b', warehouseLocation)],
+            manifestFetchAdapters: [],
+        });
+
+        expect(buildSourceAdapter).toHaveBeenCalledWith(
+            { type: DbtProjectType.NONE },
+            warehouseLocation,
+            'org-uuid',
+            expect.objectContaining({
+                warehouseCredentials: primary.warehouseCredentials,
+            }),
+        );
+    });
+
+    it("builds the source's adapter with the source's location applied to the project credentials", async () => {
+        const projectService = getMockedProjectService(
+            lightdashConfigMock,
+        ) as unknown as ProjectServiceInternals;
+        vi.mocked(warehouseClientFromCredentials).mockClear();
+
+        await projectService.buildSourceAdapter(
+            { type: DbtProjectType.NONE },
+            { database: null, schema: 'source_schema' },
+            'org-uuid',
+            primary,
+        );
+
+        expect(warehouseClientFromCredentials).toHaveBeenCalledWith(
+            expect.objectContaining({ schema: 'source_schema' }),
+        );
     });
 
     it('flag OFF returns the primary adapter by identity and never queries getSources', async () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -16,6 +16,7 @@ import {
     ApiQueryResults,
     ApiSqlQueryResults,
     ApiUpstreamDiffResults,
+    applyWarehouseLocation,
     assertEmbeddedAuth,
     assertIsAccountWithOrg,
     assertUnreachable,
@@ -244,6 +245,7 @@ import {
     type ParametersValuesMap,
     type RunQueryTags,
     type Tag,
+    type WarehouseLocation,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
 import {
@@ -4486,8 +4488,17 @@ export class ProjectService extends BaseService {
      * resolved warehouse setup (so we don't re-resolve and re-rotate credentials per
      * source). Used only to read the source's manifest, not to compile.
      */
+    /**
+     * An adapter that compiles one additional dbt source. It shares the
+     * project's warehouse connection, but compiles against the source's own
+     * database and schema when it has them — a source's models can live
+     * somewhere else in the same warehouse (its own dbt profile targets that
+     * location), and compiling with the project's location would resolve every
+     * one of its models to a table that holds different data or none.
+     */
     private async buildSourceAdapter(
         dbtConnection: DbtProjectConfig,
+        warehouseLocation: WarehouseLocation,
         organizationUuid: string | undefined,
         shared: {
             warehouseCredentials: CreateWarehouseCredentials;
@@ -4502,7 +4513,10 @@ export class ProjectService extends BaseService {
             );
         return projectAdapterFromConfig(
             resolvedConnection,
-            shared.warehouseCredentials,
+            applyWarehouseLocation(
+                shared.warehouseCredentials,
+                warehouseLocation,
+            ),
             shared.cachedWarehouse,
             shared.dbtVersionOption,
             this.lightdashConfig.dbt.environmentVariableAllowlist,
@@ -4643,6 +4657,7 @@ export class ProjectService extends BaseService {
                 try {
                     sourceAdapter = await this.buildSourceAdapter(
                         source.dbtConnection,
+                        source.warehouseLocation,
                         organizationUuid,
                         shared,
                     );

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4486,15 +4486,10 @@ export class ProjectService extends BaseService {
     /**
      * Build an adapter for an additional dbt source, reusing the project's already
      * resolved warehouse setup (so we don't re-resolve and re-rotate credentials per
-     * source). Used only to read the source's manifest, not to compile.
-     */
-    /**
-     * An adapter that compiles one additional dbt source. It shares the
-     * project's warehouse connection, but compiles against the source's own
-     * database and schema when it has them — a source's models can live
-     * somewhere else in the same warehouse (its own dbt profile targets that
-     * location), and compiling with the project's location would resolve every
-     * one of its models to a table that holds different data or none.
+     * source). Used only to read the source's manifest, not to compile. The source
+     * compiles against its own database and schema when it has them: its models can
+     * live elsewhere in the same warehouse, and the project's location would resolve
+     * every one of them to a table holding different data or none.
      */
     private async buildSourceAdapter(
         dbtConnection: DbtProjectConfig,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -304,6 +304,7 @@ export type {
     UpdateQueryTimezoneSettings,
     UpdateSchedulerSettings,
     WarehouseCredentials,
+    WarehouseLocation,
 } from './types/projects';
 export * from './types/promotion';
 export * from './types/queryHistory';
@@ -397,6 +398,7 @@ export * from './utils/resolveQueryTimezone';
 export * from './utils/externalSourceExplore';
 export * from './utils/virtualView';
 export * from './utils/warehouse';
+export * from './utils/warehouseLocation';
 export * from './utils/warehouseResourceLimits';
 export * from './visualizations/BigNumberDataModel';
 export * from './visualizations/CartesianChartDataModel';

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -1011,6 +1011,17 @@ export type DbtProjectConfig =
     | DbtManifestProjectConfig;
 
 /**
+ * Where in the warehouse a set of models lives — the two levels of a table
+ * reference, whatever a given warehouse calls them (BigQuery project and
+ * dataset, Snowflake database and schema, Databricks catalog and schema). A
+ * null field means "inherit from the project's warehouse connection".
+ */
+export type WarehouseLocation = {
+    database: string | null;
+    schema: string | null;
+};
+
+/**
  * One dbt source connected to a project (PROD-7484 multiple dbt sources). The
  * project's own `dbt_connection` is the primary source (precedence 0); when a
  * project has no source rows it runs the single-source path unchanged (N=0
@@ -1033,6 +1044,7 @@ export type ProjectDbtSource = {
     isPrimary: boolean;
     precedence: number;
     dbtConnection: DbtProjectConfig | null;
+    warehouseLocation: WarehouseLocation;
     hasCredentialError: boolean;
     createdAt: Date;
     updatedAt: Date;
@@ -1043,12 +1055,14 @@ export type CreateProjectDbtSource = {
     isPrimary: boolean;
     precedence: number;
     dbtConnection: DbtProjectConfig | null;
+    warehouseLocation: WarehouseLocation;
 };
 
 export type UpdateProjectDbtSource = {
     name?: string;
     precedence?: number;
     dbtConnection?: DbtProjectConfig | null;
+    warehouseLocation?: WarehouseLocation;
 };
 
 /**
@@ -1060,6 +1074,10 @@ export type UpdateProjectDbtSource = {
  *
  * `hasCredentialError` is always `false` for the synthesised primary source.
  * See `ProjectDbtSource` for what it means on an additional source.
+ *
+ * `warehouseLocation` is where this source's models live in the project's
+ * warehouse. For the primary source it is the location the project's warehouse
+ * connection already points at.
  */
 export type ProjectDbtSourceSummary = {
     projectDbtSourceUuid: string;
@@ -1070,12 +1088,14 @@ export type ProjectDbtSourceSummary = {
     repository: string | null;
     branch: string | null;
     projectSubPath: string | null;
+    warehouseLocation: WarehouseLocation;
     hasCredentialError: boolean;
 };
 
 export type ApiCreateProjectDbtSource = {
     name: string;
     dbtConnection: DbtProjectConfig;
+    warehouseLocation?: WarehouseLocation;
 };
 
 export type ApiProjectDbtSourcesResponse = {
@@ -1105,6 +1125,7 @@ export type ApiProjectDbtSourceWithConnectionResponse = {
 export type ApiUpdateProjectDbtSource = {
     name?: string;
     dbtConnection?: DbtProjectConfig;
+    warehouseLocation?: WarehouseLocation;
 };
 
 export const isGitProjectType = (

--- a/packages/common/src/utils/warehouseLocation.test.ts
+++ b/packages/common/src/utils/warehouseLocation.test.ts
@@ -8,6 +8,7 @@ import {
     applyWarehouseLocation,
     EMPTY_WAREHOUSE_LOCATION,
     getWarehouseLocation,
+    normalizeWarehouseLocation,
     validateWarehouseLocation,
 } from './warehouseLocation';
 
@@ -171,7 +172,7 @@ describe('getWarehouseLocation', () => {
 describe('validateWarehouseLocation', () => {
     it('accepts a database the warehouse has', () => {
         expect(() =>
-            validateWarehouseLocation(WarehouseTypes.BIGQUERY, {
+            validateWarehouseLocation(bigqueryCredentials, {
                 database: 'source-gcp-project',
                 schema: null,
             }),
@@ -180,10 +181,49 @@ describe('validateWarehouseLocation', () => {
 
     it('rejects a database the warehouse does not have', () => {
         expect(() =>
-            validateWarehouseLocation(WarehouseTypes.CLICKHOUSE, {
+            validateWarehouseLocation(clickhouseCredentials, {
                 database: 'source_database',
                 schema: null,
             }),
         ).toThrowError(/not qualified by a database/);
+    });
+
+    it('rejects any location on embedded DuckDB, which cannot compile dbt at all', () => {
+        expect(() =>
+            validateWarehouseLocation(
+                {
+                    type: WarehouseTypes.DUCKDB,
+                    connectionType: DuckdbConnectionType.EMBEDDED,
+                    dataset: 'primary_dataset',
+                },
+                { database: null, schema: 'source_schema' },
+            ),
+        ).toThrowError(/Embedded DuckDB/);
+    });
+
+    it('accepts a location on MotherDuck, which can', () => {
+        expect(() =>
+            validateWarehouseLocation(motherduckCredentials, {
+                database: null,
+                schema: 'source_schema',
+            }),
+        ).not.toThrow();
+    });
+});
+
+describe('normalizeWarehouseLocation', () => {
+    it('reads a blank field as inherit, so it never becomes an override', () => {
+        expect(
+            normalizeWarehouseLocation({ database: '', schema: '   ' }),
+        ).toEqual(EMPTY_WAREHOUSE_LOCATION);
+    });
+
+    it('trims a field the caller padded', () => {
+        expect(
+            normalizeWarehouseLocation({
+                database: ' source-gcp-project ',
+                schema: null,
+            }),
+        ).toEqual({ database: 'source-gcp-project', schema: null });
     });
 });

--- a/packages/common/src/utils/warehouseLocation.test.ts
+++ b/packages/common/src/utils/warehouseLocation.test.ts
@@ -1,0 +1,189 @@
+import {
+    BigqueryAuthenticationType,
+    DuckdbConnectionType,
+    WarehouseTypes,
+    type CreateWarehouseCredentials,
+} from '../types/projects';
+import {
+    applyWarehouseLocation,
+    EMPTY_WAREHOUSE_LOCATION,
+    getWarehouseLocation,
+    validateWarehouseLocation,
+} from './warehouseLocation';
+
+const bigqueryCredentials: CreateWarehouseCredentials = {
+    type: WarehouseTypes.BIGQUERY,
+    project: 'primary-gcp-project',
+    dataset: 'prod',
+    authenticationType: BigqueryAuthenticationType.PRIVATE_KEY,
+    keyfileContents: {},
+    timeoutSeconds: undefined,
+    priority: undefined,
+    retries: undefined,
+    location: undefined,
+    maximumBytesBilled: undefined,
+};
+
+const snowflakeCredentials: CreateWarehouseCredentials = {
+    type: WarehouseTypes.SNOWFLAKE,
+    account: 'account',
+    user: 'user',
+    password: 'password',
+    role: 'role',
+    database: 'primary_database',
+    warehouse: 'warehouse',
+    schema: 'primary_schema',
+};
+
+const databricksCredentials: CreateWarehouseCredentials = {
+    type: WarehouseTypes.DATABRICKS,
+    catalog: 'primary_catalog',
+    database: 'primary_schema',
+    serverHostName: 'host',
+    httpPath: 'path',
+    personalAccessToken: 'token',
+};
+
+const clickhouseCredentials: CreateWarehouseCredentials = {
+    type: WarehouseTypes.CLICKHOUSE,
+    host: 'host',
+    user: 'user',
+    password: 'password',
+    port: 8443,
+    schema: 'primary_schema',
+};
+
+const motherduckCredentials: CreateWarehouseCredentials = {
+    type: WarehouseTypes.DUCKDB,
+    connectionType: DuckdbConnectionType.MOTHERDUCK,
+    database: 'primary_database',
+    schema: 'primary_schema',
+    token: 'token',
+};
+
+describe('applyWarehouseLocation', () => {
+    it('returns the credentials untouched when the location is empty', () => {
+        expect(
+            applyWarehouseLocation(
+                bigqueryCredentials,
+                EMPTY_WAREHOUSE_LOCATION,
+            ),
+        ).toBe(bigqueryCredentials);
+    });
+
+    it('overrides the BigQuery project and dataset', () => {
+        expect(
+            applyWarehouseLocation(bigqueryCredentials, {
+                database: 'source-gcp-project',
+                schema: 'source_dataset',
+            }),
+        ).toMatchObject({
+            project: 'source-gcp-project',
+            dataset: 'source_dataset',
+        });
+    });
+
+    it('keeps the fields the location leaves null', () => {
+        expect(
+            applyWarehouseLocation(bigqueryCredentials, {
+                database: null,
+                schema: 'source_dataset',
+            }),
+        ).toMatchObject({
+            project: 'primary-gcp-project',
+            dataset: 'source_dataset',
+        });
+    });
+
+    it('leaves the rest of the connection alone', () => {
+        expect(
+            applyWarehouseLocation(snowflakeCredentials, {
+                database: 'source_database',
+                schema: 'source_schema',
+            }),
+        ).toEqual({
+            ...snowflakeCredentials,
+            database: 'source_database',
+            schema: 'source_schema',
+        });
+    });
+
+    it('maps a Databricks location onto its catalog and schema', () => {
+        expect(
+            applyWarehouseLocation(databricksCredentials, {
+                database: 'source_catalog',
+                schema: 'source_schema',
+            }),
+        ).toMatchObject({
+            catalog: 'source_catalog',
+            database: 'source_schema',
+        });
+    });
+
+    it('overrides the MotherDuck database and schema', () => {
+        expect(
+            applyWarehouseLocation(motherduckCredentials, {
+                database: 'source_database',
+                schema: 'source_schema',
+            }),
+        ).toMatchObject({
+            database: 'source_database',
+            schema: 'source_schema',
+        });
+    });
+
+    it('rejects a database on a warehouse that has none', () => {
+        expect(() =>
+            applyWarehouseLocation(clickhouseCredentials, {
+                database: 'source_database',
+                schema: null,
+            }),
+        ).toThrowError(/not qualified by a database/);
+    });
+
+    it('still overrides the schema on a warehouse without a database', () => {
+        expect(
+            applyWarehouseLocation(clickhouseCredentials, {
+                database: null,
+                schema: 'source_schema',
+            }),
+        ).toMatchObject({ schema: 'source_schema' });
+    });
+});
+
+describe('getWarehouseLocation', () => {
+    it('reads the location a connection already points at', () => {
+        expect(getWarehouseLocation(bigqueryCredentials)).toEqual({
+            database: 'primary-gcp-project',
+            schema: 'prod',
+        });
+        expect(getWarehouseLocation(databricksCredentials)).toEqual({
+            database: 'primary_catalog',
+            schema: 'primary_schema',
+        });
+        expect(getWarehouseLocation(clickhouseCredentials)).toEqual({
+            database: null,
+            schema: 'primary_schema',
+        });
+    });
+});
+
+describe('validateWarehouseLocation', () => {
+    it('accepts a database the warehouse has', () => {
+        expect(() =>
+            validateWarehouseLocation(WarehouseTypes.BIGQUERY, {
+                database: 'source-gcp-project',
+                schema: null,
+            }),
+        ).not.toThrow();
+    });
+
+    it('rejects a database the warehouse does not have', () => {
+        expect(() =>
+            validateWarehouseLocation(WarehouseTypes.CLICKHOUSE, {
+                database: 'source_database',
+                schema: null,
+            }),
+        ).toThrowError(/not qualified by a database/);
+    });
+});

--- a/packages/common/src/utils/warehouseLocation.ts
+++ b/packages/common/src/utils/warehouseLocation.ts
@@ -1,0 +1,218 @@
+import { ParameterError } from '../types/errors';
+import {
+    DuckdbConnectionType,
+    WarehouseTypes,
+    type CreateWarehouseCredentials,
+    type WarehouseCredentials,
+    type WarehouseLocation,
+} from '../types/projects';
+import assertUnreachable from './assertUnreachable';
+
+export const EMPTY_WAREHOUSE_LOCATION: WarehouseLocation = {
+    database: null,
+    schema: null,
+};
+
+export const hasWarehouseLocation = (location: WarehouseLocation): boolean =>
+    location.database !== null || location.schema !== null;
+
+/**
+ * What each warehouse calls the two levels of a table reference, for labelling
+ * inputs and error messages. A null database means the warehouse has no level
+ * above the schema, so a database override is not accepted for it.
+ */
+export const getWarehouseLocationLabels = (
+    warehouseType: WarehouseTypes,
+): { database: string | null; schema: string } => {
+    switch (warehouseType) {
+        case WarehouseTypes.BIGQUERY:
+            return { database: 'GCP project', schema: 'Dataset' };
+        case WarehouseTypes.DATABRICKS:
+            return { database: 'Catalog', schema: 'Schema' };
+        case WarehouseTypes.CLICKHOUSE:
+            return { database: null, schema: 'Schema' };
+        case WarehouseTypes.POSTGRES:
+        case WarehouseTypes.REDSHIFT:
+        case WarehouseTypes.TRINO:
+        case WarehouseTypes.SNOWFLAKE:
+        case WarehouseTypes.ATHENA:
+        case WarehouseTypes.DUCKDB:
+            return { database: 'Database', schema: 'Schema' };
+        default:
+            return assertUnreachable(
+                warehouseType,
+                `Unknown warehouse type ${warehouseType}`,
+            );
+    }
+};
+
+/**
+ * The location a warehouse connection already points at — what a dbt source
+ * inherits when it sets no location of its own.
+ */
+export const getWarehouseLocation = (
+    credentials: CreateWarehouseCredentials | WarehouseCredentials,
+): WarehouseLocation => {
+    switch (credentials.type) {
+        case WarehouseTypes.BIGQUERY:
+            return {
+                database: credentials.project,
+                schema: credentials.dataset,
+            };
+        case WarehouseTypes.POSTGRES:
+        case WarehouseTypes.REDSHIFT:
+        case WarehouseTypes.TRINO:
+            return {
+                database: credentials.dbname,
+                schema: credentials.schema,
+            };
+        case WarehouseTypes.SNOWFLAKE:
+        case WarehouseTypes.ATHENA:
+            return {
+                database: credentials.database,
+                schema: credentials.schema,
+            };
+        case WarehouseTypes.DATABRICKS:
+            return {
+                database: credentials.catalog ?? null,
+                // this supposed to be a `schema` but changing it will break for existing customers
+                schema: credentials.database,
+            };
+        case WarehouseTypes.CLICKHOUSE:
+            return { database: null, schema: credentials.schema };
+        case WarehouseTypes.DUCKDB:
+            switch (credentials.connectionType) {
+                case DuckdbConnectionType.MOTHERDUCK:
+                    return {
+                        database: credentials.database,
+                        schema: credentials.schema,
+                    };
+                case DuckdbConnectionType.DUCKLAKE:
+                    return {
+                        database: credentials.catalogAlias ?? null,
+                        schema: credentials.schema,
+                    };
+                case DuckdbConnectionType.EMBEDDED:
+                    return {
+                        database: null,
+                        schema: credentials.schema ?? null,
+                    };
+                default:
+                    return assertUnreachable(
+                        credentials,
+                        `Unknown DuckDB connection type`,
+                    );
+            }
+        default:
+            const { type } = credentials;
+            return assertUnreachable(
+                credentials,
+                `Unknown warehouse type ${type}`,
+            );
+    }
+};
+
+const unsupportedDatabaseOverride = (warehouseType: WarehouseTypes): Error =>
+    new ParameterError(
+        `${warehouseType} tables are not qualified by a database, so a dbt source cannot override one`,
+    );
+
+/**
+ * Copy the project's warehouse credentials with the source's own database and
+ * schema, so the dbt profile Lightdash generates for this source compiles its
+ * models against the location they really live in. Only the location changes —
+ * the connection itself, and the client that runs queries, stay the project's.
+ */
+export const applyWarehouseLocation = (
+    credentials: CreateWarehouseCredentials,
+    location: WarehouseLocation,
+): CreateWarehouseCredentials => {
+    const { database, schema } = location;
+    if (!hasWarehouseLocation(location)) {
+        return credentials;
+    }
+    switch (credentials.type) {
+        case WarehouseTypes.BIGQUERY:
+            return {
+                ...credentials,
+                project: database ?? credentials.project,
+                dataset: schema ?? credentials.dataset,
+            };
+        case WarehouseTypes.POSTGRES:
+        case WarehouseTypes.REDSHIFT:
+        case WarehouseTypes.TRINO:
+            return {
+                ...credentials,
+                dbname: database ?? credentials.dbname,
+                schema: schema ?? credentials.schema,
+            };
+        case WarehouseTypes.SNOWFLAKE:
+        case WarehouseTypes.ATHENA:
+            return {
+                ...credentials,
+                database: database ?? credentials.database,
+                schema: schema ?? credentials.schema,
+            };
+        case WarehouseTypes.DATABRICKS:
+            return {
+                ...credentials,
+                catalog: database ?? credentials.catalog,
+                // this supposed to be a `schema` but changing it will break for existing customers
+                database: schema ?? credentials.database,
+            };
+        case WarehouseTypes.CLICKHOUSE:
+            if (database !== null) {
+                throw unsupportedDatabaseOverride(credentials.type);
+            }
+            return {
+                ...credentials,
+                schema: schema ?? credentials.schema,
+            };
+        case WarehouseTypes.DUCKDB:
+            switch (credentials.connectionType) {
+                case DuckdbConnectionType.MOTHERDUCK:
+                    return {
+                        ...credentials,
+                        database: database ?? credentials.database,
+                        schema: schema ?? credentials.schema,
+                    };
+                case DuckdbConnectionType.DUCKLAKE:
+                    return {
+                        ...credentials,
+                        catalogAlias: database ?? credentials.catalogAlias,
+                        schema: schema ?? credentials.schema,
+                    };
+                case DuckdbConnectionType.EMBEDDED:
+                    throw new ParameterError(
+                        'Embedded DuckDB credentials cannot be used for dbt compilation',
+                    );
+                default:
+                    return assertUnreachable(
+                        credentials,
+                        `Unknown DuckDB connection type`,
+                    );
+            }
+        default:
+            const { type } = credentials;
+            return assertUnreachable(
+                credentials,
+                `Unknown warehouse type ${type}`,
+            );
+    }
+};
+
+/**
+ * Reject a location a warehouse cannot express, at the point the user saves it,
+ * rather than when a deploy compiles with it hours later.
+ */
+export const validateWarehouseLocation = (
+    warehouseType: WarehouseTypes,
+    location: WarehouseLocation,
+): void => {
+    if (
+        location.database !== null &&
+        getWarehouseLocationLabels(warehouseType).database === null
+    ) {
+        throw unsupportedDatabaseOverride(warehouseType);
+    }
+};

--- a/packages/common/src/utils/warehouseLocation.ts
+++ b/packages/common/src/utils/warehouseLocation.ts
@@ -17,9 +17,20 @@ export const hasWarehouseLocation = (location: WarehouseLocation): boolean =>
     location.database !== null || location.schema !== null;
 
 /**
- * What each warehouse calls the two levels of a table reference, for labelling
- * inputs and error messages. A null database means the warehouse has no level
- * above the schema, so a database override is not accepted for it.
+ * A blank field means the source inherits the project's location. Callers reach
+ * this from an API body as well as the form, so normalise before storing: an
+ * empty string stored as an override compiles to `""."table"` and fails.
+ */
+export const normalizeWarehouseLocation = (
+    location: WarehouseLocation,
+): WarehouseLocation => ({
+    database: location.database?.trim() || null,
+    schema: location.schema?.trim() || null,
+});
+
+/**
+ * A null database means the warehouse has no level above the schema, so a
+ * database override is not accepted for it.
  */
 export const getWarehouseLocationLabels = (
     warehouseType: WarehouseTypes,
@@ -46,10 +57,7 @@ export const getWarehouseLocationLabels = (
     }
 };
 
-/**
- * The location a warehouse connection already points at — what a dbt source
- * inherits when it sets no location of its own.
- */
+/** The location a warehouse connection already points at. */
 export const getWarehouseLocation = (
     credentials: CreateWarehouseCredentials | WarehouseCredentials,
 ): WarehouseLocation => {
@@ -118,10 +126,9 @@ const unsupportedDatabaseOverride = (warehouseType: WarehouseTypes): Error =>
     );
 
 /**
- * Copy the project's warehouse credentials with the source's own database and
- * schema, so the dbt profile Lightdash generates for this source compiles its
- * models against the location they really live in. Only the location changes —
- * the connection itself, and the client that runs queries, stay the project's.
+ * The project's warehouse credentials with the source's own database and schema,
+ * for generating that source's dbt profile. Only the location changes: the
+ * connection, and the client that runs queries, stay the project's.
  */
 export const applyWarehouseLocation = (
     credentials: CreateWarehouseCredentials,
@@ -202,17 +209,30 @@ export const applyWarehouseLocation = (
 };
 
 /**
- * Reject a location a warehouse cannot express, at the point the user saves it,
- * rather than when a deploy compiles with it hours later.
+ * Reject a location a warehouse cannot express when the user saves it, not when
+ * a deploy compiles with it hours later. Takes the connection rather than the
+ * type because two DuckDB connections differ: embedded cannot compile dbt at
+ * all, MotherDuck can.
  */
 export const validateWarehouseLocation = (
-    warehouseType: WarehouseTypes,
+    credentials: CreateWarehouseCredentials | WarehouseCredentials,
     location: WarehouseLocation,
 ): void => {
+    if (!hasWarehouseLocation(location)) {
+        return;
+    }
+    if (
+        credentials.type === WarehouseTypes.DUCKDB &&
+        credentials.connectionType === DuckdbConnectionType.EMBEDDED
+    ) {
+        throw new ParameterError(
+            'Embedded DuckDB credentials cannot be used for dbt compilation, so a dbt source cannot set a location for them',
+        );
+    }
     if (
         location.database !== null &&
-        getWarehouseLocationLabels(warehouseType).database === null
+        getWarehouseLocationLabels(credentials.type).database === null
     ) {
-        throw unsupportedDatabaseOverride(warehouseType);
+        throw unsupportedDatabaseOverride(credentials.type);
     }
 };

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -172,12 +172,12 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
                                     label="Target name"
                                     description={
                                         <p>
-                                            <b>target</b> is the dataset/schema
-                                            in your data warehouse that
-                                            Lightdash will look for your dbt
-                                            models. By default, we set this to
-                                            be the same value as you have as the
-                                            default in your profiles.yml file.
+                                            The name Lightdash gives the dbt
+                                            target it compiles with. Set it to
+                                            match the target your dbt code
+                                            branches on. It does not change
+                                            which database or schema your models
+                                            are read from.
                                         </p>
                                     }
                                     disabled={disabled}

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -21,6 +21,7 @@ import { useFormContext } from './formContext';
 import FormSection from './Inputs/FormSection';
 import { MultiKeyValuePairsInput } from './Inputs/MultiKeyValuePairsInput';
 import { useProjectFormContext } from './useProjectFormContext';
+import WarehouseLocationInputs from './WarehouseLocationInputs';
 import WarehouseSchemaInput from './WarehouseSchemaInput';
 
 interface DbtSettingsFormProps {
@@ -33,7 +34,7 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
     defaultType,
 }) => {
     const form = useFormContext();
-    const { isDbtSource } = useProjectFormContext();
+    const { isDbtSource, projectUuid } = useProjectFormContext();
     const selectedWarehouse = form.values.warehouse?.type;
 
     const type: DbtProjectType =
@@ -183,11 +184,15 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
                                     disabled={disabled}
                                     placeholder="prod"
                                 />
-                                {/* The schema is a warehouse-credential field; an
-                                additional dbt source shares the project's
-                                warehouse, so it's inherited rather than set per
-                                source. Also hidden when org warehouse credentials
-                                provide it. */}
+                                {/* A source shares the project's warehouse but
+                                not necessarily the same location inside it, so
+                                it sets its own here. Hidden on the project form
+                                when org warehouse credentials provide it. */}
+                                {isDbtSource && projectUuid ? (
+                                    <WarehouseLocationInputs
+                                        projectUuid={projectUuid}
+                                    />
+                                ) : null}
                                 {isDbtSource ||
                                 form.values
                                     .organizationWarehouseCredentialsUuid ? null : (

--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
@@ -81,10 +81,7 @@ const sourceIdentity = (source: ProjectDbtSourceSummary): string => {
     return source.type ?? 'no connection';
 };
 
-/**
- * The location fields as the form holds them: an empty string means "inherit
- * the project's warehouse location", which the API expresses as null.
- */
+/** An empty string means inherit, which the API expresses as null. */
 type WarehouseLocationFormValues = {
     database: string;
     schema: string;
@@ -104,11 +101,6 @@ const toApiLocation = (
     schema: values.schema.trim() || null,
 });
 
-/**
- * Where this source's models live in the project's warehouse. A source shares
- * the project's warehouse connection, but its own dbt profile can target a
- * different database and schema — left blank, the project's are used.
- */
 const WarehouseLocationInputs: FC<{
     projectUuid: string;
     value: WarehouseLocationFormValues;

--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
@@ -2,8 +2,6 @@ import {
     DbtProjectType,
     DefaultSupportedDbtVersion,
     FeatureFlags,
-    getWarehouseLocation,
-    getWarehouseLocationLabels,
     WarehouseTypes,
     type CreateWarehouseCredentials,
     type DbtProjectConfig,
@@ -33,7 +31,6 @@ import {
     IconTrash,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
-import { useProject } from '../../hooks/useProject';
 import {
     useCreateProjectDbtSourceMutation,
     useDeleteProjectDbtSourceMutation,
@@ -100,49 +97,6 @@ const toApiLocation = (
     database: values?.database.trim() || null,
     schema: values?.schema.trim() || null,
 });
-
-const WarehouseLocationInputs: FC<{
-    form: Form;
-    projectUuid: string;
-}> = ({ form, projectUuid }) => {
-    const { data: project } = useProject(projectUuid);
-    const warehouseConnection = project?.warehouseConnection;
-    if (!warehouseConnection) {
-        return null;
-    }
-    const labels = getWarehouseLocationLabels(warehouseConnection.type);
-    const inherited = getWarehouseLocation(warehouseConnection);
-
-    return (
-        <Stack gap="xs">
-            <Text size="sm" fw={500}>
-                Where this source's models live
-            </Text>
-            <Text size="xs" c="dimmed">
-                Leave blank to use the project's warehouse connection. Set these
-                when this dbt project's own profile targets a different{' '}
-                {labels.database
-                    ? `${labels.database.toLowerCase()} or ${labels.schema.toLowerCase()}`
-                    : labels.schema.toLowerCase()}
-                .
-            </Text>
-            <Group grow align="flex-start">
-                {labels.database && (
-                    <TextInput
-                        label={labels.database}
-                        placeholder={inherited.database ?? undefined}
-                        {...form.getInputProps('warehouseLocation.database')}
-                    />
-                )}
-                <TextInput
-                    label={labels.schema}
-                    placeholder={inherited.schema ?? undefined}
-                    {...form.getInputProps('warehouseLocation.schema')}
-                />
-            </Group>
-        </Stack>
-    );
-};
 
 const DbtSourceRow: FC<{
     source: ProjectDbtSourceSummary;
@@ -214,7 +168,7 @@ const DbtSourceFields: FC<{
     projectUuid: string;
 }> = ({ form, intro, projectUuid }) => (
     <FormProvider form={form}>
-        <ProjectFormProvider isDbtSource>
+        <ProjectFormProvider isDbtSource projectUuid={projectUuid}>
             <Stack gap="md">
                 <Text size="sm" c="dimmed">
                     {intro}
@@ -226,10 +180,6 @@ const DbtSourceFields: FC<{
                     {...form.getInputProps('name')}
                 />
                 <DbtSettingsForm disabled={false} />
-                <WarehouseLocationInputs
-                    form={form}
-                    projectUuid={projectUuid}
-                />
             </Stack>
         </ProjectFormProvider>
     </FormProvider>

--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
@@ -95,17 +95,16 @@ const toFormLocation = (
 });
 
 const toApiLocation = (
-    values: WarehouseLocationFormValues,
+    values: WarehouseLocationFormValues | undefined,
 ): WarehouseLocation => ({
-    database: values.database.trim() || null,
-    schema: values.schema.trim() || null,
+    database: values?.database.trim() || null,
+    schema: values?.schema.trim() || null,
 });
 
 const WarehouseLocationInputs: FC<{
+    form: Form;
     projectUuid: string;
-    value: WarehouseLocationFormValues;
-    onChange: (value: WarehouseLocationFormValues) => void;
-}> = ({ projectUuid, value, onChange }) => {
+}> = ({ form, projectUuid }) => {
     const { data: project } = useProject(projectUuid);
     const warehouseConnection = project?.warehouseConnection;
     if (!warehouseConnection) {
@@ -132,25 +131,13 @@ const WarehouseLocationInputs: FC<{
                     <TextInput
                         label={labels.database}
                         placeholder={inherited.database ?? undefined}
-                        value={value.database}
-                        onChange={(event) =>
-                            onChange({
-                                ...value,
-                                database: event.currentTarget.value,
-                            })
-                        }
+                        {...form.getInputProps('warehouseLocation.database')}
                     />
                 )}
                 <TextInput
                     label={labels.schema}
                     placeholder={inherited.schema ?? undefined}
-                    value={value.schema}
-                    onChange={(event) =>
-                        onChange({
-                            ...value,
-                            schema: event.currentTarget.value,
-                        })
-                    }
+                    {...form.getInputProps('warehouseLocation.schema')}
                 />
             </Group>
         </Stack>
@@ -225,15 +212,7 @@ const DbtSourceFields: FC<{
     form: Form;
     intro: string;
     projectUuid: string;
-    warehouseLocation: WarehouseLocationFormValues;
-    onWarehouseLocationChange: (value: WarehouseLocationFormValues) => void;
-}> = ({
-    form,
-    intro,
-    projectUuid,
-    warehouseLocation,
-    onWarehouseLocationChange,
-}) => (
+}> = ({ form, intro, projectUuid }) => (
     <FormProvider form={form}>
         <ProjectFormProvider isDbtSource>
             <Stack gap="md">
@@ -248,9 +227,8 @@ const DbtSourceFields: FC<{
                 />
                 <DbtSettingsForm disabled={false} />
                 <WarehouseLocationInputs
+                    form={form}
                     projectUuid={projectUuid}
-                    value={warehouseLocation}
-                    onChange={onWarehouseLocationChange}
                 />
             </Stack>
         </ProjectFormProvider>
@@ -263,12 +241,11 @@ const AddDbtSourceModal: FC<{
     onClose: () => void;
 }> = ({ projectUuid, opened, onClose }) => {
     const createMutation = useCreateProjectDbtSourceMutation(projectUuid);
-    const [warehouseLocation, setWarehouseLocation] =
-        useState<WarehouseLocationFormValues>(() => toFormLocation(undefined));
     const form = useForm({
         initialValues: {
             name: '',
             dbt: { ...dbtDefaults.formValues[DbtProjectType.GITHUB] },
+            warehouseLocation: toFormLocation(undefined),
             // Sources share the project's warehouse; the schema input is hidden
             // for sources so this is only here to satisfy the form shape.
             warehouse: {
@@ -285,7 +262,6 @@ const AddDbtSourceModal: FC<{
 
     const handleClose = () => {
         form.reset();
-        setWarehouseLocation(toFormLocation(undefined));
         onClose();
     };
 
@@ -296,7 +272,7 @@ const AddDbtSourceModal: FC<{
             {
                 name: form.values.name.trim(),
                 dbtConnection: form.values.dbt,
-                warehouseLocation: toApiLocation(warehouseLocation),
+                warehouseLocation: toApiLocation(form.values.warehouseLocation),
             },
             { onSuccess: handleClose },
         );
@@ -316,8 +292,6 @@ const AddDbtSourceModal: FC<{
             <DbtSourceFields
                 form={form}
                 projectUuid={projectUuid}
-                warehouseLocation={warehouseLocation}
-                onWarehouseLocationChange={setWarehouseLocation}
                 intro="Connect another git-backed dbt project. Its models are merged with the primary source on every deploy and preview, using the project's warehouse and dbt version."
             />
         </MantineModal>
@@ -331,16 +305,13 @@ const EditDbtSourceModalInner: FC<{
     onClose: () => void;
 }> = ({ projectUuid, source, connection, onClose }) => {
     const updateMutation = useUpdateProjectDbtSourceMutation(projectUuid);
-    const [warehouseLocation, setWarehouseLocation] =
-        useState<WarehouseLocationFormValues>(() =>
-            toFormLocation(source.warehouseLocation),
-        );
     const form = useForm({
         initialValues: {
             name: source.name,
             dbt: connection ?? {
                 ...dbtDefaults.formValues[DbtProjectType.GITHUB],
             },
+            warehouseLocation: toFormLocation(source.warehouseLocation),
             warehouse: {
                 type: WarehouseTypes.POSTGRES,
             } as CreateWarehouseCredentials,
@@ -362,7 +333,9 @@ const EditDbtSourceModalInner: FC<{
                 data: {
                     name: form.values.name.trim(),
                     dbtConnection: form.values.dbt,
-                    warehouseLocation: toApiLocation(warehouseLocation),
+                    warehouseLocation: toApiLocation(
+                        form.values.warehouseLocation,
+                    ),
                 },
             },
             { onSuccess: onClose },
@@ -383,8 +356,6 @@ const EditDbtSourceModalInner: FC<{
             <DbtSourceFields
                 form={form}
                 projectUuid={projectUuid}
-                warehouseLocation={warehouseLocation}
-                onWarehouseLocationChange={setWarehouseLocation}
                 intro="Update this source's connection. Leave the access token blank to keep the saved one."
             />
         </MantineModal>

--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
@@ -2,10 +2,13 @@ import {
     DbtProjectType,
     DefaultSupportedDbtVersion,
     FeatureFlags,
+    getWarehouseLocation,
+    getWarehouseLocationLabels,
     WarehouseTypes,
     type CreateWarehouseCredentials,
     type DbtProjectConfig,
     type ProjectDbtSourceSummary,
+    type WarehouseLocation,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -30,6 +33,7 @@ import {
     IconTrash,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
+import { useProject } from '../../hooks/useProject';
 import {
     useCreateProjectDbtSourceMutation,
     useDeleteProjectDbtSourceMutation,
@@ -56,6 +60,12 @@ import { ProjectFormProvider } from './ProjectFormProvider';
  * warning icon instead, not this line).
  */
 const sourceIdentity = (source: ProjectDbtSourceSummary): string => {
+    const location = [
+        source.warehouseLocation.database,
+        source.warehouseLocation.schema,
+    ]
+        .filter(Boolean)
+        .join('.');
     if (source.repository) {
         return [
             source.repository,
@@ -63,11 +73,96 @@ const sourceIdentity = (source: ProjectDbtSourceSummary): string => {
             source.projectSubPath && source.projectSubPath !== '/'
                 ? source.projectSubPath
                 : null,
+            location || null,
         ]
             .filter(Boolean)
             .join(' · ');
     }
     return source.type ?? 'no connection';
+};
+
+/**
+ * The location fields as the form holds them: an empty string means "inherit
+ * the project's warehouse location", which the API expresses as null.
+ */
+type WarehouseLocationFormValues = {
+    database: string;
+    schema: string;
+};
+
+const toFormLocation = (
+    location: WarehouseLocation | undefined,
+): WarehouseLocationFormValues => ({
+    database: location?.database ?? '',
+    schema: location?.schema ?? '',
+});
+
+const toApiLocation = (
+    values: WarehouseLocationFormValues,
+): WarehouseLocation => ({
+    database: values.database.trim() || null,
+    schema: values.schema.trim() || null,
+});
+
+/**
+ * Where this source's models live in the project's warehouse. A source shares
+ * the project's warehouse connection, but its own dbt profile can target a
+ * different database and schema — left blank, the project's are used.
+ */
+const WarehouseLocationInputs: FC<{
+    projectUuid: string;
+    value: WarehouseLocationFormValues;
+    onChange: (value: WarehouseLocationFormValues) => void;
+}> = ({ projectUuid, value, onChange }) => {
+    const { data: project } = useProject(projectUuid);
+    const warehouseConnection = project?.warehouseConnection;
+    if (!warehouseConnection) {
+        return null;
+    }
+    const labels = getWarehouseLocationLabels(warehouseConnection.type);
+    const inherited = getWarehouseLocation(warehouseConnection);
+
+    return (
+        <Stack gap="xs">
+            <Text size="sm" fw={500}>
+                Where this source's models live
+            </Text>
+            <Text size="xs" c="dimmed">
+                Leave blank to use the project's warehouse connection. Set these
+                when this dbt project's own profile targets a different{' '}
+                {labels.database
+                    ? `${labels.database.toLowerCase()} or ${labels.schema.toLowerCase()}`
+                    : labels.schema.toLowerCase()}
+                .
+            </Text>
+            <Group grow align="flex-start">
+                {labels.database && (
+                    <TextInput
+                        label={labels.database}
+                        placeholder={inherited.database ?? undefined}
+                        value={value.database}
+                        onChange={(event) =>
+                            onChange({
+                                ...value,
+                                database: event.currentTarget.value,
+                            })
+                        }
+                    />
+                )}
+                <TextInput
+                    label={labels.schema}
+                    placeholder={inherited.schema ?? undefined}
+                    value={value.schema}
+                    onChange={(event) =>
+                        onChange({
+                            ...value,
+                            schema: event.currentTarget.value,
+                        })
+                    }
+                />
+            </Group>
+        </Stack>
+    );
 };
 
 const DbtSourceRow: FC<{
@@ -134,9 +229,18 @@ const DbtSourceRow: FC<{
  * The shared body for the add/edit modals: a name field plus the full dbt
  * connection form, wrapped in the providers `DbtSettingsForm` reads from.
  */
-const DbtSourceFields: FC<{ form: Form; intro: string }> = ({
+const DbtSourceFields: FC<{
+    form: Form;
+    intro: string;
+    projectUuid: string;
+    warehouseLocation: WarehouseLocationFormValues;
+    onWarehouseLocationChange: (value: WarehouseLocationFormValues) => void;
+}> = ({
     form,
     intro,
+    projectUuid,
+    warehouseLocation,
+    onWarehouseLocationChange,
 }) => (
     <FormProvider form={form}>
         <ProjectFormProvider isDbtSource>
@@ -151,6 +255,11 @@ const DbtSourceFields: FC<{ form: Form; intro: string }> = ({
                     {...form.getInputProps('name')}
                 />
                 <DbtSettingsForm disabled={false} />
+                <WarehouseLocationInputs
+                    projectUuid={projectUuid}
+                    value={warehouseLocation}
+                    onChange={onWarehouseLocationChange}
+                />
             </Stack>
         </ProjectFormProvider>
     </FormProvider>
@@ -162,6 +271,8 @@ const AddDbtSourceModal: FC<{
     onClose: () => void;
 }> = ({ projectUuid, opened, onClose }) => {
     const createMutation = useCreateProjectDbtSourceMutation(projectUuid);
+    const [warehouseLocation, setWarehouseLocation] =
+        useState<WarehouseLocationFormValues>(() => toFormLocation(undefined));
     const form = useForm({
         initialValues: {
             name: '',
@@ -182,6 +293,7 @@ const AddDbtSourceModal: FC<{
 
     const handleClose = () => {
         form.reset();
+        setWarehouseLocation(toFormLocation(undefined));
         onClose();
     };
 
@@ -192,6 +304,7 @@ const AddDbtSourceModal: FC<{
             {
                 name: form.values.name.trim(),
                 dbtConnection: form.values.dbt,
+                warehouseLocation: toApiLocation(warehouseLocation),
             },
             { onSuccess: handleClose },
         );
@@ -210,6 +323,9 @@ const AddDbtSourceModal: FC<{
         >
             <DbtSourceFields
                 form={form}
+                projectUuid={projectUuid}
+                warehouseLocation={warehouseLocation}
+                onWarehouseLocationChange={setWarehouseLocation}
                 intro="Connect another git-backed dbt project. Its models are merged with the primary source on every deploy and preview, using the project's warehouse and dbt version."
             />
         </MantineModal>
@@ -223,6 +339,10 @@ const EditDbtSourceModalInner: FC<{
     onClose: () => void;
 }> = ({ projectUuid, source, connection, onClose }) => {
     const updateMutation = useUpdateProjectDbtSourceMutation(projectUuid);
+    const [warehouseLocation, setWarehouseLocation] =
+        useState<WarehouseLocationFormValues>(() =>
+            toFormLocation(source.warehouseLocation),
+        );
     const form = useForm({
         initialValues: {
             name: source.name,
@@ -250,6 +370,7 @@ const EditDbtSourceModalInner: FC<{
                 data: {
                     name: form.values.name.trim(),
                     dbtConnection: form.values.dbt,
+                    warehouseLocation: toApiLocation(warehouseLocation),
                 },
             },
             { onSuccess: onClose },
@@ -269,6 +390,9 @@ const EditDbtSourceModalInner: FC<{
         >
             <DbtSourceFields
                 form={form}
+                projectUuid={projectUuid}
+                warehouseLocation={warehouseLocation}
+                onWarehouseLocationChange={setWarehouseLocation}
                 intro="Update this source's connection. Leave the access token blank to keep the saved one."
             />
         </MantineModal>

--- a/packages/frontend/src/components/ProjectConnection/ProjectFormProvider.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectFormProvider.tsx
@@ -3,9 +3,9 @@ import Context, { type ProjectFormContext } from './context';
 
 export const ProjectFormProvider: FC<
     React.PropsWithChildren<ProjectFormContext>
-> = ({ savedProject, isDbtSource, children }) => {
+> = ({ savedProject, isDbtSource, projectUuid, children }) => {
     return (
-        <Context.Provider value={{ savedProject, isDbtSource }}>
+        <Context.Provider value={{ savedProject, isDbtSource, projectUuid }}>
             {children}
         </Context.Provider>
     );

--- a/packages/frontend/src/components/ProjectConnection/WarehouseLocationInputs.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseLocationInputs.tsx
@@ -1,0 +1,53 @@
+import {
+    getWarehouseLocation,
+    getWarehouseLocationLabels,
+} from '@lightdash/common';
+import { Group, Stack, Text, TextInput } from '@mantine/core';
+import { type FC } from 'react';
+import { useProject } from '../../hooks/useProject';
+import { useFormContext } from './formContext';
+
+const WarehouseLocationInputs: FC<{ projectUuid: string }> = ({
+    projectUuid,
+}) => {
+    const form = useFormContext();
+    const { data: project } = useProject(projectUuid);
+    const warehouseConnection = project?.warehouseConnection;
+    if (!warehouseConnection) {
+        return null;
+    }
+    const labels = getWarehouseLocationLabels(warehouseConnection.type);
+    const inherited = getWarehouseLocation(warehouseConnection);
+
+    return (
+        <Stack gap="xs">
+            <Text size="sm" fw={500}>
+                Where this source's models live
+            </Text>
+            <Text size="xs" c="dimmed">
+                Leave blank to use the project's warehouse connection. Set these
+                when this dbt project's own profile targets a different{' '}
+                {labels.database
+                    ? `${labels.database.toLowerCase()} or ${labels.schema.toLowerCase()}`
+                    : labels.schema.toLowerCase()}
+                .
+            </Text>
+            <Group grow align="flex-start">
+                {labels.database && (
+                    <TextInput
+                        label={labels.database}
+                        placeholder={inherited.database ?? undefined}
+                        {...form.getInputProps('warehouseLocation.database')}
+                    />
+                )}
+                <TextInput
+                    label={labels.schema}
+                    placeholder={inherited.schema ?? undefined}
+                    {...form.getInputProps('warehouseLocation.schema')}
+                />
+            </Group>
+        </Stack>
+    );
+};
+
+export default WarehouseLocationInputs;

--- a/packages/frontend/src/components/ProjectConnection/context.ts
+++ b/packages/frontend/src/components/ProjectConnection/context.ts
@@ -7,6 +7,9 @@ export type ProjectFormContext = {
     // project's primary connection): restricts providers to git and hides
     // fields inherited from the project (dbt version, warehouse schema).
     isDbtSource?: boolean;
+    // Set with isDbtSource: the project the source is being added to, for the
+    // fields that read the project's own warehouse connection.
+    projectUuid?: string;
 };
 
 const Context = createContext<ProjectFormContext | undefined>(undefined);

--- a/packages/frontend/src/components/ProjectConnection/types.ts
+++ b/packages/frontend/src/components/ProjectConnection/types.ts
@@ -10,4 +10,7 @@ export type ProjectConnectionForm = {
     warehouse: CreateWarehouseCredentials;
     organizationWarehouseCredentialsUuid?: string;
     dbtVersion: DbtVersionOption;
+    // Additional dbt sources only: where this source's models live in the
+    // project's warehouse. A blank field means inherit.
+    warehouseLocation?: { database: string; schema: string };
 };

--- a/packages/frontend/src/hooks/useProjectDbtSources.ts
+++ b/packages/frontend/src/hooks/useProjectDbtSources.ts
@@ -111,10 +111,19 @@ export const useUpdateProjectDbtSourceMutation = (projectUuid: string) => {
             updateProjectDbtSource(projectUuid, projectDbtSourceUuid, data),
         {
             mutationKey: ['update_project_dbt_source', projectUuid],
-            onSuccess: async () => {
-                await queryClient.invalidateQueries([
-                    'project_dbt_sources',
-                    projectUuid,
+            onSuccess: async (_result, { projectDbtSourceUuid }) => {
+                await Promise.all([
+                    queryClient.invalidateQueries([
+                        'project_dbt_sources',
+                        projectUuid,
+                    ]),
+                    // The edit form reads the single-source query, so a stale
+                    // entry would refill it with the pre-edit values.
+                    queryClient.invalidateQueries([
+                        'project_dbt_source',
+                        projectUuid,
+                        projectDbtSourceUuid,
+                    ]),
                 ]);
                 showToastSuccess({ title: 'dbt source updated' });
             },


### PR DESCRIPTION
Fixes #27916
Linear: PROD-10499

## The problem

A project with more than one dbt source compiled every source with the project's own warehouse connection. An additional source therefore got the primary connection's database and schema, not the ones its own dbt profile targets. Its models then resolved to tables that hold different data, or none. On BigQuery the whole table reference was wrong, because the GCP project is part of it.

A CLI deploy with `--combine-manifest` does not have this problem, because each repo compiles in CI against its own `profiles.yml`.

The "Target name" field did not help. It only names the target in the profile Lightdash generates. It never selected a database or a schema.

## The change

A dbt source now stores its own database and schema. `buildSourceAdapter` applies them to the credentials it builds that source's dbt profile from, so the source compiles where its models really live.

- Both fields are optional. A source that sets neither inherits the project's location, which is what every existing source does today, so this is a no-op for them.
- The warehouse connection itself does not change, and neither does the client that runs queries. Only the location the source compiles against changes.
- `applyWarehouseLocation` maps the location onto each warehouse's own field names (BigQuery project and dataset, Databricks catalog and schema, and so on). A database on a warehouse whose tables have none is rejected when the user saves it.
- The "Target name" help text said the target selects the dataset or schema Lightdash reads models from. It never did. Corrected.

## Tests

- `warehouseLocation.test.ts` covers the per-warehouse mapping, both directions.
- `profiles.test.ts` proves the location reaches the generated dbt profile for BigQuery, Snowflake, Databricks and Postgres.
- `ProjectService.test.ts` proves the source's own location reaches the adapter that compiles it.
- `ProjectDbtSourcesService.test.ts` covers save, inherit and reject.

Each new test was checked against a mutated fix: reverting the override alone fails them.

## Verified against a running instance

Local Postgres warehouse. Project `Jaffle shop` reads `postgres.jaffle`. A second dbt project was added as an additional source; its one model, `regional_revenue`, lives in schema `source_b`. The table exists in **both** schemas with different rows, so a wrong location reads plausible-looking data instead of failing.

Before, with no location set on the source (today's behaviour):

```sql
FROM "postgres"."jaffle"."regional_revenue"
```
```
origin: "jaffle schema (WRONG - primary project location)"   revenue: 1
```

After setting the source's schema to `source_b` (`PATCH /dbt-sources/{uuid}`) and refreshing:

```sql
FROM "postgres"."source_b"."regional_revenue"
```
```
origin: "source_b schema (correct)"   revenue: 999
```

The 62 explores from the primary source stayed on `jaffle` across both refreshes. The migration applied cleanly on a real database, and `GET /dbt-sources` reports the primary source's inherited location (`postgres` / `jaffle`) alongside the additional source's own.

## The form

![The location fields in the add dbt source modal, under Target name, with the project's own location as placeholders](https://github.com/user-attachments/assets/7d344eda-cddc-4e77-89df-caa0739ec068)
