### PR TITLE
feat(auth): add direct access role resolver

### DIFF
--- a/packages/common/src/authorization/directAccessRole.test.ts
+++ b/packages/common/src/authorization/directAccessRole.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import { SpaceMemberRole } from '../types/space';
+import {
+    canDelegateDirectAccessRole,
+    resolveDirectAccessRole,
+    type DirectAccessRoleInput,
+} from './directAccessRole';
+
+const roles = [
+    SpaceMemberRole.VIEWER,
+    SpaceMemberRole.EDITOR,
+    SpaceMemberRole.ADMIN,
+] as const;
+
+const optionalRoles = [undefined, ...roles] as const;
+const ceilings = [null, ...roles] as const;
+
+const resolve = (
+    input: Partial<DirectAccessRoleInput>,
+): SpaceMemberRole | undefined =>
+    resolveDirectAccessRole({
+        logicalSpaceRole: undefined,
+        directUserRole: undefined,
+        directGroupRoles: [],
+        capabilityCeiling: SpaceMemberRole.ADMIN,
+        ...input,
+    });
+
+describe('resolveDirectAccessRole', () => {
+    it.each([
+        {
+            name: 'keeps logical access when there are no direct grants',
+            input: { logicalSpaceRole: SpaceMemberRole.EDITOR },
+            expected: SpaceMemberRole.EDITOR,
+        },
+        {
+            name: 'lets a direct user grant raise logical access',
+            input: {
+                logicalSpaceRole: SpaceMemberRole.VIEWER,
+                directUserRole: SpaceMemberRole.EDITOR,
+            },
+            expected: SpaceMemberRole.EDITOR,
+        },
+        {
+            name: 'lets a direct group grant raise logical and user access',
+            input: {
+                logicalSpaceRole: SpaceMemberRole.VIEWER,
+                directUserRole: SpaceMemberRole.EDITOR,
+                directGroupRoles: [SpaceMemberRole.ADMIN],
+            },
+            expected: SpaceMemberRole.ADMIN,
+        },
+        {
+            name: 'does not let lower direct grants reduce logical access',
+            input: {
+                logicalSpaceRole: SpaceMemberRole.ADMIN,
+                directUserRole: SpaceMemberRole.VIEWER,
+                directGroupRoles: [SpaceMemberRole.EDITOR],
+            },
+            expected: SpaceMemberRole.ADMIN,
+        },
+        {
+            name: 'applies the capability ceiling after additive resolution',
+            input: {
+                logicalSpaceRole: SpaceMemberRole.VIEWER,
+                directUserRole: SpaceMemberRole.ADMIN,
+                capabilityCeiling: SpaceMemberRole.EDITOR,
+            },
+            expected: SpaceMemberRole.EDITOR,
+        },
+        {
+            name: 'returns no access when the principal has no capability',
+            input: {
+                directUserRole: SpaceMemberRole.ADMIN,
+                capabilityCeiling: null,
+            },
+            expected: undefined,
+        },
+        {
+            name: 'ignores inactive or missing grant sources',
+            input: {
+                directUserRole: undefined,
+                directGroupRoles: [undefined, SpaceMemberRole.VIEWER],
+            },
+            expected: SpaceMemberRole.VIEWER,
+        },
+    ])('$name', ({ input, expected }) => {
+        expect(resolve(input)).toBe(expected);
+    });
+
+    it('is unchanged when direct roles are reordered or duplicated', () => {
+        expect(
+            resolve({
+                directGroupRoles: [
+                    SpaceMemberRole.VIEWER,
+                    SpaceMemberRole.ADMIN,
+                    SpaceMemberRole.EDITOR,
+                ],
+            }),
+        ).toBe(
+            resolve({
+                directGroupRoles: [
+                    SpaceMemberRole.ADMIN,
+                    SpaceMemberRole.VIEWER,
+                    SpaceMemberRole.ADMIN,
+                    SpaceMemberRole.EDITOR,
+                ],
+            }),
+        );
+    });
+
+    it('never lets a direct role reduce the result', () => {
+        for (const logicalSpaceRole of optionalRoles) {
+            for (const directUserRole of optionalRoles) {
+                for (const directGroupRole of optionalRoles) {
+                    for (const capabilityCeiling of ceilings) {
+                        const withoutDirectRole = resolve({
+                            logicalSpaceRole,
+                            capabilityCeiling,
+                        });
+                        const withDirectRole = resolve({
+                            logicalSpaceRole,
+                            directUserRole,
+                            directGroupRoles: [directGroupRole],
+                            capabilityCeiling,
+                        });
+
+                        if (
+                            withoutDirectRole !== undefined &&
+                            withDirectRole !== undefined
+                        ) {
+                            expect(
+                                roles.indexOf(withDirectRole),
+                            ).toBeGreaterThanOrEqual(
+                                roles.indexOf(withoutDirectRole),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    it('never resolves above the capability ceiling', () => {
+        for (const logicalSpaceRole of optionalRoles) {
+            for (const directUserRole of optionalRoles) {
+                for (const directGroupRole of optionalRoles) {
+                    for (const capabilityCeiling of roles) {
+                        const result = resolve({
+                            logicalSpaceRole,
+                            directUserRole,
+                            directGroupRoles: [directGroupRole],
+                            capabilityCeiling,
+                        });
+
+                        if (result !== undefined) {
+                            expect(roles.indexOf(result)).toBeLessThanOrEqual(
+                                roles.indexOf(capabilityCeiling),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    });
+});
+
+describe('canDelegateDirectAccessRole', () => {
+    it.each([
+        [undefined, SpaceMemberRole.VIEWER, false],
+        [SpaceMemberRole.VIEWER, SpaceMemberRole.VIEWER, false],
+        [SpaceMemberRole.VIEWER, SpaceMemberRole.EDITOR, false],
+        [SpaceMemberRole.VIEWER, SpaceMemberRole.ADMIN, false],
+        [SpaceMemberRole.EDITOR, SpaceMemberRole.VIEWER, true],
+        [SpaceMemberRole.EDITOR, SpaceMemberRole.EDITOR, true],
+        [SpaceMemberRole.EDITOR, SpaceMemberRole.ADMIN, false],
+        [SpaceMemberRole.ADMIN, SpaceMemberRole.VIEWER, true],
+        [SpaceMemberRole.ADMIN, SpaceMemberRole.EDITOR, true],
+        [SpaceMemberRole.ADMIN, SpaceMemberRole.ADMIN, true],
+    ])(
+        'actor %s granting %s returns %s',
+        (actorRole, requestedRole, expected) => {
+            expect(canDelegateDirectAccessRole(actorRole, requestedRole)).toBe(
+                expected,
+            );
+        },
+    );
+});

--- a/packages/common/src/authorization/directAccessRole.ts
+++ b/packages/common/src/authorization/directAccessRole.ts
@@ -1,0 +1,46 @@
+import { SpaceRoleOrder } from '../types/projectMemberRole';
+import { SpaceMemberRole } from '../types/space';
+import { getHighestSpaceRole } from '../utils/projectMemberRole';
+
+export type DirectAccessRoleInput = {
+    logicalSpaceRole: SpaceMemberRole | undefined;
+    directUserRole: SpaceMemberRole | undefined;
+    directGroupRoles: ReadonlyArray<SpaceMemberRole | undefined>;
+    capabilityCeiling: SpaceMemberRole | null;
+};
+
+const applyCapabilityCeiling = (
+    role: SpaceMemberRole | undefined,
+    capabilityCeiling: SpaceMemberRole | null,
+): SpaceMemberRole | undefined => {
+    if (role === undefined || capabilityCeiling === null) {
+        return undefined;
+    }
+
+    return SpaceRoleOrder[role] <= SpaceRoleOrder[capabilityCeiling]
+        ? role
+        : capabilityCeiling;
+};
+
+export const resolveDirectAccessRole = ({
+    logicalSpaceRole,
+    directUserRole,
+    directGroupRoles,
+    capabilityCeiling,
+}: DirectAccessRoleInput): SpaceMemberRole | undefined => {
+    const additiveRole = getHighestSpaceRole([
+        logicalSpaceRole,
+        directUserRole,
+        ...directGroupRoles,
+    ]);
+
+    return applyCapabilityCeiling(additiveRole, capabilityCeiling);
+};
+
+export const canDelegateDirectAccessRole = (
+    actorRole: SpaceMemberRole | undefined,
+    requestedRole: SpaceMemberRole,
+): boolean =>
+    actorRole !== undefined &&
+    actorRole !== SpaceMemberRole.VIEWER &&
+    SpaceRoleOrder[requestedRole] <= SpaceRoleOrder[actorRole];

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -46,6 +46,7 @@ dayjs.extend(utc);
 export { getPermissionsFromAbilityRules } from './authorization/abilityPermissions';
 export * from './authorization/buildAccountHelpers';
 export { collapseAbilityRules } from './authorization/collapseAbilityRules';
+export * from './authorization/directAccessRole';
 export {
     defineUserAbility,
     getUserAbilityBuilder,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1249

## Summary

PR 1 of 5 adds the pure role resolver for native Direct Access. It merges logical-space, direct-user, and direct-group roles additively, then applies the caller's capability ceiling.

Stacks on `main`.

Prior work: this adapts the additive, highest-role and no-downgrade invariants proposed by @hrx-joseph-fahnestock in [houserx/lightdash-hrx#25](https://github.com/houserx/lightdash-hrx/pull/25). Joseph is credited as a co-author on this commit.

## Changes

- Adds `resolveDirectAccessRole` with highest-role-wins semantics.
- Applies capability ceilings after the additive merge, so direct access cannot create capabilities the caller's role does not hold.
- Adds delegation rules: viewers cannot delegate, editors can delegate viewer/editor, and admins can delegate every space role.
- Keeps the resolver independent of persistence, services, HTTP routes, and feature flags.

## Resolver semantics

```
logical-space role ─┐
direct-user role  ──┼─> highest role ─> capability ceiling ─> effective role
direct-group roles ─┘
```

A missing or lower direct grant never reduces logical-space access. The ceiling can only lower the merged result.

## Test plan

- [x] 20 focused resolver tests
- [x] Exhaustive finite-domain coverage for additive merge, ceilings, and delegation
- [x] `pnpm -F common typecheck:fast`
- [x] Focused common lint and formatting checks