### PR TITLE
fix(credentials): support Snowflake personal auth methods

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/snowflakeStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/snowflakeStrategy.ts
@@ -4,6 +4,7 @@ import {
     AnyType,
     ForbiddenError,
     OpenIdIdentityIssuerType,
+    ParameterError,
 } from '@lightdash/common';
 import { Strategy as OAuth2Strategy, VerifyCallback } from 'passport-oauth2';
 import { URL } from 'url';
@@ -51,6 +52,15 @@ export const snowflakePassportStrategy = !(
                   const loggedUser = req.user;
                   if (loggedUser === undefined) {
                       throw new ForbiddenError('User not authenticated');
+                  }
+
+                  // Bail before any write: upsertGrant overwrites the stored
+                  // refresh token unconditionally, so a callback without one
+                  // would corrupt the grant the user is still relying on.
+                  if (!refreshToken) {
+                      throw new ParameterError(
+                          'Snowflake did not return a refresh token. Please try signing in again.',
+                      );
                   }
 
                   const userService = req.services.getUserService();

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.test.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.test.ts
@@ -1,6 +1,8 @@
 import {
     BigqueryAuthenticationType,
     BigqueryTokenError,
+    ParameterError,
+    SnowflakeAuthenticationType,
     WarehouseTypes,
 } from '@lightdash/common';
 import { Knex } from 'knex';
@@ -125,6 +127,64 @@ describe('UserWarehouseCredentialsModel', () => {
                     password: 'password',
                 } as never),
             ).toBeUndefined();
+        });
+    });
+
+    describe('normalizeCredentialsForPersistence', () => {
+        const normalize = (credentials: object) =>
+            UserWarehouseCredentialsModel.normalizeCredentialsForPersistence({
+                name: 'Default',
+                credentials: credentials as never,
+            });
+
+        test('defaults an omitted Snowflake authentication type to password', () => {
+            expect(
+                normalize({
+                    type: WarehouseTypes.SNOWFLAKE,
+                    user: 'user',
+                    password: 'password',
+                }).credentials,
+            ).toEqual({
+                type: WarehouseTypes.SNOWFLAKE,
+                user: 'user',
+                password: 'password',
+                authenticationType: SnowflakeAuthenticationType.PASSWORD,
+            });
+        });
+
+        test('preserves an explicit Snowflake authentication type', () => {
+            expect(
+                normalize({
+                    type: WarehouseTypes.SNOWFLAKE,
+                    user: 'user',
+                    privateKey: 'private-key',
+                    authenticationType: SnowflakeAuthenticationType.PRIVATE_KEY,
+                }).credentials,
+            ).toEqual(
+                expect.objectContaining({
+                    authenticationType: SnowflakeAuthenticationType.PRIVATE_KEY,
+                }),
+            );
+        });
+
+        test('rejects a Snowflake private key credential with an empty key', () => {
+            expect(() =>
+                normalize({
+                    type: WarehouseTypes.SNOWFLAKE,
+                    user: 'user',
+                    privateKey: '',
+                    authenticationType: SnowflakeAuthenticationType.PRIVATE_KEY,
+                }),
+            ).toThrow(ParameterError);
+        });
+
+        test('leaves other warehouse types untouched', () => {
+            const postgres = {
+                type: WarehouseTypes.POSTGRES,
+                user: 'user',
+                password: 'password',
+            };
+            expect(normalize(postgres).credentials).toEqual(postgres);
         });
     });
 

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -15,6 +15,7 @@ import {
     SnowflakeAuthenticationType,
     snowflakeSsoUserCredentialsSchema,
     SnowflakeTokenError,
+    snowflakeUserCredentialsSchema,
     UnexpectedServerError,
     UpsertUserWarehouseCredentials,
     UserWarehouseCredentials,
@@ -98,9 +99,16 @@ export class UserWarehouseCredentialsModel {
                             : {}),
                     };
                     break;
+                case WarehouseTypes.SNOWFLAKE:
+                    credentials = {
+                        type: credentialsWithSecrets.type,
+                        user: credentialsWithSecrets.user,
+                        authenticationType:
+                            credentialsWithSecrets.authenticationType,
+                    };
+                    break;
                 case WarehouseTypes.POSTGRES:
                 case WarehouseTypes.TRINO:
-                case WarehouseTypes.SNOWFLAKE:
                 case WarehouseTypes.CLICKHOUSE:
                     credentials = {
                         type: credentialsWithSecrets.type,
@@ -528,6 +536,17 @@ export class UserWarehouseCredentialsModel {
             if (!result.success) {
                 throw new ParameterError(
                     'BigQuery credentials require a valid keyfile. Please reauthenticate with Google.',
+                );
+            }
+        }
+
+        if (data.credentials.type === WarehouseTypes.SNOWFLAKE) {
+            const result = snowflakeUserCredentialsSchema.safeParse(
+                data.credentials,
+            );
+            if (!result.success) {
+                throw new ParameterError(
+                    'Snowflake credentials require a username and a valid password, private key, or OAuth token.',
                 );
             }
         }

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -526,9 +526,11 @@ export class UserWarehouseCredentialsModel {
     // persist an empty shell (e.g. a masked BigQuery placeholder keyfile that
     // overwrites a working credential). Per-user BigQuery credentials are
     // always SSO, so the refresh_token requirement applies to all of them.
-    private static validateCredentialsForPersistence(
+    // Returns the credentials to persist, normalized where an omitted field
+    // would otherwise be resolved from the project connection at query time.
+    static normalizeCredentialsForPersistence(
         data: UpsertUserWarehouseCredentials,
-    ): void {
+    ): UpsertUserWarehouseCredentials {
         if (data.credentials.type === WarehouseTypes.BIGQUERY) {
             const result = bigquerySsoUserCredentialsSchema.safeParse(
                 data.credentials,
@@ -541,14 +543,23 @@ export class UserWarehouseCredentialsModel {
         }
 
         if (data.credentials.type === WarehouseTypes.SNOWFLAKE) {
-            const result = snowflakeUserCredentialsSchema.safeParse(
-                data.credentials,
-            );
+            // Persist an explicit authentication type. Without one, the project
+            // connection's own type survives the merge at query time and the
+            // warehouse client picks an authenticator the user never chose.
+            const credentials = {
+                ...data.credentials,
+                authenticationType:
+                    data.credentials.authenticationType ??
+                    SnowflakeAuthenticationType.PASSWORD,
+            };
+            const result =
+                snowflakeUserCredentialsSchema.safeParse(credentials);
             if (!result.success) {
                 throw new ParameterError(
                     'Snowflake credentials require a username and a valid password, private key, or OAuth token.',
                 );
             }
+            return { ...data, credentials };
         }
 
         if (
@@ -568,6 +579,8 @@ export class UserWarehouseCredentialsModel {
                 );
             }
         }
+
+        return data;
     }
 
     async create(
@@ -575,11 +588,14 @@ export class UserWarehouseCredentialsModel {
         data: UpsertUserWarehouseCredentials,
         projectUuid?: string,
     ): Promise<string> {
-        UserWarehouseCredentialsModel.validateCredentialsForPersistence(data);
+        const normalized =
+            UserWarehouseCredentialsModel.normalizeCredentialsForPersistence(
+                data,
+            );
         let encryptedCredentials: Buffer;
         try {
             encryptedCredentials = this.encryptionUtil.encrypt(
-                JSON.stringify(data.credentials),
+                JSON.stringify(normalized.credentials),
             );
         } catch (e) {
             throw new UnexpectedServerError('Could not save credentials.');
@@ -587,8 +603,8 @@ export class UserWarehouseCredentialsModel {
         const [result] = await this.database(UserWarehouseCredentialsTableName)
             .insert({
                 user_uuid: userUuid,
-                name: data.name,
-                warehouse_type: data.credentials.type,
+                name: normalized.name,
+                warehouse_type: normalized.credentials.type,
                 encrypted_credentials: encryptedCredentials,
                 project_uuid: projectUuid ?? null,
             })
@@ -605,19 +621,22 @@ export class UserWarehouseCredentialsModel {
         userWarehouseCredentialsUuid: string,
         data: UpsertUserWarehouseCredentials,
     ): Promise<string> {
-        UserWarehouseCredentialsModel.validateCredentialsForPersistence(data);
+        const normalized =
+            UserWarehouseCredentialsModel.normalizeCredentialsForPersistence(
+                data,
+            );
         let encryptedCredentials: Buffer;
         try {
             encryptedCredentials = this.encryptionUtil.encrypt(
-                JSON.stringify(data.credentials),
+                JSON.stringify(normalized.credentials),
             );
         } catch (e) {
             throw new UnexpectedServerError('Could not save credentials.');
         }
         const [result] = await this.database(UserWarehouseCredentialsTableName)
             .update({
-                name: data.name,
-                warehouse_type: data.credentials.type,
+                name: normalized.name,
+                warehouse_type: normalized.credentials.type,
                 encrypted_credentials: encryptedCredentials,
                 updated_at: new Date(),
             })

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -2052,6 +2052,72 @@ describe('ProjectService', () => {
             });
         });
 
+        test('should not leak project Snowflake secrets into a user private key credential', async () => {
+            service.warehouseClients = {};
+
+            const projectSnowflakeCredentials = {
+                type: WarehouseTypes.SNOWFLAKE,
+                account: 'test-account',
+                warehouse: 'test-warehouse',
+                database: 'test-db',
+                schema: 'test-schema',
+                user: 'project_user',
+                password: 'project-password',
+                privateKey: 'project-private-key',
+                privateKeyPass: 'project-passphrase',
+                authenticationType: SnowflakeAuthenticationType.PRIVATE_KEY,
+                requireUserCredentials: true,
+            };
+            (
+                projectModel.getWarehouseCredentialsForProject as import('vitest').Mock
+            ).mockImplementation(async () => projectSnowflakeCredentials);
+
+            // No passphrase: the user's key is not encrypted with one.
+            const userCredentials = {
+                uuid: 'user-snowflake-creds-uuid',
+                credentials: {
+                    type: WarehouseTypes.SNOWFLAKE,
+                    user: 'analyst',
+                    privateKey: 'user-private-key',
+                    authenticationType: SnowflakeAuthenticationType.PRIVATE_KEY,
+                },
+            };
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: import('vitest').Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.findForProjectWithSecrets = vi.fn(
+                async () => userCredentials,
+            );
+
+            const mergedCredentials = await (
+                service as unknown as {
+                    getWarehouseCredentials: (args: {
+                        projectUuid: string;
+                        userId: string;
+                        isRegisteredUser: boolean;
+                    }) => Promise<Record<string, unknown>>;
+                }
+            ).getWarehouseCredentials({
+                projectUuid,
+                userId: sessionAccount.user.id,
+                isRegisteredUser: true,
+            });
+
+            expect(mergedCredentials).toEqual(
+                expect.objectContaining({
+                    type: WarehouseTypes.SNOWFLAKE,
+                    user: 'analyst',
+                    privateKey: 'user-private-key',
+                    authenticationType: SnowflakeAuthenticationType.PRIVATE_KEY,
+                }),
+            );
+            expect(mergedCredentials.privateKeyPass).toBeUndefined();
+            expect(mergedCredentials.password).toBeUndefined();
+        });
+
         test('should use user Redshift IAM identity when requireUserCredentials is true', async () => {
             service.warehouseClients = {};
 

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -2118,6 +2118,68 @@ describe('ProjectService', () => {
             expect(mergedCredentials.password).toBeUndefined();
         });
 
+        test('should not give a legacy Snowflake password credential the project SSO mode', async () => {
+            service.warehouseClients = {};
+
+            const projectSnowflakeCredentials = {
+                type: WarehouseTypes.SNOWFLAKE,
+                account: 'test-account',
+                warehouse: 'test-warehouse',
+                database: 'test-db',
+                schema: 'test-schema',
+                user: 'project_user',
+                authenticationType: SnowflakeAuthenticationType.SSO,
+                refreshToken: 'project-refresh-token',
+                requireUserCredentials: true,
+            };
+            (
+                projectModel.getWarehouseCredentialsForProject as import('vitest').Mock
+            ).mockImplementation(async () => projectSnowflakeCredentials);
+
+            // Stored before authenticationType was persisted: no auth type.
+            const userCredentials = {
+                uuid: 'legacy-snowflake-creds-uuid',
+                credentials: {
+                    type: WarehouseTypes.SNOWFLAKE,
+                    user: 'analyst',
+                    password: 'analyst-password',
+                },
+            };
+            (
+                service as unknown as {
+                    userWarehouseCredentialsModel: {
+                        findForProjectWithSecrets: import('vitest').Mock;
+                    };
+                }
+            ).userWarehouseCredentialsModel.findForProjectWithSecrets = vi.fn(
+                async () => userCredentials,
+            );
+
+            const mergedCredentials = await (
+                service as unknown as {
+                    getWarehouseCredentials: (args: {
+                        projectUuid: string;
+                        userId: string;
+                        isRegisteredUser: boolean;
+                    }) => Promise<Record<string, unknown>>;
+                }
+            ).getWarehouseCredentials({
+                projectUuid,
+                userId: sessionAccount.user.id,
+                isRegisteredUser: true,
+            });
+
+            // Absent, not 'sso': the client then falls back to password auth.
+            expect(mergedCredentials.authenticationType).toBeUndefined();
+            expect(mergedCredentials).toEqual(
+                expect.objectContaining({
+                    user: 'analyst',
+                    password: 'analyst-password',
+                }),
+            );
+            expect(mergedCredentials.refreshToken).toBeUndefined();
+        });
+
         test('should use user Redshift IAM identity when requireUserCredentials is true', async () => {
             service.warehouseClients = {};
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1740,13 +1740,17 @@ export class ProjectService extends BaseService {
                 // Every secret has to go: the user's own credential is merged
                 // over this, so anything left here is inherited by whichever
                 // field the user didn't supply (e.g. their key decrypted with
-                // the project's passphrase).
+                // the project's passphrase). authenticationType goes too —
+                // credentials stored before it was persisted would otherwise
+                // inherit the project's mode and authenticate as SSO with no
+                // refresh token. Absent, the client falls back to password.
                 const {
                     refreshToken,
                     token,
                     password,
                     privateKey,
                     privateKeyPass,
+                    authenticationType,
                     ...rest
                 } = credentials;
                 return rest;

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1737,8 +1737,18 @@ export class ProjectService extends BaseService {
     ): CreateWarehouseCredentials {
         switch (credentials.type) {
             case WarehouseTypes.SNOWFLAKE: {
-                // Remove optional properties for snowflake OAuth
-                const { refreshToken, token, ...rest } = credentials;
+                // Every secret has to go: the user's own credential is merged
+                // over this, so anything left here is inherited by whichever
+                // field the user didn't supply (e.g. their key decrypted with
+                // the project's passphrase).
+                const {
+                    refreshToken,
+                    token,
+                    password,
+                    privateKey,
+                    privateKeyPass,
+                    ...rest
+                } = credentials;
                 return rest;
             }
             case WarehouseTypes.DATABRICKS: {

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -4674,35 +4674,36 @@ describe('UserService', () => {
         });
     });
 
+    const createSnowflakeCredentialsModel = () => ({
+        getAllByUserUuid: vi.fn().mockResolvedValue([
+            {
+                uuid: 'password-credentials-uuid',
+                name: 'Default',
+                credentials: {
+                    type: WarehouseTypes.SNOWFLAKE,
+                    user: 'snowflake-user',
+                    authenticationType: SnowflakeAuthenticationType.PASSWORD,
+                },
+                project: null,
+            },
+            {
+                uuid: 'sso-credentials-uuid',
+                name: 'My Snowflake login',
+                credentials: {
+                    type: WarehouseTypes.SNOWFLAKE,
+                    authenticationType: SnowflakeAuthenticationType.SSO,
+                },
+                project: null,
+            },
+        ]),
+        update: vi.fn().mockResolvedValue('sso-credentials-uuid'),
+        getByUuid: vi.fn().mockResolvedValue({ uuid: 'sso-credentials-uuid' }),
+        create: vi.fn(),
+    });
+
     describe('createSnowflakeWarehouseCredentials', () => {
         it('updates only an existing Snowflake SSO credential', async () => {
-            const credentialsModel = {
-                getAllByUserUuid: vi.fn().mockResolvedValue([
-                    {
-                        uuid: 'password-credentials-uuid',
-                        credentials: {
-                            type: WarehouseTypes.SNOWFLAKE,
-                            user: 'snowflake-user',
-                            authenticationType:
-                                SnowflakeAuthenticationType.PASSWORD,
-                        },
-                        project: null,
-                    },
-                    {
-                        uuid: 'sso-credentials-uuid',
-                        credentials: {
-                            type: WarehouseTypes.SNOWFLAKE,
-                            authenticationType: SnowflakeAuthenticationType.SSO,
-                        },
-                        project: null,
-                    },
-                ]),
-                update: vi.fn().mockResolvedValue('sso-credentials-uuid'),
-                getByUuid: vi.fn().mockResolvedValue({
-                    uuid: 'sso-credentials-uuid',
-                }),
-                create: vi.fn(),
-            };
+            const credentialsModel = createSnowflakeCredentialsModel();
             const service = createUserService(lightdashConfigMock, {
                 userWarehouseCredentialsModel:
                     credentialsModel as unknown as UserWarehouseCredentialsModel,
@@ -4723,6 +4724,39 @@ describe('UserService', () => {
                     }),
                 }),
             );
+            expect(credentialsModel.create).not.toHaveBeenCalled();
+        });
+
+        it('keeps the name the user gave the existing credential', async () => {
+            const credentialsModel = createSnowflakeCredentialsModel();
+            const service = createUserService(lightdashConfigMock, {
+                userWarehouseCredentialsModel:
+                    credentialsModel as unknown as UserWarehouseCredentialsModel,
+            });
+
+            await service.createSnowflakeWarehouseCredentials(
+                sessionUser,
+                'new-refresh-token',
+            );
+
+            expect(credentialsModel.update).toHaveBeenCalledWith(
+                sessionUser.userUuid,
+                'sso-credentials-uuid',
+                expect.objectContaining({ name: 'My Snowflake login' }),
+            );
+        });
+
+        it('rejects a callback without a refresh token instead of writing', async () => {
+            const credentialsModel = createSnowflakeCredentialsModel();
+            const service = createUserService(lightdashConfigMock, {
+                userWarehouseCredentialsModel:
+                    credentialsModel as unknown as UserWarehouseCredentialsModel,
+            });
+
+            await expect(
+                service.createSnowflakeWarehouseCredentials(sessionUser, ''),
+            ).rejects.toThrow(ParameterError);
+            expect(credentialsModel.update).not.toHaveBeenCalled();
             expect(credentialsModel.create).not.toHaveBeenCalled();
         });
     });

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -22,6 +22,8 @@ import {
     PossibleAbilities,
     ProjectMemberRole,
     SessionUser,
+    SnowflakeAuthenticationType,
+    WarehouseTypes,
 } from '@lightdash/common';
 import { analyticsMock } from '../analytics/LightdashAnalytics.mock';
 import EmailClient from '../clients/EmailClient/EmailClient';
@@ -223,6 +225,7 @@ const organizationMemberProfileModel = {
 
 type UserServiceTestOverrides = {
     featureFlagModel?: Pick<FeatureFlagModel, 'get'>;
+    userWarehouseCredentialsModel?: Partial<UserWarehouseCredentialsModel>;
     personalAccessTokenModel?: Pick<
         PersonalAccessTokenModel,
         'delete' | 'updateUsedDate'
@@ -284,7 +287,9 @@ const createUserService = (
             organizationSsoModel as unknown as OrganizationSsoModel,
         organizationSettingsModel:
             organizationSettingsModel as unknown as OrganizationSettingsModel,
-        userWarehouseCredentialsModel: {} as UserWarehouseCredentialsModel,
+        userWarehouseCredentialsModel:
+            (overrides.userWarehouseCredentialsModel as UserWarehouseCredentialsModel) ??
+            ({} as UserWarehouseCredentialsModel),
         warehouseAvailableTablesModel: {} as WarehouseAvailableTablesModel,
         projectModel: projectModel as unknown as ProjectModel,
         featureFlagModel:
@@ -4666,6 +4671,59 @@ describe('UserService', () => {
             expect(projectModel.ensureDefaultUserSpace).toHaveBeenCalledTimes(
                 2,
             );
+        });
+    });
+
+    describe('createSnowflakeWarehouseCredentials', () => {
+        it('updates only an existing Snowflake SSO credential', async () => {
+            const credentialsModel = {
+                getAllByUserUuid: vi.fn().mockResolvedValue([
+                    {
+                        uuid: 'password-credentials-uuid',
+                        credentials: {
+                            type: WarehouseTypes.SNOWFLAKE,
+                            user: 'snowflake-user',
+                            authenticationType:
+                                SnowflakeAuthenticationType.PASSWORD,
+                        },
+                        project: null,
+                    },
+                    {
+                        uuid: 'sso-credentials-uuid',
+                        credentials: {
+                            type: WarehouseTypes.SNOWFLAKE,
+                            authenticationType: SnowflakeAuthenticationType.SSO,
+                        },
+                        project: null,
+                    },
+                ]),
+                update: vi.fn().mockResolvedValue('sso-credentials-uuid'),
+                getByUuid: vi.fn().mockResolvedValue({
+                    uuid: 'sso-credentials-uuid',
+                }),
+                create: vi.fn(),
+            };
+            const service = createUserService(lightdashConfigMock, {
+                userWarehouseCredentialsModel:
+                    credentialsModel as unknown as UserWarehouseCredentialsModel,
+            });
+
+            await service.createSnowflakeWarehouseCredentials(
+                sessionUser,
+                'new-refresh-token',
+            );
+
+            expect(credentialsModel.update).toHaveBeenCalledWith(
+                sessionUser.userUuid,
+                'sso-credentials-uuid',
+                expect.objectContaining({
+                    credentials: expect.objectContaining({
+                        authenticationType: SnowflakeAuthenticationType.SSO,
+                        refreshToken: 'new-refresh-token',
+                    }),
+                }),
+            );
+            expect(credentialsModel.create).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -3334,15 +3334,14 @@ export class UserService extends BaseService {
         user: SessionUser,
         refreshToken: string,
     ) {
-        const snowflakeCredentials: UpsertUserWarehouseCredentials = {
-            name: 'Default',
-            credentials: {
-                user: user.userUuid,
-                type: WarehouseTypes.SNOWFLAKE,
-                authenticationType: SnowflakeAuthenticationType.SSO,
-                refreshToken,
-            },
-        };
+        // Guard before writing: an OAuth callback without a refresh token must
+        // not overwrite the user's working credentials.
+        if (!refreshToken) {
+            throw new ParameterError(
+                'Cannot create Snowflake user credentials without a refresh token',
+            );
+        }
+
         const existingSsoCredentials = (
             await this.userWarehouseCredentialsModel.getAllByUserUuid(
                 user.userUuid,
@@ -3354,6 +3353,16 @@ export class UserService extends BaseService {
                 credentials.authenticationType ===
                     SnowflakeAuthenticationType.SSO,
         );
+
+        const snowflakeCredentials: UpsertUserWarehouseCredentials = {
+            name: existingSsoCredentials?.name ?? 'Default',
+            credentials: {
+                user: user.userUuid,
+                type: WarehouseTypes.SNOWFLAKE,
+                authenticationType: SnowflakeAuthenticationType.SSO,
+                refreshToken,
+            },
+        };
 
         if (existingSsoCredentials) {
             await this.updateWarehouseCredentials(

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -3334,12 +3334,6 @@ export class UserService extends BaseService {
         user: SessionUser,
         refreshToken: string,
     ) {
-        // Remove old Snowflake credentials to prevent duplicates on re-authentication
-        await this.userWarehouseCredentialsModel.deleteAllByUserAndWarehouseType(
-            user.userUuid,
-            WarehouseTypes.SNOWFLAKE,
-        );
-
         const snowflakeCredentials: UpsertUserWarehouseCredentials = {
             name: 'Default',
             credentials: {
@@ -3349,7 +3343,27 @@ export class UserService extends BaseService {
                 refreshToken,
             },
         };
-        await this.createWarehouseCredentials(user, snowflakeCredentials);
+        const existingSsoCredentials = (
+            await this.userWarehouseCredentialsModel.getAllByUserUuid(
+                user.userUuid,
+            )
+        ).find(
+            ({ credentials, project }) =>
+                project === null &&
+                credentials.type === WarehouseTypes.SNOWFLAKE &&
+                credentials.authenticationType ===
+                    SnowflakeAuthenticationType.SSO,
+        );
+
+        if (existingSsoCredentials) {
+            await this.updateWarehouseCredentials(
+                user,
+                existingSsoCredentials.uuid,
+                snowflakeCredentials,
+            );
+        } else {
+            await this.createWarehouseCredentials(user, snowflakeCredentials);
+        }
     }
 
     async createDatabricksWarehouseCredentials(

--- a/packages/common/src/types/userWarehouseCredentials.test.ts
+++ b/packages/common/src/types/userWarehouseCredentials.test.ts
@@ -1,4 +1,57 @@
-import { bigquerySsoUserCredentialsSchema } from './userWarehouseCredentials';
+import {
+    bigquerySsoUserCredentialsSchema,
+    snowflakeUserCredentialsSchema,
+} from './userWarehouseCredentials';
+
+describe('snowflakeUserCredentialsSchema', () => {
+    it.each([
+        {
+            type: 'snowflake',
+            user: 'snowflake-user',
+            authenticationType: 'password',
+            password: 'password',
+        },
+        {
+            type: 'snowflake',
+            user: 'snowflake-user',
+            authenticationType: 'private_key',
+            privateKey: 'private-key',
+        },
+        {
+            type: 'snowflake',
+            authenticationType: 'sso',
+            refreshToken: 'refresh-token',
+        },
+    ])('accepts supported credentials: $authenticationType', (credentials) => {
+        expect(
+            snowflakeUserCredentialsSchema.safeParse(credentials).success,
+        ).toBe(true);
+    });
+
+    it.each([
+        {
+            type: 'snowflake',
+            user: 'snowflake-user',
+            authenticationType: 'password',
+            password: '',
+        },
+        {
+            type: 'snowflake',
+            user: 'snowflake-user',
+            authenticationType: 'private_key',
+            privateKey: '',
+        },
+        {
+            type: 'snowflake',
+            authenticationType: 'sso',
+            refreshToken: '',
+        },
+    ])('rejects empty secrets: $authenticationType', (credentials) => {
+        expect(
+            snowflakeUserCredentialsSchema.safeParse(credentials).success,
+        ).toBe(false);
+    });
+});
 
 describe('bigquerySsoUserCredentialsSchema', () => {
     it('rejects an empty keyfile (the reported bug value)', () => {

--- a/packages/common/src/types/userWarehouseCredentials.ts
+++ b/packages/common/src/types/userWarehouseCredentials.ts
@@ -69,15 +69,23 @@ export type UserWarehouseCredentialsWithSecrets = Pick<
               | 'assumeRoleExternalId'
           >
         | Pick<CreatePostgresCredentials, 'type' | 'user' | 'password'>
+        // Kept as two members rather than one wider Pick: merging them renames
+        // the generated OpenAPI schema, which reads as a removed `anyOf` member.
         | Pick<
               CreateSnowflakeCredentials,
               | 'type'
               | 'user'
               | 'password'
+              | 'authenticationType'
+              | 'refreshToken'
+          >
+        | Pick<
+              CreateSnowflakeCredentials,
+              | 'type'
+              | 'user'
               | 'privateKey'
               | 'privateKeyPass'
               | 'authenticationType'
-              | 'refreshToken'
           >
         | Pick<CreateTrinoCredentials, 'type' | 'user' | 'password'>
         | Pick<CreateClickhouseCredentials, 'type' | 'user' | 'password'>

--- a/packages/common/src/types/userWarehouseCredentials.ts
+++ b/packages/common/src/types/userWarehouseCredentials.ts
@@ -36,10 +36,13 @@ export type UserWarehouseCredentials = {
           >
         | Pick<
               | CreatePostgresCredentials
-              | CreateSnowflakeCredentials
               | CreateTrinoCredentials
               | CreateClickhouseCredentials,
               'type' | 'user'
+          >
+        | Pick<
+              CreateSnowflakeCredentials,
+              'type' | 'user' | 'authenticationType'
           >
         | Pick<CreateBigqueryCredentials, 'type'>
         | Pick<CreateDatabricksCredentials, 'type'>
@@ -71,6 +74,8 @@ export type UserWarehouseCredentialsWithSecrets = Pick<
               | 'type'
               | 'user'
               | 'password'
+              | 'privateKey'
+              | 'privateKeyPass'
               | 'authenticationType'
               | 'refreshToken'
           >
@@ -158,9 +163,34 @@ export const snowflakeSsoUserCredentialsSchema = z
         user: z.string().optional(),
         password: z.string().optional(),
         authenticationType: z.literal(SnowflakeAuthenticationType.SSO),
-        refreshToken: z.string(),
+        refreshToken: z.string().min(1),
     })
     .strict();
+
+export const snowflakeUserCredentialsSchema = z.union([
+    snowflakeSsoUserCredentialsSchema,
+    z
+        .object({
+            type: z.literal(WarehouseTypes.SNOWFLAKE),
+            user: z.string().trim().min(1),
+            password: z.string().min(1),
+            authenticationType: z
+                .literal(SnowflakeAuthenticationType.PASSWORD)
+                .optional(),
+        })
+        .strict(),
+    z
+        .object({
+            type: z.literal(WarehouseTypes.SNOWFLAKE),
+            user: z.string().trim().min(1),
+            privateKey: z.string().trim().min(1),
+            privateKeyPass: z.string().optional(),
+            authenticationType: z.literal(
+                SnowflakeAuthenticationType.PRIVATE_KEY,
+            ),
+        })
+        .strict(),
+]);
 
 // Zod schema for validating Databricks OAuth U2M user warehouse credentials
 // Requires refreshToken and allows optional compatibility fields

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
@@ -1,6 +1,5 @@
 import {
     RedshiftAuthenticationType,
-    SnowflakeAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
     type UserWarehouseCredentials,
@@ -11,14 +10,17 @@ import { IconPlus } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import { useIsDatabricksSsoEnabled } from '../../../hooks/useDatabricks';
 import { useUserWarehouseCredentialsCreateMutation } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
+import { useIsSnowflakeSsoEnabled } from '../../../hooks/useSnowflake';
 import MantineModal, {
     type MantineModalProps,
 } from '../../common/MantineModal';
 import { getWarehouseLabel } from '../../ProjectConnection/ProjectConnectFlow/utils';
 import {
     getDefaultDatabricksAuthenticationType,
+    getDefaultSnowflakeAuthenticationType,
     isDatabricksPersonalAccessToken,
     isSnowflakeSso,
+    validateUserWarehouseCredentials,
 } from './utils';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
@@ -34,7 +36,7 @@ type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
 
 const getDefaultCredentials = (
     warehouseType: WarehouseTypes,
-    isDatabricksSsoEnabled: boolean,
+    ssoEnabled: { databricks: boolean; snowflake: boolean },
 ): UpsertUserWarehouseCredentials['credentials'] => {
     const defaultCredentials: Record<
         WarehouseTypes,
@@ -55,7 +57,9 @@ const getDefaultCredentials = (
             type: WarehouseTypes.SNOWFLAKE,
             user: '',
             password: '',
-            authenticationType: SnowflakeAuthenticationType.PASSWORD,
+            authenticationType: getDefaultSnowflakeAuthenticationType(
+                ssoEnabled.snowflake,
+            ),
         },
         [WarehouseTypes.TRINO]: {
             type: WarehouseTypes.TRINO,
@@ -70,7 +74,7 @@ const getDefaultCredentials = (
             type: WarehouseTypes.DATABRICKS,
             personalAccessToken: '',
             authenticationType: getDefaultDatabricksAuthenticationType(
-                isDatabricksSsoEnabled,
+                ssoEnabled.databricks,
             ),
         },
         [WarehouseTypes.CLICKHOUSE]: {
@@ -112,14 +116,20 @@ export const CreateCredentialsModal: FC<Props> = ({
             onSuccess,
         });
     const isDatabricksSsoEnabled = useIsDatabricksSsoEnabled();
+    const isSnowflakeSsoEnabled = useIsSnowflakeSsoEnabled();
+    const ssoEnabled = {
+        databricks: isDatabricksSsoEnabled,
+        snowflake: isSnowflakeSsoEnabled,
+    };
     const form = useForm<UpsertUserWarehouseCredentials>({
         initialValues: {
             name: '',
             credentials: getDefaultCredentials(
                 warehouseType || WarehouseTypes.POSTGRES,
-                isDatabricksSsoEnabled,
+                ssoEnabled,
             ),
         },
+        validate: validateUserWarehouseCredentials,
     });
 
     const isRedshiftBrowserSso =
@@ -196,10 +206,7 @@ export const CreateCredentialsModal: FC<Props> = ({
                                 if (!type) return;
                                 form.setFieldValue(
                                     'credentials',
-                                    getDefaultCredentials(
-                                        type,
-                                        isDatabricksSsoEnabled,
-                                    ),
+                                    getDefaultCredentials(type, ssoEnabled),
                                 );
                             }}
                         />

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
@@ -1,5 +1,6 @@
 import {
     RedshiftAuthenticationType,
+    SnowflakeAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
     type UserWarehouseCredentials,
@@ -17,6 +18,7 @@ import { getWarehouseLabel } from '../../ProjectConnection/ProjectConnectFlow/ut
 import {
     getDefaultDatabricksAuthenticationType,
     isDatabricksPersonalAccessToken,
+    isSnowflakeSso,
 } from './utils';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
@@ -53,6 +55,7 @@ const getDefaultCredentials = (
             type: WarehouseTypes.SNOWFLAKE,
             user: '',
             password: '',
+            authenticationType: SnowflakeAuthenticationType.PASSWORD,
         },
         [WarehouseTypes.TRINO]: {
             type: WarehouseTypes.TRINO,
@@ -126,12 +129,11 @@ export const CreateCredentialsModal: FC<Props> = ({
             RedshiftAuthenticationType.IAM_BROWSER;
     const showSaveButton =
         !isRedshiftBrowserSso &&
+        !isSnowflakeSso(form.values.credentials) &&
         (isDatabricksPersonalAccessToken(form.values.credentials) ||
-            ![
-                WarehouseTypes.BIGQUERY,
-                WarehouseTypes.SNOWFLAKE,
-                WarehouseTypes.DATABRICKS,
-            ].includes(warehouseType ?? form.values.credentials.type));
+            ![WarehouseTypes.BIGQUERY, WarehouseTypes.DATABRICKS].includes(
+                warehouseType ?? form.values.credentials.type,
+            ));
 
     return (
         <MantineModal

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
@@ -18,6 +18,7 @@ import {
     getDefaultDatabricksAuthenticationType,
     isDatabricksPersonalAccessToken,
     isSnowflakeSso,
+    validateUserWarehouseCredentials,
 } from './utils';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
@@ -115,6 +116,7 @@ export const EditCredentialsModal: FC<
                 isDatabricksSsoEnabled,
             ),
         },
+        validate: validateUserWarehouseCredentials,
     });
 
     // SSO-based credentials are only ever set through their OAuth popup. They

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    SnowflakeAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
     type UserWarehouseCredentials,
@@ -16,6 +17,7 @@ import MantineModal, {
 import {
     getDefaultDatabricksAuthenticationType,
     isDatabricksPersonalAccessToken,
+    isSnowflakeSso,
 } from './utils';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
@@ -33,6 +35,23 @@ const getCredentialsWithPlaceholders = (
                 sessionToken: '',
             };
         case WarehouseTypes.SNOWFLAKE:
+            if (
+                credentials.authenticationType ===
+                SnowflakeAuthenticationType.PRIVATE_KEY
+            ) {
+                return {
+                    ...credentials,
+                    privateKey: '',
+                    privateKeyPass: '',
+                };
+            }
+            return {
+                ...credentials,
+                authenticationType:
+                    credentials.authenticationType ??
+                    SnowflakeAuthenticationType.PASSWORD,
+                password: '',
+            };
         case WarehouseTypes.POSTGRES:
         case WarehouseTypes.TRINO:
             return {
@@ -102,12 +121,11 @@ export const EditCredentialsModal: FC<
     // have no editable secret field, so a generic "Save" would persist the
     // masked placeholder and wipe the working credential.
     const showSaveButton =
-        isDatabricksPersonalAccessToken(form.values.credentials) ||
-        ![
-            WarehouseTypes.BIGQUERY,
-            WarehouseTypes.SNOWFLAKE,
-            WarehouseTypes.DATABRICKS,
-        ].includes(userCredentials.credentials.type);
+        !isSnowflakeSso(form.values.credentials) &&
+        (isDatabricksPersonalAccessToken(form.values.credentials) ||
+            ![WarehouseTypes.BIGQUERY, WarehouseTypes.DATABRICKS].includes(
+                userCredentials.credentials.type,
+            ));
 
     return (
         <MantineModal

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.test.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.test.tsx
@@ -147,7 +147,12 @@ describe('WarehouseFormInputs - Snowflake', () => {
 
 describe('validateUserWarehouseCredentials', () => {
     const credentials = (
-        overrides: Partial<{ privateKey: string }>,
+        overrides: Partial<{
+            user: string;
+            privateKey: string;
+            password: string;
+            authenticationType: SnowflakeAuthenticationType;
+        }>,
     ): UpsertUserWarehouseCredentials => ({
         name: 'my snowflake',
         credentials: {
@@ -176,6 +181,51 @@ describe('validateUserWarehouseCredentials', () => {
         expect(
             validateUserWarehouseCredentials(
                 credentials({ privateKey: '-----BEGIN PRIVATE KEY-----' }),
+            ),
+        ).toEqual({});
+    });
+
+    it('blocks renaming a password credential without re-entering the password', () => {
+        expect(
+            validateUserWarehouseCredentials(
+                credentials({
+                    authenticationType: SnowflakeAuthenticationType.PASSWORD,
+                    password: '',
+                }),
+            ),
+        ).toEqual({ 'credentials.password': expect.any(String) });
+    });
+
+    it('accepts a password credential with a password', () => {
+        expect(
+            validateUserWarehouseCredentials(
+                credentials({
+                    authenticationType: SnowflakeAuthenticationType.PASSWORD,
+                    password: 'hunter2',
+                }),
+            ),
+        ).toEqual({});
+    });
+
+    it('flags a blank username', () => {
+        expect(
+            validateUserWarehouseCredentials(
+                credentials({
+                    authenticationType: SnowflakeAuthenticationType.PASSWORD,
+                    user: '   ',
+                    password: 'hunter2',
+                }),
+            ),
+        ).toEqual({ 'credentials.user': expect.any(String) });
+    });
+
+    it('leaves the SSO credential to its OAuth popup', () => {
+        expect(
+            validateUserWarehouseCredentials(
+                credentials({
+                    authenticationType: SnowflakeAuthenticationType.SSO,
+                    user: '',
+                }),
             ),
         ).toEqual({});
     });

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.test.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.test.tsx
@@ -11,12 +11,16 @@ import { getDefaultDatabricksAuthenticationType } from './utils';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
 let isDatabricksSsoEnabled = false;
+let isSnowflakeSsoEnabled = false;
 
 vi.mock('../../../hooks/health/useHealth', () => ({
     default: () => ({
         data: {
             siteUrl: 'http://localhost:3000',
-            auth: { databricks: { enabled: isDatabricksSsoEnabled } },
+            auth: {
+                databricks: { enabled: isDatabricksSsoEnabled },
+                snowflake: { enabled: isSnowflakeSsoEnabled },
+            },
         },
     }),
 }));
@@ -39,6 +43,73 @@ const DatabricksForm: FC = () => {
         <WarehouseFormInputs form={form} disabled={false} onClose={vi.fn()} />
     );
 };
+
+const SnowflakeForm: FC = () => {
+    const form = useForm<UpsertUserWarehouseCredentials>({
+        initialValues: {
+            name: 'my snowflake',
+            credentials: {
+                type: WarehouseTypes.SNOWFLAKE,
+                user: '',
+                password: '',
+            },
+        },
+    });
+
+    return (
+        <WarehouseFormInputs form={form} disabled={false} onClose={vi.fn()} />
+    );
+};
+
+describe('WarehouseFormInputs - Snowflake', () => {
+    beforeEach(() => {
+        isSnowflakeSsoEnabled = false;
+    });
+
+    it('offers password and private key authentication without Snowflake SSO', async () => {
+        const { findByLabelText, findByRole, findAllByText, queryByRole } =
+            renderWithProviders(<SnowflakeForm />);
+
+        expect(await findByLabelText(/username\/email/i)).toBeDefined();
+        expect((await findAllByText(/^password$/i)).length).toBeGreaterThan(0);
+        expect(
+            queryByRole('button', { name: /sign in with snowflake/i }),
+        ).toBeNull();
+
+        await userEvent.click(
+            await findByRole('textbox', { name: /authentication type/i }),
+        );
+        expect(
+            queryByRole('option', { name: /sign in with snowflake/i }),
+        ).toBeNull();
+        await userEvent.click(
+            await findByRole('option', { name: /private key/i }),
+        );
+
+        expect(await findByLabelText(/private key file/i)).toBeDefined();
+        expect(await findByLabelText(/private key passphrase/i)).toBeDefined();
+    });
+
+    it('offers Snowflake sign-in alongside password and private key when SSO is enabled', async () => {
+        isSnowflakeSsoEnabled = true;
+        const { findByRole } = renderWithProviders(<SnowflakeForm />);
+
+        await userEvent.click(
+            await findByRole('textbox', { name: /authentication type/i }),
+        );
+        expect(
+            await findByRole('option', { name: /private key/i }),
+        ).toBeDefined();
+        expect(await findByRole('option', { name: /password/i })).toBeDefined();
+        await userEvent.click(
+            await findByRole('option', { name: /sign in with snowflake/i }),
+        );
+
+        expect(
+            await findByRole('button', { name: /sign in with snowflake/i }),
+        ).toBeDefined();
+    });
+});
 
 describe('WarehouseFormInputs - Databricks', () => {
     beforeEach(() => {

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.test.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.test.tsx
@@ -1,4 +1,5 @@
 import {
+    SnowflakeAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
 } from '@lightdash/common';
@@ -7,7 +8,12 @@ import userEvent from '@testing-library/user-event';
 import { type FC } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
-import { getDefaultDatabricksAuthenticationType } from './utils';
+import { getSsoLabel } from '../../ProjectConnection/WarehouseForms/util';
+import {
+    getDefaultDatabricksAuthenticationType,
+    getDefaultSnowflakeAuthenticationType,
+    validateUserWarehouseCredentials,
+} from './utils';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
 let isDatabricksSsoEnabled = false;
@@ -44,7 +50,9 @@ const DatabricksForm: FC = () => {
     );
 };
 
-const SnowflakeForm: FC = () => {
+const SnowflakeForm: FC<{
+    authenticationType?: SnowflakeAuthenticationType;
+}> = ({ authenticationType }) => {
     const form = useForm<UpsertUserWarehouseCredentials>({
         initialValues: {
             name: 'my snowflake',
@@ -52,6 +60,11 @@ const SnowflakeForm: FC = () => {
                 type: WarehouseTypes.SNOWFLAKE,
                 user: '',
                 password: '',
+                authenticationType:
+                    authenticationType ??
+                    getDefaultSnowflakeAuthenticationType(
+                        isSnowflakeSsoEnabled,
+                    ),
             },
         },
     });
@@ -108,6 +121,63 @@ describe('WarehouseFormInputs - Snowflake', () => {
         expect(
             await findByRole('button', { name: /sign in with snowflake/i }),
         ).toBeDefined();
+    });
+
+    it('defaults to Snowflake sign-in when SSO is enabled', async () => {
+        isSnowflakeSsoEnabled = true;
+        const { findByRole } = renderWithProviders(<SnowflakeForm />);
+
+        expect(
+            await findByRole('button', { name: /sign in with snowflake/i }),
+        ).toBeDefined();
+    });
+
+    it('still labels a stored SSO credential once SSO is turned off', async () => {
+        const { findByRole } = renderWithProviders(
+            <SnowflakeForm
+                authenticationType={SnowflakeAuthenticationType.SSO}
+            />,
+        );
+
+        expect(
+            await findByRole('textbox', { name: /authentication type/i }),
+        ).toHaveValue(getSsoLabel(WarehouseTypes.SNOWFLAKE));
+    });
+});
+
+describe('validateUserWarehouseCredentials', () => {
+    const credentials = (
+        overrides: Partial<{ privateKey: string }>,
+    ): UpsertUserWarehouseCredentials => ({
+        name: 'my snowflake',
+        credentials: {
+            type: WarehouseTypes.SNOWFLAKE,
+            user: 'analyst',
+            authenticationType: SnowflakeAuthenticationType.PRIVATE_KEY,
+            ...overrides,
+        },
+    });
+
+    it('blocks saving a private key credential with no uploaded key', () => {
+        expect(validateUserWarehouseCredentials(credentials({}))).toEqual({
+            'credentials.privateKey': expect.any(String),
+        });
+    });
+
+    it('blocks saving when the stored key was replaced by a placeholder', () => {
+        expect(
+            validateUserWarehouseCredentials(credentials({ privateKey: '' })),
+        ).toEqual({
+            'credentials.privateKey': expect.any(String),
+        });
+    });
+
+    it('accepts a private key credential with an uploaded key', () => {
+        expect(
+            validateUserWarehouseCredentials(
+                credentials({ privateKey: '-----BEGIN PRIVATE KEY-----' }),
+            ),
+        ).toEqual({});
     });
 });
 

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -1,6 +1,7 @@
 import {
     DatabricksAuthenticationType,
     RedshiftAuthenticationType,
+    SnowflakeAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
     type UserWarehouseCredentials,
@@ -10,6 +11,7 @@ import {
     Button,
     Code,
     Collapse,
+    FileInput,
     PasswordInput,
     Select,
     Stack,
@@ -32,7 +34,9 @@ import { useSnowflakeLoginPopup } from '../../../hooks/useSnowflake';
 import MantineIcon from '../../common/MantineIcon';
 import {
     getSsoLabel,
+    PASSWORD_LABEL,
     PERSONAL_ACCESS_TOKEN_LABEL,
+    PRIVATE_KEY_LABEL,
 } from '../../ProjectConnection/WarehouseForms/util';
 import { WarehouseSsoButton } from './WarehouseSsoButton';
 
@@ -79,24 +83,160 @@ const BigQueryFormInput: FC<{
     );
 };
 
-export const SnowflakeFormInput: FC<{ onClose: () => void }> = ({
-    onClose,
-}) => {
-    const { mutate: openLoginPopup } = useSnowflakeLoginPopup({
+export const SnowflakeFormInput: FC<{
+    disabled?: boolean;
+    form?: UseFormReturnType<UpsertUserWarehouseCredentials>;
+    onClose: () => void;
+}> = ({ disabled = false, form, onClose }) => {
+    const [privateKeyFile, setPrivateKeyFile] = useState<File | null>(null);
+    const { mutate: openLoginPopup, isSsoEnabled } = useSnowflakeLoginPopup({
         onLogin: async () => {
             onClose();
         },
     });
+    const credentials =
+        form?.values.credentials.type === WarehouseTypes.SNOWFLAKE
+            ? form.values.credentials
+            : undefined;
+    const authenticationType =
+        credentials?.authenticationType ?? SnowflakeAuthenticationType.PASSWORD;
+    const authenticationOptions = [
+        ...(isSsoEnabled
+            ? [
+                  {
+                      value: SnowflakeAuthenticationType.SSO,
+                      label: getSsoLabel(WarehouseTypes.SNOWFLAKE),
+                  },
+              ]
+            : []),
+        {
+            value: SnowflakeAuthenticationType.PRIVATE_KEY,
+            label: PRIVATE_KEY_LABEL,
+        },
+        {
+            value: SnowflakeAuthenticationType.PASSWORD,
+            label: PASSWORD_LABEL,
+        },
+    ];
 
-    // If this popup happens, it means we don't have warehouse credentials,
-    // (aka isAuthenticated is false), so we need to authenticate
+    if (!form) {
+        return (
+            <WarehouseSsoButton
+                warehouseType={WarehouseTypes.SNOWFLAKE}
+                providerName="Snowflake"
+                disabled={disabled}
+                openLoginPopup={openLoginPopup}
+            />
+        );
+    }
+
     return (
-        <WarehouseSsoButton
-            warehouseType={WarehouseTypes.SNOWFLAKE}
-            providerName="Snowflake"
-            disabled={false}
-            openLoginPopup={openLoginPopup}
-        />
+        <Stack gap="xs">
+            <Select
+                required
+                allowDeselect={false}
+                size="xs"
+                label="Authentication type"
+                data={authenticationOptions}
+                value={authenticationType}
+                disabled={disabled}
+                onChange={(value) => {
+                    if (!value || !credentials) return;
+                    form.setFieldValue('credentials', {
+                        type: WarehouseTypes.SNOWFLAKE,
+                        user: credentials.user,
+                        authenticationType:
+                            value as SnowflakeAuthenticationType,
+                    });
+                    setPrivateKeyFile(null);
+                }}
+            />
+
+            {authenticationType === SnowflakeAuthenticationType.SSO ? (
+                <WarehouseSsoButton
+                    warehouseType={WarehouseTypes.SNOWFLAKE}
+                    providerName="Snowflake"
+                    disabled={disabled}
+                    openLoginPopup={openLoginPopup}
+                />
+            ) : (
+                <>
+                    <TextInput
+                        required
+                        size="xs"
+                        label="Username/email"
+                        disabled={disabled}
+                        {...form.getInputProps('credentials.user')}
+                    />
+                    {authenticationType ===
+                    SnowflakeAuthenticationType.PRIVATE_KEY ? (
+                        <>
+                            <FileInput
+                                required
+                                size="xs"
+                                label="Private key file"
+                                description="Upload your Snowflake .p8 private key."
+                                placeholder="Choose file..."
+                                accept=".p8"
+                                value={privateKeyFile}
+                                disabled={disabled}
+                                onChange={(file) => {
+                                    setPrivateKeyFile(null);
+                                    if (!file) {
+                                        form.setFieldValue(
+                                            'credentials.privateKey',
+                                            undefined,
+                                        );
+                                        return;
+                                    }
+
+                                    const fileReader = new FileReader();
+                                    fileReader.onload = (event) => {
+                                        const contents = event.target?.result;
+                                        setPrivateKeyFile(
+                                            typeof contents === 'string'
+                                                ? file
+                                                : null,
+                                        );
+                                        form.setFieldValue(
+                                            'credentials.privateKey',
+                                            typeof contents === 'string'
+                                                ? contents
+                                                : undefined,
+                                        );
+                                    };
+                                    fileReader.onerror = () => {
+                                        setPrivateKeyFile(null);
+                                        form.setFieldValue(
+                                            'credentials.privateKey',
+                                            undefined,
+                                        );
+                                    };
+                                    fileReader.readAsText(file);
+                                }}
+                            />
+                            <PasswordInput
+                                size="xs"
+                                label="Private key passphrase"
+                                description="Optional passphrase for encrypted private keys."
+                                disabled={disabled}
+                                {...form.getInputProps(
+                                    'credentials.privateKeyPass',
+                                )}
+                            />
+                        </>
+                    ) : (
+                        <PasswordInput
+                            required
+                            size="xs"
+                            label="Password"
+                            disabled={disabled}
+                            {...form.getInputProps('credentials.password')}
+                        />
+                    )}
+                </>
+            )}
+        </Stack>
     );
 };
 
@@ -425,7 +565,13 @@ export const WarehouseFormInputs: FC<{
 
     switch (form.values.credentials.type) {
         case WarehouseTypes.SNOWFLAKE:
-            return <SnowflakeFormInput onClose={onClose} />;
+            return (
+                <SnowflakeFormInput
+                    disabled={disabled}
+                    form={form}
+                    onClose={onClose}
+                />
+            );
         case WarehouseTypes.POSTGRES:
         case WarehouseTypes.TRINO:
         case WarehouseTypes.CLICKHOUSE:

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -38,6 +38,7 @@ import {
     PERSONAL_ACCESS_TOKEN_LABEL,
     PRIVATE_KEY_LABEL,
 } from '../../ProjectConnection/WarehouseForms/util';
+import { PRIVATE_KEY_FIELD_PATH } from './utils';
 import { WarehouseSsoButton } from './WarehouseSsoButton';
 
 const BigQueryFormInput: FC<{
@@ -100,8 +101,13 @@ export const SnowflakeFormInput: FC<{
             : undefined;
     const authenticationType =
         credentials?.authenticationType ?? SnowflakeAuthenticationType.PASSWORD;
+    // Keep SSO listed for a credential already saved as SSO, so an instance
+    // that later turned Snowflake OAuth off still labels the stored value
+    // instead of rendering an empty select.
+    const showSsoOption =
+        isSsoEnabled || authenticationType === SnowflakeAuthenticationType.SSO;
     const authenticationOptions = [
-        ...(isSsoEnabled
+        ...(showSsoOption
             ? [
                   {
                       value: SnowflakeAuthenticationType.SSO,
@@ -180,6 +186,7 @@ export const SnowflakeFormInput: FC<{
                                 accept=".p8"
                                 value={privateKeyFile}
                                 disabled={disabled}
+                                error={form.errors[PRIVATE_KEY_FIELD_PATH]}
                                 onChange={(file) => {
                                     setPrivateKeyFile(null);
                                     if (!file) {

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
@@ -4,6 +4,10 @@ import {
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
 } from '@lightdash/common';
+import { type FormErrors } from '@mantine/form';
+
+/** The private key file input is controlled, so it renders this error itself. */
+export const PRIVATE_KEY_FIELD_PATH = 'credentials.privateKey';
 
 /**
  * "Sign in with Databricks" (OAuth U2M) is enterprise-only, so instances
@@ -33,3 +37,40 @@ export const isSnowflakeSso = (
 ) =>
     credentials.type === WarehouseTypes.SNOWFLAKE &&
     credentials.authenticationType === SnowflakeAuthenticationType.SSO;
+
+/**
+ * Instances with Snowflake OAuth configured keep "Sign in with Snowflake" as
+ * the default, so enabling password and private key doesn't move them off the
+ * flow they already use.
+ */
+export const getDefaultSnowflakeAuthenticationType = (
+    isSsoEnabled: boolean,
+): SnowflakeAuthenticationType =>
+    isSsoEnabled
+        ? SnowflakeAuthenticationType.SSO
+        : SnowflakeAuthenticationType.PASSWORD;
+
+/**
+ * A private key is write-only: reopening a saved credential can't prefill the
+ * file, so saving without re-uploading would persist an empty key.
+ */
+export const validateUserWarehouseCredentials = (
+    values: UpsertUserWarehouseCredentials,
+): FormErrors => {
+    const { credentials } = values;
+    if (
+        credentials.type === WarehouseTypes.SNOWFLAKE &&
+        credentials.authenticationType ===
+            SnowflakeAuthenticationType.PRIVATE_KEY
+    ) {
+        const privateKey =
+            'privateKey' in credentials ? credentials.privateKey : undefined;
+        if (!privateKey) {
+            return {
+                [PRIVATE_KEY_FIELD_PATH]:
+                    'Upload your Snowflake private key file.',
+            };
+        }
+    }
+    return {};
+};

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
@@ -1,5 +1,6 @@
 import {
     DatabricksAuthenticationType,
+    SnowflakeAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
 } from '@lightdash/common';
@@ -26,3 +27,9 @@ export const isDatabricksPersonalAccessToken = (
     credentials.type === WarehouseTypes.DATABRICKS &&
     credentials.authenticationType ===
         DatabricksAuthenticationType.PERSONAL_ACCESS_TOKEN;
+
+export const isSnowflakeSso = (
+    credentials: UpsertUserWarehouseCredentials['credentials'],
+) =>
+    credentials.type === WarehouseTypes.SNOWFLAKE &&
+    credentials.authenticationType === SnowflakeAuthenticationType.SSO;

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
@@ -8,6 +8,8 @@ import { type FormErrors } from '@mantine/form';
 
 /** The private key file input is controlled, so it renders this error itself. */
 export const PRIVATE_KEY_FIELD_PATH = 'credentials.privateKey';
+const USER_FIELD_PATH = 'credentials.user';
+const PASSWORD_FIELD_PATH = 'credentials.password';
 
 /**
  * "Sign in with Databricks" (OAuth U2M) is enterprise-only, so instances
@@ -51,26 +53,39 @@ export const getDefaultSnowflakeAuthenticationType = (
         : SnowflakeAuthenticationType.PASSWORD;
 
 /**
- * A private key is write-only: reopening a saved credential can't prefill the
- * file, so saving without re-uploading would persist an empty key.
+ * Reopening a saved credential can't prefill a secret, so every editable
+ * Snowflake field is checked here rather than letting the masked placeholder
+ * reach the server and come back as an unattributed 400.
  */
 export const validateUserWarehouseCredentials = (
     values: UpsertUserWarehouseCredentials,
 ): FormErrors => {
     const { credentials } = values;
-    if (
-        credentials.type === WarehouseTypes.SNOWFLAKE &&
-        credentials.authenticationType ===
-            SnowflakeAuthenticationType.PRIVATE_KEY
-    ) {
+    if (credentials.type !== WarehouseTypes.SNOWFLAKE) return {};
+
+    const { authenticationType } = credentials;
+    // The OAuth popup owns the SSO credential; nothing here is editable.
+    if (authenticationType === SnowflakeAuthenticationType.SSO) return {};
+
+    const errors: FormErrors = {};
+    if (!credentials.user.trim()) {
+        errors[USER_FIELD_PATH] = 'Enter your Snowflake username or email.';
+    }
+
+    if (authenticationType === SnowflakeAuthenticationType.PRIVATE_KEY) {
         const privateKey =
             'privateKey' in credentials ? credentials.privateKey : undefined;
         if (!privateKey) {
-            return {
-                [PRIVATE_KEY_FIELD_PATH]:
-                    'Upload your Snowflake private key file.',
-            };
+            errors[PRIVATE_KEY_FIELD_PATH] =
+                'Upload your Snowflake private key file.';
         }
+        return errors;
     }
-    return {};
+
+    const password =
+        'password' in credentials ? credentials.password : undefined;
+    if (!password) {
+        errors[PASSWORD_FIELD_PATH] = 'Enter your Snowflake password.';
+    }
+    return errors;
 };

--- a/packages/frontend/src/hooks/useSnowflake.ts
+++ b/packages/frontend/src/hooks/useSnowflake.ts
@@ -42,6 +42,11 @@ const triggerSnowflakeLogin = async (siteUrl: string) => {
     });
 };
 
+export const useIsSnowflakeSsoEnabled = () => {
+    const health = useHealth();
+    return !!health.data?.auth.snowflake.enabled;
+};
+
 export function useSnowflakeLoginPopup({
     onLogin: _onLogin,
 }: {


### PR DESCRIPTION
## What changed

Adds an authentication selector to personal Snowflake connections, with Password and Private Key available independently of OAuth configuration and Snowflake sign-in available when configured. Manual credentials are validated server-side, secret fields remain excluded from responses, and OAuth reauthentication updates only the existing SSO credential instead of deleting other Snowflake connections.

### Validation
- `pnpm -F 'backend' run --if-present lint` — passed
- `pnpm -F 'backend' run --if-present typecheck` — passed
- `pnpm -F 'backend' run --if-present test` — passed
- `pnpm -F 'common' run --if-present lint` — passed
- `pnpm -F 'common' run --if-present typecheck` — passed
- `pnpm -F 'common' run --if-present test` — passed
- `pnpm -F 'frontend' run --if-present lint` — passed
- `pnpm -F 'frontend' run --if-present typecheck` — passed
- `pnpm -F 'frontend' run --if-present test` — passed
- Final validation passed for backend, common, and frontend.

## Visual evidence

### Add Snowflake credentials when Snowflake OAuth is disabled

![Lightdash preview walkthrough](https://ld-linear-agent-v2.exe.xyz/evidence/fec0198c535608310b9f5f973223643887d3dcc22e31afa2722e2258b7679baf.gif)

[Open full walkthrough](https://ld-linear-agent-v2.exe.xyz/evidence/7ef7326a87d36ee2d4ab752acf180236543b6086c960496cbc385deebc626e39.mp4)

## Preview

[Open the public Lightdash preview](https://ld-runner-prod-10424-99642af57249.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10424

