### PR TITLE
fix: allow Google Sheets export from charts

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3401,6 +3401,7 @@ export default class SchedulerTask {
                 metricQuery,
                 context: QueryExecutionContext.GSHEETS,
                 pivotConfiguration,
+                parameters: payload.parameters,
             },
             SCHEDULER_POLLING_OPTIONS,
         );

--- a/packages/common/src/types/gdrive.ts
+++ b/packages/common/src/types/gdrive.ts
@@ -1,4 +1,5 @@
 import { type MetricQueryResponse } from './metricQuery';
+import { type ParametersValuesMap } from './parameters';
 import { type PivotConfig } from './pivot';
 import { type TraceTaskBase } from './scheduler';
 
@@ -20,6 +21,7 @@ export type UploadMetricGsheet = {
     customLabels?: CustomLabel;
     hiddenFields?: string[];
     pivotConfig?: PivotConfig;
+    parameters?: ParametersValuesMap;
 };
 
 export type GsheetColumnType =

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -187,6 +187,8 @@ const ExportGoogleSheet: FC<ExportGoogleSheetProps> = ({
     savedChart,
     disabled,
 }) => {
+    const parameterValues = useDashboardContext((c) => c.parameterValues);
+
     const getGsheetLink = async () => {
         return uploadGsheet({
             projectUuid: savedChart.projectUuid,
@@ -201,6 +203,7 @@ const ExportGoogleSheet: FC<ExportGoogleSheetProps> = ({
             ),
             hiddenFields: getHiddenTableFields(savedChart.chartConfig),
             pivotConfig: getPivotConfig(savedChart),
+            parameters: parameterValues,
         });
     };
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -15,6 +15,7 @@ import {
     selectIsEditMode,
     selectIsResultsExpanded,
     selectMetricQuery,
+    selectParameters,
     selectSavedChart,
     selectSorts,
     selectTableName,
@@ -57,6 +58,7 @@ const ResultsCard: FC = memo(() => {
     const sorts = useExplorerSelector(selectSorts);
     const metricQuery = useExplorerSelector(selectMetricQuery);
     const columnOrder = useExplorerSelector(selectColumnOrder);
+    const parameters = useExplorerSelector(selectParameters);
 
     // Check if grouped view is available
     const { isGroupedDisabled } = useGroupedResultsAvailability();
@@ -106,6 +108,7 @@ const ResultsCard: FC = memo(() => {
                 metricQuery,
                 columnOrder,
                 showTableNames: true,
+                parameters,
                 // No pivotConfig - ResultsCard only shows raw table data
             });
         } else {

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -403,6 +403,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
                     unsavedChartVersion.chartConfig,
                 ),
                 pivotConfig: getPivotConfig(unsavedChartVersion),
+                parameters: unsavedChartVersion.parameters,
             });
             return gsheetResponse;
         }


### PR DESCRIPTION
Closes: #27742

One-off **Export to Google Sheets** (explore, saved chart, dashboard tile) ran the warehouse query without the parameter values selected in the UI. Filters already flowed through; parameters silently fell back to explore defaults. CSV/XLSX were already correct.

This was easy to miss: the sheet looked valid, just used the wrong parameter.

**What changed**

- Frontend `uploadGsheet` payloads now send current parameter values:
  - Explorer results: `selectParameters`
  - Explorer chart: `unsavedChartVersion.parameters`
  - Dashboard tile: dashboard `parameterValues`
- `UploadMetricGsheet` accepts optional `parameters` (`ParametersValuesMap`).
- The scheduler GSheets job passes `payload.parameters` into `executeMetricQueryAndGetResults`, so the worker uses the same values the UI showed.

### Verification:

**Root cause (API)**

One-off export uses `POST /api/v1/gdrive/upload-gsheet`. Before this change, the request body (`UploadMetricGsheet`) had `metricQuery`, filters, pivot config, etc., but **no `parameters`**. The worker therefore compiled the explore with default parameter values.

After this change, the same request includes `parameters` when the UI has any selected. In DevTools → Network, the `upload-gsheet` payload should look like:

```json
{
    "projectUuid": "...",
    "exploreId": "...",
    "metricQuery": {...},
    "columnOrder": [...],
    "showTableNames": true,
    "parameters": {...}
}