### PR TITLE
fix: support Data App dashboard filter scoping

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -1,11 +1,25 @@
 import { subject } from '@casl/ability';
 import {
+    DimensionType,
+    getConditionalRuleLabel,
+    getConditionalRuleLabelFromItem,
+    getFilterTypeFromItemType,
     hashStringToBase36,
     ProjectType,
     type DashboardDataAppTile,
+    type DashboardFilterRule,
+    type FilterableItem,
 } from '@lightdash/common';
-import { Box, Loader, Stack, Text } from '@mantine/core';
-import { IconAppsOff, IconCode } from '@tabler/icons-react';
+import {
+    ActionIcon,
+    Badge,
+    Box,
+    HoverCard,
+    Loader,
+    Stack,
+    Text,
+} from '@mantine/core';
+import { IconAppsOff, IconCode, IconFilter } from '@tabler/icons-react';
 import React, { useMemo, useState, type FC } from 'react';
 import AppIframePreview from '../../features/apps/AppIframePreview';
 import { getVisiblePreviewTokenError } from '../../features/apps/hooks/previewTokenQueryOptions';
@@ -30,6 +44,92 @@ type Props = Pick<
     React.ComponentProps<typeof TileBase>,
     'tile' | 'onEdit' | 'onDelete' | 'isEditMode'
 > & { tile: DashboardDataAppTile };
+
+const DashboardFiltersIndicator: FC<{
+    filterRules: DashboardFilterRule[];
+    filterableItems: Record<string, FilterableItem>;
+}> = ({ filterRules, filterableItems }) => {
+    if (filterRules.length === 0) return null;
+
+    const labelledRules = filterRules.map((filterRule) => {
+        const filterableItem = filterableItems[filterRule.target.fieldId];
+        const labels = filterableItem
+            ? getConditionalRuleLabelFromItem(filterRule, filterableItem)
+            : getConditionalRuleLabel(
+                  filterRule,
+                  getFilterTypeFromItemType(
+                      filterRule.target.fallbackType ?? DimensionType.STRING,
+                  ),
+                  filterRule.label ?? filterRule.target.fieldId,
+              );
+
+        return { filterRule, labels };
+    });
+
+    const availableFiltersLabel = `${filterRules.length} dashboard filter${
+        filterRules.length === 1 ? '' : 's'
+    } available to this Data App`;
+
+    return (
+        <HoverCard
+            withArrow
+            withinPortal
+            shadow="md"
+            position="bottom-end"
+            offset={4}
+            arrowOffset={10}
+        >
+            <HoverCard.Dropdown>
+                <Stack gap="xs" align="flex-start">
+                    <Text c="ldGray.7" fw={500} fz="xs">
+                        Dashboard filter{filterRules.length === 1 ? '' : 's'}{' '}
+                        available to this Data App:
+                    </Text>
+                    {labelledRules.map(({ filterRule, labels }) => (
+                        <Badge
+                            key={filterRule.id}
+                            variant="outline"
+                            color="ldGray.4"
+                            radius="sm"
+                            size="lg"
+                            fz="xs"
+                            fw="normal"
+                            tt="none"
+                        >
+                            <Text fw={600} span inherit c="foreground">
+                                {labels.field}:
+                            </Text>{' '}
+                            {filterRule.disabled ? (
+                                <Text span inherit c="foreground">
+                                    is any value
+                                </Text>
+                            ) : (
+                                <>
+                                    <Text span inherit c="foreground">
+                                        {labels.operator}
+                                    </Text>{' '}
+                                    <Text fw={600} span inherit c="foreground">
+                                        {labels.value}
+                                    </Text>
+                                </>
+                            )}
+                        </Badge>
+                    ))}
+                </Stack>
+            </HoverCard.Dropdown>
+            <HoverCard.Target>
+                <ActionIcon
+                    aria-label={availableFiltersLabel}
+                    size="sm"
+                    variant="subtle"
+                    color="gray"
+                >
+                    <MantineIcon icon={IconFilter} />
+                </ActionIcon>
+            </HoverCard.Target>
+        </HoverCard>
+    );
+};
 
 const DataAppTile: FC<Props> = (props) => {
     const {
@@ -63,10 +163,33 @@ const DataAppTile: FC<Props> = (props) => {
     // whose target field isn't in a given query's explore — an app may
     // query multiple explores.
     const tileDashboardFilters = useDashboardFiltersForTile(uuid);
+    const availableDashboardFilterRules = useMemo(
+        () => [
+            ...tileDashboardFilters.dimensions,
+            ...tileDashboardFilters.metrics,
+            ...tileDashboardFilters.tableCalculations,
+        ],
+        [tileDashboardFilters],
+    );
     const dashboardFiltersForApp = useMemo(
         () => convertDateDashboardFilters(tileDashboardFilters),
         [tileDashboardFilters],
     );
+    const allFilterableFieldsMap = useDashboardContext(
+        (c) => c.allFilterableFieldsMap,
+    );
+    const allFilterableMetricsMap = useDashboardContext(
+        (c) => c.allFilterableMetricsMap,
+    );
+    const filterableItems = useMemo(
+        () => ({ ...allFilterableFieldsMap, ...allFilterableMetricsMap }),
+        [allFilterableFieldsMap, allFilterableMetricsMap],
+    );
+    const hasExtraHeaderElement =
+        (!tileHasComments && !!dashboardComments) ||
+        availableDashboardFilterRules.length > 0;
+    const hasNonMenuHeaderContent =
+        !!dashboardComments || availableDashboardFilterRules.length > 0;
 
     // The dashboard refresh button bumps `refreshCounter` and flips
     // `invalidateCache` (both via `clearCacheAndFetch`). Chart tiles re-fetch
@@ -176,7 +299,18 @@ const DataAppTile: FC<Props> = (props) => {
             visibleHeaderElement={
                 tileHasComments ? dashboardComments : undefined
             }
-            extraHeaderElement={tileHasComments ? undefined : dashboardComments}
+            hasNonMenuHeaderContent={hasNonMenuHeaderContent}
+            extraHeaderElement={
+                hasExtraHeaderElement ? (
+                    <>
+                        {tileHasComments ? undefined : dashboardComments}
+                        <DashboardFiltersIndicator
+                            filterRules={availableDashboardFilterRules}
+                            filterableItems={filterableItems}
+                        />
+                    </>
+                ) : undefined
+            }
             extraMenuItems={editMenuItem}
             {...props}
         >

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -55,6 +55,7 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     children,
     extraHeaderElement,
     visibleHeaderElement,
+    hasNonMenuHeaderContent = false,
     titleHref,
     minimal = false,
     tabs,
@@ -97,7 +98,8 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
 
     const hasMenuContent = isEditMode || !!extraMenuItems;
     const isVerified = verification !== null && verification !== undefined;
-    const hasHeaderContent = hasMenuContent || isVerified;
+    const hasHeaderContent =
+        hasMenuContent || isVerified || hasNonMenuHeaderContent;
 
     return (
         <div ref={containerRef} className={styles.tileWrapper}>

--- a/packages/frontend/src/components/DashboardTiles/TileBase/types.ts
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/types.ts
@@ -24,6 +24,7 @@ export type TileBaseProps<T> = {
     children?: ReactNode;
     extraHeaderElement?: ReactNode;
     visibleHeaderElement?: ReactNode;
+    hasNonMenuHeaderContent?: boolean;
     minimal?: boolean;
     tabs?: DashboardTab[];
     lockHeaderVisibility?: boolean;

--- a/packages/frontend/src/components/common/Filters/utils/getAutocompleteFilterGroup.test.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getAutocompleteFilterGroup.test.ts
@@ -220,6 +220,59 @@ describe('getAutocompleteFilterGroup', () => {
         expect(filterIds).toContain(isCompletedFilter.id);
     });
 
+    it('does not use a Data App as proof that filters share a query', () => {
+        const dataAppTile = {
+            uuid: 'data-app-a1',
+            type: DashboardTileTypes.DATA_APP,
+            x: 0,
+            y: 0,
+            h: 1,
+            w: 1,
+            tabUuid: TAB_A_UUID,
+            properties: {
+                appUuid: 'app-a1',
+                title: 'Data App A1',
+            },
+        } satisfies DashboardTile;
+        const currentFilter: DashboardFilterRule = {
+            ...paymentMethodFilter,
+            tileTargets: {
+                'tile-a1': {
+                    fieldId: 'payments_payment_method',
+                    tableName: 'payments',
+                },
+                'tile-a2': false,
+            },
+        };
+        const otherFilter: DashboardFilterRule = {
+            ...isCompletedFilter,
+            tileTargets: {
+                'tile-a1': false,
+                'tile-a2': {
+                    fieldId: 'orders_is_completed',
+                    tableName: 'orders',
+                },
+            },
+        };
+
+        const result = getAutocompleteFilterGroup({
+            filterId: currentFilter.id,
+            item: makeField('payments_payment_method', 'payments'),
+            dashboardFilters: {
+                dimensions: [currentFilter, otherFilter],
+                metrics: [],
+                tableCalculations: [],
+            },
+            dashboardTiles: [tileA1, tileA2, dataAppTile],
+            filterableFieldsByTileUuid,
+            activeTabUuid: TAB_A_UUID,
+        });
+
+        expect(result?.and.map((filter) => filter.id)).not.toContain(
+            otherFilter.id,
+        );
+    });
+
     it('works without tabs (activeTabUuid undefined)', () => {
         // When there are no tabs, all tiles are considered for overlap.
         // is_completed applies to tile-b1/b2, payment_method applies to all,

--- a/packages/frontend/src/components/common/Filters/utils/getAutocompleteFilterGroup.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getAutocompleteFilterGroup.ts
@@ -1,5 +1,6 @@
 import {
     getItemId,
+    isDashboardDataAppTileType,
     isField,
     type AndFilterGroup,
     type DashboardFilterableField,
@@ -40,13 +41,17 @@ export const getAutocompleteFilterGroup = ({
         (f) => f.id === filterId,
     );
 
-    // Only consider tiles on the active tab when checking overlap.
+    // Only chart tiles can prove that two filters overlap on a shared query.
+    // Data Apps choose their fields at runtime, so treating one as a shared
+    // target would make otherwise independent filters constrain each other's
+    // autocomplete values.
     // Without this, tab-scoped filters from other tabs leak into
     // autocomplete queries via tile overlap on those other tabs.
-    const tilesForOverlapCheck =
-        activeTabUuid && dashboardTiles
-            ? dashboardTiles.filter((tile) => tile.tabUuid === activeTabUuid)
-            : dashboardTiles;
+    const tilesForOverlapCheck = dashboardTiles?.filter(
+        (tile) =>
+            !isDashboardDataAppTileType(tile) &&
+            (!activeTabUuid || tile.tabUuid === activeTabUuid),
+    );
 
     // Get tiles that the current filter applies to
     const currentFilterTileUuids =

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -1,6 +1,7 @@
 import {
     getItemId,
     isDashboardChartTileType,
+    isDashboardDataAppTileType,
     isDashboardFieldTarget,
     isDashboardSqlChartTile,
     matchFieldByType,
@@ -26,7 +27,11 @@ import {
     Tooltip,
     type PopoverProps,
 } from '@mantine/core';
-import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
+import {
+    IconAppWindow,
+    IconChevronDown,
+    IconChevronRight,
+} from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import FieldSelect from '../../../components/common/FieldSelect';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -65,6 +70,26 @@ type TileWithTargetColumns = {
     tabUuid?: string | null;
     hasExactMatch: boolean;
 };
+
+type DataAppTileTarget = {
+    targetType: 'dataApp';
+    key: string;
+    label: string;
+    checked: boolean;
+    disabled: false;
+    invalidField: undefined;
+    tileUuid: string;
+    tileChartKind: undefined;
+    sortedFilters: undefined;
+    selectedField: undefined;
+    tabUuid: string | null;
+    hasExactMatch: true;
+};
+
+type TileTarget =
+    | TileWithTargetFields
+    | TileWithTargetColumns
+    | DataAppTileTarget;
 
 type Props = {
     tiles: DashboardTile[];
@@ -303,7 +328,30 @@ const TileFilterConfiguration: FC<Props> = ({
             [],
         );
 
-        return [...tileWithTargetFields, ...tileWithTargetColumns];
+        const dataAppTileTargets = tiles
+            .filter(isDashboardDataAppTileType)
+            .map<DataAppTileTarget>((tile) => ({
+                targetType: 'dataApp',
+                key: tile.uuid,
+                label: tile.properties.title,
+                checked:
+                    getFilterTileRelation(filterRule, tile.uuid).relation !==
+                    'disabled',
+                disabled: false,
+                invalidField: undefined,
+                tileUuid: tile.uuid,
+                tileChartKind: undefined,
+                sortedFilters: undefined,
+                selectedField: undefined,
+                tabUuid: tile.tabUuid ?? null,
+                hasExactMatch: true,
+            }));
+
+        return [
+            ...tileWithTargetFields,
+            ...tileWithTargetColumns,
+            ...dataAppTileTargets,
+        ];
     }, [
         sortedTileWithFilters,
         sqlChartTilesMetadata,
@@ -324,7 +372,7 @@ const TileFilterConfiguration: FC<Props> = ({
         label,
         disabled,
     }: {
-        tileList: Array<TileWithTargetFields | TileWithTargetColumns>;
+        tileList: TileTarget[];
         tabUuid: string;
         tabName: string;
         label: string;
@@ -342,7 +390,7 @@ const TileFilterConfiguration: FC<Props> = ({
         const selectedCount = tileList.filter((tile) => tile.checked).length;
 
         const getTooltipLabel = () => {
-            if (disabled) return 'No chart tiles in this tab';
+            if (disabled) return 'No tiles in this tab';
             if (!hasAnyExactMatch && !shouldBeChecked)
                 return 'No tiles in this tab have an exact field match';
             if (shouldBeChecked)
@@ -417,7 +465,7 @@ const TileFilterConfiguration: FC<Props> = ({
         tileList,
         isNested = false,
     }: {
-        tileList: Array<TileWithTargetFields | TileWithTargetColumns>;
+        tileList: TileTarget[];
         isNested?: boolean;
     }) => {
         if (tileList.length === 0) {
@@ -428,7 +476,7 @@ const TileFilterConfiguration: FC<Props> = ({
                     mt={isNested ? 'lg' : undefined}
                     ml={isNested ? 22 : undefined}
                 >
-                    No chart tiles in this tab
+                    No tiles in this tab
                 </Text>
             );
         }
@@ -469,9 +517,14 @@ const TileFilterConfiguration: FC<Props> = ({
                                             <Flex align="center" gap="xxs">
                                                 <MantineIcon
                                                     color="blue.6"
-                                                    icon={getChartIcon(
-                                                        value.tileChartKind,
-                                                    )}
+                                                    icon={
+                                                        value.targetType ===
+                                                        'dataApp'
+                                                            ? IconAppWindow
+                                                            : getChartIcon(
+                                                                  value.tileChartKind,
+                                                              )
+                                                    }
                                                 />
                                                 <Text
                                                     fz="sm"
@@ -653,7 +706,7 @@ const TileFilterConfiguration: FC<Props> = ({
                         {isIndeterminate
                             ? ` (${
                                   tileTargetList.filter((v) => v.checked).length
-                              } charts selected)`
+                              } tiles selected)`
                             : ''}
                     </Text>
                 }

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
@@ -1,9 +1,11 @@
 import {
     DimensionType,
+    DashboardTileTypes,
     FieldType,
     FilterOperator,
     type DashboardFilterableField,
     type DashboardFilterRule,
+    type DashboardTile,
 } from '@lightdash/common';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -358,5 +360,70 @@ describe('FilterConfiguration', () => {
         expect(requiredSwitch).toBeEnabled();
         expect(requiredSwitch).not.toBeChecked();
         expect(screen.getByText('Required')).toBeInTheDocument();
+    });
+
+    it('allows excluding and restoring a Data App tile filter target', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const onSave = vi.fn();
+        const activeRule: DashboardFilterRule = {
+            ...anyValueRule,
+            values: ['Adam'],
+            disabled: false,
+        };
+        const dataAppTile = {
+            uuid: 'data-app-tile-1',
+            type: DashboardTileTypes.DATA_APP,
+            x: 0,
+            y: 0,
+            h: 1,
+            w: 1,
+            tabUuid: null,
+            properties: {
+                appUuid: 'data-app-1',
+                title: 'Customer data app',
+            },
+        } satisfies DashboardTile;
+
+        renderWithProviders(
+            <FilterConfiguration
+                isEditMode
+                tiles={[dataAppTile]}
+                tabs={[]}
+                availableTileFilters={{}}
+                field={mockField}
+                defaultFilterRule={activeRule}
+                originalFilterRule={activeRule}
+                onSave={onSave}
+            />,
+        );
+
+        await user.click(screen.getByRole('tab', { name: 'Tiles' }));
+
+        const dataAppCheckbox = screen.getByRole('checkbox', {
+            name: 'Customer data app',
+        });
+        expect(dataAppCheckbox).toBeEnabled();
+        expect(dataAppCheckbox).toBeChecked();
+
+        await user.click(dataAppCheckbox);
+        fireEvent.mouseDown(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+        expect(onSave).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                tileTargets: { 'data-app-tile-1': false },
+            }),
+        );
+
+        await user.click(screen.getByRole('tab', { name: 'Tiles' }));
+        await user.click(
+            screen.getByRole('checkbox', { name: 'Customer data app' }),
+        );
+        fireEvent.mouseDown(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => expect(onSave).toHaveBeenCalledTimes(2));
+        expect(onSave).toHaveBeenLastCalledWith(
+            expect.objectContaining({ tileTargets: {} }),
+        );
     });
 });

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -7,6 +7,7 @@ import {
     getFilterTypeFromItem,
     getFilterTypeFromItemType,
     getItemId,
+    isDashboardDataAppTileType,
     isField,
     isFilterableField,
     matchFieldByType,
@@ -264,6 +265,14 @@ const FilterConfiguration: FC<Props> = ({
 
                 switch (action) {
                     case FilterActions.ADD: {
+                        const tile = tiles.find(
+                            ({ uuid }) => uuid === tileUuid,
+                        );
+                        if (tile && isDashboardDataAppTileType(tile)) {
+                            delete draftState.tileTargets[tileUuid];
+                            return draftState;
+                        }
+
                         let target: DashboardFieldTarget | undefined =
                             newTarget;
 
@@ -320,6 +329,7 @@ const FilterConfiguration: FC<Props> = ({
             setDraftFilterRule,
             draftFilterRule,
             sqlChartTilesMetadata,
+            tiles,
         ],
     );
 
@@ -327,27 +337,34 @@ const FilterConfiguration: FC<Props> = ({
         (checked: boolean, targetTileUuids: string[]) => {
             if (!checked) {
                 const newFilterRule = produce(draftFilterRule, (draftState) => {
-                    if (!draftState || !selectedField) return;
+                    if (!draftState) return;
 
-                    Object.entries(availableTileFilters).forEach(
-                        ([tileUuid]) => {
-                            if (
-                                !draftState.tileTargets ||
-                                !targetTileUuids.includes(tileUuid)
-                            )
-                                return;
-                            draftState.tileTargets[tileUuid] = false;
-                        },
-                    );
+                    draftState.tileTargets = draftState.tileTargets ?? {};
+                    targetTileUuids.forEach((tileUuid) => {
+                        if (!draftState.tileTargets) return;
+                        draftState.tileTargets[tileUuid] = false;
+                    });
                     return draftState;
                 });
 
                 setDraftFilterRule(newFilterRule);
             } else {
                 const newFilterRule = produce(draftFilterRule, (draftState) => {
-                    if (!draftState || !selectedField) return;
+                    if (!draftState) return;
+
+                    draftState.tileTargets = draftState.tileTargets ?? {};
                     targetTileUuids.forEach((tileUuid) => {
                         if (!draftState.tileTargets) return;
+
+                        const tile = tiles.find(
+                            ({ uuid }) => uuid === tileUuid,
+                        );
+                        if (tile && isDashboardDataAppTileType(tile)) {
+                            delete draftState.tileTargets[tileUuid];
+                            return;
+                        }
+
+                        if (!selectedField) return;
                         draftState.tileTargets[tileUuid] = {
                             fieldId: getItemId(selectedField),
                             tableName: selectedField.table,
@@ -359,12 +376,7 @@ const FilterConfiguration: FC<Props> = ({
                 setDraftFilterRule(newFilterRule);
             }
         },
-        [
-            selectedField,
-            availableTileFilters,
-            setDraftFilterRule,
-            draftFilterRule,
-        ],
+        [selectedField, setDraftFilterRule, draftFilterRule, tiles],
     );
 
     const handleApply = useCallback(() => {
@@ -428,7 +440,7 @@ const FilterConfiguration: FC<Props> = ({
                         <Tooltip
                             label={
                                 tabs.length > 1
-                                    ? 'Select which tabs and chart tiles this filter applies to'
+                                    ? 'Select which tabs and tiles this filter applies to'
                                     : 'Select tiles to apply filter to and which field to filter by'
                             }
                             position="top-start"
@@ -437,9 +449,7 @@ const FilterConfiguration: FC<Props> = ({
                                 value={FilterTabs.TILES}
                                 disabled={!draftFilterRule}
                             >
-                                {tabs.length > 1
-                                    ? 'Tabs & chart tiles'
-                                    : 'Chart tiles'}
+                                {tabs.length > 1 ? 'Tabs & tiles' : 'Tiles'}
                             </Tabs.Tab>
                         </Tooltip>
                     </Tabs.List>

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/utils/index.test.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/utils/index.test.ts
@@ -46,6 +46,21 @@ const createMockTile = (uuid: string, tabUuid?: string): DashboardTile =>
         },
     }) satisfies DashboardTile;
 
+const createMockDataAppTile = (uuid: string, tabUuid?: string): DashboardTile =>
+    ({
+        uuid,
+        type: DashboardTileTypes.DATA_APP,
+        x: 0,
+        y: 0,
+        h: 1,
+        w: 1,
+        tabUuid,
+        properties: {
+            appUuid: 'app-1',
+            title: `Data App ${uuid}`,
+        },
+    }) satisfies DashboardTile;
+
 // Helper to create mock filterable fields
 const createMockFilterableField = (
     fieldId: string,
@@ -123,6 +138,13 @@ describe('getFilterTileRelation', () => {
 describe('doesFilterApplyToTile', () => {
     const tile1 = createMockTile('tile-1', 'tab-1');
     const tile2 = createMockTile('tile-2', 'tab-2');
+
+    it('applies auto-targeted filters to Data App tiles with runtime query fields', () => {
+        const filterRule = createMockFilterRule({ tileTargets: undefined });
+        const dataAppTile = createMockDataAppTile('data-app-1', 'tab-1');
+
+        expect(doesFilterApplyToTile(filterRule, dataAppTile, {})).toBe(true);
+    });
 
     it('should return true when no tileTargets and tile has the filter field', () => {
         const filterRule = createMockFilterRule({ tileTargets: undefined });
@@ -268,6 +290,30 @@ describe('getTabsForFilterRule', () => {
         // tile-1 has field (tab-1), tile-3 has field (tab-2)
         // tile-2, tile-4 don't have field so tab-3 is excluded
         expect(result).toEqual(['tab-1', 'tab-2']);
+    });
+
+    it('includes a Data App tab by default and removes it when explicitly excluded', () => {
+        const dataAppTile = createMockDataAppTile('data-app-1', 'tab-2');
+
+        expect(
+            getTabsForFilterRule(
+                createMockFilterRule({ tileTargets: undefined }),
+                [dataAppTile],
+                sortedTabUuids,
+                {},
+            ),
+        ).toEqual(['tab-2']);
+
+        expect(
+            getTabsForFilterRule(
+                createMockFilterRule({
+                    tileTargets: { 'data-app-1': false },
+                }),
+                [dataAppTile],
+                sortedTabUuids,
+                {},
+            ),
+        ).toEqual([]);
     });
 
     it('should return empty when no tileTargets and no tiles have the field', () => {

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/utils/index.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/utils/index.ts
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     FilterOperator,
     getItemId,
+    isDashboardDataAppTileType,
     isDashboardFieldTarget,
     type DashboardFieldTarget,
     type DashboardFilterableField,
@@ -99,6 +100,8 @@ export const doesFilterApplyToTile = (
 
     switch (relation) {
         case 'auto':
+            if (isDashboardDataAppTileType(tile)) return true;
+
             // Filter automatically applies to tiles that have the field
             return tileHasFilterField(
                 filterRule,

--- a/packages/frontend/src/features/scheduler/utils/filterRequirements.test.ts
+++ b/packages/frontend/src/features/scheduler/utils/filterRequirements.test.ts
@@ -1,4 +1,5 @@
 import {
+    DashboardTileTypes,
     DimensionType,
     FieldType,
     FilterOperator,
@@ -292,6 +293,57 @@ describe('getSchedulerFilterRequirements tab scoping', () => {
                 { ...automaticScope, selectedTabs: ['tab-1'] },
             ).filtersWithUnmetRequirements.map((filter) => filter.id),
         ).toEqual(['automatic']);
+    });
+
+    it('keeps a Data App filter requirement until the tile is explicitly excluded', () => {
+        const dataAppTile = {
+            uuid: 'data-app-1',
+            type: DashboardTileTypes.DATA_APP,
+            x: 0,
+            y: 0,
+            h: 1,
+            w: 1,
+            tabUuid: 'tab-2',
+            properties: {
+                appUuid: 'app-1',
+                title: 'Data App 1',
+            },
+        } satisfies DashboardTile;
+        const scope: SchedulerTabScope = {
+            tiles: [tile('tile-1', 'tab-1'), dataAppTile],
+            tabUuids: ['tab-1', 'tab-2'],
+            selectedTabs: ['tab-2'],
+            filterableFieldsByTileUuid: {
+                'tile-1': [field('automatic')],
+                'data-app-1': [],
+            },
+        };
+        const automaticFilter = rule({
+            id: 'automatic',
+            required: true,
+            tileTargets: undefined,
+        });
+
+        expect(
+            getSchedulerFilterRequirements(
+                dashboardFilters([automaticFilter]),
+                [],
+                scope,
+            ).filtersWithUnmetRequirements.map((filter) => filter.id),
+        ).toEqual(['automatic']);
+
+        expect(
+            getSchedulerFilterRequirements(
+                dashboardFilters([
+                    {
+                        ...automaticFilter,
+                        tileTargets: { 'data-app-1': false },
+                    },
+                ]),
+                [],
+                scope,
+            ).filtersWithUnmetRequirements,
+        ).toEqual([]);
     });
 
     it('scopes nothing out while the tiles filterable fields are unknown', () => {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-10148/dashboard-filters-data-app-tiles-cant-be-scoped-or-excluded-from

## Summary

- show Data App tiles in dashboard filter target controls and allow them to be excluded or restored
- apply non-excluded dashboard filters to Data App runtime queries and expose the available filters in the tile header
- preserve tab, scheduler, and autocomplete semantics for runtime-selected Data App fields


## Validation

- `pnpm -F frontend typecheck`
- focused Vitest coverage: 4 files, 58 tests passed
- Oxlint, Oxfmt, and `git diff --check`
- commit hooks: frontend lint/format, secret scan, and unused-export check

## Live localhost validation

Validated against the real F1 2026 Season Overview Data App on localhost:3000 using a non-persistent browser response fixture:

- with the tile included, the real `dim_driver_standings` metric query received the dashboard filter Driver = Kimi Antonelli
- with the tile explicitly excluded, the same query received an empty `dashboardFilters.dimensions` array
- the excluded refresh issued four real metric queries and all returned HTTP 200; the standalone baseline also returned four HTTP 200 responses
- verified the filter indicator and exclude/restore controls in the UI
- removed the browser fixture afterward; no dashboard or database records were saved

## Regression safeguards

- Data Apps are excluded from static autocomplete-overlap inference because their query fields are chosen at runtime
- shared tile-header behavior is gated by an explicit non-menu-content flag
- scheduler tab scoping retains auto-targeted Data App filters until the tile is explicitly excluded