### PR TITLE
fix(api): quiet expected not-found errors

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -932,28 +932,30 @@ export default class App {
                     // This intentionally uses console vs. winston because of problems from some error/JSON payloads.
                     console.error(error);
                 }
-                Logger.error(
-                    `Handled error of type ${errorResponse.name} on [${req.method}] ${req.path}`,
-                    errorResponse,
-                );
+                if (!errorResponse.isExpected) {
+                    Logger.error(
+                        `Handled error of type ${errorResponse.name} on [${req.method}] ${req.path}`,
+                        errorResponse,
+                    );
 
-                if (process.env.NODE_ENV === 'development') {
-                    Logger.error(error.stack);
+                    if (process.env.NODE_ENV === 'development') {
+                        Logger.error(error.stack);
+                    }
+
+                    this.analytics.track({
+                        event: 'api.error',
+                        userId: req.user?.userUuid,
+                        anonymousId: !req.user?.userUuid
+                            ? LightdashAnalytics.anonymousId
+                            : undefined,
+                        properties: {
+                            name: errorResponse.name,
+                            statusCode: errorResponse.statusCode,
+                            route: req.path,
+                            method: req.method,
+                        },
+                    });
                 }
-
-                this.analytics.track({
-                    event: 'api.error',
-                    userId: req.user?.userUuid,
-                    anonymousId: !req.user?.userUuid
-                        ? LightdashAnalytics.anonymousId
-                        : undefined,
-                    properties: {
-                        name: errorResponse.name,
-                        statusCode: errorResponse.statusCode,
-                        route: req.path,
-                        method: req.method,
-                    },
-                });
 
                 // Check if this is an OAuth endpoint and return OAuth2-compliant error response
                 if (error instanceof OauthAuthenticationError) {

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -3,6 +3,7 @@ import {
     AnyType,
     ApiError,
     getErrorMessage,
+    isExpectedError,
     LightdashBuildHashHeader,
     LightdashError,
     LightdashMode,
@@ -932,7 +933,7 @@ export default class App {
                     // This intentionally uses console vs. winston because of problems from some error/JSON payloads.
                     console.error(error);
                 }
-                if (!errorResponse.isExpected) {
+                if (!isExpectedError(errorResponse)) {
                     Logger.error(
                         `Handled error of type ${errorResponse.name} on [${req.method}] ${req.path}`,
                         errorResponse,

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -2,6 +2,7 @@ import { Ability } from '@casl/ability';
 import {
     AiAgentReviewRemediation,
     DbtProjectType,
+    ExpectedNotFoundError,
     ForbiddenError,
     JobStatusType,
     OrganizationMemberRole,
@@ -1668,6 +1669,30 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
             provider: null,
             strategy: null,
             reason: 'source_thread_writeback_exists',
+        });
+    });
+});
+
+describe('AiAgentAdminService.getReviewItemByPreviewThread', () => {
+    it('classifies an unlinked thread as expected not found', async () => {
+        const findReviewRemediationByPreviewThread = vi
+            .fn()
+            .mockResolvedValue(null);
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                findReviewRemediationByPreviewThread,
+            },
+        });
+
+        await expect(
+            service.getReviewItemByPreviewThread(
+                makeAdminUser(),
+                PREVIEW_THREAD_UUID,
+            ),
+        ).rejects.toThrow(ExpectedNotFoundError);
+        expect(findReviewRemediationByPreviewThread).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            previewThreadUuid: PREVIEW_THREAD_UUID,
         });
     });
 });

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -30,6 +30,7 @@ import {
     assertUnreachable,
     CreateAiAgentReviewItem,
     DbtProjectType,
+    ExpectedNotFoundError,
     extractPreviewProjectUuidFromUrl,
     extractPreviewUrlFromComments,
     FeatureFlags,
@@ -3163,7 +3164,9 @@ export class AiAgentAdminService extends BaseService {
                 },
             );
         if (!remediation) {
-            throw new NotFoundError('No review item is linked to this thread');
+            throw new ExpectedNotFoundError(
+                'No review item is linked to this thread',
+            );
         }
 
         return this.getReviewItem(user, remediation.fingerprint);

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -2,6 +2,7 @@ import { Ability, AbilityBuilder } from '@casl/ability';
 import {
     buildAbilityFromScopes,
     defineUserAbility,
+    ExpectedNotFoundError,
     ForbiddenError,
     OrganizationMemberRole,
     ProjectMemberRole,
@@ -239,6 +240,17 @@ describe('AiRouterService', () => {
         expect(result.enabled).toBe(true);
         expect(aiRouterModel.findByOrganization).toHaveBeenCalledWith(
             organizationUuid,
+        );
+    });
+
+    it('classifies missing router config as expected not found', async () => {
+        const { service } = makeService({
+            candidates: [],
+            routerEnabled: false,
+        });
+
+        await expect(service.getConfig(account)).rejects.toThrow(
+            ExpectedNotFoundError,
         );
     });
 

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    ExpectedNotFoundError,
     ForbiddenError,
     NotFoundError,
     ParameterError,
@@ -235,7 +236,7 @@ export class AiRouterService extends BaseService {
         const router =
             await this.aiRouterModel.findByOrganization(organizationUuid);
         if (!router) {
-            throw new NotFoundError('AI router not configured');
+            throw new ExpectedNotFoundError('AI router not configured');
         }
         return router;
     }

--- a/packages/backend/src/errors.test.ts
+++ b/packages/backend/src/errors.test.ts
@@ -1,4 +1,8 @@
-import { ExpectedNotFoundError, NotFoundError } from '@lightdash/common';
+import {
+    ExpectedNotFoundError,
+    isExpectedError,
+    NotFoundError,
+} from '@lightdash/common';
 import { errorHandler } from './errors';
 
 describe('handled API error reporting', () => {
@@ -7,7 +11,7 @@ describe('handled API error reporting', () => {
         const errorResponse = errorHandler(error);
 
         expect(errorResponse).toBe(error);
-        expect(errorResponse.isExpected).toBe(true);
+        expect(isExpectedError(errorResponse)).toBe(true);
         expect(error).toBeInstanceOf(NotFoundError);
         expect(error).toMatchObject({
             name: 'NotFoundError',
@@ -19,8 +23,13 @@ describe('handled API error reporting', () => {
 
     it('continues reporting ordinary not-found errors', () => {
         expect(
-            errorHandler(new NotFoundError('Required resource not found'))
-                .isExpected,
+            isExpectedError(
+                errorHandler(new NotFoundError('Required resource not found')),
+            ),
         ).toBe(false);
+    });
+
+    it('requires expected errors to be Error instances', () => {
+        expect(isExpectedError({ isExpected: true })).toBe(false);
     });
 });

--- a/packages/backend/src/errors.test.ts
+++ b/packages/backend/src/errors.test.ts
@@ -1,0 +1,26 @@
+import { ExpectedNotFoundError, NotFoundError } from '@lightdash/common';
+import { errorHandler } from './errors';
+
+describe('handled API error reporting', () => {
+    it('preserves expected not-found errors without reporting them', () => {
+        const error = new ExpectedNotFoundError('Optional resource not found');
+        const errorResponse = errorHandler(error);
+
+        expect(errorResponse).toBe(error);
+        expect(errorResponse.isExpected).toBe(true);
+        expect(error).toBeInstanceOf(NotFoundError);
+        expect(error).toMatchObject({
+            name: 'NotFoundError',
+            statusCode: 404,
+            data: {},
+        });
+        expect(Object.keys(error)).not.toContain('isExpected');
+    });
+
+    it('continues reporting ordinary not-found errors', () => {
+        expect(
+            errorHandler(new NotFoundError('Required resource not found'))
+                .isExpected,
+        ).toBe(false);
+    });
+});

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -18,10 +18,19 @@ type LightdashErrorParams = {
     data: LightdashErrorData;
 };
 
+export interface ExpectedError {
+    readonly isExpected: true;
+}
+
 export class LightdashError extends Error {
     statusCode: number;
 
     data: LightdashErrorData;
+
+    /** Routine domain outcomes that should not produce error-level API reporting. */
+    get isExpected(): boolean {
+        return false;
+    }
 
     constructor({ message, name, statusCode, data }: LightdashErrorParams) {
         super(message);
@@ -325,6 +334,15 @@ export class ExploreSplitError extends NotFoundError {
             `Explore "${exploreName}" was split into ${candidateList}. Pick one.`,
             { exploreName, candidateExploreNames },
         );
+    }
+}
+
+export class ExpectedNotFoundError
+    extends NotFoundError
+    implements ExpectedError
+{
+    override get isExpected(): true {
+        return true;
     }
 }
 

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -18,19 +18,22 @@ type LightdashErrorParams = {
     data: LightdashErrorData;
 };
 
-export interface ExpectedError {
+/** Routine domain outcomes that should not produce error-level API reporting. */
+export type ExpectedError = {
     readonly isExpected: true;
-}
+};
+
+export const isExpectedError = (
+    error: unknown,
+): error is Error & ExpectedError =>
+    error instanceof Error &&
+    'isExpected' in error &&
+    error.isExpected === true;
 
 export class LightdashError extends Error {
     statusCode: number;
 
     data: LightdashErrorData;
-
-    /** Routine domain outcomes that should not produce error-level API reporting. */
-    get isExpected(): boolean {
-        return false;
-    }
 
     constructor({ message, name, statusCode, data }: LightdashErrorParams) {
         super(message);
@@ -341,7 +344,7 @@ export class ExpectedNotFoundError
     extends NotFoundError
     implements ExpectedError
 {
-    override get isExpected(): true {
+    get isExpected(): true {
         return true;
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -1,4 +1,5 @@
 import {
+    isApiError,
     type AiAgentAdminEvalFilters,
     type AiAgentAdminFilters,
     type AiAgentAdminMemoryFilters,
@@ -677,7 +678,9 @@ export const useAiAgentReviewItemByPreviewThread = (
             try {
                 return await getAiAgentReviewItemByPreviewThread(threadUuid!);
             } catch (error) {
-                if ((error as ApiError).error?.statusCode === 404) return null;
+                if (isApiError(error) && error.error.statusCode === 404) {
+                    return null;
+                }
                 throw error;
             }
         },

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiRouter.ts
@@ -1,4 +1,5 @@
 import {
+    isApiError,
     type AiRouter,
     type AiRouterDecisionCommitRequest,
     type AiRouterInstruction,
@@ -15,17 +16,22 @@ import { isEmbedAiAgentRoute } from './aiAgentRouting';
 
 const ROUTER_BASE = '/org/aiRouter';
 
-const getAiRouterConfig = () =>
-    lightdashApi<AiRouter>({
-        url: ROUTER_BASE,
-        method: 'GET',
-        body: undefined,
-    });
+const getAiRouterConfig = async (): Promise<AiRouter | null> => {
+    try {
+        return await lightdashApi<AiRouter>({
+            url: ROUTER_BASE,
+            method: 'GET',
+            body: undefined,
+        });
+    } catch (error) {
+        // Missing configuration is the endpoint's documented first-use state.
+        if (isApiError(error) && error.error.statusCode === 404) return null;
+        throw error;
+    }
+};
 
-// Returns the org's router configuration. 404 (no config yet) and other
-// failures resolve to `isError`; callers treat that as "router disabled".
 export const useAiRouterConfig = () =>
-    useQuery<AiRouter, ApiError>({
+    useQuery<AiRouter | null, ApiError>({
         queryKey: ['ai-router'],
         queryFn: getAiRouterConfig,
         enabled: !isEmbedAiAgentRoute(),


### PR DESCRIPTION
Keep routine API absence probes out of error reporting without changing their documented 404 responses.

- add a reusable opt-in expected-error marker with a non-enumerable runtime discriminator
- classify missing AI router config and unlinked preview threads as expected
- resolve missing router config to cached null while preserving real query failures

Risk: low — limited to read-only absence paths; HTTP status and payload stay unchanged, while ordinary errors remain logged and tracked.

Tests:
- 91 focused backend tests
- common, backend, and frontend typechecks
- targeted common, backend, and frontend lint/format
