### PR TITLE
fix: let page sidebars yield width on narrow windows

### DIFF
--- a/packages/frontend/src/components/common/Page/Page.module.css
+++ b/packages/frontend/src/components/common/Page/Page.module.css
@@ -71,6 +71,9 @@
 
 .content[data-with-sidebar='true'] {
     min-width: var(--page-min-content-width);
+    /* Absorb the row's negative free space down to the min-width above before
+       the (shrinkable) sidebars start giving up their width. */
+    flex-shrink: 1000;
 }
 
 .content[data-with-footer='true'] {

--- a/packages/frontend/src/components/common/Page/Sidebar.module.css
+++ b/packages/frontend/src/components/common/Page/Sidebar.module.css
@@ -146,6 +146,13 @@
     z-index: 1;
 }
 
+/* While open, the sidebar may give up width (down to its configured minimum)
+   before the page row overflows, so narrow windows reflow instead of clipping. */
+.sidebarContainer[data-open='true'] {
+    flex: 0 1 var(--sidebar-width);
+    min-width: min(var(--sidebar-width), var(--sidebar-min-width));
+}
+
 .sidebarPaper {
     --sidebar-padding: 16px;
 
@@ -154,6 +161,7 @@
     flex-direction: column;
     overflow: hidden;
     width: var(--sidebar-width);
+    max-width: 100%;
     padding: var(--sidebar-padding);
     padding-bottom: 0;
 }
@@ -167,5 +175,6 @@
     flex-grow: 1;
     flex-direction: column;
     width: calc(var(--sidebar-width) - 2 * var(--sidebar-padding));
+    max-width: 100%;
     min-height: 0;
 }

--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -6,7 +6,7 @@ import {
     type FlexProps,
     type MantineTransition,
 } from '@mantine/core';
-import { type FC } from 'react';
+import { useLayoutEffect, useRef, type FC } from 'react';
 import useSidebarResize from '../../../hooks/useSidebarResize';
 import { TrackSection } from '../../../providers/Tracking/TrackingProvider';
 import { SectionName } from '../../../types/Events';
@@ -75,6 +75,19 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
             onResizeEnd,
         });
 
+    // The row may flex the open sidebar below sidebarWidth. Closing slides the
+    // paper out from the width it actually rendered at (and must not animate
+    // width, or it eases in from sidebarWidth), so it never snaps back to the
+    // full width mid-animation.
+    const renderedWidthRef = useRef(sidebarWidth);
+    useLayoutEffect(() => {
+        if (isOpen && sidebarRef.current) {
+            renderedWidthRef.current =
+                sidebarRef.current.getBoundingClientRect().width;
+        }
+    });
+    const paperWidth = isOpen ? sidebarWidth : renderedWidthRef.current;
+
     // Collapsible sidebars drop out of the page flow when collapsed and
     // reveal as a floating overlay when the edge trigger (or panel) is hovered.
     if (collapsible) {
@@ -130,10 +143,11 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
     // scrollbar on every toggle.
     const transition: MantineTransition = {
         in: { opacity: 1, marginLeft: 0 },
-        out: { opacity: 0, marginLeft: -sidebarWidth },
-        transitionProperty: isResizing
-            ? 'opacity, margin'
-            : 'opacity, margin, width',
+        out: { opacity: 0, marginLeft: -paperWidth },
+        transitionProperty:
+            isResizing || !isOpen
+                ? 'opacity, margin'
+                : 'opacity, margin, width',
     };
 
     return (
@@ -142,6 +156,11 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                 ref={sidebarRef}
                 direction="column"
                 className={classes.sidebarContainer}
+                data-open={isOpen}
+                style={{
+                    '--sidebar-width': `${paperWidth}px`,
+                    '--sidebar-min-width': `${minWidth}px`,
+                }}
                 {...containerProps}
             >
                 <Transition
@@ -156,10 +175,7 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                                 shadow="lg"
                                 radius={0}
                                 className={classes.sidebarPaper}
-                                style={{
-                                    ...style,
-                                    '--sidebar-width': `${sidebarWidth}px`,
-                                }}
+                                style={style}
                                 data-no-padding={noSidebarPadding}
                                 data-testid="common-sidebar"
                             >


### PR DESCRIPTION
## Summary

Pages with a left or right sidebar overflowed horizontally as soon as the window got narrower than the sidebars plus the content's 600px minimum. Sidebars now give up width first, down to their configured minimum (320px by default), and only then does the row overflow.

- Open sidebars become `flex: 0 1 <width>` with an explicit `min-width`; the page content gets a much larger `flex-shrink`, so it absorbs the negative space down to its own minimum before the sidebars start yielding.
- Closing slides the paper out from the width it actually rendered at and stops animating `width` while closing, so the close animation never snaps back to the full width (that snap flashed a horizontal scrollbar in the reflow band).
- Collapsible (floating) sidebars are untouched.

Measured on the Explorer with both panels open: the row previously overflowed below 1400px, now below 1240px; with one sidebar, 1000px → 920px. Nothing changes above those widths.

Relates: PROD-10465