### PR TITLE
docs: add composer-viz-plan investigation and design docs

### DIFF
--- a/docs/composer-viz-plan/01-design.md
+++ b/docs/composer-viz-plan/01-design.md
@@ -1,0 +1,252 @@
+# Step 1 design — Enriched result columns
+
+Status: designed (research complete, ready to break into PRs)
+Date: 2026-08-24
+Companion to: [01-enrich-result-columns.md](01-enrich-result-columns.md) (the plan + research prompt this answers)
+
+Four research passes inform this design: column-construction inventory, format
+expression fidelity audit, provenance design comparison, and consumer refactor
+inventory. This doc is the synthesis; findings are cited inline as file:line.
+
+## 1. The type
+
+```ts
+// packages/common/src/types/results.ts
+
+export type ResultColumnProvenance = {
+    /** Key into the query's fields map (query_history.fields). */
+    fieldId: string;
+    /**
+     * Which query in a multi-source pipeline the field belongs to. Omitted
+     * for single-query results. Two composer nodes can both expose
+     * `orders_status`, so a bare fieldId is ambiguous — the MergeFieldOrigin
+     * lesson (mergeQuery.ts:620-635).
+     */
+    sourceQueryUuid?: string;
+};
+
+export type ResultColumn = {
+    reference: string;
+    type: DimensionType;
+    /** Display label. Absent ⇒ consumers fall back to the reference. */
+    label?: string;
+    /**
+     * Lightdash format expression: ECMA-376 with in-repo extensions (IEC
+     * bytes, tz-shift for date expressions). MUST be rendered with
+     * formatValueWithExpression, never raw numfmt.
+     */
+    format?: string;
+    /** The expression cannot encode locale — carried beside it, mirroring
+     *  Field.separator / getFieldFormatOverrideProps (formatting.ts:1213). */
+    separator?: NumberSeparator;
+    /** Escape hatch for the two non-expressible formats: Compact.AUTO and
+     *  negative round (magnitude rounding). Mirrors getFieldFormatOverrideProps. */
+    formatOptions?: CustomFormat;
+    /** Temporal grain. Required for QUARTER (no ECMA-376 token) and for
+     *  export paths (GSheets) that branch on grain. */
+    timeInterval?: TimeFrames;
+    /** Resolved output of getFormatterTimezone: whether values shift into the
+     *  display timezone. Saves consumers from needing skipTimezoneConversion /
+     *  baseDimensionType. */
+    shiftsTimezone?: boolean;
+    /** Absent ⇒ no semantic field behind this column (computed DuckDB column,
+     *  raw SQL column, table calc, join key). Absence gates interaction
+     *  capabilities (drill, underlying data, URLs) off — by design. */
+    provenance?: ResultColumnProvenance;
+};
+```
+
+Design decisions locked by the research:
+
+- **Provenance is inline and column-keyed, not a field-keyed sidecar.**
+  Pivot fan-out (one field → N `{field}_{agg}_{groupValue}` columns) is
+  unrepresentable in a `Record<FieldId, …>`; the codebase already ships the
+  column-keyed pattern twice (`pivotValuesColumns[col].referenceField`,
+  `MergeTypedColumn.origin`).
+- **No full `ItemsMap` synthesis for generic results.** The merge path is the
+  cautionary evidence: synthesized `Field`s pass every type guard
+  (`isField`/`isDimension`) and then silently misbehave — URL menus resolve
+  the wrong row keys, `richText`/`image`/`colors`/`showUnderlyingValues` are
+  dropped unnoticed, and invalid-field detection can never fire. A handle
+  that returns `undefined` degrades honestly; a fake field is a bug to be
+  discovered.
+- **`format` is a Lightdash expression, not portable ECMA-376.**
+  `formatValueWithExpression` (formatting.ts:752-845) layers IEC-byte
+  handling, tz-relabelling, and registered separator locales on top of
+  numfmt. Every consumer of `column.format` must call it.
+- **Parameters are interpolated server-side at column-build time.** Parameter
+  values are fixed for the lifetime of a query execution (changing one
+  re-executes), so `${ld.parameters.*}` placeholders are resolved via
+  `evaluateConditionalFormatExpression(item.format, usedParametersValues)`
+  before storing `column.format`. This makes the column self-contained and
+  deletes the frontend re-format hack (`formatCellContent`,
+  useColumns.tsx:82-104). The un-interpolated template stays in chart config
+  where it already lives.
+
+Page-level additions on `ReadyQueryResultsPage` (api.ts:1002):
+
+- `resolvedTimezone` — exists on execute responses (api.ts:901), absent from
+  the page; temporal expressions are wrong without it.
+- `fields` — the provenance-resolution map, from `query_history.fields`
+  (already persisted and already used by the page formatter,
+  AsyncQueryService.ts:1382-1389). Ship as a **projection** (label,
+  tableLabel, fieldType, type, urls, richText, image, colors,
+  showUnderlyingValues, filters) rather than full `Field`: `Field.sql` is raw
+  dbt SQL and is not currently exposed on SQL/composer results pages.
+  This addition is where step-2 (interaction capabilities) plugs in; the
+  handle ships first and is inert without it.
+
+## 2. Converter gaps to close first
+
+`getFormatExpression` → `convertCustomFormatToFormatExpression`
+(formatting.ts:1116-1184) is the population workhorse and has 11 audited gaps.
+Fix before populating, or columns will disagree with today's server-formatted
+values:
+
+| Gap | Fix |
+|---|---|
+| G1 `DEFAULT` → null | emit `#,##0.###` |
+| G2 `ID` → null | emit `@` (text format; also fixes Excel scientific-notation IDs) |
+| G3 `DATE`/`TIMESTAMP` → null, `timeInterval` unread | emit `yyyy` / `yyyy-mm` / `yyyy-mm-dd` / `yyyy-mm-dd, hh:mm:ss` per grain; QUARTER and the `(Z)` suffix stay renderer-side via `timeInterval` |
+| G4 round-default divergence (PERCENT/BYTES: expression says 2dp, structured says ≤3-trailing-dropped) | align, and extend the round-trip test that currently misses it (formatting.test.ts:2606-2712 — no bytes fixtures, percent value lands on exactly 2dp) |
+| G5 IEC bytes pseudo-expression (`"KiB"` string-match hack, :777-806) | acceptable, but document `format` as Lightdash-dialect; false-positive risk on user CUSTOM suffixes containing `KiB` |
+| G6 negative round dropped | not expressible → `formatOptions` escape hatch |
+| G7 `Compact.AUTO` → null (NUMBER/CURRENCY) and silently dropped (PERCENT/BYTES) | value-dependent → `formatOptions` escape hatch; fix the silent-drop branch |
+| G8 unescaped prefix/suffix quoting | escape `"` |
+| G9 `YEAR_NUM` invisible to converter (would emit `#,##0.###` → `2,021`) | special-case at population |
+| G10 currency symbol position under `PERIOD_COMMA`; host-locale `DEFAULT` separator | align or accept documented divergence |
+| G11 Excel COUNT override (`#,##0`) | keep in the export path — one `format` cannot hold UI and Excel variants |
+
+Renderer conventions (NOT in the expression): `null → '∅'`, `undefined → '-'`,
+booleans via `formatBoolean` keyed off `type === BOOLEAN`, `'NaT'` for bad
+temporals, fall-back-to-`String(value)` on throw. The two existing
+implementations (formatting.ts vs `formatRowValueFromWarehouse`) already
+agree; lift into one shared helper.
+
+Test seed: extend the round-trip fixture to
+`applyCustomFormat(v, f) === formatValueWithExpression(convert(f), v, locale(f.separator))`
+over every `CustomFormatType` × `{round: undefined, 0, 2, -2}` × every
+separator × `{negative, zero, fractional}` values. G1–G10 fall out as
+failures.
+
+## 3. Population rules per query source
+
+Columns are **persisted at write time** into `query_history.columns`
+(AsyncQueryService.ts:3545-3569) and read verbatim
+(QueryHistoryModel.ts:42-84) — enrichment happens on the write path.
+
+| Source | Rule | Where |
+|---|---|---|
+| **Metric queries** | `itemsMap` is already a parameter of `runQueryAndTransformRows` (AsyncQueryService.ts:2370) and the unpivoted column key *is* the field id. `getUnpivotedColumns` gains an `itemsMap` arg: when `itemsMap[key]` exists → `label = getItemLabel(item)`, `format = getFormatExpression(item)` (post-gap-fixes, parameter-interpolated), `separator`/`formatOptions`/`timeInterval`/`shiftsTimezone` from the item, `provenance = { fieldId: key }`. That single rule is the whole metric-path algorithm. | getUnpivotedColumns.ts:3-21 + call sites :2425, :2629 |
+| **Pivoted value columns** | Pass `valuesColumnData.values()` (not `.keys()`) + `itemsMap` into `getPivotedColumns`. Each `{field}_{agg}_{groupValue}` column: `provenance.fieldId = referenceField`, `format` from the source metric, `label` composed from metric label + `pivotValues[].formatted` (already computed with full formatting, :2556-2580). Index/passthrough columns inherit for free (copied by reference). The hardcoded `type: NUMBER` (getPivotedColumns.ts:53) is wrong for MAX-of-timestamp / boolean ANY — fixing it via `convertItemTypeToDimensionType` is a behavior change, stage separately. | getPivotedColumns.ts + call site :2666-2672 |
+| **Raw SQL / SQL charts** | The virtual-view item map reaches the same seam as `fieldsMap`, so `label = friendlyName(reference)` comes free from the metric-path change. **No provenance** — virtual-view dimensions are not semantic fields; marking them would resurrect the fake-field failure mode. `format` stays undefined. | SqlQueryComposer.ts:86, virtualView.ts:29-102 |
+| **DuckDB compose (composer terminal nodes)** | `buildQueryReferenceCtes` already loads each referenced query's full `QueryHistory` (columns + fields) and discards everything but the CTE string (:6927-6990). Change its return to carry `{cte, tableName, columns, fields}` per reference; thread into `runDuckdbSqlQuery`; match probed output columns against referenced columns. **Pass-through** = name matches exactly one referenced column across all references AND probed type matches → inherit label/format/provenance (for a semanticLayer upstream, fieldId is exact; add `sourceQueryUuid`). **Ambiguous** (same name in ≥2 references) or **computed** (no match / type mismatch) → bare column. Known accuracy ceiling: `SUM(revenue) AS revenue` false-positives on name; the type-match requirement narrows but doesn't eliminate it without a SQL parser — accepted. | AsyncQueryService.ts:6927-6990, :7449-7476, :7578-7584 |
+| **Compose merges** | The cheapest prototype site: at the exact line where `originalColumns` are built (:8118-8123), `compiledMerge.itemsMap[reference]` (label/format) and `typedColumns[].origin` (provenance) are both in hand and currently dropped. Warehouse merges get the metric-path rule automatically. | AsyncQueryService.ts:8118-8123 |
+| **External sources** | DuckDB `DESCRIBE` only — bare columns. Second-class sources gain typing later. | ExternalSourceService.ts:354-373 |
+| **Static autocomplete results** | Full field object in scope at :5510 — trivial. | AsyncQueryService.ts:5477-5512 |
+
+Two producer-side hazards:
+
+- **Cache hits copy old columns into new rows** (:4563-4587). For the cache
+  TTL after deploy, fresh rows serve unenriched columns. Accept it (all
+  consumers must tolerate `undefined` anyway) rather than bumping
+  `CACHE_VERSION` (warehouse-load spike). Retention window is 32 days.
+- **Two dangling states**: *no provenance* (normal, silent) vs *provenance
+  that fails to resolve* (expired source query) must both degrade silently —
+  do NOT reuse the "field not found in dbt project" warning path
+  (useColumns.tsx:609-636) for the latter.
+
+## 4. Consumer changes, ordered
+
+Every consumer change is inert until the producer populates the optional
+fields, so these can land before, after, or interleaved with population.
+
+1. **Exports (HIGH value, self-contained).** Replace the
+   `SQL_QUERY_MOCK_EXPLORER_NAME` string-comparison branch
+   (AsyncQueryService.ts:1977-1999) with a `columnsToItemsMap(columns)`
+   synthesis carrying `label ?? friendlyName(reference)` and `format`.
+   Because `formatItemValue` checks format expressions first and
+   `getExcelFormatExpression` reads `item.format` — Excel `numFmt` **is**
+   ECMA-376, zero conversion — CsvService/ExcelService/PivotTableService/
+   GSheets need no changes. Precedent: `buildItemMapFromColumns`
+   (SchedulerTask.ts:402-422). Named blocker: `GoogleDriveClient.formatCell`
+   branches on `timeInterval` and TIMESTAMP-vs-DATE — hence `timeInterval` on
+   the column. User `customLabels` from chart config must keep winning over
+   `column.label` (assert in a test). Golden-file tests. Do NOT attempt the
+   full ItemsMap→columns rewrite of the four export services.
+2. **Labels (LOW).** `getAiArtifactTableConfig` `label: column.label ??
+   column.reference` (one line; note it also feeds saved-SQL-chart creation —
+   the one write-path side effect); `SqlChartResultsRunner`/
+   `SqlRunnerResultsRunnerFrontend` stop discarding `originalColumns`
+   metadata; `IResultsRunner` gains `getColumns(): ResultColumn[]`;
+   `TableDataModel.getResultOptions` falls back `label ?? column.label ?? key`.
+3. **Format-aware cell renderer (MEDIUM).** Extend TanStack `ColumnMeta` with
+   `resultColumn?: ResultColumn`; `useVirtualTable`/`useTableDataModel` set
+   it; `getValueCell` branches to `formatValueWithExpression` when
+   `format` present, `formatRowValueFromWarehouse` stays the fallback.
+   Timezone hazard: without `resolvedTimezone` on the page, client-side
+   temporal formatting shifts to the viewer's zone — page-level timezone is a
+   prerequisite for temporal columns. Then the AI artifact table keeps `raw`
+   and renders through this (design B — preserves JSON cells and copy-raw).
+4. **Agent preview (MEDIUM, eval-sensitive).** Keep CSV values raw (models
+   re-quote values into SQL; percent display ×100 would corrupt reasoning).
+   Enrich only the `columnSummary` line with label + format so semantics
+   reach the model as metadata. Snapshot tests pin this surface.
+5. **Chart formatters (HIGH, last).** The new viz stack can express only
+   percent/SI/compact today (CartesianChartDataModel two-case switch,
+   PieChartDataModel hardcoded default, BigNumber compact-only). Route
+   through `formatValueWithExpression` with precedence
+   **display-config-wins** over `column.format` (a user's explicit "Percent"
+   choice overrides the column). Enabling one-liners ×4 in
+   `sqlRunnerPivotQueries.ts` (`Object.values(pivotResults.columns)` instead
+   of bare references) — the natural moment to retire the deprecated
+   `VizColumn` alias. Land after (3) so table and chart of the same query
+   agree. Perf note: expression formatting per tooltip callback on wide
+   pivots needs a memoized formatter per column.
+
+## 5. Compatibility (verified)
+
+- **Additive-only**: `ResultColumn` appears in responses everywhere except
+  one request body (`VirtualViewAsCode.columns`), where unknown optional
+  props are ignored (tsoa without `noImplicitAdditionalProperties`).
+  `oasdiff breaking` classifies added optional properties as non-breaking;
+  the release-safety marker computes from migrations/restApi/mcpApi/config
+  and none trips. **No release-safety declaration** (declaring one would be
+  wrong per CLAUDE.md). No migration — the jsonb columns exist.
+- Run `pnpm generate-api` locally to validate; the pre-commit hook unstages
+  the generated artifacts (by design).
+- Old `query_history` rows need **no** read-time defaulting (optionals read
+  as `undefined`; house style is default-at-consumer). If a single seam is
+  wanted later: `convertDbQueryHistoryToQueryHistory` covers every read path.
+- **`VirtualViewCoder` idempotency**: keep its `transform()` emitting the
+  minimal `{reference, type}` shape or normalize before `isEqual`, else every
+  committed virtual-view YAML reports UPDATE forever.
+- **Payload size**: columns ride every results page and are persisted twice
+  more (query_history, pre-aggregate materializations); wide pivots multiply
+  label/format strings. Measure; consider omitting `format` on pivoted value
+  columns in favor of the source column + provenance if it bites.
+- **Snapshot churn**: `expectedColumns` in ProjectService.mock.ts is asserted
+  8× in AsyncQueryService.test.ts — population PRs update these; the
+  type-only PR does not.
+
+## 6. PR slicing
+
+Each lands green on its own; 1–2 are inert to users.
+
+1. Type + converter gap fixes (G1–G4, G8, G9 minimum) + round-trip test grid.
+2. Metric-path + pivot-path population (persisting enriched columns) +
+   snapshot updates. Parameter interpolation at column build.
+3. Export fix (`columnsToItemsMap`) + golden-file tests → **first user-visible
+   win: formatted, labelled SQL/CSV/Excel exports**.
+4. Labels through the viz stack (consumer items 2).
+5. Page-level `resolvedTimezone` + format-aware cell renderer + AI artifact
+   table (consumer items 3).
+6. DuckDB propagation (composer terminal nodes inherit metadata) → **composer
+   results look like Lightdash data** — the step-1 exit criterion.
+7. Agent `columnSummary` enrichment (consumer item 4).
+8. (Step-2 boundary) `fields` projection on the results page + provenance
+   consumers; chart formatters (consumer item 5).
+
+Linear mapping (Standardize project M1): PR1 ≈ PROD-9829/9830, PR2 ≈
+PROD-9831, PR3 ≈ PROD-9833 + PROD-9835, PR6 closes the composer half of M1;
+PROD-9832 (honest SQL column metadata) is the SQL-path rule in §3.

--- a/docs/composer-viz-plan/01-enrich-result-columns.md
+++ b/docs/composer-viz-plan/01-enrich-result-columns.md
@@ -1,0 +1,140 @@
+# Step 1 — Enrich the results interface
+
+Status: proposed
+Depends on: nothing (first step)
+Unblocks: steps 2–5 (every later step consumes the enriched interface)
+
+## Goal
+
+Make the generic results shape self-describing enough to visualize: a consumer
+holding only `ReadyQueryResultsPage` (rows + columns + pivotDetails) can render
+correctly formatted, correctly labelled output — without an `ItemsMap`, an
+`Explore`, or a `MetricQuery`. This is the contract that lets the viz stack
+detach from the query stack.
+
+## Current state
+
+- `ResultColumn` is `{ reference, type: DimensionType }` —
+  `packages/common/src/types/results.ts:74`. The comment at `:76` already
+  anticipates richer column types.
+- Formatting is applied **server-side per results page**: S3 stores raw JSONL;
+  `AsyncQueryService.getAsyncQueryResults` builds a formatter closure from the
+  query's persisted `fields: ItemsMap` (`AsyncQueryService.ts:1382-1389`).
+  So metric-path results are already formatted; the *metadata* just isn't on
+  the wire in a generic form.
+- The in-repo TODO names this exact work — `AsyncQueryService.ts:1977`:
+  *"We should use the columns data instead of fields. We need to: add format
+  expression to columns type and refactor csv service, etc to use columns
+  instead of fields"* — followed by the workaround that synthesises label-only
+  `Dimension`s for SQL-query exports.
+- The generic frontend path throws formatting away:
+  `AiArtifactTableVisualization.tsx:12-17` unwraps every cell to `raw`;
+  `formatRowValueFromWarehouse.ts` is `String(value)`; the SQL runner streams
+  raw JSONL from `/query/{uuid}/results`, bypassing the formatted page
+  endpoint entirely. The agent path does the same (`unwrapCell` in
+  `AiAgentToolsService.runComposerQueries`).
+- The precedent for provenance: merge queries synthesise an `ItemsMap` plus
+  `fieldOrigins` per column (`packages/common/src/types/mergeQuery.ts:570-585`)
+  and get the full classic capability set back through `useColumns.tsx`.
+- DuckDB/compose nodes derive columns from a `LIMIT 1` probe
+  (`runDuckdbSqlQuery`) with no field metadata at all, even when every column
+  passes through unchanged from a referenced semantic-layer node whose
+  `query_history.fields` holds complete formatting metadata.
+
+## Proposed approach
+
+1. **Extend `ResultColumn` additively** with optional metadata:
+   - `label?: string`
+   - `format?: string` — a self-contained ECMA-376 format expression. The
+     engine (`formatting.ts` / `numfmt`) and the converters
+     (`convertCustomFormatToFormatExpression`, `getFormatExpression`) already
+     exist; legacy `{format, round, compact}` and `CustomFormat` both compile
+     to an expression today.
+   - a provenance handle (design TBD — see research prompt) linking a column
+     back to a semantic field id when one exists. Provenance is the tier that
+     unlocks drill-down, underlying data, `field.urls`, per-value colors.
+2. **Populate at column-build time** on the backend: the metric path already
+   has the `ItemsMap` in hand where `getUnpivotedColumns` / `getPivotedColumns`
+   run; SQL paths get label = friendly name only; the DuckDB source propagates
+   label/format/provenance for pass-through columns by resolving its
+   referenced `query_history` rows' persisted `fields`/`columns` (mirroring
+   how `buildQueryReferenceCtes` already loads referenced columns).
+3. **Consume**: stop unwrapping to raw in the artifact table and agent
+   preview; route exports (CSV/XLSX/GSheets) through columns instead of
+   synthesised dimensions, per the existing TODO.
+
+## Out of scope
+
+- Any change to how classic charts render (they keep `ItemsMap`).
+- Conditional formatting, totals, subtotals in the generic table (later,
+  possibly step 5).
+- `resolvedTimezone` for SQL paths (worth fixing here if cheap — currently
+  hardcoded `null`).
+
+## Open questions
+
+- Provenance shape: a `fieldId` string? A `fieldOrigins`-style map next to
+  columns (merge precedent)? Full `ItemsMap` synthesis for compatibility with
+  `useColumns.tsx`?
+- Where enrichment happens: persisted onto `query_history.columns` at write
+  time vs computed at page-read time.
+- Pivoted value columns: today headers are formatted via
+  `pivotValuesColumns` + `ItemsMap`; how do enriched columns represent the
+  `{field}_{agg}_{groupValue}` spread?
+- API compatibility: additive optional fields on a TSOA-generated type —
+  confirm no release-safety declaration needed.
+
+## Research prompt
+
+```
+You are researching a change to the Lightdash monorepo (repo root: lightdash/lightdash).
+Read docs/composer-viz-plan/README.md and docs/composer-viz-plan/01-enrich-result-columns.md
+first — they define the goal: enrich the generic query-results interface
+(ResultColumn in packages/common/src/types/results.ts) with label, format, and
+field-provenance metadata so that visualization no longer requires an ItemsMap.
+Do not implement; produce a concrete design doc.
+
+Investigate and answer, with file/line evidence:
+
+1. Column construction inventory. Find every place ResultColumns are built or
+   persisted: getUnpivotedColumns.ts, getPivotedColumns.ts, QueryHistoryModel
+   (columns + fields jsonb), SqlQueryComposer/virtual view, the DuckDB path in
+   AsyncQueryService (runDuckdbSqlQuery, buildQueryReferenceCtes), merge
+   queries. For each: what metadata is in scope at that moment (ItemsMap?
+   explore? referenced query_history rows?) and what it would take to attach
+   label + ECMA-376 format expression + a semantic field id.
+
+2. Format expression fidelity. In packages/common/src/utils/formatting.ts,
+   verify that every formatting behavior of formatItemValue can be represented
+   as a stored ECMA-376 expression evaluated against a raw value + timezone:
+   check legacy {format, round, compact, separator}, CustomFormat (currency,
+   bytes, prefix/suffix, timeInterval), parameter-dependent expressions
+   (${ld.parameters.*}), and date/timestamp handling. List what CANNOT be a
+   self-contained expression and propose how those cases degrade.
+
+3. Provenance design. Compare three options against the consumers in
+   packages/frontend/src/hooks/useColumns.tsx and the MetricQueryData
+   drill-down/underlying-data machinery: (a) fieldId string on ResultColumn,
+   (b) a fieldOrigins-style sidecar map (see packages/common/src/types/
+   mergeQuery.ts:570-585 and how useColumns consumes mergeResults.fields),
+   (c) synthesising a full ItemsMap for generic results. Recommend one, with
+   the migration story for pivoted value columns (pivotValuesColumns).
+
+4. Consumer refactor list. Enumerate what changes when columns carry the
+   metadata: AiArtifactTableVisualization + getAiArtifactTableConfig,
+   formatRowValueFromWarehouse/getValueCell, TableDataModel.getResultOptions,
+   CsvService/ExcelService/GSheets export paths (the TODO at
+   AsyncQueryService.ts:~1977), the SQL runner raw-stream path
+   (executeQuery.ts getResultsFromStream), and the agent's unwrapCell.
+
+5. Compatibility. Confirm additive optional fields on ResultColumn are
+   backward-compatible for the TSOA-generated OpenAPI and typed frontend
+   clients; check whether query_history.columns jsonb rows written before the
+   change need a read-time default; check release-safety implications per
+   CLAUDE.md.
+
+Deliverable: a design doc with the chosen ResultColumn shape (TypeScript),
+population rules per query source, the DuckDB propagation algorithm for
+pass-through vs computed columns, the consumer change list ordered by risk,
+and a test plan (unit tests to add, snapshot risks).
+```

--- a/docs/composer-viz-plan/02-artifact-viz-configs.md
+++ b/docs/composer-viz-plan/02-artifact-viz-configs.md
@@ -1,0 +1,145 @@
+# Step 2 — Viz configs on composer and SQL artifacts
+
+Status: proposed
+Depends on: step 1 (formatted, labelled columns make the charts worth looking at)
+Unblocks: step 3 ("save as chart" becomes a metadata operation)
+
+## Goal
+
+An AI agent run that produces a composer (or SQL) artifact can also produce a
+chart, not just a raw table: an optional `vizConfig: AllVizChartConfig` stored
+on the artifact, validated against the terminal node's `ResultColumns`, and
+rendered through the existing SQL-chart data models. This retires the fourth
+viz vocabulary (LLM tool-args JSON) for new artifact types and gives agent
+output and saved content the same render path.
+
+This step was already sketched in `docs/composer-queries-agent-plan.md:189-192`
+and `docs/multi-source-query-platform-plan.md` ("Viz stack" section); this doc
+scopes it.
+
+## Current state
+
+- `AiComposerChartArtifactConfig` (`packages/common/src/ee/AiAgent/
+  composerArtifact.ts`) has no viz config: `{source, schemaVersion, queries,
+  terminalNodeId, lastQueryUuid}`. `AiSqlChartArtifactConfig` likewise stores
+  only `{sql, limit}`.
+- Rendering is table-only: `AiArtifactPanel.tsx:111-159` composer branch feeds
+  `lastQueryUuid` into `useInfiniteQueryResults` →
+  `AiComposerArtifactVisualization` → `AiArtifactTableVisualization`
+  (raw-unwrapped `ChartDataTable`). The chart-type switcher is gated on
+  `AiResultType.QUERY_RESULT` and never reached.
+- The render machinery to reuse exists end-to-end in the SQL-chart stack:
+  `SqlChartResultsRunner` (constant-function runner over already-pivoted
+  results), `getChartDataModel`, `CartesianChartDataModel.getSpec`,
+  `ChartView`/`BigNumberView`/`Table`
+  (`useSavedSqlChartResults.tsx` shows the whole flow).
+- Pivot is the open mechanical question: cartesian/pie/big-number configs need
+  pivoted data. SQL charts get it by executing with a `PivotConfiguration`
+  derived from `config.fieldConfig` (`prepareSqlChartAsyncQueryArgs`,
+  `AsyncQueryService.ts:8517-8528`). The compose/DuckDB execution path's pivot
+  support is unverified.
+- Tool surface: `runComposerQueries` already takes `title`/`description` and
+  writes the artifact (`packages/backend/src/ee/services/ai/tools/
+  runComposerQueries.ts:193-211`); the semantic path has separate viz tools
+  (`toolVerticalBarArgs` etc.) — a design decision is whether composer viz is
+  an argument, a follow-up tool, or model-authored config validated post hoc.
+
+## Proposed approach
+
+1. Extend `AiComposerChartArtifactConfig` (and `AiSqlChartArtifactConfig`)
+   with `vizConfig?: AllVizChartConfig` (schemaVersion bump; jsonb column is
+   schemaless so no migration).
+2. Agent emits the config — likely as nullable args on `runComposerQueries`
+   (zod mirror of `AllVizChartConfig`, LLM-friendly nullable fields) —
+   validated server-side against the terminal `ResultColumns`
+   (references exist, x is time/category-compatible, y are aggregatable).
+   Invalid config degrades to table + a model-actionable error, never a
+   failed run.
+3. Frontend: composer artifact branch builds a results runner from the
+   terminal query results and dispatches on `vizConfig.type` exactly like
+   `DashboardSqlChartTile` does; table remains the fallback and the
+   "show underlying results" toggle.
+4. Pivoted execution for the terminal node when the config needs it —
+   mechanism per research below (extend the compose path with
+   `PivotConfiguration`, or re-run the terminal node through the
+   pivot-capable SQL path against the referenced CTEs).
+
+## Out of scope
+
+- Saving artifacts as charts (step 3).
+- Data-app viz bindings on artifacts (possible later extension; note the
+  copilot currently has no awareness of `ChartType.DATA_APP_VIZ`).
+- Retiring the existing semantic-artifact tool-arg vocabulary (works today;
+  converge in step 5).
+
+## Open questions
+
+- Where the viz config is authored: same tool call vs a separate
+  `configureViz` tool the model can call after seeing terminal columns
+  (columns are only known post-execution — the tool result already lists
+  them, so a same-call config is authored blind unless the model re-runs).
+- Pivot on the compose path: does `executeAsyncComposeSqlQuery` accept a
+  `PivotConfiguration` today? If not, is DuckDB-side pivot (native `PIVOT`)
+  preferable to routing through `PivotQueryBuilder`?
+- Palette resolution for artifacts (org/project palette — SQL charts resolve
+  via `resolvedColorPalette`; artifacts have no space/dashboard context).
+- Slack rendering: keep table-only, or port `getSpec` output to the Slack
+  image path?
+
+## Research prompt
+
+```
+You are researching a change to the Lightdash monorepo (repo root: lightdash/lightdash).
+Read docs/composer-viz-plan/README.md and docs/composer-viz-plan/02-artifact-viz-configs.md
+first — they define the goal: an optional vizConfig (AllVizChartConfig) on
+composer and SQL AI artifacts, validated against the terminal node's result
+columns and rendered through the existing DataViz data-model stack.
+Do not implement; produce a concrete design doc.
+
+Investigate and answer, with file/line evidence:
+
+1. Pivot feasibility on the compose path. Trace executeAsyncComposeSqlQuery →
+   runComposeSqlQuery → runDuckdbSqlQuery in packages/backend/src/services/
+   AsyncQueryService/AsyncQueryService.ts and determine whether a
+   PivotConfiguration can be applied there today. Compare with how
+   prepareSqlChartAsyncQueryArgs + SqlQueryComposer + PivotQueryBuilder do it
+   for SQL charts (packages/backend/src/utils/QueryBuilder/). Evaluate: (a)
+   route the terminal DuckDB query through PivotQueryBuilder, (b) use DuckDB
+   native PIVOT, (c) re-execute the terminal node via the SQL path with the
+   referenced CTEs inlined. Recommend one with tradeoffs (S3 round-trips,
+   result-cache reuse, pivotDetails fidelity).
+
+2. Tool-surface design. Read packages/backend/src/ee/services/ai/tools/
+   runComposerQueries.ts, the zod schemas in packages/common/src/ee/AiAgent/
+   schemas/tools/ (esp. toolComposerQueryArgs.ts and how AllVizChartConfig
+   maps to an LLM-friendly nullable zod shape), and how semantic viz tools
+   (toolVerticalBarArgs etc.) flow into artifacts. Decide: vizConfig as args
+   on runComposerQueries vs a follow-up configureViz tool vs both, given that
+   terminal columns are only known after execution. Specify the validation
+   rules against ResultColumns and the degrade-to-table behavior.
+
+3. Frontend render path. Map exactly what the composer branch of
+   AiArtifactPanel.tsx needs to reuse from useSavedSqlChartResults.tsx /
+   SqlChartResultsRunner / getChartDataModel to render vizConfig, including
+   where pivoted data comes from (getPivotQueryResults unpacking pivotDetails)
+   and how the chart-type switcher + save/export quick actions
+   (currently gated on AiResultType.QUERY_RESULT) extend to composer
+   artifacts. Note palette resolution options.
+
+4. Artifact schema evolution. Check parseAiArtifactChartConfig
+   (packages/common/src/ee/AiAgent/utils.ts) and the artifact version tables:
+   how does schemaVersion bump + optional field addition interact with
+   existing rows and with the transcriptToolPolicy / threadDumpSanitizer
+   shaping of tool results?
+
+5. Replayability interaction. The artifact stores lastQueryUuid and results
+   expire (see AiComposerArtifactVisualization expiry state). If vizConfig
+   needs pivoted execution, define what "re-run" means for an expired
+   artifact and whether the pipeline-expansion issue flagged in
+   docs/multi-source-query-platform-plan.md must be fixed in this step.
+
+Deliverable: a design doc with the extended artifact config type, the chosen
+tool surface (zod schema sketch), the pivot mechanism decision, the frontend
+component/data-flow diagram, and a test plan covering the agent tool contract
+snapshot tests (agentToolContracts.snapshot.test.ts) and runComposerQueries.test.ts.
+```

--- a/docs/composer-viz-plan/03-saved-composer-charts.md
+++ b/docs/composer-viz-plan/03-saved-composer-charts.md
@@ -1,0 +1,167 @@
+# Step 3 — Saved composer charts
+
+Status: proposed
+Depends on: steps 1–2 (enriched columns; a viz config worth saving)
+Unblocks: step 4 (the union is the seam classic charts are reinterpreted through)
+
+## Goal
+
+Composer queries become saveable, shareable, dashboard-able content — **inside
+`saved_queries`, not as a third content table**. `SavedChart`'s query becomes a
+discriminated union; a composer chart inherits the `SAVED_CHART` tile,
+`ChartScheduler`, chart-as-code, promotion, and embed paths by extending their
+switches, not by cloning them. "Add to dashboard" from an agent artifact
+becomes: create saved chart (composer variant) + append a `SAVED_CHART` tile.
+
+## Current state
+
+- `SavedChart.metricQuery` is required (`packages/common/src/types/
+  savedCharts.ts:919-992`); the MetricQuery is shredded across
+  `saved_queries_versions` + 6 child tables with NOT NULL columns
+  (`explore_name`, `filters`, `row_limit`); `createSavedChartVersion`
+  destructures `metricQuery` unconditionally (`SavedChartModel.ts:222-436`).
+- Precedent for an alternative query model on a chart version:
+  `saved_queries_version_merges` (jsonb `merge` + `schema_version`,
+  migration `20260812230500`).
+- **The cautionary tale**: `executeAsyncSavedChartQuery` branches on
+  `savedChart.merge` (`AsyncQueryService.ts:5768`) but
+  `executeAsyncDashboardChartQuery` (`:6117`) never reads it — merged charts
+  on dashboards silently render the first leg only. Merged charts are also
+  invisible to chart-as-code (`CoderService.transformChart` never reads
+  `merge`) and promotion.
+- Composer execution today is author-gated: `FeatureFlags.MultiSourceQuery` +
+  `manage Explore` (`QuerySourceService.ts:76-112`), plus per-source checks;
+  compose additionally needs `FeatureFlags.ComposeSqlRunner`. Saved charts are
+  viewer-visible via `view SavedChart` + space access.
+- Saved pipelines must be self-contained: artifact pipelines referencing bare
+  `queryUuid`s stop replaying when results expire
+  (`docs/multi-source-query-platform-plan.md:37-44` — "copy-on-save pipeline
+  expansion").
+- Dashboard filters: the saved-chart contract is
+  `applyDashboardFiltersForTile` → `addDashboardFiltersToMetricQuery` against
+  an Explore (`packages/common/src/utils/filters.ts:1546,1606`); the SQL-chart
+  contract is explicitly-mapped, dimension-only column filters
+  (`isSqlColumn` targets, `getDashboardFilterRulesForTileAndReferences`
+  `filters.ts:1017`, applied in `SqlQueryComposer.ts:160-190`). The
+  filterable-field catalogue is built from saved-chart tiles only
+  (`DashboardProvider.tsx:850-920`).
+
+## Proposed approach
+
+1. **Type**: `SavedChartQuery = { kind: 'metricQuery'; metricQuery } |
+   { kind: 'composer'; queries: SourceQuery[]; terminalNodeId }`, surfaced on
+   `SavedChart`/`SavedChartDAO`/`CreateSavedChartVersion`. Keep `metricQuery`
+   on the wire for the classic variant (API back-compat); make every consumer
+   switch exhaustive.
+2. **DB**: one nullable `composer_query` jsonb column on
+   `saved_queries_versions`; relax the NOT NULLs (or write sentinels) for
+   composer rows; child tables simply have no rows for the composer variant.
+   Composer charts use the new viz vocabulary, so `chart_config` stores
+   `AllVizChartConfig` (or a data-app viz binding) discriminated by the query
+   kind + `chart_type`/`chart_kind` mapping (decide in research).
+3. **Copy-on-save expansion**: saving resolves any `queryUuid`-form
+   references into in-pipeline nodes so the stored pipeline is fully
+   self-contained.
+4. **Execution**: a chart-scoped `executeAsyncComposerChartQuery` (and
+   dashboard variant) that authorizes via `view SavedChart` + space access —
+   *not* the ad-hoc `manage Explore` gate — then submits the pipeline and
+   returns the terminal `queryUuid`. Thread the union through every entry
+   point in the same change: saved-chart view, dashboard tile, scheduler
+   delivery + exports, embed, validation, chart-as-code, promotion, version
+   history/rollback.
+5. **Dashboard filters**: a per-rule router — semantic-field rules push into
+   each `semanticLayer` node whose explore has the field (reusing
+   `addDashboardFiltersToMetricQuery` per node); column rules target the
+   terminal node via the existing `isSqlColumn` mechanism. Register both
+   target kinds in the dashboard's filterable-field catalogue.
+6. **Authoring permission**: saving a pipeline containing `sql` nodes requires
+   the SQL-chart authoring permission (`manage SqlRunner` / `CustomSql`
+   equivalents); semantic-only pipelines align with saved-chart authoring.
+
+## Out of scope
+
+- Explorer editing of composer charts (refuse-and-redirect; authoring stays
+  in agents for now).
+- Reinterpreting classic charts (step 4).
+- Folding `saved_sql` into `saved_queries` (end-state cleanup, after step 4).
+- Date zoom and threshold alerts for composer charts (design in research,
+  ship later).
+
+## Open questions
+
+- `chart_type` column vs `ChartKind` for composer charts' denormalised kind;
+  how content listing (`ChartSourceType`) labels them.
+- Node-level result caching across viewers/tiles (intermediate nodes are
+  billed warehouse queries; `query_history` + cache-key machinery is most of
+  the answer).
+- Parameters: per-node `ParametersValuesMap` threading and dashboard
+  parameter merging for multi-node pipelines.
+- Whether `tableConfig.columnOrder` moves into the viz config
+  (`VizColumnConfig.order`) for the composer variant.
+- Feature-flag posture for viewing (a saved chart that viewers can't render
+  because a flag is off is worse than not saving it).
+
+## Research prompt
+
+```
+You are researching a change to the Lightdash monorepo (repo root: lightdash/lightdash).
+Read docs/composer-viz-plan/README.md and docs/composer-viz-plan/03-saved-composer-charts.md
+first — they define the goal: SavedChart's query becomes a discriminated union
+(metricQuery | composer pipeline), stored as a nullable jsonb column on
+saved_queries_versions, executed through chart-scoped authorized paths, and
+threaded through EVERY consumer of SavedChart. Do not implement; produce a
+concrete design doc whose centerpiece is an exhaustive consumer inventory.
+
+Investigate and answer, with file/line evidence:
+
+1. Consumer inventory (the critical deliverable). Enumerate every code path
+   that reads SavedChart.metricQuery, SavedChartDAO, or DbSavedChartVersion
+   fields, grouped by: execution (AsyncQueryService executeAsyncSavedChartQuery,
+   executeAsyncDashboardChartQuery, ProjectService legacy paths, EmbedService,
+   SchedulerTask, CsvService/ExcelService/GSheets, calculate-total,
+   underlying-data), content (CoderService chart-as-code, PromoteService,
+   ValidationService, CatalogService chart_usage, search/content listing,
+   dbt exposures), and frontend (useSavedQuery, SavedExplorer,
+   DashboardChartTile, chart version history/rollback). For each: what does
+   the composer variant do — branch, degrade, or explicitly unsupported-with-
+   error? Use the merge-query gaps (dashboard execution, as-code, promotion)
+   as the checklist of what silent failure looks like.
+
+2. Storage design. Read SavedChartModel.createSavedChartVersion and .get, the
+   entities in packages/backend/src/database/entities/savedCharts.ts, and the
+   merge precedent (saved_queries_version_merges migration 20260812230500).
+   Specify: the composer_query jsonb shape (schema_version included), which
+   NOT NULL columns must relax vs take sentinels, how get() hydrates the
+   union, what last_version_chart_kind holds for composer charts, and the
+   knex migration outline including release-safety declaration needs (see
+   packages/backend/src/database/migrations/CLAUDE.md).
+
+3. Authorization. Read QuerySourceService.throwIfCannotRunQueries, the
+   per-source checks (SemanticLayerQuerySource, SqlQuerySource,
+   DuckdbQuerySource), and how executeAsyncSavedChartQuery /
+   executeAsyncDashboardSqlChartQuery authorize viewers (CASL SavedChart /
+   CustomSql subjects, embed JWT branches). Design the chart-scoped composer
+   execution wrapper: what a viewer needs, what saving requires when the
+   pipeline contains sql nodes, and how feature flags gate authoring vs
+   viewing. Use the ld-permissions skill conventions.
+
+4. Dashboard filter router. Read applyDashboardFiltersForTile /
+   addDashboardFiltersToMetricQuery (common/src/utils/filters.ts), the SQL
+   column-filter path (getDashboardFilterRulesForTileAndReferences,
+   SqlQueryComposer.ts:160-190, TileFilterConfiguration.tsx sqlChartTilesMetadata),
+   and DashboardProvider's filterable-field catalogue. Design: per-rule
+   routing to semantic nodes and/or terminal columns, how a composer tile
+   registers BOTH target kinds, what happens to dashboard sorts, parameters,
+   and date zoom (metricQuery.metadata.hasADateDimension derivation).
+
+5. Copy-on-save expansion + caching. Define the save-time transform from an
+   artifact pipeline (possibly referencing external queryUuids) to a
+   self-contained pipeline, and evaluate node-level result reuse across
+   viewers/tiles using query_history + cache metadata.
+
+Deliverable: a design doc containing the SavedChartQuery type, the migration
+outline, the exhaustive consumer table (path → behavior for composer variant),
+the authz matrix, the filter-router design, and a phased PR breakdown (this
+step is too big for one PR — propose vertical slices behind one feature flag,
+per the breakup-pr conventions).
+```

--- a/docs/composer-viz-plan/04-classic-charts-as-pipelines.md
+++ b/docs/composer-viz-plan/04-classic-charts-as-pipelines.md
@@ -1,0 +1,142 @@
+# Step 4 — Classic charts interpreted as pipelines
+
+Status: proposed
+Depends on: step 3 (the union and the composer execution path exist)
+Unblocks: step 5; the end-state of one execution path for all chart content
+
+## Goal
+
+Read the existing 90%+ of content — classic metric-query charts, and later SQL
+charts — *through the composer lens*: an adapter maps a classic chart to a
+single-node pipeline at the execution seam, so one code path serves both union
+variants. Zero data migration, zero behavior change for single-node pipelines,
+flag-gated with a parity harness proving equivalence before rollout.
+
+## Current state
+
+- `SemanticLayerSourceQuery` (`packages/common/src/types/querySources.ts:75`)
+  mirrors `MetricQuery` **except**: `metricOverrides`, `dimensionOverrides`
+  (viz-relevant format overrides applied in `QueryComposer.getFields()`),
+  parameters, `pivotDimensions`, and `metadata` (e.g. `hasADateDimension`
+  used by date zoom).
+- The semanticLayer source already routes to
+  `AsyncQueryService.executeAsyncMetricQuery`
+  (`packages/backend/src/services/QuerySourceService/sources/
+  SemanticLayerQuerySource.ts`) — the same execution machinery saved charts
+  use — so a single-node pipeline is *already* the saved-chart path with a
+  thin wrapper.
+- Saved-chart execution today adds chart-scoped behavior around the metric
+  query: filter overrides (`addFiltersToMetricQuery`), dashboard filters/
+  sorts/parameters/date zoom (`executeAsyncDashboardChartQuery:6117-6320`),
+  pivot derivation (`derivePivotConfigurationFromChart`), limit clamping
+  (`applyMetricQueryLimit`), CSV cell limits, embed/JWT authorization.
+- A SQL chart is likewise a single-`sql`-node pipeline: `sql` + `limit` map
+  directly; its pivot already derives from viz config at execution time
+  (`prepareSqlChartAsyncQueryArgs`).
+- Merge charts map naturally too: `MergeQueryMetricSource[]` ≈ N
+  semanticLayer nodes + a DuckDB join node — a candidate for retiring the
+  bespoke merge execution path later.
+
+## Proposed approach
+
+1. **Close the node-fidelity gaps**: add `metricOverrides`,
+   `dimensionOverrides`, and per-node parameters to
+   `SemanticLayerSourceQuery` (additive optional fields; the tool zod schema
+   in `toolComposerQueryArgs.ts` compiles against the canonical type, so both
+   move together). Derive — don't store — `pivotDimensions` and
+   date-dimension metadata.
+2. **The adapter**: `savedChartToPipeline(chart): {queries, terminalNodeId}` —
+   pure function in `packages/common`, unit-tested for round-trip fidelity
+   (`pipeline → executed metric query` deep-equals `chart.metricQuery` after
+   normalization).
+3. **Seam placement**: inside `executeAsyncSavedChartQuery` /
+   `executeAsyncDashboardChartQuery`, after chart-scoped mutations
+   (dashboard filters, sorts, date zoom, parameter merging, limit clamping)
+   are applied to the metric query — i.e. adapt the *effective* query, so all
+   dashboard behavior stays in one place and works identically for both
+   variants.
+4. **Parity harness**: behind `FeatureFlags`, run both paths and compare
+   compiled SQL (and/or result checksums) in dev/CI across a corpus of seeded
+   charts; promote to default only when parity holds. The existing
+   `docs/ai-agent-merge-query-parity.md` pattern is prior art.
+5. **SQL charts second**: same adapter shape over `saved_sql`, unifying the
+   tile/scheduler forks afterwards.
+
+## Out of scope
+
+- Rewriting stored rows (never).
+- Retiring the legacy renderer or `ChartConfig` (classic charts keep their
+  renderer; provenance-carrying columns from step 1 keep `useColumns.tsx`
+  working).
+- Merge-execution retirement (candidate follow-up, not this step).
+
+## Open questions
+
+- Whether single-node pipelines bypass `QuerySourceService` submission
+  entirely (direct call, zero overhead) vs go through it for uniformity —
+  performance and query_history semantics.
+- Query-history/analytics continuity: `QueryExecutionContext` values, chart
+  view analytics, and usage metrics must not shift when the flag flips.
+- Result-cache key stability: the adapter must not change cache keys for
+  identical queries, or every dashboard cold-loads on rollout.
+- How `executeAsyncMetricQuery`'s warnings/fields response fields surface
+  through the pipeline wrapper (the frontend consumes `fields: ItemsMap` from
+  the execute response today).
+
+## Research prompt
+
+```
+You are researching a change to the Lightdash monorepo (repo root: lightdash/lightdash).
+Read docs/composer-viz-plan/README.md and docs/composer-viz-plan/04-classic-charts-as-pipelines.md
+first — they define the goal: an adapter that interprets classic saved charts
+(and later SQL charts) as single-node composer pipelines at the execution
+seam, flag-gated, with a parity harness proving no behavior change.
+Do not implement; produce a concrete design doc.
+
+Investigate and answer, with file/line evidence:
+
+1. Fidelity diff, exhaustively. Field-by-field compare MetricQuery
+   (packages/common/src/types/metricQuery.ts) with SemanticLayerSourceQuery
+   (packages/common/src/types/querySources.ts) AND compare what
+   executeAsyncSavedChartQuery/executeAsyncDashboardChartQuery do around the
+   metric query (filter overrides, dashboard filters/sorts, date zoom,
+   parameter merging, limit clamping via applyMetricQueryLimit, timezone,
+   pivot derivation, hasADateDimension metadata, embed authorization,
+   analytics events) versus what QuerySourceService +
+   SemanticLayerQuerySource.submitQuery pass through to
+   executeAsyncMetricQuery. Produce the complete list of gaps and, for each:
+   add to the node type, derive at execution, or keep in the chart-scoped
+   wrapper.
+
+2. Seam design. Given the gaps, decide where the adapter runs: (a) inside the
+   two saved-chart execute methods after chart-scoped mutations (adapt the
+   effective MetricQuery), (b) at QuerySourceService with chart context passed
+   down, or (c) a new executeAsyncComposerChartQuery from step 3 that both
+   variants converge into. Evaluate against: dashboard filter router (step 3),
+   embed/JWT paths, scheduler delivery, and the frontend's dependence on the
+   execute response carrying metricQuery + fields: ItemsMap
+   (ApiExecuteAsyncMetricQueryResults, useDashboardChartReadyQuery).
+
+3. Invariance requirements. Identify everything that must NOT change when the
+   flag flips: result cache keys (find how cache keys are computed in the
+   async query pipeline), query_history rows and QueryExecutionContext values,
+   usage analytics (addChartViewEvent), csvCellsLimit behavior, and warnings.
+   Specify how the adapter guarantees each.
+
+4. Parity harness. Read docs/ai-agent-merge-query-parity.md for prior art.
+   Design a harness that runs both paths over seeded charts (jaffle shop seed
+   data) comparing compiled SQL and/or result checksums; where should it run
+   (unit-level against QueryComposer output? integration in CI? shadow mode in
+   dev?), and what normalization is needed for legitimate SQL differences.
+
+5. SQL charts second wave. Sketch savedSqlChartToPipeline over saved_sql
+   (sql, limit, config-derived pivot) and list what the SQL-chart execution
+   path does that the sql-node path doesn't (parameter replacement, user
+   attribute replacement, dashboard column filters, column discovery probe) —
+   same gap-table treatment as question 1.
+
+Deliverable: a design doc with the adapter signature and placement decision,
+the complete gap table with per-gap resolution, the invariance checklist, the
+parity-harness design, and a rollout plan (flag stages, corpus, abort
+criteria).
+```

--- a/docs/composer-viz-plan/05-viz-config-convergence.md
+++ b/docs/composer-viz-plan/05-viz-config-convergence.md
@@ -1,0 +1,141 @@
+# Step 5 — Viz config convergence
+
+Status: proposed
+Depends on: steps 1–4 (the interface, the render path, the saved union, the adapter)
+Unblocks: retiring renderers; one viz vocabulary for humans and agents
+
+## Goal
+
+Reduce four viz-config vocabularies toward one system, opportunistically and
+per chart kind — never as a big-bang migration. Target state: the
+column-addressed stack (`AllVizChartConfig` + data models) for built-in chart
+kinds, data app custom vizzes (`DataAppVizSchema` bindings) for everything
+bespoke, classic `ChartConfig` surviving only where its expressiveness isn't
+yet matched, and the AI tool-arg vocabulary retired.
+
+## Current state — the four vocabularies
+
+| Vocabulary | Addressing | Types | Wiring cost per new type |
+|---|---|---|---|
+| `ChartConfig`/`ChartType` (classic) | field ids via `ItemsMap`/Explore | 11 | ~9 layers (`LightdashVisualization/CLAUDE.md`) |
+| `AllVizChartConfig`/`ChartKind` (SQL charts) | column references | 5 | ~4 layers (config type, data model, slice, switches) |
+| AI tool-args JSON | field ids, synthesised to `ChartConfig` via `getWebAiChartConfig` | 7 enum values | n/a (LLM-authored) |
+| `DataAppVizSchema` + `{dataAppVizUuid, fieldMapping, optionValues}` | declared slots → field ids | unbounded (generated code) | none (generated) |
+
+Translation layers exist only in the AI direction; classic ↔ new have none.
+
+Capability deltas that keep classic alive: pivot-table rendering with
+subtotals (`PivotData` + `PivotTable/`), conditional formatting, table-calc
+totals/row calculations, custom Vega, treemap/gauge/map/sankey, per-value
+dimension colors, rich text/image cells, `field.urls` actions.
+
+Data-app viz specifics: it is already a classic `ChartType` (`DATA_APP_VIZ`)
+bound to metric-query results; its runtime payload (`DataAppVizContext`: rows,
+fieldMapping, options, palette, pivotDetails) is essentially the generic
+results interface; its `fieldMapping` targets are metric-query field ids
+today. The copilot has no awareness of it (`getAvailableChartTypes` /
+`canRenderAsChart` don't know `ChartType.DATA_APP_VIZ`).
+
+## Proposed approach
+
+1. **Measure first.** Query production/telemetry for chart population per
+   `ChartType` and per config feature (conditional formatting present?
+   subtotals on? custom Vega?) so convergence order follows real usage, and
+   "retire when population reaches zero" is checkable.
+2. **Lossless translations where they exist**: per-kind
+   `ChartConfig → AllVizChartConfig` converters (big number and simple
+   cartesian/pie first), applied at *read/render* time initially (render
+   classic configs through the new stack behind a flag), with write-migration
+   only after parity.
+3. **Data-app vizzes bind to columns**: extend `fieldMapping` targets to
+   column references so a data-app viz can sit on a composer chart; make the
+   copilot aware of project chart types.
+4. **Retire the AI vocabulary**: semantic artifacts move to emitting
+   `AllVizChartConfig` (step 2 did composer/SQL); `getWebAiChartConfig`
+   becomes legacy-read-only.
+5. **Close the biggest capability gaps in the new stack** in priority order
+   from the measurement: table conditional formatting and totals are the
+   likely first two (both have partial precedents:
+   `VizBigNumberDisplay.conditionalFormatting`, `VizColumnConfig`
+   aggregation/display fields; step 1's enriched columns supply the
+   numeric/type gates that classic conditional formatting reads from
+   `ItemsMap`).
+
+## Out of scope
+
+- Pivot-table (subtotals) parity in the new stack — track separately; it is
+  the deepest gap (`TableDataModel.getPivotedChartData` is a stub).
+- Migrating custom Vega charts (position data-app vizzes as the successor;
+  the picker already presents them side by side in `CustomVisConfig.tsx`).
+- Deleting any renderer.
+
+## Open questions
+
+- Whether translated-at-render classic charts keep byte-identical saved
+  configs (yes — write-migration is a separate, later decision per kind).
+- How color assignment converges: classic palette cycling per group
+  (`useChartColorConfig`) vs the new stack's explicit per-series hex.
+- Whether `ChartKind` and `ChartType` unify or stay as (storage kind, config
+  discriminant) pair.
+- Where funnel/treemap/gauge/map/sankey land: new-stack data models, data-app
+  vizzes, or stay classic indefinitely.
+
+## Research prompt
+
+```
+You are researching a change to the Lightdash monorepo (repo root: lightdash/lightdash).
+Read docs/composer-viz-plan/README.md and docs/composer-viz-plan/05-viz-config-convergence.md
+first — they define the goal: converge four viz-config vocabularies onto the
+column-addressed stack (AllVizChartConfig + data models) plus data-app custom
+vizzes, opportunistically per chart kind, translations at render time first.
+Do not implement; produce a concrete design doc.
+
+Investigate and answer, with file/line evidence:
+
+1. Translation feasibility per kind. For each ChartConfig variant
+   (packages/common/src/types/savedCharts.ts:899-910), map its config surface
+   against the corresponding Viz*Config (packages/common/src/visualizations/
+   types/index.ts) and classify every property: direct-translatable,
+   translatable-with-loss (name the loss), or no-target-exists. Do BigNumber,
+   Cartesian, Pie, Table in full detail; summarize Funnel/Treemap/Gauge/Map/
+   Sankey/Custom. Key subtleties: field-id → column-reference resolution
+   (pivoted references, table calc names, custom dimensions), CartesianChart
+   layout+eChartsConfig series shape vs PivotChartLayout+CartesianChartDisplay,
+   and where aggregation lives (semantic layer vs fieldConfig.y[].aggregation).
+
+2. Measurement queries. Write the SQL (against the Lightdash app database
+   schema: saved_queries, saved_queries_versions.chart_type/chart_config)
+   that counts current-version charts per ChartType and detects config
+   feature usage (conditional formattings non-empty, showSubtotals,
+   showColumnCalculation, custom vega spec present, metricsAsRows, etc.).
+   These queries drive convergence order and retirement criteria.
+
+3. Gap-closure design for the two likely-first gaps: (a) conditional
+   formatting in the generic table — read
+   packages/common/src/utils/conditionalFormatting.ts and its ItemsMap-typed
+   gates (isNumericItem etc.) and specify what it needs from step 1's
+   enriched columns; (b) column/row totals — compare useAsyncCalculateTotal /
+   TotalQueryBuilder with what a composer terminal node could support.
+
+4. Data-app viz on columns. Read the fieldMapping/auto-mapping chain
+   (autoMapDataAppVizFields.ts, getDataAppVizFieldItems.ts,
+   deriveDataAppVizPivotConfig.ts, DataAppVizRenderer/index.tsx,
+   reconcileDataAppVizFieldMapping) and specify what changes when mapping
+   targets are column references from a composer terminal result instead of
+   metric-query field ids — including how the series-slot → pivot derivation
+   works when pivot is executed by the composer path, and what the copilot
+   needs (getAvailableChartTypes.ts, canRenderAsChart.ts) to select a
+   project's data-app viz.
+
+5. Render-time translation architecture. Where does a
+   chartConfigToVizConfig(chart) converter slot into the frontend so a
+   classic chart renders through getChartDataModel behind a flag —
+   VisualizationProvider? DashboardChartTile? — and how does the parity check
+   work (visual regression? spec diff?). Check what
+   getWebAiChartConfig already proves about ChartConfig synthesis in the
+   other direction.
+
+Deliverable: a design doc with the per-kind translation matrix, the
+measurement SQL, the two gap-closure designs, the data-app-viz column-binding
+spec, and a convergence order recommendation with retirement criteria.
+```

--- a/docs/composer-viz-plan/README.md
+++ b/docs/composer-viz-plan/README.md
@@ -1,0 +1,57 @@
+# Charts on Composer Queries — Plan Index
+
+Status: proposed (investigation complete, no implementation)
+Date: 2026-08-24
+
+## Goal
+
+Collapse Lightdash's parallel chart stacks (saved metric-query charts, saved SQL
+charts, AI artifacts, metrics-explorer output) onto one architecture:
+
+- **Query stack**: composer queries (`SourceQuery[]` pipelines,
+  `packages/common/src/types/querySources.ts`). A classic chart is a
+  single-`semanticLayer`-node pipeline; a SQL chart is a single-`sql`-node
+  pipeline.
+- **Interface**: the generic v2 results shape
+  (`ReadyQueryResultsPage`: rows + columns + pivotDetails), enriched with
+  enough column metadata (label, format, provenance) to drive visualization.
+- **Viz stack**: the newer column-addressed viz system (`AllVizChartConfig` +
+  `IResultsRunner` + data models) for built-ins, and data app custom vizzes
+  (`DataAppVizSchema` bindings) as the extensible end.
+
+Background and full findings: see the investigation report (internal artifact,
+"Charts on Composer Queries") and the prior in-repo docs
+`docs/multi-source-queries.md`, `docs/multi-source-query-platform-plan.md`,
+`docs/composer-queries-agent-plan.md`.
+
+## The sequence
+
+Each step ships value on its own and none blocks on migrating existing chart
+configs. Each doc ends with a **research prompt**: a self-contained brief to
+hand to a fresh research agent to turn the plan into a concrete design.
+
+| Step | Doc | One-liner |
+|---|---|---|
+| 1 | [01-enrich-result-columns.md](01-enrich-result-columns.md) | Add label/format/provenance to `ResultColumn` so generic results can drive viz |
+| 2 | [02-artifact-viz-configs.md](02-artifact-viz-configs.md) | Optional `AllVizChartConfig` on composer + SQL artifacts; agent output gets real charts |
+| 3 | [03-saved-composer-charts.md](03-saved-composer-charts.md) | `SavedChart` query becomes a discriminated union; save/share/tile composer charts |
+| 4 | [04-classic-charts-as-pipelines.md](04-classic-charts-as-pipelines.md) | Interpret existing charts as single-node pipelines at the execution seam |
+| 5 | [05-viz-config-convergence.md](05-viz-config-convergence.md) | Opportunistically converge the four viz config vocabularies |
+
+## Design tenets (apply to every step)
+
+1. **Union, not optional.** `metricQuery` never becomes `metricQuery?:`.
+   Query kind is a discriminated union so `assertUnreachable` finds every
+   consumer at compile time.
+2. **The merge-query lesson.** `executeAsyncSavedChartQuery` handles
+   `savedChart.merge`; `executeAsyncDashboardChartQuery` never reads it, so
+   merged charts silently render wrong on dashboards. Any new query kind must
+   be threaded through *every* execution entry point in the same change.
+3. **Interpretation before migration.** Existing rows are never rewritten;
+   classic charts are *read* through the composer lens via adapters.
+4. **Pivot belongs to the viz layer**, derived at execution time from the viz
+   config (the SQL-chart precedent: `fieldConfig` → `PivotConfiguration`), not
+   stored on query nodes.
+5. **Query unification ≠ config migration.** The classic `ChartConfig` tail
+   (pivot tables with subtotals, conditional formatting, custom Vega, maps…)
+   keeps its legacy renderer indefinitely; step 5 is opportunistic.


### PR DESCRIPTION
## Description

This PR adds planning documentation for collapsing Lightdash's parallel chart stacks (saved metric-query charts, SQL charts, AI artifacts) onto a unified architecture built on composer queries and enriched result columns.

The documentation consists of:

1. **README.md** — Plan index and design tenets establishing the five-step sequence
2. **01-enrich-result-columns.md** — Plan for adding label/format/provenance metadata to `ResultColumn` so generic results can drive visualization without requiring an `ItemsMap`
3. **01-design.md** — The completed step-1 design: type definitions, converter gap analysis, population rules per query source, consumer change ordering, and PR slicing
4. **02-artifact-viz-configs.md** — Plan for optional `AllVizChartConfig` on composer and SQL AI artifacts, enabling agent output to produce real charts
5. **03-saved-composer-charts.md** — Plan for making `SavedChart`'s query a discriminated union (metricQuery | composer pipeline), enabling save/share/dashboard capabilities for composer charts
6. **04-classic-charts-as-pipelines.md** — Plan for interpreting existing classic charts as single-node pipelines at the execution seam, flag-gated with parity verification
7. **05-viz-config-convergence.md** — Plan for opportunistically converging four viz-config vocabularies onto the column-addressed stack

Each plan document includes current-state analysis with file/line evidence, a proposed approach, out-of-scope boundaries, open questions, and a self-contained research prompt for turning the plan into a detailed design. Step 1's research is complete and synthesized in `01-design.md`; the other steps carry research prompts for follow-up agents.

Tracking lives in the "Standardize query results interface for viz" and "Query & Explore V2" Linear projects, whose descriptions link these docs.

## Risk assessment

- [ ] This is a high-risk change

This is a documentation-only change (no code modifications). It adds planning and design guidance for future implementation work. No runtime behavior is affected.

Relates: PROD-9829

https://claude.ai/code/session_01Vpu7y6TKTE92UH4YsUdmgm