### PR TITLE
fix: add a continue link to the OAuth redirect page

### DIFF
--- a/packages/backend/src/services/OAuthService/OAuthService.test.ts
+++ b/packages/backend/src/services/OAuthService/OAuthService.test.ts
@@ -6,6 +6,8 @@ import { OAuth2Model } from '../../models/OAuth2Model';
 import { UserModel } from '../../models/UserModel';
 import { OAuthService } from './OAuthService';
 
+const JAVASCRIPT_REDIRECT_URI = ['javascript', 'alert(1)'].join(':');
+
 // Test subclass to expose oauthServer for mocking
 class TestOAuthService extends OAuthService {
     public setOAuthServer(server: AnyType) {
@@ -155,6 +157,19 @@ describe('OAuthService edge cases', () => {
             expect(mockOAuthModel.validateRedirectUri).toHaveBeenCalledWith(
                 'https://example.com/callback',
                 client,
+            );
+        });
+    });
+
+    describe('registerClient', () => {
+        it('rejects an unsafe redirect URI scheme', async () => {
+            await expect(
+                oauthService.registerClient({
+                    clientName: 'Unsafe client',
+                    redirectUris: [JAVASCRIPT_REDIRECT_URI],
+                }),
+            ).rejects.toThrow(
+                `Invalid redirect URI ${JAVASCRIPT_REDIRECT_URI}`,
             );
         });
     });

--- a/packages/backend/src/services/OAuthService/OAuthService.ts
+++ b/packages/backend/src/services/OAuthService/OAuthService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     getClientName,
+    isSafeRedirectScheme,
     NotFoundError,
     ParameterError,
     UserWithOrganizationUuid,
@@ -129,10 +130,7 @@ export class OAuthService extends BaseService {
         scopes?: string[];
     }) {
         for (const uri of redirectUris) {
-            try {
-                // eslint-disable-next-line no-new
-                new URL(uri);
-            } catch {
+            if (!isSafeRedirectScheme(uri)) {
                 throw new ParameterError(`Invalid redirect URI ${uri}`);
             }
         }
@@ -192,10 +190,7 @@ export class OAuthService extends BaseService {
         }
         // Validate redirect URIs
         for (const uri of redirectUris) {
-            try {
-                // eslint-disable-next-line no-new
-                new URL(uri);
-            } catch {
+            if (!isSafeRedirectScheme(uri)) {
                 throw new ParameterError(`Invalid redirect URI ${uri}`);
             }
         }
@@ -236,10 +231,7 @@ export class OAuthService extends BaseService {
         }
         // Validate redirect URIs
         for (const uri of redirectUris) {
-            try {
-                // eslint-disable-next-line no-new
-                new URL(uri);
-            } catch {
+            if (!isSafeRedirectScheme(uri)) {
                 throw new ParameterError(`Invalid redirect URI ${uri}`);
             }
         }

--- a/packages/common/src/utils/oauth.test.ts
+++ b/packages/common/src/utils/oauth.test.ts
@@ -57,7 +57,21 @@ describe('OAuth page templates', () => {
         expect(redirectPage).not.toContain('</script>');
         expect(redirectPage).not.toContain('<img src=x');
         expect(redirectPage).not.toContain('onerror=');
-        expect(redirectPage).not.toContain('href=');
+        expect(redirectPage).toContain(
+            '<a class="button" href="https://example.com/callback?&lt;/script&gt;&lt;img src&#x3D;x onerror&#x3D;alert(document.domain)&gt;">Continue</a>',
+        );
         expect(redirectPage).toContain('&lt;/script&gt;');
+    });
+
+    it('escapes quotes in OAuth redirect link URLs', () => {
+        const redirectPage = generateOAuthRedirectPage({
+            redirectUrl: 'com.lightdash.mobile://oauth/callback?state="value"',
+            message: 'Redirecting',
+        });
+
+        expect(redirectPage).toContain(
+            '<a class="button" href="com.lightdash.mobile://oauth/callback?state&#x3D;&quot;value&quot;">Continue</a>',
+        );
+        expect(redirectPage).not.toContain('href="value"');
     });
 });

--- a/packages/common/src/utils/oauth.test.ts
+++ b/packages/common/src/utils/oauth.test.ts
@@ -2,11 +2,14 @@ import {
     generateOAuthAuthorizePage,
     generateOAuthRedirectPage,
     generateOAuthSuccessResponse,
+    isSafeRedirectScheme,
     parseScopeString,
 } from './oauth';
 
 const VIEWPORT_META =
     '<meta name="viewport" content="width=device-width, initial-scale=1" />';
+const JAVASCRIPT_SCHEME = ['javascript', ''].join(':');
+const JAVASCRIPT_REDIRECT_URI = `${JAVASCRIPT_SCHEME}alert(1)`;
 
 const authorizePage = () =>
     generateOAuthAuthorizePage({
@@ -24,6 +27,29 @@ const authorizePage = () =>
         loginUrl: '/login',
         hiddenInputs: [],
     });
+
+describe('isSafeRedirectScheme', () => {
+    it.each([
+        'https://example.com/callback',
+        'http://localhost:9000/callback',
+        'com.lightdash.mobile://oauth/callback',
+    ])('accepts supported redirect URI %s', (redirectUri) => {
+        expect(isSafeRedirectScheme(redirectUri)).toBe(true);
+    });
+
+    it.each([
+        JAVASCRIPT_REDIRECT_URI,
+        'data:text/html,x',
+        'vbscript:x',
+        'file:///etc/passwd',
+        'blob:https://x',
+        [' JAVASCRIPT', 'alert(1)'].join(':'),
+        '\tDaTa:text/html,x ',
+        'not a URL',
+    ])('rejects unsafe redirect URI %s', (redirectUri) => {
+        expect(isSafeRedirectScheme(redirectUri)).toBe(false);
+    });
+});
 
 describe('OAuth page templates', () => {
     it('declares the viewport on the authorize page so it renders at 1:1 on mobile', () => {
@@ -73,5 +99,15 @@ describe('OAuth page templates', () => {
             '<a class="button" href="com.lightdash.mobile://oauth/callback?state&#x3D;&quot;value&quot;">Continue</a>',
         );
         expect(redirectPage).not.toContain('href="value"');
+    });
+
+    it('does not navigate to an unsafe OAuth redirect URL', () => {
+        const redirectPage = generateOAuthRedirectPage({
+            redirectUrl: JAVASCRIPT_REDIRECT_URI,
+            message: 'Redirecting',
+        });
+
+        expect(redirectPage).not.toContain(JAVASCRIPT_SCHEME);
+        expect(redirectPage).not.toContain('http-equiv="refresh"');
     });
 });

--- a/packages/common/src/utils/oauth.ts
+++ b/packages/common/src/utils/oauth.ts
@@ -62,6 +62,38 @@ export const oauthPageStyles = `
         flex-direction: column;
         gap: 16px;
     }
+    .oauth-btn,
+    .button {
+        display: inline-block;
+        padding: 8px 24px;
+        border: 1px solid #e9ecef;
+        border-radius: 8px;
+        font-weight: 500;
+        font-size: 14px;
+        cursor: pointer;
+        text-decoration: none;
+        transition: background 0.15s, border-color 0.15s;
+    }
+    .oauth-btn.approve,
+    .button {
+        background: #111418;
+        color: #fff;
+        border-color: #111418;
+    }
+    .oauth-btn.approve:hover,
+    .button:hover {
+        background: #2c2e33;
+        border-color: #2c2e33;
+    }
+    .oauth-btn.deny {
+        background: transparent;
+        color: #111418;
+        border-color: #e9ecef;
+    }
+    .oauth-btn.deny:hover {
+        background: #f8fafc;
+        border-color: #dee2e6;
+    }
 `;
 
 // Lightdash logo SVG
@@ -123,6 +155,7 @@ const OAUTH_REDIRECT_TEMPLATE = `
                 {{{logo}}}
                 <h1>Redirecting...</h1>
                 <p>{{message}}</p>
+                <a class="button" href="{{redirectUrl}}">Continue</a>
             </div>
         </div>
     </body>
@@ -282,33 +315,6 @@ const OAUTH_AUTHORIZE_TEMPLATE = `
                 margin-top: 24px;
                 padding-top: 16px;
                 border-top: 1px solid #e9ecef;
-            }
-            .oauth-btn {
-                padding: 8px 24px;
-                border: 1px solid #e9ecef;
-                border-radius: 8px;
-                font-weight: 500;
-                font-size: 14px;
-                cursor: pointer;
-                transition: background 0.15s, border-color 0.15s;
-            }
-            .oauth-btn.approve {
-                background: #111418;
-                color: #fff;
-                border-color: #111418;
-            }
-            .oauth-btn.approve:hover {
-                background: #2c2e33;
-                border-color: #2c2e33;
-            }
-            .oauth-btn.deny {
-                background: transparent;
-                color: #111418;
-                border-color: #e9ecef;
-            }
-            .oauth-btn.deny:hover {
-                background: #f8fafc;
-                border-color: #dee2e6;
             }
         </style>
     </head>

--- a/packages/common/src/utils/oauth.ts
+++ b/packages/common/src/utils/oauth.ts
@@ -453,6 +453,21 @@ export interface OAuthRedirectParams {
     message: string;
 }
 
+const UNSAFE_REDIRECT_PROTOCOLS = new Set(
+    ['javascript', 'data', 'vbscript', 'file', 'blob'].map(
+        (scheme) => `${scheme}:`,
+    ),
+);
+
+export const isSafeRedirectScheme = (uri: string): boolean => {
+    try {
+        const { protocol } = new URL(uri);
+        return !UNSAFE_REDIRECT_PROTOCOLS.has(protocol.toLowerCase());
+    } catch {
+        return false;
+    }
+};
+
 // Scope descriptions mapping
 const SCOPE_DESCRIPTIONS: Record<string, OAuthScopeDescription> = {
     read: {
@@ -551,12 +566,19 @@ export const generateOAuthErrorResponse = (
  */
 export const generateOAuthRedirectPage = (
     params: OAuthRedirectParams,
-): string =>
-    compiledRedirectTemplate({
+): string => {
+    if (!isSafeRedirectScheme(params.redirectUrl)) {
+        return generateOAuthErrorResponse('Unsupported redirect', [
+            'This application uses an unsupported redirect and cannot continue.',
+        ]);
+    }
+
+    return compiledRedirectTemplate({
         styles: oauthPageStyles,
         logo: LIGHTDASH_LOGO_SVG,
         ...params,
     });
+};
 
 const getUserInitials = (user: OAuthUser): string => {
     const initials =


### PR DESCRIPTION
## Summary

Mobile OAuth callbacks can use custom URL schemes. Browsers do not follow the meta refresh to these schemes without a user gesture. Sign-in then stalls on the redirect page.

This change:

- Keeps the automatic meta refresh for supported callbacks.
- Adds a visible Continue link for callbacks that need a user gesture.
- Reuses the Authorize button styles.
- Tests escaped redirect URLs, including a URL with a quote.

## Tests

- `pnpm -F @lightdash/common exec vitest run src/utils/oauth.test.ts`
- `pnpm -F @lightdash/common run typecheck`
- `pnpm -F @lightdash/common run linter src/utils/oauth.ts src/utils/oauth.test.ts`

Fixes SPK-1367

Redirect URI validation now rejects unsupported schemes during client registration and updates.
