### PR TITLE
feat(explorer): embed the chart type builder behind explorer-chart-gallery

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
@@ -84,9 +84,14 @@
     min-width: 0;
 }
 
+/* One step off the panel in each scheme: the dark panel already sits on
+   ldGray-0, so the same shade there would hide the hover. */
 .row:hover:not(:disabled),
 .card:hover:not(:disabled) {
-    background: var(--mantine-color-ldGray-0);
+    background: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldGray-1)
+    );
 }
 
 .row[data-selected='true'],

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
@@ -20,6 +20,7 @@ const { mocks } = vi.hoisted(() => ({
         refetch: vi.fn(),
         fetchNextPage: vi.fn(),
         navigate: vi.fn(),
+        dispatch: vi.fn(),
         canCreateDataApp: vi.fn(() => true),
     },
 }));
@@ -64,6 +65,15 @@ vi.mock(
 );
 vi.mock('../../../features/apps/hooks/useCanCreateDataApp', () => ({
     useCanCreateDataApp: () => mocks.canCreateDataApp(),
+}));
+vi.mock('../../../features/explorer/store', () => ({
+    useExplorerDispatch: () => mocks.dispatch,
+    explorerActions: {
+        startChartTypeAuthoring: (payload: unknown) => ({
+            type: 'startChartTypeAuthoring',
+            payload,
+        }),
+    },
 }));
 vi.mock('react-router', async (importOriginal) => ({
     ...(await importOriginal<typeof ReactRouter>()),
@@ -314,17 +324,18 @@ describe('ExplorerChartTypeGallery', () => {
         expect(onSelected).toHaveBeenCalledTimes(1);
     });
 
-    it('opens the chart type builder from the project section', async () => {
+    it('starts authoring a new chart type in place from the project section', async () => {
         renderGallery();
 
         await userEvent.click(
             screen.getByRole('button', { name: /Create new chart type/ }),
         );
 
-        expect(mocks.navigate).toHaveBeenCalledWith({
-            pathname: '/projects/project-uuid/chart-types/new',
-            search: '?tableName=orders',
+        expect(mocks.dispatch).toHaveBeenCalledWith({
+            type: 'startChartTypeAuthoring',
+            payload: { dataAppVizUuid: null },
         });
+        expect(mocks.navigate).not.toHaveBeenCalled();
     });
 
     it('hides the create action without permission to author chart types', () => {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -19,11 +19,13 @@ import {
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconPlus, IconSearch } from '@tabler/icons-react';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
-import { useLocation, useNavigate } from 'react-router';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataAppChecker } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualizations } from '../../../features/chartTypes/hooks/useDataAppVisualizations';
-import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
+import {
+    explorerActions,
+    useExplorerDispatch,
+} from '../../../features/explorer/store';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
@@ -278,21 +280,29 @@ const RowsSectionActions: FC<{ section: ChartTypeGalleryRowsSection }> = ({
                 Load more
             </Button>
         ) : null}
+    </>
+);
 
-        {/* An action, not a chart type; wanted even when the section is empty. */}
-        {section.onCreateNew !== null ? (
+/* An action, not a chart type; beside the label so it is never below the fold. */
+const SectionHeader: FC<{ section: ChartTypeGallerySection }> = ({
+    section,
+}) => (
+    <Group justify="space-between" wrap="nowrap" gap="xs">
+        <Text fz="xs" fw={600} c="dimmed">
+            {section.label}
+        </Text>
+        {section.layout === 'rows' && section.onCreateNew !== null ? (
             <Button
                 variant="subtle"
-                size="xs"
-                px="xs"
+                size="compact-xs"
                 leftSection={<MantineIcon icon={IconPlus} />}
+                aria-label="Create new chart type"
                 onClick={section.onCreateNew}
-                justify="flex-start"
             >
-                Create new chart type
+                New
             </Button>
         ) : null}
-    </>
+    </Group>
 );
 
 type GalleryProps = {
@@ -327,9 +337,7 @@ export const ChartTypeGallery: FC<GalleryProps> = ({
             <Stack gap="lg" pb="xs">
                 {sections.map((section) => (
                     <Stack key={section.label} gap="xs">
-                        <Text fz="xs" fw={600} c="dimmed">
-                            {section.label}
-                        </Text>
+                        <SectionHeader section={section} />
 
                         <SectionBody section={section} />
 
@@ -351,8 +359,7 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
     onSelected,
 }) => {
     const projectUuid = useProjectUuid();
-    const location = useLocation();
-    const navigate = useNavigate();
+    const dispatch = useExplorerDispatch();
     const [search, setSearch] = useState('');
     const [debouncedSearch] = useDebouncedValue(search, 300);
     const [showAllProjectTypes, setShowAllProjectTypes] = useState(false);
@@ -420,13 +427,11 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
                 },
                 onEdit: canEditChartType(dataAppViz)
                     ? () =>
-                          void navigate({
-                              pathname: chartTypeBuilderPath(
-                                  projectUuid ?? '',
-                                  dataAppViz.dataAppVizUuid,
-                              ),
-                              search: location.search,
-                          })
+                          dispatch(
+                              explorerActions.startChartTypeAuthoring({
+                                  dataAppVizUuid: dataAppViz.dataAppVizUuid,
+                              }),
+                          )
                     : null,
             };
         },
@@ -467,12 +472,11 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
                       loadingMore: isFetchingNextPage,
                       onCreateNew: canCreateChartType
                           ? () =>
-                                void navigate({
-                                    pathname: chartTypeBuilderPath(
-                                        projectUuid ?? '',
-                                    ),
-                                    search: location.search,
-                                })
+                                dispatch(
+                                    explorerActions.startChartTypeAuthoring({
+                                        dataAppVizUuid: null,
+                                    }),
+                                )
                           : null,
                   },
               ]

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -1,0 +1,481 @@
+import {
+    ChartType,
+    DimensionType,
+    FieldType,
+    MetricType,
+    type ApiAppVersionSummary,
+    type DataAppViz,
+    type DataAppVizContext,
+    type ItemsMap,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
+import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
+import {
+    useChartTypeBuilderWorkspace,
+    type ChartTypeBuilderWorkspaceState,
+} from '../../../features/chartTypes/builder/useChartTypeBuilderWorkspace';
+import { clarificationStub } from '../../../features/chartTypes/testing/clarificationRoundStub';
+import { buildStub } from '../../../features/chartTypes/testing/dataAppVizBuildStub';
+import {
+    createExplorerStore,
+    explorerActions,
+} from '../../../features/explorer/store';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useExplorerResultsData } from '../VisualizationCard/useExplorerResultsData';
+import ExplorerChartTypeAuthoring from './ExplorerChartTypeAuthoring';
+
+const { showToastError, setFetchAll, previewContexts, deleteApp } = vi.hoisted(
+    () => ({
+        showToastError: vi.fn(),
+        setFetchAll: vi.fn(),
+        previewContexts: [] as (DataAppVizContext | null)[],
+        deleteApp: vi.fn(),
+    }),
+);
+
+vi.mock(
+    '../../../features/chartTypes/builder/useChartTypeBuilderWorkspace',
+    () => ({
+        useChartTypeBuilderWorkspace: vi.fn(),
+    }),
+);
+vi.mock('../VisualizationCard/useExplorerResultsData', () => ({
+    useExplorerResultsData: vi.fn(),
+}));
+vi.mock('../VisualizationCard/useExplorerChartColorPalette', () => ({
+    useExplorerChartColorPalette: () => ['#explorer-1', '#explorer-2'],
+}));
+vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({
+        data: { enabled: true },
+        isLoading: false,
+    }),
+}));
+vi.mock('../../../features/apps/hooks/useCanCreateDataApp', () => ({
+    useCanCreateDataApp: vi.fn(() => true),
+}));
+vi.mock('../../../features/apps/hooks/useCanEditDataApp', () => ({
+    useCanEditDataApp: vi.fn(() => true),
+}));
+vi.mock('../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-1',
+}));
+vi.mock('../../../features/apps/hooks/useDeleteApp', () => ({
+    useDeleteApp: () => ({ mutate: deleteApp }),
+}));
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastError }),
+}));
+vi.mock(
+    '../../../features/chartTypes/builder/ChartTypeBuilderWorkspace',
+    () => ({
+        default: ({
+            previewContext,
+        }: {
+            previewContext: DataAppVizContext | null;
+        }) => {
+            previewContexts.push(previewContext);
+            return <div data-testid="workspace" />;
+        },
+    }),
+);
+
+const itemsMap = {
+    orders_status: {
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.STRING,
+        name: 'status',
+        label: 'Status',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.status',
+        hidden: false,
+    },
+    orders_region: {
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.STRING,
+        name: 'region',
+        label: 'Region',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.region',
+        hidden: false,
+    },
+    orders_count: {
+        fieldType: FieldType.METRIC,
+        type: MetricType.COUNT,
+        name: 'count',
+        label: 'Count',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.id',
+        hidden: false,
+    },
+} satisfies ItemsMap;
+
+const rows = [{ orders_status: { value: { raw: 'new', formatted: 'New' } } }];
+
+const dataAppViz = {
+    dataAppVizUuid: 'viz-1',
+    name: 'Grouped bars',
+    description: '',
+    projectUuid: 'project-1',
+    spaceUuid: null,
+    schema: {
+        fields: [
+            {
+                name: 'category',
+                label: 'Category',
+                type: 'dimension',
+                required: true,
+            },
+            { name: 'value', label: 'Value', type: 'metric', required: true },
+        ],
+        configOptions: [
+            {
+                type: 'boolean',
+                name: 'showLegend',
+                label: 'Show legend',
+                default: true,
+            },
+        ],
+        colorPalette: null,
+    },
+    createdAt: new Date('2026-08-19T00:00:00Z'),
+    createdByUserUuid: 'user-1',
+} satisfies DataAppViz;
+
+const readyVersion = {
+    version: 1,
+    status: 'ready',
+} as ApiAppVersionSummary;
+
+const workspaceStub = (
+    overrides: Partial<ChartTypeBuilderWorkspaceState> = {},
+): ChartTypeBuilderWorkspaceState => ({
+    dataAppVizUuid: 'viz-1',
+    build: buildStub(),
+    clarification: clarificationStub(),
+    history: {
+        versions: [readyVersion],
+        oldest: readyVersion,
+        latest: readyVersion,
+        latestReadyVersion: 1,
+        hasOrigin: true,
+        hasEarlier: false,
+        isLoading: false,
+        isError: false,
+        isFetchingEarlier: false,
+        fetchEarlier: vi.fn(),
+    },
+    modelSelection: {} as ChartTypeBuilderWorkspaceState['modelSelection'],
+    isBuilding: false,
+    buildingPrompt: null,
+    elapsed: null,
+    narration: {} as ChartTypeBuilderWorkspaceState['narration'],
+    onCancelBuild: null,
+    failureMessage: null,
+    isClarifyRoundOpen: false,
+    previewVersion: 1,
+    viewedVersion: null,
+    onViewVersion: vi.fn(),
+    dataAppViz,
+    isFetchingSchema: false,
+    hasHistory: true,
+    isHistoryOpen: false,
+    openHistory: vi.fn(),
+    closeHistory: vi.fn(),
+    toggleHistory: vi.fn(),
+    isPromptBarMounted: true,
+    promptSessionKey: 'viz-1',
+    composerAppUuid: 'viz-1',
+    sdkUpgradeOffer: {
+        status: 'unknown',
+    } as ChartTypeBuilderWorkspaceState['sdkUpgradeOffer'],
+    onSdkManifest: vi.fn(),
+    promptBarRef: { current: null },
+    onPickExample: null,
+    ...overrides,
+});
+
+const newTypeWorkspace = () =>
+    workspaceStub({
+        dataAppVizUuid: null,
+        dataAppViz: undefined,
+        previewVersion: null,
+        hasHistory: false,
+        history: {
+            ...workspaceStub().history,
+            versions: [],
+            oldest: null,
+            latest: null,
+            latestReadyVersion: null,
+            hasOrigin: false,
+        },
+    });
+
+const renderAuthoring = ({
+    dataAppVizUuid = 'viz-1' as string | null,
+    claimedUuid = null as string | null,
+    step = 'choose' as 'choose' | 'configure',
+    chartConfig = null as null | {
+        dataAppVizUuid: string;
+        fieldMapping: Record<string, string>;
+        optionValues: Record<string, unknown>;
+    },
+} = {}) => {
+    const store = createExplorerStore();
+    store.dispatch(explorerActions.openVisualizationConfig());
+    store.dispatch(explorerActions.setChartSidebarStep(step));
+    if (chartConfig) {
+        store.dispatch(
+            explorerActions.setChartConfig({
+                chartConfig: {
+                    type: ChartType.DATA_APP_VIZ,
+                    config: chartConfig as never,
+                },
+            }),
+        );
+    }
+    store.dispatch(explorerActions.startChartTypeAuthoring({ dataAppVizUuid }));
+    if (claimedUuid) {
+        store.dispatch(explorerActions.claimChartTypeAuthoringViz(claimedUuid));
+    }
+
+    const Harness = () => {
+        const authoring = store.getState().explorer.chartTypeAuthoring;
+        return authoring ? (
+            <ExplorerChartTypeAuthoring authoring={authoring} />
+        ) : (
+            <div>explorer</div>
+        );
+    };
+
+    renderWithProviders(
+        <Provider store={store}>
+            <MemoryRouter>
+                <Harness />
+            </MemoryRouter>
+        </Provider>,
+    );
+    return store;
+};
+
+describe('ExplorerChartTypeAuthoring', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        previewContexts.length = 0;
+        vi.mocked(useCanCreateDataApp).mockReturnValue(true);
+        vi.mocked(useCanEditDataApp).mockReturnValue(true);
+        vi.mocked(useChartTypeBuilderWorkspace).mockReturnValue(
+            workspaceStub(),
+        );
+        vi.mocked(useExplorerResultsData).mockReturnValue({
+            resultsData: {
+                rows,
+                fields: itemsMap,
+                pivotDetails: null,
+                setFetchAll,
+            },
+        } as unknown as ReturnType<typeof useExplorerResultsData>);
+    });
+
+    it('binds the chart to the type once its schema is known', () => {
+        const store = renderAuthoring();
+
+        expect(
+            store.getState().explorer.unsavedChartVersion.chartConfig,
+        ).toEqual({
+            type: ChartType.DATA_APP_VIZ,
+            config: {
+                dataAppVizUuid: 'viz-1',
+                fieldMapping: {
+                    category: 'orders_status',
+                    value: 'orders_count',
+                },
+                optionValues: {},
+            },
+        });
+        expect(store.getState().explorer.chartSidebarStep).toBe('configure');
+    });
+
+    it('previews the chart binding against every Explorer row with the chart palette', () => {
+        renderAuthoring();
+
+        expect(setFetchAll).toHaveBeenCalledWith(true);
+        const context = previewContexts.at(-1);
+        expect(context?.rows).toBe(rows);
+        expect(context?.fieldMapping).toEqual({
+            category: 'orders_status',
+            value: 'orders_count',
+        });
+        expect(context?.colorPalette).toEqual(['#explorer-1', '#explorer-2']);
+        expect(context?.underlyingData).toEqual({ enabled: false });
+    });
+
+    it('keeps the binding and options the chart already has for this type', () => {
+        renderAuthoring({
+            chartConfig: {
+                dataAppVizUuid: 'viz-1',
+                fieldMapping: { category: 'orders_region' },
+                optionValues: { showLegend: false },
+            },
+        });
+
+        const context = previewContexts.at(-1);
+        expect(context?.fieldMapping.category).toBe('orders_region');
+        expect(context?.options).toEqual({ showLegend: false });
+    });
+
+    it('puts the chart back and returns to the prior step when nothing was built', async () => {
+        vi.mocked(useChartTypeBuilderWorkspace).mockReturnValue(
+            newTypeWorkspace(),
+        );
+        const store = renderAuthoring({ dataAppVizUuid: null, step: 'choose' });
+        expect(
+            store.getState().explorer.unsavedChartVersion.chartConfig.type,
+        ).toBe(ChartType.DATA_APP_VIZ);
+
+        await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+
+        const { explorer } = store.getState();
+        expect(explorer.chartTypeAuthoring).toBeNull();
+        expect(explorer.isVisualizationConfigOpen).toBe(true);
+        expect(explorer.chartSidebarStep).toBe('choose');
+        expect(explorer.unsavedChartVersion.chartConfig.type).toBe(
+            ChartType.CARTESIAN,
+        );
+    });
+
+    it('discards a first build still running when done early', async () => {
+        const discard = vi.fn();
+        vi.mocked(useChartTypeBuilderWorkspace).mockReturnValue(
+            workspaceStub({
+                ...newTypeWorkspace(),
+                isBuilding: true,
+                build: buildStub({
+                    isBuilding: true,
+                    draft: {
+                        appUuid: 'viz-new',
+                        version: 1,
+                        startedAt: new Date(),
+                    },
+                    discard,
+                }),
+            }),
+        );
+        renderAuthoring({ dataAppVizUuid: null });
+
+        await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+
+        expect(discard).toHaveBeenCalledTimes(1);
+    });
+
+    it('finishes on Configure with the chart on the authored type', async () => {
+        const store = renderAuthoring({ step: 'choose' });
+
+        await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+
+        const { explorer } = store.getState();
+        expect(explorer.chartTypeAuthoring).toBeNull();
+        expect(explorer.isVisualizationConfigOpen).toBe(true);
+        expect(explorer.chartSidebarStep).toBe('configure');
+        expect(explorer.unsavedChartVersion.chartConfig).toEqual(
+            expect.objectContaining({ type: ChartType.DATA_APP_VIZ }),
+        );
+    });
+
+    it('leaves a new type on the empty custom config until it has a version', () => {
+        vi.mocked(useChartTypeBuilderWorkspace).mockReturnValue(
+            newTypeWorkspace(),
+        );
+        const store = renderAuthoring({ dataAppVizUuid: null });
+
+        expect(
+            store.getState().explorer.unsavedChartVersion.chartConfig,
+        ).toEqual({
+            type: ChartType.DATA_APP_VIZ,
+            config: {
+                dataAppVizUuid: '',
+                fieldMapping: {},
+                optionValues: {},
+            },
+        });
+        expect(previewContexts.at(-1)).toBeNull();
+    });
+
+    it('discards a type created here that never got a version when done', async () => {
+        vi.mocked(useChartTypeBuilderWorkspace).mockReturnValue(
+            workspaceStub({
+                ...newTypeWorkspace(),
+                dataAppVizUuid: 'viz-new',
+            }),
+        );
+        renderAuthoring({ dataAppVizUuid: null, claimedUuid: 'viz-new' });
+
+        await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+
+        expect(deleteApp).toHaveBeenCalledWith(
+            expect.objectContaining({
+                projectUuid: 'project-1',
+                appUuid: 'viz-new',
+            }),
+        );
+    });
+
+    it('keeps a revised type when done', async () => {
+        renderAuthoring();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+
+        expect(deleteApp).not.toHaveBeenCalled();
+    });
+
+    it('takes focus on entry and hands it back to the sidebar on exit', async () => {
+        const sidebarTitle = document.createElement('p');
+        sidebarTitle.id = 'chart-gallery-sidebar-title';
+        sidebarTitle.tabIndex = -1;
+        document.body.appendChild(sidebarTitle);
+        try {
+            renderAuthoring();
+            expect(screen.getByRole('heading', { level: 2 })).toHaveFocus();
+
+            await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+
+            expect(sidebarTitle).toHaveFocus();
+        } finally {
+            sidebarTitle.remove();
+        }
+    });
+
+    it('carries the app a first build claims into the session', () => {
+        vi.mocked(useChartTypeBuilderWorkspace).mockReturnValue(
+            workspaceStub({
+                ...newTypeWorkspace(),
+                build: buildStub({ appUuid: 'viz-new' }),
+            }),
+        );
+        const store = renderAuthoring({ dataAppVizUuid: null });
+
+        expect(
+            store.getState().explorer.chartTypeAuthoring?.dataAppVizUuid,
+        ).toBe('viz-new');
+    });
+
+    it('leaves authoring when the user may not create chart types', () => {
+        vi.mocked(useCanCreateDataApp).mockReturnValue(false);
+        vi.mocked(useChartTypeBuilderWorkspace).mockReturnValue(
+            newTypeWorkspace(),
+        );
+        const store = renderAuthoring({ dataAppVizUuid: null });
+
+        expect(showToastError).toHaveBeenCalled();
+        expect(store.getState().explorer.chartTypeAuthoring).toBeNull();
+    });
+});

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
@@ -1,0 +1,222 @@
+import {
+    ChartType,
+    FeatureFlags,
+    type DataAppVizOptionValues,
+    type ItemsMap,
+} from '@lightdash/common';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, type FC } from 'react';
+import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
+import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
+import { useDeleteApp } from '../../../features/apps/hooks/useDeleteApp';
+import { useChartTypeBuilderWorkspace } from '../../../features/chartTypes/builder/useChartTypeBuilderWorkspace';
+import { buildExplorerVizContext } from '../../../features/chartTypes/utils/explorerVizContext';
+import {
+    explorerActions,
+    selectChartConfig,
+    useExplorerDispatch,
+    useExplorerSelector,
+} from '../../../features/explorer/store';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { type ChartTypeAuthoringState } from '../../../providers/Explorer/types';
+import { CHART_GALLERY_SIDEBAR_TITLE_ID } from '../../common/ChartGallery/ChartGalleryContext';
+import { useSelectProjectChartType } from '../../VisualizationConfigs/CustomChartType/useSelectProjectChartType';
+import { useExplorerChartColorPalette } from '../VisualizationCard/useExplorerChartColorPalette';
+import { useExplorerResultsData } from '../VisualizationCard/useExplorerResultsData';
+import ExplorerChartTypeAuthoringView from './ExplorerChartTypeAuthoringView';
+
+// Stable identities, so the workspace does not rebind before results land.
+const NO_ITEMS: ItemsMap = {};
+const NO_OPTIONS: DataAppVizOptionValues = {};
+
+type Props = {
+    authoring: ChartTypeAuthoringState;
+};
+
+/** The builder hosted by the Explorer: the chart moves onto the type being
+ *  authored, so the sidebar configures what the preview renders. */
+const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
+    const projectUuid = useProjectUuid();
+    const dispatch = useExplorerDispatch();
+    const queryClient = useQueryClient();
+    const { showToastError } = useToaster();
+    const selectProjectChartType = useSelectProjectChartType();
+    const { mutate: deleteApp } = useDeleteApp();
+
+    const { resultsData } = useExplorerResultsData();
+    // Every page, so the preview sees what the chart would.
+    useEffect(() => {
+        resultsData.setFetchAll(true);
+    }, [resultsData]);
+    const itemsMap = resultsData.fields ?? NO_ITEMS;
+
+    const workspace = useChartTypeBuilderWorkspace({
+        projectUuid,
+        dataAppVizUuid: authoring.dataAppVizUuid,
+        itemsMap,
+    });
+    const { build, dataAppViz, dataAppVizUuid, history } = workspace;
+
+    // A first build claimed an app; the session continues under it.
+    useEffect(() => {
+        if (authoring.dataAppVizUuid === null && build.appUuid) {
+            dispatch(explorerActions.claimChartTypeAuthoringViz(build.appUuid));
+        }
+    }, [authoring.dataAppVizUuid, build.appUuid, dispatch]);
+
+    const chartConfig = useExplorerSelector(selectChartConfig);
+    const chartUsesThisType =
+        chartConfig.type === ChartType.DATA_APP_VIZ &&
+        dataAppVizUuid !== null &&
+        chartConfig.config?.dataAppVizUuid === dataAppVizUuid;
+    const chartTypeConfig =
+        chartUsesThisType && chartConfig.type === ChartType.DATA_APP_VIZ
+            ? (chartConfig.config ?? null)
+            : null;
+
+    // Bound once per type when its schema lands; the sidebar owns it after.
+    const boundUuid = useRef<string | null>(null);
+    useEffect(() => {
+        if (!dataAppViz?.schema || dataAppVizUuid === null) return;
+        if (chartUsesThisType || boundUuid.current === dataAppVizUuid) return;
+        boundUuid.current = dataAppVizUuid;
+        selectProjectChartType(dataAppViz, itemsMap);
+    }, [
+        dataAppViz,
+        dataAppVizUuid,
+        chartUsesThisType,
+        itemsMap,
+        selectProjectChartType,
+    ]);
+
+    // The entry points gate already; this closes a door opened by hand.
+    const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const canCreate = useCanCreateDataApp(projectUuid);
+    const canEdit = useCanEditDataApp(projectUuid, {
+        spaceUuid: dataAppViz?.spaceUuid ?? null,
+        createdByUserUuid: dataAppViz?.createdByUserUuid ?? null,
+    });
+    const isForbidden =
+        (!dataAppsFlag.isLoading && !dataAppsFlag.data?.enabled) ||
+        (dataAppVizUuid === null && !canCreate) ||
+        (dataAppViz !== undefined && !canEdit);
+    useEffect(() => {
+        if (!isForbidden) return;
+        showToastError({ title: 'You cannot author this chart type' });
+        dispatch(explorerActions.cancelChartTypeAuthoring());
+    }, [isForbidden, showToastError, dispatch]);
+
+    const colorPalette = useExplorerChartColorPalette(projectUuid);
+    const schema = dataAppViz?.schema ?? null;
+    const persistedFieldMapping = chartTypeConfig?.fieldMapping ?? null;
+    const optionValues = chartTypeConfig?.optionValues ?? NO_OPTIONS;
+    const previewContext = useMemo(
+        () =>
+            schema
+                ? buildExplorerVizContext({
+                      schema,
+                      itemsMap,
+                      persistedFieldMapping,
+                      rows: resultsData.rows,
+                      pivotDetails: resultsData.pivotDetails ?? null,
+                      colorPalette,
+                      optionValues,
+                  })
+                : null,
+        [
+            schema,
+            itemsMap,
+            persistedFieldMapping,
+            resultsData.rows,
+            resultsData.pivotDetails,
+            colorPalette,
+            optionValues,
+        ],
+    );
+
+    // The sidebar stays mounted, so it can take focus back from the workspace.
+    const focusSidebar = () =>
+        requestAnimationFrame(() =>
+            document.getElementById(CHART_GALLERY_SIDEBAR_TITLE_ID)?.focus(),
+        );
+
+    // One exit: keep the type the chart now uses, or, with nothing usable
+    // built, put the chart back the way it was.
+    const handleDone = () => {
+        if (chartUsesThisType && dataAppVizUuid !== null) {
+            // The chart renders through metadata that may still hold the
+            // version before this build; the gallery list may not know the
+            // type yet.
+            void queryClient.invalidateQueries({
+                queryKey: [
+                    'data-app-viz-render-metadata',
+                    projectUuid,
+                    dataAppVizUuid,
+                ],
+            });
+            void queryClient.invalidateQueries({ queryKey: ['data-app-vizs'] });
+            dispatch(explorerActions.finishChartTypeAuthoring());
+        } else {
+            if (build.isBuilding && build.draft !== null && build.discard) {
+                // A first build still running would leave an orphan behind.
+                build.discard();
+            } else if (
+                projectUuid &&
+                authoring.createdInSession &&
+                dataAppVizUuid !== null &&
+                history.latestReadyVersion === null
+            ) {
+                // Created here and never got a usable version: nothing to keep.
+                deleteApp({
+                    projectUuid,
+                    appUuid: dataAppVizUuid,
+                    successTitle: 'Chart type discarded',
+                });
+            }
+            dispatch(explorerActions.cancelChartTypeAuthoring());
+        }
+        focusSidebar();
+    };
+
+    // A rename lands in the app row; the type the header and rail read
+    // comes from the viz queries.
+    const handleDetailsSaved = () => {
+        void queryClient.invalidateQueries({
+            queryKey: ['data-app-viz', projectUuid, dataAppVizUuid],
+        });
+        void queryClient.invalidateQueries({ queryKey: ['data-app-vizs'] });
+    };
+
+    if (!projectUuid) return null;
+
+    return (
+        <ExplorerChartTypeAuthoringView
+            projectUuid={projectUuid}
+            app={
+                dataAppViz
+                    ? {
+                          appUuid: dataAppViz.dataAppVizUuid,
+                          name: dataAppViz.name,
+                          description: dataAppViz.description,
+                      }
+                    : null
+            }
+            upgrade={
+                dataAppVizUuid !== null && history.latestReadyVersion !== null
+                    ? {
+                          ...workspace.sdkUpgradeOffer,
+                          disabled: workspace.isBuilding,
+                      }
+                    : null
+            }
+            workspace={workspace}
+            previewContext={previewContext}
+            onDetailsSaved={handleDetailsSaved}
+            onDone={handleDone}
+        />
+    );
+};
+
+export default ExplorerChartTypeAuthoring;

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.module.css
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.module.css
@@ -1,0 +1,36 @@
+.header {
+    flex: 0 0 auto;
+    min-width: 0;
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+    background: var(--mantine-color-background-0);
+}
+
+/* The one element allowed to give way, so the actions never do. */
+.title {
+    flex: 1 1 auto;
+    min-width: 0;
+    max-width: 280px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.status {
+    flex: 0 0 auto;
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: 500;
+}
+
+.actions {
+    flex: 0 0 auto;
+    margin-left: auto;
+}
+
+/* Below a laptop width with both rails open, the title yields first. */
+@container authoring (max-width: 640px) {
+    .title {
+        max-width: 160px;
+    }
+}

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.test.tsx
@@ -1,0 +1,115 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import ExplorerChartTypeAuthoringHeader from './ExplorerChartTypeAuthoringHeader';
+
+vi.mock('../../../components/common/modal/AppUpdateModal', () => ({
+    default: ({ initialName }: { initialName: string }) => (
+        <div role="dialog">Editing {initialName}</div>
+    ),
+}));
+vi.mock('../../../features/apps/components/AppUpgradeModal', () => ({
+    default: () => <div role="dialog">Upgrade</div>,
+}));
+
+const app = {
+    appUuid: 'viz-1',
+    name: 'Revenue changes waterfall',
+    description: 'By tier',
+};
+
+const renderHeader = (
+    overrides: Partial<
+        React.ComponentProps<typeof ExplorerChartTypeAuthoringHeader>
+    > = {},
+) => {
+    const props = {
+        projectUuid: 'project-1',
+        titleId: 'title',
+        app,
+        status: null,
+        upgrade: null,
+        hasHistory: true,
+        isHistoryOpen: false,
+        onToggleHistory: vi.fn(),
+        onUpgradeStarted: vi.fn(),
+        onDetailsSaved: vi.fn(),
+        onDone: vi.fn(),
+        ...overrides,
+    };
+    renderWithProviders(<ExplorerChartTypeAuthoringHeader {...props} />);
+    return props;
+};
+
+describe('ExplorerChartTypeAuthoringHeader', () => {
+    it('names the surface with a focused heading and says nothing while describing', () => {
+        renderHeader();
+
+        const heading = screen.getByRole('heading', {
+            level: 2,
+            name: 'Revenue changes waterfall',
+        });
+        expect(heading).toHaveFocus();
+        expect(screen.getByRole('status')).toHaveTextContent('');
+    });
+
+    it('calls a type with no app yet a new one, with nothing to edit', () => {
+        renderHeader({ app: null });
+
+        expect(
+            screen.getByRole('heading', { level: 2, name: 'New chart type' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Edit chart type details' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('announces a build and the version on screen', () => {
+        renderHeader({ status: { kind: 'building', elapsed: '0:42' } });
+        expect(screen.getByRole('status')).toHaveTextContent('Building 0:42');
+    });
+
+    it('opens the details editor on the type it shows', async () => {
+        renderHeader();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Edit chart type details' }),
+        );
+
+        expect(screen.getByRole('dialog')).toHaveTextContent(
+            'Editing Revenue changes waterfall',
+        );
+    });
+
+    it('offers an upgrade only when the bundle is behind', async () => {
+        const stale = {
+            status: 'stale' as const,
+            newFeatures: [],
+            candidateFeatures: [],
+            reportedSdkVersion: '1.0.0',
+            reportedFeatures: [],
+            disabled: false,
+        };
+        renderHeader({ upgrade: { ...stale, status: 'current' } });
+        expect(
+            screen.queryByRole('button', { name: 'Upgrade available' }),
+        ).not.toBeInTheDocument();
+
+        renderHeader({ upgrade: stale });
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Upgrade available' }),
+        );
+        expect(screen.getByRole('dialog')).toHaveTextContent('Upgrade');
+    });
+
+    it('always offers Done and reports whether history is open', async () => {
+        const props = renderHeader({ isHistoryOpen: true });
+
+        expect(
+            screen.getByRole('button', { name: 'Version history' }),
+        ).toHaveAttribute('aria-pressed', 'true');
+        await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+        expect(props.onDone).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.tsx
@@ -1,0 +1,169 @@
+import { getAppDisplayName } from '@lightdash/common';
+import {
+    ActionIcon,
+    Badge,
+    Button,
+    Group,
+    Loader,
+    Title,
+    Tooltip,
+    VisuallyHidden,
+} from '@mantine/core';
+import { IconHistory, IconPencil, IconSparkles } from '@tabler/icons-react';
+import { useEffect, useRef, useState, type FC } from 'react';
+import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
+import AppUpgradeModal from '../../../features/apps/components/AppUpgradeModal';
+import { type SdkUpgradeOffer } from '../../../features/apps/hooks/useSdkUpgradeStatus';
+import MantineIcon from '../../common/MantineIcon';
+import { authoringStatusLabel, type AuthoringStatus } from './authoringStatus';
+import classes from './ExplorerChartTypeAuthoringHeader.module.css';
+
+type Props = {
+    projectUuid: string;
+    titleId: string;
+    /** Null while no app exists yet (a new type before its first build). */
+    app: { appUuid: string; name: string; description: string } | null;
+    status: AuthoringStatus | null;
+    upgrade: (SdkUpgradeOffer & { disabled: boolean }) | null;
+    hasHistory: boolean;
+    isHistoryOpen: boolean;
+    onToggleHistory: () => void;
+    onUpgradeStarted: () => void;
+    onDetailsSaved: () => void;
+    onDone: () => void;
+};
+
+const ExplorerChartTypeAuthoringHeader: FC<Props> = ({
+    projectUuid,
+    titleId,
+    app,
+    status,
+    upgrade,
+    hasHistory,
+    isHistoryOpen,
+    onToggleHistory,
+    onUpgradeStarted,
+    onDetailsSaved,
+    onDone,
+}) => {
+    const [isEditingDetails, setIsEditingDetails] = useState(false);
+    const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
+    const upgradeAvailable =
+        upgrade?.status === 'stale' || upgrade?.status === 'legacy';
+    const title = app
+        ? getAppDisplayName(app.name, app.appUuid)
+        : 'New chart type';
+
+    // Entering replaces what had focus; land on what this surface is.
+    const titleRef = useRef<HTMLHeadingElement>(null);
+    useEffect(() => {
+        titleRef.current?.focus();
+    }, []);
+
+    return (
+        <Group className={classes.header} gap="sm" wrap="nowrap">
+            <Title
+                ref={titleRef}
+                id={titleId}
+                order={2}
+                className={classes.title}
+                fz="sm"
+                fw={600}
+                title={title}
+                tabIndex={-1}
+            >
+                {title}
+            </Title>
+            {app && (
+                <Tooltip label="Edit details" position="bottom">
+                    <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        size="sm"
+                        aria-label="Edit chart type details"
+                        onClick={() => setIsEditingDetails(true)}
+                    >
+                        <MantineIcon icon={IconPencil} />
+                    </ActionIcon>
+                </Tooltip>
+            )}
+            {status && (
+                <Badge
+                    className={classes.status}
+                    size="sm"
+                    radius="sm"
+                    variant={status.kind === 'ready' ? 'filled' : 'light'}
+                    leftSection={
+                        status.kind === 'building' ? (
+                            <Loader size={8} color="currentColor" />
+                        ) : undefined
+                    }
+                >
+                    {authoringStatusLabel(status)}
+                </Badge>
+            )}
+            <VisuallyHidden role="status">
+                {status ? authoringStatusLabel(status) : ''}
+            </VisuallyHidden>
+            <Group className={classes.actions} gap="xs" wrap="nowrap">
+                {upgradeAvailable && (
+                    <Button
+                        size="compact-sm"
+                        variant="light"
+                        leftSection={<MantineIcon icon={IconSparkles} />}
+                        disabled={upgrade.disabled}
+                        onClick={() => setIsUpgradeModalOpen(true)}
+                    >
+                        Upgrade available
+                    </Button>
+                )}
+                {hasHistory && (
+                    <Tooltip label="Version history" position="bottom">
+                        <ActionIcon
+                            variant={isHistoryOpen ? 'light' : 'subtle'}
+                            color="gray"
+                            size="md"
+                            aria-label="Version history"
+                            aria-pressed={isHistoryOpen}
+                            onClick={onToggleHistory}
+                        >
+                            <MantineIcon icon={IconHistory} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+                <Button size="compact-sm" onClick={onDone}>
+                    Done
+                </Button>
+            </Group>
+            {app && isEditingDetails && (
+                <AppUpdateModal
+                    opened
+                    onClose={() => setIsEditingDetails(false)}
+                    onConfirm={() => {
+                        setIsEditingDetails(false);
+                        onDetailsSaved();
+                    }}
+                    projectUuid={projectUuid}
+                    uuid={app.appUuid}
+                    initialName={title}
+                    initialDescription={app.description}
+                    resourceLabel="Chart Type"
+                    icon={IconPencil}
+                />
+            )}
+            {app && upgrade && isUpgradeModalOpen && (
+                <AppUpgradeModal
+                    opened
+                    onClose={() => setIsUpgradeModalOpen(false)}
+                    projectUuid={projectUuid}
+                    appUuid={app.appUuid}
+                    offer={upgrade}
+                    resource="chartType"
+                    onStarted={onUpgradeStarted}
+                />
+            )}
+        </Group>
+    );
+};
+
+export default ExplorerChartTypeAuthoringHeader;

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.module.css
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.module.css
@@ -1,0 +1,11 @@
+.root {
+    container: authoring / inline-size;
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md);
+    background: var(--mantine-color-ldGray-0);
+    overflow: hidden;
+}

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.tsx
@@ -1,0 +1,63 @@
+import { type DataAppVizContext } from '@lightdash/common';
+import { Box } from '@mantine/core';
+import { useId, type FC } from 'react';
+import { type SdkUpgradeOffer } from '../../../features/apps/hooks/useSdkUpgradeStatus';
+import ChartTypeBuilderWorkspace from '../../../features/chartTypes/builder/ChartTypeBuilderWorkspace';
+import { type ChartTypeBuilderWorkspaceState } from '../../../features/chartTypes/builder/useChartTypeBuilderWorkspace';
+import { deriveAuthoringStatus } from './authoringStatus';
+import ExplorerChartTypeAuthoringHeader from './ExplorerChartTypeAuthoringHeader';
+import classes from './ExplorerChartTypeAuthoringView.module.css';
+
+type Props = {
+    projectUuid: string;
+    app: { appUuid: string; name: string; description: string } | null;
+    upgrade: (SdkUpgradeOffer & { disabled: boolean }) | null;
+    workspace: ChartTypeBuilderWorkspaceState;
+    previewContext: DataAppVizContext | null;
+    onDetailsSaved: () => void;
+    onDone: () => void;
+};
+
+/** The Author step as it looks; the container decides what it does. */
+const ExplorerChartTypeAuthoringView: FC<Props> = ({
+    projectUuid,
+    app,
+    upgrade,
+    workspace,
+    previewContext,
+    onDetailsSaved,
+    onDone,
+}) => {
+    const titleId = useId();
+    return (
+        <Box
+            component="section"
+            className={classes.root}
+            aria-labelledby={titleId}
+            data-testid="chart-type-authoring"
+        >
+            <ExplorerChartTypeAuthoringHeader
+                projectUuid={projectUuid}
+                titleId={titleId}
+                app={app}
+                status={deriveAuthoringStatus(workspace)}
+                upgrade={upgrade}
+                hasHistory={workspace.hasHistory}
+                isHistoryOpen={workspace.isHistoryOpen}
+                onToggleHistory={workspace.toggleHistory}
+                onUpgradeStarted={workspace.openHistory}
+                onDetailsSaved={onDetailsSaved}
+                onDone={onDone}
+            />
+            <ChartTypeBuilderWorkspace
+                projectUuid={projectUuid}
+                workspace={workspace}
+                previewContext={previewContext}
+                syncPreviewUrlState={false}
+                configurePanel={null}
+            />
+        </Box>
+    );
+};
+
+export default ExplorerChartTypeAuthoringView;

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/authoringStatus.test.ts
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/authoringStatus.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { authoringStatusLabel, deriveAuthoringStatus } from './authoringStatus';
+
+const history = (latestReadyVersion: number | null) =>
+    ({ latestReadyVersion }) as Parameters<
+        typeof deriveAuthoringStatus
+    >[0]['history'];
+
+describe('deriveAuthoringStatus', () => {
+    it('says nothing while the author is still describing', () => {
+        expect(
+            deriveAuthoringStatus({
+                isBuilding: false,
+                elapsed: null,
+                previewVersion: null,
+                history: history(null),
+            }),
+        ).toBeNull();
+    });
+
+    it('reports a build with its clock', () => {
+        const status = deriveAuthoringStatus({
+            isBuilding: true,
+            elapsed: '0:42',
+            previewVersion: 1,
+            history: history(1),
+        });
+        expect(status).toEqual({ kind: 'building', elapsed: '0:42' });
+        expect(authoringStatusLabel(status!)).toBe('Building 0:42');
+    });
+
+    it('reports the version on screen once it is the current one', () => {
+        const status = deriveAuthoringStatus({
+            isBuilding: false,
+            elapsed: null,
+            previewVersion: 2,
+            history: history(2),
+        });
+        expect(status).toEqual({ kind: 'ready', version: 2 });
+        expect(authoringStatusLabel(status!)).toBe('v2 ready');
+    });
+
+    it('says nothing while an older version is pinned', () => {
+        expect(
+            deriveAuthoringStatus({
+                isBuilding: false,
+                elapsed: null,
+                previewVersion: 1,
+                history: history(2),
+            }),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/authoringStatus.ts
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/authoringStatus.ts
@@ -1,0 +1,33 @@
+import { type ChartTypeBuilderWorkspaceState } from '../../../features/chartTypes/builder/useChartTypeBuilderWorkspace';
+
+/** What the header says beside the title; null while nothing is happening. */
+export type AuthoringStatus =
+    | { kind: 'building'; elapsed: string | null }
+    | { kind: 'ready'; version: number };
+
+export const deriveAuthoringStatus = ({
+    isBuilding,
+    elapsed,
+    previewVersion,
+    history,
+}: Pick<
+    ChartTypeBuilderWorkspaceState,
+    'isBuilding' | 'elapsed' | 'previewVersion' | 'history'
+>): AuthoringStatus | null => {
+    if (isBuilding) return { kind: 'building', elapsed };
+    if (
+        previewVersion !== null &&
+        previewVersion === history.latestReadyVersion
+    )
+        return { kind: 'ready', version: previewVersion };
+    return null;
+};
+
+export const authoringStatusLabel = (status: AuthoringStatus): string => {
+    switch (status.kind) {
+        case 'building':
+            return status.elapsed ? `Building ${status.elapsed}` : 'Building';
+        case 'ready':
+            return `v${status.version} ready`;
+    }
+};

--- a/packages/frontend/src/components/Explorer/Explorer.authoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/Explorer.authoring.test.tsx
@@ -1,0 +1,135 @@
+import { screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    createExplorerStore,
+    explorerActions,
+} from '../../features/explorer/store';
+import { renderWithProviders } from '../../testing/testUtils';
+import Explorer from './index';
+
+const { cardProps } = vi.hoisted(() => ({
+    cardProps: [] as { renderVisualization: boolean }[],
+}));
+
+vi.mock('./VisualizationCard/VisualizationCard', () => ({
+    default: (props: { renderVisualization: boolean }) => {
+        cardProps.push(props);
+        return <div data-testid="visualization-card" />;
+    },
+}));
+vi.mock('./ChartTypeAuthoring/ExplorerChartTypeAuthoring', () => ({
+    default: () => <div data-testid="chart-type-authoring" />,
+}));
+vi.mock('./ExplorerHeader', () => ({
+    default: () => <div data-testid="explorer-header" />,
+}));
+vi.mock('./ResultsCard/ResultsCard', () => ({
+    default: () => <div data-testid="results-card" />,
+}));
+vi.mock('./SqlCard/SqlCard', () => ({ default: () => null }));
+vi.mock('./FiltersCard/FiltersCard', () => ({
+    default: () => <div data-testid="filters-card" />,
+}));
+vi.mock('./ParametersCard/ParametersCard', () => ({ default: () => null }));
+vi.mock('../RefreshDbtButton', () => ({ default: () => null }));
+vi.mock('../common/ScreenshotReadyIndicator', () => ({ default: () => null }));
+vi.mock('../MetricQueryData/MetricQueryDataProvider', () => ({
+    default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../MetricQueryData/UnderlyingDataModal', () => ({
+    default: () => null,
+}));
+vi.mock('../MetricQueryData/DrillDownModal', () => ({
+    DrillDownModal: () => null,
+}));
+vi.mock('./CustomDimensionModal', () => ({ CustomDimensionModal: () => null }));
+vi.mock('./CustomMetricModal', () => ({ CustomMetricModal: () => null }));
+vi.mock('./FormatModal', () => ({ FormatModal: () => null }));
+vi.mock('./WriteBackModal', () => ({ WriteBackModal: () => null }));
+vi.mock(
+    './PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal',
+    () => ({
+        PeriodOverPeriodComparisonModal: () => null,
+    }),
+);
+vi.mock('../../features/mergeQuery/components/MergeAutoRun', () => ({
+    MergeAutoRun: () => <div data-testid="merge-auto-run" />,
+}));
+vi.mock('../../features/mergeQuery/components/MergeReadOnlyBar', () => ({
+    MergeReadOnlyBar: () => null,
+}));
+vi.mock('../../features/mergeQuery/components/MergeRelationshipCard', () => ({
+    MergeRelationshipCard: () => null,
+}));
+vi.mock('../../hooks/useExplore', () => ({
+    useExplore: () => ({ data: undefined }),
+}));
+vi.mock('../../hooks/useCompiledSql', () => ({
+    useCompiledSql: () => ({ data: undefined }),
+}));
+vi.mock('../../hooks/useDefaultSortField', () => ({
+    default: () => undefined,
+}));
+vi.mock('../../hooks/parameters/useParameters', () => ({
+    useParameters: () => ({ data: undefined }),
+}));
+vi.mock('../../hooks/organization/useOrganization', () => ({
+    useOrganization: () => ({ data: undefined }),
+}));
+vi.mock('../../hooks/useExplorerQuery', () => ({
+    useExplorerQuery: () => ({
+        query: { data: undefined, error: null },
+        queryResults: { error: null },
+    }),
+}));
+vi.mock('../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project-1',
+}));
+vi.mock('../../providers/Fullscreen/useFullscreen', () => ({
+    default: () => ({ isFullscreen: false }),
+}));
+
+const renderExplorer = ({ authoring = false } = {}) => {
+    const store = createExplorerStore();
+    store.dispatch(explorerActions.setIsEditMode(true));
+    if (authoring) {
+        store.dispatch(
+            explorerActions.startChartTypeAuthoring({ dataAppVizUuid: null }),
+        );
+    }
+    cardProps.length = 0;
+    renderWithProviders(
+        <Provider store={store}>
+            <MemoryRouter>
+                <Explorer />
+            </MemoryRouter>
+        </Provider>,
+    );
+};
+
+describe('Explorer while a chart type is authored', () => {
+    it('shows the chart and its cards when nothing is authored', () => {
+        renderExplorer();
+
+        expect(screen.getByTestId('explorer-header')).toBeInTheDocument();
+        expect(screen.getByTestId('results-card')).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('chart-type-authoring'),
+        ).not.toBeInTheDocument();
+        expect(cardProps.at(-1)?.renderVisualization).toBe(true);
+    });
+
+    it('puts the builder in the chart’s place and keeps the card alive without drawing it', () => {
+        renderExplorer({ authoring: true });
+
+        expect(screen.getByTestId('chart-type-authoring')).toBeInTheDocument();
+        expect(screen.queryByTestId('explorer-header')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('results-card')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('filters-card')).not.toBeInTheDocument();
+        expect(screen.getByTestId('merge-auto-run')).toBeInTheDocument();
+        expect(screen.getByTestId('visualization-card')).not.toBeVisible();
+        expect(cardProps.at(-1)?.renderVisualization).toBe(false);
+    });
+});

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -72,6 +72,10 @@ export type EchartsClickEvent = {
 
 type Props = {
     projectUuid?: string;
+    /** False keeps the card, its provider and the config sidebar alive
+     *  without drawing the chart, so nothing renders twice while a chart
+     *  type is authored in its place. */
+    renderVisualization: boolean;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
     minimal?: boolean;
@@ -80,6 +84,7 @@ type Props = {
 const VisualizationCard: FC<Props> = memo((props) => {
     const {
         projectUuid: fallBackUUid,
+        renderVisualization,
         onScreenshotReady,
         onScreenshotError,
         minimal = false,
@@ -469,19 +474,25 @@ const VisualizationCard: FC<Props> = memo((props) => {
                         )
                     }
                 >
-                    <LightdashVisualization
-                        ref={measureRef}
-                        className="sentry-block ph-no-capture"
-                        data-testid="visualization"
-                        onScreenshotReady={onScreenshotReady}
-                        onScreenshotError={onScreenshotError}
-                    />
-                    <SeriesContextMenu
-                        echartsSeriesClickEvent={echartsClickEvent?.event}
-                        dimensions={echartsClickEvent?.dimensions}
-                        series={echartsClickEvent?.series}
-                        explore={explore}
-                    />
+                    {renderVisualization && (
+                        <>
+                            <LightdashVisualization
+                                ref={measureRef}
+                                className="sentry-block ph-no-capture"
+                                data-testid="visualization"
+                                onScreenshotReady={onScreenshotReady}
+                                onScreenshotError={onScreenshotError}
+                            />
+                            <SeriesContextMenu
+                                echartsSeriesClickEvent={
+                                    echartsClickEvent?.event
+                                }
+                                dimensions={echartsClickEvent?.dimensions}
+                                series={echartsClickEvent?.series}
+                                explore={explore}
+                            />
+                        </>
+                    )}
                 </CollapsableCard>
             </VisualizationProvider>
         </ErrorBoundary>

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -3,7 +3,7 @@ import {
     getExploreParameterDefinitions,
     getReferencedParameterDefinitions,
 } from '@lightdash/common';
-import { Stack } from '@mantine/core';
+import { Box, Stack } from '@mantine/core';
 import {
     memo,
     useCallback,
@@ -16,9 +16,11 @@ import {
 import {
     explorerActions,
     selectAdditionalMetricModal,
+    selectChartTypeAuthoring,
     selectColumnOrder,
     selectDimensions,
     selectFormatModal,
+    selectIsChartTypeAuthoring,
     selectIsEditMode,
     selectMetricQuery,
     selectMetrics,
@@ -49,6 +51,7 @@ import { DrillDownModal } from '../MetricQueryData/DrillDownModal';
 import MetricQueryDataProvider from '../MetricQueryData/MetricQueryDataProvider';
 import UnderlyingDataModal from '../MetricQueryData/UnderlyingDataModal';
 import RefreshDbtButton from '../RefreshDbtButton';
+import ExplorerChartTypeAuthoring from './ChartTypeAuthoring/ExplorerChartTypeAuthoring';
 import { CustomDimensionModal } from './CustomDimensionModal';
 import { CustomMetricModal } from './CustomMetricModal';
 import ExplorerHeader from './ExplorerHeader';
@@ -74,6 +77,12 @@ const Explorer: FC<{ hideHeader?: boolean; chartView?: boolean }> = memo(
         const isEditMode = useExplorerSelector(selectIsEditMode);
         const showQueryBuilder = isEditMode || !chartView;
         const showMinimalChart = chartView && !isEditMode;
+        // Authoring a chart type takes the chart's place; the query keeps
+        // running underneath so the preview renders against it.
+        const chartTypeAuthoring = useExplorerSelector(
+            selectChartTypeAuthoring,
+        );
+        const isAuthoring = useExplorerSelector(selectIsChartTypeAuthoring);
         const parameterReferencesFromRedux = useExplorerSelector(
             selectParameterReferences,
         );
@@ -267,21 +276,30 @@ const Explorer: FC<{ hideHeader?: boolean; chartView?: boolean }> = memo(
                 resolvedTimezone={query.data?.resolvedTimezone}
             >
                 <Stack style={{ flexGrow: 1 }}>
-                    {!hideHeader &&
+                    <MergeAutoRun />
+                    {isAuthoring && chartTypeAuthoring && (
+                        <ExplorerChartTypeAuthoring
+                            authoring={chartTypeAuthoring}
+                        />
+                    )}
+                    {!isAuthoring &&
+                        !hideHeader &&
                         (isEditMode ? (
                             <ExplorerHeader />
                         ) : (
                             !savedChart && <RefreshDbtButton />
                         ))}
 
-                    <MergeAutoRun />
-                    {!isFullscreen && showQueryBuilder && <MergeReadOnlyBar />}
+                    {!isAuthoring && !isFullscreen && showQueryBuilder && (
+                        <MergeReadOnlyBar />
+                    )}
 
-                    {!isFullscreen && showQueryBuilder && (
+                    {!isAuthoring && !isFullscreen && showQueryBuilder && (
                         <MergeRelationshipCard />
                     )}
 
-                    {!isFullscreen &&
+                    {!isAuthoring &&
+                        !isFullscreen &&
                         showQueryBuilder &&
                         !!tableName &&
                         hasReferencedUserParameters && (
@@ -292,16 +310,23 @@ const Explorer: FC<{ hideHeader?: boolean; chartView?: boolean }> = memo(
                             />
                         )}
 
-                    {!isFullscreen && showQueryBuilder && <FiltersCard />}
+                    {!isAuthoring && !isFullscreen && showQueryBuilder && (
+                        <FiltersCard />
+                    )}
 
-                    <VisualizationCard
-                        projectUuid={projectUuid}
-                        onScreenshotReady={handleScreenshotReady}
-                        onScreenshotError={handleScreenshotError}
-                        minimal={showMinimalChart}
-                    />
+                    {/* Stays mounted while authoring: it hosts the sidebar
+                        that configures the type being built. */}
+                    <Box display={isAuthoring ? 'none' : 'contents'}>
+                        <VisualizationCard
+                            projectUuid={projectUuid}
+                            renderVisualization={!isAuthoring}
+                            onScreenshotReady={handleScreenshotReady}
+                            onScreenshotError={handleScreenshotError}
+                            minimal={showMinimalChart}
+                        />
+                    </Box>
 
-                    {!isFullscreen && showQueryBuilder && (
+                    {!isAuthoring && !isFullscreen && showQueryBuilder && (
                         <>
                             <ResultsCard />
 

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -45,6 +45,7 @@ const {
     locationSearch,
     navigate,
     pickerProps,
+    authoringState,
 } = vi.hoisted(() => ({
     dispatch: vi.fn(),
     fieldSelectItems: [] as Item[][],
@@ -52,12 +53,17 @@ const {
     locationSearch: { current: '' },
     navigate: vi.fn(),
     pickerProps: [] as PickerProps[],
+    authoringState: {
+        current: null as { dataAppVizUuid: string | null } | null,
+    },
 }));
 
 // The picker routes project-type selection through the Redux-based
 // useSelectProjectChartType hook; assert on what it dispatches.
 vi.mock('../../../features/explorer/store', () => ({
     useExplorerDispatch: () => dispatch,
+    useExplorerSelector: () => authoringState.current,
+    selectChartTypeAuthoring: () => null,
     explorerActions: {
         setChartType: (payload: unknown) => ({ type: 'setChartType', payload }),
         setChartConfig: (payload: unknown) => ({
@@ -66,6 +72,10 @@ vi.mock('../../../features/explorer/store', () => ({
         }),
         setPivotConfig: (payload: unknown) => ({
             type: 'setPivotConfig',
+            payload,
+        }),
+        startChartTypeAuthoring: (payload: unknown) => ({
+            type: 'startChartTypeAuthoring',
             payload,
         }),
     },
@@ -483,6 +493,54 @@ describe('DataAppVizConfigTabs', () => {
             pathname: '/projects/project-1/chart-types/new',
             search: locationSearch.current,
         });
+    });
+
+    it('starts authoring in place from inside the chart gallery', async () => {
+        signInAs(OrganizationMemberRole.EDITOR);
+        mockContext(queryColumns, '');
+        vi.mocked(useDataAppVisualization).mockReturnValue({
+            data: undefined,
+        } as unknown as ReturnType<typeof useDataAppVisualization>);
+
+        renderWithProviders(
+            <ChartGalleryContext.Provider value={true}>
+                <ConfigTabs />
+            </ChartGalleryContext.Provider>,
+        );
+
+        const builder = await screen.findByText('builder');
+        expect(builder.closest('a')).toBeNull();
+        await userEvent.click(builder);
+
+        expect(dispatch).toHaveBeenCalledWith({
+            type: 'startChartTypeAuthoring',
+            payload: { dataAppVizUuid: null },
+        });
+        expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('explains the empty configuration while a new type is being authored', async () => {
+        signInAs(OrganizationMemberRole.EDITOR);
+        mockContext(queryColumns, '');
+        authoringState.current = { dataAppVizUuid: null };
+        vi.mocked(useDataAppVisualization).mockReturnValue({
+            data: undefined,
+        } as unknown as ReturnType<typeof useDataAppVisualization>);
+
+        try {
+            renderWithProviders(
+                <ChartGalleryContext.Provider value={true}>
+                    <ConfigTabs />
+                </ChartGalleryContext.Provider>,
+            );
+
+            expect(
+                await screen.findByText(/Describe the chart type you need/),
+            ).toBeInTheDocument();
+            expect(screen.queryByText('builder')).not.toBeInTheDocument();
+        } finally {
+            authoringState.current = null;
+        }
     });
 
     it('offers no builder link to who cannot create chart types', async () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -14,6 +14,12 @@ import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useD
 import { reconcileDataAppVizFieldMapping } from '../../../features/chartTypes/utils/autoMapDataAppVizFields';
 import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
 import { getDataAppVizFieldItems } from '../../../features/chartTypes/utils/getDataAppVizFieldItems';
+import {
+    explorerActions,
+    selectChartTypeAuthoring,
+    useExplorerDispatch,
+    useExplorerSelector,
+} from '../../../features/explorer/store';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useIsInsideChartGallery } from '../../common/ChartGallery/ChartGalleryContext';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
@@ -36,6 +42,8 @@ export const ConfigTabs: FC = memo(() => {
     const { visualizationConfig, itemsMap, setChartType, setPivotDimensions } =
         useVisualizationContext();
     const selectProjectChartType = useSelectProjectChartType();
+    const dispatch = useExplorerDispatch();
+    const isAuthoring = useExplorerSelector(selectChartTypeAuthoring) !== null;
 
     const isDataAppViz = isDataAppVizVisualizationConfig(visualizationConfig);
     const dataAppVizUuid = isDataAppViz
@@ -130,7 +138,7 @@ export const ConfigTabs: FC = memo(() => {
                 fieldMapping={effectiveMapping}
                 onFieldChange={handleFieldChange}
             />
-            {dataAppViz && !isInsideChartGallery && (
+            {dataAppViz && (!isInsideChartGallery || isAuthoring) && (
                 <Box className={classes.typeCard}>
                     <Text fz="xs" fw={500}>
                         {getAppDisplayName(
@@ -141,7 +149,7 @@ export const ConfigTabs: FC = memo(() => {
                     <Text fz="xs" c="dimmed" lh={1.5}>
                         {dataAppViz.description || 'No description'}
                     </Text>
-                    {canEditSelectedType && (
+                    {canEditSelectedType && !isInsideChartGallery && (
                         <Anchor
                             component={Link}
                             to={{
@@ -216,24 +224,46 @@ export const ConfigTabs: FC = memo(() => {
                         colorPalette={colorPalette}
                         paletteControl={<ColorPaletteSection size="xs" />}
                     />
+                ) : isAuthoring ? (
+                    <Text size="xs" c="dimmed">
+                        Describe the chart type you need. Its bindings and
+                        options appear here once the first version is ready.
+                    </Text>
                 ) : (
                     <Text size="xs" c="dimmed">
                         Pick a chart type above
                         {canCreateApp ? (
                             <>
                                 , or create a new one in the{' '}
-                                <Anchor
-                                    component={Link}
-                                    to={{
-                                        pathname: chartTypeBuilderPath(
-                                            projectUuid ?? '',
-                                        ),
-                                        search: location.search,
-                                    }}
-                                    size="xs"
-                                >
-                                    builder
-                                </Anchor>
+                                {isInsideChartGallery ? (
+                                    <Anchor
+                                        component="button"
+                                        type="button"
+                                        size="xs"
+                                        onClick={() =>
+                                            dispatch(
+                                                explorerActions.startChartTypeAuthoring(
+                                                    { dataAppVizUuid: null },
+                                                ),
+                                            )
+                                        }
+                                    >
+                                        builder
+                                    </Anchor>
+                                ) : (
+                                    <Anchor
+                                        component={Link}
+                                        to={{
+                                            pathname: chartTypeBuilderPath(
+                                                projectUuid ?? '',
+                                            ),
+                                            search: location.search,
+                                        }}
+                                        size="xs"
+                                    >
+                                        builder
+                                    </Anchor>
+                                )}
                             </>
                         ) : null}
                         .

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -91,6 +91,11 @@ export const selectChartSidebarStep = createSelector(
     (explorer) => explorer.chartSidebarStep,
 );
 
+export const selectChartTypeAuthoring = createSelector(
+    [selectExplorerState],
+    (explorer) => explorer.chartTypeAuthoring,
+);
+
 // Authoring only takes over the Explorer in edit mode.
 export const selectIsChartTypeAuthoring = createSelector(
     [selectExplorerState],


### PR DESCRIPTION
## Summary

Behind the `explorer-chart-gallery` feature flag, creating or revising a project chart type no longer leaves the Explorer. From the Choose step, **New** (in the Project section header) and the hover-revealed **Edit** on a project type open the Chart Type Builder in place of the chart, and the chart itself moves onto the type being authored so the sidebar configures it the same way it will afterwards:

- **Author**: the field rail and the query stay put; the right rail stays open on **Configure** for the type being built (bindings, generated options, palette — the existing `DataAppVizConfigTabs`, with Change / Close hidden for the duration); the main area shows the builder workspace from #27940 without its own options column, under a header with the type's name (with the standalone builder's rename / describe pencil), a status chip only while it matters ("Building 0:42", "v3 ready", announced through a live region), the SDK **Upgrade available** offer when the bundle is behind, version history, and **Done**. The preview renders the exact version being built against the Explorer's own results through `buildExplorerVizContext`, using the chart's binding, options and palette, so what the sidebar says is what the preview shows. Every page of rows is fetched, as the chart renderer does.
- **Binding**: a revised type is bound to the chart on entry (auto-mapped unless the chart already uses it); a new type starts as the empty custom config with an explanatory sidebar message and binds once its first version lands ready. The chart card stays mounted for its provider and the sidebar portal, but stops drawing the chart while authoring, so nothing renders twice.
- **Done** is the one way out. With a usable version it ends the session on Configure with the chart using the type (invalidating the render metadata and the gallery list). With nothing built it puts the chart config, pivot and sidebar step back the way they were; a first build still running is discarded, and a type created in this session that never got a usable version is deleted rather than left as an orphan. Abandoning a type that did build is Done, then Change in the rail. Focus lands on the title when authoring starts and returns to the sidebar's title when it ends.
- The header gives way in one place only (the title), so both rails can stay open at laptop widths without clipping the actions. The rail shows the type's name and description while authoring.

The Explorer URL and store are untouched throughout; the standalone `/chart-types/*` page is unchanged and still round-trips with the flag off. The flag stays in `PREVIEW_EXCLUDED_FEATURE_FLAGS`.

Known limits, deliberately out of scope here: the authoring session lives in the store only (a refresh, a table switch or leaving edit mode drops it); a chart with no query results yet previews an empty chart with no hint; the sidebar keeps its "once the first version is ready" message after a failed first build (the canvas explains the failure).

## How to test

1. Enable `explorer-chart-gallery` (a `feature_flag_overrides` row in previews).
2. Open a saved chart in edit mode with results, then Configure → Change → **New** next to "Project": the builder takes the chart's place, the fields stay on the left, the rail shows Configure with the "describe a chart type" message, the page's Save changes / Cancel are disabled, the URL does not change.
3. **Done** with nothing built returns to Choose with the chart as it was. Pick **Edit** on a project type: the rail shows its name, bindings and options, the preview shows the Explorer's rows, the chip says "v1 ready"; the pencil renames it; change a binding in the rail and the preview follows; **Done** lands on Configure with the chart rendering the type.
4. Narrow the window until both rails and the card fit in ~1280px: the title truncates, Done stays in view.
5. Storybook: `pnpm -F frontend storybook` → `Explorer / Chart type authoring` has one story per stage and `Choose Author Configure`, which walks the flow on the real reducers.
6. Flag off: the legacy picker and the standalone builder page behave as on main.

Closes: GLITCH-680
