### PR TITLE
feat: finalize embedded chart builder access

### DIFF
--- a/examples/api/embedding.http
+++ b/examples/api/embedding.http
@@ -52,6 +52,10 @@ Content-Type: application/json
 
 ### Generate dashboard embed url
 #### use the dashboardUuid you want to embed
+#### writeActions enables dashboard editing when its actor can update the dashboard.
+#### With canExplore enabled, the embedded chart builder is available when the
+#### actor can also create saved charts in this space (for example via
+#### manage:Dashboard@space and manage:SavedChart@space custom-role scopes).
 
 POST http://localhost:8080/api/v1/embed/{{projectUuid}}/get-embed-url
 Content-Type: application/json
@@ -69,6 +73,10 @@ Content-Type: application/json
         "canDateZoom": true,
         "canExportPagePdf": true,
         "projectUuid": "{{projectUuid}}"
+    },
+    "writeActions": {
+        "serviceAccountUserUuid": "{{serviceAccountUserUuid}}",
+        "spaceUuid": "{{spaceUuid}}"
     }
 }
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -2551,17 +2551,18 @@ export class EmbedService extends BaseService {
                         embedWriteUserPromise,
                     ]);
 
-                const embedWriteContext = await this.getEmbedWriteContext(
-                    decodedToken,
-                    embedWriteUser,
-                    projectUuid,
-                );
-
                 if (!content) {
                     throw new NotFoundError(
                         'Cannot verify JWT. Content not found',
                     );
                 }
+
+                const embedWriteContext = await this.getEmbedWriteContext(
+                    decodedToken,
+                    embedWriteUser,
+                    projectUuid,
+                    content,
+                );
 
                 // Secure-by-default: a standalone data app embed is honoured
                 // only when the project opted the app in — via the broad
@@ -2630,6 +2631,7 @@ export class EmbedService extends BaseService {
         decodedToken: CreateEmbedJwt,
         embedWriteUser: SessionUser | undefined,
         projectUuid: string,
+        content: EmbedContent,
     ): Promise<AnonymousAccount['embedWriteContext']> {
         const { writeActions } = decodedToken;
         if (!writeActions || !embedWriteUser) {
@@ -2648,6 +2650,7 @@ export class EmbedService extends BaseService {
 
             if (spaceAccessContext.projectUuid !== projectUuid) {
                 return {
+                    canUpdateDashboard: false,
                     canCreateSavedChart: false,
                     canUseAiAgent: false,
                     aiAgentErrorMessage:
@@ -2656,6 +2659,18 @@ export class EmbedService extends BaseService {
             }
 
             const auditedAbility = this.createAuditedAbility(embedWriteUser);
+            const canUpdateDashboard =
+                content.type === 'dashboard' &&
+                content.dashboardUuid !== undefined &&
+                auditedAbility.can(
+                    'update',
+                    subject('Dashboard', {
+                        ...spaceAccessContext,
+                        metadata: {
+                            dashboardUuid: content.dashboardUuid,
+                        },
+                    }),
+                );
             const canCreateSavedChart = auditedAbility.can(
                 'create',
                 subject('SavedChart', {
@@ -2683,6 +2698,7 @@ export class EmbedService extends BaseService {
                 canViewProject;
 
             return {
+                canUpdateDashboard,
                 canCreateSavedChart,
                 canUseAiAgent,
                 aiAgentErrorMessage: canUseAiAgent
@@ -2700,6 +2716,7 @@ export class EmbedService extends BaseService {
                 error instanceof NotFoundError
             ) {
                 return {
+                    canUpdateDashboard: false,
                     canCreateSavedChart: false,
                     canUseAiAgent: false,
                     aiAgentErrorMessage:

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -182,6 +182,7 @@ export type AnonymousAccount = BaseAccountWithHelpers & {
     user: ExternalUser;
     embedWriteUser?: SessionUser;
     embedWriteContext?: {
+        canUpdateDashboard: boolean;
         canCreateSavedChart: boolean;
         canUseAiAgent: boolean;
         aiAgentErrorMessage?: string;

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -114,14 +114,6 @@ export enum FeatureFlags {
     ExplorerChartGallery = 'explorer-chart-gallery',
 
     /**
-     * Let embedded dashboard builders create and edit charts in place ("New
-     * chart" in the add-tile menu and "Edit chart" on tiles). Resolved with
-     * the embed write actor and organization, surfaced via embedWriteContext.
-     * Disabled by default.
-     */
-    EmbedChartBuilder = 'embed-chart-builder',
-
-    /**
      * Per-organization gate for declaring custom npm dependencies in data
      * apps. Disabled by default; self-hosted instances can enable it globally
      * via LIGHTDASH_ENABLE_FEATURE_FLAGS.

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -1,7 +1,6 @@
 import {
     ChartType,
     DashboardTileTypes,
-    FeatureFlags,
     QueryExecutionContext,
     assertUnreachable,
     getDefaultChartTileSize,
@@ -38,12 +37,12 @@ import {
     appendNewTilesToBottom,
     useUpdateDashboard,
 } from '../../../../../hooks/dashboard/useDashboard';
-import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
 import { type EmbedExploreChart } from '../../../../providers/Embed/types';
 import useEmbed from '../../../../providers/Embed/useEmbed';
 import { embedContractClass } from '../../styles/embedClassContract';
 import { useEmbedDashboard } from '../hooks';
+import { canUseEmbeddedChartBuilder } from '../utils';
 import EmbedDashboardChartEditorModal from './EmbedDashboardChartEditorModal';
 import EmbedDashboardChartTile from './EmbedDashboardChartTile';
 import EmbedDashboardHeader from './EmbedDashboardHeader';
@@ -465,20 +464,17 @@ const EmbedDashboard: FC<{
     );
 
     const canWriteDashboard =
-        !!writeActions && dashboard?.spaceUuid === writeActions.spaceUuid;
-    // Creating/editing charts in the builder is flag-gated and needs the
-    // token to allow ad-hoc exploring (canExplore) plus a write actor that
-    // can create charts in the write space.
-    const chartBuilderFlag = useServerFeatureFlag(
-        FeatureFlags.EmbedChartBuilder,
-    );
-    const canAddNewChart =
-        chartBuilderFlag.data?.enabled === true &&
-        canWriteDashboard &&
-        embedWriteContext?.canCreateSavedChart === true &&
-        content !== undefined &&
-        isDashboardContent(content) &&
-        content.canExplore === true;
+        !!writeActions &&
+        dashboard?.spaceUuid === writeActions.spaceUuid &&
+        embedWriteContext?.canUpdateDashboard === true;
+    const canUseChartBuilder = canUseEmbeddedChartBuilder({
+        canWriteDashboard,
+        canCreateSavedChart: embedWriteContext?.canCreateSavedChart === true,
+        canExplore:
+            content !== undefined &&
+            isDashboardContent(content) &&
+            content.canExplore === true,
+    });
     const [isNewChartOpen, setIsNewChartOpen] = useState(false);
     const [chartToEdit, setChartToEdit] = useState<SavedChart>();
     const hasDashboardNameChanged =
@@ -755,7 +751,7 @@ const EmbedDashboard: FC<{
                     maxSelectedValues={1}
                     disabled={isSaving}
                     onNewChart={
-                        canAddNewChart
+                        canUseChartBuilder
                             ? () => setIsNewChartOpen(true)
                             : undefined
                     }
@@ -836,7 +832,7 @@ const EmbedDashboard: FC<{
                 onBreakpointChange={setCurrentCols}
                 onDeleteTile={handleDeleteTile}
                 onEditTile={handleEditTile}
-                onEditChart={canAddNewChart ? setChartToEdit : undefined}
+                onEditChart={canUseChartBuilder ? setChartToEdit : undefined}
                 onExplore={onExplore}
                 useDashboardEditorTileQueries={canWriteDashboard}
             />
@@ -912,7 +908,7 @@ const EmbedDashboard: FC<{
                     {renderGridWithGuidedSetup()}
                 </>
             )}
-            {canAddNewChart && (
+            {canUseChartBuilder && (
                 <EmbedDashboardChartEditorModal
                     opened={isNewChartOpen || chartToEdit !== undefined}
                     onClose={() => {

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/utils.test.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/utils.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import {
+    canUseEmbeddedChartBuilder,
     convertSdkFilterToDashboardFilter,
     shouldDeferSdkFilters,
 } from './utils';
@@ -32,6 +33,41 @@ const baseFilter = {
     operator: `${FilterOperator.EQUALS}` as const,
     value: 'bank_transfer',
 };
+
+describe('canUseEmbeddedChartBuilder', () => {
+    it('allows the chart builder when the write actor can update the dashboard and create charts', () => {
+        expect(
+            canUseEmbeddedChartBuilder({
+                canWriteDashboard: true,
+                canCreateSavedChart: true,
+                canExplore: true,
+            }),
+        ).toBe(true);
+    });
+
+    it.each([
+        {
+            canWriteDashboard: false,
+            canCreateSavedChart: true,
+            canExplore: true,
+        },
+        {
+            canWriteDashboard: true,
+            canCreateSavedChart: false,
+            canExplore: true,
+        },
+        {
+            canWriteDashboard: true,
+            canCreateSavedChart: true,
+            canExplore: false,
+        },
+    ])(
+        'denies the chart builder when a required ability is missing',
+        (args) => {
+            expect(canUseEmbeddedChartBuilder(args)).toBe(false);
+        },
+    );
+});
 
 describe('convertSdkFilterToDashboardFilter', () => {
     it('returns empty tileTargets when filterableFieldsByTileUuid is not provided', () => {

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/utils.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/utils.ts
@@ -10,6 +10,16 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { type SdkFilter } from './types';
 
+export const canUseEmbeddedChartBuilder = ({
+    canWriteDashboard,
+    canCreateSavedChart,
+    canExplore,
+}: {
+    canWriteDashboard: boolean;
+    canCreateSavedChart: boolean;
+    canExplore: boolean;
+}): boolean => canWriteDashboard && canCreateSavedChart && canExplore;
+
 /**
  * Whether SDK filter conversion should be deferred until the data needed to
  * build cross-explore tileTargets is available.

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -98,12 +98,14 @@ const EmbedPreviewDashboardForm: FC<{
     dashboards: DashboardBasicDetails[];
     writeActions?: CreateEmbedJwt['writeActions'];
     writeActionsPanel?: ReactNode;
+    onDashboardSpaceChange?: (spaceUuid: string | undefined) => void;
 }> = ({
     projectUuid,
     siteUrl,
     dashboards,
     writeActions,
     writeActionsPanel,
+    onDashboardSpaceChange,
 }) => {
     const { mutateAsync: createEmbedUrl } =
         useEmbedUrlCreateMutation(projectUuid);
@@ -257,6 +259,17 @@ const EmbedPreviewDashboardForm: FC<{
                     placeholder="Select a dashboard..."
                     searchable
                     {...form.getInputProps('dashboardUuid')}
+                    onChange={(dashboardUuid) => {
+                        form.setFieldValue(
+                            'dashboardUuid',
+                            dashboardUuid ?? undefined,
+                        );
+                        onDashboardSpaceChange?.(
+                            dashboards.find(
+                                (dashboard) => dashboard.uuid === dashboardUuid,
+                            )?.spaceUuid,
+                        );
+                    }}
                 />
 
                 <Stack gap="xs">

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedWriteActionsForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedWriteActionsForm.tsx
@@ -92,6 +92,7 @@ type Props = {
     value: CreateEmbedJwt['writeActions'] | undefined;
     onChange: (value: CreateEmbedJwt['writeActions'] | undefined) => void;
     required?: boolean;
+    fixedSpaceUuid?: string;
 };
 
 const EmbedWriteActionsForm: FC<Props> = ({
@@ -99,6 +100,7 @@ const EmbedWriteActionsForm: FC<Props> = ({
     value,
     onChange,
     required = false,
+    fixedSpaceUuid,
 }) => {
     const { listAccounts, createAccount } = useServiceAccounts();
     const { listRoles } = useCustomRoles();
@@ -225,12 +227,21 @@ const EmbedWriteActionsForm: FC<Props> = ({
 
     useEffect(() => {
         const nextSpaceUuid =
-            value?.spaceUuid &&
-            spaces.some((space) => space.uuid === value.spaceUuid)
-                ? value.spaceUuid
-                : spaces[0]?.uuid;
+            fixedSpaceUuid &&
+            spaces.some((space) => space.uuid === fixedSpaceUuid)
+                ? fixedSpaceUuid
+                : value?.spaceUuid &&
+                    spaces.some((space) => space.uuid === value.spaceUuid)
+                  ? value.spaceUuid
+                  : spaces[0]?.uuid;
 
         setSelectedSpaceUuid((currentUuid) => {
+            if (
+                fixedSpaceUuid &&
+                spaces.some((space) => space.uuid === fixedSpaceUuid)
+            ) {
+                return fixedSpaceUuid;
+            }
             if (
                 currentUuid &&
                 spaces.some((space) => space.uuid === currentUuid)
@@ -239,7 +250,7 @@ const EmbedWriteActionsForm: FC<Props> = ({
             }
             return nextSpaceUuid;
         });
-    }, [spaces, value?.spaceUuid]);
+    }, [fixedSpaceUuid, spaces, value?.spaceUuid]);
 
     useEffect(() => {
         if (!isEnabled || !selectedServiceAccount || !selectedSpace) {
@@ -446,6 +457,7 @@ const EmbedWriteActionsForm: FC<Props> = ({
                                     fullWidth
                                     justify="space-between"
                                     loading={isLoadingSpaces}
+                                    disabled={fixedSpaceUuid !== undefined}
                                     rightSection={
                                         <MantineIcon icon={IconChevronDown} />
                                     }
@@ -494,8 +506,9 @@ const EmbedWriteActionsForm: FC<Props> = ({
                             </Menu.Dropdown>
                         </Menu>
                         <Text c="dimmed" fz="xs">
-                            Charts and other created content from this embed
-                            token are written to this space.
+                            {fixedSpaceUuid
+                                ? "This is the selected dashboard's space. Embedded dashboard editing requires created content to use the same space."
+                                : 'Charts and other created content from this embed token are written to this space.'}
                         </Text>
                     </Stack>
 

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
@@ -161,6 +161,8 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
         useEmbedConfigUpdateMutation(projectUuid);
     const [writeActions, setWriteActions] =
         useState<CreateEmbedJwt['writeActions']>();
+    const [selectedDashboardSpaceUuid, setSelectedDashboardSpaceUuid] =
+        useState<string>();
     const [activeTab, setActiveTab] = useState<
         'dashboards' | 'charts' | 'apps' | 'aiAgents'
     >('dashboards');
@@ -341,12 +343,18 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                                 siteUrl={health.data.siteUrl}
                                 dashboards={allowedDashboards}
                                 writeActions={writeActions}
+                                onDashboardSpaceChange={
+                                    setSelectedDashboardSpaceUuid
+                                }
                                 writeActionsPanel={
                                     activeTab === 'dashboards' ? (
                                         <EmbedWriteActionsForm
                                             projectUuid={projectUuid}
                                             value={writeActions}
                                             onChange={setWriteActions}
+                                            fixedSpaceUuid={
+                                                selectedDashboardSpaceUuid
+                                            }
                                         />
                                     ) : null
                                 }


### PR DESCRIPTION
## Summary

- removes the `embed-chart-builder` feature flag without introducing a replacement JWT boolean
- keeps the existing embedded-write token contract: `content.canExplore` plus `writeActions`
- derives chart-builder access from the write actor's existing abilities in the target space
- keeps dashboard editing and adding existing charts available when the actor can update the dashboard
- shows New chart and Edit chart only when that actor can also create saved charts
- locks dashboard write actions to the selected dashboard's space

## Permission behavior

| Write actor in the selected space | Dashboard editor | Add existing chart | New/Edit chart |
| --- | --- | --- | --- |
| Can update dashboards and create saved charts | Yes | Yes | Yes |
| Can update dashboards but cannot create saved charts | Yes | Yes | No |
| Cannot update dashboards | No | No | No |

This reuses the existing `manage:Dashboard@space` and `manage:SavedChart@space` custom-role scopes. Existing embed tokens do not need a new claim, and no permission migration is required.

## Validation

- `pnpm -F common typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F frontend typecheck`
- focused frontend tests: 29 passed
- common/frontend lint and formatting
- `pnpm generate-api`
- no remaining references to `canCreateAndEditCharts`, `embed-chart-builder`, or `EmbedChartBuilder`

## Live preview verification

Tested on the deployed PR preview with generated tokens that contain `content.canExplore` and `writeActions`, but no chart-builder JWT boolean:

- chart-capable Admin actor: dashboard Edit is available; Add tile includes New chart; the embedded chart builder opens successfully
- dashboard-only custom role (`manage:Dashboard`, no `manage:SavedChart`): dashboard Edit and Saved chart remain available; New chart is absent
- Viewer actor: the dashboard loads read-only with no Edit or Add tile controls
- generated embed snippets contain the selected write actor and no `canCreateAndEditCharts` claim

| Chart-capable actor | Dashboard-only custom role | Viewer actor |
| --- | --- | --- |
| ![New chart builder](https://gist.githubusercontent.com/rephus/4ac60e81c2a2038ab4138f7b75b7e2db/raw/b8287285948564dc6c3f51c53dfcd9841828083e/pr27926-admin-chart-builder.svg) | ![Saved chart available without New chart](https://gist.githubusercontent.com/rephus/4ac60e81c2a2038ab4138f7b75b7e2db/raw/4af3922dfa9edba969a70c93ece90db061fa6b56/pr27926-dashboard-only.svg) | ![Read-only dashboard](https://gist.githubusercontent.com/rephus/4ac60e81c2a2038ab4138f7b75b7e2db/raw/972e21b1a37685589c58edda4d7973c8161b7be3/pr27926-viewer.svg) |

Closes: PROD-9484
