### PR TITLE
feat(auth): add transactional direct access writes

### DIFF
--- a/packages/backend/src/models/AppAccessModel.ts
+++ b/packages/backend/src/models/AppAccessModel.ts
@@ -258,9 +258,12 @@ export class AppAccessModel implements DirectAccessModel {
                 })
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
+            if (existing === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
             assertCanRevokeDirectAccess({
                 actorRole,
-                existingRole: existing?.space_role,
+                existingRole: existing.space_role,
                 isSelfRevoke: false,
             });
             await trx(AppGroupAccessTableName)
@@ -271,7 +274,7 @@ export class AppAccessModel implements DirectAccessModel {
                 .delete();
             return {
                 ...context,
-                beforeRole: existing?.space_role ?? null,
+                beforeRole: existing.space_role,
                 afterRole: null,
             };
         });

--- a/packages/backend/src/models/AppAccessModel.ts
+++ b/packages/backend/src/models/AppAccessModel.ts
@@ -1,3 +1,4 @@
+import { NotFoundError, type SpaceMemberRole } from '@lightdash/common';
 import { type Knex } from 'knex';
 import {
     AppGroupAccessTableName,
@@ -10,17 +11,299 @@ import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectTableName } from '../database/entities/projects';
 import { UserTableName } from '../database/entities/users';
 import {
+    assertCanGrantDirectAccess,
+    assertCanResetDirectAccess,
+    assertCanRevokeDirectAccess,
     getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
+    validateDirectAccessGroup,
+    validateDirectAccessUser,
     type DirectAccess,
+    type DirectAccessModel,
+    type DirectAccessModelActorRoleResolver,
+    type DirectAccessMutationContext,
+    type DirectAccessMutationResult,
+    type DirectAccessResetResult,
     type DirectAccessRow,
 } from './directAccessModelUtils';
 
 export type AppDirectAccess = DirectAccess;
 
-export class AppAccessModel {
+export class AppAccessModel implements DirectAccessModel {
     constructor(private readonly database: Knex) {}
+
+    private static async getMutationContext(
+        trx: Knex,
+        resourceUuid: string,
+    ): Promise<DirectAccessMutationContext> {
+        const context = await trx(AppsTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${AppsTableName}.project_uuid`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(`${AppsTableName}.app_id`, resourceUuid)
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .select<DirectAccessMutationContext>({
+                organizationId: `${OrganizationTableName}.organization_id`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectId: `${ProjectTableName}.project_id`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+            })
+            .forUpdate(AppsTableName)
+            .first();
+        if (context === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+        return context;
+    }
+
+    async upsertUserAccess(input: {
+        resourceUuid: string;
+        userUuid: string;
+        role: SpaceMemberRole;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        grantedByUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanGrantDirectAccess(input.actorRole, input.role);
+        return this.database.transaction(async (trx) => {
+            const context = await AppAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanGrantDirectAccess(actorRole, input.role);
+            if (
+                !(await validateDirectAccessUser(trx, context, input.userUuid))
+            ) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(AppUserAccessTableName)
+                .where({
+                    app_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: input.grantedByUserUuid === input.userUuid,
+            });
+            await trx(AppUserAccessTableName)
+                .insert({
+                    app_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                })
+                .onConflict(['app_uuid', 'user_uuid'])
+                .merge({
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: input.role,
+            };
+        });
+    }
+
+    async upsertGroupAccess(input: {
+        resourceUuid: string;
+        groupUuid: string;
+        role: SpaceMemberRole;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        grantedByUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanGrantDirectAccess(input.actorRole, input.role);
+        return this.database.transaction(async (trx) => {
+            const context = await AppAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanGrantDirectAccess(actorRole, input.role);
+            if (
+                !(await validateDirectAccessGroup(
+                    trx,
+                    context,
+                    input.groupUuid,
+                ))
+            ) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(AppGroupAccessTableName)
+                .where({
+                    app_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: false,
+            });
+            await trx(AppGroupAccessTableName)
+                .insert({
+                    app_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                })
+                .onConflict(['app_uuid', 'group_uuid'])
+                .merge({
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: input.role,
+            };
+        });
+    }
+
+    async revokeUserAccess(input: {
+        resourceUuid: string;
+        userUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        actorUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        const isSelfRevoke = input.actorUserUuid === input.userUuid;
+        assertCanRevokeDirectAccess({
+            actorRole: input.actorRole,
+            isSelfRevoke,
+        });
+        return this.database.transaction(async (trx) => {
+            const context = await AppAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            const existing = await trx(AppUserAccessTableName)
+                .where({
+                    app_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            if (existing === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing.space_role,
+                isSelfRevoke,
+            });
+            await trx(AppUserAccessTableName)
+                .where({
+                    app_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing.space_role,
+                afterRole: null,
+            };
+        });
+    }
+
+    async revokeGroupAccess(input: {
+        resourceUuid: string;
+        groupUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanRevokeDirectAccess({
+            actorRole: input.actorRole,
+            isSelfRevoke: false,
+        });
+        return this.database.transaction(async (trx) => {
+            const context = await AppAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            const existing = await trx(AppGroupAccessTableName)
+                .where({
+                    app_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: false,
+            });
+            await trx(AppGroupAccessTableName)
+                .where({
+                    app_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: null,
+            };
+        });
+    }
+
+    async resetAccess(input: {
+        resourceUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+    }): Promise<DirectAccessResetResult> {
+        assertCanResetDirectAccess(input.actorRole);
+        return this.database.transaction(async (trx) => {
+            const context = await AppAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanResetDirectAccess(actorRole);
+            const [revokedUsers, revokedGroups] = await Promise.all([
+                trx(AppUserAccessTableName)
+                    .where('app_uuid', input.resourceUuid)
+                    .delete(),
+                trx(AppGroupAccessTableName)
+                    .where('app_uuid', input.resourceUuid)
+                    .delete(),
+            ]);
+            return { ...context, revokedUsers, revokedGroups };
+        });
+    }
 
     async getUserAccess(
         appUuids: string[],

--- a/packages/backend/src/models/DashboardAccessModel.ts
+++ b/packages/backend/src/models/DashboardAccessModel.ts
@@ -267,9 +267,12 @@ export class DashboardAccessModel implements DirectAccessModel {
                 .where({ dashboard_uuid: resourceUuid, group_uuid: groupUuid })
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
+            if (existing === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
             assertCanRevokeDirectAccess({
                 actorRole,
-                existingRole: existing?.space_role,
+                existingRole: existing.space_role,
                 isSelfRevoke: false,
             });
             await trx(DashboardGroupAccessTableName)
@@ -277,7 +280,7 @@ export class DashboardAccessModel implements DirectAccessModel {
                 .delete();
             return {
                 ...context,
-                beforeRole: existing?.space_role ?? null,
+                beforeRole: existing.space_role,
                 afterRole: null,
             };
         });

--- a/packages/backend/src/models/DashboardAccessModel.ts
+++ b/packages/backend/src/models/DashboardAccessModel.ts
@@ -1,3 +1,4 @@
+import { NotFoundError, type SpaceMemberRole } from '@lightdash/common';
 import { type Knex } from 'knex';
 import {
     DashboardGroupAccessTableName,
@@ -11,17 +12,308 @@ import { ProjectTableName } from '../database/entities/projects';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import {
+    assertCanGrantDirectAccess,
+    assertCanResetDirectAccess,
+    assertCanRevokeDirectAccess,
     getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
+    validateDirectAccessGroup,
+    validateDirectAccessUser,
     type DirectAccess,
+    type DirectAccessModel,
+    type DirectAccessModelActorRoleResolver,
+    type DirectAccessMutationContext,
+    type DirectAccessMutationResult,
+    type DirectAccessResetResult,
     type DirectAccessRow,
 } from './directAccessModelUtils';
 
 export type DashboardDirectAccess = DirectAccess;
 
-export class DashboardAccessModel {
+export class DashboardAccessModel implements DirectAccessModel {
     constructor(private readonly database: Knex) {}
+
+    private static async getMutationContext(
+        trx: Knex,
+        resourceUuid: string,
+    ): Promise<DirectAccessMutationContext> {
+        const context = await trx(DashboardsTableName)
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${DashboardsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(`${DashboardsTableName}.dashboard_uuid`, resourceUuid)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
+            .select<DirectAccessMutationContext>({
+                organizationId: `${OrganizationTableName}.organization_id`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectId: `${ProjectTableName}.project_id`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+            })
+            .forUpdate(DashboardsTableName)
+            .first();
+
+        if (context === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+        return context;
+    }
+
+    async upsertUserAccess({
+        resourceUuid,
+        userUuid,
+        role,
+        actorRole: preflightActorRole,
+        actorRoleResolver,
+        grantedByUserUuid,
+    }: {
+        resourceUuid: string;
+        userUuid: string;
+        role: SpaceMemberRole;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        grantedByUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanGrantDirectAccess(preflightActorRole, role);
+        return this.database.transaction(async (trx) => {
+            const context = await DashboardAccessModel.getMutationContext(
+                trx,
+                resourceUuid,
+            );
+            const actorRole = await actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanGrantDirectAccess(actorRole, role);
+            if (!(await validateDirectAccessUser(trx, context, userUuid))) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(DashboardUserAccessTableName)
+                .where({ dashboard_uuid: resourceUuid, user_uuid: userUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: grantedByUserUuid === userUuid,
+            });
+            await trx(DashboardUserAccessTableName)
+                .insert({
+                    dashboard_uuid: resourceUuid,
+                    user_uuid: userUuid,
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                })
+                .onConflict(['dashboard_uuid', 'user_uuid'])
+                .merge({
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: role,
+            };
+        });
+    }
+
+    async upsertGroupAccess({
+        resourceUuid,
+        groupUuid,
+        role,
+        actorRole: preflightActorRole,
+        actorRoleResolver,
+        grantedByUserUuid,
+    }: {
+        resourceUuid: string;
+        groupUuid: string;
+        role: SpaceMemberRole;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        grantedByUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanGrantDirectAccess(preflightActorRole, role);
+        return this.database.transaction(async (trx) => {
+            const context = await DashboardAccessModel.getMutationContext(
+                trx,
+                resourceUuid,
+            );
+            const actorRole = await actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanGrantDirectAccess(actorRole, role);
+            if (!(await validateDirectAccessGroup(trx, context, groupUuid))) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(DashboardGroupAccessTableName)
+                .where({ dashboard_uuid: resourceUuid, group_uuid: groupUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: false,
+            });
+            await trx(DashboardGroupAccessTableName)
+                .insert({
+                    dashboard_uuid: resourceUuid,
+                    group_uuid: groupUuid,
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                })
+                .onConflict(['dashboard_uuid', 'group_uuid'])
+                .merge({
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: role,
+            };
+        });
+    }
+
+    async revokeUserAccess({
+        resourceUuid,
+        userUuid,
+        actorRole: preflightActorRole,
+        actorRoleResolver,
+        actorUserUuid,
+    }: {
+        resourceUuid: string;
+        userUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        actorUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        const isSelfRevoke = actorUserUuid === userUuid;
+        assertCanRevokeDirectAccess({
+            actorRole: preflightActorRole,
+            isSelfRevoke,
+        });
+        return this.database.transaction(async (trx) => {
+            const context = await DashboardAccessModel.getMutationContext(
+                trx,
+                resourceUuid,
+            );
+            const actorRole = await actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            const existing = await trx(DashboardUserAccessTableName)
+                .where({ dashboard_uuid: resourceUuid, user_uuid: userUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            if (existing === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing.space_role,
+                isSelfRevoke,
+            });
+            await trx(DashboardUserAccessTableName)
+                .where({ dashboard_uuid: resourceUuid, user_uuid: userUuid })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing.space_role,
+                afterRole: null,
+            };
+        });
+    }
+
+    async revokeGroupAccess({
+        resourceUuid,
+        groupUuid,
+        actorRole: preflightActorRole,
+        actorRoleResolver,
+    }: {
+        resourceUuid: string;
+        groupUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanRevokeDirectAccess({
+            actorRole: preflightActorRole,
+            isSelfRevoke: false,
+        });
+        return this.database.transaction(async (trx) => {
+            const context = await DashboardAccessModel.getMutationContext(
+                trx,
+                resourceUuid,
+            );
+            const actorRole = await actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            const existing = await trx(DashboardGroupAccessTableName)
+                .where({ dashboard_uuid: resourceUuid, group_uuid: groupUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: false,
+            });
+            await trx(DashboardGroupAccessTableName)
+                .where({ dashboard_uuid: resourceUuid, group_uuid: groupUuid })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: null,
+            };
+        });
+    }
+
+    async resetAccess({
+        resourceUuid,
+        actorRole: preflightActorRole,
+        actorRoleResolver,
+    }: {
+        resourceUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+    }): Promise<DirectAccessResetResult> {
+        assertCanResetDirectAccess(preflightActorRole);
+        return this.database.transaction(async (trx) => {
+            const context = await DashboardAccessModel.getMutationContext(
+                trx,
+                resourceUuid,
+            );
+            const actorRole = await actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanResetDirectAccess(actorRole);
+            const [revokedUsers, revokedGroups] = await Promise.all([
+                trx(DashboardUserAccessTableName)
+                    .where('dashboard_uuid', resourceUuid)
+                    .delete(),
+                trx(DashboardGroupAccessTableName)
+                    .where('dashboard_uuid', resourceUuid)
+                    .delete(),
+            ]);
+            return { ...context, revokedUsers, revokedGroups };
+        });
+    }
 
     async getUserAccess(
         dashboardUuids: string[],

--- a/packages/backend/src/models/DirectAccessModels.integration.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.integration.test.ts
@@ -536,11 +536,6 @@ describe('direct access read models PostgreSQL integration', () => {
     });
 
     it('atomically writes and resets grants for every concrete resource', async () => {
-        await transaction(ProjectGroupAccessTableName).insert({
-            project_uuid: projectUuid,
-            group_uuid: groupUuid,
-            role: ProjectMemberRole.VIEWER,
-        });
         const cases = [
             {
                 model: new DashboardAccessModel(transaction),
@@ -783,11 +778,6 @@ describe('direct access read models PostgreSQL integration', () => {
                 actorRoleResolver: async () => SpaceMemberRole.EDITOR,
             }),
         ).rejects.toMatchObject({ name: 'ForbiddenError' });
-        await transaction(ProjectGroupAccessTableName).insert({
-            project_uuid: projectUuid,
-            group_uuid: groupUuid,
-            role: ProjectMemberRole.VIEWER,
-        });
         await expect(
             model.upsertGroupAccess({
                 resourceUuid: dashboardUuid,

--- a/packages/backend/src/models/DirectAccessModels.integration.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.integration.test.ts
@@ -851,6 +851,44 @@ describe('direct access read models PostgreSQL integration', () => {
         });
     });
 
+    it('throws NotFoundError when revoking a missing group grant', async () => {
+        const missingGroupUuid = randomUUID();
+        const cases = [
+            {
+                model: new DashboardAccessModel(transaction),
+                resourceUuid: dashboardUuid,
+            },
+            {
+                model: new SavedChartAccessModel(transaction),
+                resourceUuid: savedChartUuid,
+            },
+            {
+                model: new SavedSqlAccessModel(transaction),
+                resourceUuid: savedSqlUuid,
+            },
+            {
+                model: new AppAccessModel(transaction),
+                resourceUuid: appUuid,
+            },
+        ];
+
+        await Promise.all(
+            cases.map(({ model: accessModel, resourceUuid }) =>
+                expect(
+                    accessModel.revokeGroupAccess({
+                        resourceUuid,
+                        groupUuid: missingGroupUuid,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                    }),
+                ).rejects.toMatchObject({
+                    name: 'NotFoundError',
+                    message: 'Direct access target not found',
+                }),
+            ),
+        );
+    });
+
     it('rolls back a role replacement when grantor attribution is invalid', async () => {
         await expect(
             model.upsertUserAccess({

--- a/packages/backend/src/models/DirectAccessModels.integration.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.integration.test.ts
@@ -380,6 +380,26 @@ describe('direct access read models PostgreSQL integration', () => {
                 SEED_ORG_1_ADMIN.user_uuid,
             ),
         ).resolves.toEqual({});
+        await expect(
+            new SavedChartAccessModel(transaction).upsertUserAccess({
+                resourceUuid: savedChart.saved_query_uuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.VIEWER,
+                actorRole: SpaceMemberRole.ADMIN,
+                actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).rejects.toMatchObject({ name: 'NotFoundError' });
+        await expect(
+            new SavedSqlAccessModel(transaction).upsertUserAccess({
+                resourceUuid: savedSql.saved_sql_uuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.VIEWER,
+                actorRole: SpaceMemberRole.ADMIN,
+                actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).rejects.toMatchObject({ name: 'NotFoundError' });
     });
 
     it('makes a group grant inert immediately after membership removal', async () => {
@@ -513,5 +533,563 @@ describe('direct access read models PostgreSQL integration', () => {
             `${dashboardUuid}.userRole`,
             SpaceMemberRole.EDITOR,
         );
+    });
+
+    it('atomically writes and resets grants for every concrete resource', async () => {
+        await transaction(ProjectGroupAccessTableName).insert({
+            project_uuid: projectUuid,
+            group_uuid: groupUuid,
+            role: ProjectMemberRole.VIEWER,
+        });
+        const cases = [
+            {
+                model: new DashboardAccessModel(transaction),
+                resourceUuid: dashboardUuid,
+                upsertUser: () =>
+                    new DashboardAccessModel(transaction).upsertUserAccess({
+                        resourceUuid: dashboardUuid,
+                        userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                        role: SpaceMemberRole.EDITOR,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                        grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    }),
+                upsertGroup: () =>
+                    new DashboardAccessModel(transaction).upsertGroupAccess({
+                        resourceUuid: dashboardUuid,
+                        groupUuid,
+                        role: SpaceMemberRole.VIEWER,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                        grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    }),
+                reset: () =>
+                    new DashboardAccessModel(transaction).resetAccess({
+                        resourceUuid: dashboardUuid,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                    }),
+            },
+            {
+                model: new SavedChartAccessModel(transaction),
+                resourceUuid: savedChartUuid,
+                upsertUser: () =>
+                    new SavedChartAccessModel(transaction).upsertUserAccess({
+                        resourceUuid: savedChartUuid,
+                        userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                        role: SpaceMemberRole.EDITOR,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                        grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    }),
+                upsertGroup: () =>
+                    new SavedChartAccessModel(transaction).upsertGroupAccess({
+                        resourceUuid: savedChartUuid,
+                        groupUuid,
+                        role: SpaceMemberRole.VIEWER,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                        grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    }),
+                reset: () =>
+                    new SavedChartAccessModel(transaction).resetAccess({
+                        resourceUuid: savedChartUuid,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                    }),
+            },
+            {
+                model: new SavedSqlAccessModel(transaction),
+                resourceUuid: savedSqlUuid,
+                upsertUser: () =>
+                    new SavedSqlAccessModel(transaction).upsertUserAccess({
+                        resourceUuid: savedSqlUuid,
+                        userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                        role: SpaceMemberRole.EDITOR,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                        grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    }),
+                upsertGroup: () =>
+                    new SavedSqlAccessModel(transaction).upsertGroupAccess({
+                        resourceUuid: savedSqlUuid,
+                        groupUuid,
+                        role: SpaceMemberRole.VIEWER,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                        grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    }),
+                reset: () =>
+                    new SavedSqlAccessModel(transaction).resetAccess({
+                        resourceUuid: savedSqlUuid,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                    }),
+            },
+            {
+                model: new AppAccessModel(transaction),
+                resourceUuid: appUuid,
+                upsertUser: () =>
+                    new AppAccessModel(transaction).upsertUserAccess({
+                        resourceUuid: appUuid,
+                        userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                        role: SpaceMemberRole.EDITOR,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                        grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    }),
+                upsertGroup: () =>
+                    new AppAccessModel(transaction).upsertGroupAccess({
+                        resourceUuid: appUuid,
+                        groupUuid,
+                        role: SpaceMemberRole.VIEWER,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                        grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    }),
+                reset: () =>
+                    new AppAccessModel(transaction).resetAccess({
+                        resourceUuid: appUuid,
+                        actorRole: SpaceMemberRole.ADMIN,
+                        actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                    }),
+            },
+        ];
+
+        await Promise.all(
+            cases.map(async (testCase) => {
+                await expect(testCase.upsertUser()).resolves.toMatchObject({
+                    organizationUuid,
+                    projectUuid,
+                    beforeRole: SpaceMemberRole.VIEWER,
+                    afterRole: SpaceMemberRole.EDITOR,
+                });
+                await expect(testCase.upsertGroup()).resolves.toMatchObject({
+                    beforeRole: SpaceMemberRole.ADMIN,
+                    afterRole: SpaceMemberRole.VIEWER,
+                });
+                await expect(
+                    testCase.model.getUserAccess(
+                        [testCase.resourceUuid],
+                        SEED_ORG_1_ADMIN.user_uuid,
+                    ),
+                ).resolves.toMatchObject({
+                    [testCase.resourceUuid]: {
+                        userRole: SpaceMemberRole.EDITOR,
+                        groupRoles: [SpaceMemberRole.VIEWER],
+                    },
+                });
+                await expect(testCase.reset()).resolves.toMatchObject({
+                    revokedUsers: 1,
+                    revokedGroups: 1,
+                });
+                await expect(
+                    testCase.model.getUserAccess(
+                        [testCase.resourceUuid],
+                        SEED_ORG_1_ADMIN.user_uuid,
+                    ),
+                ).resolves.toEqual({});
+            }),
+        );
+    });
+
+    it('rejects unauthorized and cross-tenant writes without revealing targets', async () => {
+        let queryCount = 0;
+        const countQueries = () => {
+            queryCount += 1;
+        };
+        transaction.on('query', countQueries);
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: randomUUID(),
+                userUuid: randomUUID(),
+                role: SpaceMemberRole.ADMIN,
+                actorRole: SpaceMemberRole.EDITOR,
+                actorRoleResolver: async () => SpaceMemberRole.EDITOR,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).rejects.toMatchObject({ name: 'ForbiddenError' });
+        transaction.removeListener('query', countQueries);
+        expect(queryCount).toBe(0);
+
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: randomUUID(),
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.VIEWER,
+                actorRole: SpaceMemberRole.ADMIN,
+                actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).rejects.toMatchObject({
+            name: 'NotFoundError',
+            message: 'Direct access target not found',
+        });
+
+        const [foreignOrganization] = await transaction(OrganizationTableName)
+            .insert({ organization_name: `Foreign org ${randomUUID()}` })
+            .returning('organization_id');
+        const foreignUserUuid = randomUUID();
+        const [foreignUser] = await transaction(UserTableName)
+            .insert({
+                user_uuid: foreignUserUuid,
+                first_name: 'Foreign',
+                last_name: 'Principal',
+                is_marketing_opted_in: false,
+                is_tracking_anonymized: false,
+                is_setup_complete: true,
+                is_active: true,
+            })
+            .returning('user_id');
+        await transaction(OrganizationMembershipsTableName).insert({
+            organization_id: foreignOrganization.organization_id,
+            user_id: foreignUser.user_id,
+            role: OrganizationMemberRole.ADMIN,
+        });
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: dashboardUuid,
+                userUuid: foreignUserUuid,
+                role: SpaceMemberRole.VIEWER,
+                actorRole: SpaceMemberRole.ADMIN,
+                actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).rejects.toMatchObject({
+            name: 'NotFoundError',
+            message: 'Direct access target not found',
+        });
+    });
+
+    it('allows self-revoke but prevents an editor from revoking admin access', async () => {
+        await expect(
+            model.revokeUserAccess({
+                resourceUuid: dashboardUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                actorRole: SpaceMemberRole.VIEWER,
+                actorRoleResolver: async () => SpaceMemberRole.VIEWER,
+                actorUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).resolves.toMatchObject({
+            beforeRole: SpaceMemberRole.VIEWER,
+            afterRole: null,
+        });
+
+        await expect(
+            model.revokeGroupAccess({
+                resourceUuid: dashboardUuid,
+                groupUuid,
+                actorRole: SpaceMemberRole.EDITOR,
+                actorRoleResolver: async () => SpaceMemberRole.EDITOR,
+            }),
+        ).rejects.toMatchObject({ name: 'ForbiddenError' });
+        await transaction(ProjectGroupAccessTableName).insert({
+            project_uuid: projectUuid,
+            group_uuid: groupUuid,
+            role: ProjectMemberRole.VIEWER,
+        });
+        await expect(
+            model.upsertGroupAccess({
+                resourceUuid: dashboardUuid,
+                groupUuid,
+                role: SpaceMemberRole.VIEWER,
+                actorRole: SpaceMemberRole.EDITOR,
+                actorRoleResolver: async () => SpaceMemberRole.EDITOR,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).rejects.toMatchObject({ name: 'ForbiddenError' });
+    });
+
+    it('hides resource existence when a self-revoke has no direct grant', async () => {
+        const principalUuid = randomUUID();
+        const cases = [
+            {
+                model: new DashboardAccessModel(transaction),
+                resourceUuid: dashboardUuid,
+            },
+            {
+                model: new SavedChartAccessModel(transaction),
+                resourceUuid: savedChartUuid,
+            },
+            {
+                model: new SavedSqlAccessModel(transaction),
+                resourceUuid: savedSqlUuid,
+            },
+            {
+                model: new AppAccessModel(transaction),
+                resourceUuid: appUuid,
+            },
+        ];
+
+        await Promise.all(
+            cases.map(({ model: accessModel, resourceUuid }) =>
+                expect(
+                    accessModel.revokeUserAccess({
+                        resourceUuid,
+                        userUuid: principalUuid,
+                        actorRole: SpaceMemberRole.VIEWER,
+                        actorRoleResolver: async () => SpaceMemberRole.VIEWER,
+                        actorUserUuid: principalUuid,
+                    }),
+                ).rejects.toMatchObject({
+                    name: 'NotFoundError',
+                    message: 'Direct access target not found',
+                }),
+            ),
+        );
+        await expect(
+            model.revokeUserAccess({
+                resourceUuid: randomUUID(),
+                userUuid: principalUuid,
+                actorRole: SpaceMemberRole.VIEWER,
+                actorRoleResolver: async () => SpaceMemberRole.VIEWER,
+                actorUserUuid: principalUuid,
+            }),
+        ).rejects.toMatchObject({
+            name: 'NotFoundError',
+            message: 'Direct access target not found',
+        });
+    });
+
+    it('rolls back a role replacement when grantor attribution is invalid', async () => {
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: dashboardUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.EDITOR,
+                actorRole: SpaceMemberRole.ADMIN,
+                actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                grantedByUserUuid: randomUUID(),
+            }),
+        ).rejects.toBeDefined();
+
+        await expect(
+            transaction(DashboardUserAccessTableName)
+                .where({
+                    dashboard_uuid: dashboardUuid,
+                    user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                })
+                .first('space_role'),
+        ).resolves.toMatchObject({ space_role: SpaceMemberRole.VIEWER });
+    });
+
+    it('preserves a grant after its attributed grantor is deleted', async () => {
+        const grantor = await createMemberPrincipal();
+        await transaction(ProjectMembershipsTableName).insert({
+            project_id: projectId,
+            user_id: grantor.userId,
+            role: ProjectMemberRole.ADMIN,
+        });
+        await model.upsertUserAccess({
+            resourceUuid: dashboardUuid,
+            userUuid: SEED_ORG_1_ADMIN.user_uuid,
+            role: SpaceMemberRole.EDITOR,
+            actorRole: SpaceMemberRole.ADMIN,
+            actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+            grantedByUserUuid: grantor.userUuid,
+        });
+        await expect(
+            transaction(DashboardUserAccessTableName)
+                .where({
+                    dashboard_uuid: dashboardUuid,
+                    user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                })
+                .first('granted_by_user_uuid'),
+        ).resolves.toMatchObject({
+            granted_by_user_uuid: grantor.userUuid,
+        });
+
+        await transaction(UserTableName)
+            .where('user_uuid', grantor.userUuid)
+            .delete();
+        await expect(
+            transaction(DashboardUserAccessTableName)
+                .where({
+                    dashboard_uuid: dashboardUuid,
+                    user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                })
+                .first('granted_by_user_uuid'),
+        ).resolves.toMatchObject({ granted_by_user_uuid: null });
+    });
+
+    it('holds actor authority locks through the direct mutation', async () => {
+        const actor = await createMemberPrincipal();
+        await transaction(ProjectMembershipsTableName).insert({
+            project_id: projectId,
+            user_id: actor.userId,
+            role: ProjectMemberRole.ADMIN,
+        });
+        await transaction.commit();
+
+        const grantBlocker = await database.transaction();
+        let downgradeTransaction: Knex.Transaction | undefined;
+        let mutation:
+            | ReturnType<DashboardAccessModel['upsertUserAccess']>
+            | undefined;
+        let downgrade: Promise<number> | undefined;
+
+        try {
+            await grantBlocker(DashboardUserAccessTableName)
+                .where({
+                    dashboard_uuid: dashboardUuid,
+                    user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                })
+                .forUpdate()
+                .first();
+
+            let markActorResolved: () => void = () => undefined;
+            const actorResolved = new Promise<void>((resolve) => {
+                markActorResolved = resolve;
+            });
+            mutation = new DashboardAccessModel(database).upsertUserAccess({
+                resourceUuid: dashboardUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.EDITOR,
+                actorRole: SpaceMemberRole.ADMIN,
+                actorRoleResolver: async ({ transaction: mutationTrx }) => {
+                    const membership = await mutationTrx(
+                        ProjectMembershipsTableName,
+                    )
+                        .where({
+                            project_id: projectId,
+                            user_id: actor.userId,
+                        })
+                        .forShare()
+                        .first<{ role: SpaceMemberRole }>('role');
+                    markActorResolved();
+                    return membership?.role;
+                },
+                grantedByUserUuid: actor.userUuid,
+            });
+
+            await actorResolved;
+            downgradeTransaction = await database.transaction();
+            const backend = await downgradeTransaction.raw<{
+                rows: Array<{ pid: number }>;
+            }>('SELECT pg_backend_pid() AS pid');
+            const [{ pid: downgradePid }] = backend.rows;
+            downgrade = downgradeTransaction(ProjectMembershipsTableName)
+                .where({ project_id: projectId, user_id: actor.userId })
+                .update({ role: ProjectMemberRole.VIEWER })
+                .then((updatedRows) => updatedRows);
+
+            const waitForDowngradeLock = async (
+                attemptsRemaining: number,
+            ): Promise<void> => {
+                const activity = await database('pg_stat_activity')
+                    .where('pid', downgradePid)
+                    .first<{ wait_event_type: string | null }>(
+                        'wait_event_type',
+                    );
+                if (activity?.wait_event_type === 'Lock') {
+                    return;
+                }
+                if (attemptsRemaining === 0) {
+                    throw new Error(
+                        'Concurrent authority downgrade did not wait on a lock',
+                    );
+                }
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 10);
+                });
+                return waitForDowngradeLock(attemptsRemaining - 1);
+            };
+            await waitForDowngradeLock(50);
+
+            await grantBlocker.commit();
+            await expect(mutation).resolves.toMatchObject({
+                afterRole: SpaceMemberRole.EDITOR,
+            });
+            await downgrade;
+            await downgradeTransaction.commit();
+
+            await expect(
+                database(DashboardUserAccessTableName)
+                    .where({
+                        dashboard_uuid: dashboardUuid,
+                        user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                    })
+                    .first('space_role'),
+            ).resolves.toMatchObject({ space_role: SpaceMemberRole.EDITOR });
+        } finally {
+            if (!grantBlocker.isCompleted()) {
+                await grantBlocker.rollback();
+            }
+            if (mutation !== undefined) {
+                await Promise.allSettled([mutation]);
+            }
+            if (downgrade !== undefined) {
+                await Promise.allSettled([downgrade]);
+            }
+            if (
+                downgradeTransaction !== undefined &&
+                !downgradeTransaction.isCompleted()
+            ) {
+                await downgradeTransaction.rollback();
+            }
+            await database(DashboardsTableName)
+                .where('dashboard_uuid', dashboardUuid)
+                .delete();
+            await database(SavedChartsTableName)
+                .where('saved_query_uuid', savedChartUuid)
+                .delete();
+            await database(SavedSqlTableName)
+                .where('saved_sql_uuid', savedSqlUuid)
+                .delete();
+            await database(AppsTableName).where('app_id', appUuid).delete();
+            await database(GroupTableName)
+                .where('group_uuid', groupUuid)
+                .delete();
+            await database(UserTableName)
+                .where('user_uuid', actor.userUuid)
+                .delete();
+        }
+    });
+
+    it('serializes concurrent replacements without duplicate rows', async () => {
+        await transaction.commit();
+        try {
+            const committedModel = new DashboardAccessModel(database);
+            await Promise.all([
+                committedModel.upsertUserAccess({
+                    resourceUuid: dashboardUuid,
+                    userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    role: SpaceMemberRole.VIEWER,
+                    actorRole: SpaceMemberRole.ADMIN,
+                    actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                    grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                }),
+                committedModel.upsertUserAccess({
+                    resourceUuid: dashboardUuid,
+                    userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    role: SpaceMemberRole.EDITOR,
+                    actorRole: SpaceMemberRole.ADMIN,
+                    actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                    grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                }),
+            ]);
+            const rows = await database(DashboardUserAccessTableName).where({
+                dashboard_uuid: dashboardUuid,
+                user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            });
+            expect(rows).toHaveLength(1);
+            expect([SpaceMemberRole.VIEWER, SpaceMemberRole.EDITOR]).toContain(
+                rows[0].space_role,
+            );
+        } finally {
+            await database(DashboardsTableName)
+                .where('dashboard_uuid', dashboardUuid)
+                .delete();
+            await database(SavedChartsTableName)
+                .where('saved_query_uuid', savedChartUuid)
+                .delete();
+            await database(SavedSqlTableName)
+                .where('saved_sql_uuid', savedSqlUuid)
+                .delete();
+            await database(AppsTableName).where('app_id', appUuid).delete();
+            await database(GroupTableName)
+                .where('group_uuid', groupUuid)
+                .delete();
+        }
     });
 });

--- a/packages/backend/src/models/SavedChartAccessModel.ts
+++ b/packages/backend/src/models/SavedChartAccessModel.ts
@@ -1,3 +1,4 @@
+import { NotFoundError, type SpaceMemberRole } from '@lightdash/common';
 import { type Knex } from 'knex';
 import { GroupMembershipTableName } from '../database/entities/groupMemberships';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
@@ -10,17 +11,300 @@ import {
 import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { UserTableName } from '../database/entities/users';
 import {
+    assertCanGrantDirectAccess,
+    assertCanResetDirectAccess,
+    assertCanRevokeDirectAccess,
     getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
+    validateDirectAccessGroup,
+    validateDirectAccessUser,
     type DirectAccess,
+    type DirectAccessModel,
+    type DirectAccessModelActorRoleResolver,
+    type DirectAccessMutationContext,
+    type DirectAccessMutationResult,
+    type DirectAccessResetResult,
     type DirectAccessRow,
 } from './directAccessModelUtils';
 
 export type SavedChartDirectAccess = DirectAccess;
 
-export class SavedChartAccessModel {
+export class SavedChartAccessModel implements DirectAccessModel {
     constructor(private readonly database: Knex) {}
+
+    private static async getMutationContext(
+        trx: Knex,
+        resourceUuid: string,
+    ): Promise<DirectAccessMutationContext> {
+        const context = await trx(SavedChartsTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${SavedChartsTableName}.project_uuid`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(`${SavedChartsTableName}.saved_query_uuid`, resourceUuid)
+            .whereNull(`${SavedChartsTableName}.dashboard_uuid`)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .select<DirectAccessMutationContext>({
+                organizationId: `${OrganizationTableName}.organization_id`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectId: `${ProjectTableName}.project_id`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+            })
+            .forUpdate(SavedChartsTableName)
+            .first();
+        if (context === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+        return context;
+    }
+
+    async upsertUserAccess(input: {
+        resourceUuid: string;
+        userUuid: string;
+        role: SpaceMemberRole;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        grantedByUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanGrantDirectAccess(input.actorRole, input.role);
+        return this.database.transaction(async (trx) => {
+            const context = await SavedChartAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanGrantDirectAccess(actorRole, input.role);
+            if (
+                !(await validateDirectAccessUser(trx, context, input.userUuid))
+            ) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(SavedChartUserAccessTableName)
+                .where({
+                    saved_chart_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: input.grantedByUserUuid === input.userUuid,
+            });
+            await trx(SavedChartUserAccessTableName)
+                .insert({
+                    saved_chart_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                })
+                .onConflict(['saved_chart_uuid', 'user_uuid'])
+                .merge({
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: input.role,
+            };
+        });
+    }
+
+    async upsertGroupAccess(input: {
+        resourceUuid: string;
+        groupUuid: string;
+        role: SpaceMemberRole;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        grantedByUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanGrantDirectAccess(input.actorRole, input.role);
+        return this.database.transaction(async (trx) => {
+            const context = await SavedChartAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanGrantDirectAccess(actorRole, input.role);
+            if (
+                !(await validateDirectAccessGroup(
+                    trx,
+                    context,
+                    input.groupUuid,
+                ))
+            ) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(SavedChartGroupAccessTableName)
+                .where({
+                    saved_chart_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: false,
+            });
+            await trx(SavedChartGroupAccessTableName)
+                .insert({
+                    saved_chart_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                })
+                .onConflict(['saved_chart_uuid', 'group_uuid'])
+                .merge({
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: input.role,
+            };
+        });
+    }
+
+    async revokeUserAccess(input: {
+        resourceUuid: string;
+        userUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        actorUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        const isSelfRevoke = input.actorUserUuid === input.userUuid;
+        assertCanRevokeDirectAccess({
+            actorRole: input.actorRole,
+            isSelfRevoke,
+        });
+        return this.database.transaction(async (trx) => {
+            const context = await SavedChartAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            const existing = await trx(SavedChartUserAccessTableName)
+                .where({
+                    saved_chart_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            if (existing === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing.space_role,
+                isSelfRevoke,
+            });
+            await trx(SavedChartUserAccessTableName)
+                .where({
+                    saved_chart_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing.space_role,
+                afterRole: null,
+            };
+        });
+    }
+
+    async revokeGroupAccess(input: {
+        resourceUuid: string;
+        groupUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanRevokeDirectAccess({
+            actorRole: input.actorRole,
+            isSelfRevoke: false,
+        });
+        return this.database.transaction(async (trx) => {
+            const context = await SavedChartAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            const existing = await trx(SavedChartGroupAccessTableName)
+                .where({
+                    saved_chart_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: false,
+            });
+            await trx(SavedChartGroupAccessTableName)
+                .where({
+                    saved_chart_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: null,
+            };
+        });
+    }
+
+    async resetAccess(input: {
+        resourceUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+    }): Promise<DirectAccessResetResult> {
+        assertCanResetDirectAccess(input.actorRole);
+        return this.database.transaction(async (trx) => {
+            const context = await SavedChartAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanResetDirectAccess(actorRole);
+            const [revokedUsers, revokedGroups] = await Promise.all([
+                trx(SavedChartUserAccessTableName)
+                    .where('saved_chart_uuid', input.resourceUuid)
+                    .delete(),
+                trx(SavedChartGroupAccessTableName)
+                    .where('saved_chart_uuid', input.resourceUuid)
+                    .delete(),
+            ]);
+            return { ...context, revokedUsers, revokedGroups };
+        });
+    }
 
     async getUserAccess(
         savedChartUuids: string[],

--- a/packages/backend/src/models/SavedChartAccessModel.ts
+++ b/packages/backend/src/models/SavedChartAccessModel.ts
@@ -259,9 +259,12 @@ export class SavedChartAccessModel implements DirectAccessModel {
                 })
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
+            if (existing === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
             assertCanRevokeDirectAccess({
                 actorRole,
-                existingRole: existing?.space_role,
+                existingRole: existing.space_role,
                 isSelfRevoke: false,
             });
             await trx(SavedChartGroupAccessTableName)
@@ -272,7 +275,7 @@ export class SavedChartAccessModel implements DirectAccessModel {
                 .delete();
             return {
                 ...context,
-                beforeRole: existing?.space_role ?? null,
+                beforeRole: existing.space_role,
                 afterRole: null,
             };
         });

--- a/packages/backend/src/models/SavedSqlAccessModel.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.ts
@@ -259,9 +259,12 @@ export class SavedSqlAccessModel implements DirectAccessModel {
                 })
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
+            if (existing === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
             assertCanRevokeDirectAccess({
                 actorRole,
-                existingRole: existing?.space_role,
+                existingRole: existing.space_role,
                 isSelfRevoke: false,
             });
             await trx(SavedSqlGroupAccessTableName)
@@ -272,7 +275,7 @@ export class SavedSqlAccessModel implements DirectAccessModel {
                 .delete();
             return {
                 ...context,
-                beforeRole: existing?.space_role ?? null,
+                beforeRole: existing.space_role,
                 afterRole: null,
             };
         });

--- a/packages/backend/src/models/SavedSqlAccessModel.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.ts
@@ -1,3 +1,4 @@
+import { NotFoundError, type SpaceMemberRole } from '@lightdash/common';
 import { type Knex } from 'knex';
 import { GroupMembershipTableName } from '../database/entities/groupMemberships';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
@@ -10,17 +11,300 @@ import {
 } from '../database/entities/savedSqlAccess';
 import { UserTableName } from '../database/entities/users';
 import {
+    assertCanGrantDirectAccess,
+    assertCanResetDirectAccess,
+    assertCanRevokeDirectAccess,
     getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
+    validateDirectAccessGroup,
+    validateDirectAccessUser,
     type DirectAccess,
+    type DirectAccessModel,
+    type DirectAccessModelActorRoleResolver,
+    type DirectAccessMutationContext,
+    type DirectAccessMutationResult,
+    type DirectAccessResetResult,
     type DirectAccessRow,
 } from './directAccessModelUtils';
 
 export type SavedSqlDirectAccess = DirectAccess;
 
-export class SavedSqlAccessModel {
+export class SavedSqlAccessModel implements DirectAccessModel {
     constructor(private readonly database: Knex) {}
+
+    private static async getMutationContext(
+        trx: Knex,
+        resourceUuid: string,
+    ): Promise<DirectAccessMutationContext> {
+        const context = await trx(SavedSqlTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${SavedSqlTableName}.project_uuid`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(`${SavedSqlTableName}.saved_sql_uuid`, resourceUuid)
+            .whereNull(`${SavedSqlTableName}.dashboard_uuid`)
+            .whereNull(`${SavedSqlTableName}.deleted_at`)
+            .select<DirectAccessMutationContext>({
+                organizationId: `${OrganizationTableName}.organization_id`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectId: `${ProjectTableName}.project_id`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+            })
+            .forUpdate(SavedSqlTableName)
+            .first();
+        if (context === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+        return context;
+    }
+
+    async upsertUserAccess(input: {
+        resourceUuid: string;
+        userUuid: string;
+        role: SpaceMemberRole;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        grantedByUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanGrantDirectAccess(input.actorRole, input.role);
+        return this.database.transaction(async (trx) => {
+            const context = await SavedSqlAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanGrantDirectAccess(actorRole, input.role);
+            if (
+                !(await validateDirectAccessUser(trx, context, input.userUuid))
+            ) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(SavedSqlUserAccessTableName)
+                .where({
+                    saved_sql_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: input.grantedByUserUuid === input.userUuid,
+            });
+            await trx(SavedSqlUserAccessTableName)
+                .insert({
+                    saved_sql_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                })
+                .onConflict(['saved_sql_uuid', 'user_uuid'])
+                .merge({
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: input.role,
+            };
+        });
+    }
+
+    async upsertGroupAccess(input: {
+        resourceUuid: string;
+        groupUuid: string;
+        role: SpaceMemberRole;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        grantedByUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanGrantDirectAccess(input.actorRole, input.role);
+        return this.database.transaction(async (trx) => {
+            const context = await SavedSqlAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanGrantDirectAccess(actorRole, input.role);
+            if (
+                !(await validateDirectAccessGroup(
+                    trx,
+                    context,
+                    input.groupUuid,
+                ))
+            ) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(SavedSqlGroupAccessTableName)
+                .where({
+                    saved_sql_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: false,
+            });
+            await trx(SavedSqlGroupAccessTableName)
+                .insert({
+                    saved_sql_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                })
+                .onConflict(['saved_sql_uuid', 'group_uuid'])
+                .merge({
+                    space_role: input.role,
+                    granted_by_user_uuid: input.grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: input.role,
+            };
+        });
+    }
+
+    async revokeUserAccess(input: {
+        resourceUuid: string;
+        userUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        actorUserUuid: string;
+    }): Promise<DirectAccessMutationResult> {
+        const isSelfRevoke = input.actorUserUuid === input.userUuid;
+        assertCanRevokeDirectAccess({
+            actorRole: input.actorRole,
+            isSelfRevoke,
+        });
+        return this.database.transaction(async (trx) => {
+            const context = await SavedSqlAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            const existing = await trx(SavedSqlUserAccessTableName)
+                .where({
+                    saved_sql_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            if (existing === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing.space_role,
+                isSelfRevoke,
+            });
+            await trx(SavedSqlUserAccessTableName)
+                .where({
+                    saved_sql_uuid: input.resourceUuid,
+                    user_uuid: input.userUuid,
+                })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing.space_role,
+                afterRole: null,
+            };
+        });
+    }
+
+    async revokeGroupAccess(input: {
+        resourceUuid: string;
+        groupUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+    }): Promise<DirectAccessMutationResult> {
+        assertCanRevokeDirectAccess({
+            actorRole: input.actorRole,
+            isSelfRevoke: false,
+        });
+        return this.database.transaction(async (trx) => {
+            const context = await SavedSqlAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            const existing = await trx(SavedSqlGroupAccessTableName)
+                .where({
+                    saved_sql_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            assertCanRevokeDirectAccess({
+                actorRole,
+                existingRole: existing?.space_role,
+                isSelfRevoke: false,
+            });
+            await trx(SavedSqlGroupAccessTableName)
+                .where({
+                    saved_sql_uuid: input.resourceUuid,
+                    group_uuid: input.groupUuid,
+                })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: null,
+            };
+        });
+    }
+
+    async resetAccess(input: {
+        resourceUuid: string;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+    }): Promise<DirectAccessResetResult> {
+        assertCanResetDirectAccess(input.actorRole);
+        return this.database.transaction(async (trx) => {
+            const context = await SavedSqlAccessModel.getMutationContext(
+                trx,
+                input.resourceUuid,
+            );
+            const actorRole = await input.actorRoleResolver({
+                transaction: trx,
+                context,
+            });
+            assertCanResetDirectAccess(actorRole);
+            const [revokedUsers, revokedGroups] = await Promise.all([
+                trx(SavedSqlUserAccessTableName)
+                    .where('saved_sql_uuid', input.resourceUuid)
+                    .delete(),
+                trx(SavedSqlGroupAccessTableName)
+                    .where('saved_sql_uuid', input.resourceUuid)
+                    .delete(),
+            ]);
+            return { ...context, revokedUsers, revokedGroups };
+        });
+    }
 
     async getUserAccess(
         savedSqlUuids: string[],

--- a/packages/backend/src/models/directAccessModelUtils.ts
+++ b/packages/backend/src/models/directAccessModelUtils.ts
@@ -1,9 +1,13 @@
 import {
+    canDelegateDirectAccessRole,
+    ForbiddenError,
     OrganizationMemberRole,
-    type SpaceMemberRole,
+    SpaceMemberRole,
+    type UUID,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { GroupTableName } from '../database/entities/groups';
 import { OrganizationMembershipCustomRolesTableName } from '../database/entities/organizationMembershipCustomRoles';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
@@ -12,39 +16,129 @@ import { ProjectTableName } from '../database/entities/projects';
 import { UserTableName } from '../database/entities/users';
 
 export type DirectAccess = {
-    organizationUuid: string;
-    projectUuid: string;
+    organizationUuid: UUID;
+    projectUuid: UUID;
     userRole: SpaceMemberRole | null;
     groupRoles: SpaceMemberRole[];
 };
 
 export type DirectAccessRow = {
-    resourceUuid: string;
-    organizationUuid: string;
-    projectUuid: string;
+    resourceUuid: UUID;
+    organizationUuid: UUID;
+    projectUuid: UUID;
     role: SpaceMemberRole;
-    groupUuid: string | null;
+    groupUuid: UUID | null;
 };
 
-export const groupDirectAccessRows = (
-    rows: DirectAccessRow[],
-): Record<string, DirectAccess> => {
-    const accessByResource: Record<string, DirectAccess> = {};
-    for (const row of rows) {
-        const access = accessByResource[row.resourceUuid] ?? {
-            organizationUuid: row.organizationUuid,
-            projectUuid: row.projectUuid,
-            userRole: null,
-            groupRoles: [],
-        };
-        if (row.groupUuid === null) {
-            access.userRole = row.role;
-        } else {
-            access.groupRoles.push(row.role);
-        }
-        accessByResource[row.resourceUuid] = access;
+export type DirectAccessMutationContext = {
+    organizationId: number;
+    organizationUuid: UUID;
+    projectId: number;
+    projectUuid: UUID;
+};
+
+export type DirectAccessMutationResult = DirectAccessMutationContext & {
+    beforeRole: SpaceMemberRole | null;
+    afterRole: SpaceMemberRole | null;
+};
+
+export type DirectAccessResetResult = DirectAccessMutationContext & {
+    revokedUsers: number;
+    revokedGroups: number;
+};
+
+/**
+ * The resolver must return only after locking every authority source that
+ * could lower the actor's role. Those locks must be held by `transaction`
+ * until the direct access mutation completes. When authority depends on the
+ * absence of a row, the resolver must lock a stable anchor or use an
+ * equivalent serialization mechanism.
+ */
+export type DirectAccessModelActorRoleResolver = (input: {
+    transaction: Knex.Transaction;
+    context: DirectAccessMutationContext;
+}) => Promise<SpaceMemberRole | undefined>;
+
+export type DirectAccessModel = {
+    getUserAccess(
+        resourceUuids: UUID[],
+        userUuid: UUID,
+    ): Promise<Record<string, DirectAccess>>;
+    upsertUserAccess(input: {
+        resourceUuid: UUID;
+        userUuid: UUID;
+        role: SpaceMemberRole;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        grantedByUserUuid: UUID;
+    }): Promise<DirectAccessMutationResult>;
+    upsertGroupAccess(input: {
+        resourceUuid: UUID;
+        groupUuid: UUID;
+        role: SpaceMemberRole;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        grantedByUserUuid: UUID;
+    }): Promise<DirectAccessMutationResult>;
+    revokeUserAccess(input: {
+        resourceUuid: UUID;
+        userUuid: UUID;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+        actorUserUuid: UUID;
+    }): Promise<DirectAccessMutationResult>;
+    revokeGroupAccess(input: {
+        resourceUuid: UUID;
+        groupUuid: UUID;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+    }): Promise<DirectAccessMutationResult>;
+    resetAccess(input: {
+        resourceUuid: UUID;
+        actorRole: SpaceMemberRole | undefined;
+        actorRoleResolver: DirectAccessModelActorRoleResolver;
+    }): Promise<DirectAccessResetResult>;
+};
+
+export const assertCanGrantDirectAccess = (
+    actorRole: SpaceMemberRole | undefined,
+    requestedRole: SpaceMemberRole,
+): void => {
+    if (!canDelegateDirectAccessRole(actorRole, requestedRole)) {
+        throw new ForbiddenError(
+            'You cannot grant the requested direct access role',
+        );
     }
-    return accessByResource;
+};
+
+export const assertCanRevokeDirectAccess = ({
+    actorRole,
+    existingRole,
+    isSelfRevoke,
+}: {
+    actorRole: SpaceMemberRole | undefined;
+    existingRole?: SpaceMemberRole;
+    isSelfRevoke: boolean;
+}): void => {
+    if (isSelfRevoke) {
+        return;
+    }
+    if (
+        actorRole === undefined ||
+        actorRole === SpaceMemberRole.VIEWER ||
+        (existingRole !== undefined &&
+            !canDelegateDirectAccessRole(actorRole, existingRole))
+    ) {
+        throw new ForbiddenError('You cannot revoke this direct access role');
+    }
+};
+
+export const assertCanResetDirectAccess = (
+    actorRole: SpaceMemberRole | undefined,
+): void => {
+    if (actorRole !== SpaceMemberRole.ADMIN) {
+        throw new ForbiddenError('Only admins can reset direct access');
+    }
 };
 
 /**
@@ -153,3 +247,70 @@ export const getActiveGrantedGroupPredicate =
                 );
         });
     };
+
+export const validateDirectAccessUser = async (
+    trx: Knex,
+    context: DirectAccessMutationContext,
+    userUuid: string,
+): Promise<boolean> => {
+    const user = await trx(UserTableName)
+        .innerJoin(
+            OrganizationMembershipsTableName,
+            `${OrganizationMembershipsTableName}.user_id`,
+            `${UserTableName}.user_id`,
+        )
+        .innerJoin(
+            ProjectTableName,
+            `${ProjectTableName}.organization_id`,
+            `${OrganizationMembershipsTableName}.organization_id`,
+        )
+        .where(`${UserTableName}.user_uuid`, userUuid)
+        .where(`${ProjectTableName}.project_id`, context.projectId)
+        .where(getActiveProjectMemberPredicate(trx))
+        .first(`${UserTableName}.user_id`);
+
+    return user !== undefined;
+};
+
+export const validateDirectAccessGroup = async (
+    trx: Knex,
+    context: DirectAccessMutationContext,
+    groupUuid: string,
+): Promise<boolean> => {
+    const group = await trx(GroupTableName)
+        .innerJoin(
+            ProjectGroupAccessTableName,
+            `${ProjectGroupAccessTableName}.group_uuid`,
+            `${GroupTableName}.group_uuid`,
+        )
+        .where(`${GroupTableName}.group_uuid`, groupUuid)
+        .where(`${GroupTableName}.organization_id`, context.organizationId)
+        .where(
+            `${ProjectGroupAccessTableName}.project_uuid`,
+            context.projectUuid,
+        )
+        .first(`${GroupTableName}.group_uuid`);
+
+    return group !== undefined;
+};
+
+export const groupDirectAccessRows = (
+    rows: DirectAccessRow[],
+): Record<string, DirectAccess> => {
+    const accessByResource: Record<string, DirectAccess> = {};
+    for (const row of rows) {
+        const access = accessByResource[row.resourceUuid] ?? {
+            organizationUuid: row.organizationUuid,
+            projectUuid: row.projectUuid,
+            userRole: null,
+            groupRoles: [],
+        };
+        if (row.groupUuid === null) {
+            access.userRole = row.role;
+        } else {
+            access.groupRoles.push(row.role);
+        }
+        accessByResource[row.resourceUuid] = access;
+    }
+    return accessByResource;
+};

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
@@ -1,0 +1,249 @@
+import { SpaceMemberRole, type RegisteredAccount } from '@lightdash/common';
+import { describe, expect, it, vi } from 'vitest';
+import { type DirectAccessModel } from '../../models/directAccessModelUtils';
+import {
+    DirectAccessService,
+    type DirectAccessModels,
+    type DirectAccessResourceType,
+} from './DirectAccessService';
+
+const account = {
+    authentication: {
+        type: 'service-account',
+        source: 'test',
+        serviceAccountUuid: 'audit-service-account-uuid',
+        serviceAccountDescription: 'Test service account',
+    },
+    organization: { organizationUuid: 'organization-uuid' },
+    user: {
+        userUuid: 'persisted-user-uuid',
+        role: 'admin',
+    },
+    requestContext: { requestId: 'request-id' },
+    isAnonymousUser: () => false,
+    isServiceAccount: () => true,
+} as unknown as RegisteredAccount;
+
+const mutationResult = {
+    organizationId: 1,
+    organizationUuid: 'organization-uuid',
+    projectId: 2,
+    projectUuid: 'project-uuid',
+    beforeRole: null,
+    afterRole: SpaceMemberRole.VIEWER,
+};
+
+const resetResult = {
+    organizationId: 1,
+    organizationUuid: 'organization-uuid',
+    projectId: 2,
+    projectUuid: 'project-uuid',
+    revokedUsers: 1,
+    revokedGroups: 1,
+};
+
+const createModel = (): DirectAccessModel =>
+    ({
+        getUserAccess: vi.fn(),
+        upsertUserAccess: vi.fn().mockResolvedValue(mutationResult),
+        upsertGroupAccess: vi.fn().mockResolvedValue(mutationResult),
+        revokeUserAccess: vi.fn().mockResolvedValue(mutationResult),
+        revokeGroupAccess: vi.fn().mockResolvedValue(mutationResult),
+        resetAccess: vi.fn().mockResolvedValue(resetResult),
+    }) as unknown as DirectAccessModel;
+
+const createModels = (): DirectAccessModels => ({
+    dashboard: createModel(),
+    savedChart: createModel(),
+    savedSql: createModel(),
+    app: createModel(),
+});
+
+const createActorRoleResolver = () =>
+    vi.fn().mockResolvedValue(SpaceMemberRole.ADMIN);
+
+describe('DirectAccessService', () => {
+    it('dispatches every resource type to its concrete model', async () => {
+        const models = createModels();
+        const actorRoleResolver = createActorRoleResolver();
+        const service = new DirectAccessService(models, actorRoleResolver);
+        const resourceTypes: DirectAccessResourceType[] = [
+            'dashboard',
+            'savedChart',
+            'savedSql',
+            'app',
+        ];
+
+        await Promise.all(
+            resourceTypes.map((type) =>
+                service.upsertUserAccess({
+                    account,
+                    resource: { type, uuid: `${type}-uuid` },
+                    userUuid: 'principal-uuid',
+                    role: SpaceMemberRole.VIEWER,
+                }),
+            ),
+        );
+
+        const transactionResolutions = resourceTypes.map((type) => {
+            expect(models[type].upsertUserAccess).toHaveBeenCalledWith({
+                resourceUuid: `${type}-uuid`,
+                userUuid: 'principal-uuid',
+                role: SpaceMemberRole.VIEWER,
+                actorRole: SpaceMemberRole.ADMIN,
+                actorRoleResolver: expect.any(Function),
+                grantedByUserUuid: 'persisted-user-uuid',
+            });
+            const [{ actorRoleResolver: resolveInsideTransaction }] = vi.mocked(
+                models[type].upsertUserAccess,
+            ).mock.calls[0];
+            return resolveInsideTransaction({
+                transaction: {} as never,
+                context: mutationResult,
+            });
+        });
+        await Promise.all(transactionResolutions);
+        expect(actorRoleResolver).toHaveBeenCalledTimes(8);
+        expect(actorRoleResolver).toHaveBeenCalledWith({
+            account,
+            organizationUuid: 'organization-uuid',
+            phase: 'preflight',
+            resource: { type: 'dashboard', uuid: 'dashboard-uuid' },
+        });
+        expect(actorRoleResolver).toHaveBeenCalledWith({
+            account,
+            organizationUuid: 'organization-uuid',
+            phase: 'transaction',
+            transaction: {},
+            context: mutationResult,
+            resource: { type: 'dashboard', uuid: 'dashboard-uuid' },
+        });
+    });
+
+    it('routes every mutation through the shared service contract', async () => {
+        const models = createModels();
+        const auditLogger = vi.fn();
+        const service = new DirectAccessService(
+            models,
+            createActorRoleResolver(),
+            auditLogger,
+        );
+        const mutationActor = {
+            account,
+            resource: {
+                type: 'dashboard' as const,
+                uuid: 'dashboard-uuid',
+            },
+        };
+
+        await service.upsertUserAccess({
+            ...mutationActor,
+            userUuid: 'principal-uuid',
+            role: SpaceMemberRole.VIEWER,
+        });
+        await service.upsertGroupAccess({
+            ...mutationActor,
+            groupUuid: 'group-uuid',
+            role: SpaceMemberRole.EDITOR,
+        });
+        await service.revokeUserAccess({
+            ...mutationActor,
+            userUuid: 'principal-uuid',
+        });
+        await service.revokeGroupAccess({
+            ...mutationActor,
+            groupUuid: 'group-uuid',
+        });
+        await service.resetAccess(mutationActor);
+
+        expect(models.dashboard.upsertGroupAccess).toHaveBeenCalledWith({
+            resourceUuid: 'dashboard-uuid',
+            groupUuid: 'group-uuid',
+            role: SpaceMemberRole.EDITOR,
+            actorRole: SpaceMemberRole.ADMIN,
+            actorRoleResolver: expect.any(Function),
+            grantedByUserUuid: 'persisted-user-uuid',
+        });
+        expect(models.dashboard.revokeUserAccess).toHaveBeenCalledWith({
+            resourceUuid: 'dashboard-uuid',
+            userUuid: 'principal-uuid',
+            actorRole: SpaceMemberRole.ADMIN,
+            actorRoleResolver: expect.any(Function),
+            actorUserUuid: 'persisted-user-uuid',
+        });
+        expect(models.dashboard.revokeGroupAccess).toHaveBeenCalledWith({
+            resourceUuid: 'dashboard-uuid',
+            groupUuid: 'group-uuid',
+            actorRole: SpaceMemberRole.ADMIN,
+            actorRoleResolver: expect.any(Function),
+        });
+        expect(models.dashboard.resetAccess).toHaveBeenCalledWith({
+            resourceUuid: 'dashboard-uuid',
+            actorRole: SpaceMemberRole.ADMIN,
+            actorRoleResolver: expect.any(Function),
+        });
+        expect(auditLogger).toHaveBeenCalledTimes(5);
+        expect(auditLogger).toHaveBeenCalledWith(
+            expect.objectContaining({
+                actor: expect.objectContaining({
+                    type: 'service-account',
+                    uuid: 'audit-service-account-uuid',
+                }),
+                context: { requestId: 'request-id' },
+                resource: expect.objectContaining({
+                    type: 'Dashboard',
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                }),
+            }),
+        );
+    });
+
+    it('does not emit an audit event when the model rejects the write', async () => {
+        const models = createModels();
+        const auditLogger = vi.fn();
+        vi.mocked(models.dashboard.upsertUserAccess).mockRejectedValue(
+            new Error('write failed'),
+        );
+        const service = new DirectAccessService(
+            models,
+            createActorRoleResolver(),
+            auditLogger,
+        );
+
+        await expect(
+            service.upsertUserAccess({
+                account,
+                resource: {
+                    type: 'dashboard',
+                    uuid: 'dashboard-uuid',
+                },
+                userUuid: 'principal-uuid',
+                role: SpaceMemberRole.VIEWER,
+            }),
+        ).rejects.toThrow('write failed');
+        expect(auditLogger).not.toHaveBeenCalled();
+    });
+
+    it('rejects an account without a selected organization before authorization', async () => {
+        const models = createModels();
+        const actorRoleResolver = createActorRoleResolver();
+        const service = new DirectAccessService(models, actorRoleResolver);
+        const accountWithoutOrganization = {
+            ...account,
+            organization: {},
+        } as RegisteredAccount;
+
+        await expect(
+            service.resetAccess({
+                account: accountWithoutOrganization,
+                resource: {
+                    type: 'dashboard',
+                    uuid: 'dashboard-uuid',
+                },
+            }),
+        ).rejects.toMatchObject({ name: 'ForbiddenError' });
+        expect(actorRoleResolver).not.toHaveBeenCalled();
+        expect(models.dashboard.resetAccess).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.ts
@@ -1,0 +1,263 @@
+import {
+    ForbiddenError,
+    type RegisteredAccount,
+    type SpaceMemberRole,
+    type UUID,
+} from '@lightdash/common';
+import { createActorFromAccount } from '../../logging/caslAuditWrapper';
+import {
+    type DirectAccessModel,
+    type DirectAccessModelActorRoleResolver,
+    type DirectAccessMutationContext,
+    type DirectAccessMutationResult,
+    type DirectAccessResetResult,
+} from '../../models/directAccessModelUtils';
+import { BaseService } from '../BaseService';
+import {
+    auditDirectAccessMutation,
+    auditDirectAccessReset,
+    type DirectAccessAuditLogger,
+} from './directAccessAudit';
+
+export type DirectAccessResourceType =
+    | 'dashboard'
+    | 'savedChart'
+    | 'savedSql'
+    | 'app';
+
+export type DirectAccessResource = {
+    type: DirectAccessResourceType;
+    uuid: UUID;
+};
+
+export type DirectAccessModels = Record<
+    DirectAccessResourceType,
+    DirectAccessModel
+>;
+
+const auditResourceTypes: Record<DirectAccessResourceType, string> = {
+    dashboard: 'Dashboard',
+    savedChart: 'SavedChart',
+    savedSql: 'SavedSql',
+    app: 'App',
+};
+
+type DirectAccessActorRoleResolverInput = {
+    account: RegisteredAccount;
+    organizationUuid: UUID;
+    resource: DirectAccessResource;
+} & (
+    | { phase: 'preflight' }
+    | {
+          phase: 'transaction';
+          transaction: Parameters<DirectAccessModelActorRoleResolver>[0]['transaction'];
+          context: DirectAccessMutationContext;
+      }
+);
+
+/**
+ * `preflight` is an advisory, read-only check used to fail closed before any
+ * target lookup. `transaction` is authoritative: it must lock every source
+ * whose state could lower the returned role until the supplied transaction
+ * completes. Authority based on an absent row requires a stable anchor lock
+ * or an equivalent serialization mechanism.
+ */
+export type DirectAccessActorRoleResolver = (
+    input: DirectAccessActorRoleResolverInput,
+) => Promise<SpaceMemberRole | undefined>;
+
+type DirectAccessMutationInput = {
+    account: RegisteredAccount;
+    resource: DirectAccessResource;
+};
+
+export class DirectAccessService extends BaseService {
+    constructor(
+        private readonly models: DirectAccessModels,
+        private readonly actorRoleResolver: DirectAccessActorRoleResolver,
+        private readonly auditLogger?: DirectAccessAuditLogger,
+    ) {
+        super();
+    }
+
+    private static getOrganizationUuid(account: RegisteredAccount): UUID {
+        const { organizationUuid } = account.organization;
+        if (organizationUuid === undefined) {
+            throw new ForbiddenError('Direct access is not available');
+        }
+        return organizationUuid;
+    }
+
+    private createActorRoleResolver(
+        input: DirectAccessMutationInput,
+    ): DirectAccessModelActorRoleResolver {
+        const organizationUuid = DirectAccessService.getOrganizationUuid(
+            input.account,
+        );
+        return ({ transaction, context }) => {
+            if (context.organizationUuid !== organizationUuid) {
+                throw new ForbiddenError('Direct access is not available');
+            }
+            return this.actorRoleResolver({
+                account: input.account,
+                organizationUuid,
+                phase: 'transaction',
+                transaction,
+                context,
+                resource: input.resource,
+            });
+        };
+    }
+
+    private resolveActorRole(
+        input: DirectAccessMutationInput,
+    ): Promise<SpaceMemberRole | undefined> {
+        const organizationUuid = DirectAccessService.getOrganizationUuid(
+            input.account,
+        );
+        return this.actorRoleResolver({
+            account: input.account,
+            organizationUuid,
+            phase: 'preflight',
+            resource: input.resource,
+        });
+    }
+
+    private getModel(
+        resourceType: DirectAccessResourceType,
+    ): DirectAccessModel {
+        return this.models[resourceType];
+    }
+
+    private auditMutation(
+        input: DirectAccessMutationInput,
+        principal: { type: 'user' | 'group'; uuid: UUID },
+        result: DirectAccessMutationResult,
+    ): void {
+        auditDirectAccessMutation({
+            actor: createActorFromAccount(input.account),
+            context: input.account.requestContext ?? {},
+            resourceType: auditResourceTypes[input.resource.type],
+            resourceUuid: input.resource.uuid,
+            principal,
+            result,
+            auditLogger: this.auditLogger,
+        });
+    }
+
+    private auditReset(
+        input: DirectAccessMutationInput,
+        result: DirectAccessResetResult,
+    ): void {
+        auditDirectAccessReset({
+            actor: createActorFromAccount(input.account),
+            context: input.account.requestContext ?? {},
+            resourceType: auditResourceTypes[input.resource.type],
+            resourceUuid: input.resource.uuid,
+            result,
+            auditLogger: this.auditLogger,
+        });
+    }
+
+    async upsertUserAccess(
+        input: DirectAccessMutationInput & {
+            userUuid: UUID;
+            role: SpaceMemberRole;
+        },
+    ): Promise<void> {
+        const actorRole = await this.resolveActorRole(input);
+        const actorRoleResolver = this.createActorRoleResolver(input);
+        const result = await this.getModel(
+            input.resource.type,
+        ).upsertUserAccess({
+            resourceUuid: input.resource.uuid,
+            userUuid: input.userUuid,
+            role: input.role,
+            actorRole,
+            actorRoleResolver,
+            grantedByUserUuid: input.account.user.userUuid,
+        });
+        this.auditMutation(
+            input,
+            { type: 'user', uuid: input.userUuid },
+            result,
+        );
+    }
+
+    async upsertGroupAccess(
+        input: DirectAccessMutationInput & {
+            groupUuid: UUID;
+            role: SpaceMemberRole;
+        },
+    ): Promise<void> {
+        const actorRole = await this.resolveActorRole(input);
+        const actorRoleResolver = this.createActorRoleResolver(input);
+        const result = await this.getModel(
+            input.resource.type,
+        ).upsertGroupAccess({
+            resourceUuid: input.resource.uuid,
+            groupUuid: input.groupUuid,
+            role: input.role,
+            actorRole,
+            actorRoleResolver,
+            grantedByUserUuid: input.account.user.userUuid,
+        });
+        this.auditMutation(
+            input,
+            { type: 'group', uuid: input.groupUuid },
+            result,
+        );
+    }
+
+    async revokeUserAccess(
+        input: DirectAccessMutationInput & { userUuid: UUID },
+    ): Promise<void> {
+        const actorRole = await this.resolveActorRole(input);
+        const actorRoleResolver = this.createActorRoleResolver(input);
+        const result = await this.getModel(
+            input.resource.type,
+        ).revokeUserAccess({
+            resourceUuid: input.resource.uuid,
+            userUuid: input.userUuid,
+            actorRole,
+            actorRoleResolver,
+            actorUserUuid: input.account.user.userUuid,
+        });
+        this.auditMutation(
+            input,
+            { type: 'user', uuid: input.userUuid },
+            result,
+        );
+    }
+
+    async revokeGroupAccess(
+        input: DirectAccessMutationInput & { groupUuid: UUID },
+    ): Promise<void> {
+        const actorRole = await this.resolveActorRole(input);
+        const actorRoleResolver = this.createActorRoleResolver(input);
+        const result = await this.getModel(
+            input.resource.type,
+        ).revokeGroupAccess({
+            resourceUuid: input.resource.uuid,
+            groupUuid: input.groupUuid,
+            actorRole,
+            actorRoleResolver,
+        });
+        this.auditMutation(
+            input,
+            { type: 'group', uuid: input.groupUuid },
+            result,
+        );
+    }
+
+    async resetAccess(input: DirectAccessMutationInput): Promise<void> {
+        const actorRole = await this.resolveActorRole(input);
+        const actorRoleResolver = this.createActorRoleResolver(input);
+        const result = await this.getModel(input.resource.type).resetAccess({
+            resourceUuid: input.resource.uuid,
+            actorRole,
+            actorRoleResolver,
+        });
+        this.auditReset(input, result);
+    }
+}

--- a/packages/backend/src/services/DirectAccess/directAccessAudit.test.ts
+++ b/packages/backend/src/services/DirectAccess/directAccessAudit.test.ts
@@ -1,0 +1,122 @@
+import { SpaceMemberRole } from '@lightdash/common';
+import { describe, expect, it, vi } from 'vitest';
+import { type AuditActor } from '../../logging/auditLog';
+import {
+    auditDirectAccessMutation,
+    auditDirectAccessReset,
+} from './directAccessAudit';
+
+const actor: AuditActor = {
+    type: 'session',
+    uuid: 'actor-uuid',
+    organizationUuid: 'organization-uuid',
+    organizationRole: 'admin',
+};
+
+const mutationResult = {
+    organizationId: 1,
+    organizationUuid: 'organization-uuid',
+    projectId: 2,
+    projectUuid: 'project-uuid',
+};
+
+describe('direct access audit events', () => {
+    it.each([
+        {
+            beforeRole: null,
+            afterRole: SpaceMemberRole.VIEWER,
+            action: 'direct_access.grant',
+        },
+        {
+            beforeRole: SpaceMemberRole.VIEWER,
+            afterRole: SpaceMemberRole.EDITOR,
+            action: 'direct_access.role_change',
+        },
+        {
+            beforeRole: SpaceMemberRole.EDITOR,
+            afterRole: null,
+            action: 'direct_access.revoke',
+        },
+    ] as const)('emits $action with attribution', (testCase) => {
+        const auditLogger = vi.fn();
+        auditDirectAccessMutation({
+            actor,
+            context: { requestId: 'request-id' },
+            resourceType: 'Dashboard',
+            resourceUuid: 'dashboard-uuid',
+            principal: { type: 'user', uuid: 'principal-uuid' },
+            result: { ...mutationResult, ...testCase },
+            auditLogger,
+        });
+
+        expect(auditLogger).toHaveBeenCalledWith(
+            expect.objectContaining({
+                actor,
+                action: testCase.action,
+                context: { requestId: 'request-id' },
+                status: 'allowed',
+                resource: {
+                    type: 'Dashboard',
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    metadata: {
+                        resourceUuid: 'dashboard-uuid',
+                        principalType: 'user',
+                        principalUuid: 'principal-uuid',
+                        beforeRole: testCase.beforeRole,
+                        afterRole: testCase.afterRole,
+                    },
+                },
+            }),
+        );
+    });
+
+    it('emits reset counts', () => {
+        const auditLogger = vi.fn();
+        auditDirectAccessReset({
+            actor,
+            context: {},
+            resourceType: 'App',
+            resourceUuid: 'app-uuid',
+            result: {
+                ...mutationResult,
+                revokedUsers: 3,
+                revokedGroups: 2,
+            },
+            auditLogger,
+        });
+
+        expect(auditLogger).toHaveBeenCalledWith(
+            expect.objectContaining({
+                action: 'direct_access.reset',
+                resource: expect.objectContaining({
+                    metadata: {
+                        resourceUuid: 'app-uuid',
+                        revokedUsers: 3,
+                        revokedGroups: 2,
+                    },
+                }),
+            }),
+        );
+    });
+
+    it('does not report a committed mutation as failed when audit logging throws', () => {
+        expect(() =>
+            auditDirectAccessMutation({
+                actor,
+                context: {},
+                resourceType: 'Dashboard',
+                resourceUuid: 'dashboard-uuid',
+                principal: { type: 'user', uuid: 'principal-uuid' },
+                result: {
+                    ...mutationResult,
+                    beforeRole: null,
+                    afterRole: SpaceMemberRole.VIEWER,
+                },
+                auditLogger: () => {
+                    throw new Error('logger unavailable');
+                },
+            }),
+        ).not.toThrow();
+    });
+});

--- a/packages/backend/src/services/DirectAccess/directAccessAudit.ts
+++ b/packages/backend/src/services/DirectAccess/directAccessAudit.ts
@@ -1,0 +1,108 @@
+import {
+    createAuditLogEvent,
+    type AuditActor,
+    type AuditContext,
+    type AuditLogEvent,
+} from '../../logging/auditLog';
+import Logger from '../../logging/logger';
+import { logAuditEvent } from '../../logging/winston';
+import {
+    type DirectAccessMutationResult,
+    type DirectAccessResetResult,
+} from '../../models/directAccessModelUtils';
+
+export type DirectAccessAuditLogger = (event: AuditLogEvent) => void;
+
+type Principal =
+    | { type: 'user'; uuid: string }
+    | { type: 'group'; uuid: string };
+
+export const auditDirectAccessMutation = ({
+    actor,
+    context,
+    resourceType,
+    resourceUuid,
+    principal,
+    result,
+    auditLogger = logAuditEvent,
+}: {
+    actor: AuditActor;
+    context: AuditContext;
+    resourceType: string;
+    resourceUuid: string;
+    principal: Principal;
+    result: DirectAccessMutationResult;
+    auditLogger?: DirectAccessAuditLogger;
+}): void => {
+    let action = 'direct_access.role_change';
+    if (result.afterRole === null) {
+        action = 'direct_access.revoke';
+    } else if (result.beforeRole === null) {
+        action = 'direct_access.grant';
+    }
+    try {
+        auditLogger(
+            createAuditLogEvent(
+                actor,
+                action,
+                {
+                    type: resourceType,
+                    organizationUuid: result.organizationUuid,
+                    projectUuid: result.projectUuid,
+                    metadata: {
+                        resourceUuid,
+                        principalType: principal.type,
+                        principalUuid: principal.uuid,
+                        beforeRole: result.beforeRole,
+                        afterRole: result.afterRole,
+                    },
+                },
+                context,
+                'allowed',
+            ),
+        );
+    } catch (error) {
+        Logger.warn('Failed to write direct access audit event', { error });
+    }
+};
+
+export const auditDirectAccessReset = ({
+    actor,
+    context,
+    resourceType,
+    resourceUuid,
+    result,
+    auditLogger = logAuditEvent,
+}: {
+    actor: AuditActor;
+    context: AuditContext;
+    resourceType: string;
+    resourceUuid: string;
+    result: DirectAccessResetResult;
+    auditLogger?: DirectAccessAuditLogger;
+}): void => {
+    try {
+        auditLogger(
+            createAuditLogEvent(
+                actor,
+                'direct_access.reset',
+                {
+                    type: resourceType,
+                    organizationUuid: result.organizationUuid,
+                    projectUuid: result.projectUuid,
+                    metadata: {
+                        resourceUuid,
+                        revokedUsers: result.revokedUsers,
+                        revokedGroups: result.revokedGroups,
+                    },
+                },
+                context,
+                'allowed',
+            ),
+        );
+    } catch (error) {
+        Logger.warn('Failed to write direct access reset audit event', {
+            error,
+        });
+    }
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1249

## Summary

PR 4 of 5 adds transactional direct-access writes and one shared `DirectAccessService` across dashboards, saved charts, saved SQL, and apps.

Stacks on PR 3 ([#27923](https://github.com/lightdash/lightdash/pull/27923)), which adds the four native batched read models.

Prior work: @hrx-joseph-fahnestock's [resolver proposal](https://github.com/houserx/lightdash-hrx/pull/25) established the additive access invariant used by this stack. This PR adds the native mutation, validation, authorization, and audit layers; it does not copy the proposal's implementation.

## Changes

- Adds user/group grant, replacement, revoke, and reset operations to all four native models.
- Routes the operation family through one typed `DirectAccessService`; persistence and joins remain resource-specific.
- Requires a trusted two-phase actor-role resolver: advisory preflight authorization followed by authoritative resolution inside the locked mutation transaction.
- Requires transaction-phase resolvers to hold every role-lowering authority source, including absence anchors, until mutation completion.
- Validates active principals and tenant membership without exposing target existence to unauthorized callers.
- Emits grant, change, revoke, and reset audit events only after successful persistence.

## Write path

```text
preflight authorization
        |
        v
lock concrete resource -> resolve + lock current authority -> mutate atomically
                                                               |
                                                               v
                                                           audit event
```

## Test plan

- [x] 20 focused model, service, and audit tests
- [x] 14 PostgreSQL integration scenarios, including deterministic authority-lock and concurrent replacement coverage
- [x] `pnpm -F backend typecheck`
- [x] Backend lint and formatting checks
