### PR TITLE
fix: slide the page sidebar open in step with the content

### DIFF
--- a/packages/frontend/src/components/common/Page/Sidebar.module.css
+++ b/packages/frontend/src/components/common/Page/Sidebar.module.css
@@ -144,13 +144,12 @@
     height: 100%;
     max-height: 100%;
     z-index: 1;
-}
-
-/* While open, the sidebar may give up width (down to its configured minimum)
-   before the page row overflows, so narrow windows reflow instead of clipping. */
-.sidebarContainer[data-open='true'] {
-    flex: 0 1 var(--sidebar-width);
-    min-width: min(var(--sidebar-width), var(--sidebar-min-width));
+    /* Sized by the paper, so the page content moves with its sliding margin,
+       yet free to yield down to the configured minimum before the page row
+       overflows. `width` only feeds the flex automatic minimum size (the
+       smaller of content and width): `flex-basis: content` ignores it. */
+    flex: 0 1 content;
+    width: var(--sidebar-min-width);
 }
 
 .sidebarPaper {
@@ -177,4 +176,11 @@
     width: calc(var(--sidebar-width) - 2 * var(--sidebar-padding));
     max-width: 100%;
     min-height: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    /* No slide, but the fade still confirms the toggle. */
+    .sidebarPaper {
+        transition-property: opacity !important;
+    }
 }

--- a/packages/frontend/src/components/common/Page/Sidebar.tsx
+++ b/packages/frontend/src/components/common/Page/Sidebar.tsx
@@ -156,7 +156,6 @@ const Sidebar: FC<React.PropsWithChildren<Props>> = ({
                 ref={sidebarRef}
                 direction="column"
                 className={classes.sidebarContainer}
-                data-open={isOpen}
                 style={{
                     '--sidebar-width': `${paperWidth}px`,
                     '--sidebar-min-width': `${minWidth}px`,


### PR DESCRIPTION
With the explorer chart gallery on, opening the right (Configure chart) sidebar flashed: the page content snapped to its final width in the first frame and the panel then slid into the gap from inside the content, left to right. Closing was smooth in the opposite direction.

#27932 gave an open sidebar an explicit `flex: 0 1 <width>` so it can yield on narrow windows, keyed on `data-open`. That attribute flipped on the same render as `isOpen`, so on open the container jumped to its full flex basis before the paper's margin animation started; on close the rule dropped immediately, which is why that direction stayed margin-driven and smooth.

- The container now uses `flex-basis: content` with `width: var(--sidebar-min-width)`. `content` sizes the flex basis from the paper *including its animated margin*, so the container (and the page content) moves with the slide in both directions. `width` only feeds flexbox's automatic minimum size (`min(content, width)`), so the sidebar can still give up width down to its configured minimum before the page row overflows, from the first frame of the enter as well as when settled. The narrow-window reflow from #27932 is unchanged.
- No JS involved: `data-open` is gone and the `Transition` lifecycle isn't needed.
- Per-frame log on the explorer at 1440px: container width and paper margin advance together (0 → 45 → 139 → 231 → 400), the paper stays pinned at the page edge fading in, and nothing moves once the transition ends. At 1100px, where the row overflows, the container grows to the 320px minimum and stops there instead of overshooting to 400 and snapping back.
- Left sidebars (SQL runner toggle, saved chart edit mode) and the drag resize keep their behaviour; the collapsible `floatContainer` variant is untouched.
- `prefers-reduced-motion` now drops the slide on the in-flow sidebar and keeps the fade, matching the existing rule for the collapsible one.

Relates: PROD-10465
