### PR TITLE
fix(data-apps): interaction hygiene rules for generated vizes

### DIFF
--- a/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
+++ b/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
@@ -229,6 +229,28 @@ exactly ONE source row and ONE metric-slot field, and only when
 show each action on its own flag (a viewer may have one permission but not
 the other).
 
+### Interaction hygiene
+
+One floating surface at a time, and no leftover emphasis — native Lightdash
+charts show a menu OR a tooltip, never both, and clicking leaves no mark
+highlighted:
+
+- **Opening the action menu closes the tooltip.** Drive tooltip visibility
+  from your own state (recharts: gate `<Tooltip>` via controlled props or a
+  wrapper's visibility; echarts: `dispatchAction({ type: 'hideTip' })` on
+  click). While the menu is open the tooltip stays hidden, and it must not
+  reappear until the pointer moves again after the menu closes.
+- **No persistent focus or active styling on a clicked mark.** Disable click
+  emphasis (recharts: no `activeShape` on click state; echarts: turn off
+  lingering `emphasis`/`select`) and blur any focused SVG node after opening
+  the menu. Only hover may emphasise, and only while hovering.
+- **Subtle hover, no cursor band.** The library-default full-height band
+  behind the hovered mark (recharts `<Tooltip cursor>`) is not native
+  behaviour — use `cursor={false}` or a faint theme-token fill.
+- **Tooltips are themed and deduplicated.** Background, text and border come
+  from the theme tokens (never library-default white), and each value appears
+  once: one line per series actually under the pointer.
+
 ## The declaration
 
 Alongside the component you emit one structured declaration — as **structured output, not a
@@ -364,4 +386,6 @@ Finally, if any mark maps to exactly one source row, the data-point action
 menu is wired: each interactive datum carries `sourceRow`, the underlying-data
 action is gated on `underlyingData.enabled`, and the drill action is gated on
 `drillDown.enabled`. Omitting the menu on a chart whose marks satisfy
-provenance is a defect, not a simplification.
+provenance is a defect, not a simplification. Then click a mark mentally:
+the tooltip closes, nothing stays highlighted, and only the menu remains —
+one floating surface at a time.


### PR DESCRIPTION
## Summary

Testing viz drill-down surfaced interaction pile-ups in generated vizes that native Lightdash charts don't have: clicking a mark opened the data-point action menu while the hover tooltip stayed visible beneath it, the clicked mark kept focus/active emphasis, the default recharts cursor painted a full-height band behind hovered marks, and tooltips rendered library-default white regardless of theme.

Adds an **Interaction hygiene** subsection to the reusable-visualization skill (the generation-time contract for `data_app_viz`): one floating surface at a time (menu open ⇒ tooltip dismissed until the pointer moves again), no persistent focus/active styling after click, no default cursor band, themed + deduplicated tooltips. The final-pass checklist gains a matching check.

Prose steers the generation agent but is probabilistic per build; a follow-up worth discussing separately is an SDK primitive owning the menu/tooltip choreography so generated code consumes it instead of reimplementing it (tracked in the ticket).

Takes effect for newly generated vizes once sandbox templates rebuild with this skill text.

Closes: GLITCH-690

🤖 Generated with [Claude Code](https://claude.com/claude-code)
