### PR TITLE
fix(ai): score chart context without result rows

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/llmAsAJudge.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsAJudge.test.ts
@@ -1,0 +1,44 @@
+import { generateObject } from 'ai';
+import { llmAsAJudge } from './llmAsAJudge';
+
+vi.mock('ai', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('ai')>()),
+    generateObject: vi.fn(),
+}));
+
+const mockedGenerateObject = vi.mocked(generateObject);
+
+describe('llmAsAJudge context relevancy', () => {
+    it('does not require chart context to contain computed result values', async () => {
+        mockedGenerateObject.mockResolvedValue({
+            object: {
+                score: 0.8,
+                reason: 'The chart configuration is relevant to the query.',
+            },
+            usage: undefined,
+        } as never);
+
+        await llmAsAJudge({
+            query: 'What was the average metric last week?',
+            response: 'The average metric was 42.5 units.',
+            context: [
+                'Artifact type: chart',
+                'Chart config: {"metric":"average_metric","period":"last_week"}',
+            ],
+            judge: {
+                provider: 'test-provider',
+                modelId: 'test-model',
+            } as never,
+            callOptions: {},
+            scorerType: 'contextRelevancy',
+        });
+
+        expect(mockedGenerateObject).toHaveBeenCalledWith(
+            expect.objectContaining({
+                prompt: expect.stringContaining(
+                    'When the context includes a chart artifact and configuration that identifies the requested metric and applicable dimensions, filters, and time range, missing computed result rows alone must not lower the relevancy score or require independently verifying the response',
+                ),
+            }),
+        );
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsAJudge.ts
@@ -314,7 +314,9 @@ ${context.map((c, i) => `${i + 1}. ${c}`).join('\n')}
 ************
 [END DATA]
 
-Evaluate how relevant the provided context is to answering the query. Consider:
+Evaluate how relevant the provided context is to answering the query. This is not a factuality assessment: do not use the response as supporting context or judge whether its claims are correct. When the context includes a chart artifact and configuration that identifies the requested metric and applicable dimensions, filters, and time range, missing computed result rows alone must not lower the relevancy score or require independently verifying the response.
+
+Consider:
 1. Does the context contain information needed to answer the query?
 2. Is the context directly related to the query topic?
 3. How much of the context is actually useful for answering the query?


### PR DESCRIPTION
## What changed

Corrects the Context Relevancy judge guidance for chart artifacts whose configuration matches the requested metric, dimensions, filters, and time range but does not include computed rows. The change keeps factual correctness separate and preserves the existing general relevancy criteria, with regression coverage for the chart-only aggregate scenario.

### Validation
- `pnpm -F 'backend' exec oxfmt 'src/ee/services/ai/utils/llmAsAJudge.test.ts' 'src/ee/services/ai/utils/llmAsAJudge.ts'` — passed
- `pnpm -F 'backend' run --if-present lint` — passed
- `pnpm -F 'backend' run --if-present typecheck` — passed
- `pnpm -F 'backend' run --if-present test` — passed

## Preview

[Open the public Lightdash preview](https://ld-runner-prod-10436-d488f3cbd373.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10436

