### PR TITLE
feat(ai): improve agent and project filtering UX

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AgentsFilter.tsx
@@ -8,16 +8,20 @@ import FilterFacet, {
 import { useProjects } from '../../../../../hooks/useProjects';
 import { useAiAgentAdminAgents } from '../../hooks/useAiAgentAdmin';
 import { type useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
+import { buildAgentFilterGroups } from './projectFilterOrdering';
 
 type AgentsFilterProps = Pick<
     ReturnType<typeof useAiAgentAdminFilters>,
     'selectedAgentUuids' | 'setSelectedAgentUuids' | 'selectedProjectUuids'
->;
+> & {
+    hidePreviewProjects?: boolean;
+};
 
 const AgentsFilter: FC<AgentsFilterProps> = ({
     selectedAgentUuids,
     setSelectedAgentUuids,
     selectedProjectUuids,
+    hidePreviewProjects = false,
 }) => {
     const [searchValue, setSearchValue] = useState('');
     const organizationAiAgents = useAiAgentAdminAgents();
@@ -33,72 +37,43 @@ const AgentsFilter: FC<AgentsFilterProps> = ({
         if (!organizationAiAgents.data || !projects) return [];
 
         const search = searchValue.trim().toLowerCase();
-        const projectByUuid = new Map(
-            projects.map((project) => [project.projectUuid, project]),
-        );
 
-        const groupedByProject = new Map<
-            string,
-            { projectName: string; agents: typeof organizationAiAgents.data }
-        >();
-
-        for (const agent of organizationAiAgents.data) {
-            const project = projectByUuid.get(agent.projectUuid);
-            if (!project) continue;
-
-            const existing = groupedByProject.get(agent.projectUuid);
-            if (existing) {
-                existing.agents.push(agent);
-            } else {
-                groupedByProject.set(agent.projectUuid, {
-                    projectName: project.name,
-                    agents: [agent],
-                });
-            }
-        }
-
-        return Array.from(groupedByProject.entries()).map(
-            ([projectUuid, { projectName, agents }]) => ({
-                label: projectName,
-                options: agents
-                    .filter(
-                        (agent) =>
-                            !search ||
-                            agent.name.toLowerCase().includes(search),
-                    )
-                    .map((agent) => {
-                        const disabled =
-                            hasSelectedProjects &&
-                            !selectedProjectsSet.has(projectUuid);
-                        return {
-                            value: agent.uuid,
-                            searchLabel: agent.name,
-                            disabled,
-                            label: (
-                                <Group gap="two" wrap="nowrap">
-                                    <LightdashUserAvatar
-                                        size={16}
-                                        name={agent.name}
-                                        src={agent.imageUrl}
-                                    />
-                                    <Text
-                                        fz="xs"
-                                        c={disabled ? 'ldGray.5' : 'ldGray.9'}
-                                        truncate
-                                    >
-                                        {agent.name}
-                                    </Text>
-                                </Group>
-                            ),
-                        };
-                    }),
-            }),
-        );
+        return buildAgentFilterGroups({
+            agents: organizationAiAgents.data,
+            projects,
+            hidePreviewProjects,
+            selectedProjectUuids,
+            selectedAgentUuids,
+        }).map(({ projectName, agents }) => ({
+            label: projectName,
+            options: agents
+                .filter(
+                    (agent) =>
+                        !search || agent.name.toLowerCase().includes(search),
+                )
+                .map((agent) => ({
+                    value: agent.uuid,
+                    searchLabel: agent.name,
+                    label: (
+                        <Group gap="two" wrap="nowrap">
+                            <LightdashUserAvatar
+                                size={16}
+                                name={agent.name}
+                                src={agent.imageUrl}
+                            />
+                            <Text fz="xs" c="ldGray.9" truncate>
+                                {agent.name}
+                            </Text>
+                        </Group>
+                    ),
+                })),
+        }));
     }, [
         organizationAiAgents.data,
         projects,
-        hasSelectedProjects,
-        selectedProjectsSet,
+        hidePreviewProjects,
+        selectedProjectUuids,
+        selectedAgentUuids,
         searchValue,
     ]);
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminEvalsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminEvalsTable.tsx
@@ -10,6 +10,7 @@ import {
     Divider,
     Group,
     Stack,
+    Switch,
     Text,
     Tooltip,
     useMantineTheme,
@@ -63,6 +64,8 @@ const AiAgentAdminEvalsTable = ({
         setSelectedProjectUuids,
         setSelectedAgentUuids,
         setSorting,
+        hidePreviewProjects,
+        setHidePreviewProjects,
         hasActiveFilters,
         resetFilters,
     } = useAiAgentAdminFilters();
@@ -370,6 +373,7 @@ const AiAgentAdminEvalsTable = ({
                         <ProjectsFilter
                             selectedProjectUuids={selectedProjectUuids}
                             setSelectedProjectUuids={setSelectedProjectUuids}
+                            hidePreviewProjects={hidePreviewProjects}
                         />
                         <Divider
                             orientation="vertical"
@@ -381,6 +385,23 @@ const AiAgentAdminEvalsTable = ({
                             selectedAgentUuids={selectedAgentUuids}
                             setSelectedAgentUuids={setSelectedAgentUuids}
                             selectedProjectUuids={selectedProjectUuids}
+                            hidePreviewProjects={hidePreviewProjects}
+                        />
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{ alignSelf: 'center' }}
+                        />
+                        <Switch
+                            size="xs"
+                            label="Hide preview projects"
+                            checked={hidePreviewProjects}
+                            onChange={(event) =>
+                                setHidePreviewProjects(
+                                    event.currentTarget.checked,
+                                )
+                            }
                         />
                         {hasActiveFilters && (
                             <>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -145,6 +145,8 @@ const AiAgentAdminThreadsTable = ({
         setSelectedSource,
         setSelectedFeedback,
         setSorting,
+        hidePreviewProjects,
+        setHidePreviewProjects,
         hasActiveFilters,
         resetFilters,
     } = useAiAgentAdminFilters();
@@ -731,6 +733,8 @@ const AiAgentAdminThreadsTable = ({
                 setSelectedSource={setSelectedSource}
                 selectedFeedback={selectedFeedback}
                 setSelectedFeedback={setSelectedFeedback}
+                hidePreviewProjects={hidePreviewProjects}
+                setHidePreviewProjects={setHidePreviewProjects}
                 totalResults={totalResults}
                 isFetching={isFetching}
                 hasNextPage={hasNextPage ?? false}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
@@ -3,6 +3,7 @@ import {
     Button,
     Divider,
     Group,
+    Switch,
     Text,
     useMantineTheme,
     type GroupProps,
@@ -33,6 +34,8 @@ type AiAgentAdminTopToolbarProps = GroupProps &
         | 'setSelectedUserUuids'
         | 'setSelectedSource'
         | 'setSelectedFeedback'
+        | 'hidePreviewProjects'
+        | 'setHidePreviewProjects'
     > & {
         totalResults: number;
         isFetching: boolean;
@@ -56,6 +59,8 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
         setSelectedSource,
         selectedFeedback,
         setSelectedFeedback,
+        hidePreviewProjects,
+        setHidePreviewProjects,
         totalResults,
         isFetching,
         hasNextPage,
@@ -99,6 +104,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                         <ProjectsFilter
                             selectedProjectUuids={selectedProjectUuids}
                             setSelectedProjectUuids={setSelectedProjectUuids}
+                            hidePreviewProjects={hidePreviewProjects}
                         />
 
                         <Divider
@@ -113,6 +119,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                             selectedAgentUuids={selectedAgentUuids}
                             setSelectedAgentUuids={setSelectedAgentUuids}
                             selectedProjectUuids={selectedProjectUuids}
+                            hidePreviewProjects={hidePreviewProjects}
                         />
                         <Divider
                             orientation="vertical"
@@ -150,6 +157,25 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                         <SourceFilter
                             selectedSource={selectedSource}
                             setSelectedSource={setSelectedSource}
+                        />
+
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{
+                                alignSelf: 'center',
+                            }}
+                        />
+                        <Switch
+                            size="xs"
+                            label="Hide preview projects"
+                            checked={hidePreviewProjects}
+                            onChange={(event) =>
+                                setHidePreviewProjects(
+                                    event.currentTarget.checked,
+                                )
+                            }
                         />
 
                         {hasActiveFilters && onClearFilters && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectsFilter.tsx
@@ -6,6 +6,7 @@ import FilterFacet, {
 import { useProjects } from '../../../../../hooks/useProjects';
 import { useAiAgentAdminAgents } from '../../hooks/useAiAgentAdmin';
 import { type useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
+import { sortAndFilterVisibleProjects } from './projectFilterOrdering';
 
 type ProjectsFilterProps = Pick<
     ReturnType<typeof useAiAgentAdminFilters>,
@@ -15,6 +16,7 @@ type ProjectsFilterProps = Pick<
     // 'with-agents' hides projects that have no agent; 'all' lists every
     // project, which audit surfaces need since content outlives its agent
     projectScope?: 'with-agents' | 'all';
+    hidePreviewProjects?: boolean;
 };
 
 const ProjectsFilter: FC<ProjectsFilterProps> = ({
@@ -22,6 +24,7 @@ const ProjectsFilter: FC<ProjectsFilterProps> = ({
     setSelectedProjectUuids,
     tooltipLabel = 'Filter threads by project',
     projectScope = 'with-agents',
+    hidePreviewProjects = false,
 }) => {
     const [searchValue, setSearchValue] = useState('');
     const { data: projects, isLoading } = useProjects();
@@ -37,8 +40,15 @@ const ProjectsFilter: FC<ProjectsFilterProps> = ({
             label: project.name,
         });
 
+        const toVisibleSortedOptions = (scopedProjects: typeof projects) =>
+            sortAndFilterVisibleProjects({
+                projects: scopedProjects,
+                hidePreviewProjects,
+                selectedProjectUuids,
+            }).map(toOption);
+
         if (projectScope === 'all') {
-            return projects.map(toOption);
+            return toVisibleSortedOptions(projects);
         }
 
         if (!organizationAiAgents.data) return [];
@@ -47,12 +57,18 @@ const ProjectsFilter: FC<ProjectsFilterProps> = ({
             organizationAiAgents.data.map((agent) => agent.projectUuid),
         );
 
-        return projects
-            .filter((project) =>
+        return toVisibleSortedOptions(
+            projects.filter((project) =>
                 projectUuidsWithAgents.has(project.projectUuid),
-            )
-            .map(toOption);
-    }, [projects, organizationAiAgents.data, projectScope]);
+            ),
+        );
+    }, [
+        projects,
+        organizationAiAgents.data,
+        projectScope,
+        hidePreviewProjects,
+        selectedProjectUuids,
+    ]);
 
     const filteredOptions = useMemo<FilterFacetOption[]>(() => {
         const search = searchValue.trim().toLowerCase();

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/projectFilterOrdering.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/projectFilterOrdering.test.ts
@@ -1,0 +1,151 @@
+import { ProjectType } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    buildAgentFilterGroups,
+    sortAndFilterVisibleProjects,
+    type FilterProject,
+} from './projectFilterOrdering';
+
+const project = (
+    name: string,
+    type: ProjectType = ProjectType.DEFAULT,
+): FilterProject => ({
+    projectUuid: `uuid-${name}`,
+    name,
+    type,
+});
+
+const agent = (name: string, projectName: string) => ({
+    uuid: `agent-${name}`,
+    name,
+    projectUuid: `uuid-${projectName}`,
+});
+
+const preview = (name: string) => project(name, ProjectType.PREVIEW);
+
+describe('sortAndFilterVisibleProjects', () => {
+    it('sorts production projects first, previews last, alphabetically within tiers', () => {
+        const result = sortAndFilterVisibleProjects({
+            projects: [
+                preview('Zeta preview'),
+                project('beta'),
+                preview('Alpha preview'),
+                project('Alpha'),
+            ],
+            hidePreviewProjects: false,
+            selectedProjectUuids: [],
+        });
+
+        expect(result.map((p) => p.name)).toEqual([
+            'Alpha',
+            'beta',
+            'Alpha preview',
+            'Zeta preview',
+        ]);
+    });
+
+    it('hides preview projects when hidePreviewProjects is on', () => {
+        const result = sortAndFilterVisibleProjects({
+            projects: [preview('Preview'), project('Prod')],
+            hidePreviewProjects: true,
+            selectedProjectUuids: [],
+        });
+
+        expect(result.map((p) => p.name)).toEqual(['Prod']);
+    });
+
+    it('keeps selected preview projects visible while hiding is on', () => {
+        const result = sortAndFilterVisibleProjects({
+            projects: [
+                preview('Selected preview'),
+                preview('Other preview'),
+                project('Prod'),
+            ],
+            hidePreviewProjects: true,
+            selectedProjectUuids: ['uuid-Selected preview'],
+        });
+
+        expect(result.map((p) => p.name)).toEqual(['Prod', 'Selected preview']);
+    });
+});
+
+describe('buildAgentFilterGroups', () => {
+    const projects = [
+        preview('Preview A'),
+        project('Prod B'),
+        project('Prod A'),
+    ];
+    const agents = [
+        agent('zed', 'Prod A'),
+        agent('amy', 'Prod A'),
+        agent('bot', 'Prod B'),
+        agent('pre', 'Preview A'),
+    ];
+
+    const build = (
+        overrides: Partial<Parameters<typeof buildAgentFilterGroups>[0]> = {},
+    ) =>
+        buildAgentFilterGroups({
+            agents,
+            projects,
+            hidePreviewProjects: false,
+            selectedProjectUuids: [],
+            selectedAgentUuids: [],
+            ...overrides,
+        });
+
+    it('orders groups production-first alphabetically and agents alphabetically', () => {
+        const result = build();
+
+        expect(result.map((g) => g.projectName)).toEqual([
+            'Prod A',
+            'Prod B',
+            'Preview A',
+        ]);
+        expect(result[0].agents.map((a) => a.name)).toEqual(['amy', 'zed']);
+    });
+
+    it('hides preview project groups when hidePreviewProjects is on', () => {
+        const result = build({ hidePreviewProjects: true });
+
+        expect(result.map((g) => g.projectName)).toEqual(['Prod A', 'Prod B']);
+    });
+
+    it('keeps a hidden preview group when one of its agents is selected', () => {
+        const result = build({
+            hidePreviewProjects: true,
+            selectedAgentUuids: ['agent-pre'],
+        });
+
+        expect(result.map((g) => g.projectName)).toEqual([
+            'Prod A',
+            'Prod B',
+            'Preview A',
+        ]);
+    });
+
+    it('removes groups from non-selected projects entirely when a project filter is applied', () => {
+        const result = build({ selectedProjectUuids: ['uuid-Prod B'] });
+
+        expect(result.map((g) => g.projectName)).toEqual(['Prod B']);
+    });
+
+    it('keeps a selected preview project group even while hiding is on', () => {
+        const result = build({
+            hidePreviewProjects: true,
+            selectedProjectUuids: ['uuid-Preview A'],
+        });
+
+        expect(result.map((g) => g.projectName)).toEqual(['Preview A']);
+    });
+
+    it('skips agents whose project is unknown', () => {
+        const result = build({
+            agents: [...agents, agent('ghost', 'Deleted project')],
+        });
+
+        expect(
+            result.flatMap((g) => g.agents.map((a) => a.name)),
+        ).not.toContain('ghost');
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/projectFilterOrdering.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/projectFilterOrdering.ts
@@ -1,0 +1,105 @@
+import { ProjectType } from '@lightdash/common';
+
+export type FilterProject = {
+    projectUuid: string;
+    name: string;
+    type: ProjectType;
+};
+
+export type AgentFilterGroup<TAgent> = {
+    projectUuid: string;
+    projectName: string;
+    agents: TAgent[];
+};
+
+type AgentLike = {
+    uuid: string;
+    name: string;
+    projectUuid: string;
+};
+
+const projectTier = (type: ProjectType): number =>
+    type === ProjectType.PREVIEW ? 1 : 0;
+
+const byNameCaseInsensitive = (a: string, b: string): number =>
+    a.localeCompare(b, undefined, { sensitivity: 'base' });
+
+const compareProjectsForDisplay = (
+    a: Pick<FilterProject, 'name' | 'type'>,
+    b: Pick<FilterProject, 'name' | 'type'>,
+): number =>
+    projectTier(a.type) - projectTier(b.type) ||
+    byNameCaseInsensitive(a.name, b.name);
+
+// Selected previews stay visible so shared links and existing selections
+// never point at options the user can no longer see or unselect.
+const isProjectVisible = (
+    project: Pick<FilterProject, 'projectUuid' | 'type'>,
+    hidePreviewProjects: boolean,
+    selectedProjectUuids: Set<string>,
+): boolean =>
+    !hidePreviewProjects ||
+    project.type !== ProjectType.PREVIEW ||
+    selectedProjectUuids.has(project.projectUuid);
+
+export const sortAndFilterVisibleProjects = <T extends FilterProject>(args: {
+    projects: T[];
+    hidePreviewProjects: boolean;
+    selectedProjectUuids: string[];
+}): T[] => {
+    const selected = new Set(args.selectedProjectUuids);
+    return args.projects
+        .filter((project) =>
+            isProjectVisible(project, args.hidePreviewProjects, selected),
+        )
+        .sort(compareProjectsForDisplay);
+};
+
+export const buildAgentFilterGroups = <TAgent extends AgentLike>(args: {
+    agents: TAgent[];
+    projects: FilterProject[];
+    hidePreviewProjects: boolean;
+    selectedProjectUuids: string[];
+    selectedAgentUuids: string[];
+}): AgentFilterGroup<TAgent>[] => {
+    const projectByUuid = new Map(
+        args.projects.map((project) => [project.projectUuid, project]),
+    );
+    const selectedProjects = new Set(args.selectedProjectUuids);
+    const selectedAgents = new Set(args.selectedAgentUuids);
+    const hasSelectedProjects = selectedProjects.size > 0;
+
+    const agentsByProject = args.agents.reduce((acc, agent) => {
+        if (!projectByUuid.has(agent.projectUuid)) return acc;
+        const existing = acc.get(agent.projectUuid);
+        if (existing) {
+            existing.push(agent);
+        } else {
+            acc.set(agent.projectUuid, [agent]);
+        }
+        return acc;
+    }, new Map<string, TAgent[]>());
+
+    return Array.from(agentsByProject.entries())
+        .map(([projectUuid, agents]) => ({
+            project: projectByUuid.get(projectUuid)!,
+            agents,
+        }))
+        .filter(({ project, agents }) =>
+            hasSelectedProjects
+                ? selectedProjects.has(project.projectUuid)
+                : isProjectVisible(
+                      project,
+                      args.hidePreviewProjects,
+                      selectedProjects,
+                  ) || agents.some((agent) => selectedAgents.has(agent.uuid)),
+        )
+        .sort((a, b) => compareProjectsForDisplay(a.project, b.project))
+        .map(({ project, agents }) => ({
+            projectUuid: project.projectUuid,
+            projectName: project.name,
+            agents: [...agents].sort((a, b) =>
+                byNameCaseInsensitive(a.name, b.name),
+            ),
+        }));
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminFilters.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminFilters.ts
@@ -3,7 +3,7 @@ import type {
     AiAgentAdminSort,
     AiAgentAdminSortField,
 } from '@lightdash/common';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import useSearchParams from '../../../../hooks/useSearchParams';
 
@@ -46,6 +46,10 @@ export const useAiAgentAdminFilters = () => {
     );
     const sortByParam = useSearchParams<AiAgentAdminSortField>('sortBy');
     const sortDirectionParam = useSearchParams<'asc' | 'desc'>('sortDirection');
+
+    // View preference for the filter dropdowns, not a thread filter — kept out
+    // of the URL and out of hasActiveFilters
+    const [hidePreviewProjects, setHidePreviewProjects] = useState(true);
 
     const currentFilters = useMemo(
         () => ({
@@ -205,6 +209,7 @@ export const useAiAgentAdminFilters = () => {
 
     const resetFilters = useCallback(() => {
         updateUrl(DEFAULT_FILTERS);
+        setHidePreviewProjects(true);
     }, [updateUrl]);
 
     const hasActiveFilters = useMemo(() => {
@@ -276,6 +281,9 @@ export const useAiAgentAdminFilters = () => {
         setSelectedSource,
         setSelectedFeedback,
         setSorting,
+
+        hidePreviewProjects,
+        setHidePreviewProjects,
 
         resetFilters,
         hasActiveFilters,


### PR DESCRIPTION
In orgs that use preview environments heavily, the Ask AI admin Threads and Evals filter dropdowns listed timestamped preview projects above production ones in API response order, burying the agents admins actually look for; selecting a project also only greyed out other projects' agents instead of narrowing the list. Dropdowns are now sorted production-first (previews last, alphabetical within each tier), preview projects are hidden behind a default-on "Hide preview projects" toggle (selected items stay visible), and filtering by project hides out-of-scope agent groups entirely.

Closes: #24728