### PR TITLE
ci: add trusted contributors check for external pull requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,5 @@
 pnpm-workspace.yaml @lightdash/engineering
 renovate.json @lightdash/engineering
 .github/workflows/ @lightdash/engineering
+.github/scripts/ @lightdash/engineering
+.github/trusted-contributors.yml @lightdash/engineering

--- a/.github/scripts/trusted-contributors.cjs
+++ b/.github/scripts/trusted-contributors.cjs
@@ -1,0 +1,123 @@
+/**
+ * Closes pull requests from external authors who are not listed in
+ * .github/trusted-contributors.yml. Runs under pull_request_target, so the
+ * list is read from the default branch and a pull request cannot change the
+ * rules that apply to itself.
+ */
+
+const TRUSTED_LIST_PATH = '.github/trusted-contributors.yml';
+const LABEL = 'closed-external';
+
+const INTERNAL_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+
+const parseTrustedUsernames = (fileContent) =>
+    fileContent
+        .split('\n')
+        .map((line) => line.replace(/#.*/, ''))
+        .map((line) => line.match(/^\s*-\s*([A-Za-z0-9][A-Za-z0-9-]*)\s*$/))
+        .filter(Boolean)
+        .map((match) => match[1].toLowerCase());
+
+const closeComment = (repoUrl, author) =>
+    [
+        `Hi @${author}, thanks for taking the time to open this.`,
+        '',
+        `Lightdash no longer accepts unsolicited code contributions. We close pull requests unless the author is a [trusted contributor](${repoUrl}/blob/main/${TRUSTED_LIST_PATH}) and the work was agreed with our team in advance.`,
+        '',
+        `This is not a judgment of your work. We would still like to understand the problem, so please open a [bug report](${repoUrl}/issues/new?template=bug_report.yml) or [feature request](${repoUrl}/issues/new?template=feature-request.yml) instead. If you are a Lightdash customer, please contact us through your support channel.`,
+        '',
+        `See our [contributing guide](${repoUrl}/blob/main/.github/CONTRIBUTING.md) for the full policy.`,
+    ].join('\n');
+
+module.exports = async ({ github, context, core }) => {
+    const pr = context.payload.pull_request;
+    const author = pr.user.login;
+
+    if (pr.user.type === 'Bot') {
+        core.info(`Skipping: ${author} is a bot`);
+        return;
+    }
+
+    if (INTERNAL_ASSOCIATIONS.includes(pr.author_association)) {
+        core.info(`Skipping: ${author} is ${pr.author_association}`);
+        return;
+    }
+
+    // author_association reports org members with private membership as
+    // CONTRIBUTOR or NONE, so verify actual repository permission before
+    // treating anyone as external.
+    const hasWriteAccess = async (username) => {
+        try {
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                ...context.repo,
+                username,
+            });
+            return ['admin', 'write'].includes(data.permission);
+        } catch (error) {
+            if (error.status === 404) return false;
+            throw error;
+        }
+    };
+
+    if (await hasWriteAccess(author)) {
+        core.info(`Skipping: ${author} has write access`);
+        return;
+    }
+
+    // A maintainer reopening an external PR is a deliberate human override;
+    // closing it again would fight them.
+    if (
+        context.payload.action === 'reopened' &&
+        context.actor !== author &&
+        (await hasWriteAccess(context.actor))
+    ) {
+        core.info(`Skipping: reopened by ${context.actor}, who has write access`);
+        return;
+    }
+
+    const { data: file } = await github.rest.repos.getContent({
+        ...context.repo,
+        path: TRUSTED_LIST_PATH,
+        ref: context.payload.repository.default_branch,
+    });
+    const trusted = parseTrustedUsernames(
+        Buffer.from(file.content, 'base64').toString('utf8'),
+    );
+
+    if (trusted.includes(author.toLowerCase())) {
+        core.info(`Skipping: ${author} is a trusted contributor`);
+        return;
+    }
+
+    core.info(`Closing: ${author} is not in ${TRUSTED_LIST_PATH}`);
+
+    try {
+        await github.rest.issues.getLabel({ ...context.repo, name: LABEL });
+    } catch (error) {
+        if (error.status !== 404) throw error;
+        await github.rest.issues.createLabel({
+            ...context.repo,
+            name: LABEL,
+            color: 'ededed',
+            description: 'Closed automatically: author is not a trusted contributor',
+        });
+    }
+    await github.rest.issues.addLabels({
+        ...context.repo,
+        issue_number: pr.number,
+        labels: [LABEL],
+    });
+
+    const repoUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}`;
+    await github.rest.issues.createComment({
+        ...context.repo,
+        issue_number: pr.number,
+        body: closeComment(repoUrl, author),
+    });
+
+    await github.rest.pulls.update({
+        ...context.repo,
+        pull_number: pr.number,
+        state: 'closed',
+    });
+};

--- a/.github/trusted-contributors.yml
+++ b/.github/trusted-contributors.yml
@@ -1,0 +1,10 @@
+# GitHub usernames of external contributors whose pull requests stay open.
+# Pull requests from any other external author are closed automatically —
+# see .github/workflows/trusted-contributors.yml and CONTRIBUTING.md.
+#
+# Usernames only. Never annotate entries with company or customer
+# information — this repository is public.
+#
+# trusted:
+#     - some-username
+trusted: []

--- a/.github/workflows/trusted-contributors.yml
+++ b/.github/workflows/trusted-contributors.yml
@@ -1,0 +1,34 @@
+name: Trusted Contributors
+
+# Closes pull requests from external authors who are not listed in
+# .github/trusted-contributors.yml. The workflow, the script, and the list are
+# all read from base/default branches (pull_request_target, base-branch
+# checkout), so a pull request cannot change the rules that apply to itself.
+# The PR's code is never checked out.
+on:
+    pull_request_target:
+        types:
+            - opened
+            - reopened
+
+permissions:
+    pull-requests: write
+    issues: write
+    contents: read
+
+jobs:
+    check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+              with:
+                  egress-policy: audit
+            # Default checkout under pull_request_target is the PR's base
+            # branch in this repository, never the PR's own code.
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - name: Close untrusted external pull requests
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              with:
+                  script: |
+                      const check = require('${{ github.workspace }}/.github/scripts/trusted-contributors.cjs');
+                      await check({ github, context, core });


### PR DESCRIPTION
Reviewing unsolicited external pull requests now costs the team more than the changes are worth, so our contributions policy is moving to an allowlist. This enforces it: pull requests from external authors not listed in `.github/trusted-contributors.yml` are labeled, answered with an explanatory comment, and closed automatically.

Stacked on #27935.