### PR TITLE
fix(chart-types): align palette control with generated config options

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -216,7 +216,7 @@ export const Series: FC<Props> = ({ items }) => {
 
     return (
         <Stack gap="md">
-            <ColorPaletteSection />
+            <ColorPaletteSection variant="section" />
             <Divider />
             {hasMultipleSeries && (
                 <SeriesDrawOrderBar

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -214,7 +214,7 @@ export const ConfigTabs: FC = memo(() => {
                             setOption(dataAppVizUuid, name, value)
                         }
                         colorPalette={colorPalette}
-                        paletteControl={<ColorPaletteSection />}
+                        paletteControl={<ColorPaletteSection variant="field" />}
                     />
                 ) : (
                     <Text size="xs" c="dimmed">

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
@@ -168,7 +168,7 @@ export const ConfigTabs: FC = memo(() => {
                     label: 'Steps',
                     panel: (
                         <Stack>
-                            <ColorPaletteSection />
+                            <ColorPaletteSection variant="section" />
                             <Config>
                                 <Config.Section>
                                     <Config.Heading>Labels</Config.Heading>

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartSeriesConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartSeriesConfig.tsx
@@ -62,7 +62,7 @@ export const Series: FC = () => {
 
     return (
         <Stack>
-            <ColorPaletteSection />
+            <ColorPaletteSection variant="section" />
             <Config>
                 <Config.Section>
                     <Config.Group>

--- a/packages/frontend/src/components/VisualizationConfigs/common/ColorPaletteSection.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/ColorPaletteSection.test.tsx
@@ -1,0 +1,46 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { ColorPaletteSection } from './ColorPaletteSection';
+
+vi.mock('../../../features/explorer/store', () => ({
+    useExplorerDispatch: () => vi.fn(),
+    useExplorerSelector: (selector: () => unknown) => selector(),
+    selectSavedChart: () => null,
+    selectUnsavedColorPaletteUuid: () => null,
+}));
+
+vi.mock('../../../hooks/appearance/useOrganizationAppearance', () => ({
+    useColorPalettes: () => ({ data: [] }),
+}));
+
+vi.mock('../../../hooks/health/useHealth', () => ({
+    default: () => ({ data: { appearance: { overrideColorPalette: null } } }),
+}));
+
+vi.mock('../../LightdashVisualization/useVisualizationContext', () => ({
+    useVisualizationContext: () => ({
+        pivotDimensions: undefined,
+        itemsMap: undefined,
+    }),
+}));
+
+describe('ColorPaletteSection', () => {
+    it('heads the picker with a section heading in the section variant', () => {
+        renderWithProviders(<ColorPaletteSection variant="section" />);
+
+        // The heading names the section; the input itself carries no label.
+        expect(screen.getByText('Color palette')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('textbox', { name: 'Color palette' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('labels the input itself in the field variant', () => {
+        renderWithProviders(<ColorPaletteSection variant="field" />);
+
+        expect(
+            screen.getByRole('textbox', { name: 'Color palette' }),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/VisualizationConfigs/common/ColorPaletteSection.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/ColorPaletteSection.tsx
@@ -14,7 +14,17 @@ import { PalettePicker } from '../../common/PalettePicker/PalettePicker';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from './Config';
 
-export const ColorPaletteSection: FC = () => {
+type Props = {
+    /**
+     * `section` heads the picker with a config heading, matching the other
+     * sections of a chart config panel. `field` labels the input itself at the
+     * size the surrounding controls use, so the picker reads as one more
+     * option rather than a section of its own.
+     */
+    variant: 'section' | 'field';
+};
+
+export const ColorPaletteSection: FC<Props> = ({ variant }) => {
     const dispatch = useExplorerDispatch();
     const savedChart = useExplorerSelector(selectSavedChart);
     const value = useExplorerSelector(selectUnsavedColorPaletteUuid);
@@ -52,7 +62,9 @@ export const ColorPaletteSection: FC = () => {
     return (
         <Config>
             <Config.Section>
-                <Config.Heading>Color palette</Config.Heading>
+                {variant === 'section' && (
+                    <Config.Heading>Color palette</Config.Heading>
+                )}
                 {overrideActive && (
                     <Callout variant="info">
                         A color palette override is set in your instance
@@ -70,7 +82,8 @@ export const ColorPaletteSection: FC = () => {
                     </Callout>
                 )}
                 <PalettePicker
-                    size="sm"
+                    size={variant === 'section' ? 'sm' : 'xs'}
+                    label={variant === 'field' ? 'Color palette' : undefined}
                     value={value}
                     onChange={(next) =>
                         dispatch(explorerActions.setColorPaletteUuid(next))


### PR DESCRIPTION
In a custom chart type's config tabs, the colour palette control is rendered by the shared `ColorPaletteSection`, which heads itself with a `Config.Heading` and uses a `sm` select. Its neighbours in that tab are the viz's generated option controls, which are `xs` with the input's own label — so the palette showed up as a larger, differently-labelled control in the middle of the list.

`ColorPaletteSection` now takes a `variant`: `section` keeps the heading and size the cartesian/pie/funnel config panels rely on (unchanged), and `field` labels the input itself at the size the surrounding option controls use. The custom-viz tabs pass `field`; everything else passes `section`.

Verified with `pnpm -F frontend typecheck`, `lint`, `format`, and the `DataAppVizConfig` / `ConfigurePanel` tests, plus a new `ColorPaletteSection` test covering both variants.
