### PR TITLE
fix(warehouses): retry lost databricks sessions

### DIFF
--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
@@ -14,6 +14,40 @@ const mocks = vi.hoisted(() => ({
     closeConnection: vi.fn(),
 }));
 
+const invalidSessionError = () =>
+    new StatusError({
+        statusCode: TStatusCode.ERROR_STATUS,
+        errorMessage:
+            'Session handle: SessionHandle [session-id] has not been initialized',
+    });
+
+type MockFunction = ReturnType<typeof vi.fn>;
+type OperationOverrides = Partial<
+    Record<
+        'getSchema' | 'fetchChunk' | 'fetchAll' | 'hasMoreRows' | 'close',
+        MockFunction
+    >
+>;
+type SessionOverrides = Partial<
+    Record<'executeStatement' | 'getColumns' | 'close', MockFunction>
+>;
+
+const createOperation = (overrides: OperationOverrides = {}) => ({
+    getSchema: vi.fn(async () => schema),
+    fetchChunk: mocks.fetchChunk,
+    fetchAll: vi.fn(async () => []),
+    hasMoreRows: vi.fn(async () => false),
+    close: vi.fn(async () => undefined),
+    ...overrides,
+});
+
+const createSession = (overrides: SessionOverrides = {}) => ({
+    executeStatement: vi.fn(async () => createOperation()),
+    getColumns: vi.fn(async () => createOperation()),
+    close: vi.fn(async () => undefined),
+    ...overrides,
+});
+
 vi.mock('@databricks/sql', async () => ({
     ...(await vi.importActual<typeof import('@databricks/sql')>(
         '@databricks/sql',
@@ -32,15 +66,7 @@ describe('DatabricksWarehouseClient', () => {
     beforeEach(() => {
         mocks.fetchChunk.mockReset().mockResolvedValue(rows);
         mocks.closeConnection.mockReset().mockResolvedValue(undefined);
-        mocks.openSession.mockReset().mockResolvedValue({
-            executeStatement: vi.fn(() => ({
-                getSchema: vi.fn(async () => schema),
-                fetchChunk: mocks.fetchChunk,
-                hasMoreRows: vi.fn(async () => false),
-                close: vi.fn(async () => undefined),
-            })),
-            close: vi.fn(async () => undefined),
-        });
+        mocks.openSession.mockReset().mockResolvedValue(createSession());
     });
 
     it('surfaces Databricks status messages when opening a session fails', async () => {
@@ -74,6 +100,180 @@ describe('DatabricksWarehouseClient', () => {
         await warehouse.runQuery('fake sql');
 
         expect(mocks.fetchChunk).toHaveBeenCalledWith({ maxRows: 5000 });
+    });
+
+    it('reopens the session when it is invalid before rows are streamed', async () => {
+        const firstSession = createSession({
+            executeStatement: vi.fn(() =>
+                Promise.reject(invalidSessionError()),
+            ),
+        });
+        const secondSession = createSession();
+        mocks.openSession
+            .mockResolvedValueOnce(firstSession)
+            .mockResolvedValueOnce(secondSession);
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        const results = await warehouse.runQuery('fake sql');
+
+        expect(results.rows).toEqual(rows);
+        expect(mocks.openSession).toHaveBeenCalledTimes(2);
+        expect(firstSession.close).toHaveBeenCalledOnce();
+    });
+
+    it('retries when an empty chunk was emitted before session loss', async () => {
+        const firstSession = createSession({
+            executeStatement: vi.fn(async () =>
+                createOperation({
+                    fetchChunk: vi.fn(async () => []),
+                    hasMoreRows: vi.fn(() =>
+                        Promise.reject(invalidSessionError()),
+                    ),
+                }),
+            ),
+        });
+        mocks.openSession
+            .mockResolvedValueOnce(firstSession)
+            .mockResolvedValueOnce(createSession());
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        const results = await warehouse.runQuery('fake sql');
+
+        expect(results.rows).toEqual(rows);
+        expect(mocks.openSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('stops retrying after three invalid sessions', async () => {
+        mocks.openSession.mockResolvedValue(
+            createSession({
+                executeStatement: vi.fn(() =>
+                    Promise.reject(invalidSessionError()),
+                ),
+            }),
+        );
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        await expect(warehouse.runQuery('fake sql')).rejects.toMatchObject({
+            message:
+                'Session handle: SessionHandle [session-id] has not been initialized',
+        });
+        expect(mocks.openSession).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not retry invalid sessions after rows are streamed', async () => {
+        const streamCallback = vi.fn();
+        const firstSession = createSession({
+            executeStatement: vi.fn(async () =>
+                createOperation({
+                    hasMoreRows: vi.fn(() =>
+                        Promise.reject(invalidSessionError()),
+                    ),
+                }),
+            ),
+        });
+        mocks.openSession.mockResolvedValueOnce(firstSession);
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        await expect(
+            warehouse.streamQuery('fake sql', streamCallback, {}),
+        ).rejects.toMatchObject({
+            message:
+                'Session handle: SessionHandle [session-id] has not been initialized',
+        });
+
+        expect(streamCallback).toHaveBeenCalledOnce();
+        expect(mocks.openSession).toHaveBeenCalledOnce();
+    });
+
+    it('does not retry other Databricks status errors', async () => {
+        const sqlError = new StatusError({
+            statusCode: TStatusCode.ERROR_STATUS,
+            errorMessage: 'Syntax error near FROM',
+        });
+        const firstSession = createSession({
+            executeStatement: vi.fn(() => Promise.reject(sqlError)),
+        });
+        mocks.openSession.mockResolvedValueOnce(firstSession);
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        await expect(warehouse.runQuery('fake sql')).rejects.toMatchObject({
+            message: 'Syntax error near FROM',
+        });
+        expect(mocks.openSession).toHaveBeenCalledOnce();
+    });
+
+    it('bounds session replacements across the entire catalog fetch', async () => {
+        const createCatalogSession = (invalidTable: string) =>
+            createSession({
+                getColumns: vi.fn(
+                    (request: { tableName?: string } | undefined) =>
+                        request?.tableName === invalidTable
+                            ? Promise.reject(invalidSessionError())
+                            : Promise.resolve(createOperation()),
+                ),
+            });
+        mocks.openSession
+            .mockResolvedValueOnce(createCatalogSession('table_0'))
+            .mockResolvedValueOnce(createCatalogSession('table_100'))
+            .mockResolvedValueOnce(createCatalogSession('table_200'));
+        const warehouse = new DatabricksWarehouseClient(credentials);
+        const requests = Array.from({ length: 201 }, (_, index) => ({
+            database: 'database',
+            schema: 'schema',
+            table: `table_${index}`,
+        }));
+
+        await expect(warehouse.getCatalog(requests)).rejects.toMatchObject({
+            message:
+                'Session handle: SessionHandle [session-id] has not been initialized',
+        });
+        expect(mocks.openSession).toHaveBeenCalledTimes(3);
+    });
+
+    it('resumes catalog requests on a replacement session', async () => {
+        const tableOneColumns = [
+            {
+                COLUMN_NAME: 'id',
+                TYPE_NAME: 'BIGINT',
+            },
+        ];
+        const tableTwoColumns = [
+            {
+                COLUMN_NAME: 'name',
+                TYPE_NAME: 'STRING',
+            },
+        ];
+        const firstGetColumns = vi
+            .fn()
+            .mockResolvedValueOnce(
+                createOperation({
+                    fetchAll: vi.fn(async () => tableOneColumns),
+                }),
+            )
+            .mockRejectedValueOnce(invalidSessionError());
+        const secondGetColumns = vi.fn(async () =>
+            createOperation({
+                fetchAll: vi.fn(async () => tableTwoColumns),
+            }),
+        );
+        mocks.openSession
+            .mockResolvedValueOnce(
+                createSession({ getColumns: firstGetColumns }),
+            )
+            .mockResolvedValueOnce(
+                createSession({ getColumns: secondGetColumns }),
+            );
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        const catalog = await warehouse.getCatalog([
+            { database: 'database', schema: 'schema', table: 'table_one' },
+            { database: 'database', schema: 'schema', table: 'table_two' },
+        ]);
+
+        expect(catalog.DEFAULT.schema.table_one.id).toBe('number');
+        expect(catalog.DEFAULT.schema.table_two.name).toBe('string');
+        expect(firstGetColumns).toHaveBeenCalledTimes(2);
+        expect(secondGetColumns).toHaveBeenCalledOnce();
     });
 });
 

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -295,6 +295,8 @@ const DATABRICKS_QUERY_TIMEOUT_SECONDS = 300;
 const DATABRICKS_FETCH_CHUNK_MAX_ROWS = 5000;
 const DATABRICKS_SESSION_MAX_ATTEMPTS = 3;
 const DATABRICKS_SESSION_RETRY_DELAY_MS = 250;
+// The driver exposes these as generic StatusErrors without a distinct error code;
+// match the message narrowly while allowing for the dynamic session handle.
 const DATABRICKS_INVALID_SESSION_REGEX =
     /Session handle:? .* (has not been initialized|had already closed)/;
 

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -293,11 +293,24 @@ const DATABRICKS_QUERY_TIMEOUT_SECONDS = 300;
 // @databricks/sql defaults fetchChunk to 100k rows, which materializes entire
 // wide results in one array and can OOM the worker on large queries
 const DATABRICKS_FETCH_CHUNK_MAX_ROWS = 5000;
+const DATABRICKS_SESSION_MAX_ATTEMPTS = 3;
+const DATABRICKS_SESSION_RETRY_DELAY_MS = 250;
+const DATABRICKS_INVALID_SESSION_REGEX =
+    /Session handle:? .* (has not been initialized|had already closed)/;
 
 const getDatabricksErrorMessage = (error: unknown) =>
     error instanceof StatusError && error.message
         ? error.message
         : getErrorMessage(error);
+
+const isDatabricksInvalidSessionError = (error: unknown): boolean =>
+    error instanceof StatusError &&
+    DATABRICKS_INVALID_SESSION_REGEX.test(error.message);
+
+const waitForDatabricksSessionRetry = (attempt: number) =>
+    new Promise<void>((resolve) => {
+        setTimeout(resolve, DATABRICKS_SESSION_RETRY_DELAY_MS * attempt);
+    });
 
 export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabricksCredentials> {
     schema: string;
@@ -388,55 +401,51 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
         return {
             session,
             close: async () => {
-                await session.close();
-                await connection.close();
+                try {
+                    await session.close();
+                } finally {
+                    await connection.close();
+                }
             },
         };
     }
 
-    async streamQuery(
+    private async streamQueryOnce(
         sql: string,
         streamCallback: (data: WarehouseResults) => void | Promise<void>,
         options: {
             values?: AnyType[];
-            tags?: Record<string, string>;
             timezone?: string;
         },
+        onRowsStreamed: () => void,
     ): Promise<void> {
         const { session, close } = await this.getSession();
         let query: IOperation | null = null;
 
-        let alteredQuery = sql;
-        if (options?.tags) {
-            alteredQuery = `${alteredQuery}\n-- ${JSON.stringify(
-                options?.tags,
-            )}`;
-        }
-
         try {
-            if (options?.timezone) {
+            if (options.timezone) {
                 console.debug(
-                    `Setting databricks timezone to ${options?.timezone}`,
+                    `Setting databricks timezone to ${options.timezone}`,
                 );
                 const setTimezoneOp = await session.executeStatement(
                     `SET TIME ZONE '${options.timezone}'`,
                 );
                 try {
-                    await setTimezoneOp.finished(); // ensures SET is applied before main query
+                    await setTimezoneOp.finished();
                 } finally {
                     await setTimezoneOp.close();
                 }
             }
 
-            query = await session.executeStatement(alteredQuery, {
+            query = await session.executeStatement(sql, {
                 ...(this.enableTimeouts && {
                     queryTimeout: DATABRICKS_QUERY_TIMEOUT_SECONDS,
                 }),
-                ordinalParameters: options?.values,
+                ordinalParameters: options.values,
             });
 
-            const schema = await query.getSchema();
-            const fields = (schema?.columns ?? []).reduce<
+            const querySchema = await query.getSchema();
+            const fields = (querySchema?.columns ?? []).reduce<
                 Record<string, { type: DimensionType }>
             >(
                 (acc, column) => ({
@@ -456,22 +465,67 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
                 const chunk = await query.fetchChunk({
                     maxRows: DATABRICKS_FETCH_CHUNK_MAX_ROWS,
                 });
+                if (chunk.length > 0) {
+                    onRowsStreamed();
+                }
                 // eslint-disable-next-line no-await-in-loop
                 await streamCallback({ fields, rows: chunk });
                 // eslint-disable-next-line no-await-in-loop
             } while (await query.hasMoreRows());
-        } catch (e: unknown) {
-            throw new WarehouseQueryError(getDatabricksErrorMessage(e));
         } finally {
             try {
                 if (query) await query.close();
                 await close();
             } catch (e: unknown) {
-                // Only console error. Don't allow close errors to override the original error
                 console.error(
                     'Error closing Databricks session on streamQuery',
                     e,
                 );
+            }
+        }
+    }
+
+    async streamQuery(
+        sql: string,
+        streamCallback: (data: WarehouseResults) => void | Promise<void>,
+        options: {
+            values?: AnyType[];
+            tags?: Record<string, string>;
+            timezone?: string;
+        },
+    ): Promise<void> {
+        const alteredQuery = options.tags
+            ? `${sql}\n-- ${JSON.stringify(options.tags)}`
+            : sql;
+        let rowsStreamed = false;
+        const onRowsStreamed = () => {
+            rowsStreamed = true;
+        };
+
+        for (
+            let attempt = 1;
+            attempt <= DATABRICKS_SESSION_MAX_ATTEMPTS;
+            attempt += 1
+        ) {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await this.streamQueryOnce(
+                    alteredQuery,
+                    streamCallback,
+                    options,
+                    onRowsStreamed,
+                );
+                return;
+            } catch (e: unknown) {
+                const retry =
+                    !rowsStreamed &&
+                    attempt < DATABRICKS_SESSION_MAX_ATTEMPTS &&
+                    isDatabricksInvalidSessionError(e);
+                if (!retry) {
+                    throw new WarehouseQueryError(getDatabricksErrorMessage(e));
+                }
+                // eslint-disable-next-line no-await-in-loop
+                await waitForDatabricksSessionRetry(attempt);
             }
         }
     }
@@ -483,35 +537,86 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
             table: string;
         }[],
     ) {
-        const { session, close } = await this.getSession();
+        let sessionHandle = await this.getSession();
+        let sessionAttempts = 1;
+        let refreshPromise: Promise<typeof sessionHandle> | null = null;
         let results: SchemaResult[][];
+
+        const refreshSession = async (
+            staleHandle: typeof sessionHandle,
+            invalidSessionError: unknown,
+        ) => {
+            if (sessionHandle !== staleHandle) {
+                return sessionHandle;
+            }
+            if (refreshPromise) {
+                return refreshPromise;
+            }
+            if (sessionAttempts >= DATABRICKS_SESSION_MAX_ATTEMPTS) {
+                throw invalidSessionError;
+            }
+
+            const retryAttempt = sessionAttempts;
+            sessionAttempts += 1;
+            refreshPromise = (async () => {
+                await waitForDatabricksSessionRetry(retryAttempt);
+                const newHandle = await this.getSession();
+                sessionHandle = newHandle;
+                try {
+                    await staleHandle.close();
+                } catch (e: unknown) {
+                    console.error(
+                        'Error closing invalid Databricks session on getCatalog',
+                        e,
+                    );
+                }
+                return newHandle;
+            })().finally(() => {
+                refreshPromise = null;
+            });
+
+            return refreshPromise;
+        };
 
         try {
             results = await processPromisesInBatches(
                 requests,
                 DEFAULT_BATCH_SIZE,
                 async (request) => {
-                    let query: IOperation | null = null;
-                    try {
-                        query = await session.getColumns({
-                            catalogName: request.database,
-                            schemaName: request.schema,
-                            tableName: request.table,
-                        });
-                        return (await query.fetchAll()) as SchemaResult[];
-                    } catch (e: unknown) {
-                        throw new WarehouseQueryError(
-                            getDatabricksErrorMessage(e),
-                        );
-                    } finally {
+                    let currentHandle = sessionHandle;
+                    while (true) {
+                        let query: IOperation | null = null;
                         try {
-                            if (query) await query.close();
+                            currentHandle = sessionHandle;
+                            // eslint-disable-next-line no-await-in-loop
+                            query = await currentHandle.session.getColumns({
+                                catalogName: request.database,
+                                schemaName: request.schema,
+                                tableName: request.table,
+                            });
+                            // eslint-disable-next-line no-await-in-loop
+                            return (await query.fetchAll()) as SchemaResult[];
                         } catch (e: unknown) {
-                            // Only console error. Don't allow close errors to override the original error
-                            console.error(
-                                'Error closing Databricks query on getCatalog',
+                            if (!isDatabricksInvalidSessionError(e)) {
+                                throw e;
+                            }
+                            // eslint-disable-next-line no-await-in-loop
+                            currentHandle = await refreshSession(
+                                currentHandle,
                                 e,
                             );
+                        } finally {
+                            try {
+                                if (query) {
+                                    // eslint-disable-next-line no-await-in-loop
+                                    await query.close();
+                                }
+                            } catch (e: unknown) {
+                                console.error(
+                                    'Error closing Databricks query on getCatalog',
+                                    e,
+                                );
+                            }
                         }
                     }
                 },
@@ -520,9 +625,8 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
             throw new WarehouseQueryError(getDatabricksErrorMessage(e));
         } finally {
             try {
-                await close();
+                await sessionHandle.close();
             } catch (e: unknown) {
-                // Only console error. Don't allow close errors to override the original error
                 console.error(
                     'Error closing Databricks session on getCatalog',
                     e,


### PR DESCRIPTION
## What changed

Adds targeted recovery for Databricks invalid-session `StatusError`s with up to three session attempts and increasing backoff. Catalog fetches share one retry budget and resume affected work on replacement sessions; streamed queries retry only before non-empty rows are emitted, and connections are closed even when invalid session cleanup fails.

Regression coverage includes successful query/catalog recovery, global retry bounds, empty chunks, post-row failures, and unrelated Databricks status errors.

### Validation
- `pnpm -F warehouses exec oxfmt 'src/warehouseClients/DatabricksWarehouseClient.test.ts' 'src/warehouseClients/DatabricksWarehouseClient.ts'` — passed
- `pnpm -F warehouses run --if-present lint` — passed
- `pnpm -F warehouses run --if-present typecheck` — passed
- `pnpm -F warehouses run --if-present test` — passed

## Preview

[Open the public Lightdash preview](https://ld-runner-prod-10521-deeecc4ba2f4.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10521

