### PR TITLE
fix(ai): Slack explore link opens custom chart type answers as data app viz

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -11403,6 +11403,16 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 ? promptArtifactVersions
                 : promptArtifacts,
             toolResults,
+            async (dataAppVizUuid) => {
+                const app = await this.appModel.findVisualizationApp(
+                    dataAppVizUuid,
+                    slackPrompt.projectUuid,
+                );
+                const parsedSchema = dataAppVizSchema.safeParse(
+                    app?.viz_schema,
+                );
+                return parsedSchema.success ? parsedSchema.data.fields : null;
+            },
         );
         const sqlArtifactBlocks = await getSqlArtifactCardBlocks(
             slackPrompt.promptUuid,

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -399,6 +399,192 @@ describe('Slack AI agent blocks', () => {
         ]);
     });
 
+    it('links custom chart type answers with a data app viz config and schema-derived pivot', async () => {
+        let sharedParams: string | undefined;
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async (_path, params) => {
+                sharedParams = params;
+                return 'https://lightdash.example.com/share/custom';
+            },
+            async () => ({}) as never,
+            async () => true,
+            'agent-1',
+            [
+                {
+                    artifactUuid: 'artifact-1',
+                    threadUuid: 'thread-1',
+                    promptUuid: 'prompt-1',
+                    artifactType: 'chart',
+                    savedQueryUuid: null,
+                    savedDashboardUuid: null,
+                    createdAt: new Date(),
+                    versionNumber: 1,
+                    versionUuid: 'version-1',
+                    title: 'Monthly Orders by Status',
+                    description: null,
+                    dashboardConfig: null,
+                    versionCreatedAt: new Date(),
+                    verifiedByUserUuid: null,
+                    verifiedAt: null,
+                    chartConfig: {
+                        source: 'customChartType',
+                        schemaVersion: 1,
+                        dataAppVizUuid: 'data-app-viz-1',
+                        config: {
+                            title: 'Monthly Orders by Status',
+                            description: 'Orders by month and status',
+                            queryConfig: {
+                                exploreName: 'orders',
+                                dimensions: [
+                                    'orders_order_date_month',
+                                    'orders_status',
+                                ],
+                                metrics: ['orders_unique_order_count'],
+                                sorts: [],
+                                limit: 500,
+                                parameters: null,
+                                customMetrics: [],
+                                tableCalculations: [],
+                                filters: null,
+                            },
+                            chartConfig: {
+                                customChartTypeSlug: 'fuzzy-bar',
+                                fieldMapping: {
+                                    x: 'orders_order_date_month',
+                                    y: 'orders_unique_order_count',
+                                    series: 'orders_status',
+                                },
+                                options: null,
+                            },
+                        },
+                    },
+                },
+            ],
+            [],
+            async (dataAppVizUuid) => {
+                expect(dataAppVizUuid).toBe('data-app-viz-1');
+                return [
+                    {
+                        name: 'x',
+                        label: 'X',
+                        type: 'dimension',
+                        required: true,
+                    },
+                    { name: 'y', label: 'Y', type: 'metric', required: true },
+                    {
+                        name: 'series',
+                        label: 'Series',
+                        type: 'series',
+                        required: false,
+                    },
+                ];
+            },
+        );
+
+        expect(blocks).toHaveLength(1);
+        const savedRaw = new URLSearchParams(sharedParams).get(
+            'create_saved_chart_version',
+        );
+        expect(savedRaw).toBeTruthy();
+        const saved = JSON.parse(savedRaw!);
+        expect(saved.chartConfig).toEqual({
+            type: ChartType.DATA_APP_VIZ,
+            config: {
+                dataAppVizUuid: 'data-app-viz-1',
+                fieldMapping: {
+                    x: 'orders_order_date_month',
+                    y: 'orders_unique_order_count',
+                    series: 'orders_status',
+                },
+            },
+        });
+        expect(saved.pivotConfig).toEqual({ columns: ['orders_status'] });
+    });
+
+    it('keeps the table fallback for custom chart type answers when the schema is unavailable', async () => {
+        let sharedParams: string | undefined;
+        await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async (_path, params) => {
+                sharedParams = params;
+                return 'https://lightdash.example.com/share/custom';
+            },
+            async () => ({}) as never,
+            async () => true,
+            'agent-1',
+            [
+                {
+                    artifactUuid: 'artifact-1',
+                    threadUuid: 'thread-1',
+                    promptUuid: 'prompt-1',
+                    artifactType: 'chart',
+                    savedQueryUuid: null,
+                    savedDashboardUuid: null,
+                    createdAt: new Date(),
+                    versionNumber: 1,
+                    versionUuid: 'version-1',
+                    title: 'Monthly Orders by Status',
+                    description: null,
+                    dashboardConfig: null,
+                    versionCreatedAt: new Date(),
+                    verifiedByUserUuid: null,
+                    verifiedAt: null,
+                    chartConfig: {
+                        source: 'customChartType',
+                        schemaVersion: 1,
+                        dataAppVizUuid: 'data-app-viz-1',
+                        config: {
+                            title: 'Monthly Orders by Status',
+                            description: 'Orders by month and status',
+                            queryConfig: {
+                                exploreName: 'orders',
+                                dimensions: ['orders_order_date_month'],
+                                metrics: ['orders_unique_order_count'],
+                                sorts: [],
+                                limit: 500,
+                                parameters: null,
+                                customMetrics: [],
+                                tableCalculations: [],
+                                filters: null,
+                            },
+                            chartConfig: {
+                                customChartTypeSlug: 'fuzzy-bar',
+                                fieldMapping: {
+                                    x: 'orders_order_date_month',
+                                    y: 'orders_unique_order_count',
+                                },
+                                options: null,
+                            },
+                        },
+                    },
+                },
+            ],
+            [],
+            async () => null,
+        );
+
+        const saved = JSON.parse(
+            new URLSearchParams(sharedParams).get(
+                'create_saved_chart_version',
+            )!,
+        );
+        expect(saved.chartConfig.type).toBe(ChartType.TABLE);
+        expect(saved.pivotConfig).toBeUndefined();
+    });
+
     it('omits the hero but keeps the Open image button when the image URL is unreachable', async () => {
         const blocks = await getModernArtifactCardBlocks(
             {

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -4,6 +4,8 @@ import {
     AiAgentToolResult,
     AiArtifact,
     ChartType,
+    deriveDataAppVizPivotConfig,
+    getDataAppVizChartFromArtifact,
     getGroupByDimensions,
     getItemMap,
     getWebAiChartConfig,
@@ -16,6 +18,7 @@ import {
     SlackPrompt,
     type AiLegacySemanticChartArtifactConfig,
     type ChartConfig,
+    type DataAppVizField,
     type Explore,
 } from '@lightdash/common';
 import { Block, KnownBlock } from '@slack/bolt';
@@ -546,6 +549,9 @@ export async function getModernArtifactCardBlocks(
         }
     >,
     toolResults?: AiAgentToolResult[],
+    getDataAppVizSchemaFields?: (
+        dataAppVizUuid: string,
+    ) => Promise<DataAppVizField[] | null>,
 ): Promise<(Block | KnownBlock)[]> {
     if (!artifacts || artifacts.length === 0) {
         return [];
@@ -726,27 +732,52 @@ export async function getModernArtifactCardBlocks(
                     },
                 };
                 let pivotConfig: { columns: string[] } | undefined;
-                try {
-                    const webAiChartConfig = getWebAiChartConfig({
-                        vizConfig: artifact.chartConfig.config,
-                        metricQuery: metricQueryWithSql,
-                        maxQueryLimit,
-                        fieldsMap: getItemMap(
-                            explore,
-                            additionalMetricsWithSql,
-                            vizConfig.metricQuery.tableCalculations,
-                        ),
-                    });
-                    if (webAiChartConfig.echartsConfig) {
-                        chartConfig = webAiChartConfig.echartsConfig;
+                if (artifact.chartConfig.source === 'customChartType') {
+                    // Mirror the web save flow: DATA_APP_VIZ config plus the
+                    // type's schema-derived pivot. Without the schema (app
+                    // deleted / invalid) keep the table fallback so the link
+                    // still works.
+                    const dataAppVizChart = getDataAppVizChartFromArtifact(
+                        artifact.chartConfig,
+                    );
+                    const schemaFields = dataAppVizChart
+                        ? await getDataAppVizSchemaFields?.(
+                              artifact.chartConfig.dataAppVizUuid,
+                          )
+                        : null;
+                    if (dataAppVizChart && schemaFields) {
+                        chartConfig = {
+                            type: ChartType.DATA_APP_VIZ,
+                            config: dataAppVizChart,
+                        };
+                        pivotConfig = deriveDataAppVizPivotConfig(
+                            schemaFields,
+                            dataAppVizChart.fieldMapping,
+                        );
                     }
-                    const groupByDimensions =
-                        getGroupByDimensions(webAiChartConfig);
-                    pivotConfig = groupByDimensions?.length
-                        ? { columns: groupByDimensions }
-                        : undefined;
-                } catch {
-                    // keep the table fallback
+                } else {
+                    try {
+                        const webAiChartConfig = getWebAiChartConfig({
+                            vizConfig: artifact.chartConfig.config,
+                            metricQuery: metricQueryWithSql,
+                            maxQueryLimit,
+                            fieldsMap: getItemMap(
+                                explore,
+                                additionalMetricsWithSql,
+                                vizConfig.metricQuery.tableCalculations,
+                            ),
+                        });
+                        if (webAiChartConfig.echartsConfig) {
+                            chartConfig = webAiChartConfig.echartsConfig;
+                        }
+                        const groupByDimensions =
+                            getGroupByDimensions(webAiChartConfig);
+                        pivotConfig = groupByDimensions?.length
+                            ? { columns: groupByDimensions }
+                            : undefined;
+                    } catch {
+                        // keep the table fallback
+                    }
                 }
 
                 const path = `/projects/${slackPrompt.projectUuid}/tables/${vizConfig.metricQuery.exploreName}`;


### PR DESCRIPTION
## Problem

The Slack card's "Explore in Lightdash" link for a custom chart type answer opened the explorer with a plain table viz. The card builder went through `getRunQueryChartConfig`, which intentionally returns a table config for custom chart type slugs, so every custom answer hit the table fallback.

## Fix

Mirror the web thread's save/explore flow in `getModernArtifactCardBlocks`: when the artifact envelope is `source: 'customChartType'`, build a `DATA_APP_VIZ` chart config from the envelope (`getDataAppVizChartFromArtifact`) and derive the pivot from the type's schema series slots (`deriveDataAppVizPivotConfig`), so the explorer opens rendering the custom viz pivoted exactly like the thread.

- Schema fetch is injected from `AiAgentService` (`appModel.findVisualizationApp` + `dataAppVizSchema` parse), same derivation as `deriveCustomChartTypePivotConfiguration`.
- If the schema is unavailable (app deleted / invalid), the link keeps the table fallback so it always works.

## Tests

- URL carries `data_app_viz` chart config + schema-derived pivot
- table fallback when the schema is unavailable

No ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MDtcEEDhT6tcXPTSk4t6a
