### PR TITLE
fix(frontend): align custom visualization controls

### DIFF
--- a/packages/frontend/sdk/index.test.tsx
+++ b/packages/frontend/sdk/index.test.tsx
@@ -390,6 +390,7 @@ describe('SDK AI agent', () => {
 
     it('calls onThreadChange for matching embed AI agent thread messages', async () => {
         const onThreadChange = vi.fn();
+        const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
         const { container } = render(
             <AiAgent
                 token={mockToken}
@@ -410,6 +411,13 @@ describe('SDK AI agent', () => {
             window.location.origin,
         );
 
+        await waitFor(() =>
+            expect(addEventListenerSpy).toHaveBeenCalledWith(
+                'message',
+                expect.any(Function),
+            ),
+        );
+
         window.dispatchEvent(
             new MessageEvent('message', {
                 origin: mockInstanceUrl,
@@ -425,10 +433,8 @@ describe('SDK AI agent', () => {
             }),
         );
 
-        await waitFor(() => {
-            expect(onThreadChange).toHaveBeenCalledWith({
-                threadUuid: 'test-thread-uuid',
-            });
+        expect(onThreadChange).toHaveBeenCalledExactlyOnceWith({
+            threadUuid: 'test-thread-uuid',
         });
     });
 });

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.test.tsx
@@ -217,7 +217,7 @@ describe('CreateProjectConnection in-flight job recovery', () => {
         expect(
             calls.filter(({ url }) => url === CREATE_PROJECT_URL),
         ).toHaveLength(1);
-    });
+    }, 10_000);
 
     it('shows an informational conflict without registering another active job', async () => {
         const message =

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionControl.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionControl.test.tsx
@@ -13,6 +13,46 @@ const textOption: DataAppVizConfigOption = {
 };
 
 describe('DataAppVizOptionControl', () => {
+    it.each([
+        {
+            option: {
+                name: 'layout',
+                label: 'Layout',
+                type: 'select',
+                choices: [{ value: 'vertical', label: 'Vertical' }],
+                default: 'vertical',
+            } satisfies DataAppVizConfigOption,
+            value: 'vertical',
+        },
+        {
+            option: {
+                name: 'fontSize',
+                label: 'Font size',
+                type: 'number',
+                default: 12,
+            } satisfies DataAppVizConfigOption,
+            value: 12,
+        },
+        { option: textOption, value: 'Untitled' },
+    ])(
+        'aligns the $option.type control with its label',
+        ({ option, value }) => {
+            renderWithProviders(
+                <DataAppVizOptionControl
+                    option={option}
+                    value={value}
+                    onChange={vi.fn()}
+                />,
+            );
+
+            expect(
+                screen
+                    .getByText(option.label)
+                    .closest('[data-data-app-viz-control-row]'),
+            ).toBeInTheDocument();
+        },
+    );
+
     it('debounces text edits rather than pushing every keystroke', async () => {
         vi.useFakeTimers();
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionControl.tsx
@@ -10,6 +10,7 @@ import { useState, type FC } from 'react';
 import { NumberInput } from '../../common/NumberInput';
 import ColorSelector from '../ColorSelector';
 import { Config } from '../common/Config';
+import { DATA_APP_VIZ_CONTROL_WIDTH } from './dataAppVizControlLayout';
 
 // Free-text and colour edits fire continuously while typing / dragging, so
 // they're debounced before reaching chart state (and the iframe re-render).
@@ -68,14 +69,19 @@ const SelectOptionControl: FC<{
     value: string;
     onChange: (value: string) => void;
 }> = ({ option, value, onChange }) => (
-    <Select
-        size="xs"
-        label={option.label}
-        data={option.choices}
-        value={value}
-        allowDeselect={false}
-        onChange={(next) => onChange(next ?? option.default)}
-    />
+    <Config.Group wrap="nowrap" data-data-app-viz-control-row>
+        <Config.Label>{option.label}</Config.Label>
+        <Select
+            size="xs"
+            aria-label={option.label}
+            data={option.choices}
+            value={value}
+            w={DATA_APP_VIZ_CONTROL_WIDTH}
+            miw={DATA_APP_VIZ_CONTROL_WIDTH}
+            allowDeselect={false}
+            onChange={(next) => onChange(next ?? option.default)}
+        />
+    </Config.Group>
 );
 
 const NumberOptionControl: FC<{
@@ -83,15 +89,20 @@ const NumberOptionControl: FC<{
     value: number;
     onChange: (value: number) => void;
 }> = ({ option, value, onChange }) => (
-    <NumberInput
-        size="xs"
-        label={option.label}
-        value={value}
-        min={option.min}
-        max={option.max}
-        decimalScale="unlimited"
-        onNumberChange={(next) => onChange(next ?? option.default)}
-    />
+    <Config.Group wrap="nowrap" data-data-app-viz-control-row>
+        <Config.Label>{option.label}</Config.Label>
+        <NumberInput
+            size="xs"
+            aria-label={option.label}
+            value={value}
+            min={option.min}
+            max={option.max}
+            w={DATA_APP_VIZ_CONTROL_WIDTH}
+            miw={DATA_APP_VIZ_CONTROL_WIDTH}
+            decimalScale="unlimited"
+            onNumberChange={(next) => onChange(next ?? option.default)}
+        />
+    </Config.Group>
 );
 
 const TextOptionControl: FC<{
@@ -101,12 +112,17 @@ const TextOptionControl: FC<{
 }> = ({ option, value, onChange }) => {
     const draft = usePendingEdit(value, onChange);
     return (
-        <TextInput
-            size="xs"
-            label={option.label}
-            value={draft.current}
-            onChange={(event) => draft.edit(event.currentTarget.value)}
-        />
+        <Config.Group wrap="nowrap" data-data-app-viz-control-row>
+            <Config.Label>{option.label}</Config.Label>
+            <TextInput
+                size="xs"
+                aria-label={option.label}
+                value={draft.current}
+                w={DATA_APP_VIZ_CONTROL_WIDTH}
+                miw={DATA_APP_VIZ_CONTROL_WIDTH}
+                onChange={(event) => draft.edit(event.currentTarget.value)}
+            />
+        </Config.Group>
     );
 };
 

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizPaletteControl.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizPaletteControl.tsx
@@ -1,0 +1,30 @@
+import { type OrganizationColorPalette } from '@lightdash/common';
+import { Box } from '@mantine/core';
+import { type FC } from 'react';
+import { PalettePicker } from '../../common/PalettePicker/PalettePicker';
+import { Config } from '../common/Config';
+import { DATA_APP_VIZ_CONTROL_WIDTH } from './dataAppVizControlLayout';
+
+type Props = {
+    value: string | null;
+    onChange: (value: string | null) => void;
+    palettes: OrganizationColorPalette[];
+};
+
+const DataAppVizPaletteControl: FC<Props> = ({ value, onChange, palettes }) => (
+    <Config.Group wrap="nowrap" data-data-app-viz-control-row>
+        <Config.Label>Color palette</Config.Label>
+        <Box w={DATA_APP_VIZ_CONTROL_WIDTH} miw={DATA_APP_VIZ_CONTROL_WIDTH}>
+            <PalettePicker
+                ariaLabel="Color palette"
+                value={value}
+                onChange={onChange}
+                palettes={palettes}
+                parentLabel="Project default"
+                showPreview={false}
+            />
+        </Box>
+    </Config.Group>
+);
+
+export default DataAppVizPaletteControl;

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/dataAppVizControlLayout.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/dataAppVizControlLayout.ts
@@ -1,0 +1,1 @@
+export const DATA_APP_VIZ_CONTROL_WIDTH = 144;

--- a/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
+++ b/packages/frontend/src/components/common/PalettePicker/PalettePicker.tsx
@@ -24,6 +24,7 @@ type Props = {
     parentLabel: string;
     disabled?: boolean;
     label?: string;
+    ariaLabel?: string;
     description?: string;
     placeholder?: string;
     size?: 'xs' | 'sm' | 'md' | 'lg';
@@ -161,6 +162,7 @@ export const PalettePicker: FC<Props> = ({
     parentLabel,
     disabled,
     label,
+    ariaLabel,
     description,
     placeholder,
     size = 'xs',
@@ -190,6 +192,7 @@ export const PalettePicker: FC<Props> = ({
             <Select
                 size={size}
                 label={label}
+                aria-label={ariaLabel}
                 description={description}
                 placeholder={placeholder}
                 data={data}

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
@@ -26,6 +26,7 @@ describe('getStreamToolCallPart', () => {
             },
             toolResult: null,
             isPreliminary: undefined,
+            isArgsPartial: false,
         });
     });
 
@@ -59,6 +60,7 @@ describe('getStreamToolCallPart', () => {
             },
             toolResult: output,
             isPreliminary: false,
+            isArgsPartial: false,
         });
     });
 });
@@ -90,7 +92,12 @@ describe('getStepProgressFromChunk', () => {
                 },
                 transient: true,
             }),
-        ).toEqual({ message: 'Cloning project', toolName: 'editDbtProject' });
+        ).toEqual({
+            message: 'Cloning project',
+            toolName: 'editDbtProject',
+            progressId: null,
+            progressStatus: null,
+        });
     });
 
     it('parses progress data chunks without a tool name (toolName null)', () => {
@@ -100,7 +107,12 @@ describe('getStepProgressFromChunk', () => {
                 data: { message: 'Running your query...' },
                 transient: true,
             }),
-        ).toEqual({ message: 'Running your query...', toolName: null });
+        ).toEqual({
+            message: 'Running your query...',
+            toolName: null,
+            progressId: null,
+            progressStatus: null,
+        });
     });
 
     it('ignores unrelated chunks', () => {

--- a/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.test.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.test.tsx
@@ -93,7 +93,7 @@ describe('RoleBuilder presets', () => {
                 ],
             }),
         );
-    });
+    }, 10_000);
 
     it('clears seeded values when returning to Start from scratch', async () => {
         renderRoleBuilder({ presets: rolePresets });

--- a/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.test.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.test.tsx
@@ -79,6 +79,19 @@ describe('ConfigurePanel', () => {
         expect(screen.getByLabelText('Show grid')).toBeChecked();
     });
 
+    it('aligns the palette picker with the declared options', () => {
+        renderPanel({ schema: { ...schema, colorPalette: {} } });
+
+        expect(
+            screen
+                .getByText('Color palette')
+                .closest('[data-data-app-viz-control-row]'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('textbox', { name: 'Color palette' }),
+        ).toBeInTheDocument();
+    });
+
     it('says so when a chart type declares nothing to configure', () => {
         renderPanel({
             schema: { fields: [], configOptions: [], colorPalette: null },

--- a/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ConfigurePanel.tsx
@@ -7,9 +7,9 @@ import {
 import { Box, Stack, Tabs, Text } from '@mantine/core';
 import { useMemo, useState, type FC } from 'react';
 import OverflowTabsList from '../../../components/common/OverflowTabsList/OverflowTabsList';
-import { PalettePicker } from '../../../components/common/PalettePicker/PalettePicker';
 import DataAppVizOptionControl from '../../../components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionControl';
 import { groupDataAppVizOptions } from '../../../components/VisualizationConfigs/DataAppVizConfig/dataAppVizOptionGroups';
+import DataAppVizPaletteControl from '../../../components/VisualizationConfigs/DataAppVizConfig/DataAppVizPaletteControl';
 import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
 import classes from './ConfigurePanel.module.css';
 
@@ -103,13 +103,10 @@ const ConfigurePanel: FC<Props> = ({
                                     />
                                 ))}
                                 {group.hasPalette && (
-                                    <PalettePicker
-                                        label="Color palette"
+                                    <DataAppVizPaletteControl
                                         value={colorPaletteUuid}
                                         onChange={onPaletteChange}
                                         palettes={palettes}
-                                        parentLabel="Project default"
-                                        showPreview={false}
                                     />
                                 )}
                             </Stack>

--- a/packages/frontend/src/features/chartTypes/components/DataAppVizTestPanel.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/DataAppVizTestPanel.test.tsx
@@ -53,12 +53,18 @@ vi.mock('../../../components/common/FieldSelect', () => ({
 vi.mock('../../../components/common/PalettePicker/PalettePicker', () => ({
     PalettePicker: ({
         label,
+        ariaLabel,
         onChange,
     }: {
-        label: string;
+        label?: string;
+        ariaLabel?: string;
         onChange: (value: string | null) => void;
     }) => (
-        <button type="button" onClick={() => onChange('ocean-palette')}>
+        <button
+            type="button"
+            aria-label={ariaLabel}
+            onClick={() => onChange('ocean-palette')}
+        >
             {label}
         </button>
     ),

--- a/packages/frontend/src/features/chartTypes/components/DataAppVizTestPanel.tsx
+++ b/packages/frontend/src/features/chartTypes/components/DataAppVizTestPanel.tsx
@@ -6,8 +6,8 @@ import {
 import { Button, Card, Group, Stack, Text } from '@mantine/core';
 import { type FC } from 'react';
 import Callout from '../../../components/common/Callout';
-import { PalettePicker } from '../../../components/common/PalettePicker/PalettePicker';
 import DataAppVizOptionTabs from '../../../components/VisualizationConfigs/DataAppVizConfig/DataAppVizOptionTabs';
+import DataAppVizPaletteControl from '../../../components/VisualizationConfigs/DataAppVizConfig/DataAppVizPaletteControl';
 import { useDataAppVizTestContext } from '../hooks/useDataAppVizTestContext';
 import DataAppVizTestInputs from './DataAppVizTestInputs';
 
@@ -60,13 +60,10 @@ const DataAppVizTestPanel: FC<Props> = ({
                     onChange={setOption}
                     colorPalette={schema.colorPalette}
                     paletteControl={
-                        <PalettePicker
-                            label="Color palette"
+                        <DataAppVizPaletteControl
                             value={colorPaletteUuid}
                             onChange={setColorPaletteUuid}
                             palettes={palettes}
-                            parentLabel="Project default"
-                            showPreview={false}
                         />
                     }
                 />


### PR DESCRIPTION
## What changed

Aligned custom visualization option controls into consistent label/value rows with a shared fixed control width, including the color palette picker across builder and test surfaces. Preserved accessible names and existing edit behavior.

### Validation
- `pnpm -F frontend exec oxfmt <changed frontend files>` — passed
- `pnpm -F frontend run --if-present lint` — passed
- `pnpm -F frontend run --if-present typecheck` — passed
- `pnpm -F frontend run --if-present test` — passed

### Review notes
- The final frontend suite exposed stale AI streaming expectations and several load-sensitive tests outside this feature. Their expectations, listener synchronization, and timeouts were repaired in this commit so the required full validation gate could pass; separating those test-only fixes was the alternative, but would leave this exact submitted tree unable to satisfy the mandatory gate.

## References

Closes: PROD-10514

