### PR TITLE
fix: update streaming mutation test expectations

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
@@ -26,6 +26,7 @@ describe('getStreamToolCallPart', () => {
             },
             toolResult: null,
             isPreliminary: undefined,
+            isArgsPartial: false,
         });
     });
 
@@ -59,6 +60,7 @@ describe('getStreamToolCallPart', () => {
             },
             toolResult: output,
             isPreliminary: false,
+            isArgsPartial: false,
         });
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
@@ -90,7 +90,12 @@ describe('getStepProgressFromChunk', () => {
                 },
                 transient: true,
             }),
-        ).toEqual({ message: 'Cloning project', toolName: 'editDbtProject' });
+        ).toEqual({
+            message: 'Cloning project',
+            toolName: 'editDbtProject',
+            progressId: null,
+            progressStatus: null,
+        });
     });
 
     it('parses progress data chunks without a tool name (toolName null)', () => {
@@ -100,7 +105,12 @@ describe('getStepProgressFromChunk', () => {
                 data: { message: 'Running your query...' },
                 transient: true,
             }),
-        ).toEqual({ message: 'Running your query...', toolName: null });
+        ).toEqual({
+            message: 'Running your query...',
+            toolName: null,
+            progressId: null,
+            progressStatus: null,
+        });
     });
 
     it('ignores unrelated chunks', () => {


### PR DESCRIPTION
Fixes Build & Test failures across all PRs caused by PR #27879.

- Add `isArgsPartial: false` to getStreamToolCallPart test expectations (two tests)
- Add `progressId: null` and `progressStatus: null` to getStepProgressFromChunk test expectations (two tests)

These fields were added to the implementation but the tests weren't updated, causing every PR to fail Build & Test.