### PR TITLE
refactor(chart-types): extract the builder workspace from the standalone page

### DIFF
--- a/packages/frontend/src/features/apps/components/AppPreview.tsx
+++ b/packages/frontend/src/features/apps/components/AppPreview.tsx
@@ -37,6 +37,8 @@ export type AppPreviewProps = {
     onLineageCancelled?: () => void;
     dataAppVizContext?: DataAppVizContext;
     onSdkManifest?: (manifest: SdkManifest) => void;
+    /** Whether the app may mirror its own state into the page URL. */
+    urlStateSync?: boolean;
 };
 
 const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
@@ -61,6 +63,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
             onLineageCancelled,
             dataAppVizContext,
             onSdkManifest,
+            urlStateSync = true,
         },
         ref,
     ) => {
@@ -124,7 +127,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
                 onLineageCancelled={onLineageCancelled}
                 capabilities={{ gsheetExport: true }}
                 dataAppVizContext={dataAppVizContext}
-                urlStateSync
+                urlStateSync={urlStateSync}
                 onSdkManifest={onSdkManifest}
             />
         );

--- a/packages/frontend/src/features/chartTypes/builder/BuilderCanvas.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/BuilderCanvas.tsx
@@ -31,6 +31,8 @@ type Props = {
      *  mounted to receive one. */
     onPickExample: ((prompt: string) => void) | null;
     onSdkManifest: (manifest: SdkManifest) => void;
+    /** Whether the previewed viz may write its own state into the page URL. */
+    syncPreviewUrlState: boolean;
 };
 
 /** Same footprint and viewBox as an example card's thumbnail, so the canvas
@@ -85,6 +87,7 @@ const BuilderCanvas: FC<Props> = ({
     configurePanel,
     onPickExample,
     onSdkManifest,
+    syncPreviewUrlState,
 }) => {
     const hasPreview = appUuid !== null && previewVersion !== null;
     const isFirstBuild = isBuilding && !hasPreview;
@@ -106,6 +109,7 @@ const BuilderCanvas: FC<Props> = ({
                             refreshKey={0}
                             dataAppVizContext={previewContext ?? undefined}
                             onSdkManifest={onSdkManifest}
+                            urlStateSync={syncPreviewUrlState}
                         />
                     </Box>
                 </Box>

--- a/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderWorkspace.module.css
+++ b/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderWorkspace.module.css
@@ -1,0 +1,32 @@
+.main {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+}
+
+.content {
+    height: 100%;
+    flex: 1;
+    min-width: 0;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+.historyResizeHandle {
+    width: 1px;
+    flex: 0 0 1px;
+    cursor: col-resize;
+    background-color: var(--mantine-color-ldGray-2);
+    transition:
+        background-color 120ms ease,
+        box-shadow 120ms ease;
+}
+
+.historyResizeHandle[data-resize-handle-state='hover'],
+.historyResizeHandle[data-resize-handle-state='drag'],
+.historyResizeHandle:focus-visible {
+    background-color: var(--mantine-color-ldGray-4);
+    box-shadow: 0 0 0 1px var(--mantine-color-ldGray-4);
+}

--- a/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderWorkspace.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderWorkspace.tsx
@@ -1,0 +1,133 @@
+import { type DataAppVizContext } from '@lightdash/common';
+import { Box } from '@mantine/core';
+import { type FC, type ReactNode } from 'react';
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import BuilderCanvas from './BuilderCanvas';
+import BuilderPromptBar from './BuilderPromptBar';
+import classes from './ChartTypeBuilderWorkspace.module.css';
+import { type ChartTypeBuilderWorkspaceState } from './useChartTypeBuilderWorkspace';
+import VersionHistoryPanel from './VersionHistoryPanel';
+
+type Props = {
+    projectUuid: string;
+    workspace: ChartTypeBuilderWorkspaceState;
+    /** What the preview renders with; null renders the app bare. */
+    previewContext: DataAppVizContext | null;
+    /** Whether the previewed viz may write its own state into the page URL. */
+    syncPreviewUrlState: boolean;
+    /** The previewed version's options beside it; null when the host
+     *  configures the type elsewhere. */
+    configurePanel: ReactNode;
+};
+
+/**
+ * The builder's working area: canvas with the previewed version and its
+ * options, the prompt bar, and the version history beside them. Hosts add
+ * their own header and decide what the preview renders against.
+ */
+const ChartTypeBuilderWorkspace: FC<Props> = ({
+    projectUuid,
+    workspace,
+    previewContext,
+    syncPreviewUrlState,
+    configurePanel,
+}) => {
+    const {
+        dataAppVizUuid,
+        build,
+        clarification,
+        history,
+        modelSelection,
+        isBuilding,
+        buildingPrompt,
+        elapsed,
+        narration,
+        onCancelBuild,
+        failureMessage,
+        isClarifyRoundOpen,
+        previewVersion,
+        viewedVersion,
+        onViewVersion,
+        hasHistory,
+        isHistoryOpen,
+        closeHistory,
+        isPromptBarMounted,
+        promptSessionKey,
+        composerAppUuid,
+        onSdkManifest,
+        promptBarRef,
+        onPickExample,
+    } = workspace;
+
+    return (
+        <PanelGroup direction="horizontal" className={classes.main}>
+            <Panel id="chart-type-builder-canvas" order={1} minSize={50}>
+                <Box className={classes.content}>
+                    <BuilderCanvas
+                        projectUuid={projectUuid}
+                        appUuid={dataAppVizUuid}
+                        previewVersion={previewVersion}
+                        isBuilding={isBuilding}
+                        failureMessage={failureMessage}
+                        isClarifyRoundOpen={isClarifyRoundOpen}
+                        clarifierUnavailable={clarification.fellThrough}
+                        previewContext={previewContext}
+                        configurePanel={configurePanel}
+                        onPickExample={onPickExample}
+                        onSdkManifest={onSdkManifest}
+                        syncPreviewUrlState={syncPreviewUrlState}
+                    />
+                    {isPromptBarMounted && (
+                        <BuilderPromptBar
+                            ref={promptBarRef}
+                            sessionKey={promptSessionKey}
+                            projectUuid={projectUuid}
+                            composerAppUuid={composerAppUuid}
+                            hasVersions={history.versions.length > 0}
+                            isBuilding={isBuilding}
+                            buildingPrompt={buildingPrompt}
+                            elapsed={elapsed}
+                            latestReadyVersion={history.latestReadyVersion}
+                            build={build}
+                            onCancelBuild={onCancelBuild}
+                            narration={narration}
+                            modelSelection={modelSelection}
+                            clarification={clarification}
+                        />
+                    )}
+                </Box>
+            </Panel>
+            {hasHistory && isHistoryOpen && dataAppVizUuid !== null && (
+                <>
+                    <PanelResizeHandle
+                        className={classes.historyResizeHandle}
+                        aria-label="Resize version history"
+                    />
+                    <Panel
+                        id="chart-type-builder-history"
+                        order={2}
+                        defaultSize={20}
+                        minSize={15}
+                        maxSize={50}
+                    >
+                        <VersionHistoryPanel
+                            projectUuid={projectUuid}
+                            appUuid={dataAppVizUuid}
+                            versions={history.versions}
+                            latestReadyVersion={history.latestReadyVersion}
+                            viewedVersion={viewedVersion}
+                            onView={onViewVersion}
+                            onClose={closeHistory}
+                            build={build}
+                            hasEarlier={history.hasEarlier}
+                            isFetchingEarlier={history.isFetchingEarlier}
+                            fetchEarlier={history.fetchEarlier}
+                        />
+                    </Panel>
+                </>
+            )}
+        </PanelGroup>
+    );
+};
+
+export default ChartTypeBuilderWorkspace;

--- a/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.test.ts
+++ b/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.test.ts
@@ -1,0 +1,326 @@
+import { type ApiAppVersionSummary, type DataAppViz } from '@lightdash/common';
+import { act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHookWithProviders } from '../../../testing/testUtils';
+import {
+    useAppVersionHistory,
+    type AppVersionHistory,
+} from '../../apps/hooks/useAppVersionHistory';
+import { useClarificationRound } from '../../apps/hooks/useClarificationRound';
+import { useDataAppModelSelection } from '../../apps/hooks/useDataAppModelSelection';
+import { useSdkUpgradeStatus } from '../../apps/hooks/useSdkUpgradeStatus';
+import { appVersion } from '../../apps/testing/appVersionHistory';
+import { useDataAppVisualization } from '../hooks/useDataAppVisualization';
+import {
+    useDataAppVizBuild,
+    type VizBuildRequest,
+} from '../hooks/useDataAppVizBuild';
+import { clarificationStub } from '../testing/clarificationRoundStub';
+import { buildStub } from '../testing/dataAppVizBuildStub';
+import {
+    useChartTypeBuilderWorkspace,
+    type ChartTypeBuilderWorkspaceArgs,
+} from './useChartTypeBuilderWorkspace';
+
+vi.mock('../hooks/useDataAppVizBuild', () => ({
+    useDataAppVizBuild: vi.fn(),
+}));
+vi.mock('../../apps/hooks/useClarificationRound', () => ({
+    useClarificationRound: vi.fn(),
+}));
+vi.mock('../../apps/hooks/useAppVersionHistory', () => ({
+    useAppVersionHistory: vi.fn(),
+}));
+vi.mock('../../apps/hooks/useAppBuildPoller', () => ({
+    useAppBuildPoller: vi.fn(),
+}));
+vi.mock('../../apps/hooks/useDataAppModelSelection', () => ({
+    useDataAppModelSelection: vi.fn(),
+}));
+vi.mock('../../apps/hooks/useSdkUpgradeStatus', () => ({
+    useSdkUpgradeStatus: vi.fn(),
+}));
+vi.mock('../hooks/useDataAppVisualization', () => ({
+    useDataAppVisualization: vi.fn(),
+}));
+
+const historyStub = (
+    versions: ApiAppVersionSummary[],
+    latestReadyVersion: number | null,
+): AppVersionHistory => ({
+    versions,
+    oldest: versions.length ? versions[versions.length - 1] : null,
+    latest: versions.length ? versions[0] : null,
+    latestReadyVersion,
+    hasOrigin: versions.some((v) => v.version === 1),
+    hasEarlier: false,
+    isLoading: false,
+    isError: false,
+    isFetchingEarlier: false,
+    fetchEarlier: vi.fn(),
+});
+
+const mockedClarificationRound = vi.mocked(
+    useClarificationRound<VizBuildRequest>,
+);
+const clearPick = vi.fn();
+const resetClarification = vi.fn();
+
+const renderWorkspace = (args: Partial<ChartTypeBuilderWorkspaceArgs> = {}) =>
+    renderHookWithProviders(
+        (props: ChartTypeBuilderWorkspaceArgs) =>
+            useChartTypeBuilderWorkspace(props),
+        undefined,
+        {
+            initialProps: {
+                projectUuid: 'project-1',
+                dataAppVizUuid: 'viz-1',
+                itemsMap: {},
+                ...args,
+            },
+        },
+    );
+
+describe('useChartTypeBuilderWorkspace', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(useDataAppVizBuild).mockReturnValue(buildStub());
+        mockedClarificationRound.mockReturnValue(
+            clarificationStub({ reset: resetClarification }),
+        );
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub([appVersion({ version: 1 })], 1),
+        );
+        vi.mocked(useDataAppModelSelection).mockReturnValue({
+            clearPick,
+        } as unknown as ReturnType<typeof useDataAppModelSelection>);
+        vi.mocked(useSdkUpgradeStatus).mockReturnValue({
+            offer: { status: 'unknown' },
+            renderedManifest: null,
+            onSdkManifest: vi.fn(),
+        } as unknown as ReturnType<typeof useSdkUpgradeStatus>);
+        vi.mocked(useDataAppVisualization).mockReturnValue({
+            data: undefined,
+            isFetching: false,
+        } as unknown as ReturnType<typeof useDataAppVisualization>);
+    });
+
+    it('asks clarifying questions only while no viz exists yet', () => {
+        const { rerender } = renderWorkspace({ dataAppVizUuid: null });
+        expect(mockedClarificationRound).toHaveBeenLastCalledWith(
+            expect.objectContaining({ isFirstBuild: true }),
+        );
+
+        rerender({
+            projectUuid: 'project-1',
+            dataAppVizUuid: 'viz-1',
+            itemsMap: {},
+        });
+        expect(mockedClarificationRound).toHaveBeenLastCalledWith(
+            expect.objectContaining({ isFirstBuild: false }),
+        );
+    });
+
+    it('resets the session when the host moves to another viz', () => {
+        const { result, rerender } = renderWorkspace();
+        act(() => {
+            result.current.openHistory();
+            result.current.onViewVersion(1);
+        });
+        expect(result.current.viewedVersion).toBe(1);
+        clearPick.mockClear();
+        resetClarification.mockClear();
+
+        rerender({
+            projectUuid: 'project-1',
+            dataAppVizUuid: 'viz-2',
+            itemsMap: {},
+        });
+
+        expect(result.current.isHistoryOpen).toBe(false);
+        expect(result.current.viewedVersion).toBeNull();
+        expect(result.current.promptSessionKey).toBe('viz-2');
+        expect(clearPick).toHaveBeenCalledTimes(1);
+        expect(resetClarification).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the session when the host adopts the uuid a first build claimed', () => {
+        const { result, rerender } = renderWorkspace({ dataAppVizUuid: null });
+        expect(result.current.promptSessionKey).toBe('draft-app-1');
+        act(() => result.current.openHistory());
+        clearPick.mockClear();
+        resetClarification.mockClear();
+
+        rerender({
+            projectUuid: 'project-1',
+            dataAppVizUuid: 'viz-1',
+            itemsMap: {},
+        });
+
+        expect(result.current.isHistoryOpen).toBe(true);
+        expect(result.current.promptSessionKey).toBe('draft-app-1');
+        expect(clearPick).not.toHaveBeenCalled();
+        expect(resetClarification).not.toHaveBeenCalled();
+    });
+
+    it('drops a pinned version once a newer build lands past it', () => {
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [appVersion({ version: 2 }), appVersion({ version: 1 })],
+                2,
+            ),
+        );
+        const { result, rerender } = renderWorkspace();
+        act(() => result.current.onViewVersion(1));
+        expect(result.current.previewVersion).toBe(1);
+
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [
+                    appVersion({ version: 3 }),
+                    appVersion({ version: 2 }),
+                    appVersion({ version: 1 }),
+                ],
+                3,
+            ),
+        );
+        rerender({
+            projectUuid: 'project-1',
+            dataAppVizUuid: 'viz-1',
+            itemsMap: {},
+        });
+
+        expect(result.current.viewedVersion).toBeNull();
+        expect(result.current.previewVersion).toBe(3);
+    });
+
+    it('fetches the schema of the previewed version and returns to current when history closes', () => {
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [appVersion({ version: 2 }), appVersion({ version: 1 })],
+                2,
+            ),
+        );
+        const { result } = renderWorkspace();
+        act(() => {
+            result.current.openHistory();
+            result.current.onViewVersion(1);
+        });
+        expect(vi.mocked(useDataAppVisualization)).toHaveBeenLastCalledWith(
+            'project-1',
+            'viz-1',
+            1,
+        );
+
+        act(() => result.current.closeHistory());
+
+        expect(result.current.isHistoryOpen).toBe(false);
+        expect(result.current.viewedVersion).toBeNull();
+        expect(result.current.previewVersion).toBe(2);
+    });
+
+    it('explains a failed build only while nothing is renderable', () => {
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [
+                    appVersion({
+                        version: 1,
+                        status: 'error',
+                        statusMessage: 'Sandbox crashed',
+                    }),
+                ],
+                null,
+            ),
+        );
+        const { result, rerender } = renderWorkspace();
+        expect(result.current.failureMessage).toBe('Sandbox crashed');
+        expect(result.current.previewVersion).toBeNull();
+
+        vi.mocked(useAppVersionHistory).mockReturnValue(
+            historyStub(
+                [
+                    appVersion({
+                        version: 2,
+                        status: 'error',
+                        statusMessage: 'Sandbox crashed',
+                    }),
+                    appVersion({ version: 1 }),
+                ],
+                1,
+            ),
+        );
+        rerender({
+            projectUuid: 'project-1',
+            dataAppVizUuid: 'viz-1',
+            itemsMap: {},
+        });
+        expect(result.current.failureMessage).toBeNull();
+        expect(result.current.previewVersion).toBe(1);
+    });
+
+    it('discards a first build but only cancels a revision', () => {
+        const discard = vi.fn();
+        const cancel = vi.fn();
+        vi.mocked(useDataAppVizBuild).mockReturnValue(
+            buildStub({
+                isBuilding: true,
+                draft: {
+                    appUuid: 'viz-new',
+                    version: 1,
+                    startedAt: new Date(),
+                },
+                discard,
+                cancel,
+            }),
+        );
+        const { result, rerender } = renderWorkspace({ dataAppVizUuid: null });
+        expect(result.current.onCancelBuild).toBe(discard);
+
+        vi.mocked(useDataAppVizBuild).mockReturnValue(
+            buildStub({ isBuilding: true, draft: null, discard, cancel }),
+        );
+        rerender({
+            projectUuid: 'project-1',
+            dataAppVizUuid: 'viz-1',
+            itemsMap: {},
+        });
+        expect(result.current.onCancelBuild).toBe(cancel);
+    });
+
+    it('scopes the composer to the viz, the claimed app, then the draft', () => {
+        const { result, rerender } = renderWorkspace({ dataAppVizUuid: null });
+        expect(result.current.composerAppUuid).toBe('draft-app-1');
+
+        vi.mocked(useDataAppVizBuild).mockReturnValue(
+            buildStub({ appUuid: 'viz-claimed' }),
+        );
+        rerender({
+            projectUuid: 'project-1',
+            dataAppVizUuid: null,
+            itemsMap: {},
+        });
+        expect(result.current.composerAppUuid).toBe('viz-claimed');
+        expect(vi.mocked(useAppVersionHistory)).toHaveBeenLastCalledWith(
+            'project-1',
+            'viz-claimed',
+        );
+
+        rerender({
+            projectUuid: 'project-1',
+            dataAppVizUuid: 'viz-1',
+            itemsMap: {},
+        });
+        expect(result.current.composerAppUuid).toBe('viz-1');
+    });
+
+    it('exposes the previewed schema for hosts to build a context from', () => {
+        const dataAppViz = { dataAppVizUuid: 'viz-1' } as DataAppViz;
+        vi.mocked(useDataAppVisualization).mockReturnValue({
+            data: dataAppViz,
+            isFetching: true,
+        } as unknown as ReturnType<typeof useDataAppVisualization>);
+        const { result } = renderWorkspace();
+        expect(result.current.dataAppViz).toBe(dataAppViz);
+        expect(result.current.isFetchingSchema).toBe(true);
+    });
+});

--- a/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.ts
+++ b/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.ts
@@ -1,0 +1,346 @@
+import {
+    DATA_APP_VIZ_TEMPLATE,
+    isAppVersionInProgress,
+    type AppClarification,
+    type DataAppViz,
+    type ItemsMap,
+} from '@lightdash/common';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type RefObject,
+} from 'react';
+import { getAppVersionFailureMessage } from '../../apps/getAppVersionFailureMessage';
+import { useAppBuildPoller } from '../../apps/hooks/useAppBuildPoller';
+import { type SdkManifest } from '../../apps/hooks/useAppSdkBridge';
+import {
+    useAppVersionHistory,
+    type AppVersionHistory,
+} from '../../apps/hooks/useAppVersionHistory';
+import {
+    useClarificationRound,
+    type ClarificationRound,
+    type ClarifyParams,
+} from '../../apps/hooks/useClarificationRound';
+import {
+    useDataAppModelSelection,
+    type DataAppModelSelection,
+} from '../../apps/hooks/useDataAppModelSelection';
+import { useElapsedClock } from '../../apps/hooks/useElapsedClock';
+import {
+    useSdkUpgradeStatus,
+    type SdkUpgradeOffer,
+} from '../../apps/hooks/useSdkUpgradeStatus';
+import {
+    getVersionNarration,
+    type AppVersionNarrationData,
+} from '../../apps/utils/versionNarration';
+import { useDataAppVisualization } from '../hooks/useDataAppVisualization';
+import {
+    useDataAppVizBuild,
+    type DataAppVizBuildState,
+    type VizBuildRequest,
+} from '../hooks/useDataAppVizBuild';
+import { type BuilderPromptBarHandle } from './BuilderPromptBar';
+
+const noop = () => undefined;
+
+const toVizClarifyParams = (request: VizBuildRequest): ClarifyParams => ({
+    prompt: request.description,
+    template: DATA_APP_VIZ_TEMPLATE,
+    fileIds: request.fileIds.length > 0 ? request.fileIds : undefined,
+});
+
+export type ChartTypeBuilderWorkspaceArgs = {
+    projectUuid: string | undefined;
+    /** The viz being revised; null while authoring a new one. A host that
+     *  adopts the uuid a first build claims passes it back here without
+     *  resetting the session. */
+    dataAppVizUuid: string | null;
+    /** Result columns the build binds fields against; {} when no query
+     *  backs the session. */
+    itemsMap: ItemsMap;
+};
+
+export type ChartTypeBuilderWorkspaceState = {
+    dataAppVizUuid: string | null;
+    build: DataAppVizBuildState;
+    clarification: ClarificationRound<VizBuildRequest>;
+    history: AppVersionHistory;
+    modelSelection: DataAppModelSelection;
+    isBuilding: boolean;
+    buildingPrompt: string | null;
+    elapsed: string | null;
+    narration: AppVersionNarrationData;
+    onCancelBuild: (() => void) | null;
+    failureMessage: string | null;
+    isClarifyRoundOpen: boolean;
+    /** The version the preview renders; null when nothing is renderable. */
+    previewVersion: number | null;
+    /** The pinned version from history; null when following the current one. */
+    viewedVersion: number | null;
+    onViewVersion: (version: number | null) => void;
+    /** The schema of the previewed version. */
+    dataAppViz: DataAppViz | undefined;
+    isFetchingSchema: boolean;
+    hasHistory: boolean;
+    isHistoryOpen: boolean;
+    openHistory: () => void;
+    closeHistory: () => void;
+    toggleHistory: () => void;
+    isPromptBarMounted: boolean;
+    promptSessionKey: string;
+    composerAppUuid: string;
+    sdkUpgradeOffer: SdkUpgradeOffer;
+    onSdkManifest: (manifest: SdkManifest) => void;
+    promptBarRef: RefObject<BuilderPromptBarHandle | null>;
+    onPickExample: ((prompt: string) => void) | null;
+};
+
+/** The builder session without its host: build, clarify, history and the
+ *  previewed version. Hosts supply the uuid and what the preview renders against. */
+export const useChartTypeBuilderWorkspace = ({
+    projectUuid,
+    dataAppVizUuid,
+    itemsMap,
+}: ChartTypeBuilderWorkspaceArgs): ChartTypeBuilderWorkspaceState => {
+    const build = useDataAppVizBuild({
+        projectUuid,
+        itemsMap,
+        dataAppVizUuid,
+        // Selection is the host's explicit act; nothing binds on landing.
+        onCreated: noop,
+    });
+
+    // Depend on the send function, not on `build` — that is a fresh object
+    // every render, so the memo would never hold.
+    const sendBuild = build.send;
+    const onClarifiedBuild = useCallback(
+        (request: VizBuildRequest, clarifications: AppClarification[]) =>
+            sendBuild({ ...request, clarifications }),
+        [sendBuild],
+    );
+
+    // Questions only before the first build: once a version exists, intent is
+    // grounded in what is on screen.
+    const clarification = useClarificationRound<VizBuildRequest>({
+        projectUuid,
+        isFirstBuild: dataAppVizUuid === null,
+        toClarifyParams: toVizClarifyParams,
+        onBuild: onClarifiedBuild,
+    });
+    const { reset: resetClarification } = clarification;
+
+    const historyUuid = dataAppVizUuid ?? build.appUuid;
+    const history = useAppVersionHistory(projectUuid ?? '', historyUuid);
+
+    // Covers builds sent here and builds found already running in history.
+    const historyLatestInProgress =
+        history.latest !== null &&
+        isAppVersionInProgress(history.latest.status);
+    const buildStartedAt =
+        build.startedAt ??
+        (historyLatestInProgress && history.latest
+            ? new Date(history.latest.createdAt)
+            : null);
+    const elapsed = useElapsedClock(buildStartedAt);
+
+    // The model the next prompt builds with; the latest version's own model
+    // pre-selects it, so reopening a chart type keeps building the way it was.
+    const modelSelection = useDataAppModelSelection({
+        appUuid: dataAppVizUuid,
+        latestVersionModel:
+            history.latest?.resources?.codexModel ??
+            history.latest?.resources?.claudeModel ??
+            null,
+    });
+    const { clearPick: clearModelPick } = modelSelection;
+
+    // Intentional navigation between vizs resets session state; a host
+    // adopting the uuid a first build claimed (null → uuid) must not.
+    const prevVizUuid = useRef(dataAppVizUuid);
+    const latestDraftAppUuid = useRef(build.draftAppUuid);
+    latestDraftAppUuid.current = build.draftAppUuid;
+    const [promptSessionKey, setPromptSessionKey] = useState(
+        () => dataAppVizUuid ?? build.draftAppUuid,
+    );
+    const [pin, setPin] = useState<{
+        appUuid: string;
+        version: number;
+        /** Latest ready version at the moment of pinning; the pin is treated
+         *  as cleared once a newer build finishes past this snapshot. */
+        pinnedAtLatest: number | null;
+    } | null>(null);
+    const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+    useEffect(() => {
+        const prev = prevVizUuid.current;
+        prevVizUuid.current = dataAppVizUuid;
+        if (prev === null && dataAppVizUuid !== null) return;
+        setPromptSessionKey(dataAppVizUuid ?? latestDraftAppUuid.current);
+        setPin(null);
+        setIsHistoryOpen(false);
+        clearModelPick();
+        resetClarification();
+    }, [dataAppVizUuid, clearModelPick, resetClarification]);
+
+    const isBuilding = build.isBuilding || historyLatestInProgress;
+    const narration = useMemo(
+        () =>
+            getVersionNarration(
+                historyLatestInProgress
+                    ? history.latest?.statusHistory
+                    : undefined,
+            ),
+        [history.latest, historyLatestInProgress],
+    );
+
+    // A build started elsewhere needs polling here; a build sent from this
+    // session already polls inside useDataAppVizBuild.
+    const externalBuildRunning = !build.isBuilding && historyLatestInProgress;
+    useAppBuildPoller(
+        projectUuid,
+        historyUuid ?? undefined,
+        externalBuildRunning,
+        noop,
+    );
+
+    // Derived pin: ignored when it belongs to another app, a newer version
+    // landed since, or the pinned version is no longer ready.
+    const viewedVersion = useMemo(() => {
+        if (pin === null || pin.appUuid !== dataAppVizUuid) return null;
+        if (
+            pin.pinnedAtLatest !== null &&
+            history.latestReadyVersion !== null &&
+            history.latestReadyVersion > pin.pinnedAtLatest
+        ) {
+            return null;
+        }
+        const stillReady = history.versions.some(
+            (v) => v.version === pin.version && v.status === 'ready',
+        );
+        return stillReady ? pin.version : null;
+    }, [pin, dataAppVizUuid, history.latestReadyVersion, history.versions]);
+
+    const previewVersion = viewedVersion ?? history.latestReadyVersion;
+    const { offer: sdkUpgradeOffer, onSdkManifest } = useSdkUpgradeStatus({
+        bundleKey:
+            dataAppVizUuid && history.latestReadyVersion !== null
+                ? `${dataAppVizUuid}:${history.latestReadyVersion}`
+                : null,
+        renderedKey:
+            dataAppVizUuid && previewVersion !== null
+                ? `${dataAppVizUuid}:${previewVersion}`
+                : null,
+        isRendering:
+            previewVersion !== null &&
+            previewVersion === history.latestReadyVersion,
+    });
+
+    // The schema follows the preview: the options beside a version are the
+    // ones that version declares.
+    const { data: dataAppViz, isFetching: isFetchingSchema } =
+        useDataAppVisualization(
+            projectUuid,
+            dataAppVizUuid ?? undefined,
+            previewVersion,
+        );
+
+    const onViewVersion = useCallback(
+        (version: number | null) => {
+            if (version === null) {
+                setPin(null);
+                return;
+            }
+            if (!dataAppVizUuid) return;
+            setPin({
+                appUuid: dataAppVizUuid,
+                version,
+                pinnedAtLatest: history.latestReadyVersion,
+            });
+        },
+        [dataAppVizUuid, history.latestReadyVersion],
+    );
+
+    const openHistory = useCallback(() => setIsHistoryOpen(true), []);
+    // The panel is the only place an older version can be selected, so it is
+    // also the only place that can show you are off the current one — closing
+    // it returns the preview to current rather than stranding the pin.
+    const closeHistory = useCallback(() => {
+        setIsHistoryOpen(false);
+        setPin(null);
+    }, []);
+    const toggleHistory = useCallback(
+        () => (isHistoryOpen ? closeHistory() : openHistory()),
+        [isHistoryOpen, closeHistory, openHistory],
+    );
+
+    const promptBarRef = useRef<BuilderPromptBarHandle>(null);
+    const onPickExample = useCallback(
+        (prompt: string) => promptBarRef.current?.setPrompt(prompt),
+        [],
+    );
+
+    // The request in flight, or the stored prompt of a build found in history.
+    const buildingPrompt =
+        build.pendingPrompt ??
+        (historyLatestInProgress ? (history.latest?.prompt ?? null) : null);
+    // A first build on a brand-new viz is discarded whole; a revision is only
+    // cancelled. Builds found in history (started elsewhere) offer no cancel.
+    const onCancelBuild = build.isBuilding
+        ? build.draft !== null
+            ? build.discard
+            : build.cancel
+        : null;
+
+    // With nothing renderable, the newest terminal version explains itself.
+    const failureMessage =
+        history.latestReadyVersion === null &&
+        history.latest !== null &&
+        !isAppVersionInProgress(history.latest.status) &&
+        history.latest.status !== 'ready'
+            ? getAppVersionFailureMessage(history.latest)
+            : null;
+
+    const hasHistory = dataAppVizUuid !== null && history.versions.length > 0;
+
+    // The composer captures its placeholder at mount, so wait for history
+    // before choosing create vs revise wording.
+    const isPromptBarMounted = !(dataAppVizUuid && history.isLoading);
+
+    return {
+        dataAppVizUuid,
+        build,
+        clarification,
+        history,
+        modelSelection,
+        isBuilding,
+        buildingPrompt,
+        elapsed,
+        narration,
+        onCancelBuild,
+        failureMessage,
+        isClarifyRoundOpen:
+            clarification.clarifyingPrompt !== null ||
+            clarification.pending !== null,
+        previewVersion,
+        viewedVersion,
+        onViewVersion,
+        dataAppViz,
+        isFetchingSchema,
+        hasHistory,
+        isHistoryOpen,
+        openHistory,
+        closeHistory,
+        toggleHistory,
+        isPromptBarMounted,
+        promptSessionKey,
+        composerAppUuid: dataAppVizUuid ?? build.appUuid ?? build.draftAppUuid,
+        sdkUpgradeOffer,
+        onSdkManifest,
+        promptBarRef,
+        onPickExample: isPromptBarMounted ? onPickExample : null,
+    };
+};

--- a/packages/frontend/src/features/chartTypes/builder/useConfigurePanelState.test.ts
+++ b/packages/frontend/src/features/chartTypes/builder/useConfigurePanelState.test.ts
@@ -1,0 +1,45 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useConfigurePanelState } from './useConfigurePanelState';
+
+describe('useConfigurePanelState', () => {
+    it('keeps only what the author changed', () => {
+        const { result } = renderHook(() => useConfigurePanelState('viz-1'));
+
+        act(() => {
+            result.current.onOptionChange('legend', 'top');
+            result.current.onPaletteChange('palette-1');
+        });
+
+        expect(result.current.optionValues).toEqual({ legend: 'top' });
+        expect(result.current.colorPaletteUuid).toBe('palette-1');
+    });
+
+    it('resets when the host moves to another viz', () => {
+        const { result, rerender } = renderHook(
+            ({ uuid }: { uuid: string | null }) => useConfigurePanelState(uuid),
+            { initialProps: { uuid: 'viz-1' } },
+        );
+        act(() => {
+            result.current.onOptionChange('legend', 'top');
+            result.current.onPaletteChange('palette-1');
+        });
+
+        rerender({ uuid: 'viz-2' });
+
+        expect(result.current.optionValues).toEqual({});
+        expect(result.current.colorPaletteUuid).toBeNull();
+    });
+
+    it('keeps edits when the host adopts the uuid a first build claimed', () => {
+        const { result, rerender } = renderHook(
+            ({ uuid }: { uuid: string | null }) => useConfigurePanelState(uuid),
+            { initialProps: { uuid: null as string | null } },
+        );
+        act(() => result.current.onOptionChange('legend', 'top'));
+
+        rerender({ uuid: 'viz-1' });
+
+        expect(result.current.optionValues).toEqual({ legend: 'top' });
+    });
+});

--- a/packages/frontend/src/features/chartTypes/builder/useConfigurePanelState.ts
+++ b/packages/frontend/src/features/chartTypes/builder/useConfigurePanelState.ts
@@ -1,0 +1,50 @@
+import {
+    type DataAppVizOptionValue,
+    type DataAppVizOptionValues,
+} from '@lightdash/common';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type ConfigurePanelState = {
+    /** Only what the author explicitly changed; defaults resolve at render. */
+    optionValues: DataAppVizOptionValues;
+    onOptionChange: (name: string, value: DataAppVizOptionValue) => void;
+    /** Preview-only palette pick; null follows the host's palette. */
+    colorPaletteUuid: string | null;
+    onPaletteChange: (colorPaletteUuid: string | null) => void;
+};
+
+/**
+ * The edits a host makes in the builder's own configure panel. Reset when the
+ * host moves to another viz; kept when it adopts the uuid a first build claimed.
+ */
+export const useConfigurePanelState = (
+    dataAppVizUuid: string | null,
+): ConfigurePanelState => {
+    const [optionValues, setOptionValues] = useState<DataAppVizOptionValues>(
+        {},
+    );
+    const [colorPaletteUuid, setColorPaletteUuid] = useState<string | null>(
+        null,
+    );
+    const prevVizUuid = useRef(dataAppVizUuid);
+    useEffect(() => {
+        const prev = prevVizUuid.current;
+        prevVizUuid.current = dataAppVizUuid;
+        if (prev === null && dataAppVizUuid !== null) return;
+        setOptionValues({});
+        setColorPaletteUuid(null);
+    }, [dataAppVizUuid]);
+
+    const onOptionChange = useCallback(
+        (name: string, value: DataAppVizOptionValue) =>
+            setOptionValues((prev) => ({ ...prev, [name]: value })),
+        [],
+    );
+
+    return {
+        optionValues,
+        onOptionChange,
+        colorPaletteUuid,
+        onPaletteChange: setColorPaletteUuid,
+    };
+};

--- a/packages/frontend/src/pages/ChartTypeBuilder.module.css
+++ b/packages/frontend/src/pages/ChartTypeBuilder.module.css
@@ -5,46 +5,9 @@
     background: var(--mantine-color-ldGray-0);
 }
 
-.main {
-    flex: 1;
-    min-height: 0;
-    overflow: hidden;
-    display: flex;
-}
-
-.content {
+.notFound {
     height: 100%;
     flex: 1;
-    min-width: 0;
-    position: relative;
     display: flex;
     flex-direction: column;
-}
-
-.historyPanel {
-    min-width: 240px;
-}
-
-.historyResizeHandle {
-    width: 1px;
-    flex: 0 0 1px;
-    cursor: col-resize;
-    background-color: light-dark(
-        var(--mantine-color-ldGray-2),
-        var(--mantine-color-ldDark-4)
-    );
-    transition:
-        background-color 120ms ease,
-        box-shadow 120ms ease;
-}
-
-.historyResizeHandle[data-resize-handle-state='hover'],
-.historyResizeHandle[data-resize-handle-state='drag'],
-.historyResizeHandle:focus-visible {
-    background-color: light-dark(
-        var(--mantine-color-ldGray-4),
-        var(--mantine-color-ldDark-3)
-    );
-    box-shadow: 0 0 0 1px
-        light-dark(var(--mantine-color-ldGray-4), var(--mantine-color-ldDark-3));
 }

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -2,21 +2,10 @@ import {
     ChartType,
     DATA_APP_VIZ_TEMPLATE,
     FeatureFlags,
-    isAppVersionInProgress,
-    type AppClarification,
-    type DataAppVizOptionValue,
-    type DataAppVizOptionValues,
+    type ItemsMap,
 } from '@lightdash/common';
 import { Box, Button } from '@mantine/core';
-import {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-    type FC,
-} from 'react';
-import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import { useEffect, useMemo, type FC } from 'react';
 import {
     Link,
     Navigate,
@@ -27,32 +16,14 @@ import {
 import { validate as isUuidString } from 'uuid';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
-import { getAppVersionFailureMessage } from '../features/apps/getAppVersionFailureMessage';
-import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
-import { useAppVersionHistory } from '../features/apps/hooks/useAppVersionHistory';
 import { useCanCreateDataApp } from '../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
-import {
-    useClarificationRound,
-    type ClarifyParams,
-} from '../features/apps/hooks/useClarificationRound';
-import { useDataAppModelSelection } from '../features/apps/hooks/useDataAppModelSelection';
-import { useElapsedClock } from '../features/apps/hooks/useElapsedClock';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
-import { useSdkUpgradeStatus } from '../features/apps/hooks/useSdkUpgradeStatus';
-import { getVersionNarration } from '../features/apps/utils/versionNarration';
-import BuilderCanvas from '../features/chartTypes/builder/BuilderCanvas';
-import BuilderPromptBar, {
-    type BuilderPromptBarHandle,
-} from '../features/chartTypes/builder/BuilderPromptBar';
 import ChartTypeBuilderHeader from '../features/chartTypes/builder/ChartTypeBuilderHeader';
+import ChartTypeBuilderWorkspace from '../features/chartTypes/builder/ChartTypeBuilderWorkspace';
 import ConfigurePanel from '../features/chartTypes/builder/ConfigurePanel';
-import VersionHistoryPanel from '../features/chartTypes/builder/VersionHistoryPanel';
-import { useDataAppVisualization } from '../features/chartTypes/hooks/useDataAppVisualization';
-import {
-    useDataAppVizBuild,
-    type VizBuildRequest,
-} from '../features/chartTypes/hooks/useDataAppVizBuild';
+import { useChartTypeBuilderWorkspace } from '../features/chartTypes/builder/useChartTypeBuilderWorkspace';
+import { useConfigurePanelState } from '../features/chartTypes/builder/useConfigurePanelState';
 import { chartTypeBuilderPath } from '../features/chartTypes/utils/chartTypeBuilderPath';
 import { buildSampleVizContext } from '../features/chartTypes/utils/sampleVizContext';
 import { useResolvedColorPalette } from '../hooks/appearance/useResolvedColorPalette';
@@ -64,19 +35,14 @@ import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import classes from './ChartTypeBuilder.module.css';
 
-const noop = () => undefined;
+// No chart query here; auto-mapping belongs to charts binding fields.
+const NO_ITEMS: ItemsMap = {};
 
 /**
  * The dedicated chart type builder. Mounted at both `chart-types/new`
  * (create) and `chart-types/:dataAppVizUuid` (edit); the create flow
  * adopts the new uuid into the URL once the first build is accepted.
  */
-const toVizClarifyParams = (request: VizBuildRequest): ClarifyParams => ({
-    prompt: request.description,
-    template: DATA_APP_VIZ_TEMPLATE,
-    fileIds: request.fileIds.length > 0 ? request.fileIds : undefined,
-});
-
 const ChartTypeBuilder: FC = () => {
     const { dataAppVizUuid: urlVizUuid } = useParams();
     const projectUuid = useProjectUuid();
@@ -102,57 +68,13 @@ const ChartTypeBuilder: FC = () => {
         appMeta?.appUuid ??
         (isUuidString(urlVizUuid ?? '') ? urlVizUuid : undefined);
 
-    const build = useDataAppVizBuild({
+    const workspace = useChartTypeBuilderWorkspace({
         projectUuid,
-        // No chart query here; auto-mapping belongs to charts binding fields.
-        itemsMap: {},
         dataAppVizUuid: activeVizUuid ?? null,
-        onCreated: noop,
+        itemsMap: NO_ITEMS,
     });
-
-    // Depend on the send function, not on `build` — that is a fresh object
-    // every render, so the memo would never hold.
-    const sendBuild = build.send;
-    const onClarifiedBuild = useCallback(
-        (request: VizBuildRequest, clarifications: AppClarification[]) =>
-            sendBuild({ ...request, clarifications }),
-        [sendBuild],
-    );
-
-    // Questions only before the first build: once a version exists, intent is
-    // grounded in what is on screen.
-    const clarification = useClarificationRound<VizBuildRequest>({
-        projectUuid,
-        isFirstBuild: activeVizUuid === undefined,
-        toClarifyParams: toVizClarifyParams,
-        onBuild: onClarifiedBuild,
-    });
-    const { reset: resetClarification } = clarification;
-
-    const historyUuid = activeVizUuid ?? build.appUuid;
-    const history = useAppVersionHistory(projectUuid ?? '', historyUuid);
-
-    // Covers builds sent here and builds found already running in history.
-    const historyLatestInProgress =
-        history.latest !== null &&
-        isAppVersionInProgress(history.latest.status);
-    const buildStartedAt =
-        build.startedAt ??
-        (historyLatestInProgress && history.latest
-            ? new Date(history.latest.createdAt)
-            : null);
-    const elapsed = useElapsedClock(buildStartedAt);
-
-    // The model the next prompt builds with; the latest version's own model
-    // pre-selects it, so reopening a chart type keeps building the way it was.
-    const modelSelection = useDataAppModelSelection({
-        appUuid: activeVizUuid ?? null,
-        latestVersionModel:
-            history.latest?.resources?.codexModel ??
-            history.latest?.resources?.claudeModel ??
-            null,
-    });
-    const { clearPick: clearModelPick } = modelSelection;
+    const { build, history, isBuilding, isHistoryOpen } = workspace;
+    const panel = useConfigurePanelState(activeVizUuid ?? null);
 
     // On `/new`, move to the edit route as soon as the build claims an app so
     // a refresh mid-build lands on the in-progress version.
@@ -168,152 +90,23 @@ const ChartTypeBuilder: FC = () => {
         }
     }, [urlVizUuid, build.appUuid, projectUuid, location.search, navigate]);
 
-    // Intentional navigation between vizs resets session state; the
-    // post-submit `/new` → uuid replace must not.
-    const prevUrlVizUuid = useRef(urlVizUuid);
-    const latestDraftAppUuid = useRef(build.draftAppUuid);
-    latestDraftAppUuid.current = build.draftAppUuid;
-    const [promptSessionKey, setPromptSessionKey] = useState(
-        () => urlVizUuid ?? build.draftAppUuid,
-    );
-    const [pin, setPin] = useState<{
-        appUuid: string;
-        version: number;
-        /** Latest ready version at the moment of pinning; the pin is treated
-         *  as cleared once a newer build finishes past this snapshot. */
-        pinnedAtLatest: number | null;
-    } | null>(null);
-    // Only what the author explicitly changed; defaults resolve at render.
-    const [optionValues, setOptionValues] = useState<DataAppVizOptionValues>(
-        {},
-    );
-    // Preview-only; a chart using the viz owns the palette the normal way.
-    const [colorPaletteUuid, setColorPaletteUuid] = useState<string | null>(
-        null,
-    );
-    const [isHistoryOpen, setIsHistoryOpen] = useState(false);
-    useEffect(() => {
-        const prev = prevUrlVizUuid.current;
-        prevUrlVizUuid.current = urlVizUuid;
-        // Post-submit redirect: undefined → new uuid. Don't clear state.
-        if (!prev && urlVizUuid) return;
-        setPromptSessionKey(urlVizUuid ?? latestDraftAppUuid.current);
-        setPin(null);
-        setOptionValues({});
-        setColorPaletteUuid(null);
-        setIsHistoryOpen(false);
-        clearModelPick();
-        resetClarification();
-    }, [urlVizUuid, clearModelPick, resetClarification]);
-
-    const isBuilding = build.isBuilding || historyLatestInProgress;
-    const liveNarration = useMemo(
-        () =>
-            getVersionNarration(
-                historyLatestInProgress
-                    ? history.latest?.statusHistory
-                    : undefined,
-            ),
-        [history.latest, historyLatestInProgress],
-    );
-
-    // A build started elsewhere needs polling here; a build sent from this
-    // page already polls inside useDataAppVizBuild.
-    const externalBuildRunning = !build.isBuilding && historyLatestInProgress;
-    useAppBuildPoller(
+    const colorPalette = useResolvedColorPalette(
         projectUuid,
-        historyUuid ?? undefined,
-        externalBuildRunning,
-        noop,
+        panel.colorPaletteUuid,
     );
-
-    // Derived pin: ignored when it belongs to another app, a newer version
-    // landed since, or the pinned version is no longer ready.
-    const effectiveViewedVersion = useMemo(() => {
-        if (pin === null || pin.appUuid !== activeVizUuid) return null;
-        if (
-            pin.pinnedAtLatest !== null &&
-            history.latestReadyVersion !== null &&
-            history.latestReadyVersion > pin.pinnedAtLatest
-        ) {
-            return null;
-        }
-        const stillReady = history.versions.some(
-            (v) => v.version === pin.version && v.status === 'ready',
-        );
-        return stillReady ? pin.version : null;
-    }, [pin, activeVizUuid, history.latestReadyVersion, history.versions]);
-
-    const previewVersion = effectiveViewedVersion ?? history.latestReadyVersion;
-    const { offer: sdkUpgradeOffer, onSdkManifest: handleSdkManifest } =
-        useSdkUpgradeStatus({
-            bundleKey:
-                activeVizUuid && history.latestReadyVersion !== null
-                    ? `${activeVizUuid}:${history.latestReadyVersion}`
-                    : null,
-            renderedKey:
-                activeVizUuid && previewVersion !== null
-                    ? `${activeVizUuid}:${previewVersion}`
-                    : null,
-            isRendering:
-                previewVersion !== null &&
-                previewVersion === history.latestReadyVersion,
-        });
-
-    // The schema follows the preview: the options beside a version are the ones
-    // that version declares, and the sample data is built from its fields.
-    const { data: dataAppViz, isFetching: isFetchingSchema } =
-        useDataAppVisualization(projectUuid, activeVizUuid, previewVersion);
-
-    const colorPalette = useResolvedColorPalette(projectUuid, colorPaletteUuid);
     // The sample-data preview context, rebuilt on any option or palette edit.
     const previewContext = useMemo(
         () =>
-            dataAppViz?.schema
+            workspace.dataAppViz?.schema
                 ? buildSampleVizContext(
-                      dataAppViz.schema,
+                      workspace.dataAppViz.schema,
                       colorPalette,
-                      optionValues,
+                      panel.optionValues,
                   )
                 : null,
-        [dataAppViz?.schema, colorPalette, optionValues],
+        [workspace.dataAppViz?.schema, colorPalette, panel.optionValues],
     );
 
-    const handleOptionChange = useCallback(
-        (name: string, value: DataAppVizOptionValue) =>
-            setOptionValues((prev) => ({ ...prev, [name]: value })),
-        [],
-    );
-
-    const handleView = useCallback(
-        (version: number | null) => {
-            if (version === null) {
-                setPin(null);
-                return;
-            }
-            if (!activeVizUuid) return;
-            setPin({
-                appUuid: activeVizUuid,
-                version,
-                pinnedAtLatest: history.latestReadyVersion,
-            });
-        },
-        [activeVizUuid, history.latestReadyVersion],
-    );
-
-    // The panel is the only place an older version can be selected, so it is
-    // also the only place that can show you are off the current one — closing
-    // it returns the preview to current rather than stranding the pin.
-    const handleCloseHistory = useCallback(() => {
-        setIsHistoryOpen(false);
-        setPin(null);
-    }, []);
-
-    const promptBarRef = useRef<BuilderPromptBarHandle>(null);
-    const handlePickExample = useCallback(
-        (prompt: string) => promptBarRef.current?.setPrompt(prompt),
-        [],
-    );
     const explorerDestination = useMemo(() => {
         if (!explorerChart || !activeVizUuid) return null;
 
@@ -361,7 +154,7 @@ const ChartTypeBuilder: FC = () => {
     if (appQuery.error?.error.statusCode === 404) {
         return (
             <Box className={classes.root}>
-                <Box className={classes.content}>
+                <Box className={classes.notFound}>
                     <SuboptimalState
                         title="Chart type not found"
                         description="It may have been deleted, or the link is wrong."
@@ -395,51 +188,23 @@ const ChartTypeBuilder: FC = () => {
         }
     }
 
-    // The request in flight, or the stored prompt of a build found in history.
-    const buildingPrompt =
-        build.pendingPrompt ??
-        (historyLatestInProgress ? (history.latest?.prompt ?? null) : null);
-    // A first build on a brand-new viz is discarded whole; a revision is only
-    // cancelled. Builds found in history (started elsewhere) offer no cancel.
-    const onCancelBuild = build.isBuilding
-        ? build.draft !== null
-            ? build.discard
-            : build.cancel
-        : null;
-
-    // With nothing renderable, the newest terminal version explains itself.
-    const failureMessage =
-        history.latestReadyVersion === null &&
-        history.latest !== null &&
-        !isAppVersionInProgress(history.latest.status) &&
-        history.latest.status !== 'ready'
-            ? getAppVersionFailureMessage(history.latest)
-            : null;
-
     const provenanceVersion = history.hasOrigin
         ? history.oldest
         : history.latest;
 
-    // Always beside the chart it configures; remounted per viz so the selected
-    // tab belongs to the declaration on screen.
-    const configurePanel = dataAppViz?.schema ? (
+    // Remounted per viz so the selected tab belongs to the declaration on screen.
+    const configurePanel = workspace.dataAppViz?.schema ? (
         <ConfigurePanel
             key={activeVizUuid}
-            schema={dataAppViz.schema}
-            optionValues={optionValues}
-            onOptionChange={handleOptionChange}
-            colorPaletteUuid={colorPaletteUuid}
-            onPaletteChange={setColorPaletteUuid}
-            isStale={isFetchingSchema}
+            schema={workspace.dataAppViz.schema}
+            optionValues={panel.optionValues}
+            onOptionChange={panel.onOptionChange}
+            colorPaletteUuid={panel.colorPaletteUuid}
+            onPaletteChange={panel.onPaletteChange}
+            isStale={workspace.isFetchingSchema}
         />
     ) : null;
 
-    const hasHistory =
-        activeVizUuid !== undefined && history.versions.length > 0;
-
-    // The composer captures its placeholder at mount, so wait for history
-    // before choosing create vs revise wording.
-    const isPromptBarMounted = !(activeVizUuid && history.isLoading);
     const backLink = explorerChart
         ? {
               label: 'Explorer',
@@ -463,97 +228,24 @@ const ChartTypeBuilder: FC = () => {
                 latestReadyVersion={history.latestReadyVersion}
                 provenanceVersion={provenanceVersion}
                 hasOrigin={history.hasOrigin}
-                hasHistory={hasHistory}
+                hasHistory={workspace.hasHistory}
                 isHistoryOpen={isHistoryOpen}
                 upgrade={
                     activeVizUuid && history.latestReadyVersion !== null
-                        ? { ...sdkUpgradeOffer, disabled: isBuilding }
+                        ? { ...workspace.sdkUpgradeOffer, disabled: isBuilding }
                         : null
                 }
-                onUpgradeStarted={() => setIsHistoryOpen(true)}
-                onToggleHistory={() =>
-                    isHistoryOpen
-                        ? handleCloseHistory()
-                        : setIsHistoryOpen(true)
-                }
+                onUpgradeStarted={workspace.openHistory}
+                onToggleHistory={workspace.toggleHistory}
                 previewInExplorerLink={previewInExplorerLink}
             />
-            <PanelGroup direction="horizontal" className={classes.main}>
-                <Panel id="chart-type-builder-canvas" order={1} minSize={50}>
-                    <Box className={classes.content}>
-                        <BuilderCanvas
-                            projectUuid={projectUuid}
-                            appUuid={activeVizUuid ?? null}
-                            previewVersion={previewVersion}
-                            isBuilding={isBuilding}
-                            failureMessage={failureMessage}
-                            isClarifyRoundOpen={
-                                clarification.clarifyingPrompt !== null ||
-                                clarification.pending !== null
-                            }
-                            clarifierUnavailable={clarification.fellThrough}
-                            previewContext={previewContext}
-                            configurePanel={configurePanel}
-                            onPickExample={
-                                isPromptBarMounted ? handlePickExample : null
-                            }
-                            onSdkManifest={handleSdkManifest}
-                        />
-                        {isPromptBarMounted && (
-                            <BuilderPromptBar
-                                ref={promptBarRef}
-                                sessionKey={promptSessionKey}
-                                projectUuid={projectUuid}
-                                composerAppUuid={
-                                    activeVizUuid ??
-                                    build.appUuid ??
-                                    build.draftAppUuid
-                                }
-                                hasVersions={history.versions.length > 0}
-                                isBuilding={isBuilding}
-                                buildingPrompt={buildingPrompt}
-                                elapsed={elapsed}
-                                latestReadyVersion={history.latestReadyVersion}
-                                build={build}
-                                onCancelBuild={onCancelBuild}
-                                narration={liveNarration}
-                                modelSelection={modelSelection}
-                                clarification={clarification}
-                            />
-                        )}
-                    </Box>
-                </Panel>
-                {hasHistory && isHistoryOpen && (
-                    <>
-                        <PanelResizeHandle
-                            className={classes.historyResizeHandle}
-                            aria-label="Resize version history"
-                        />
-                        <Panel
-                            id="chart-type-builder-history"
-                            order={2}
-                            defaultSize={20}
-                            minSize={15}
-                            maxSize={50}
-                            className={classes.historyPanel}
-                        >
-                            <VersionHistoryPanel
-                                projectUuid={projectUuid}
-                                appUuid={activeVizUuid}
-                                versions={history.versions}
-                                latestReadyVersion={history.latestReadyVersion}
-                                viewedVersion={effectiveViewedVersion}
-                                onView={handleView}
-                                onClose={handleCloseHistory}
-                                build={build}
-                                hasEarlier={history.hasEarlier}
-                                isFetchingEarlier={history.isFetchingEarlier}
-                                fetchEarlier={history.fetchEarlier}
-                            />
-                        </Panel>
-                    </>
-                )}
-            </PanelGroup>
+            <ChartTypeBuilderWorkspace
+                projectUuid={projectUuid}
+                workspace={workspace}
+                previewContext={previewContext}
+                syncPreviewUrlState
+                configurePanel={configurePanel}
+            />
         </Box>
     );
 };


### PR DESCRIPTION
## Summary

Groundwork for hosting the Chart Type Builder inside the Explorer. The standalone page (`pages/ChartTypeBuilder.tsx`) owned everything: routing, guards, header, and the build / clarification / history / preview-version logic. This splits it so a second host can reuse the working parts without forking them.

- **`useChartTypeBuilderWorkspace`** (`features/chartTypes/builder/`): the headless session. It takes a resolved `dataAppVizUuid` (null while creating) and an `itemsMap`, and owns the build, the clarifying round, version history, the pinned / previewed version and the SDK upgrade status. The "null → uuid is adoption, not navigation" rule that kept the page's session alive after a first build moves here unchanged.
- **`useConfigurePanelState`**: the page's own option and palette edits, kept separate so a host that configures the type elsewhere carries no dead state.
- **`ChartTypeBuilderWorkspace`**: the canvas + prompt bar + version history panels, i.e. the page's `PanelGroup` moved verbatim so aria labels, resize handle and dimming behave exactly as before. Hosts pass the configure panel (or null) as a node.
- **`AppPreview.urlStateSync`** (default `true`): lets a host stop the previewed viz from writing `?state=` into the page URL. The page keeps the old behaviour.
- The moved resize-handle CSS drops a `light-dark(ldGray, ldDark)` wrapper (the ramps already swap for dark mode in JS) and the history panel's pixel `min-width`, which fought the panel group's percentage limits.

The page keeps slug resolution (`useGetApp`), the six redirect guards, the `/new` → uuid URL adoption, the Explorer round-trip links, `DocumentTitle` and the header, and still previews against `buildSampleVizContext`. Behaviour is equivalent by construction; nothing user-facing changes in this PR.

## How to test

- `pnpm -F frontend exec vitest run src/pages/ChartTypeBuilder.test.tsx src/features/chartTypes/builder` — the page's 30 tests pass unchanged; the hook tests cover the session reset rules, pin invalidation, failure copy, cancel-vs-discard, composer scoping and the configure-panel state.
- Manually: `/projects/<project>/chart-types/new` and `/chart-types/<uuid>` behave as on main (build, clarify, history pin / restore, SDK upgrade offer, Preview in explorer link).

Relates: GLITCH-680
