### PR TITLE
feat(data-apps): add native full-app drill-down

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -747,9 +747,16 @@ Generated apps can offer the same kinds of row-level exploration users expect fr
 to wire those interactions explicitly in its React UI. The agent is taught these patterns in
 `sandboxes/data-apps/template/skill.md`; `docs/data-apps.md` is the architecture-level contract.
 
-**Drilldowns** are SDK-side query composition. `drillDown()` takes the source `QueryBuilder`, the clicked row, a metric,
-and a new drill-by dimension, then returns another `QueryBuilder`. The app passes that query to `useLightdash()` like
-any other metric query, so it uses the existing `POST /query/metric-query` bridge route and normal query polling.
+**Native drilldown** is the default for full data apps hosted by Lightdash. Each `useLightdash()` result exposes
+`drillDown: { enabled, open({ row, metric }) }`. The SDK binds the click to the loaded query UUID, qualifies and formats
+the original row, and posts the semantic intent to the bridge-only `POST /__sdk/drill-down` route. The host resolves
+that UUID against the canonical `metricQuery` and fields captured from the backend query response, then opens core's
+existing drill dimension picker and Explore flow. The virtual route is never forwarded to the API and is advertised
+only on host surfaces where the viewer has drill permission.
+
+**Custom drilldown queries** remain available through `buildDrillDownQuery()` (with `drillDown()` retained as a
+backwards-compatible alias). This is SDK-side query composition for standalone clients or apps that intentionally want
+to render drilled results inline rather than use the native host UI.
 
 **Underlying data** uses Lightdash's native "View underlying data" backend path. `useLightdash()` returns
 `getUnderlyingData({ row, metric, limit? })` after the source query has loaded. The app calls it from a user action

--- a/packages/common/src/ee/apps/sdkFeatures.ts
+++ b/packages/common/src/ee/apps/sdkFeatures.ts
@@ -45,6 +45,13 @@ export const SDK_FEATURES: SdkFeature[] = [
             'Derive drill-down queries from a clicked result row to build explore-style interactions.',
     },
     {
+        key: 'app-drill-down',
+        label: 'Native drill-down',
+        description:
+            'Open Lightdash’s native dimension picker and drilled Explore view from a full data app query result.',
+        wiring: 'For each metric data point, keep the original row returned by useLightdash(), show “Drill into …” only when that query result’s drillDown.enabled is true, and call drillDown.open({ row, metric }). Use buildDrillDownQuery() only when the app needs a custom inline or standalone drill experience.',
+    },
+    {
         key: 'inspect',
         label: 'Element inspection',
         description:

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -1125,6 +1125,19 @@ export type DataAppVizDrillDownIntent = {
     metric: string;
 };
 
+// Bridge-only virtual route: a full data app asks the host to drill from one
+// of its loaded SDK queries. The host owns the dimension picker and Explore
+// navigation; this route is never forwarded to the API.
+export const APP_SDK_DRILL_DOWN_PATH = '/__sdk/drill-down';
+
+// Unlike a reusable viz, a full app can run many queries. The query UUID binds
+// the click to the exact canonical metric query recorded by the host bridge.
+export type DataAppDrillDownIntent = {
+    queryUuid: string;
+    row: ResultRow;
+    metric: string;
+};
+
 // Host-owned render context pushed into a data app viz: field name → bound query
 // field id, the host-fetched result rows the renderer reads, the effective
 // config option values (stored value ?? declared default), and the palette

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -357,7 +357,7 @@ const DataAppTile: FC<Props> = (props) => {
                         identityKey={`${appUuid}:${latestReadyVersion}`}
                         dashboardFilters={dashboardFiltersForApp}
                         invalidateCache={invalidateCache}
-                        capabilities={{ gsheetExport: true }}
+                        capabilities={{ gsheetExport: true, drillDown: true }}
                     />
                 )}
             </Box>

--- a/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
@@ -146,6 +146,7 @@ type DrillDownExploreUrlArgs = {
     pivotReference?: PivotReference;
     explore?: Explore;
     timezone?: string;
+    parameters?: CreateSavedChartVersion['parameters'];
 };
 
 const drillDownExploreUrl = ({
@@ -159,6 +160,7 @@ const drillDownExploreUrl = ({
     pivotReference,
     explore,
     timezone,
+    parameters,
 }: DrillDownExploreUrlArgs) => {
     const createSavedChartVersion: CreateSavedChartVersion = {
         tableName,
@@ -193,6 +195,7 @@ const drillDownExploreUrl = ({
             type: ChartType.CARTESIAN,
             config: { layout: {}, eChartsConfig: {} },
         },
+        parameters,
     };
     const { pathname, search } = getExplorerUrlFromCreateSavedChartVersion(
         projectUuid,
@@ -215,6 +218,7 @@ export const DrillDownModal: FC = () => {
         tableName,
         drillDownConfig,
         resolvedTimezone,
+        parameters: contextParameters,
     } = useMetricQueryDataContext();
     const source = drillDownConfig?.source;
     const metricQuery = source?.metricQuery ?? contextMetricQuery;
@@ -257,6 +261,7 @@ export const DrillDownModal: FC = () => {
                 pivotReference: drillDownConfig.pivotReference,
                 explore,
                 timezone: resolvedTimezone,
+                parameters: source?.parameters ?? contextParameters,
             });
         }
     }, [
@@ -266,6 +271,8 @@ export const DrillDownModal: FC = () => {
         drillDownConfig,
         projectUuid,
         resolvedTimezone,
+        contextParameters,
+        source?.parameters,
     ]);
 
     const onClose = useCallback(() => {

--- a/packages/frontend/src/components/MetricQueryData/types.ts
+++ b/packages/frontend/src/components/MetricQueryData/types.ts
@@ -2,6 +2,7 @@ import {
     type DateZoom,
     type ItemsMap,
     type MetricQuery,
+    type ParametersValuesMap,
     type PivotReference,
     type ResultValue,
 } from '@lightdash/common';
@@ -9,6 +10,7 @@ import {
 export type MetricQueryDataSource = {
     tableName: string;
     metricQuery: MetricQuery;
+    parameters?: ParametersValuesMap;
 };
 
 export type UnderlyingDataConfig = {

--- a/packages/frontend/src/features/apps/AppDrillDownModalHost.tsx
+++ b/packages/frontend/src/features/apps/AppDrillDownModalHost.tsx
@@ -1,0 +1,46 @@
+import { useEffect, type FC } from 'react';
+import { DrillDownModal } from '../../components/MetricQueryData/DrillDownModal';
+import MetricQueryDataProvider from '../../components/MetricQueryData/MetricQueryDataProvider';
+import { type DrillDownConfig } from '../../components/MetricQueryData/types';
+import { useMetricQueryDataContext } from '../../components/MetricQueryData/useMetricQueryDataContext';
+import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
+
+const OpenRequest: FC<{ request: DrillDownConfig | undefined }> = ({
+    request,
+}) => {
+    const { openDrillDownModal } = useMetricQueryDataContext();
+
+    useEffect(() => {
+        if (request) openDrillDownModal(request);
+    }, [openDrillDownModal, request]);
+
+    return null;
+};
+
+/** Supplies the existing core DrillDownModal with per-query source context
+ * captured from a full data app's SDK bridge. */
+export const AppDrillDownModalHost: FC<{
+    projectUuid: string;
+    request: DrillDownConfig | undefined;
+    onPermissionChange: (allowed: boolean) => void;
+}> = ({ projectUuid, request, onPermissionChange }) => {
+    const { canDrillInto } = useContextMenuPermissions({ projectUuid });
+
+    useEffect(() => {
+        onPermissionChange(canDrillInto);
+        return () => onPermissionChange(false);
+    }, [canDrillInto, onPermissionChange]);
+
+    if (!canDrillInto) return null;
+
+    return (
+        <MetricQueryDataProvider
+            tableName=""
+            explore={undefined}
+            metricQuery={undefined}
+        >
+            <OpenRequest request={request} />
+            <DrillDownModal />
+        </MetricQueryDataProvider>
+    );
+};

--- a/packages/frontend/src/features/apps/AppIframePreview.test.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.test.tsx
@@ -23,6 +23,10 @@ vi.mock('./hooks/useIframeScreenshot', () => ({
     useIframeScreenshot: () => ({ captureScreenshot: vi.fn() }),
 }));
 
+vi.mock('../../hooks/useContextMenuPermissions', () => ({
+    useContextMenuPermissions: () => ({ canDrillInto: false }),
+}));
+
 const SRC =
     'https://preview.example/api/apps/a/versions/1/t/tok/#transport=postMessage&projectUuid=p';
 

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -14,6 +14,8 @@ import {
     useRef,
     useState,
 } from 'react';
+import { type DrillDownConfig } from '../../components/MetricQueryData/types';
+import { AppDrillDownModalHost } from './AppDrillDownModalHost';
 import { type DeliveryCaptureAccumulator } from './deliveryCapture/deliveryCaptureAccumulator';
 import {
     useAppSdkBridge,
@@ -112,8 +114,9 @@ type Props = {
     onIframeLoad?: () => void;
     /** SDK capabilities the host opts into. Closed by default — hosts that
      *  serve untrusted viewers (embed/JWT) must omit each capability flag.
-     *  `gsheetExport`: enables `exportToSheets()` from the iframe SDK. */
-    capabilities?: { gsheetExport?: boolean };
+     *  `gsheetExport` enables `exportToSheets()`; `drillDown` is additionally
+     *  permission-gated and opens core's native drill dialog. */
+    capabilities?: { gsheetExport?: boolean; drillDown?: boolean };
     // Render context for data app vizs: the field mapping + host rows, pushed
     // into the iframe over the SDK bridge. Undefined for ordinary data apps.
     dataAppVizContext?: DataAppVizContext;
@@ -196,6 +199,17 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
         ref,
     ) => {
         const iframeRef = useRef<HTMLIFrameElement>(null);
+        const appDrillDownRequested =
+            capabilities?.drillDown === true && !dataAppVizContext;
+        const [appDrillDownAllowed, setAppDrillDownAllowed] = useState(false);
+        const [appDrillDownRequest, setAppDrillDownRequest] =
+            useState<DrillDownConfig>();
+        const appDrillDownEnabled =
+            appDrillDownRequested && appDrillDownAllowed;
+        const handleAppDrillDownIntent = useCallback(
+            (request: DrillDownConfig) => setAppDrillDownRequest(request),
+            [],
+        );
         // Resolves to an exact light/dark (embed routes force it from
         // `?theme=`), so this is the scheme the surrounding page renders in.
         const hostColorScheme = useComputedColorScheme('light');
@@ -288,6 +302,9 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             dataAppVizContext,
             rewriteVizUnderlyingDataRequest,
             onVizDrillDownIntent,
+            onAppDrillDownIntent: appDrillDownEnabled
+                ? handleAppDrillDownIntent
+                : undefined,
             onUrlStateChange: urlStateSync ? handleUrlStateChange : undefined,
             onSdkManifest,
             colorScheme,
@@ -364,15 +381,24 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
         };
 
         return (
-            <iframe
-                ref={iframeRef}
-                src={effectiveSrc}
-                style={{ width: '100%', height: '100%', border: 'none' }}
-                title="App preview"
-                sandbox="allow-scripts allow-modals allow-downloads allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
-                allow=""
-                onLoad={handleLoad}
-            />
+            <>
+                <iframe
+                    ref={iframeRef}
+                    src={effectiveSrc}
+                    style={{ width: '100%', height: '100%', border: 'none' }}
+                    title="App preview"
+                    sandbox="allow-scripts allow-modals allow-downloads allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+                    allow=""
+                    onLoad={handleLoad}
+                />
+                {appDrillDownRequested && (
+                    <AppDrillDownModalHost
+                        projectUuid={projectUuid}
+                        request={appDrillDownRequest}
+                        onPermissionChange={setAppDrillDownAllowed}
+                    />
+                )}
+            </>
         );
     },
 );

--- a/packages/frontend/src/features/apps/components/AppPreview.tsx
+++ b/packages/frontend/src/features/apps/components/AppPreview.tsx
@@ -122,7 +122,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
                 onLineageSelected={onLineageSelected}
                 lineageHighlightQueryUuid={lineageHighlightQueryUuid}
                 onLineageCancelled={onLineageCancelled}
-                capabilities={{ gsheetExport: true }}
+                capabilities={{ gsheetExport: true, drillDown: true }}
                 dataAppVizContext={dataAppVizContext}
                 urlStateSync
                 onSdkManifest={onSdkManifest}

--- a/packages/frontend/src/features/apps/hooks/resolveAppDrillDown.test.ts
+++ b/packages/frontend/src/features/apps/hooks/resolveAppDrillDown.test.ts
@@ -1,0 +1,86 @@
+import { type ItemsMap, type MetricQuery } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    resolveAppDrillDown,
+    type AppDrillDownSource,
+} from './resolveAppDrillDown';
+
+const metricItem = {
+    fieldType: 'metric',
+    type: 'sum',
+    name: 'revenue',
+    table: 'orders',
+    label: 'Revenue',
+    hidden: false,
+} as unknown as ItemsMap[string];
+
+const metricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_status'],
+    metrics: ['orders_revenue'],
+    filters: {},
+    sorts: [],
+    tableCalculations: [],
+    additionalMetrics: [],
+    customDimensions: [],
+    limit: 500,
+} as MetricQuery;
+
+const source: AppDrillDownSource = {
+    metricQuery,
+    fields: { orders_revenue: metricItem } as ItemsMap,
+    parameters: { currency: 'USD' },
+};
+
+const sources = new Map([['q-1', source]]);
+const row = {
+    orders_status: { value: { raw: 'paid', formatted: 'Paid' } },
+    orders_revenue: { value: { raw: 42, formatted: '$42' } },
+};
+
+describe('resolveAppDrillDown', () => {
+    it('uses only trusted query context while preserving values and parameters', () => {
+        const config = resolveAppDrillDown(
+            { queryUuid: 'q-1', row, metric: 'orders_revenue' },
+            sources,
+        );
+
+        expect(config).toEqual({
+            item: metricItem,
+            fieldValues: {
+                orders_status: { raw: 'paid', formatted: 'Paid' },
+                orders_revenue: { raw: 42, formatted: '$42' },
+            },
+            source: {
+                tableName: 'orders',
+                metricQuery,
+                parameters: { currency: 'USD' },
+            },
+        });
+    });
+
+    it('rejects unknown queries, non-source metrics, and incomplete rows', () => {
+        expect(() =>
+            resolveAppDrillDown(
+                { queryUuid: 'stale', row, metric: 'orders_revenue' },
+                sources,
+            ),
+        ).toThrow(/source query.*no longer available/i);
+        expect(() =>
+            resolveAppDrillDown(
+                { queryUuid: 'q-1', row, metric: 'orders_profit' },
+                sources,
+            ),
+        ).toThrow(/not a metric in this query/i);
+        expect(() =>
+            resolveAppDrillDown(
+                {
+                    queryUuid: 'q-1',
+                    row: { orders_revenue: row.orders_revenue },
+                    metric: 'orders_revenue',
+                },
+                sources,
+            ),
+        ).toThrow(/missing dimension "orders_status"/i);
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/resolveAppDrillDown.ts
+++ b/packages/frontend/src/features/apps/hooks/resolveAppDrillDown.ts
@@ -1,0 +1,81 @@
+import {
+    isField,
+    isMetric,
+    isResultValue,
+    type ItemsMap,
+    type MetricQuery,
+    type ParametersValuesMap,
+} from '@lightdash/common';
+import { type DrillDownConfig } from '../../../components/MetricQueryData/types';
+
+export type AppDrillDownSource = {
+    metricQuery: MetricQuery;
+    fields: ItemsMap;
+    parameters?: ParametersValuesMap;
+};
+
+type AppDrillDownIntent = {
+    queryUuid: string;
+    row: Record<string, unknown>;
+    metric: string;
+};
+
+const parseIntent = (input: unknown): AppDrillDownIntent => {
+    if (
+        typeof input !== 'object' ||
+        input === null ||
+        typeof (input as { queryUuid?: unknown }).queryUuid !== 'string' ||
+        typeof (input as { metric?: unknown }).metric !== 'string' ||
+        typeof (input as { row?: unknown }).row !== 'object' ||
+        (input as { row?: unknown }).row === null
+    ) {
+        throw new Error('Invalid drill-down request.');
+    }
+    return input as AppDrillDownIntent;
+};
+
+/** Resolve an untrusted full-app click intent against query context captured
+ * by the host itself. Nothing query-shaped from the iframe is trusted. */
+export const resolveAppDrillDown = (
+    input: unknown,
+    sources: ReadonlyMap<string, AppDrillDownSource>,
+): DrillDownConfig => {
+    const intent = parseIntent(input);
+    const source = sources.get(intent.queryUuid);
+    if (!source) {
+        throw new Error(
+            'The source query for this data point is no longer available. Refresh the app and try again.',
+        );
+    }
+
+    if (!source.metricQuery.metrics.includes(intent.metric)) {
+        throw new Error(`"${intent.metric}" is not a metric in this query.`);
+    }
+    const item = source.fields[intent.metric];
+    if (!item || !isField(item) || !isMetric(item)) {
+        throw new Error(`"${intent.metric}" is not a drillable metric.`);
+    }
+
+    const fieldValues = Object.fromEntries(
+        Object.entries(intent.row).flatMap(([fieldId, cell]) =>
+            isResultValue(cell) ? [[fieldId, cell.value]] : [],
+        ),
+    );
+    for (const dimension of source.metricQuery.dimensions) {
+        if (!Object.prototype.hasOwnProperty.call(fieldValues, dimension)) {
+            throw new Error(
+                `Cannot drill down because the row is missing dimension "${dimension}". Pass the original row returned by useLightdash().`,
+            );
+        }
+    }
+
+    return {
+        item,
+        fieldValues,
+        source: {
+            tableName: source.metricQuery.exploreName,
+            metricQuery: source.metricQuery,
+            parameters: source.parameters,
+        },
+    };
+};

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1927,3 +1927,164 @@ describe('viz drill-down virtual route', () => {
         expect(fetch).not.toHaveBeenCalled();
     });
 });
+
+describe('full-app native drill-down virtual route', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    const query = {
+        ...METRIC_QUERY,
+        dimensions: ['orders_status'],
+        metrics: ['orders_revenue'],
+    };
+    const metricItem = {
+        fieldType: 'metric',
+        type: 'sum',
+        name: 'revenue',
+        table: 'orders',
+        label: 'Revenue',
+        hidden: false,
+    };
+    const intent = {
+        queryUuid: QUERY_UUID,
+        metric: 'orders_revenue',
+        row: {
+            orders_status: {
+                value: { raw: 'paid', formatted: 'Paid' },
+            },
+            orders_revenue: { value: { raw: 42, formatted: '$42' } },
+        },
+    };
+
+    const renderNativeBridge = (
+        handler?: Parameters<typeof useAppSdkBridge>[0]['onAppDrillDownIntent'],
+    ) => {
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        return renderHook(() =>
+            useAppSdkBridge({
+                colorScheme: 'light',
+                iframeRef,
+                expectedPreviewOrigin: window.location.origin,
+                projectUuid: PROJECT_UUID,
+                appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
+                capabilities: { drillDown: true },
+                onAppDrillDownIntent: handler,
+            }),
+        );
+    };
+
+    it('advertises the capability and resolves clicks against the canonical query response', async () => {
+        const handler = vi.fn();
+        const { result } = renderNativeBridge(handler);
+        const postMessageSpy = vi.spyOn(window, 'postMessage');
+        result.current.handleIframeLoad();
+        expect(postMessageSpy).toHaveBeenCalledWith(
+            {
+                type: 'lightdash:sdk:ready',
+                drillDown: { enabled: true },
+            },
+            '*',
+        );
+
+        mockFetchOk({
+            status: 'ok',
+            results: {
+                queryUuid: QUERY_UUID,
+                metricQuery: query,
+                fields: { orders_revenue: metricItem },
+                usedParametersValues: { currency: 'EUR' },
+            },
+        });
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:fetch',
+            id: POST_ID,
+            method: 'POST',
+            path: POST_PATH,
+            body: { query, parameters: { currency: 'USD' } },
+        });
+        await vi.waitFor(() =>
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'lightdash:sdk:fetch-response',
+                    id: POST_ID,
+                    result: expect.objectContaining({
+                        queryUuid: QUERY_UUID,
+                    }),
+                }),
+                '*',
+            ),
+        );
+
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:fetch',
+            id: GET_ID,
+            method: 'POST',
+            path: '/__sdk/drill-down',
+            body: intent,
+        });
+
+        await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
+        expect(handler).toHaveBeenCalledWith(
+            expect.objectContaining({
+                item: metricItem,
+                fieldValues: {
+                    orders_status: { raw: 'paid', formatted: 'Paid' },
+                    orders_revenue: { raw: 42, formatted: '$42' },
+                },
+                source: expect.objectContaining({
+                    metricQuery: query,
+                    parameters: { currency: 'EUR' },
+                }),
+            }),
+        );
+        expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails closed when the host does not opt in', async () => {
+        const handler = vi.fn();
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        renderHook(() =>
+            useAppSdkBridge({
+                colorScheme: 'light',
+                iframeRef,
+                expectedPreviewOrigin: window.location.origin,
+                projectUuid: PROJECT_UUID,
+                appUuid: APP_UUID,
+                previewToken: PREVIEW_TOKEN,
+                onAppDrillDownIntent: handler,
+            }),
+        );
+        const postMessageSpy = vi.spyOn(window, 'postMessage');
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:fetch',
+            id: GET_ID,
+            method: 'POST',
+            path: '/__sdk/drill-down',
+            body: intent,
+        });
+
+        await vi.waitFor(() =>
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'lightdash:sdk:fetch-response',
+                    id: GET_ID,
+                    error: expect.stringMatching(/not available/i),
+                }),
+                '*',
+            ),
+        );
+        expect(handler).not.toHaveBeenCalled();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -1,4 +1,5 @@
 import {
+    APP_SDK_DRILL_DOWN_PATH,
     APP_SDK_COLOR_SCHEME_MESSAGE,
     APP_SDK_COLOR_SCHEME_REQUEST_MESSAGE,
     APP_SDK_DATA_APP_VIZ_CONTEXT_MESSAGE,
@@ -15,10 +16,14 @@ import {
     type AppColorScheme,
     type DashboardFilters,
     type DataAppVizContext,
+    type ItemsMap,
+    type MetricQuery,
+    type ParametersValuesMap,
     type QueryExecutionContext,
 } from '@lightdash/common';
 import { useCallback, useEffect, useRef, type RefObject } from 'react';
 import { lightdashApi } from '../../../api';
+import { type DrillDownConfig } from '../../../components/MetricQueryData/types';
 import useEmbed from '../../../ee/providers/Embed/useEmbed';
 import {
     getGdriveAccessToken,
@@ -31,6 +36,10 @@ import {
     type GsheetExportColumn,
     type GsheetExportRow,
 } from './handleGsheetExport';
+import {
+    resolveAppDrillDown,
+    type AppDrillDownSource,
+} from './resolveAppDrillDown';
 
 // Same key the SDK persists `instanceUrl` under (sdk/index.tsx, api.ts).
 // Duplicated rather than imported to avoid threading a shared export through
@@ -238,11 +247,10 @@ export type UseAppSdkBridgeParams = {
      */
     invalidateCache?: boolean;
     /**
-     * Feature capabilities the host page opts into. Currently gates the
-     * Google Sheets export flow — hosts that don't pass `gsheetExport: true`
-     * will receive an error response for those requests.
+     * Feature capabilities the host page opts into. Each capability is closed
+     * by default; unsupported requests receive an error response.
      */
-    capabilities?: { gsheetExport?: boolean };
+    capabilities?: { gsheetExport?: boolean; drillDown?: boolean };
     onLineageAvailable?: () => void;
     onLineageSelected?: (event: { queryUuid: string }) => void;
     /**
@@ -284,6 +292,8 @@ export type UseAppSdkBridgeParams = {
      * iframe input).
      */
     onVizDrillDownIntent?: (intentBody: unknown) => void;
+    /** Opens core's drill dialog for a query-bound full-app click intent. */
+    onAppDrillDownIntent?: (config: DrillDownConfig) => void;
     // When set, `lightdash:sdk:url-state-change` messages from the iframe SDK
     // are validated and forwarded. Left undefined, they're ignored.
     onUrlStateChange?: (state: Record<string, unknown>) => void;
@@ -326,6 +336,7 @@ export function useAppSdkBridge({
     dataAppVizContext,
     rewriteVizUnderlyingDataRequest,
     onVizDrillDownIntent,
+    onAppDrillDownIntent,
     onUrlStateChange,
     onSdkManifest,
     deliveryCapture,
@@ -354,6 +365,12 @@ export function useAppSdkBridge({
     // in-flight set never drains and the screenshot indicator never
     // mounts).
     const queryUuidToPostIdRef = useRef<Map<string, string>>(new Map());
+    // Canonical query context captured from successful backend submissions.
+    // Full apps can run many queries, so the click intent carries only a UUID
+    // and is resolved against this trusted host-owned registry.
+    const drillDownSourcesRef = useRef<Map<string, AppDrillDownSource>>(
+        new Map(),
+    );
 
     // Push the render context into the iframe. Sent in response to the iframe's
     // `viz-context-request` handshake (the renderer mounts after its bundle
@@ -760,6 +777,32 @@ export function useAppSdkBridge({
                 return;
             }
 
+            // Full-app native drill-down is also host-owned, but unlike a viz
+            // the app may have many loaded queries. Resolve its UUID against
+            // the canonical query response recorded by this bridge.
+            if (path === APP_SDK_DRILL_DOWN_PATH) {
+                if (capabilities?.drillDown !== true || !onAppDrillDownIntent) {
+                    respond({
+                        error: 'Native drill-down is not available for this data app.',
+                    });
+                    return;
+                }
+                try {
+                    onAppDrillDownIntent(
+                        resolveAppDrillDown(body, drillDownSourcesRef.current),
+                    );
+                    respond({ result: {} });
+                } catch (err) {
+                    respond({
+                        error:
+                            err instanceof Error
+                                ? err.message
+                                : 'Invalid drill-down request.',
+                    });
+                }
+                return;
+            }
+
             if (!isAllowedAppSdkRoute(method, path)) {
                 respond({ error: `Blocked: ${method} ${path}` });
                 return;
@@ -950,6 +993,38 @@ export function useAppSdkBridge({
                             id,
                             json.results ?? null,
                         );
+
+                        const queryUuid = json.results?.queryUuid;
+                        const metricQuery = json.results?.metricQuery;
+                        const fields = json.results?.fields;
+                        if (
+                            capabilities?.drillDown === true &&
+                            onAppDrillDownIntent &&
+                            typeof queryUuid === 'string' &&
+                            typeof metricQuery === 'object' &&
+                            metricQuery !== null &&
+                            typeof fields === 'object' &&
+                            fields !== null
+                        ) {
+                            const usedParametersValues =
+                                json.results?.usedParametersValues;
+                            const parameters =
+                                typeof usedParametersValues === 'object' &&
+                                usedParametersValues !== null
+                                    ? (usedParametersValues as ParametersValuesMap)
+                                    : (
+                                          effectiveBody as
+                                              | {
+                                                    parameters?: ParametersValuesMap;
+                                                }
+                                              | undefined
+                                      )?.parameters;
+                            drillDownSourcesRef.current.set(queryUuid, {
+                                metricQuery: metricQuery as MetricQuery,
+                                fields: fields as ItemsMap,
+                                parameters,
+                            });
+                        }
                     }
 
                     // Track metric query initiation response (has queryUuid)
@@ -1109,6 +1184,7 @@ export function useAppSdkBridge({
             pushDataAppVizContext,
             rewriteVizUnderlyingDataRequest,
             onVizDrillDownIntent,
+            onAppDrillDownIntent,
             pushColorScheme,
             onUrlStateChange,
             onSdkManifest,
@@ -1131,7 +1207,7 @@ export function useAppSdkBridge({
         pushColorScheme();
     }, [pushColorScheme]);
 
-    const handleIframeLoad = useCallback(() => {
+    const pushSdkReady = useCallback(() => {
         // `*` because the load event fires once for the initial about:blank
         // (which inherits the parent's origin) and again after the iframe
         // navigates to its actual src. With a specific targetOrigin the
@@ -1144,11 +1220,32 @@ export function useAppSdkBridge({
                 // which ignore unknown fields — and new SDKs on old hosts
                 // both default to `useDeliveryRender() === false`.
                 ...(captureRender ? { deliveryRender: true } : {}),
+                ...(capabilities?.drillDown === true && onAppDrillDownIntent
+                    ? { drillDown: { enabled: true } }
+                    : {}),
             },
             '*',
         );
+    }, [
+        iframeRef,
+        captureRender,
+        capabilities?.drillDown,
+        onAppDrillDownIntent,
+    ]);
+
+    const handleIframeLoad = useCallback(() => {
+        queryUuidToPostIdRef.current.clear();
+        drillDownSourcesRef.current.clear();
+        pushSdkReady();
         pushColorScheme();
-    }, [iframeRef, pushColorScheme, captureRender]);
+    }, [pushSdkReady, pushColorScheme]);
+
+    // Permissions can resolve after the iframe's load event. Re-advertise the
+    // capability when that happens; new SDKs update their host capability from
+    // every ready message, while the normal load path remains the fallback.
+    useEffect(() => {
+        pushSdkReady();
+    }, [pushSdkReady]);
 
     // Re-push the render context whenever the host's field mapping or rows
     // change, so an already-loaded iframe re-renders live. The initial delivery

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -279,7 +279,7 @@ export default function AppPreviewTest() {
                     onQueryEvent={handleQueryEvent}
                     onExternalRequestEvent={handleExternalRequestEvent}
                     urlStateSync
-                    capabilities={{ gsheetExport: true }}
+                    capabilities={{ gsheetExport: true, drillDown: true }}
                     lineageEnabled={lineageEnabled}
                     onLineageAvailabilityChange={setLineageAvailable}
                     onLineageSelected={handleLineageSelected}

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -301,6 +301,7 @@ export default function MinimalApp() {
                 identityKey={`${appUuid}:${latestReadyVersion}`}
                 onIframeLoad={handleIframeLoad}
                 onQueryEvent={handleQueryEvent}
+                capabilities={{ drillDown: captureMode === null }}
                 onScreenshotAvailabilityChange={handleScreenshotAvailable}
                 deliveryCapture={deliveryCapture}
                 // Both capture modes need every tab's data mounted: the

--- a/packages/query-sdk/README.md
+++ b/packages/query-sdk/README.md
@@ -155,9 +155,40 @@ strings, numbers, or arrays of either. They are sent at the top level of the API
 | `error`   | `Error \| null` | Error if the query failed.                                       |
 | `refetch` | `() => void`    | Re-run the query.                                                |
 | `queryUuid` | `string \| null` | Async query UUID for the loaded source query.                 |
+| `drillDown` | `{ enabled, open({ row, metric }) }` | Open Lightdash's native dimension picker for a metric value. |
 | `getUnderlyingData` | `({ row, metric, limit? }) => Promise<UnderlyingDataResult>` | Fetch raw rows behind an aggregated metric value. |
 | `downloadUnderlyingData` | `({ row, metric, fileType?, values?, limit?, filename? }) => Promise<DownloadResultsResult>` | Schedule a backend CSV/XLSX export for raw rows behind an aggregated metric value. |
 | `downloadResults` | `({ fileType?, values?, limit?, filename? }) => Promise<DownloadResultsResult>` | Schedule a backend CSV/XLSX export for this query. |
+
+## Native drill-down
+
+Inside a full data app hosted by Lightdash, each loaded query exposes a native
+drill-down action. Keep the original result row on the interactive datum and
+show the action only when `enabled` is true:
+
+```tsx
+const { data, drillDown } = useLightdash(revenueQuery);
+
+return data.map((row) =>
+    drillDown.enabled ? (
+        <button
+            onClick={() =>
+                drillDown.open({ row, metric: 'total_revenue' })
+            }
+        >
+            Drill into revenue
+        </button>
+    ) : null,
+);
+```
+
+Lightdash opens its own dimension picker and then the drilled query in Explore.
+The action is bound to the exact loaded query, so saved charts, parameters,
+dashboard filters, and custom query fields stay in host-owned query context.
+
+For a custom inline drill experience or a standalone SDK client, use
+`buildDrillDownQuery()` (the original `drillDown()` export remains as a
+backwards-compatible alias) and execute the returned query with `useLightdash()`.
 
 ## Underlying data
 

--- a/packages/query-sdk/src/apiTransport.ts
+++ b/packages/query-sdk/src/apiTransport.ts
@@ -15,12 +15,15 @@ import type {
     DownloadResultsOptions,
     DownloadResultsResult,
     DownloadUnderlyingDataOptions,
+    DrillDownAction,
     ExternalFetchOptions,
     ExternalFetchResult,
     FormatFunction,
+    HostDrillDownIntent,
     InternalFilterDefinition,
     LightdashClientConfig,
     LightdashUser,
+    NativeDrillDownOptions,
     ParametersValuesMap,
     QueryDefinition,
     QueryResult,
@@ -42,6 +45,83 @@ const MAX_BACKOFF_MS = 1000;
 const MAX_POLL_DURATION_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_DOWNLOAD_POLL_DURATION_MS = 10 * 60 * 1000; // 10 minutes
 const ALL_RESULTS_LIMIT = Number.MAX_SAFE_INTEGER;
+
+export type HostDrillDownBridge = {
+    isEnabled: () => boolean;
+    open: (intent: HostDrillDownIntent) => Promise<void>;
+};
+
+type HostDrillDownField = {
+    /** Public key on the flat SDK row. */
+    name: string;
+    /** Canonical field id used by the host metric query. */
+    fieldId: string;
+};
+
+export function buildHostDrillDownAction({
+    bridge,
+    queryUuid,
+    fields,
+    requiredDimensions,
+    resolveMetric,
+    validMetricIds,
+    format,
+}: {
+    bridge?: HostDrillDownBridge;
+    queryUuid: string;
+    fields: HostDrillDownField[];
+    requiredDimensions: string[];
+    resolveMetric: (metric: string) => string;
+    validMetricIds: string[];
+    format: FormatFunction;
+}): DrillDownAction {
+    return {
+        get enabled() {
+            return bridge?.isEnabled() === true;
+        },
+        open: async ({ row, metric }: NativeDrillDownOptions) => {
+            if (!bridge?.isEnabled()) {
+                throw new Error(
+                    'Native drill-down is not available in this Lightdash host. Use buildDrillDownQuery() for a custom or standalone drill experience.',
+                );
+            }
+
+            for (const dimension of requiredDimensions) {
+                if (!Object.prototype.hasOwnProperty.call(row, dimension)) {
+                    throw new Error(
+                        `Cannot drill down because the row is missing dimension "${dimension}". Pass the original row returned by useLightdash().`,
+                    );
+                }
+            }
+
+            const metricId = resolveMetric(metric);
+            if (!validMetricIds.includes(metricId)) {
+                throw new Error(
+                    `Cannot drill down into "${metric}" because it is not a metric in the source query.`,
+                );
+            }
+
+            const intentRow: HostDrillDownIntent['row'] = {};
+            for (const field of fields) {
+                if (!Object.prototype.hasOwnProperty.call(row, field.name)) {
+                    continue;
+                }
+                intentRow[field.fieldId] = {
+                    value: {
+                        raw: row[field.name],
+                        formatted: format(row, field.name),
+                    },
+                };
+            }
+
+            return bridge.open({
+                queryUuid,
+                row: intentRow,
+                metric: metricId,
+            });
+        },
+    };
+}
 
 type ApiResponse<T> = {
     status: 'ok';
@@ -779,6 +859,7 @@ function mapApiRowsToQueryResult({
 export function createApiTransport(
     config: LightdashClientConfig,
     adapter?: FetchAdapter,
+    hostDrillDownBridge?: HostDrillDownBridge,
 ): Transport {
     const fetchFn = adapter ?? createDefaultFetchAdapter(config);
 
@@ -822,6 +903,19 @@ export function createApiTransport(
                 fieldIds: allQualified,
                 fieldNameForId: (fieldId) =>
                     qualifiedToShort.get(fieldId) ?? fieldId,
+            });
+
+            const drillDown = buildHostDrillDownAction({
+                bridge: hostDrillDownBridge,
+                queryUuid,
+                fields: allShort.map((name, index) => ({
+                    name,
+                    fieldId: allQualified[index],
+                })),
+                requiredDimensions: query.dimensions,
+                resolveMetric: qualify,
+                validMetricIds: qualifiedMetrics,
+                format: mappedResult.format,
             });
 
             const getUnderlyingData = async (
@@ -944,6 +1038,7 @@ export function createApiTransport(
                 ...mappedResult,
                 totalResults: firstReadyPage.totalResults,
                 queryUuid,
+                drillDown,
                 getUnderlyingData,
                 downloadUnderlyingData,
                 downloadResults,
@@ -1014,6 +1109,19 @@ export function createApiTransport(
             });
 
             const chartMetrics = metricQuery?.metrics ?? [];
+
+            const drillDown = buildHostDrillDownAction({
+                bridge: hostDrillDownBridge,
+                queryUuid,
+                fields: fieldIds.map((fieldId) => ({
+                    name: fieldId,
+                    fieldId,
+                })),
+                requiredDimensions: metricQuery?.dimensions ?? [],
+                resolveMetric: (metric) => metric,
+                validMetricIds: chartMetrics,
+                format: mappedResult.format,
+            });
 
             const execUnderlying = async (
                 options: { metric: string; row: Row },
@@ -1126,6 +1234,7 @@ export function createApiTransport(
                 ...mappedResult,
                 totalResults: firstReadyPage.totalResults,
                 queryUuid,
+                drillDown,
                 getUnderlyingData,
                 downloadUnderlyingData,
                 downloadResults,

--- a/packages/query-sdk/src/features.ts
+++ b/packages/query-sdk/src/features.ts
@@ -45,6 +45,13 @@ export const SDK_FEATURES: SdkFeature[] = [
             'Derive drill-down queries from a clicked result row to build explore-style interactions.',
     },
     {
+        key: 'app-drill-down',
+        label: 'Native drill-down',
+        description:
+            'Open Lightdash’s native dimension picker and drilled Explore view from a full data app query result.',
+        wiring: 'For each metric data point, keep the original row returned by useLightdash(), show “Drill into …” only when that query result’s drillDown.enabled is true, and call drillDown.open({ row, metric }). Use buildDrillDownQuery() only when the app needs a custom inline or standalone drill experience.',
+    },
+    {
         key: 'inspect',
         label: 'Element inspection',
         description:

--- a/packages/query-sdk/src/hostDrillDown.test.ts
+++ b/packages/query-sdk/src/hostDrillDown.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    buildHostDrillDownAction,
+    type HostDrillDownBridge,
+} from './apiTransport';
+
+const makeAction = (bridge?: HostDrillDownBridge) =>
+    buildHostDrillDownAction({
+        bridge,
+        queryUuid: 'q-1',
+        fields: [
+            { name: 'status', fieldId: 'orders_status' },
+            { name: 'revenue', fieldId: 'orders_revenue' },
+        ],
+        requiredDimensions: ['status'],
+        resolveMetric: (metric) => `orders_${metric}`,
+        validMetricIds: ['orders_revenue'],
+        format: (row, field) =>
+            field === 'revenue' ? `$${row[field]}` : String(row[field]),
+    });
+
+describe('host drill-down action', () => {
+    it('qualifies and formats the original SDK row before posting', async () => {
+        const open = vi.fn().mockResolvedValue(undefined);
+        const action = makeAction({ isEnabled: () => true, open });
+
+        expect(action.enabled).toBe(true);
+        await action.open({
+            row: { status: 'paid', revenue: 42 },
+            metric: 'revenue',
+        });
+
+        expect(open).toHaveBeenCalledWith({
+            queryUuid: 'q-1',
+            metric: 'orders_revenue',
+            row: {
+                orders_status: {
+                    value: { raw: 'paid', formatted: 'paid' },
+                },
+                orders_revenue: {
+                    value: { raw: 42, formatted: '$42' },
+                },
+            },
+        });
+    });
+
+    it('is disabled without a current host capability', async () => {
+        const action = makeAction();
+        expect(action.enabled).toBe(false);
+        await expect(
+            action.open({ row: { status: 'paid' }, metric: 'revenue' }),
+        ).rejects.toThrow(/not available/i);
+    });
+
+    it('reflects capability changes announced after the query loaded', () => {
+        let enabled = false;
+        const action = makeAction({
+            isEnabled: () => enabled,
+            open: vi.fn(),
+        });
+
+        expect(action.enabled).toBe(false);
+        enabled = true;
+        expect(action.enabled).toBe(true);
+    });
+
+    it('rejects transformed rows and non-source metrics', async () => {
+        const action = makeAction({
+            isEnabled: () => true,
+            open: vi.fn(),
+        });
+        await expect(
+            action.open({ row: { revenue: 42 }, metric: 'revenue' }),
+        ).rejects.toThrow(/missing dimension "status"/i);
+        await expect(
+            action.open({
+                row: { status: 'paid', revenue: 42 },
+                metric: 'profit',
+            }),
+        ).rejects.toThrow(/not a metric in the source query/i);
+    });
+});

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -2,8 +2,10 @@
 export { query } from './query';
 export { savedChart, type SavedChartQuery } from './savedChart';
 
-// Drill-down helper
-export { drillDown } from './drillDown';
+// Drill-down query builder (custom/standalone escape hatch). The original
+// name remains backwards compatible; the explicit alias distinguishes it
+// from the native `useLightdash().drillDown` action.
+export { drillDown, drillDown as buildDrillDownQuery } from './drillDown';
 
 // Client
 export { createClient, LightdashClient } from './client';
@@ -39,6 +41,7 @@ export type {
     DownloadResultsResult,
     DownloadResultsValues,
     DownloadUnderlyingDataOptions,
+    DrillDownAction,
     ExternalFetchMethod,
     ExternalFetchOptions,
     ExternalFetchResult,
@@ -49,6 +52,7 @@ export type {
     LightdashClientConfig,
     LightdashUser,
     MetricType,
+    NativeDrillDownOptions,
     QueryDefinition,
     QueryResult,
     Row,

--- a/packages/query-sdk/src/postMessageTransport.ts
+++ b/packages/query-sdk/src/postMessageTransport.ts
@@ -16,8 +16,10 @@ import type {
     ExternalFetchMethod,
     ExternalFetchOptions,
     ExternalFetchResult,
+    HostDrillDownIntent,
     Transport,
 } from './types';
+import { DRILL_DOWN_PATH } from './types';
 
 // ---------------------------------------------------------------------------
 // Protocol types — shared with the parent-side bridge (useAppSdkBridge)
@@ -46,6 +48,8 @@ export type SdkReadyMessage = {
      *  or its preview. Absent (never `false`) on ordinary interactive loads —
      *  see `deliveryRender.ts`'s `useDeliveryRender()`. */
     deliveryRender?: boolean;
+    /** Native full-app drill-down is available in this host for this viewer. */
+    drillDown?: { enabled?: boolean };
 };
 
 export type SdkScreenshotRequest = {
@@ -88,7 +92,10 @@ export type SdkGsheetExportColumn = {
     type?: SdkGsheetExportColumnType;
 };
 
-export type SdkGsheetExportRow = Record<string, string | number | boolean | null>;
+export type SdkGsheetExportRow = Record<
+    string,
+    string | number | boolean | null
+>;
 
 /**
  * Iframe → parent. The parent host (useAppSdkBridge) runs the Google OAuth
@@ -163,8 +170,9 @@ export const createRequestId = (): string =>
 function createPostMessageFetchAdapter(config: {
     targetWindow: Window;
     timeoutMs?: number;
+    onReady?: (message: SdkReadyMessage) => void;
 }): FetchAdapter {
-    const { targetWindow, timeoutMs = DEFAULT_TIMEOUT_MS } = config;
+    const { targetWindow, timeoutMs = DEFAULT_TIMEOUT_MS, onReady } = config;
     const pending = new Map<string, PendingRequest>();
 
     let readyResolve: (() => void) | null = null;
@@ -180,12 +188,17 @@ function createPostMessageFetchAdapter(config: {
         // The UUID ids already make spoofing hard — this closes the gap cheaply.
         if (event.source !== targetWindow) return;
         const { data } = event;
-        if (!data || typeof data !== 'object' || typeof data.type !== 'string') {
+        if (
+            !data ||
+            typeof data !== 'object' ||
+            typeof data.type !== 'string'
+        ) {
             return;
         }
 
         if (data.type === 'lightdash:sdk:ready') {
             clearTimeout(readyTimer);
+            onReady?.(data as SdkReadyMessage);
             readyResolve?.();
             readyResolve = null;
             return;
@@ -220,7 +233,11 @@ function createPostMessageFetchAdapter(config: {
         return new Promise<T>((resolve, reject) => {
             const timer = setTimeout(() => {
                 pending.delete(id);
-                reject(new Error(`SDK fetch timed out after ${timeoutMs}ms: ${method} ${path}`));
+                reject(
+                    new Error(
+                        `SDK fetch timed out after ${timeoutMs}ms: ${method} ${path}`,
+                    ),
+                );
             }, timeoutMs);
 
             pending.set(id, {
@@ -286,7 +303,11 @@ function createPostMessageExternalFetch(config: {
         // The UUID ids already make spoofing hard — this closes the gap cheaply.
         if (event.source !== targetWindow) return;
         const { data } = event;
-        if (!data || typeof data !== 'object' || typeof data.type !== 'string') {
+        if (
+            !data ||
+            typeof data !== 'object' ||
+            typeof data.type !== 'string'
+        ) {
             return;
         }
 
@@ -376,13 +397,27 @@ export function createPostMessageTransport(
     // Listen for the delivery/preview capture flag riding on the same
     // `lightdash:sdk:ready` handshake — see `useDeliveryRender()`.
     mountDeliveryRender(config.targetWindow);
+    let hostDrillDownEnabled = false;
     const adapter = createPostMessageFetchAdapter({
         targetWindow: config.targetWindow,
         timeoutMs: config.timeoutMs,
+        onReady: (message) => {
+            hostDrillDownEnabled = message.drillDown?.enabled === true;
+        },
     });
     const httpTransport = createApiTransport(
         { apiKey: '', baseUrl: '', projectUuid: config.projectUuid },
         adapter,
+        {
+            isEnabled: () => hostDrillDownEnabled,
+            open: async (intent: HostDrillDownIntent) => {
+                await adapter<Record<string, never>>(
+                    'POST',
+                    DRILL_DOWN_PATH,
+                    intent,
+                );
+            },
+        },
     );
     const externalFetch = createPostMessageExternalFetch({
         targetWindow: config.targetWindow,

--- a/packages/query-sdk/src/types.ts
+++ b/packages/query-sdk/src/types.ts
@@ -156,6 +156,21 @@ export type Row = Record<string, string | number | boolean | null>;
 
 export type FormatFunction = (row: Row, fieldId: string) => string;
 
+export type NativeDrillDownOptions = {
+    /** Original row returned by this query result. */
+    row: Row;
+    /** Metric from the source query. */
+    metric: string;
+};
+
+/** Native Lightdash drill-down bound to one loaded query result. */
+export type DrillDownAction = {
+    /** False outside a current Lightdash iframe host or without permission. */
+    enabled: boolean;
+    /** Ask the host to open its dimension picker and drilled Explore view. */
+    open: (options: NativeDrillDownOptions) => Promise<void>;
+};
+
 export type QueryResult = {
     rows: Row[];
     columns: Column[];
@@ -164,6 +179,8 @@ export type QueryResult = {
     totalResults?: number;
     /** Async query UUID for the source query. Useful for debugging and advanced flows. */
     queryUuid?: string;
+    /** Host-owned drill-down for a metric value from this query result. */
+    drillDown?: DrillDownAction;
     /**
      * Fetch raw rows behind an aggregated metric value from this query result.
      * Available when the transport supports Lightdash underlying-data queries.
@@ -277,6 +294,24 @@ export const VIZ_DRILL_DOWN_PATH = '/__sdk/viz/drill-down';
  * subsequent UI.
  */
 export type VizDrillDownIntent = {
+    row: Record<
+        string,
+        { value?: { raw?: unknown; formatted?: string } } | undefined
+    >;
+    metric: string;
+};
+
+/**
+ * Bridge-only virtual route for native drill-down from a full data app.
+ * Duplicated from `@lightdash/common` (`APP_SDK_DRILL_DOWN_PATH`) because the
+ * published SDK intentionally has no common-package dependency.
+ */
+export const DRILL_DOWN_PATH = '/__sdk/drill-down';
+
+/** Internal full-app click intent. Public callers pass a flat SDK row; the
+ * transport qualifies its keys and restores formatted values before posting. */
+export type HostDrillDownIntent = {
+    queryUuid: string;
     row: Record<
         string,
         { value?: { raw?: unknown; formatted?: string } } | undefined

--- a/packages/query-sdk/src/useLightdash.ts
+++ b/packages/query-sdk/src/useLightdash.ts
@@ -19,9 +19,10 @@ import { QueryBuilder } from './query';
 import { savedChartQueryKey, type SavedChartQuery } from './savedChart';
 import type {
     Column,
-    DownloadUnderlyingDataOptions,
     DownloadResultsOptions,
     DownloadResultsResult,
+    DownloadUnderlyingDataOptions,
+    DrillDownAction,
     FormatFunction,
     Row,
     UnderlyingDataOptions,
@@ -39,6 +40,13 @@ export const buildLineageProps = (queryUuid: string | null): LineageProps =>
     queryUuid ? { 'data-ld-query': queryUuid } : {};
 
 const noopFormat: FormatFunction = (_row, _fieldId) => '';
+
+const drillDownUnavailable = (message: string): DrillDownAction => ({
+    enabled: false,
+    open: async () => {
+        throw new Error(message);
+    },
+});
 
 type UseLightdashResult = {
     /** Result rows as flat objects. Numbers are numbers, strings are strings. */
@@ -59,6 +67,8 @@ type UseLightdashResult = {
     queryUuid: string | null;
     /** Spread onto the root element of this query's UI block to enable data lineage. */
     lineage: LineageProps;
+    /** Native host drill-down bound to this loaded query. */
+    drillDown: DrillDownAction;
     /** Fetch raw rows behind an aggregated metric value from this query result. */
     getUnderlyingData: (
         options: UnderlyingDataOptions,
@@ -85,6 +95,11 @@ export function useLightdash(
     const [error, setError] = useState<Error | null>(null);
     const [fetchCount, setFetchCount] = useState(0);
     const [queryUuid, setQueryUuid] = useState<string | null>(null);
+    const [drillDown, setDrillDown] = useState<DrillDownAction>(() =>
+        drillDownUnavailable(
+            'Drill-down is not available before the query loads.',
+        ),
+    );
     const [getUnderlyingData, setGetUnderlyingData] = useState<
         UseLightdashResult['getUnderlyingData']
     >(() => async () => {
@@ -125,6 +140,11 @@ export function useLightdash(
         setError(null);
         setQueryUuid(null);
         setTotalResults(null);
+        setDrillDown(
+            drillDownUnavailable(
+                'Drill-down is not available before the query loads.',
+            ),
+        );
         setGetUnderlyingData(() => async () => {
             throw new Error(
                 'Underlying data is not available before the query loads.',
@@ -159,6 +179,12 @@ export function useLightdash(
                 setFormat(() => res.format);
                 setTotalResults(res.totalResults ?? res.rows.length);
                 setQueryUuid(res.queryUuid ?? null);
+                setDrillDown(
+                    res.drillDown ??
+                        drillDownUnavailable(
+                            'Native drill-down is not supported by this Lightdash transport. Use buildDrillDownQuery() for a custom or standalone drill experience.',
+                        ),
+                );
                 setGetUnderlyingData(
                     () => async (options: UnderlyingDataOptions) => {
                         if (!res.getUnderlyingData) {
@@ -216,6 +242,7 @@ export function useLightdash(
         refetch,
         queryUuid,
         lineage,
+        drillDown,
         getUnderlyingData,
         downloadUnderlyingData,
         downloadResults,

--- a/sandboxes/data-apps/template/.claude/skills/sdk-features/SKILL.md
+++ b/sandboxes/data-apps/template/.claude/skills/sdk-features/SKILL.md
@@ -19,7 +19,8 @@ Users describe features by what they see in the Lightdash editor. Translate:
 | "Inspect data" (Queries panel button) | `lineage` | required — see below |
 | "select an element", editor element picker | `inspect` | none (automatic) |
 | thumbnails / screenshots / scheduled deliveries | `screenshot` | required — see below |
-| drill down, click into a chart | `drill-down` | app code opt-in |
+| native drill down in a full app | `app-drill-down` | app code opt-in |
+| custom inline drill query | `drill-down` | app code opt-in |
 | drill into a viz data point (reusable visualization) | `viz-drill-down` | app code opt-in |
 | "share this view", URL that restores state | `url-state` | app code opt-in |
 | Google Sheets export | `gsheet-export` | app code opt-in |
@@ -101,12 +102,19 @@ order, `sortBy` describes result ordering, `totalColumnCount` exposes truncation
 
 ### App-code opt-ins (call the API where it fits the app)
 
-- `drill-down`: `drillDown(...)` derives a more detailed query from a clicked
-  result row — wire it to click handlers on charts/rows.
+- `app-drill-down`: every loaded `useLightdash()` result exposes
+  `drillDown: { enabled, open }`. Keep the original result row on each metric
+  datum, show "Drill into …" only when `drillDown.enabled`, and call
+  `drillDown.open({ row, metric })`. Lightdash opens its native dimension
+  picker and Explore flow.
+- `drill-down`: `buildDrillDownQuery(...)` (also exported under its original
+  name, `drillDown`) derives a query for a custom inline or standalone drill
+  experience. Do not use it for the ordinary hosted-app action.
 - `viz-drill-down`: in a reusable visualization, the data-point action menu
   offers "Drill into …" when `useVizContext().drillDown.enabled`; selection
   calls `drillDown.open({ row, metric })` and Lightdash opens its drill
-  dialog. Distinct from `drill-down`, which is the full-app query helper.
+  dialog. Distinct from `app-drill-down`, which is bound to a full app's
+  `useLightdash()` result.
 - `url-state`: `useUrlState(...)` syncs a piece of app state into the page URL
   so views can be shared and restored.
 - `gsheet-export`: `exportToSheets(...)` sends tabular results to a new

--- a/sandboxes/data-apps/template/references/drilldown.md
+++ b/sandboxes/data-apps/template/references/drilldown.md
@@ -1,17 +1,17 @@
-# `drillDown()` API reference
+# Custom drill-down query reference
 
-> Read this when adding drill-down actions beyond the basic pattern shown in the action-menu example.
+> Read this only when the user needs an inline/standalone drill result or a predetermined drill dimension. For normal Lightdash-hosted apps, use the native `drillDown.open({ row, metric })` action returned by `useLightdash()`.
 
-`drillDown()` builds a new query from a clicked row. Import it alongside `query` and `useLightdash`:
+`buildDrillDownQuery()` builds a new query from a clicked row. Import it alongside `query` and `useLightdash`:
 
 ```ts
-import { query, useLightdash, drillDown } from '@lightdash/query-sdk';
+import { buildDrillDownQuery, query, useLightdash } from '@lightdash/query-sdk';
 ```
 
 ### API
 
 ```ts
-drillDown({
+buildDrillDownQuery({
     sourceQuery,   // The QueryBuilder that produced the clicked data
     metric,        // Which metric to drill into (string)
     dimension,     // Which dimension to drill by (string)
@@ -42,7 +42,7 @@ The agent decides the drill dimension at build time from the dbt YAML. For user-
 ```tsx
 const [drillDim, setDrillDim] = useState('order_date');
 // In the menu item onClick:
-setDrillQuery(drillDown({ sourceQuery, metric: 'total_revenue', dimension: drillDim, row }));
+setDrillQuery(buildDrillDownQuery({ sourceQuery, metric: 'total_revenue', dimension: drillDim, row }));
 ```
 
 ### Displaying drill results

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -330,6 +330,7 @@ If the dbt YAML declares a `parameters:` block (under a model's `meta:` / `confi
 | `lineage` | `LineageProps` | **Spread on the root element of every rendered query block** (`<div {...lineage}>`). Stamps the block so the host's Inspect data button can trace it back to this query — without it that button stays disabled. |
 | `refetch` | `() => void` | Re-run the query on demand. |
 | `queryUuid` | `string \| null` | The async Lightdash query UUID for the loaded source query. Rarely needed directly. |
+| `drillDown` | `{ enabled: boolean; open: ({ row, metric }) => Promise<void> }` | Open Lightdash's native drill-down dialog for a metric result. Show the action only when `enabled` is true and call it from a user action with the original result row. |
 | `getUnderlyingData` | `({ row, metric, limit? }) => Promise<{ rows, columns, format, queryUuid }>` | Fetch raw rows behind an aggregated metric value. Call from a user action, never on initial render. |
 | `downloadUnderlyingData` | `({ row, metric, fileType?, values?, limit?, filename? }) => Promise<{ fileUrl, truncated, queryUuid, jobId }>` | Schedule a backend CSV/XLSX export for raw rows behind an aggregated metric value. Call from a user action. |
 | `downloadResults` | `({ fileType?, values?, limit?, filename? }) => Promise<{ fileUrl, truncated, queryUuid, jobId }>` | Schedule a backend CSV/XLSX export. Call from a user action. |
@@ -800,7 +801,7 @@ Every user-triggered async data action must also show a loading state while it i
 - `downloadResults()` and `downloadUnderlyingData()` exports: disable export controls and show a spinner or "Exporting..." label until the promise settles.
 - PDF exports: disable the Download PDF button and show a spinner or "Exporting..." label until the file has been saved.
 - `getUnderlyingData()` requests: show a spinner in the dialog/sheet/table area until rows arrive.
-- Drilldown queries: show a spinner in the drilldown dialog while the drill query loads.
+- Custom inline drilldown queries: show a spinner in the app-owned dialog while the drill query loads. Native `drillDown.open()` loading is owned by Lightdash.
 - `refetch()` flows: show an inline refresh spinner or disabled refreshing state.
 
 **Keep the surrounding UI stable during loading.** Cards, headings, and layout should always render — only the data-driven content (chart, table body, KPI value) should be replaced with a spinner. This prevents the page from flashing or reflowing when data arrives.
@@ -985,16 +986,18 @@ wrong from the first frame.
 
 **When the clicked value represents a metric result, the same default action menu should also include "View underlying data".** Users should not have to explicitly ask for underlying data support. Add it for bars, points, slices, KPI values, pivot value cells, and table metric cells whenever you have the original source `row` and metric name. It should call `getUnderlyingData({ row, metric })` from a user action and show the rows in a dialog/sheet with loading and error states. That underlying-data table/dialog must include a Download button that calls `downloadUnderlyingData({ row, metric, ... })`. If the clicked cell is only a dimension/category value with no metric context, underlying-data actions can be omitted.
 
-Additional contextual options can be added when useful:
+The same metric-value menu should include **"Drill into …"** whenever the loaded result's `drillDown.enabled` is true. Call `drillDown.open({ row, metric })` with the original result row. Lightdash owns the dimension picker and results dialog, so app code must not choose the drill dimension or build a second query for this default interaction.
 
-- **Drill down** — see this metric broken down by another dimension
+Additional contextual options can be added when useful.
+
+For a custom inline or standalone drill experience, use `buildDrillDownQuery()` as described in [Custom drill-down queries](#custom-drill-down-queries).
 
 Use the `DropdownMenu` component. The menu opens on click; each option triggers its respective action.
 
 ```tsx
 import { useState, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { query, useLightdash, drillDown } from '@lightdash/query-sdk';
+import { query, useLightdash } from '@lightdash/query-sdk';
 import { Bar, BarChart } from 'recharts';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { useGlobalFilters } from '@/lib/filters';
@@ -1012,10 +1015,15 @@ function RevenueChart() {
         () => baseQuery.filters(filtersFor(EXPLORE)),
         [filtersFor],
     );
-    const { data, format, loading, getUnderlyingData, downloadUnderlyingData } =
-        useLightdash(chartQuery);
+    const {
+        data,
+        format,
+        loading,
+        drillDown,
+        getUnderlyingData,
+        downloadUnderlyingData,
+    } = useLightdash(chartQuery);
     const [menuState, setMenuState] = useState(null); // { row, x, y }
-    const [drillState, setDrillState] = useState(null); // { query, title }
     const [underlyingState, setUnderlyingState] = useState(null); // { title, row, metric, promise }
 
     return (
@@ -1075,33 +1083,21 @@ function RevenueChart() {
                         }}>
                             View underlying data
                         </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => {
-                            const row = menuState.row;
-                            setDrillState({
-                                query: drillDown({
-                                    sourceQuery: chartQuery,
-                                    metric: 'total_revenue',
-                                    dimension: 'order_date',
+                        {drillDown.enabled && (
+                            <DropdownMenuItem onClick={() => {
+                                const row = menuState.row;
+                                setMenuState(null);
+                                void drillDown.open({
                                     row,
-                                }),
-                                title: `Revenue for ${format(row, 'customer_segment')}`,
-                            });
-                            setMenuState(null);
-                        }}>
-                            Drill into revenue
-                        </DropdownMenuItem>
+                                    metric: 'total_revenue',
+                                });
+                            }}>
+                                Drill into revenue
+                            </DropdownMenuItem>
+                        )}
                     </DropdownMenuContent>
                 </DropdownMenu>,
                 document.body,
-            )}
-
-            {drillState && (
-                <Dialog open onOpenChange={() => setDrillState(null)}>
-                    <DialogContent className="max-w-3xl">
-                        <DialogHeader><DialogTitle>{drillState.title}</DialogTitle></DialogHeader>
-                        <DrillResults query={drillState.query} />
-                    </DialogContent>
-                </Dialog>
             )}
 
             {underlyingState && (
@@ -1131,7 +1127,7 @@ function RevenueChart() {
 
 `UnderlyingRows` should be a small component that resolves the promise, shows a spinner while pending, handles errors, and renders `result.columns` / `result.rows` in a scrollable table. Its header should include a Download button wired to `onDownload`, disabled while exporting, with a spinner or "Exporting..." label until the promise settles.
 
-**This is the default for every chart and table that renders Lightdash query data.** The "Filter by &lt;value&gt;" option is mandatory. "View underlying data" is also expected for metric values when the source row and metric are unambiguous, and every underlying-data table/dialog should include a Download button. "Drill into …" is encouraged where it makes sense.
+**This is the default for every chart and table that renders Lightdash query data.** The "Filter by &lt;value&gt;" option is mandatory. "View underlying data" is also expected for metric values when the source row and metric are unambiguous, and every underlying-data table/dialog should include a Download button. Include "Drill into …" for metric values whenever `drillDown.enabled` is true.
 
 If the user explicitly asks for a different interaction (e.g., "clicking should always filter without showing a menu" or "no drill-down needed"), follow their instructions. Otherwise, every data-powered chart and table gets the action menu — at minimum with the "Filter by &lt;value&gt;" option wired into the global filter context.
 
@@ -1232,9 +1228,9 @@ If a Recharts component covers it, **use Recharts** — even if a D3 version wou
 
 When you do need D3, **read `/app/references/d3.md` first.** It contains the React-19 + D3 integration pattern, five worked examples (bar, sankey, sunburst, word cloud, geo choropleth/globe), the cross-cutting rules (`CHART_COLORS`, `filtersFor`, action menu, no-cross-refetch animation), and a common-mistakes table. Don't try to wire D3 from memory — load the reference.
 
-## `drillDown()` Reference
+## Custom drill-down queries
 
-The action-menu example above shows typical `drillDown()` usage. For the full API (argument semantics, choosing the drill dimension, and the results-dialog pattern), read `/app/references/drilldown.md`.
+Native `drillDown.open({ row, metric })` is the default in Lightdash-hosted data apps. If a user explicitly requests an inline drill result, a predetermined drill dimension, or a standalone app experience, use `buildDrillDownQuery()` to compose and render that custom query. For the full helper API and results-dialog pattern, read `/app/references/drilldown.md`.
 
 ## Common Pitfalls
 


### PR DESCRIPTION
## Summary

- add a query-bound native drill-down action to each loaded `useLightdash()` result in full data apps
- resolve iframe click intents against canonical query context captured by the host, then reuse core's existing dimension picker and Explore flow
- enable the capability by default on authenticated full-app surfaces while keeping embeds, capture renders, and reusable viz routing closed/separate
- preserve query parameters in the drilled Explore URL
- retain the existing `drillDown()` query builder and add the clearer `buildDrillDownQuery()` alias for custom inline or standalone experiences
- update SDK docs and data-app generation guidance so native drill-down is the default pattern

This closes the corresponding full-data-app gap after #27903, #27904, and #27905 added the reusable-viz path.

## Safety

The virtual drill route is never forwarded to the API. The host advertises it only after the normal drill permission check, binds each request to a host-recorded query UUID, and validates the requested metric and original query dimensions before opening core UI.

## Tests

- `pnpm -F common typecheck`
- `pnpm -F query-sdk typecheck`
- `pnpm -F frontend typecheck`
- `pnpm -F common lint`
- `pnpm -F frontend lint`
- `pnpm -F query-sdk test -- hostDrillDown.test.ts` (145 passed)
- focused frontend bridge, resolver, iframe, and drill modal tests (68 passed)
