### PR TITLE
fix(frontend): close the update mutation call in the dbt sources panel

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSourcesPanel.tsx
@@ -301,7 +301,7 @@ const EditDbtSourceModalInner: FC<{
                 },
             },
             { onSuccess: onClose },
-        });
+        );
     };
 
     return (


### PR DESCRIPTION
Fixes SPK-1362

Main's frontend build fails: `DbtSourcesPanel.tsx` closes a two-argument `updateMutation.mutate(...)` call with `});` instead of `);`. PR CI did not build the frontend for the source branches, so the error only surfaced on main's full build.

Verified locally: `pnpm --filter @lightdash/frontend... build` fails on main and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)