### PR TITLE
feat(auth): add direct access grant schema

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -11,6 +11,12 @@ import {
     AnalyticsDashboardViewsTableName,
 } from '../database/entities/analytics';
 import {
+    AppGroupAccessTable,
+    AppGroupAccessTableName,
+    AppUserAccessTable,
+    AppUserAccessTableName,
+} from '../database/entities/appAccess';
+import {
     AppsTable,
     AppsTableName,
     AppVersionsTable,
@@ -38,6 +44,12 @@ import {
     ContentVerificationTable,
     ContentVerificationTableName,
 } from '../database/entities/contentVerification';
+import {
+    DashboardGroupAccessTable,
+    DashboardGroupAccessTableName,
+    DashboardUserAccessTable,
+    DashboardUserAccessTableName,
+} from '../database/entities/dashboardAccess';
 import {
     DashboardsTableName,
     DashboardTable,
@@ -262,6 +274,12 @@ import {
     ScopedRoleTable,
 } from '../database/entities/roles';
 import {
+    SavedChartGroupAccessTable,
+    SavedChartGroupAccessTableName,
+    SavedChartUserAccessTable,
+    SavedChartUserAccessTableName,
+} from '../database/entities/savedChartAccess';
+import {
     SavedChartAdditionalMetricTable,
     SavedChartAdditionalMetricTableName,
     SavedChartCustomDimensionsTable,
@@ -289,6 +307,12 @@ import {
     SavedSqlVersionsTable,
     SavedSqlVersionsTableName,
 } from '../database/entities/savedSql';
+import {
+    SavedSqlGroupAccessTable,
+    SavedSqlGroupAccessTableName,
+    SavedSqlUserAccessTable,
+    SavedSqlUserAccessTableName,
+} from '../database/entities/savedSqlAccess';
 import {
     SchedulerEmailTargetTable,
     SchedulerEmailTargetTableName,
@@ -582,6 +606,8 @@ declare module 'knex/types/tables' {
         [ProjectTableName]: ProjectTable;
         [ProjectDbtSourcesTableName]: ProjectDbtSourcesTable;
         [SavedChartsTableName]: SavedChartTable;
+        [SavedChartUserAccessTableName]: SavedChartUserAccessTable;
+        [SavedChartGroupAccessTableName]: SavedChartGroupAccessTable;
         [SavedChartSlugMappingsTableName]: SavedChartSlugMappingTable;
         [SavedChartVersionsTableName]: SavedChartVersionsTable;
         [SavedChartVersionFieldsTableName]: SavedChartVersionFieldsTable;
@@ -589,9 +615,13 @@ declare module 'knex/types/tables' {
         [SavedChartTableCalculationTableName]: SavedChartTableCalculationTable;
         [SavedChartAdditionalMetricTableName]: SavedChartAdditionalMetricTable;
         [SavedSqlTableName]: SavedSqlTable;
+        [SavedSqlUserAccessTableName]: SavedSqlUserAccessTable;
+        [SavedSqlGroupAccessTableName]: SavedSqlGroupAccessTable;
         [SavedSqlVersionsTableName]: SavedSqlVersionsTable;
         [SpaceTableName]: SpaceTable;
         [DashboardsTableName]: DashboardTable;
+        [DashboardUserAccessTableName]: DashboardUserAccessTable;
+        [DashboardGroupAccessTableName]: DashboardGroupAccessTable;
         [DashboardVersionsTableName]: DashboardVersionTable;
         [DashboardViewsTableName]: DashboardViewTable;
         [DashboardTilesTableName]: DashboardTileTable;
@@ -746,6 +776,8 @@ declare module 'knex/types/tables' {
         [UserFavoritesTableName]: UserFavoritesTable;
         [ContentVerificationTableName]: ContentVerificationTable;
         [AppsTableName]: AppsTable;
+        [AppUserAccessTableName]: AppUserAccessTable;
+        [AppGroupAccessTableName]: AppGroupAccessTable;
         [AppVersionsTableName]: AppVersionsTable;
         [AiRouterTableName]: AiRouterTable;
         [AiRouterDecisionTableName]: AiRouterDecisionTable;

--- a/packages/backend/src/database/entities/appAccess.ts
+++ b/packages/backend/src/database/entities/appAccess.ts
@@ -1,0 +1,35 @@
+import { type SpaceMemberRole } from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const AppUserAccessTableName = 'app_user_access';
+export const AppGroupAccessTableName = 'app_group_access';
+
+export type DbAppUserAccess = {
+    app_uuid: string;
+    user_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AppUserAccessTable = Knex.CompositeTableType<
+    DbAppUserAccess,
+    Omit<DbAppUserAccess, 'created_at' | 'updated_at'>,
+    Pick<DbAppUserAccess, 'space_role' | 'granted_by_user_uuid' | 'updated_at'>
+>;
+
+export type DbAppGroupAccess = {
+    app_uuid: string;
+    group_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AppGroupAccessTable = Knex.CompositeTableType<
+    DbAppGroupAccess,
+    Omit<DbAppGroupAccess, 'created_at' | 'updated_at'>,
+    Pick<DbAppGroupAccess, 'space_role' | 'granted_by_user_uuid' | 'updated_at'>
+>;

--- a/packages/backend/src/database/entities/dashboardAccess.ts
+++ b/packages/backend/src/database/entities/dashboardAccess.ts
@@ -1,0 +1,41 @@
+import { type SpaceMemberRole } from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const DashboardUserAccessTableName = 'dashboard_user_access';
+export const DashboardGroupAccessTableName = 'dashboard_group_access';
+
+export type DbDashboardUserAccess = {
+    dashboard_uuid: string;
+    user_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type DashboardUserAccessTable = Knex.CompositeTableType<
+    DbDashboardUserAccess,
+    Omit<DbDashboardUserAccess, 'created_at' | 'updated_at'>,
+    Pick<
+        DbDashboardUserAccess,
+        'space_role' | 'granted_by_user_uuid' | 'updated_at'
+    >
+>;
+
+export type DbDashboardGroupAccess = {
+    dashboard_uuid: string;
+    group_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type DashboardGroupAccessTable = Knex.CompositeTableType<
+    DbDashboardGroupAccess,
+    Omit<DbDashboardGroupAccess, 'created_at' | 'updated_at'>,
+    Pick<
+        DbDashboardGroupAccess,
+        'space_role' | 'granted_by_user_uuid' | 'updated_at'
+    >
+>;

--- a/packages/backend/src/database/entities/savedChartAccess.ts
+++ b/packages/backend/src/database/entities/savedChartAccess.ts
@@ -1,0 +1,41 @@
+import { type SpaceMemberRole } from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const SavedChartUserAccessTableName = 'saved_chart_user_access';
+export const SavedChartGroupAccessTableName = 'saved_chart_group_access';
+
+export type DbSavedChartUserAccess = {
+    saved_chart_uuid: string;
+    user_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type SavedChartUserAccessTable = Knex.CompositeTableType<
+    DbSavedChartUserAccess,
+    Omit<DbSavedChartUserAccess, 'created_at' | 'updated_at'>,
+    Pick<
+        DbSavedChartUserAccess,
+        'space_role' | 'granted_by_user_uuid' | 'updated_at'
+    >
+>;
+
+export type DbSavedChartGroupAccess = {
+    saved_chart_uuid: string;
+    group_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type SavedChartGroupAccessTable = Knex.CompositeTableType<
+    DbSavedChartGroupAccess,
+    Omit<DbSavedChartGroupAccess, 'created_at' | 'updated_at'>,
+    Pick<
+        DbSavedChartGroupAccess,
+        'space_role' | 'granted_by_user_uuid' | 'updated_at'
+    >
+>;

--- a/packages/backend/src/database/entities/savedSqlAccess.ts
+++ b/packages/backend/src/database/entities/savedSqlAccess.ts
@@ -1,0 +1,41 @@
+import { type SpaceMemberRole } from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const SavedSqlUserAccessTableName = 'saved_sql_user_access';
+export const SavedSqlGroupAccessTableName = 'saved_sql_group_access';
+
+export type DbSavedSqlUserAccess = {
+    saved_sql_uuid: string;
+    user_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type SavedSqlUserAccessTable = Knex.CompositeTableType<
+    DbSavedSqlUserAccess,
+    Omit<DbSavedSqlUserAccess, 'created_at' | 'updated_at'>,
+    Pick<
+        DbSavedSqlUserAccess,
+        'space_role' | 'granted_by_user_uuid' | 'updated_at'
+    >
+>;
+
+export type DbSavedSqlGroupAccess = {
+    saved_sql_uuid: string;
+    group_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type SavedSqlGroupAccessTable = Knex.CompositeTableType<
+    DbSavedSqlGroupAccess,
+    Omit<DbSavedSqlGroupAccess, 'created_at' | 'updated_at'>,
+    Pick<
+        DbSavedSqlGroupAccess,
+        'space_role' | 'granted_by_user_uuid' | 'updated_at'
+    >
+>;

--- a/packages/backend/src/database/migrations/20260824120000_create_dashboard_access_tables.ts
+++ b/packages/backend/src/database/migrations/20260824120000_create_dashboard_access_tables.ts
@@ -1,0 +1,53 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Creates two empty dashboard access tables without reading or rewriting existing rows',
+} as const;
+
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.raw(`
+        CREATE TABLE dashboard_user_access (
+            dashboard_uuid uuid NOT NULL,
+            user_uuid uuid NOT NULL,
+            space_role text NOT NULL,
+            granted_by_user_uuid uuid,
+            created_at timestamp NOT NULL DEFAULT now(),
+            updated_at timestamp NOT NULL DEFAULT now(),
+            CONSTRAINT dashboard_user_access_pk PRIMARY KEY (dashboard_uuid, user_uuid),
+            CONSTRAINT dashboard_user_access_dashboard_fk FOREIGN KEY (dashboard_uuid) REFERENCES dashboards (dashboard_uuid) ON DELETE CASCADE,
+            CONSTRAINT dashboard_user_access_user_fk FOREIGN KEY (user_uuid) REFERENCES users (user_uuid) ON DELETE CASCADE,
+            CONSTRAINT dashboard_user_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
+            CONSTRAINT dashboard_user_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
+        );
+        CREATE INDEX dashboard_user_access_principal_idx ON dashboard_user_access (user_uuid, dashboard_uuid);
+        CREATE INDEX dashboard_user_access_grantor_idx ON dashboard_user_access (granted_by_user_uuid);
+
+        CREATE TABLE dashboard_group_access (
+            dashboard_uuid uuid NOT NULL,
+            group_uuid uuid NOT NULL,
+            space_role text NOT NULL,
+            granted_by_user_uuid uuid,
+            created_at timestamp NOT NULL DEFAULT now(),
+            updated_at timestamp NOT NULL DEFAULT now(),
+            CONSTRAINT dashboard_group_access_pk PRIMARY KEY (dashboard_uuid, group_uuid),
+            CONSTRAINT dashboard_group_access_dashboard_fk FOREIGN KEY (dashboard_uuid) REFERENCES dashboards (dashboard_uuid) ON DELETE CASCADE,
+            CONSTRAINT dashboard_group_access_group_fk FOREIGN KEY (group_uuid) REFERENCES groups (group_uuid) ON DELETE CASCADE,
+            CONSTRAINT dashboard_group_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
+            CONSTRAINT dashboard_group_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
+        );
+        CREATE INDEX dashboard_group_access_principal_idx ON dashboard_group_access (group_uuid, dashboard_uuid);
+        CREATE INDEX dashboard_group_access_grantor_idx ON dashboard_group_access (granted_by_user_uuid);
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.raw(`
+        DROP TABLE dashboard_group_access;
+        DROP TABLE dashboard_user_access;
+    `);
+}

--- a/packages/backend/src/database/migrations/20260824120000_create_dashboard_access_tables.ts
+++ b/packages/backend/src/database/migrations/20260824120000_create_dashboard_access_tables.ts
@@ -5,49 +5,89 @@ export const classification = {
     reason: 'Creates two empty dashboard access tables without reading or rewriting existing rows',
 } as const;
 
+const DASHBOARD_USER_ACCESS_TABLE = 'dashboard_user_access';
+const DASHBOARD_GROUP_ACCESS_TABLE = 'dashboard_group_access';
+const DASHBOARDS_TABLE = 'dashboards';
+const USERS_TABLE = 'users';
+const GROUPS_TABLE = 'groups';
+const SPACE_ROLES = ['viewer', 'editor', 'admin'];
 const LOCK_TIMEOUT = '5s';
 
 export async function up(knex: Knex): Promise<void> {
     await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
-    await knex.raw(`
-        CREATE TABLE dashboard_user_access (
-            dashboard_uuid uuid NOT NULL,
-            user_uuid uuid NOT NULL,
-            space_role text NOT NULL,
-            granted_by_user_uuid uuid,
-            created_at timestamp NOT NULL DEFAULT now(),
-            updated_at timestamp NOT NULL DEFAULT now(),
-            CONSTRAINT dashboard_user_access_pk PRIMARY KEY (dashboard_uuid, user_uuid),
-            CONSTRAINT dashboard_user_access_dashboard_fk FOREIGN KEY (dashboard_uuid) REFERENCES dashboards (dashboard_uuid) ON DELETE CASCADE,
-            CONSTRAINT dashboard_user_access_user_fk FOREIGN KEY (user_uuid) REFERENCES users (user_uuid) ON DELETE CASCADE,
-            CONSTRAINT dashboard_user_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
-            CONSTRAINT dashboard_user_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
-        );
-        CREATE INDEX dashboard_user_access_principal_idx ON dashboard_user_access (user_uuid, dashboard_uuid);
-        CREATE INDEX dashboard_user_access_grantor_idx ON dashboard_user_access (granted_by_user_uuid);
 
-        CREATE TABLE dashboard_group_access (
-            dashboard_uuid uuid NOT NULL,
-            group_uuid uuid NOT NULL,
-            space_role text NOT NULL,
-            granted_by_user_uuid uuid,
-            created_at timestamp NOT NULL DEFAULT now(),
-            updated_at timestamp NOT NULL DEFAULT now(),
-            CONSTRAINT dashboard_group_access_pk PRIMARY KEY (dashboard_uuid, group_uuid),
-            CONSTRAINT dashboard_group_access_dashboard_fk FOREIGN KEY (dashboard_uuid) REFERENCES dashboards (dashboard_uuid) ON DELETE CASCADE,
-            CONSTRAINT dashboard_group_access_group_fk FOREIGN KEY (group_uuid) REFERENCES groups (group_uuid) ON DELETE CASCADE,
-            CONSTRAINT dashboard_group_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
-            CONSTRAINT dashboard_group_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
-        );
-        CREATE INDEX dashboard_group_access_principal_idx ON dashboard_group_access (group_uuid, dashboard_uuid);
-        CREATE INDEX dashboard_group_access_grantor_idx ON dashboard_group_access (granted_by_user_uuid);
-    `);
+    await knex.schema.createTable(DASHBOARD_USER_ACCESS_TABLE, (table) => {
+        table
+            .uuid('dashboard_uuid')
+            .notNullable()
+            .references('dashboard_uuid')
+            .inTable(DASHBOARDS_TABLE)
+            .onDelete('CASCADE');
+        table
+            .uuid('user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('CASCADE');
+        table.text('space_role').notNullable().checkIn(SPACE_ROLES);
+        table
+            .uuid('granted_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.primary(['dashboard_uuid', 'user_uuid']);
+        table.index(['user_uuid', 'dashboard_uuid']);
+    });
+
+    await knex.schema.createTable(DASHBOARD_GROUP_ACCESS_TABLE, (table) => {
+        table
+            .uuid('dashboard_uuid')
+            .notNullable()
+            .references('dashboard_uuid')
+            .inTable(DASHBOARDS_TABLE)
+            .onDelete('CASCADE');
+        table
+            .uuid('group_uuid')
+            .notNullable()
+            .references('group_uuid')
+            .inTable(GROUPS_TABLE)
+            .onDelete('CASCADE');
+        table.text('space_role').notNullable().checkIn(SPACE_ROLES);
+        table
+            .uuid('granted_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.primary(['dashboard_uuid', 'group_uuid']);
+        table.index(['group_uuid', 'dashboard_uuid']);
+    });
 }
 
 export async function down(knex: Knex): Promise<void> {
     await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
-    await knex.raw(`
-        DROP TABLE dashboard_group_access;
-        DROP TABLE dashboard_user_access;
-    `);
+
+    await knex.schema.dropTableIfExists(DASHBOARD_GROUP_ACCESS_TABLE);
+    await knex.schema.dropTableIfExists(DASHBOARD_USER_ACCESS_TABLE);
 }

--- a/packages/backend/src/database/migrations/20260824120100_create_saved_chart_access_tables.ts
+++ b/packages/backend/src/database/migrations/20260824120100_create_saved_chart_access_tables.ts
@@ -1,0 +1,53 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Creates two empty saved chart access tables without reading or rewriting existing rows',
+} as const;
+
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.raw(`
+        CREATE TABLE saved_chart_user_access (
+            saved_chart_uuid uuid NOT NULL,
+            user_uuid uuid NOT NULL,
+            space_role text NOT NULL,
+            granted_by_user_uuid uuid,
+            created_at timestamp NOT NULL DEFAULT now(),
+            updated_at timestamp NOT NULL DEFAULT now(),
+            CONSTRAINT saved_chart_user_access_pk PRIMARY KEY (saved_chart_uuid, user_uuid),
+            CONSTRAINT saved_chart_user_access_chart_fk FOREIGN KEY (saved_chart_uuid) REFERENCES saved_queries (saved_query_uuid) ON DELETE CASCADE,
+            CONSTRAINT saved_chart_user_access_user_fk FOREIGN KEY (user_uuid) REFERENCES users (user_uuid) ON DELETE CASCADE,
+            CONSTRAINT saved_chart_user_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
+            CONSTRAINT saved_chart_user_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
+        );
+        CREATE INDEX saved_chart_user_access_principal_idx ON saved_chart_user_access (user_uuid, saved_chart_uuid);
+        CREATE INDEX saved_chart_user_access_grantor_idx ON saved_chart_user_access (granted_by_user_uuid);
+
+        CREATE TABLE saved_chart_group_access (
+            saved_chart_uuid uuid NOT NULL,
+            group_uuid uuid NOT NULL,
+            space_role text NOT NULL,
+            granted_by_user_uuid uuid,
+            created_at timestamp NOT NULL DEFAULT now(),
+            updated_at timestamp NOT NULL DEFAULT now(),
+            CONSTRAINT saved_chart_group_access_pk PRIMARY KEY (saved_chart_uuid, group_uuid),
+            CONSTRAINT saved_chart_group_access_chart_fk FOREIGN KEY (saved_chart_uuid) REFERENCES saved_queries (saved_query_uuid) ON DELETE CASCADE,
+            CONSTRAINT saved_chart_group_access_group_fk FOREIGN KEY (group_uuid) REFERENCES groups (group_uuid) ON DELETE CASCADE,
+            CONSTRAINT saved_chart_group_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
+            CONSTRAINT saved_chart_group_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
+        );
+        CREATE INDEX saved_chart_group_access_principal_idx ON saved_chart_group_access (group_uuid, saved_chart_uuid);
+        CREATE INDEX saved_chart_group_access_grantor_idx ON saved_chart_group_access (granted_by_user_uuid);
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.raw(`
+        DROP TABLE saved_chart_group_access;
+        DROP TABLE saved_chart_user_access;
+    `);
+}

--- a/packages/backend/src/database/migrations/20260824120100_create_saved_chart_access_tables.ts
+++ b/packages/backend/src/database/migrations/20260824120100_create_saved_chart_access_tables.ts
@@ -5,49 +5,89 @@ export const classification = {
     reason: 'Creates two empty saved chart access tables without reading or rewriting existing rows',
 } as const;
 
+const SAVED_CHART_USER_ACCESS_TABLE = 'saved_chart_user_access';
+const SAVED_CHART_GROUP_ACCESS_TABLE = 'saved_chart_group_access';
+const SAVED_QUERIES_TABLE = 'saved_queries';
+const USERS_TABLE = 'users';
+const GROUPS_TABLE = 'groups';
+const SPACE_ROLES = ['viewer', 'editor', 'admin'];
 const LOCK_TIMEOUT = '5s';
 
 export async function up(knex: Knex): Promise<void> {
     await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
-    await knex.raw(`
-        CREATE TABLE saved_chart_user_access (
-            saved_chart_uuid uuid NOT NULL,
-            user_uuid uuid NOT NULL,
-            space_role text NOT NULL,
-            granted_by_user_uuid uuid,
-            created_at timestamp NOT NULL DEFAULT now(),
-            updated_at timestamp NOT NULL DEFAULT now(),
-            CONSTRAINT saved_chart_user_access_pk PRIMARY KEY (saved_chart_uuid, user_uuid),
-            CONSTRAINT saved_chart_user_access_chart_fk FOREIGN KEY (saved_chart_uuid) REFERENCES saved_queries (saved_query_uuid) ON DELETE CASCADE,
-            CONSTRAINT saved_chart_user_access_user_fk FOREIGN KEY (user_uuid) REFERENCES users (user_uuid) ON DELETE CASCADE,
-            CONSTRAINT saved_chart_user_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
-            CONSTRAINT saved_chart_user_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
-        );
-        CREATE INDEX saved_chart_user_access_principal_idx ON saved_chart_user_access (user_uuid, saved_chart_uuid);
-        CREATE INDEX saved_chart_user_access_grantor_idx ON saved_chart_user_access (granted_by_user_uuid);
 
-        CREATE TABLE saved_chart_group_access (
-            saved_chart_uuid uuid NOT NULL,
-            group_uuid uuid NOT NULL,
-            space_role text NOT NULL,
-            granted_by_user_uuid uuid,
-            created_at timestamp NOT NULL DEFAULT now(),
-            updated_at timestamp NOT NULL DEFAULT now(),
-            CONSTRAINT saved_chart_group_access_pk PRIMARY KEY (saved_chart_uuid, group_uuid),
-            CONSTRAINT saved_chart_group_access_chart_fk FOREIGN KEY (saved_chart_uuid) REFERENCES saved_queries (saved_query_uuid) ON DELETE CASCADE,
-            CONSTRAINT saved_chart_group_access_group_fk FOREIGN KEY (group_uuid) REFERENCES groups (group_uuid) ON DELETE CASCADE,
-            CONSTRAINT saved_chart_group_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
-            CONSTRAINT saved_chart_group_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
-        );
-        CREATE INDEX saved_chart_group_access_principal_idx ON saved_chart_group_access (group_uuid, saved_chart_uuid);
-        CREATE INDEX saved_chart_group_access_grantor_idx ON saved_chart_group_access (granted_by_user_uuid);
-    `);
+    await knex.schema.createTable(SAVED_CHART_USER_ACCESS_TABLE, (table) => {
+        table
+            .uuid('saved_chart_uuid')
+            .notNullable()
+            .references('saved_query_uuid')
+            .inTable(SAVED_QUERIES_TABLE)
+            .onDelete('CASCADE');
+        table
+            .uuid('user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('CASCADE');
+        table.text('space_role').notNullable().checkIn(SPACE_ROLES);
+        table
+            .uuid('granted_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.primary(['saved_chart_uuid', 'user_uuid']);
+        table.index(['user_uuid', 'saved_chart_uuid']);
+    });
+
+    await knex.schema.createTable(SAVED_CHART_GROUP_ACCESS_TABLE, (table) => {
+        table
+            .uuid('saved_chart_uuid')
+            .notNullable()
+            .references('saved_query_uuid')
+            .inTable(SAVED_QUERIES_TABLE)
+            .onDelete('CASCADE');
+        table
+            .uuid('group_uuid')
+            .notNullable()
+            .references('group_uuid')
+            .inTable(GROUPS_TABLE)
+            .onDelete('CASCADE');
+        table.text('space_role').notNullable().checkIn(SPACE_ROLES);
+        table
+            .uuid('granted_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.primary(['saved_chart_uuid', 'group_uuid']);
+        table.index(['group_uuid', 'saved_chart_uuid']);
+    });
 }
 
 export async function down(knex: Knex): Promise<void> {
     await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
-    await knex.raw(`
-        DROP TABLE saved_chart_group_access;
-        DROP TABLE saved_chart_user_access;
-    `);
+
+    await knex.schema.dropTableIfExists(SAVED_CHART_GROUP_ACCESS_TABLE);
+    await knex.schema.dropTableIfExists(SAVED_CHART_USER_ACCESS_TABLE);
 }

--- a/packages/backend/src/database/migrations/20260824120200_create_saved_sql_access_tables.ts
+++ b/packages/backend/src/database/migrations/20260824120200_create_saved_sql_access_tables.ts
@@ -5,49 +5,89 @@ export const classification = {
     reason: 'Creates two empty saved SQL access tables without reading or rewriting existing rows',
 } as const;
 
+const SAVED_SQL_USER_ACCESS_TABLE = 'saved_sql_user_access';
+const SAVED_SQL_GROUP_ACCESS_TABLE = 'saved_sql_group_access';
+const SAVED_SQL_TABLE = 'saved_sql';
+const USERS_TABLE = 'users';
+const GROUPS_TABLE = 'groups';
+const SPACE_ROLES = ['viewer', 'editor', 'admin'];
 const LOCK_TIMEOUT = '5s';
 
 export async function up(knex: Knex): Promise<void> {
     await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
-    await knex.raw(`
-        CREATE TABLE saved_sql_user_access (
-            saved_sql_uuid uuid NOT NULL,
-            user_uuid uuid NOT NULL,
-            space_role text NOT NULL,
-            granted_by_user_uuid uuid,
-            created_at timestamp NOT NULL DEFAULT now(),
-            updated_at timestamp NOT NULL DEFAULT now(),
-            CONSTRAINT saved_sql_user_access_pk PRIMARY KEY (saved_sql_uuid, user_uuid),
-            CONSTRAINT saved_sql_user_access_sql_fk FOREIGN KEY (saved_sql_uuid) REFERENCES saved_sql (saved_sql_uuid) ON DELETE CASCADE,
-            CONSTRAINT saved_sql_user_access_user_fk FOREIGN KEY (user_uuid) REFERENCES users (user_uuid) ON DELETE CASCADE,
-            CONSTRAINT saved_sql_user_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
-            CONSTRAINT saved_sql_user_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
-        );
-        CREATE INDEX saved_sql_user_access_principal_idx ON saved_sql_user_access (user_uuid, saved_sql_uuid);
-        CREATE INDEX saved_sql_user_access_grantor_idx ON saved_sql_user_access (granted_by_user_uuid);
 
-        CREATE TABLE saved_sql_group_access (
-            saved_sql_uuid uuid NOT NULL,
-            group_uuid uuid NOT NULL,
-            space_role text NOT NULL,
-            granted_by_user_uuid uuid,
-            created_at timestamp NOT NULL DEFAULT now(),
-            updated_at timestamp NOT NULL DEFAULT now(),
-            CONSTRAINT saved_sql_group_access_pk PRIMARY KEY (saved_sql_uuid, group_uuid),
-            CONSTRAINT saved_sql_group_access_sql_fk FOREIGN KEY (saved_sql_uuid) REFERENCES saved_sql (saved_sql_uuid) ON DELETE CASCADE,
-            CONSTRAINT saved_sql_group_access_group_fk FOREIGN KEY (group_uuid) REFERENCES groups (group_uuid) ON DELETE CASCADE,
-            CONSTRAINT saved_sql_group_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
-            CONSTRAINT saved_sql_group_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
-        );
-        CREATE INDEX saved_sql_group_access_principal_idx ON saved_sql_group_access (group_uuid, saved_sql_uuid);
-        CREATE INDEX saved_sql_group_access_grantor_idx ON saved_sql_group_access (granted_by_user_uuid);
-    `);
+    await knex.schema.createTable(SAVED_SQL_USER_ACCESS_TABLE, (table) => {
+        table
+            .uuid('saved_sql_uuid')
+            .notNullable()
+            .references('saved_sql_uuid')
+            .inTable(SAVED_SQL_TABLE)
+            .onDelete('CASCADE');
+        table
+            .uuid('user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('CASCADE');
+        table.text('space_role').notNullable().checkIn(SPACE_ROLES);
+        table
+            .uuid('granted_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.primary(['saved_sql_uuid', 'user_uuid']);
+        table.index(['user_uuid', 'saved_sql_uuid']);
+    });
+
+    await knex.schema.createTable(SAVED_SQL_GROUP_ACCESS_TABLE, (table) => {
+        table
+            .uuid('saved_sql_uuid')
+            .notNullable()
+            .references('saved_sql_uuid')
+            .inTable(SAVED_SQL_TABLE)
+            .onDelete('CASCADE');
+        table
+            .uuid('group_uuid')
+            .notNullable()
+            .references('group_uuid')
+            .inTable(GROUPS_TABLE)
+            .onDelete('CASCADE');
+        table.text('space_role').notNullable().checkIn(SPACE_ROLES);
+        table
+            .uuid('granted_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.primary(['saved_sql_uuid', 'group_uuid']);
+        table.index(['group_uuid', 'saved_sql_uuid']);
+    });
 }
 
 export async function down(knex: Knex): Promise<void> {
     await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
-    await knex.raw(`
-        DROP TABLE saved_sql_group_access;
-        DROP TABLE saved_sql_user_access;
-    `);
+
+    await knex.schema.dropTableIfExists(SAVED_SQL_GROUP_ACCESS_TABLE);
+    await knex.schema.dropTableIfExists(SAVED_SQL_USER_ACCESS_TABLE);
 }

--- a/packages/backend/src/database/migrations/20260824120200_create_saved_sql_access_tables.ts
+++ b/packages/backend/src/database/migrations/20260824120200_create_saved_sql_access_tables.ts
@@ -1,0 +1,53 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Creates two empty saved SQL access tables without reading or rewriting existing rows',
+} as const;
+
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.raw(`
+        CREATE TABLE saved_sql_user_access (
+            saved_sql_uuid uuid NOT NULL,
+            user_uuid uuid NOT NULL,
+            space_role text NOT NULL,
+            granted_by_user_uuid uuid,
+            created_at timestamp NOT NULL DEFAULT now(),
+            updated_at timestamp NOT NULL DEFAULT now(),
+            CONSTRAINT saved_sql_user_access_pk PRIMARY KEY (saved_sql_uuid, user_uuid),
+            CONSTRAINT saved_sql_user_access_sql_fk FOREIGN KEY (saved_sql_uuid) REFERENCES saved_sql (saved_sql_uuid) ON DELETE CASCADE,
+            CONSTRAINT saved_sql_user_access_user_fk FOREIGN KEY (user_uuid) REFERENCES users (user_uuid) ON DELETE CASCADE,
+            CONSTRAINT saved_sql_user_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
+            CONSTRAINT saved_sql_user_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
+        );
+        CREATE INDEX saved_sql_user_access_principal_idx ON saved_sql_user_access (user_uuid, saved_sql_uuid);
+        CREATE INDEX saved_sql_user_access_grantor_idx ON saved_sql_user_access (granted_by_user_uuid);
+
+        CREATE TABLE saved_sql_group_access (
+            saved_sql_uuid uuid NOT NULL,
+            group_uuid uuid NOT NULL,
+            space_role text NOT NULL,
+            granted_by_user_uuid uuid,
+            created_at timestamp NOT NULL DEFAULT now(),
+            updated_at timestamp NOT NULL DEFAULT now(),
+            CONSTRAINT saved_sql_group_access_pk PRIMARY KEY (saved_sql_uuid, group_uuid),
+            CONSTRAINT saved_sql_group_access_sql_fk FOREIGN KEY (saved_sql_uuid) REFERENCES saved_sql (saved_sql_uuid) ON DELETE CASCADE,
+            CONSTRAINT saved_sql_group_access_group_fk FOREIGN KEY (group_uuid) REFERENCES groups (group_uuid) ON DELETE CASCADE,
+            CONSTRAINT saved_sql_group_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
+            CONSTRAINT saved_sql_group_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
+        );
+        CREATE INDEX saved_sql_group_access_principal_idx ON saved_sql_group_access (group_uuid, saved_sql_uuid);
+        CREATE INDEX saved_sql_group_access_grantor_idx ON saved_sql_group_access (granted_by_user_uuid);
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.raw(`
+        DROP TABLE saved_sql_group_access;
+        DROP TABLE saved_sql_user_access;
+    `);
+}

--- a/packages/backend/src/database/migrations/20260824120300_create_app_access_tables.ts
+++ b/packages/backend/src/database/migrations/20260824120300_create_app_access_tables.ts
@@ -1,0 +1,53 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Creates two empty app access tables without reading or rewriting existing rows',
+} as const;
+
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.raw(`
+        CREATE TABLE app_user_access (
+            app_uuid uuid NOT NULL,
+            user_uuid uuid NOT NULL,
+            space_role text NOT NULL,
+            granted_by_user_uuid uuid,
+            created_at timestamp NOT NULL DEFAULT now(),
+            updated_at timestamp NOT NULL DEFAULT now(),
+            CONSTRAINT app_user_access_pk PRIMARY KEY (app_uuid, user_uuid),
+            CONSTRAINT app_user_access_app_fk FOREIGN KEY (app_uuid) REFERENCES apps (app_id) ON DELETE CASCADE,
+            CONSTRAINT app_user_access_user_fk FOREIGN KEY (user_uuid) REFERENCES users (user_uuid) ON DELETE CASCADE,
+            CONSTRAINT app_user_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
+            CONSTRAINT app_user_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
+        );
+        CREATE INDEX app_user_access_principal_idx ON app_user_access (user_uuid, app_uuid);
+        CREATE INDEX app_user_access_grantor_idx ON app_user_access (granted_by_user_uuid);
+
+        CREATE TABLE app_group_access (
+            app_uuid uuid NOT NULL,
+            group_uuid uuid NOT NULL,
+            space_role text NOT NULL,
+            granted_by_user_uuid uuid,
+            created_at timestamp NOT NULL DEFAULT now(),
+            updated_at timestamp NOT NULL DEFAULT now(),
+            CONSTRAINT app_group_access_pk PRIMARY KEY (app_uuid, group_uuid),
+            CONSTRAINT app_group_access_app_fk FOREIGN KEY (app_uuid) REFERENCES apps (app_id) ON DELETE CASCADE,
+            CONSTRAINT app_group_access_group_fk FOREIGN KEY (group_uuid) REFERENCES groups (group_uuid) ON DELETE CASCADE,
+            CONSTRAINT app_group_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
+            CONSTRAINT app_group_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
+        );
+        CREATE INDEX app_group_access_principal_idx ON app_group_access (group_uuid, app_uuid);
+        CREATE INDEX app_group_access_grantor_idx ON app_group_access (granted_by_user_uuid);
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.raw(`
+        DROP TABLE app_group_access;
+        DROP TABLE app_user_access;
+    `);
+}

--- a/packages/backend/src/database/migrations/20260824120300_create_app_access_tables.ts
+++ b/packages/backend/src/database/migrations/20260824120300_create_app_access_tables.ts
@@ -5,49 +5,89 @@ export const classification = {
     reason: 'Creates two empty app access tables without reading or rewriting existing rows',
 } as const;
 
+const APP_USER_ACCESS_TABLE = 'app_user_access';
+const APP_GROUP_ACCESS_TABLE = 'app_group_access';
+const APPS_TABLE = 'apps';
+const USERS_TABLE = 'users';
+const GROUPS_TABLE = 'groups';
+const SPACE_ROLES = ['viewer', 'editor', 'admin'];
 const LOCK_TIMEOUT = '5s';
 
 export async function up(knex: Knex): Promise<void> {
     await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
-    await knex.raw(`
-        CREATE TABLE app_user_access (
-            app_uuid uuid NOT NULL,
-            user_uuid uuid NOT NULL,
-            space_role text NOT NULL,
-            granted_by_user_uuid uuid,
-            created_at timestamp NOT NULL DEFAULT now(),
-            updated_at timestamp NOT NULL DEFAULT now(),
-            CONSTRAINT app_user_access_pk PRIMARY KEY (app_uuid, user_uuid),
-            CONSTRAINT app_user_access_app_fk FOREIGN KEY (app_uuid) REFERENCES apps (app_id) ON DELETE CASCADE,
-            CONSTRAINT app_user_access_user_fk FOREIGN KEY (user_uuid) REFERENCES users (user_uuid) ON DELETE CASCADE,
-            CONSTRAINT app_user_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
-            CONSTRAINT app_user_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
-        );
-        CREATE INDEX app_user_access_principal_idx ON app_user_access (user_uuid, app_uuid);
-        CREATE INDEX app_user_access_grantor_idx ON app_user_access (granted_by_user_uuid);
 
-        CREATE TABLE app_group_access (
-            app_uuid uuid NOT NULL,
-            group_uuid uuid NOT NULL,
-            space_role text NOT NULL,
-            granted_by_user_uuid uuid,
-            created_at timestamp NOT NULL DEFAULT now(),
-            updated_at timestamp NOT NULL DEFAULT now(),
-            CONSTRAINT app_group_access_pk PRIMARY KEY (app_uuid, group_uuid),
-            CONSTRAINT app_group_access_app_fk FOREIGN KEY (app_uuid) REFERENCES apps (app_id) ON DELETE CASCADE,
-            CONSTRAINT app_group_access_group_fk FOREIGN KEY (group_uuid) REFERENCES groups (group_uuid) ON DELETE CASCADE,
-            CONSTRAINT app_group_access_grantor_fk FOREIGN KEY (granted_by_user_uuid) REFERENCES users (user_uuid) ON DELETE SET NULL,
-            CONSTRAINT app_group_access_role_chk CHECK (space_role IN ('viewer', 'editor', 'admin'))
-        );
-        CREATE INDEX app_group_access_principal_idx ON app_group_access (group_uuid, app_uuid);
-        CREATE INDEX app_group_access_grantor_idx ON app_group_access (granted_by_user_uuid);
-    `);
+    await knex.schema.createTable(APP_USER_ACCESS_TABLE, (table) => {
+        table
+            .uuid('app_uuid')
+            .notNullable()
+            .references('app_id')
+            .inTable(APPS_TABLE)
+            .onDelete('CASCADE');
+        table
+            .uuid('user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('CASCADE');
+        table.text('space_role').notNullable().checkIn(SPACE_ROLES);
+        table
+            .uuid('granted_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.primary(['app_uuid', 'user_uuid']);
+        table.index(['user_uuid', 'app_uuid']);
+    });
+
+    await knex.schema.createTable(APP_GROUP_ACCESS_TABLE, (table) => {
+        table
+            .uuid('app_uuid')
+            .notNullable()
+            .references('app_id')
+            .inTable(APPS_TABLE)
+            .onDelete('CASCADE');
+        table
+            .uuid('group_uuid')
+            .notNullable()
+            .references('group_uuid')
+            .inTable(GROUPS_TABLE)
+            .onDelete('CASCADE');
+        table.text('space_role').notNullable().checkIn(SPACE_ROLES);
+        table
+            .uuid('granted_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.primary(['app_uuid', 'group_uuid']);
+        table.index(['group_uuid', 'app_uuid']);
+    });
 }
 
 export async function down(knex: Knex): Promise<void> {
     await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
-    await knex.raw(`
-        DROP TABLE app_group_access;
-        DROP TABLE app_user_access;
-    `);
+
+    await knex.schema.dropTableIfExists(APP_GROUP_ACCESS_TABLE);
+    await knex.schema.dropTableIfExists(APP_USER_ACCESS_TABLE);
 }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1249

## Summary

PR 2 of 5 adds native user and group grant tables for dashboards, saved charts, saved SQL charts, and apps. The migrations are additive, reversible, and contain no generic resource discriminator.

Stacks on PR 1 ([#27921](https://github.com/lightdash/lightdash/pull/27921)), which adds the pure role resolver.

Prior work: @hrx-joseph-fahnestock's [direct-resource resolver proposal](https://github.com/houserx/lightdash-hrx/pull/25) established the additive access semantics. This PR implements the native persistence design selected for SPK-1249; it does not copy the proposal's persistence code.

## Changes

- Adds `dashboard_user_access` and `dashboard_group_access`.
- Adds `saved_chart_user_access` and `saved_chart_group_access`.
- Adds `saved_sql_user_access` and `saved_sql_group_access`.
- Adds `app_user_access` and `app_group_access`.
- Uses concrete resource and principal foreign keys, composite primary keys, role constraints, principal indexes, and nullable grantor references.
- Uses `ON DELETE CASCADE` for resources/principals and `ON DELETE SET NULL` for grantors.

## Schema shape

```
dashboard ─┬─ dashboard_user_access ─ user
           └─ dashboard_group_access ─ group

saved chart / saved SQL / app repeat the same concrete two-table shape
```

The authoritative resource table supplies tenant identity, avoiding duplicated project or organization columns on grants.

## Test plan

- [x] Migration up and down against PostgreSQL
- [x] Release-safety classification
- [x] Backend entity and Knex table typechecks
- [x] Focused backend lint and formatting checks