### PR TITLE
feat(auth): add batched direct access reads

### DIFF
--- a/packages/backend/src/models/AppAccessModel.ts
+++ b/packages/backend/src/models/AppAccessModel.ts
@@ -1,0 +1,139 @@
+import { type Knex } from 'knex';
+import {
+    AppGroupAccessTableName,
+    AppUserAccessTableName,
+} from '../database/entities/appAccess';
+import { AppsTableName } from '../database/entities/apps';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectTableName } from '../database/entities/projects';
+import { UserTableName } from '../database/entities/users';
+import {
+    getActiveProjectMemberPredicate,
+    groupDirectAccessRows,
+    type DirectAccess,
+    type DirectAccessRow,
+} from './directAccessModelUtils';
+
+export type AppDirectAccess = DirectAccess;
+
+export class AppAccessModel {
+    constructor(private readonly database: Knex) {}
+
+    async getUserAccess(
+        appUuids: string[],
+        userUuid: string,
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<Record<string, AppDirectAccess>> {
+        const uniqueAppUuids = [...new Set(appUuids)];
+        if (uniqueAppUuids.length === 0) {
+            return {};
+        }
+
+        const rows: DirectAccessRow[] = await trx(AppUserAccessTableName)
+            .select({
+                resourceUuid: `${AppUserAccessTableName}.app_uuid`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+                role: `${AppUserAccessTableName}.space_role`,
+                groupUuid: trx.raw('NULL'),
+            })
+            .innerJoin(
+                AppsTableName,
+                `${AppsTableName}.app_id`,
+                `${AppUserAccessTableName}.app_uuid`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${AppsTableName}.project_uuid`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${AppUserAccessTableName}.user_uuid`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                function joinCurrentOrganizationMembership() {
+                    this.on(
+                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOn(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    );
+                },
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .whereIn(`${AppUserAccessTableName}.app_uuid`, uniqueAppUuids)
+            .where(`${AppUserAccessTableName}.user_uuid`, userUuid)
+            .where(getActiveProjectMemberPredicate(trx))
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .unionAll(
+                trx(AppGroupAccessTableName)
+                    .select({
+                        resourceUuid: `${AppGroupAccessTableName}.app_uuid`,
+                        organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                        projectUuid: `${ProjectTableName}.project_uuid`,
+                        role: `${AppGroupAccessTableName}.space_role`,
+                        groupUuid: `${AppGroupAccessTableName}.group_uuid`,
+                    })
+                    .innerJoin(
+                        AppsTableName,
+                        `${AppsTableName}.app_id`,
+                        `${AppGroupAccessTableName}.app_uuid`,
+                    )
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_uuid`,
+                        `${AppsTableName}.project_uuid`,
+                    )
+                    .innerJoin(
+                        OrganizationTableName,
+                        `${OrganizationTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    )
+                    .innerJoin(
+                        GroupMembershipTableName,
+                        `${GroupMembershipTableName}.group_uuid`,
+                        `${AppGroupAccessTableName}.group_uuid`,
+                    )
+                    .innerJoin(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${GroupMembershipTableName}.user_id`,
+                    )
+                    .innerJoin(
+                        OrganizationMembershipsTableName,
+                        function joinCurrentOrganizationMembership() {
+                            this.on(
+                                `${OrganizationMembershipsTableName}.user_id`,
+                                `${UserTableName}.user_id`,
+                            ).andOn(
+                                `${OrganizationMembershipsTableName}.organization_id`,
+                                `${ProjectTableName}.organization_id`,
+                            );
+                        },
+                    )
+                    .whereIn(
+                        `${AppGroupAccessTableName}.app_uuid`,
+                        uniqueAppUuids,
+                    )
+                    .where(`${UserTableName}.user_uuid`, userUuid)
+                    .where(getActiveProjectMemberPredicate(trx))
+                    .whereRaw('?? = ??', [
+                        `${GroupMembershipTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    ])
+                    .whereNull(`${AppsTableName}.deleted_at`),
+            );
+
+        return groupDirectAccessRows(rows);
+    }
+}

--- a/packages/backend/src/models/AppAccessModel.ts
+++ b/packages/backend/src/models/AppAccessModel.ts
@@ -128,10 +128,10 @@ export class AppAccessModel {
                     )
                     .where(`${UserTableName}.user_uuid`, userUuid)
                     .where(getActiveProjectMemberPredicate(trx))
-                    .whereRaw('?? = ??', [
+                    .where(
                         `${GroupMembershipTableName}.organization_id`,
-                        `${ProjectTableName}.organization_id`,
-                    ])
+                        trx.ref(`${ProjectTableName}.organization_id`),
+                    )
                     .where(
                         getActiveGrantedGroupPredicate(
                             trx,

--- a/packages/backend/src/models/AppAccessModel.ts
+++ b/packages/backend/src/models/AppAccessModel.ts
@@ -10,6 +10,7 @@ import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectTableName } from '../database/entities/projects';
 import { UserTableName } from '../database/entities/users';
 import {
+    getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
     type DirectAccess,
@@ -131,6 +132,12 @@ export class AppAccessModel {
                         `${GroupMembershipTableName}.organization_id`,
                         `${ProjectTableName}.organization_id`,
                     ])
+                    .where(
+                        getActiveGrantedGroupPredicate(
+                            trx,
+                            AppGroupAccessTableName,
+                        ),
+                    )
                     .whereNull(`${AppsTableName}.deleted_at`),
             );
 

--- a/packages/backend/src/models/DashboardAccessModel.ts
+++ b/packages/backend/src/models/DashboardAccessModel.ts
@@ -1,0 +1,153 @@
+import { type Knex } from 'knex';
+import {
+    DashboardGroupAccessTableName,
+    DashboardUserAccessTableName,
+} from '../database/entities/dashboardAccess';
+import { DashboardsTableName } from '../database/entities/dashboards';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectTableName } from '../database/entities/projects';
+import { SpaceTableName } from '../database/entities/spaces';
+import { UserTableName } from '../database/entities/users';
+import {
+    getActiveProjectMemberPredicate,
+    groupDirectAccessRows,
+    type DirectAccess,
+    type DirectAccessRow,
+} from './directAccessModelUtils';
+
+export type DashboardDirectAccess = DirectAccess;
+
+export class DashboardAccessModel {
+    constructor(private readonly database: Knex) {}
+
+    async getUserAccess(
+        dashboardUuids: string[],
+        userUuid: string,
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<Record<string, DashboardDirectAccess>> {
+        const uniqueDashboardUuids = [...new Set(dashboardUuids)];
+        if (uniqueDashboardUuids.length === 0) {
+            return {};
+        }
+
+        const rows: DirectAccessRow[] = await trx(DashboardUserAccessTableName)
+            .select({
+                resourceUuid: `${DashboardUserAccessTableName}.dashboard_uuid`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+                role: `${DashboardUserAccessTableName}.space_role`,
+                groupUuid: trx.raw('NULL'),
+            })
+            .innerJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${DashboardUserAccessTableName}.dashboard_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${DashboardsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${DashboardUserAccessTableName}.user_uuid`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                function joinCurrentOrganizationMembership() {
+                    this.on(
+                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOn(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    );
+                },
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .whereIn(
+                `${DashboardUserAccessTableName}.dashboard_uuid`,
+                uniqueDashboardUuids,
+            )
+            .where(`${DashboardUserAccessTableName}.user_uuid`, userUuid)
+            .where(getActiveProjectMemberPredicate(trx))
+            .whereNull(`${DashboardsTableName}.deleted_at`)
+            .unionAll(
+                trx(DashboardGroupAccessTableName)
+                    .select({
+                        resourceUuid: `${DashboardGroupAccessTableName}.dashboard_uuid`,
+                        organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                        projectUuid: `${ProjectTableName}.project_uuid`,
+                        role: `${DashboardGroupAccessTableName}.space_role`,
+                        groupUuid: `${DashboardGroupAccessTableName}.group_uuid`,
+                    })
+                    .innerJoin(
+                        DashboardsTableName,
+                        `${DashboardsTableName}.dashboard_uuid`,
+                        `${DashboardGroupAccessTableName}.dashboard_uuid`,
+                    )
+                    .innerJoin(
+                        SpaceTableName,
+                        `${SpaceTableName}.space_id`,
+                        `${DashboardsTableName}.space_id`,
+                    )
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_id`,
+                        `${SpaceTableName}.project_id`,
+                    )
+                    .innerJoin(
+                        OrganizationTableName,
+                        `${OrganizationTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    )
+                    .innerJoin(
+                        GroupMembershipTableName,
+                        `${GroupMembershipTableName}.group_uuid`,
+                        `${DashboardGroupAccessTableName}.group_uuid`,
+                    )
+                    .innerJoin(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${GroupMembershipTableName}.user_id`,
+                    )
+                    .innerJoin(
+                        OrganizationMembershipsTableName,
+                        function joinCurrentOrganizationMembership() {
+                            this.on(
+                                `${OrganizationMembershipsTableName}.user_id`,
+                                `${UserTableName}.user_id`,
+                            ).andOn(
+                                `${OrganizationMembershipsTableName}.organization_id`,
+                                `${ProjectTableName}.organization_id`,
+                            );
+                        },
+                    )
+                    .whereIn(
+                        `${DashboardGroupAccessTableName}.dashboard_uuid`,
+                        uniqueDashboardUuids,
+                    )
+                    .where(`${UserTableName}.user_uuid`, userUuid)
+                    .where(getActiveProjectMemberPredicate(trx))
+                    .whereRaw('?? = ??', [
+                        `${GroupMembershipTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    ])
+                    .whereNull(`${DashboardsTableName}.deleted_at`),
+            );
+
+        return groupDirectAccessRows(rows);
+    }
+}

--- a/packages/backend/src/models/DashboardAccessModel.ts
+++ b/packages/backend/src/models/DashboardAccessModel.ts
@@ -11,6 +11,7 @@ import { ProjectTableName } from '../database/entities/projects';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import {
+    getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
     type DirectAccess,
@@ -145,6 +146,12 @@ export class DashboardAccessModel {
                         `${GroupMembershipTableName}.organization_id`,
                         `${ProjectTableName}.organization_id`,
                     ])
+                    .where(
+                        getActiveGrantedGroupPredicate(
+                            trx,
+                            DashboardGroupAccessTableName,
+                        ),
+                    )
                     .whereNull(`${DashboardsTableName}.deleted_at`),
             );
 

--- a/packages/backend/src/models/DashboardAccessModel.ts
+++ b/packages/backend/src/models/DashboardAccessModel.ts
@@ -142,10 +142,10 @@ export class DashboardAccessModel {
                     )
                     .where(`${UserTableName}.user_uuid`, userUuid)
                     .where(getActiveProjectMemberPredicate(trx))
-                    .whereRaw('?? = ??', [
+                    .where(
                         `${GroupMembershipTableName}.organization_id`,
-                        `${ProjectTableName}.organization_id`,
-                    ])
+                        trx.ref(`${ProjectTableName}.organization_id`),
+                    )
                     .where(
                         getActiveGrantedGroupPredicate(
                             trx,

--- a/packages/backend/src/models/DirectAccessModels.integration.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.integration.test.ts
@@ -187,6 +187,11 @@ describe('direct access read models PostgreSQL integration', () => {
             group_uuid: groupUuid,
             user_id: userId,
         });
+        await transaction(ProjectGroupAccessTableName).insert({
+            project_uuid: projectUuid,
+            group_uuid: groupUuid,
+            role: ProjectMemberRole.VIEWER,
+        });
         await transaction(DashboardUserAccessTableName).insert({
             dashboard_uuid: dashboardUuid,
             user_uuid: SEED_ORG_1_ADMIN.user_uuid,
@@ -434,11 +439,6 @@ describe('direct access read models PostgreSQL integration', () => {
             group_uuid: groupUuid,
             user_id: principal.userId,
         });
-        await transaction(ProjectGroupAccessTableName).insert({
-            project_uuid: projectUuid,
-            group_uuid: groupUuid,
-            role: ProjectMemberRole.VIEWER,
-        });
 
         await expect(
             model.getUserAccess([dashboardUuid], principal.userUuid),
@@ -453,6 +453,33 @@ describe('direct access read models PostgreSQL integration', () => {
         await expect(
             model.getUserAccess([dashboardUuid], principal.userUuid),
         ).resolves.toEqual({});
+    });
+
+    it('makes a group grant inert after the group loses project access', async () => {
+        const principal = await createMemberPrincipal();
+        await transaction(ProjectMembershipsTableName).insert({
+            project_id: projectId,
+            user_id: principal.userId,
+            role: ProjectMemberRole.VIEWER,
+        });
+        await transaction(GroupMembershipTableName).insert({
+            organization_id: organizationId,
+            group_uuid: groupUuid,
+            user_id: principal.userId,
+        });
+
+        await expect(
+            model.getUserAccess([dashboardUuid], principal.userUuid),
+        ).resolves.toHaveProperty(`${dashboardUuid}.groupRoles`, [
+            SpaceMemberRole.ADMIN,
+        ]);
+
+        await transaction(ProjectGroupAccessTableName)
+            .where({ project_uuid: projectUuid, group_uuid: groupUuid })
+            .delete();
+        await expect(
+            model.getUserAccess([dashboardUuid], principal.userUuid),
+        ).resolves.toHaveProperty(`${dashboardUuid}.groupRoles`, []);
     });
 
     it('accepts primary and extra organization custom-role access paths', async () => {

--- a/packages/backend/src/models/DirectAccessModels.integration.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.integration.test.ts
@@ -1,0 +1,490 @@
+import {
+    ChartKind,
+    OrganizationMemberRole,
+    ProjectMemberRole,
+    SEED_ORG_1_ADMIN,
+    SEED_PROJECT,
+    SpaceMemberRole,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { randomUUID } from 'node:crypto';
+import {
+    AppGroupAccessTableName,
+    AppUserAccessTableName,
+} from '../database/entities/appAccess';
+import { AppsTableName } from '../database/entities/apps';
+import {
+    DashboardGroupAccessTableName,
+    DashboardUserAccessTableName,
+} from '../database/entities/dashboardAccess';
+import { DashboardsTableName } from '../database/entities/dashboards';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
+import { ProjectTableName } from '../database/entities/projects';
+import { RolesTableName } from '../database/entities/roles';
+import {
+    SavedChartGroupAccessTableName,
+    SavedChartUserAccessTableName,
+} from '../database/entities/savedChartAccess';
+import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { SavedSqlTableName } from '../database/entities/savedSql';
+import {
+    SavedSqlGroupAccessTableName,
+    SavedSqlUserAccessTableName,
+} from '../database/entities/savedSqlAccess';
+import { SpaceTableName } from '../database/entities/spaces';
+import { UserTableName } from '../database/entities/users';
+import { getTestContext } from '../vitest.setup.integration';
+import { AppAccessModel } from './AppAccessModel';
+import { DashboardAccessModel } from './DashboardAccessModel';
+import { type DirectAccess } from './directAccessModelUtils';
+import { SavedChartAccessModel } from './SavedChartAccessModel';
+import { SavedSqlAccessModel } from './SavedSqlAccessModel';
+
+type AccessModel = {
+    getUserAccess(
+        resourceUuids: string[],
+        userUuid: string,
+    ): Promise<Record<string, DirectAccess>>;
+};
+
+describe('direct access read models PostgreSQL integration', () => {
+    let database: Knex;
+    let transaction: Knex.Transaction;
+    let model: DashboardAccessModel;
+    let dashboardUuid: string;
+    let savedChartUuid: string;
+    let savedSqlUuid: string;
+    let appUuid: string;
+    let groupUuid: string;
+    let userId: number;
+    let organizationId: number;
+    let organizationUuid: string;
+    let projectId: number;
+    let projectUuid: string;
+    let spaceId: number;
+    let spaceUuid: string;
+
+    beforeAll(() => {
+        database = getTestContext().db;
+    });
+
+    beforeEach(async () => {
+        transaction = await database.transaction();
+        model = new DashboardAccessModel(transaction);
+
+        const projectSpace = await transaction(SpaceTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .select(
+                `${SpaceTableName}.space_id`,
+                `${SpaceTableName}.space_uuid`,
+                `${ProjectTableName}.project_id`,
+                `${ProjectTableName}.project_uuid`,
+                `${ProjectTableName}.organization_id`,
+                `${OrganizationTableName}.organization_uuid`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(
+                `${ProjectTableName}.project_uuid`,
+                SEED_PROJECT.project_uuid,
+            )
+            .first();
+        if (!projectSpace) {
+            throw new Error('Seed project space not found');
+        }
+        organizationId = projectSpace.organization_id;
+        organizationUuid = projectSpace.organization_uuid;
+        projectId = projectSpace.project_id;
+        projectUuid = projectSpace.project_uuid;
+        spaceId = projectSpace.space_id;
+        spaceUuid = projectSpace.space_uuid;
+
+        const user = await transaction(UserTableName)
+            .where('user_uuid', SEED_ORG_1_ADMIN.user_uuid)
+            .select('user_id')
+            .first();
+        if (!user) {
+            throw new Error('Seed user not found');
+        }
+        userId = user.user_id;
+
+        const [dashboard] = await transaction(DashboardsTableName)
+            .insert({
+                project_uuid: projectSpace.project_uuid,
+                name: `Direct access dashboard ${randomUUID()}`,
+                description: undefined,
+                space_id: projectSpace.space_id,
+                slug: `direct-access-dashboard-${randomUUID()}`,
+            })
+            .returning('dashboard_uuid');
+        dashboardUuid = dashboard.dashboard_uuid;
+
+        const [savedChart] = await transaction(SavedChartsTableName)
+            .insert({
+                project_uuid: projectUuid,
+                space_id: spaceId,
+                dashboard_uuid: null,
+                name: `Direct access chart ${randomUUID()}`,
+                description: undefined,
+                last_version_chart_kind: ChartKind.VERTICAL_BAR,
+                last_version_updated_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                color_palette_uuid: null,
+                slug: `direct-access-chart-${randomUUID()}`,
+            })
+            .returning('saved_query_uuid');
+        savedChartUuid = savedChart.saved_query_uuid;
+
+        const [savedSql] = await transaction(SavedSqlTableName)
+            .insert({
+                project_uuid: projectUuid,
+                space_uuid: spaceUuid,
+                dashboard_uuid: null,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                name: `Direct access SQL ${randomUUID()}`,
+                description: null,
+                slug: `direct-access-sql-${randomUUID()}`,
+            })
+            .returning('saved_sql_uuid');
+        savedSqlUuid = savedSql.saved_sql_uuid;
+
+        const [app] = await transaction(AppsTableName)
+            .insert({
+                project_uuid: projectUuid,
+                space_uuid: spaceUuid,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                name: `Direct access app ${randomUUID()}`,
+                description: '',
+                slug: `direct-access-app-${randomUUID()}`,
+            })
+            .returning('app_id');
+        appUuid = app.app_id;
+
+        const [group] = await transaction(GroupTableName)
+            .insert({
+                organization_id: projectSpace.organization_id,
+                name: `Direct access group ${randomUUID()}`,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                updated_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })
+            .returning('group_uuid');
+        groupUuid = group.group_uuid;
+
+        await transaction(GroupMembershipTableName).insert({
+            organization_id: projectSpace.organization_id,
+            group_uuid: groupUuid,
+            user_id: userId,
+        });
+        await transaction(DashboardUserAccessTableName).insert({
+            dashboard_uuid: dashboardUuid,
+            user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            space_role: SpaceMemberRole.VIEWER,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        await transaction(DashboardGroupAccessTableName).insert({
+            dashboard_uuid: dashboardUuid,
+            group_uuid: groupUuid,
+            space_role: SpaceMemberRole.ADMIN,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        await transaction(SavedChartUserAccessTableName).insert({
+            saved_chart_uuid: savedChartUuid,
+            user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            space_role: SpaceMemberRole.VIEWER,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        await transaction(SavedChartGroupAccessTableName).insert({
+            saved_chart_uuid: savedChartUuid,
+            group_uuid: groupUuid,
+            space_role: SpaceMemberRole.ADMIN,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        await transaction(SavedSqlUserAccessTableName).insert({
+            saved_sql_uuid: savedSqlUuid,
+            user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            space_role: SpaceMemberRole.VIEWER,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        await transaction(SavedSqlGroupAccessTableName).insert({
+            saved_sql_uuid: savedSqlUuid,
+            group_uuid: groupUuid,
+            space_role: SpaceMemberRole.ADMIN,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        await transaction(AppUserAccessTableName).insert({
+            app_uuid: appUuid,
+            user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            space_role: SpaceMemberRole.VIEWER,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        await transaction(AppGroupAccessTableName).insert({
+            app_uuid: appUuid,
+            group_uuid: groupUuid,
+            space_role: SpaceMemberRole.ADMIN,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+    });
+
+    afterEach(async () => {
+        if (!transaction.isCompleted()) {
+            await transaction.rollback();
+        }
+    });
+
+    const createMemberPrincipal = async (roleUuid?: string) => {
+        const userUuid = randomUUID();
+        const [user] = await transaction(UserTableName)
+            .insert({
+                user_uuid: userUuid,
+                first_name: 'Direct',
+                last_name: 'Principal',
+                is_marketing_opted_in: false,
+                is_tracking_anonymized: false,
+                is_setup_complete: true,
+                is_active: true,
+            })
+            .returning('user_id');
+        await transaction(OrganizationMembershipsTableName).insert({
+            organization_id: organizationId,
+            user_id: user.user_id,
+            role: OrganizationMemberRole.MEMBER,
+            role_uuid: roleUuid,
+        });
+        await transaction(DashboardUserAccessTableName).insert({
+            dashboard_uuid: dashboardUuid,
+            user_uuid: userUuid,
+            space_role: SpaceMemberRole.EDITOR,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        return { userId: user.user_id, userUuid };
+    };
+
+    it('loads every concrete resource in one statement with derived tenancy', async () => {
+        const cases: Array<{
+            model: AccessModel;
+            resourceUuid: string;
+            accessTable: string;
+        }> = [
+            {
+                model,
+                resourceUuid: dashboardUuid,
+                accessTable: DashboardUserAccessTableName,
+            },
+            {
+                model: new SavedChartAccessModel(transaction),
+                resourceUuid: savedChartUuid,
+                accessTable: SavedChartUserAccessTableName,
+            },
+            {
+                model: new SavedSqlAccessModel(transaction),
+                resourceUuid: savedSqlUuid,
+                accessTable: SavedSqlUserAccessTableName,
+            },
+            {
+                model: new AppAccessModel(transaction),
+                resourceUuid: appUuid,
+                accessTable: AppUserAccessTableName,
+            },
+        ];
+
+        await Promise.all(
+            cases.map(async (testCase) => {
+                let accessQueryCount = 0;
+                const countAccessQueries = ({ sql }: { sql: string }) => {
+                    if (sql.includes(testCase.accessTable)) {
+                        accessQueryCount += 1;
+                    }
+                };
+                transaction.on('query', countAccessQueries);
+                const result = await testCase.model.getUserAccess(
+                    [testCase.resourceUuid, testCase.resourceUuid],
+                    SEED_ORG_1_ADMIN.user_uuid,
+                );
+                transaction.removeListener('query', countAccessQueries);
+
+                expect(result[testCase.resourceUuid]).toEqual({
+                    organizationUuid,
+                    projectUuid,
+                    userRole: SpaceMemberRole.VIEWER,
+                    groupRoles: [SpaceMemberRole.ADMIN],
+                });
+                expect(accessQueryCount).toBe(1);
+            }),
+        );
+    });
+
+    it('excludes dashboard-owned chart definitions', async () => {
+        const [savedChart] = await transaction(SavedChartsTableName)
+            .insert({
+                project_uuid: projectUuid,
+                space_id: null,
+                dashboard_uuid: dashboardUuid,
+                name: `Dashboard chart ${randomUUID()}`,
+                description: undefined,
+                last_version_chart_kind: ChartKind.VERTICAL_BAR,
+                last_version_updated_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                color_palette_uuid: null,
+                slug: `dashboard-chart-${randomUUID()}`,
+            })
+            .returning('saved_query_uuid');
+        const [savedSql] = await transaction(SavedSqlTableName)
+            .insert({
+                project_uuid: projectUuid,
+                space_uuid: null,
+                dashboard_uuid: dashboardUuid,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                name: `Dashboard SQL ${randomUUID()}`,
+                description: null,
+                slug: `dashboard-sql-${randomUUID()}`,
+            })
+            .returning('saved_sql_uuid');
+        await transaction(SavedChartUserAccessTableName).insert({
+            saved_chart_uuid: savedChart.saved_query_uuid,
+            user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            space_role: SpaceMemberRole.ADMIN,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        await transaction(SavedSqlUserAccessTableName).insert({
+            saved_sql_uuid: savedSql.saved_sql_uuid,
+            user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            space_role: SpaceMemberRole.ADMIN,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+
+        await expect(
+            new SavedChartAccessModel(transaction).getUserAccess(
+                [savedChart.saved_query_uuid],
+                SEED_ORG_1_ADMIN.user_uuid,
+            ),
+        ).resolves.toEqual({});
+        await expect(
+            new SavedSqlAccessModel(transaction).getUserAccess(
+                [savedSql.saved_sql_uuid],
+                SEED_ORG_1_ADMIN.user_uuid,
+            ),
+        ).resolves.toEqual({});
+    });
+
+    it('makes a group grant inert immediately after membership removal', async () => {
+        await transaction(GroupMembershipTableName)
+            .where({ group_uuid: groupUuid, user_id: userId })
+            .delete();
+
+        await expect(
+            model.getUserAccess([dashboardUuid], SEED_ORG_1_ADMIN.user_uuid),
+        ).resolves.toMatchObject({
+            [dashboardUuid]: {
+                userRole: SpaceMemberRole.VIEWER,
+                groupRoles: [],
+            },
+        });
+    });
+
+    it('makes direct grants inert after project removal or deactivation', async () => {
+        const principal = await createMemberPrincipal();
+        await transaction(ProjectMembershipsTableName).insert({
+            project_id: projectId,
+            user_id: principal.userId,
+            role: ProjectMemberRole.VIEWER,
+        });
+
+        await expect(
+            model.getUserAccess([dashboardUuid], principal.userUuid),
+        ).resolves.toHaveProperty(
+            `${dashboardUuid}.userRole`,
+            SpaceMemberRole.EDITOR,
+        );
+
+        await transaction(ProjectMembershipsTableName)
+            .where({ project_id: projectId, user_id: principal.userId })
+            .delete();
+        await expect(
+            model.getUserAccess([dashboardUuid], principal.userUuid),
+        ).resolves.toEqual({});
+
+        await transaction(ProjectMembershipsTableName).insert({
+            project_id: projectId,
+            user_id: principal.userId,
+            role: ProjectMemberRole.VIEWER,
+        });
+        await transaction(UserTableName)
+            .where('user_id', principal.userId)
+            .update({ is_active: false });
+        await expect(
+            model.getUserAccess([dashboardUuid], principal.userUuid),
+        ).resolves.toEqual({});
+    });
+
+    it('accepts current project-group access and invalidates it on removal', async () => {
+        const principal = await createMemberPrincipal();
+        await transaction(GroupMembershipTableName).insert({
+            organization_id: organizationId,
+            group_uuid: groupUuid,
+            user_id: principal.userId,
+        });
+        await transaction(ProjectGroupAccessTableName).insert({
+            project_uuid: projectUuid,
+            group_uuid: groupUuid,
+            role: ProjectMemberRole.VIEWER,
+        });
+
+        await expect(
+            model.getUserAccess([dashboardUuid], principal.userUuid),
+        ).resolves.toHaveProperty(
+            `${dashboardUuid}.userRole`,
+            SpaceMemberRole.EDITOR,
+        );
+
+        await transaction(GroupMembershipTableName)
+            .where({ group_uuid: groupUuid, user_id: principal.userId })
+            .delete();
+        await expect(
+            model.getUserAccess([dashboardUuid], principal.userUuid),
+        ).resolves.toEqual({});
+    });
+
+    it('accepts primary and extra organization custom-role access paths', async () => {
+        const [role] = await transaction(RolesTableName)
+            .insert({
+                name: `Direct access role ${randomUUID()}`,
+                description: null,
+                level: 'organization',
+                organization_uuid: organizationUuid,
+                created_by: SEED_ORG_1_ADMIN.user_uuid,
+            })
+            .returning('role_uuid');
+        const principal = await createMemberPrincipal(role.role_uuid);
+
+        await expect(
+            model.getUserAccess([dashboardUuid], principal.userUuid),
+        ).resolves.toHaveProperty(
+            `${dashboardUuid}.userRole`,
+            SpaceMemberRole.EDITOR,
+        );
+
+        const extraRolePrincipal = await createMemberPrincipal();
+        await transaction(OrganizationMembershipCustomRolesTableName).insert({
+            organization_id: organizationId,
+            user_id: extraRolePrincipal.userId,
+            role_uuid: role.role_uuid,
+        });
+        await expect(
+            model.getUserAccess([dashboardUuid], extraRolePrincipal.userUuid),
+        ).resolves.toHaveProperty(
+            `${dashboardUuid}.userRole`,
+            SpaceMemberRole.EDITOR,
+        );
+    });
+});

--- a/packages/backend/src/models/DirectAccessModels.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.test.ts
@@ -5,30 +5,18 @@ import {
     AppGroupAccessTableName,
     AppUserAccessTableName,
 } from '../database/entities/appAccess';
-import { AppsTableName } from '../database/entities/apps';
 import {
     DashboardGroupAccessTableName,
     DashboardUserAccessTableName,
 } from '../database/entities/dashboardAccess';
-import { DashboardsTableName } from '../database/entities/dashboards';
-import { GroupMembershipTableName } from '../database/entities/groupMemberships';
-import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
-import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
-import { OrganizationTableName } from '../database/entities/organizations';
-import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
-import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
-import { ProjectTableName } from '../database/entities/projects';
 import {
     SavedChartGroupAccessTableName,
     SavedChartUserAccessTableName,
 } from '../database/entities/savedChartAccess';
-import { SavedChartsTableName } from '../database/entities/savedCharts';
-import { SavedSqlTableName } from '../database/entities/savedSql';
 import {
     SavedSqlGroupAccessTableName,
     SavedSqlUserAccessTableName,
 } from '../database/entities/savedSqlAccess';
-import { SpaceTableName } from '../database/entities/spaces';
 import { AppAccessModel } from './AppAccessModel';
 import { DashboardAccessModel } from './DashboardAccessModel';
 import { type DirectAccess } from './directAccessModelUtils';
@@ -52,35 +40,30 @@ const modelCases: Array<{
     model: AccessModel;
     userAccessTable: string;
     groupAccessTable: string;
-    resourceTable: string;
 }> = [
     {
         name: 'dashboard',
         model: new DashboardAccessModel(database),
         userAccessTable: DashboardUserAccessTableName,
         groupAccessTable: DashboardGroupAccessTableName,
-        resourceTable: DashboardsTableName,
     },
     {
         name: 'saved chart',
         model: new SavedChartAccessModel(database),
         userAccessTable: SavedChartUserAccessTableName,
         groupAccessTable: SavedChartGroupAccessTableName,
-        resourceTable: SavedChartsTableName,
     },
     {
         name: 'saved SQL',
         model: new SavedSqlAccessModel(database),
         userAccessTable: SavedSqlUserAccessTableName,
         groupAccessTable: SavedSqlGroupAccessTableName,
-        resourceTable: SavedSqlTableName,
     },
     {
         name: 'app',
         model: new AppAccessModel(database),
         userAccessTable: AppUserAccessTableName,
         groupAccessTable: AppGroupAccessTableName,
-        resourceTable: AppsTableName,
     },
 ];
 
@@ -106,8 +89,8 @@ describe('direct access read models', () => {
     );
 
     it.each(modelCases)(
-        '$name resolves direct user and current group roles in one query',
-        async ({ model, userAccessTable, groupAccessTable, resourceTable }) => {
+        '$name resolves direct user and current group roles',
+        async ({ model, userAccessTable }) => {
             tracker.on.select(userAccessTable).responseOnce([
                 {
                     resourceUuid: 'resource-a',
@@ -145,75 +128,6 @@ describe('direct access read models', () => {
                     groupRoles: [SpaceMemberRole.EDITOR, SpaceMemberRole.ADMIN],
                 },
             });
-
-            expect(tracker.history.select).toHaveLength(1);
-            const [query] = tracker.history.select;
-            expect(query.sql).toContain(`"${userAccessTable}"`);
-            expect(query.sql).toContain(`"${groupAccessTable}"`);
-            expect(query.sql).toContain(`"${resourceTable}"`);
-            expect(query.sql).toContain(`"${GroupMembershipTableName}"`);
-            expect(query.sql).toContain(
-                `"${OrganizationMembershipsTableName}"`,
-            );
-            expect(query.sql).toContain(
-                `"${OrganizationMembershipCustomRolesTableName}"`,
-            );
-            expect(query.sql).toContain(`"${ProjectMembershipsTableName}"`);
-            expect(query.sql).toContain(`"${ProjectGroupAccessTableName}"`);
-            expect(query.sql).toContain(`"${ProjectTableName}"`);
-            expect(query.sql).toContain(`"${OrganizationTableName}"`);
-            expect(query.sql).toContain('union all');
-            expect(query.bindings).toContain('user-uuid');
-            expect(
-                query.bindings.filter((binding) => binding === 'resource-a'),
-            ).toHaveLength(2);
-            expect(query.bindings).toContain('resource-without-grants');
-            expect(query.sql).toContain(
-                `"${GroupMembershipTableName}"."organization_id" = "${ProjectTableName}"."organization_id"`,
-            );
-            expect(query.sql).toContain(`"users"."is_active" = TRUE`);
-        },
-    );
-
-    it('derives dashboard tenancy through its parent space', async () => {
-        tracker.on.select(DashboardUserAccessTableName).responseOnce([]);
-
-        await new DashboardAccessModel(database).getUserAccess(
-            ['dashboard-uuid'],
-            'user-uuid',
-        );
-
-        const [query] = tracker.history.select;
-        expect(query.sql).toContain(`"${SpaceTableName}"`);
-        expect(query.sql).toContain(
-            `"${SpaceTableName}"."space_id" = "${DashboardsTableName}"."space_id"`,
-        );
-    });
-
-    it.each([
-        {
-            name: 'saved chart',
-            model: new SavedChartAccessModel(database),
-            userAccessTable: SavedChartUserAccessTableName,
-            resourceTable: SavedChartsTableName,
-        },
-        {
-            name: 'saved SQL',
-            model: new SavedSqlAccessModel(database),
-            userAccessTable: SavedSqlUserAccessTableName,
-            resourceTable: SavedSqlTableName,
-        },
-    ])(
-        '$name excludes dashboard-owned resources',
-        async ({ model, userAccessTable, resourceTable }) => {
-            tracker.on.select(userAccessTable).responseOnce([]);
-
-            await model.getUserAccess(['resource-uuid'], 'user-uuid');
-
-            const [query] = tracker.history.select;
-            expect(query.sql).toContain(
-                `"${resourceTable}"."dashboard_uuid" is null`,
-            );
         },
     );
 });

--- a/packages/backend/src/models/DirectAccessModels.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.test.ts
@@ -1,0 +1,219 @@
+import { SpaceMemberRole } from '@lightdash/common';
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import {
+    AppGroupAccessTableName,
+    AppUserAccessTableName,
+} from '../database/entities/appAccess';
+import { AppsTableName } from '../database/entities/apps';
+import {
+    DashboardGroupAccessTableName,
+    DashboardUserAccessTableName,
+} from '../database/entities/dashboardAccess';
+import { DashboardsTableName } from '../database/entities/dashboards';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
+import { ProjectTableName } from '../database/entities/projects';
+import {
+    SavedChartGroupAccessTableName,
+    SavedChartUserAccessTableName,
+} from '../database/entities/savedChartAccess';
+import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { SavedSqlTableName } from '../database/entities/savedSql';
+import {
+    SavedSqlGroupAccessTableName,
+    SavedSqlUserAccessTableName,
+} from '../database/entities/savedSqlAccess';
+import { SpaceTableName } from '../database/entities/spaces';
+import { AppAccessModel } from './AppAccessModel';
+import { DashboardAccessModel } from './DashboardAccessModel';
+import { type DirectAccess } from './directAccessModelUtils';
+import { SavedChartAccessModel } from './SavedChartAccessModel';
+import { SavedSqlAccessModel } from './SavedSqlAccessModel';
+
+type AccessResult = Record<string, DirectAccess>;
+
+type AccessModel = {
+    getUserAccess(
+        resourceUuids: string[],
+        userUuid: string,
+        options?: { trx?: Knex },
+    ): Promise<AccessResult>;
+};
+
+const database = knex({ client: MockClient, dialect: 'pg' });
+
+const modelCases: Array<{
+    name: string;
+    model: AccessModel;
+    userAccessTable: string;
+    groupAccessTable: string;
+    resourceTable: string;
+}> = [
+    {
+        name: 'dashboard',
+        model: new DashboardAccessModel(database),
+        userAccessTable: DashboardUserAccessTableName,
+        groupAccessTable: DashboardGroupAccessTableName,
+        resourceTable: DashboardsTableName,
+    },
+    {
+        name: 'saved chart',
+        model: new SavedChartAccessModel(database),
+        userAccessTable: SavedChartUserAccessTableName,
+        groupAccessTable: SavedChartGroupAccessTableName,
+        resourceTable: SavedChartsTableName,
+    },
+    {
+        name: 'saved SQL',
+        model: new SavedSqlAccessModel(database),
+        userAccessTable: SavedSqlUserAccessTableName,
+        groupAccessTable: SavedSqlGroupAccessTableName,
+        resourceTable: SavedSqlTableName,
+    },
+    {
+        name: 'app',
+        model: new AppAccessModel(database),
+        userAccessTable: AppUserAccessTableName,
+        groupAccessTable: AppGroupAccessTableName,
+        resourceTable: AppsTableName,
+    },
+];
+
+describe('direct access read models', () => {
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it.each(modelCases)(
+        '$name does not query for an empty resource list',
+        async ({ model }) => {
+            await expect(model.getUserAccess([], 'user-uuid')).resolves.toEqual(
+                {},
+            );
+            expect(tracker.history.select).toHaveLength(0);
+        },
+    );
+
+    it.each(modelCases)(
+        '$name resolves direct user and current group roles in one query',
+        async ({ model, userAccessTable, groupAccessTable, resourceTable }) => {
+            tracker.on.select(userAccessTable).responseOnce([
+                {
+                    resourceUuid: 'resource-a',
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    role: SpaceMemberRole.VIEWER,
+                    groupUuid: null,
+                },
+                {
+                    resourceUuid: 'resource-a',
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    role: SpaceMemberRole.EDITOR,
+                    groupUuid: 'group-a',
+                },
+                {
+                    resourceUuid: 'resource-a',
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    role: SpaceMemberRole.ADMIN,
+                    groupUuid: 'group-b',
+                },
+            ]);
+
+            await expect(
+                model.getUserAccess(
+                    ['resource-a', 'resource-without-grants', 'resource-a'],
+                    'user-uuid',
+                ),
+            ).resolves.toEqual({
+                'resource-a': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    userRole: SpaceMemberRole.VIEWER,
+                    groupRoles: [SpaceMemberRole.EDITOR, SpaceMemberRole.ADMIN],
+                },
+            });
+
+            expect(tracker.history.select).toHaveLength(1);
+            const [query] = tracker.history.select;
+            expect(query.sql).toContain(`"${userAccessTable}"`);
+            expect(query.sql).toContain(`"${groupAccessTable}"`);
+            expect(query.sql).toContain(`"${resourceTable}"`);
+            expect(query.sql).toContain(`"${GroupMembershipTableName}"`);
+            expect(query.sql).toContain(
+                `"${OrganizationMembershipsTableName}"`,
+            );
+            expect(query.sql).toContain(
+                `"${OrganizationMembershipCustomRolesTableName}"`,
+            );
+            expect(query.sql).toContain(`"${ProjectMembershipsTableName}"`);
+            expect(query.sql).toContain(`"${ProjectGroupAccessTableName}"`);
+            expect(query.sql).toContain(`"${ProjectTableName}"`);
+            expect(query.sql).toContain(`"${OrganizationTableName}"`);
+            expect(query.sql).toContain('union all');
+            expect(query.bindings).toContain('user-uuid');
+            expect(
+                query.bindings.filter((binding) => binding === 'resource-a'),
+            ).toHaveLength(2);
+            expect(query.bindings).toContain('resource-without-grants');
+            expect(query.sql).toContain(
+                `"${GroupMembershipTableName}"."organization_id" = "${ProjectTableName}"."organization_id"`,
+            );
+            expect(query.sql).toContain(`"users"."is_active" = TRUE`);
+        },
+    );
+
+    it('derives dashboard tenancy through its parent space', async () => {
+        tracker.on.select(DashboardUserAccessTableName).responseOnce([]);
+
+        await new DashboardAccessModel(database).getUserAccess(
+            ['dashboard-uuid'],
+            'user-uuid',
+        );
+
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain(`"${SpaceTableName}"`);
+        expect(query.sql).toContain(
+            `"${SpaceTableName}"."space_id" = "${DashboardsTableName}"."space_id"`,
+        );
+    });
+
+    it.each([
+        {
+            name: 'saved chart',
+            model: new SavedChartAccessModel(database),
+            userAccessTable: SavedChartUserAccessTableName,
+            resourceTable: SavedChartsTableName,
+        },
+        {
+            name: 'saved SQL',
+            model: new SavedSqlAccessModel(database),
+            userAccessTable: SavedSqlUserAccessTableName,
+            resourceTable: SavedSqlTableName,
+        },
+    ])(
+        '$name excludes dashboard-owned resources',
+        async ({ model, userAccessTable, resourceTable }) => {
+            tracker.on.select(userAccessTable).responseOnce([]);
+
+            await model.getUserAccess(['resource-uuid'], 'user-uuid');
+
+            const [query] = tracker.history.select;
+            expect(query.sql).toContain(
+                `"${resourceTable}"."dashboard_uuid" is null`,
+            );
+        },
+    );
+});

--- a/packages/backend/src/models/SavedChartAccessModel.ts
+++ b/packages/backend/src/models/SavedChartAccessModel.ts
@@ -10,6 +10,7 @@ import {
 import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { UserTableName } from '../database/entities/users';
 import {
+    getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
     type DirectAccess,
@@ -135,6 +136,12 @@ export class SavedChartAccessModel {
                         `${GroupMembershipTableName}.organization_id`,
                         `${ProjectTableName}.organization_id`,
                     ])
+                    .where(
+                        getActiveGrantedGroupPredicate(
+                            trx,
+                            SavedChartGroupAccessTableName,
+                        ),
+                    )
                     .whereNull(`${SavedChartsTableName}.dashboard_uuid`)
                     .whereNull(`${SavedChartsTableName}.deleted_at`),
             );

--- a/packages/backend/src/models/SavedChartAccessModel.ts
+++ b/packages/backend/src/models/SavedChartAccessModel.ts
@@ -132,10 +132,10 @@ export class SavedChartAccessModel {
                     )
                     .where(`${UserTableName}.user_uuid`, userUuid)
                     .where(getActiveProjectMemberPredicate(trx))
-                    .whereRaw('?? = ??', [
+                    .where(
                         `${GroupMembershipTableName}.organization_id`,
-                        `${ProjectTableName}.organization_id`,
-                    ])
+                        trx.ref(`${ProjectTableName}.organization_id`),
+                    )
                     .where(
                         getActiveGrantedGroupPredicate(
                             trx,

--- a/packages/backend/src/models/SavedChartAccessModel.ts
+++ b/packages/backend/src/models/SavedChartAccessModel.ts
@@ -1,0 +1,144 @@
+import { type Knex } from 'knex';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectTableName } from '../database/entities/projects';
+import {
+    SavedChartGroupAccessTableName,
+    SavedChartUserAccessTableName,
+} from '../database/entities/savedChartAccess';
+import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { UserTableName } from '../database/entities/users';
+import {
+    getActiveProjectMemberPredicate,
+    groupDirectAccessRows,
+    type DirectAccess,
+    type DirectAccessRow,
+} from './directAccessModelUtils';
+
+export type SavedChartDirectAccess = DirectAccess;
+
+export class SavedChartAccessModel {
+    constructor(private readonly database: Knex) {}
+
+    async getUserAccess(
+        savedChartUuids: string[],
+        userUuid: string,
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<Record<string, SavedChartDirectAccess>> {
+        const uniqueSavedChartUuids = [...new Set(savedChartUuids)];
+        if (uniqueSavedChartUuids.length === 0) {
+            return {};
+        }
+
+        const rows: DirectAccessRow[] = await trx(SavedChartUserAccessTableName)
+            .select({
+                resourceUuid: `${SavedChartUserAccessTableName}.saved_chart_uuid`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+                role: `${SavedChartUserAccessTableName}.space_role`,
+                groupUuid: trx.raw('NULL'),
+            })
+            .innerJoin(
+                SavedChartsTableName,
+                `${SavedChartsTableName}.saved_query_uuid`,
+                `${SavedChartUserAccessTableName}.saved_chart_uuid`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${SavedChartsTableName}.project_uuid`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${SavedChartUserAccessTableName}.user_uuid`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                function joinCurrentOrganizationMembership() {
+                    this.on(
+                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOn(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    );
+                },
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .whereIn(
+                `${SavedChartUserAccessTableName}.saved_chart_uuid`,
+                uniqueSavedChartUuids,
+            )
+            .where(`${SavedChartUserAccessTableName}.user_uuid`, userUuid)
+            .where(getActiveProjectMemberPredicate(trx))
+            .whereNull(`${SavedChartsTableName}.dashboard_uuid`)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .unionAll(
+                trx(SavedChartGroupAccessTableName)
+                    .select({
+                        resourceUuid: `${SavedChartGroupAccessTableName}.saved_chart_uuid`,
+                        organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                        projectUuid: `${ProjectTableName}.project_uuid`,
+                        role: `${SavedChartGroupAccessTableName}.space_role`,
+                        groupUuid: `${SavedChartGroupAccessTableName}.group_uuid`,
+                    })
+                    .innerJoin(
+                        SavedChartsTableName,
+                        `${SavedChartsTableName}.saved_query_uuid`,
+                        `${SavedChartGroupAccessTableName}.saved_chart_uuid`,
+                    )
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_uuid`,
+                        `${SavedChartsTableName}.project_uuid`,
+                    )
+                    .innerJoin(
+                        OrganizationTableName,
+                        `${OrganizationTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    )
+                    .innerJoin(
+                        GroupMembershipTableName,
+                        `${GroupMembershipTableName}.group_uuid`,
+                        `${SavedChartGroupAccessTableName}.group_uuid`,
+                    )
+                    .innerJoin(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${GroupMembershipTableName}.user_id`,
+                    )
+                    .innerJoin(
+                        OrganizationMembershipsTableName,
+                        function joinCurrentOrganizationMembership() {
+                            this.on(
+                                `${OrganizationMembershipsTableName}.user_id`,
+                                `${UserTableName}.user_id`,
+                            ).andOn(
+                                `${OrganizationMembershipsTableName}.organization_id`,
+                                `${ProjectTableName}.organization_id`,
+                            );
+                        },
+                    )
+                    .whereIn(
+                        `${SavedChartGroupAccessTableName}.saved_chart_uuid`,
+                        uniqueSavedChartUuids,
+                    )
+                    .where(`${UserTableName}.user_uuid`, userUuid)
+                    .where(getActiveProjectMemberPredicate(trx))
+                    .whereRaw('?? = ??', [
+                        `${GroupMembershipTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    ])
+                    .whereNull(`${SavedChartsTableName}.dashboard_uuid`)
+                    .whereNull(`${SavedChartsTableName}.deleted_at`),
+            );
+
+        return groupDirectAccessRows(rows);
+    }
+}

--- a/packages/backend/src/models/SavedSqlAccessModel.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.ts
@@ -1,0 +1,144 @@
+import { type Knex } from 'knex';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectTableName } from '../database/entities/projects';
+import { SavedSqlTableName } from '../database/entities/savedSql';
+import {
+    SavedSqlGroupAccessTableName,
+    SavedSqlUserAccessTableName,
+} from '../database/entities/savedSqlAccess';
+import { UserTableName } from '../database/entities/users';
+import {
+    getActiveProjectMemberPredicate,
+    groupDirectAccessRows,
+    type DirectAccess,
+    type DirectAccessRow,
+} from './directAccessModelUtils';
+
+export type SavedSqlDirectAccess = DirectAccess;
+
+export class SavedSqlAccessModel {
+    constructor(private readonly database: Knex) {}
+
+    async getUserAccess(
+        savedSqlUuids: string[],
+        userUuid: string,
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<Record<string, SavedSqlDirectAccess>> {
+        const uniqueSavedSqlUuids = [...new Set(savedSqlUuids)];
+        if (uniqueSavedSqlUuids.length === 0) {
+            return {};
+        }
+
+        const rows: DirectAccessRow[] = await trx(SavedSqlUserAccessTableName)
+            .select({
+                resourceUuid: `${SavedSqlUserAccessTableName}.saved_sql_uuid`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+                role: `${SavedSqlUserAccessTableName}.space_role`,
+                groupUuid: trx.raw('NULL'),
+            })
+            .innerJoin(
+                SavedSqlTableName,
+                `${SavedSqlTableName}.saved_sql_uuid`,
+                `${SavedSqlUserAccessTableName}.saved_sql_uuid`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${SavedSqlTableName}.project_uuid`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${SavedSqlUserAccessTableName}.user_uuid`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                function joinCurrentOrganizationMembership() {
+                    this.on(
+                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOn(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    );
+                },
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .whereIn(
+                `${SavedSqlUserAccessTableName}.saved_sql_uuid`,
+                uniqueSavedSqlUuids,
+            )
+            .where(`${SavedSqlUserAccessTableName}.user_uuid`, userUuid)
+            .where(getActiveProjectMemberPredicate(trx))
+            .whereNull(`${SavedSqlTableName}.dashboard_uuid`)
+            .whereNull(`${SavedSqlTableName}.deleted_at`)
+            .unionAll(
+                trx(SavedSqlGroupAccessTableName)
+                    .select({
+                        resourceUuid: `${SavedSqlGroupAccessTableName}.saved_sql_uuid`,
+                        organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                        projectUuid: `${ProjectTableName}.project_uuid`,
+                        role: `${SavedSqlGroupAccessTableName}.space_role`,
+                        groupUuid: `${SavedSqlGroupAccessTableName}.group_uuid`,
+                    })
+                    .innerJoin(
+                        SavedSqlTableName,
+                        `${SavedSqlTableName}.saved_sql_uuid`,
+                        `${SavedSqlGroupAccessTableName}.saved_sql_uuid`,
+                    )
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_uuid`,
+                        `${SavedSqlTableName}.project_uuid`,
+                    )
+                    .innerJoin(
+                        OrganizationTableName,
+                        `${OrganizationTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    )
+                    .innerJoin(
+                        GroupMembershipTableName,
+                        `${GroupMembershipTableName}.group_uuid`,
+                        `${SavedSqlGroupAccessTableName}.group_uuid`,
+                    )
+                    .innerJoin(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${GroupMembershipTableName}.user_id`,
+                    )
+                    .innerJoin(
+                        OrganizationMembershipsTableName,
+                        function joinCurrentOrganizationMembership() {
+                            this.on(
+                                `${OrganizationMembershipsTableName}.user_id`,
+                                `${UserTableName}.user_id`,
+                            ).andOn(
+                                `${OrganizationMembershipsTableName}.organization_id`,
+                                `${ProjectTableName}.organization_id`,
+                            );
+                        },
+                    )
+                    .whereIn(
+                        `${SavedSqlGroupAccessTableName}.saved_sql_uuid`,
+                        uniqueSavedSqlUuids,
+                    )
+                    .where(`${UserTableName}.user_uuid`, userUuid)
+                    .where(getActiveProjectMemberPredicate(trx))
+                    .whereRaw('?? = ??', [
+                        `${GroupMembershipTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    ])
+                    .whereNull(`${SavedSqlTableName}.dashboard_uuid`)
+                    .whereNull(`${SavedSqlTableName}.deleted_at`),
+            );
+
+        return groupDirectAccessRows(rows);
+    }
+}

--- a/packages/backend/src/models/SavedSqlAccessModel.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.ts
@@ -10,6 +10,7 @@ import {
 } from '../database/entities/savedSqlAccess';
 import { UserTableName } from '../database/entities/users';
 import {
+    getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
     type DirectAccess,
@@ -135,6 +136,12 @@ export class SavedSqlAccessModel {
                         `${GroupMembershipTableName}.organization_id`,
                         `${ProjectTableName}.organization_id`,
                     ])
+                    .where(
+                        getActiveGrantedGroupPredicate(
+                            trx,
+                            SavedSqlGroupAccessTableName,
+                        ),
+                    )
                     .whereNull(`${SavedSqlTableName}.dashboard_uuid`)
                     .whereNull(`${SavedSqlTableName}.deleted_at`),
             );

--- a/packages/backend/src/models/SavedSqlAccessModel.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.ts
@@ -132,10 +132,10 @@ export class SavedSqlAccessModel {
                     )
                     .where(`${UserTableName}.user_uuid`, userUuid)
                     .where(getActiveProjectMemberPredicate(trx))
-                    .whereRaw('?? = ??', [
+                    .where(
                         `${GroupMembershipTableName}.organization_id`,
-                        `${ProjectTableName}.organization_id`,
-                    ])
+                        trx.ref(`${ProjectTableName}.organization_id`),
+                    )
                     .where(
                         getActiveGrantedGroupPredicate(
                             trx,

--- a/packages/backend/src/models/directAccessModelUtils.ts
+++ b/packages/backend/src/models/directAccessModelUtils.ts
@@ -51,53 +51,82 @@ export const groupDirectAccessRows = (
  * Direct grants cannot create project membership. This predicate keeps stored
  * grants inert unless the principal still has a current project access path.
  */
-export const getActiveProjectMemberPredicate = (trx: Knex): Knex.Raw =>
-    trx.raw(
-        `
-            ?? = TRUE AND (
-                ??.role != ?
-                OR ??.role_uuid IS NOT NULL
-                OR EXISTS (
-                    SELECT 1
-                    FROM ?? AS organization_extra_role
-                    WHERE organization_extra_role.user_id = ??.user_id
-                      AND organization_extra_role.organization_id = ??.organization_id
-                )
-                OR EXISTS (
-                    SELECT 1
-                    FROM ?? AS direct_project_membership
-                    WHERE direct_project_membership.user_id = ??.user_id
-                      AND direct_project_membership.project_id = ??.project_id
-                )
-                OR EXISTS (
-                    SELECT 1
-                    FROM ?? AS project_group_membership
-                    INNER JOIN ?? AS current_project_group_membership
-                        ON current_project_group_membership.group_uuid = project_group_membership.group_uuid
-                    WHERE project_group_membership.project_uuid = ??.project_uuid
-                      AND current_project_group_membership.user_id = ??.user_id
-                      AND current_project_group_membership.organization_id = ??.organization_id
-                )
-            )
-        `,
-        [
-            `${UserTableName}.is_active`,
-            OrganizationMembershipsTableName,
-            OrganizationMemberRole.MEMBER,
-            OrganizationMembershipsTableName,
-            OrganizationMembershipCustomRolesTableName,
-            UserTableName,
-            ProjectTableName,
-            ProjectMembershipsTableName,
-            UserTableName,
-            ProjectTableName,
-            ProjectGroupAccessTableName,
-            GroupMembershipTableName,
-            ProjectTableName,
-            UserTableName,
-            ProjectTableName,
-        ],
-    );
+export const getActiveProjectMemberPredicate =
+    (trx: Knex) =>
+    (predicate: Knex.QueryBuilder): void => {
+        void predicate
+            .where(`${UserTableName}.is_active`, true)
+            .andWhere((accessPath) => {
+                void accessPath
+                    .whereNot(
+                        `${OrganizationMembershipsTableName}.role`,
+                        OrganizationMemberRole.MEMBER,
+                    )
+                    .orWhereNotNull(
+                        `${OrganizationMembershipsTableName}.role_uuid`,
+                    )
+                    .orWhereExists((subquery) => {
+                        void subquery
+                            .select('*')
+                            .from({
+                                organization_extra_role:
+                                    OrganizationMembershipCustomRolesTableName,
+                            })
+                            .where(
+                                'organization_extra_role.user_id',
+                                trx.ref(`${UserTableName}.user_id`),
+                            )
+                            .where(
+                                'organization_extra_role.organization_id',
+                                trx.ref(`${ProjectTableName}.organization_id`),
+                            );
+                    })
+                    .orWhereExists((subquery) => {
+                        void subquery
+                            .select('*')
+                            .from({
+                                direct_project_membership:
+                                    ProjectMembershipsTableName,
+                            })
+                            .where(
+                                'direct_project_membership.user_id',
+                                trx.ref(`${UserTableName}.user_id`),
+                            )
+                            .where(
+                                'direct_project_membership.project_id',
+                                trx.ref(`${ProjectTableName}.project_id`),
+                            );
+                    })
+                    .orWhereExists((subquery) => {
+                        void subquery
+                            .select('*')
+                            .from({
+                                project_group_membership:
+                                    ProjectGroupAccessTableName,
+                            })
+                            .innerJoin(
+                                {
+                                    current_project_group_membership:
+                                        GroupMembershipTableName,
+                                },
+                                'current_project_group_membership.group_uuid',
+                                'project_group_membership.group_uuid',
+                            )
+                            .where(
+                                'project_group_membership.project_uuid',
+                                trx.ref(`${ProjectTableName}.project_uuid`),
+                            )
+                            .where(
+                                'current_project_group_membership.user_id',
+                                trx.ref(`${UserTableName}.user_id`),
+                            )
+                            .where(
+                                'current_project_group_membership.organization_id',
+                                trx.ref(`${ProjectTableName}.organization_id`),
+                            );
+                    });
+            });
+    };
 
 /**
  * A group grant is inert unless the granted group itself still holds current
@@ -105,18 +134,22 @@ export const getActiveProjectMemberPredicate = (trx: Knex): Knex.Raw =>
  * project group would keep working after the group is removed from the
  * project, for any member who retains a separate project access path.
  */
-export const getActiveGrantedGroupPredicate = (
-    trx: Knex,
-    groupAccessTable: string,
-): Knex.Raw =>
-    trx.raw(
-        `
-            EXISTS (
-                SELECT 1
-                FROM ?? AS granted_group_project_access
-                WHERE granted_group_project_access.group_uuid = ??.group_uuid
-                  AND granted_group_project_access.project_uuid = ??.project_uuid
-            )
-        `,
-        [ProjectGroupAccessTableName, groupAccessTable, ProjectTableName],
-    );
+export const getActiveGrantedGroupPredicate =
+    (trx: Knex, groupAccessTable: string) =>
+    (predicate: Knex.QueryBuilder): void => {
+        void predicate.whereExists((subquery) => {
+            void subquery
+                .select('*')
+                .from({
+                    granted_group_project_access: ProjectGroupAccessTableName,
+                })
+                .where(
+                    'granted_group_project_access.group_uuid',
+                    trx.ref(`${groupAccessTable}.group_uuid`),
+                )
+                .where(
+                    'granted_group_project_access.project_uuid',
+                    trx.ref(`${ProjectTableName}.project_uuid`),
+                );
+        });
+    };

--- a/packages/backend/src/models/directAccessModelUtils.ts
+++ b/packages/backend/src/models/directAccessModelUtils.ts
@@ -1,0 +1,100 @@
+import {
+    OrganizationMemberRole,
+    type SpaceMemberRole,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
+import { ProjectTableName } from '../database/entities/projects';
+import { UserTableName } from '../database/entities/users';
+
+export type DirectAccess = {
+    organizationUuid: string;
+    projectUuid: string;
+    userRole: SpaceMemberRole | null;
+    groupRoles: SpaceMemberRole[];
+};
+
+export type DirectAccessRow = {
+    resourceUuid: string;
+    organizationUuid: string;
+    projectUuid: string;
+    role: SpaceMemberRole;
+    groupUuid: string | null;
+};
+
+export const groupDirectAccessRows = (
+    rows: DirectAccessRow[],
+): Record<string, DirectAccess> => {
+    const accessByResource: Record<string, DirectAccess> = {};
+    for (const row of rows) {
+        const access = accessByResource[row.resourceUuid] ?? {
+            organizationUuid: row.organizationUuid,
+            projectUuid: row.projectUuid,
+            userRole: null,
+            groupRoles: [],
+        };
+        if (row.groupUuid === null) {
+            access.userRole = row.role;
+        } else {
+            access.groupRoles.push(row.role);
+        }
+        accessByResource[row.resourceUuid] = access;
+    }
+    return accessByResource;
+};
+
+/**
+ * Direct grants cannot create project membership. This predicate keeps stored
+ * grants inert unless the principal still has a current project access path.
+ */
+export const getActiveProjectMemberPredicate = (trx: Knex): Knex.Raw =>
+    trx.raw(
+        `
+            ?? = TRUE AND (
+                ??.role != ?
+                OR ??.role_uuid IS NOT NULL
+                OR EXISTS (
+                    SELECT 1
+                    FROM ?? AS organization_extra_role
+                    WHERE organization_extra_role.user_id = ??.user_id
+                      AND organization_extra_role.organization_id = ??.organization_id
+                )
+                OR EXISTS (
+                    SELECT 1
+                    FROM ?? AS direct_project_membership
+                    WHERE direct_project_membership.user_id = ??.user_id
+                      AND direct_project_membership.project_id = ??.project_id
+                )
+                OR EXISTS (
+                    SELECT 1
+                    FROM ?? AS project_group_membership
+                    INNER JOIN ?? AS current_project_group_membership
+                        ON current_project_group_membership.group_uuid = project_group_membership.group_uuid
+                    WHERE project_group_membership.project_uuid = ??.project_uuid
+                      AND current_project_group_membership.user_id = ??.user_id
+                      AND current_project_group_membership.organization_id = ??.organization_id
+                )
+            )
+        `,
+        [
+            `${UserTableName}.is_active`,
+            OrganizationMembershipsTableName,
+            OrganizationMemberRole.MEMBER,
+            OrganizationMembershipsTableName,
+            OrganizationMembershipCustomRolesTableName,
+            UserTableName,
+            ProjectTableName,
+            ProjectMembershipsTableName,
+            UserTableName,
+            ProjectTableName,
+            ProjectGroupAccessTableName,
+            GroupMembershipTableName,
+            ProjectTableName,
+            UserTableName,
+            ProjectTableName,
+        ],
+    );

--- a/packages/backend/src/models/directAccessModelUtils.ts
+++ b/packages/backend/src/models/directAccessModelUtils.ts
@@ -98,3 +98,25 @@ export const getActiveProjectMemberPredicate = (trx: Knex): Knex.Raw =>
             ProjectTableName,
         ],
     );
+
+/**
+ * A group grant is inert unless the granted group itself still holds current
+ * access to the resource's project. Without this predicate, a grant made to a
+ * project group would keep working after the group is removed from the
+ * project, for any member who retains a separate project access path.
+ */
+export const getActiveGrantedGroupPredicate = (
+    trx: Knex,
+    groupAccessTable: string,
+): Knex.Raw =>
+    trx.raw(
+        `
+            EXISTS (
+                SELECT 1
+                FROM ?? AS granted_group_project_access
+                WHERE granted_group_project_access.group_uuid = ??.group_uuid
+                  AND granted_group_project_access.project_uuid = ??.project_uuid
+            )
+        `,
+        [ProjectGroupAccessTableName, groupAccessTable, ProjectTableName],
+    );


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1249

## Summary

PR 3 of 5 adds concrete read models for dashboards, saved charts, saved SQL charts, and apps. Each model batches user and current-group grants while deriving organization scope through the resource.

Stacks on PR 2 ([#27922](https://github.com/lightdash/lightdash/pull/27922)), which adds the eight grant tables.

Prior work: @hrx-joseph-fahnestock's [resolver proposal](https://github.com/houserx/lightdash-hrx/pull/25) defines the additive access behavior consumed by these models. This PR supplies the native, tenant-scoped read layer and does not incorporate its code.

## Changes

- Adds `DashboardAccessModel`, `SavedChartAccessModel`, `SavedSqlAccessModel`, and `AppAccessModel`.
- Fetches grants for batches of resource UUIDs rather than querying once per resource.
- Resolves direct user and current group grants in bounded queries.
- Derives tenant scope by joining each concrete resource through its owning project and organization.
- Returns grants grouped by resource for the service-layer resolver.

## Read path

```
resource UUIDs + account
        │
        v
resource → project → organization
        │
        ├─ user grants
        └─ current-group grants
                 │
                 v
       grants grouped by resource
```

Query count stays bounded by resource type rather than resource count or group size.

## Test plan

- [x] 11 focused model unit tests
- [x] 6 PostgreSQL integration scenarios
- [x] `pnpm -F backend typecheck:fast`
- [x] Focused backend lint and formatting checks