### PR TITLE
feat: Learn scope-group modules — per-role lesson filtering and visible counts (CS-170)

### DIFF
--- a/packages/common/src/types/learn.ts
+++ b/packages/common/src/types/learn.ts
@@ -17,8 +17,27 @@ export type LearnCatalogueEntry = {
     durationMinutes: number | null;
     tags: string[];
     track: string | null;
-    /** Scope tag this module teaches: `action:Subject` or `action:Subject@global`; null = untagged */
+    /**
+     * Scope tag this module teaches: `action:Subject` or
+     * `action:Subject@global`; null = untagged. For a CS-169 scope-group
+     * module this is the ENTRY scope — the member whose minimum holding role
+     * is lowest — so pre-CS-169 consumers keep working unchanged.
+     */
     scope: string | null;
+    /**
+     * CS-169 scope groups: the sorted unique set of the module's lesson
+     * scopes (singleton for a single-scope module, empty for an untagged
+     * one). Optional in the type — not just schema-defaulted like `scope` —
+     * so the board test fixtures shared byte-identically with the academy
+     * twin need not carry it; the schema default fills it on parse.
+     */
+    scopes?: string[];
+    /**
+     * One scope tag per lesson, in lesson order (null = untagged lesson).
+     * Empty for a pre-CS-169 catalogue. Optional for the same twin-fixture
+     * reason as `scopes`.
+     */
+    lessonScopes?: (string | null)[];
     requires: LearnFeatureRequirement[];
     publishedAt: string;
 };
@@ -54,6 +73,8 @@ export const LearnCatalogueEntrySchema: z.ZodType<LearnCatalogueEntry> = z
         tags: z.array(z.string()),
         track: z.string().nullable(),
         scope: z.string().nullable().default(null),
+        scopes: z.array(z.string()).default([]),
+        lessonScopes: z.array(z.string().nullable()).default([]),
         requires: z.array(LearnFeatureRequirementSchema).default([]),
         publishedAt: z.string(),
     })
@@ -83,6 +104,12 @@ export type LearnLesson = {
     id: string;
     title: string;
     html: string;
+    /**
+     * CS-169: the scope this lesson teaches (null = untagged, always
+     * visible). Defaulted by the schema so a pre-CS-169 course.json —
+     * immutable per contentHash, never rewritten — still parses.
+     */
+    scope: string | null;
 };
 
 /** A clickable region on a demo step, as fractions of the image. */
@@ -160,6 +187,7 @@ export const LearnCourseSchema = z
                     id: z.string().min(1),
                     title: z.string().min(1),
                     html: z.string(),
+                    scope: z.string().nullable().default(null),
                 })
                 .passthrough(),
         ),

--- a/packages/frontend/src/features/learn/board/components/BoardRail.tsx
+++ b/packages/frontend/src/features/learn/board/components/BoardRail.tsx
@@ -15,6 +15,8 @@ type Props = {
     rail: RailModel;
     rollups: Map<string, Rollup>;
     role: ProjectMemberRole;
+    /** The scope names the selected role holds — the pane filters its lesson list with them (CS-169). */
+    held: string[];
     heldEntries: LearnCatalogueEntry[];
     tiers: Map<string, LearnBadgeTier> | null;
     tiersLoading: boolean;
@@ -28,6 +30,7 @@ export const BoardRail: FC<Props> = ({
     rail,
     rollups,
     role,
+    held,
     heldEntries,
     tiers,
     tiersLoading,
@@ -72,6 +75,7 @@ export const BoardRail: FC<Props> = ({
             {selected ? (
                 <ModulePane
                     module={selected}
+                    held={held}
                     rollup={rollups.get(selected.entry.id)}
                     onClose={onClearSelection}
                     onOpen={onOpen}

--- a/packages/frontend/src/features/learn/board/components/LearnBoardPanel.test.tsx
+++ b/packages/frontend/src/features/learn/board/components/LearnBoardPanel.test.tsx
@@ -50,6 +50,23 @@ const catalogue = [
     }),
 ];
 
+// Swappable so a test can serve a differently shaped catalogue (CS-169).
+const catalogueState: { courses: typeof catalogue } = { courses: catalogue };
+
+const defaultRollups = () =>
+    new Map([
+        [
+            'foundation',
+            {
+                ...emptyRollup(),
+                started: true,
+                lessonsCompleted: new Set(['l1']),
+            },
+        ],
+    ]);
+// Swappable so a test can hand the board different progress (CS-169).
+const rollupsState = { map: defaultRollups() };
+
 type AskCallbacks = {
     onSuccess?: (data: { matches: LearnAskMatch[] }) => void;
     onError?: () => void;
@@ -94,7 +111,7 @@ vi.mock('../../hooks', () => ({
     useLearnCatalogue: () => ({
         data: {
             generatedAt: '2026-08-01T00:00:00.000Z',
-            courses: catalogue,
+            courses: catalogueState.courses,
             suggestions: [
                 { query: 'Where do I find a chart?', courseId: 'foundation' },
                 { query: 'How do I build one?', courseId: 'dashboards' },
@@ -107,16 +124,7 @@ vi.mock('../../hooks', () => ({
         isError: false,
     }),
     useLearnRollups: () => ({
-        rollups: new Map([
-            [
-                'foundation',
-                {
-                    ...emptyRollup(),
-                    started: true,
-                    lessonsCompleted: new Set(['l1']),
-                },
-            ],
-        ]),
+        rollups: rollupsState.map,
         isLoading: false,
         serverSynced: false,
     }),
@@ -152,6 +160,107 @@ describe('LearnBoardPanel', () => {
         askState.isError = false;
         badgesState.data = bronzeEverywhere;
         badgesState.isInitialLoading = false;
+        catalogueState.courses = catalogue;
+        rollupsState.map = defaultRollups();
+    });
+
+    it('re-opens a completed module when a role change unlocks a lesson', async () => {
+        // Completed (quiz passed) with the 2 lessons visible to interactive
+        // viewer; the editor role holds all 3 — the module must leave the
+        // completed state and queue up as 2 of 3, not stay complete.
+        catalogueState.courses = [
+            entry({
+                id: 'comments',
+                title: 'Commenting on dashboards',
+                scope: 'view:DashboardComments',
+                lessonCount: 3,
+                lessonScopes: [
+                    'view:DashboardComments',
+                    'create:DashboardComments',
+                    'manage:DashboardComments',
+                ],
+            }),
+        ];
+        rollupsState.map = new Map([
+            [
+                'comments',
+                {
+                    ...emptyRollup(),
+                    started: true,
+                    passed: true,
+                    completed: true,
+                    lessonsCompleted: new Set(['l1', 'l2']),
+                },
+            ],
+        ]);
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.EDITOR },
+        });
+        await waitFor(() =>
+            expect(screen.getByRole('tab', { name: 'editor' })).toHaveAttribute(
+                'aria-selected',
+                'true',
+            ),
+        );
+        expect(screen.getByText(/1 module, 0 finished/)).toBeInTheDocument();
+        // The overall rail line and the queue card both count 2 of 3.
+        expect(screen.getAllByText(/2 of 3 lessons/).length).toBeGreaterThan(0);
+        // On the interactive viewer tab everything visible is done, so the
+        // module stays complete.
+        fireEvent.click(
+            screen.getByRole('tab', { name: 'interactive viewer' }),
+        );
+        expect(screen.getByText(/1 module, 1 finished/)).toBeInTheDocument();
+    });
+
+    it('counts only role-visible lessons for held modules and keeps full counts on locked ones', async () => {
+        // CS-169 scope-group module: a viewer holds view:DashboardComments
+        // but not create/manage, so 1 of 3 lessons is visible. The locked
+        // manage:Dashboard module keeps its full count — a locked node
+        // describes the whole module.
+        catalogueState.courses = [
+            entry({
+                id: 'comments',
+                title: 'Commenting on dashboards',
+                scope: 'view:DashboardComments',
+                lessonCount: 3,
+                lessonScopes: [
+                    'view:DashboardComments',
+                    'create:DashboardComments',
+                    'manage:DashboardComments',
+                ],
+            }),
+            entry({
+                id: 'dashboards',
+                title: 'Building dashboards',
+                scope: 'manage:Dashboard',
+                lessonCount: 3,
+                lessonScopes: ['manage:Dashboard', 'manage:Dashboard', null],
+            }),
+        ];
+        renderWithProviders(<LearnBoardPanel />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        await waitFor(() =>
+            expect(screen.getByRole('tab', { name: 'viewer' })).toHaveAttribute(
+                'aria-selected',
+                'true',
+            ),
+        );
+        const board = screen.getByTestId('learn-board');
+        expect(
+            board.querySelector(
+                '[aria-label="Commenting on dashboards, 1 lesson"]',
+            ),
+        ).not.toBeNull();
+        // Locked node: full lesson count, not the viewer-visible one.
+        expect(
+            board.querySelector(
+                '[aria-label="Building dashboards, 3 lessons"]',
+            ),
+        ).not.toBeNull();
+        // The rail totals sum visible lessons of held modules only.
+        expect(screen.getByText(/0 of 1 lesson ·/)).toBeInTheDocument();
     });
 
     it('defaults to the org role and lights only the held modules', async () => {

--- a/packages/frontend/src/features/learn/board/components/LearnBoardPanel.tsx
+++ b/packages/frontend/src/features/learn/board/components/LearnBoardPanel.tsx
@@ -23,12 +23,14 @@ import {
     useLearnCatalogue,
     useLearnRollups,
 } from '../../hooks';
+import { effectiveEntry, effectiveRollup } from '../../visibility';
 import { suggestionsFor } from '../ask';
 import { boardHighlights, resolveMatches } from '../askView';
 import { BOARD_WIDTH, type Seat } from '../layout';
 import {
     courseFor,
     defaultRoleFor,
+    isUnlocked,
     plural,
     railModel,
     ROLE_LABEL,
@@ -48,7 +50,7 @@ export const LearnBoardPanel: FC = () => {
     const navigate = useNavigate();
     const { user } = useApp();
     const catalogue = useLearnCatalogue();
-    const { rollups } = useLearnRollups();
+    const { rollups: rawRollups } = useLearnRollups();
     const badges = useLearnBadges();
     const ask = useLearnAsk();
     const [answer, setAnswer] = useState<AskAnswer | null>(null);
@@ -160,11 +162,37 @@ export const LearnBoardPanel: FC = () => {
         (node ?? tab)?.focus();
     }, []);
 
-    const entries = useMemo(
-        () => catalogue.data?.courses ?? [],
-        [catalogue.data],
-    );
     const held = useMemo(() => roleScopes(role), [role]);
+    // CS-169: every lessonCount downstream of here — railModel/moduleProgress
+    // denominators, node numerals, rail and pane "N lessons" — is the count of
+    // lessons visible to the selected role, so the twin board model stays
+    // untouched while a scope-group module renders per-role counts.
+    // Visible-lesson counts only make sense for modules the selected role
+    // HOLDS. A locked ask-match or a completed row from a previous role still
+    // describes the whole module — showing '0 lessons' there would be a lie.
+    const entries = useMemo(
+        () =>
+            (catalogue.data?.courses ?? []).map((entry) =>
+                isUnlocked(entry, held) ? effectiveEntry(entry, held) : entry,
+            ),
+        [catalogue.data, held],
+    );
+    // Doneness is derived too (CS-169 §6): a completed module whose visible
+    // lesson set grew re-opens. effectiveRollup is the identity for a module
+    // the role doesn't hold (visible count 0), so completed rows from other
+    // roles stay completed.
+    const rollups = useMemo(() => {
+        const derived = new Map(rawRollups);
+        for (const entry of entries) {
+            const rollup = effectiveRollup(
+                entry,
+                rawRollups.get(entry.id),
+                held,
+            );
+            if (rollup) derived.set(entry.id, rollup);
+        }
+        return derived;
+    }, [rawRollups, entries, held]);
     const prevHeld = useMemo(
         () => (prevRole ? roleScopes(prevRole) : null),
         [prevRole],
@@ -278,6 +306,7 @@ export const LearnBoardPanel: FC = () => {
                     rail={rail}
                     rollups={rollups}
                     role={role}
+                    held={held}
                     heldEntries={heldEntries}
                     tiers={tiers}
                     tiersLoading={badges.isInitialLoading}

--- a/packages/frontend/src/features/learn/board/components/ModulePane.tsx
+++ b/packages/frontend/src/features/learn/board/components/ModulePane.tsx
@@ -2,10 +2,12 @@ import { Group, Stack, Text } from '@mantine/core';
 import { type FC } from 'react';
 import { useLearnCourse } from '../../hooks';
 import { type Rollup } from '../../model';
+import { lessonVisible, manifestScopeKnown } from '../../visibility';
 import {
     ctaLabel,
     GROUP_LABEL,
     heldBy,
+    isUnlocked,
     parseScopeTag,
     plural,
     ROLE_LABEL,
@@ -16,18 +18,35 @@ import styles from './LearnBoard.module.css';
 
 type Props = {
     module: BoardModule;
+    /** The scope names the selected role holds (CS-169 lesson filtering). */
+    held: string[];
     rollup: Rollup | undefined;
     onClose: () => void;
     onOpen: (courseId: string) => void;
 };
 
-export const ModulePane: FC<Props> = ({ module, rollup, onClose, onOpen }) => {
+export const ModulePane: FC<Props> = ({
+    module,
+    held,
+    rollup,
+    onClose,
+    onOpen,
+}) => {
     const { entry, progress, group, done: moduleComplete } = module;
     const course = useLearnCourse(entry.id);
     const pct = Math.round(progress * 100);
     const holders = heldBy(entry).map((role) => ROLE_LABEL[role]);
     const permits = scopePermits(entry);
     const done = rollup?.lessonsCompleted ?? new Set<string>();
+    // CS-169: a held scope-group module lists only the lessons the selected
+    // role can see, matching the effective lessonCount the panel mapped in. A
+    // module the role does NOT hold (a completed row from another role) still
+    // describes the whole module, so its list stays unfiltered.
+    const lessons = (course.data?.lessons ?? []).filter(
+        (lesson) =>
+            !isUnlocked(entry, held) ||
+            lessonVisible(lesson.scope, held, manifestScopeKnown),
+    );
 
     return (
         <Stack gap={16}>
@@ -90,7 +109,7 @@ export const ModulePane: FC<Props> = ({ module, rollup, onClose, onOpen }) => {
                         Loading lessons…
                     </Text>
                 )}
-                {(course.data?.lessons ?? []).map((lesson, i) => {
+                {lessons.map((lesson, i) => {
                     const finished = moduleComplete || done.has(lesson.id);
                     return (
                         <div key={lesson.id} className={styles.lessonRow}>

--- a/packages/frontend/src/features/learn/components/LearnCoursePlayer.test.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCoursePlayer.test.tsx
@@ -1,7 +1,7 @@
-import { type LearnCourse } from '@lightdash/common';
+import { OrganizationMemberRole, type LearnCourse } from '@lightdash/common';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import type * as ReactRouter from 'react-router';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import { emptyRollup } from '../model';
 import { LearnCoursePlayer } from './LearnCoursePlayer';
@@ -26,6 +26,7 @@ const course: LearnCourse = {
         {
             id: 'l1',
             title: 'Save a chart',
+            scope: null,
             html:
                 '<p>Open the chart<a class="cit" href="#fig-1" data-hl="r1">1</a>.</p>' +
                 '<div data-demo="save-chart"></div>' +
@@ -55,9 +56,27 @@ const course: LearnCourse = {
     assetBaseUrl: 'https://cdn/courses/saving-charts/abc',
 };
 
+// Swappable so a test can serve a differently scoped course.
+const courseState: { data: LearnCourse } = { data: course };
+
 vi.mock('../hooks', () => ({
+    useLearnCatalogue: () => ({
+        data: {
+            generatedAt: '2026-08-01T00:00:00.000Z',
+            courses: [
+                {
+                    id: 'saving-charts',
+                    title: 'Saving charts',
+                    lessonCount: 1,
+                },
+            ],
+            suggestions: [],
+        },
+        isLoading: false,
+        isError: false,
+    }),
     useLearnCourse: () => ({
-        data: course,
+        data: courseState.data,
         isInitialLoading: false,
         isError: false,
     }),
@@ -73,6 +92,48 @@ vi.mock('../hooks', () => ({
 }));
 
 describe('LearnCoursePlayer', () => {
+    beforeEach(() => {
+        courseState.data = course;
+    });
+
+    it('renders an empty state instead of the player when the role holds none of the lesson scopes', async () => {
+        courseState.data = {
+            ...course,
+            lessons: [
+                {
+                    id: 'l1',
+                    title: 'Tidy the thread',
+                    scope: 'manage:DashboardComments',
+                    html: '<p>manage-only</p>',
+                },
+            ],
+            quiz: {
+                questions: [
+                    {
+                        id: 'q1',
+                        prompt: 'Q?',
+                        choices: ['a', 'b'],
+                        answer: 0,
+                    },
+                ],
+            },
+        };
+        // An org viewer maps to the viewer board role, which does not hold
+        // manage:DashboardComments.
+        renderWithProviders(<LearnCoursePlayer />, {
+            user: { role: OrganizationMemberRole.VIEWER },
+        });
+        await waitFor(() =>
+            expect(
+                screen.getByText(
+                    /None of this course's lessons are available to your role/,
+                ),
+            ).toBeInTheDocument(),
+        );
+        expect(screen.queryByText('manage-only')).not.toBeInTheDocument();
+        expect(screen.queryByText(/Lesson 1 of/)).not.toBeInTheDocument();
+    });
+
     it('mounts a click-through demo where the lesson left its placeholder', async () => {
         renderWithProviders(<LearnCoursePlayer />);
         await waitFor(() =>

--- a/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
+++ b/packages/frontend/src/features/learn/components/LearnCoursePlayer.tsx
@@ -20,16 +20,20 @@ import { createPortal } from 'react-dom';
 import { useNavigate, useParams } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
+import useApp from '../../../providers/App/useApp';
+import { defaultRoleFor, roleScopes } from '../board/model';
 import { wireCitations } from '../citations';
 import {
     getLessonBookmark,
     setLastCourseId,
     setLessonBookmark,
+    useLearnCatalogue,
     useLearnCourse,
     useLearnRollups,
     useRecordLearnEvent,
 } from '../hooks';
 import { cardState, emptyRollup } from '../model';
+import { effectiveRollup, filterCourseForScopes } from '../visibility';
 import { LearnDemo } from './LearnDemo';
 import styles from './LearnLesson.module.css';
 
@@ -57,12 +61,11 @@ export const LearnCoursePlayer: FC = () => {
         courseId: string;
     }>();
     const navigate = useNavigate();
+    const { user } = useApp();
+    const catalogue = useLearnCatalogue();
     const course = useLearnCourse(courseId);
     const { rollups } = useLearnRollups();
     const { record } = useRecordLearnEvent();
-
-    const rollup = (courseId && rollups.get(courseId)) || emptyRollup();
-    const state = cardState(courseId ? rollups.get(courseId) : undefined);
 
     // page ∈ [0, lessonCount-1] = lessons; page === lessonCount = quiz.
     const [page, setPage] = useState<number | null>(null);
@@ -74,7 +77,33 @@ export const LearnCoursePlayer: FC = () => {
         if (courseId) setLastCourseId(courseId);
     }, [courseId]);
 
-    const data = course.data;
+    // CS-169: the course is filtered to the held scopes BEFORE the paging and
+    // the index-parallel quiz answers state are built, so a hidden lesson can
+    // never be paged to and a hidden lesson's quiz question is never scored.
+    // The board's role picker is component-local and not shared with this
+    // route, so the held scopes derive from the learner's org role the same
+    // way the board derives its default tab.
+    const held = useMemo(
+        () => roleScopes(defaultRoleFor(user.data?.role)),
+        [user.data?.role],
+    );
+    const data = useMemo(
+        () =>
+            course.data ? filterCourseForScopes(course.data, held) : undefined,
+        [course.data, held],
+    );
+
+    // Doneness is derived against the visible lesson set (CS-169 §6): a
+    // module completed under a smaller set re-opens when the role holds more
+    // lessons. The catalogue entry carries the per-lesson scopes; when the
+    // catalogue is unavailable the raw rollup stands (legacy behaviour).
+    const entry = catalogue.data?.courses.find((c) => c.id === courseId);
+    const baseRollup = courseId ? rollups.get(courseId) : undefined;
+    const derivedRollup = entry
+        ? effectiveRollup(entry, baseRollup, held)
+        : baseRollup;
+    const rollup = derivedRollup ?? emptyRollup();
+    const state = cardState(derivedRollup);
 
     const eventObject = useMemo(
         () =>
@@ -97,7 +126,10 @@ export const LearnCoursePlayer: FC = () => {
     }, [data, page, courseId]);
 
     useEffect(() => {
-        if (!data || started || state !== 'open' || !eventObject) return;
+        // A course with no visible lessons is never "started" — the learner
+        // only ever sees the empty state below.
+        if (!data || data.lessons.length === 0) return;
+        if (started || state !== 'open' || !eventObject) return;
         setStarted(true);
         record({
             verb: 'started',
@@ -152,7 +184,35 @@ export const LearnCoursePlayer: FC = () => {
         );
     }
 
+    // CS-169: a role that holds none of the course's lesson scopes would
+    // reach the player with zero lessons and a zero-question quiz (scored
+    // NaN). Render an honest empty state instead.
+    if (data.lessons.length === 0) {
+        return (
+            <Stack gap="md" py="lg" maw={760} w="100%" mx="auto">
+                <Anchor
+                    size="sm"
+                    onClick={() => navigate(`/projects/${projectUuid}/learn`)}
+                >
+                    <Group gap={4}>
+                        <MantineIcon icon={IconArrowLeft} />
+                        All courses
+                    </Group>
+                </Anchor>
+                <SuboptimalState
+                    title="No lessons for your role"
+                    description="None of this course's lessons are available to your role. Head back to the course board to see what your role unlocks."
+                />
+            </Stack>
+        );
+    }
+
     const lessonCount = data.lessons.length;
+    // CS-169: the rollup can hold ids of lessons the role does not see, so
+    // the header count is the intersection with the visible lesson set.
+    const doneCount = data.lessons.filter((l) =>
+        rollup.lessonsCompleted.has(l.id),
+    ).length;
     const onQuiz = page >= lessonCount;
     const progressPct = Math.round(((page + 1) / (lessonCount + 1)) * 100);
 
@@ -212,8 +272,8 @@ export const LearnCoursePlayer: FC = () => {
                 <Stack gap={4}>
                     <Title order={2}>{data.title}</Title>
                     <Text size="sm" c="dimmed">
-                        {lessonCount} lessons · {rollup.lessonsCompleted.size}{' '}
-                        of {lessonCount} done
+                        {lessonCount} lessons · {doneCount} of {lessonCount}{' '}
+                        done
                         {rollup.passed ? ' · Passed' : ''}
                     </Text>
                 </Stack>

--- a/packages/frontend/src/features/learn/visibility.test.ts
+++ b/packages/frontend/src/features/learn/visibility.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest';
+import {
+    effectiveEntry,
+    effectiveRollup,
+    filterCourseForScopes,
+    lessonVisible,
+    manifestScopeKnown,
+    visibleLessonCount,
+} from './visibility';
+
+// Real registry scopes: the DashboardComments trio is the CS-169 reference
+// scope group (view held from interactive viewer, create from editor,
+// manage from developer).
+const VIEW = 'view:DashboardComments';
+const CREATE = 'create:DashboardComments';
+const MANAGE = 'manage:DashboardComments';
+
+describe('lessonVisible', () => {
+    it('an untagged lesson (null or undefined) is always visible', () => {
+        expect(lessonVisible(null, [], manifestScopeKnown)).toBe(true);
+        expect(lessonVisible(undefined, [], manifestScopeKnown)).toBe(true);
+    });
+
+    it('a scope whose base the registry does not know is always visible (forward compat)', () => {
+        expect(manifestScopeKnown('view:FluxCapacitor')).toBe(false);
+        expect(
+            lessonVisible('view:FluxCapacitor', [], manifestScopeKnown),
+        ).toBe(true);
+    });
+
+    it('a known scope is visible only when held', () => {
+        expect(lessonVisible(VIEW, [VIEW], manifestScopeKnown)).toBe(true);
+        expect(lessonVisible(MANAGE, [VIEW], manifestScopeKnown)).toBe(false);
+    });
+
+    it('a bare tag is held under any modifier; @global only unmodified', () => {
+        expect(
+            lessonVisible(MANAGE, [`${MANAGE}@space`], manifestScopeKnown),
+        ).toBe(true);
+        expect(
+            lessonVisible(
+                `${VIEW}@global`,
+                [`${VIEW}@space`],
+                manifestScopeKnown,
+            ),
+        ).toBe(false);
+        expect(
+            lessonVisible(`${VIEW}@global`, [VIEW], manifestScopeKnown),
+        ).toBe(true);
+    });
+
+    it('honours a caller-supplied scopeKnown', () => {
+        // Pretend the base is unknown: the lesson stays visible even unheld.
+        expect(lessonVisible(MANAGE, [], () => false)).toBe(true);
+    });
+});
+
+describe('visibleLessonCount', () => {
+    const entry = { lessonCount: 3, lessonScopes: [VIEW, null, MANAGE] };
+
+    it('counts lessons visible to the held scopes, nulls always counted', () => {
+        expect(visibleLessonCount(entry, [VIEW])).toBe(2);
+        expect(visibleLessonCount(entry, [VIEW, CREATE, MANAGE])).toBe(3);
+        expect(visibleLessonCount(entry, [])).toBe(1);
+    });
+
+    it('falls back to lessonCount when the catalogue has no lessonScopes', () => {
+        expect(visibleLessonCount({ lessonCount: 5 }, [])).toBe(5);
+    });
+});
+
+describe('effectiveEntry', () => {
+    it('replaces lessonCount with the visible count, leaving the original untouched', () => {
+        const entry = {
+            id: 'dashboard-comments',
+            lessonCount: 3,
+            lessonScopes: [VIEW, CREATE, MANAGE],
+        };
+        const eff = effectiveEntry(entry, [VIEW]);
+        expect(eff.lessonCount).toBe(1);
+        expect(eff.id).toBe('dashboard-comments');
+        expect(entry.lessonCount).toBe(3);
+    });
+
+    it('is the identity for an entry without lessonScopes (pre-CS-169 catalogue)', () => {
+        const entry = { id: 'legacy', lessonCount: 4 };
+        expect(effectiveEntry(entry, [])).toBe(entry);
+    });
+});
+
+describe('filterCourseForScopes', () => {
+    const course = {
+        title: 'Dashboard comments',
+        lessons: [
+            { id: '01-read', title: 'Read', html: '', scope: VIEW },
+            { id: '02-post', title: 'Post', html: '', scope: CREATE },
+            { id: '03-tidy', title: 'Tidy', html: '', scope: MANAGE },
+        ],
+        quiz: {
+            questions: [
+                {
+                    id: 'q1',
+                    prompt: 'a',
+                    choices: ['x', 'y'],
+                    answer: 0,
+                    lesson: '01-read',
+                },
+                {
+                    id: 'q2',
+                    prompt: 'b',
+                    choices: ['x', 'y'],
+                    answer: 1,
+                    lesson: '02-post',
+                },
+                {
+                    id: 'q3',
+                    prompt: 'c',
+                    choices: ['x', 'y'],
+                    answer: 0,
+                    lesson: '03-tidy',
+                },
+                { id: 'q4', prompt: 'd', choices: ['x', 'y'], answer: 1 },
+            ],
+        },
+    };
+
+    it('drops hidden lessons and their quiz questions, keeping questions without a lesson key', () => {
+        const filtered = filterCourseForScopes(course, [VIEW, CREATE]);
+        expect(filtered.lessons.map((l) => l.id)).toEqual([
+            '01-read',
+            '02-post',
+        ]);
+        expect(filtered.quiz.questions.map((q) => q.id)).toEqual([
+            'q1',
+            'q2',
+            'q4',
+        ]);
+    });
+
+    it('keeps untagged and unknown-scope lessons visible', () => {
+        const mixed = {
+            lessons: [
+                { id: 'a', scope: null },
+                { id: 'b' },
+                { id: 'c', scope: 'view:FluxCapacitor' },
+                { id: 'd', scope: MANAGE },
+            ],
+            quiz: { questions: [] },
+        };
+        expect(
+            filterCourseForScopes(mixed, []).lessons.map((l) => l.id),
+        ).toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns the same course object when nothing is hidden (pre-CS-169 course.json)', () => {
+        const legacy = {
+            lessons: [
+                { id: 'l1', title: 'One', html: '' },
+                { id: 'l2', title: 'Two', html: '' },
+            ],
+            quiz: {
+                questions: [
+                    { id: 'q1', prompt: 'a', choices: ['x'], answer: 0 },
+                ],
+            },
+        };
+        expect(filterCourseForScopes(legacy, [])).toBe(legacy);
+        expect(filterCourseForScopes(course, [VIEW, CREATE, MANAGE])).toBe(
+            course,
+        );
+    });
+
+    it('does not mutate the original course', () => {
+        const filtered = filterCourseForScopes(course, [VIEW]);
+        expect(filtered).not.toBe(course);
+        expect(course.lessons).toHaveLength(3);
+        expect(course.quiz.questions).toHaveLength(4);
+        expect(filtered.lessons).toHaveLength(1);
+        expect(filtered.quiz.questions.map((q) => q.id)).toEqual(['q1', 'q4']);
+    });
+});
+
+describe('effectiveRollup', () => {
+    const entry = { lessonCount: 3, lessonScopes: [VIEW, CREATE, MANAGE] };
+    const completedTwo = {
+        completed: true,
+        passed: true,
+        lessonsCompleted: new Set(['l1', 'l2']),
+    };
+
+    it('re-opens a completed module when a role change unlocks a lesson', () => {
+        // Completed with 2 visible lessons as interactive viewer, then
+        // switched to editor: 3 visible, only 2 done — the module must stop
+        // reading as done.
+        const derived = effectiveRollup(entry, completedTwo, [
+            VIEW,
+            CREATE,
+            MANAGE,
+        ]);
+        expect(derived).toEqual({
+            completed: false,
+            passed: false,
+            lessonsCompleted: completedTwo.lessonsCompleted,
+        });
+    });
+
+    it('keeps done on a downgrade — everything the role can see is finished', () => {
+        // Completed all 3 as editor, then switched to viewer: 1 visible, 3 done.
+        const all = {
+            completed: true,
+            passed: true,
+            lessonsCompleted: new Set(['l1', 'l2', 'l3']),
+        };
+        expect(effectiveRollup(entry, all, [VIEW])).toBe(all);
+    });
+
+    it('is the identity for a module the role does not hold at all', () => {
+        const locked = { lessonCount: 2, lessonScopes: [MANAGE, MANAGE] };
+        expect(effectiveRollup(locked, completedTwo, [VIEW])).toBe(
+            completedTwo,
+        );
+    });
+
+    it('is the identity when the rollup is not completed, and for undefined', () => {
+        const open = {
+            completed: false,
+            passed: false,
+            lessonsCompleted: new Set<string>(),
+        };
+        expect(effectiveRollup(entry, open, [VIEW, CREATE, MANAGE])).toBe(open);
+        expect(effectiveRollup(entry, undefined, [VIEW])).toBeUndefined();
+    });
+});

--- a/packages/frontend/src/features/learn/visibility.ts
+++ b/packages/frontend/src/features/learn/visibility.ts
@@ -1,0 +1,138 @@
+/**
+ * CS-169 per-lesson scope visibility. Lightdash-only adopter code — NOT one
+ * of the byte-identical twin files under `board/` (model, layout, motion,
+ * ask, badges, testFixtures stay untouched): the panel maps catalogue entries
+ * through `effectiveEntry` BEFORE handing them to railModel / moduleProgress
+ * / lessonCount renders, so all board math sees visible counts without the
+ * twin model changing.
+ *
+ * Visibility rule mirrors `board/model.ts` `isUnlocked`: a null/untagged
+ * lesson is always visible, and a scope whose base the scope registry does
+ * not know is always visible (forward compat — an unknown scope never hides
+ * content).
+ */
+import { getAllScopeMap, type Scope } from '@lightdash/common';
+import { holds, parseScopeTag } from './board/model';
+
+const scopeMap = getAllScopeMap({ isEnterprise: true }) as Record<
+    string,
+    Scope | undefined
+>;
+
+/** Whether the scope registry knows this base scope name. */
+export const manifestScopeKnown = (base: string): boolean =>
+    scopeMap[base] !== undefined;
+
+/**
+ * Whether a lesson with this scope tag is visible to a learner holding
+ * `held`. null/undefined (untagged, or published before the field existed)
+ * and unknown-base tags are always visible, matching isUnlocked's
+ * forward-compat rule; otherwise the same holds() predicate the board uses
+ * for modules.
+ */
+export const lessonVisible = (
+    scope: string | null | undefined,
+    held: string[],
+    scopeKnown: (base: string) => boolean,
+): boolean => {
+    if (scope === null || scope === undefined) return true;
+    const { base } = parseScopeTag(scope);
+    if (!scopeKnown(base)) return true;
+    return holds(held, scope);
+};
+
+type CountableEntry = {
+    lessonCount: number;
+    lessonScopes?: (string | null)[];
+};
+
+/**
+ * How many of the entry's lessons are visible to `held`. Derived from
+ * `lessonScopes` when the catalogue carries it (one tag per lesson, in
+ * lesson order); a pre-CS-169 catalogue has no per-lesson data, so the full
+ * lessonCount stands.
+ */
+export const visibleLessonCount = (
+    entry: CountableEntry,
+    held: string[],
+): number => {
+    if (!entry.lessonScopes) return entry.lessonCount;
+    return entry.lessonScopes.filter((scope) =>
+        lessonVisible(scope, held, manifestScopeKnown),
+    ).length;
+};
+
+/**
+ * The entry with `lessonCount` replaced by the visible-lesson count. The
+ * panel maps entries through this before every model call and every
+ * lessonCount render, which is what keeps the twin model.ts byte-identical
+ * while its denominators become visible counts.
+ */
+export const effectiveEntry = <T extends CountableEntry>(
+    entry: T,
+    held: string[],
+): T => {
+    if (!entry.lessonScopes) return entry;
+    return { ...entry, lessonCount: visibleLessonCount(entry, held) };
+};
+
+type FilterableCourse = {
+    lessons: { id: string; scope?: string | null }[];
+    quiz: { questions: { id: string; lesson?: string }[] };
+};
+
+/**
+ * The course with hidden lessons removed and the quiz filtered to questions
+ * whose `lesson` stem names a visible lesson (questions without a lesson key
+ * are kept — legacy quizzes predate the key, which reaches us through the
+ * schema's passthrough). Must run on the course object BEFORE the player
+ * builds its index-parallel answers array.
+ */
+export const filterCourseForScopes = <T extends FilterableCourse>(
+    course: T,
+    held: string[],
+): T => {
+    const lessons = course.lessons.filter((lesson) =>
+        lessonVisible(lesson.scope, held, manifestScopeKnown),
+    );
+    if (lessons.length === course.lessons.length) return course;
+    const visibleIds = new Set(lessons.map((lesson) => lesson.id));
+    const questions = course.quiz.questions.filter(
+        (q) => q.lesson === undefined || visibleIds.has(q.lesson),
+    );
+    return { ...course, lessons, quiz: { ...course.quiz, questions } };
+};
+
+/**
+ * Display-state derivation for a rollup against the currently visible lesson
+ * set (CS-169 §6: module "completed" is derived — a role change that unlocks
+ * new lessons re-opens the module, "2 of 3, new lessons unlocked"). The quiz
+ * pass and the completed event stay durable facts in the raw rollup; only
+ * the card/board doneness is derived here. Count-compare is exact for role
+ * upgrades because system role scope sets nest (previously visible lessons
+ * are a subset of now-visible ones); on a downgrade the completed size
+ * exceeds the visible count and the module stays done — the learner
+ * finished everything their role can see.
+ */
+export const effectiveRollup = <
+    R extends {
+        completed: boolean;
+        passed: boolean;
+        lessonsCompleted: Set<string>;
+    },
+>(
+    entry: CountableEntry,
+    rollup: R | undefined,
+    held: string[],
+): R | undefined => {
+    // Legacy (pre-CS-169) entry: no per-lesson data, nothing to derive from.
+    if (!entry.lessonScopes) return rollup;
+    if (!rollup || (!rollup.completed && !rollup.passed)) return rollup;
+    // Covers downgrades and not-held modules (visible count 0): everything
+    // the role can see is finished, so the module stays done.
+    if (rollup.lessonsCompleted.size >= visibleLessonCount(entry, held))
+        return rollup;
+    // Derived copy only — the raw rollup (and server tiers) keep the durable
+    // quiz-pass and completed facts.
+    return { ...rollup, completed: false, passed: false };
+};


### PR DESCRIPTION
Part of the CS-73 Learn stack (follows #27887 on `learn-6-rail`). **DO NOT MERGE ahead of the stack.**

## What

Consumes the CS-169 scope-group contract now published by lu-content. The new fields (`scopes`, `lessonScopes` on catalogue entries; `scope` on course lessons) already arrive through the zod schemas' `.passthrough()` — this PR types them in `@lightdash/common` (schema-defaulted, so pre-CS-169 content and immutable older `course.json` still parse) and uses them in the Learn UI.

- **New `features/learn/visibility.ts`** (deliberately outside `board/` — it is not one of the byte-identical academy twin files, which are untouched; `board:sync-check` reports all 11 files in step). Ports the academy reference helper: `lessonVisible`, `visibleLessonCount`, `effectiveEntry`, `filterCourseForScopes` (quiz questions follow their `lesson` stem; keyless legacy questions are kept) and `effectiveRollup`. Null/untagged and unknown-base scopes are always visible (forward compat).
- **Board panel**: catalogue entries map through `effectiveEntry(entry, held)` **only when the selected role holds the module** — a locked ask-match or a completed row from another role still describes the whole module, so it keeps the full `lessonCount` (this held-only rule was a review finding on the academy side, copied here).
- **Derived doneness** (CS-169 §6, ports lightdash-university PR #71): the panel and the player hand the board model a rollup derived by `effectiveRollup`, so a module completed under a smaller visible lesson set re-opens ("2 of 3") when a role change unlocks lessons. Identity for legacy entries without `lessonScopes`, for not-completed rollups, and whenever everything visible is finished (covers downgrades and not-held modules). The raw rollup and server-derived badge tiers are never mutated.
- **Module pane** lists only the lessons visible to the selected role (unfiltered for modules the role doesn't hold, matching the full count shown there).
- **Course player** filters `lessons` and lesson-keyed quiz questions **before** the paging/answers state is built. If zero lessons remain it renders an empty state ("None of this course's lessons are available to your role") instead of the player — never a zero-lesson quiz, which would score NaN. The header's done count intersects the rollup with the visible lesson set.

### Held-scope source in the player

The board's role picker is component-local state and not shared with the player route, so the player derives held scopes from `roleScopes(defaultRoleFor(user's org role))` — the same default the board opens on. A learner previewing a different role on the board and then opening a course is filtered by their real role, not the preview.

### Not included

`packages/backend/src/generated/{routes.ts,swagger.json}` were regenerated locally to verify the tsoa flow, but the repo's pre-commit hook unstages them by design ("committed by the release workflow"), so they are not part of this PR.

## Tests

- `visibility.test.ts`: null/unknown-base scopes, held/not-held, @global modifier semantics, quiz filtering incl. keyless questions, missing-`lessonScopes` identity, and the `effectiveRollup` re-open/downgrade/not-held/legacy cases.
- `LearnBoardPanel.test.tsx`: visible counts on held modules with full counts kept on locked ones; the re-open-on-role-change board test mirroring the academy's.
- `LearnCoursePlayer.test.tsx`: the zero-visible-lessons empty-state guard.
- `pnpm -F frontend exec vitest run src/features/learn`: 17 files, 157 tests passed. `common`/`frontend`/`backend` typechecks clean; oxlint clean; LU `board:sync-check` in step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GF8txWvDRwYoD9rigExBXN