### PR TITLE
fix(warehouses): surface databricks status errors

### DIFF
--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
@@ -1,4 +1,6 @@
 /* eslint-disable prefer-arrow-callback, func-names */
+import StatusError from '@databricks/sql/dist/errors/StatusError';
+import { TStatusCode } from '@databricks/sql/thrift/TCLIService_types';
 import {
     DatabricksSqlBuilder,
     DatabricksWarehouseClient,
@@ -8,6 +10,8 @@ import { expectedFields } from './WarehouseClient.mock';
 
 const mocks = vi.hoisted(() => ({
     fetchChunk: vi.fn(),
+    openSession: vi.fn(),
+    closeConnection: vi.fn(),
 }));
 
 vi.mock('@databricks/sql', async () => ({
@@ -17,24 +21,44 @@ vi.mock('@databricks/sql', async () => ({
     DBSQLClient: vi.fn(function () {
         return {
             connect: vi.fn(() => ({
-                openSession: vi.fn(() => ({
-                    executeStatement: vi.fn(() => ({
-                        getSchema: vi.fn(async () => schema),
-                        fetchChunk: mocks.fetchChunk.mockImplementation(
-                            async () => rows,
-                        ),
-                        hasMoreRows: vi.fn(async () => false),
-                        close: vi.fn(async () => undefined),
-                    })),
-                    close: vi.fn(async () => undefined),
-                })),
-                close: vi.fn(async () => undefined),
+                openSession: mocks.openSession,
+                close: mocks.closeConnection,
             })),
         };
     }),
 }));
 
 describe('DatabricksWarehouseClient', () => {
+    beforeEach(() => {
+        mocks.fetchChunk.mockReset().mockResolvedValue(rows);
+        mocks.closeConnection.mockReset().mockResolvedValue(undefined);
+        mocks.openSession.mockReset().mockResolvedValue({
+            executeStatement: vi.fn(() => ({
+                getSchema: vi.fn(async () => schema),
+                fetchChunk: mocks.fetchChunk,
+                hasMoreRows: vi.fn(async () => false),
+                close: vi.fn(async () => undefined),
+            })),
+            close: vi.fn(async () => undefined),
+        });
+    });
+
+    it('surfaces Databricks status messages when opening a session fails', async () => {
+        const message =
+            'SQL warehouse xyz is not ready to accept connections (current state: STARTING)';
+        mocks.openSession.mockRejectedValueOnce(
+            new StatusError({
+                statusCode: TStatusCode.ERROR_STATUS,
+                errorMessage: message,
+            }),
+        );
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        await expect(warehouse.runQuery('fake sql')).rejects.toMatchObject({
+            message,
+        });
+    });
+
     it('expect query fields and rows', async () => {
         const warehouse = new DatabricksWarehouseClient(credentials);
 

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -4,6 +4,7 @@ import IDBSQLClient, {
 } from '@databricks/sql/dist/contracts/IDBSQLClient';
 import IDBSQLSession from '@databricks/sql/dist/contracts/IDBSQLSession';
 import IOperation from '@databricks/sql/dist/contracts/IOperation';
+import StatusError from '@databricks/sql/dist/errors/StatusError';
 import { TTypeId as DatabricksDataTypes } from '@databricks/sql/thrift/TCLIService_types';
 import {
     AnyType,
@@ -293,6 +294,11 @@ const DATABRICKS_QUERY_TIMEOUT_SECONDS = 300;
 // wide results in one array and can OOM the worker on large queries
 const DATABRICKS_FETCH_CHUNK_MAX_ROWS = 5000;
 
+const getDatabricksErrorMessage = (error: unknown) =>
+    error instanceof StatusError && error.message
+        ? error.message
+        : getErrorMessage(error);
+
 export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabricksCredentials> {
     schema: string;
 
@@ -359,7 +365,7 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
         try {
             connection = await client.connect(this.connectionOptions);
         } catch (e: unknown) {
-            throw new WarehouseConnectionError(getErrorMessage(e));
+            throw new WarehouseConnectionError(getDatabricksErrorMessage(e));
         }
 
         try {
@@ -376,7 +382,7 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
                     closeError,
                 );
             }
-            throw new WarehouseConnectionError(getErrorMessage(e));
+            throw new WarehouseConnectionError(getDatabricksErrorMessage(e));
         }
 
         return {
@@ -455,7 +461,7 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
                 // eslint-disable-next-line no-await-in-loop
             } while (await query.hasMoreRows());
         } catch (e: unknown) {
-            throw new WarehouseQueryError(getErrorMessage(e));
+            throw new WarehouseQueryError(getDatabricksErrorMessage(e));
         } finally {
             try {
                 if (query) await query.close();
@@ -494,7 +500,9 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
                         });
                         return (await query.fetchAll()) as SchemaResult[];
                     } catch (e: unknown) {
-                        throw new WarehouseQueryError(getErrorMessage(e));
+                        throw new WarehouseQueryError(
+                            getDatabricksErrorMessage(e),
+                        );
                     } finally {
                         try {
                             if (query) await query.close();
@@ -509,7 +517,7 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
                 },
             );
         } catch (e: unknown) {
-            throw new WarehouseQueryError(getErrorMessage(e));
+            throw new WarehouseQueryError(getDatabricksErrorMessage(e));
         } finally {
             try {
                 await close();


### PR DESCRIPTION
## What changed

Preserve messages from Databricks `StatusError` instances across connection and query failure paths, including warehouse startup errors. Add regression coverage using the driver’s real non-`Error` status class.

### Validation
- `pnpm -F warehouses exec vitest run --config vitest.config.ts src/warehouseClients/DatabricksWarehouseClient.test.ts` — passed (7 tests)
- `pnpm -F warehouses exec oxfmt 'src/warehouseClients/DatabricksWarehouseClient.test.ts' 'src/warehouseClients/DatabricksWarehouseClient.ts'` — passed
- `pnpm -F warehouses run --if-present lint` — passed
- `pnpm -F warehouses run --if-present typecheck` — passed
- `pnpm -F warehouses run --if-present test` — passed

## Preview

[Open the public Lightdash preview](https://ld-runner-prod-10501-9a17bd60ee40.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10501

