### PR TITLE
fix(backend): restore the getModelsFromManifest import

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -103,6 +103,7 @@ import {
     getMergeSourceTableLabel,
     getMetricOverridesWithPopInheritance,
     getMetrics,
+    getModelsFromManifest,
     getParameterReferences,
     getPreAggregateExploreName,
     getTimezoneLabel,


### PR DESCRIPTION
Fixes SPK-1360

Main fails to build: `ProjectService.ts` uses `getModelsFromManifest` but the import was removed when two squash-merged changes interleaved. This restores the import from `@lightdash/common`.

Verified locally: `pnpm --filter backend... build` fails on main with TS2304 and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)