### PR TITLE
fix(table-calculations): rerun query after changes

### DIFF
--- a/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
@@ -1,3 +1,4 @@
+import { type TableCalculation } from '@lightdash/common';
 import { explorerActions, explorerReducer } from './explorerSlice';
 
 describe('explorerSlice pivot axis updates', () => {
@@ -50,5 +51,40 @@ describe('explorerSlice pivot axis updates', () => {
             columns: ['months_since_start'],
             rows: ['cohort_month', 'plan_name'],
         });
+    });
+});
+
+describe('explorerSlice table calculation updates', () => {
+    const tableCalculation: TableCalculation = {
+        name: 'revenue_growth',
+        displayName: 'Revenue growth',
+        sql: '${orders.revenue}',
+    };
+
+    it.each([
+        {
+            name: 'adding',
+            action: explorerActions.addTableCalculation(tableCalculation),
+        },
+        {
+            name: 'updating',
+            action: explorerActions.updateTableCalculation({
+                oldName: tableCalculation.name,
+                tableCalculation: {
+                    ...tableCalculation,
+                    sql: '${orders.net_revenue}',
+                },
+            }),
+        },
+        {
+            name: 'deleting',
+            action: explorerActions.deleteTableCalculation(
+                tableCalculation.name,
+            ),
+        },
+    ])('requests a query after $name a calculation', ({ action }) => {
+        const result = explorerReducer(undefined, action);
+
+        expect(result.queryExecution.pendingFetch).toBe(true);
     });
 });

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -546,11 +546,13 @@ const explorerSlice = createSlice({
             );
         },
 
-        // Table calculations
+        // Table calculation changes must run even when auto-fetch is disabled,
+        // so a broken calculation can recover as soon as it is fixed or removed.
         addTableCalculation: (
             state,
             action: PayloadAction<TableCalculation>,
         ) => {
+            state.queryExecution.pendingFetch = true;
             state.unsavedChartVersion.metricQuery.tableCalculations.push(
                 action.payload,
             );
@@ -578,6 +580,8 @@ const explorerSlice = createSlice({
         ) => {
             const { oldName, tableCalculation } = action.payload;
             const newName = tableCalculation.name;
+
+            state.queryExecution.pendingFetch = true;
 
             // Update metadata to track the name change, this is used
             // by consuming visualizations to translate old field names
@@ -628,6 +632,8 @@ const explorerSlice = createSlice({
         },
         deleteTableCalculation: (state, action: PayloadAction<string>) => {
             const nameToRemove = action.payload;
+
+            state.queryExecution.pendingFetch = true;
 
             // Remove from metadata if it exists
             if (state.metadata?.tableCalculations) {


### PR DESCRIPTION
Closes: #27509

### Description:

Table calculation mutations now explicitly request a query execution, even when auto-fetch is disabled. This lets users recover from a broken calculation by editing or deleting it without reloading the page or manually running the query.

The reducer coverage verifies that adding, updating, and deleting a table calculation all set `queryExecution.pendingFetch`.

Browser reproduction and verification on localhost:3000:

1. Created a table calculation using the missing alias `not_a_real_column`, which produced an Error loading results state.
2. Edited the calculation to use the valid `fct_race_results_driver_name` field.
3. Saved the modal without reloading the page or clicking Run query.
4. Verified the error cleared and results returned automatically.

Automated verification:

- `pnpm --dir packages/frontend exec vitest run src/features/explorer/store/explorerSlice.test.ts`
- `pnpm -F frontend typecheck`
- `pnpm --dir packages/frontend exec oxlint -c .oxlintrc.json src/features/explorer/store/explorerSlice.ts src/features/explorer/store/explorerSlice.test.ts`
- `git diff --check`

### Risk assessment:

Low. The change restores query execution after the three existing table calculation mutation paths and is covered at the reducer boundary.

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.