### PR TITLE
fix(backend): scope scheduled delivery run lookup

### DIFF
--- a/packages/backend/src/database/migrations/20260824120000_index_scheduler_log_scheduler_uuid_scheduled_time.ts
+++ b/packages/backend/src/database/migrations/20260824120000_index_scheduler_log_scheduler_uuid_scheduled_time.ts
@@ -1,0 +1,46 @@
+import { Knex } from 'knex';
+
+export const config = { transaction: false };
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Builds a secondary scheduler log index concurrently without changing application data or blocking reads and writes.',
+};
+
+const TableName = 'scheduler_log';
+const IndexName = 'scheduler_log_scheduler_uuid_scheduled_time_index';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    await knex.raw("SET lock_timeout = '5s'");
+    try {
+        const invalidIndex = await knex.raw<{ rowCount: number }>(
+            `SELECT 1
+             FROM pg_class
+             JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+             WHERE pg_class.relname = ?
+               AND pg_index.indrelid = ?::regclass
+               AND NOT pg_index.indisvalid`,
+            [IndexName, TableName],
+        );
+        if ((invalidIndex.rowCount ?? 0) > 0) {
+            await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${IndexName}`);
+        }
+        await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${IndexName}
+             ON ${TableName} (scheduler_uuid, scheduled_time)`,
+        );
+    } finally {
+        await knex.raw('RESET lock_timeout');
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET lock_timeout = '5s'");
+    try {
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${IndexName}`);
+    } finally {
+        await knex.raw('RESET lock_timeout');
+    }
+}

--- a/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
+++ b/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
@@ -1,4 +1,10 @@
-import { AnyType, SchedulerJobStatus, SchedulerLog } from '@lightdash/common';
+import {
+    AnyType,
+    SchedulerFormat,
+    SchedulerJobStatus,
+    SchedulerLog,
+    type SchedulerAndTargets,
+} from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { SchedulerTableName } from '../../database/entities/scheduler';
@@ -204,6 +210,71 @@ describe('Scheduler model test', () => {
             const sql = schedulerSelectSql();
             expect(sql).toContain('"users"."is_active"');
             expect(sql).not.toContain('service_accounts');
+        });
+    });
+
+    describe('getRunsForSchedulers', () => {
+        const database = knex({ client: MockClient, dialect: 'pg' });
+        const model = new SchedulerModel({ database });
+        let tracker: Tracker;
+
+        beforeAll(() => {
+            tracker = getTracker();
+        });
+
+        afterEach(() => {
+            tracker.reset();
+        });
+
+        it('limits child job ranking to runs for the requested schedulers', async () => {
+            tracker.on.select(/scheduler_log/).response([]);
+            const scheduler: SchedulerAndTargets = {
+                schedulerUuid: 'scheduler-1',
+                slug: 'daily-dashboard',
+                name: 'Daily dashboard',
+                message: undefined,
+                createdAt: new Date('2026-08-24T00:00:00Z'),
+                updatedAt: new Date('2026-08-24T00:00:00Z'),
+                createdBy: 'user-1',
+                createdByName: 'Test user',
+                format: SchedulerFormat.PDF,
+                cron: '0 9 * * *',
+                timezone: 'UTC',
+                savedChartUuid: null,
+                savedChartName: null,
+                dashboardUuid: 'dashboard-1',
+                dashboardName: 'Dashboard',
+                savedSqlUuid: null,
+                savedSqlName: null,
+                appUuid: null,
+                appName: null,
+                options: {},
+                filters: undefined,
+                parameters: undefined,
+                selectedTabs: null,
+                enabled: true,
+                includeLinks: true,
+                plainTextEmail: false,
+                targets: [],
+            };
+
+            await model.getRunsForSchedulers({ schedulers: [scheduler] });
+
+            const [query] = tracker.history.select;
+            const normalizedSql = query.sql.replace(/\$\d+/g, '?');
+            expect(normalizedSql).toContain(
+                '"job_group" in (select distinct "job_id" from "scheduler_log" where job_id = job_group and "scheduler_uuid" in (?) and "scheduled_time" > ? and "scheduled_time" < ?)',
+            );
+            expect(normalizedSql.match(/job_id = job_group/g)).toHaveLength(2);
+            const dateBindings = query.bindings.filter(
+                (binding): binding is Date => binding instanceof Date,
+            );
+            expect(dateBindings).toHaveLength(4);
+            expect(dateBindings[0]).toEqual(dateBindings[2]);
+            expect(dateBindings[1]).toEqual(dateBindings[3]);
+            expect(
+                query.bindings.filter((binding) => binding === 'scheduler-1'),
+            ).toHaveLength(2);
         });
     });
 

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -2206,6 +2206,16 @@ export class SchedulerModel {
         const sevenDaysAgo: Date = new Date(
             Date.now() - 7 * 24 * 60 * 60 * 1000,
         );
+        const now = new Date();
+
+        const relevantParentRunsQuery = this.database(SchedulerLogTableName)
+            .whereRaw('job_id = job_group')
+            .whereIn('scheduler_uuid', schedulerUuids)
+            .where('scheduled_time', '>', sevenDaysAgo)
+            .where('scheduled_time', '<', now);
+        const relevantParentJobIdsSubquery = relevantParentRunsQuery
+            .clone()
+            .distinct('job_id');
 
         // Build subquery for child job counts - only count most recent status per child
         // First, get the most recent entry for each child job
@@ -2220,6 +2230,7 @@ export class SchedulerModel {
                 ),
             )
             .whereRaw('job_id != job_group') // Only child jobs
+            .whereIn('job_group', relevantParentJobIdsSubquery)
             .as('ranked_children');
 
         // Then count only the most recent status of each child (rn = 1)
@@ -2264,7 +2275,8 @@ export class SchedulerModel {
 
         // Use window function (ROW_NUMBER) to get only the most recent parent job per run
         // This approach is safer and more compatible than DISTINCT ON
-        const rankedRunsSubquery = this.database(SchedulerLogTableName)
+        const rankedRunsSubquery = relevantParentRunsQuery
+            .clone()
             .select(
                 'job_id',
                 'scheduler_uuid',
@@ -2276,10 +2288,6 @@ export class SchedulerModel {
                     'ROW_NUMBER() OVER (PARTITION BY job_id ORDER BY created_at DESC) as rn',
                 ),
             )
-            .whereRaw('job_id = job_group') // Only parent jobs
-            .whereIn('scheduler_uuid', schedulerUuids)
-            .where('scheduled_time', '>', sevenDaysAgo)
-            .where('scheduled_time', '<', new Date())
             .as('ranked_runs');
 
         const distinctRunsSubquery = this.database


### PR DESCRIPTION
## What changed

Limits child-job status ranking to parent runs for the requested schedulers within the shared seven-day window, avoiding a full-table scheduler log ranking. Adds a safe concurrent `(scheduler_uuid, scheduled_time)` index migration and regression coverage for the generated SQL and shared bounds.

### Validation
- `pnpm -F backend exec oxfmt src/database/migrations/20260824120000_index_scheduler_log_scheduler_uuid_scheduled_time.ts src/models/SchedulerModel/SchedulerModel.test.ts src/models/SchedulerModel/index.ts` — passed
- `pnpm -F backend run --if-present lint` — passed
- `pnpm -F backend run --if-present typecheck` — passed
- `pnpm -F backend run --if-present test` — passed
- `pnpm test:release-safety` — passed

## Preview

[Open the public Lightdash preview](https://ld-runner-prod-10463-230975bb7382.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10463

