### PR TITLE
fix(frontend): update step progress test expectations

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
@@ -26,6 +26,7 @@ describe('getStreamToolCallPart', () => {
             },
             toolResult: null,
             isPreliminary: undefined,
+            isArgsPartial: false,
         });
     });
 
@@ -59,6 +60,7 @@ describe('getStreamToolCallPart', () => {
             },
             toolResult: output,
             isPreliminary: false,
+            isArgsPartial: false,
         });
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
@@ -90,7 +90,12 @@ describe('getStepProgressFromChunk', () => {
                 },
                 transient: true,
             }),
-        ).toEqual({ message: 'Cloning project', toolName: 'editDbtProject' });
+        ).toEqual({
+            message: 'Cloning project',
+            toolName: 'editDbtProject',
+            progressId: null,
+            progressStatus: null,
+        });
     });
 
     it('parses progress data chunks without a tool name (toolName null)', () => {
@@ -100,7 +105,12 @@ describe('getStepProgressFromChunk', () => {
                 data: { message: 'Running your query...' },
                 transient: true,
             }),
-        ).toEqual({ message: 'Running your query...', toolName: null });
+        ).toEqual({
+            message: 'Running your query...',
+            toolName: null,
+            progressId: null,
+            progressStatus: null,
+        });
     });
 
     it('ignores unrelated chunks', () => {


### PR DESCRIPTION
Fixes SPK-1359

PR #27879 added `progressId` and `progressStatus` to `getStepProgressFromChunk` without updating this test. Main's own workflows do not run the frontend unit suite, so every open PR now fails Build & Test on these two assertions. This adds the two nullable fields to the expected objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)