### PR TITLE
feat: add embedded chart edit mode

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -3,6 +3,7 @@ import {
     ForbiddenError,
     type AnonymousAccount,
     type CreateEmbedJwt,
+    type EmbedContent,
     type PossibleAbilities,
     type SessionUser,
 } from '@lightdash/common';
@@ -335,6 +336,115 @@ describe('EmbedService', () => {
                     },
                 }),
             );
+        });
+    });
+
+    describe('getEmbedWriteContext', () => {
+        const chartUuid = 'chart-uuid';
+        const chartSpaceUuid = 'chart-space-uuid';
+        const content: EmbedContent = {
+            type: 'chart',
+            chartUuids: [chartUuid],
+            explores: ['orders'],
+        };
+        const token: CreateEmbedJwt = {
+            content: {
+                type: 'chart',
+                contentId: chartUuid,
+            },
+            writeActions: {
+                spaceUuid: chartSpaceUuid,
+                userUuid: mockUserUuid,
+            },
+        };
+        const spaceAccessContext = {
+            organizationUuid: mockOrganizationUuid,
+            projectUuid: mockProjectUuid,
+            inheritsFromOrgOrProject: true,
+            access: [],
+        };
+
+        const getContext = async ({
+            canUpdate,
+            savedChartSpaceUuid = chartSpaceUuid,
+        }: {
+            canUpdate: boolean;
+            savedChartSpaceUuid?: string;
+        }) => {
+            const embedWriteUser = {
+                ...mockAccountWithPermission.user,
+                organizationUuid: mockOrganizationUuid,
+                organizationName: 'Test Org',
+                organizationCreatedAt: new Date(),
+                ability: new Ability<PossibleAbilities>(
+                    canUpdate
+                        ? [{ action: 'update', subject: 'SavedChart' }]
+                        : [],
+                ),
+            } as unknown as SessionUser;
+            const scopedService = new EmbedService({
+                ...EmbedServiceArgumentsMock,
+                projectModel: {
+                    getSummary: vi.fn().mockResolvedValue({
+                        organizationUuid: mockOrganizationUuid,
+                    }),
+                },
+                savedChartModel: {
+                    get: vi.fn().mockResolvedValue({
+                        uuid: chartUuid,
+                        spaceUuid: savedChartSpaceUuid,
+                    }),
+                },
+                spacePermissionService: {
+                    getSpaceAccessContext: vi
+                        .fn()
+                        .mockResolvedValue(spaceAccessContext),
+                },
+            } as unknown as ConstructorParameters<typeof EmbedService>[0]);
+            const getEmbedWriteContext = (
+                scopedService as unknown as {
+                    getEmbedWriteContext: (
+                        decodedToken: CreateEmbedJwt,
+                        embedWriteUser: SessionUser,
+                        projectUuid: string,
+                        content: EmbedContent,
+                    ) => Promise<AnonymousAccount['embedWriteContext']>;
+                }
+            ).getEmbedWriteContext.bind(scopedService);
+
+            return getEmbedWriteContext(
+                token,
+                embedWriteUser,
+                mockProjectUuid,
+                content,
+            );
+        };
+
+        test('allows editing when the write actor can update the chart in the write space', async () => {
+            await expect(
+                getContext({ canUpdate: true }),
+            ).resolves.toMatchObject({
+                canUpdateSavedChart: true,
+            });
+        });
+
+        test('denies editing when the write actor cannot update saved charts', async () => {
+            await expect(
+                getContext({ canUpdate: false }),
+            ).resolves.toMatchObject({
+                canUpdateSavedChart: false,
+            });
+        });
+
+        test('denies editing when the chart is outside the write space', async () => {
+            await expect(
+                getContext({
+                    canUpdate: true,
+                    savedChartSpaceUuid: 'other-space-uuid',
+                }),
+            ).resolves.toMatchObject({
+                canUpdateSavedChart: false,
+            });
         });
     });
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -2651,6 +2651,7 @@ export class EmbedService extends BaseService {
             if (spaceAccessContext.projectUuid !== projectUuid) {
                 return {
                     canUpdateDashboard: false,
+                    canUpdateSavedChart: false,
                     canCreateSavedChart: false,
                     canUseAiAgent: false,
                     aiAgentErrorMessage:
@@ -2669,6 +2670,25 @@ export class EmbedService extends BaseService {
                         metadata: {
                             dashboardUuid: content.dashboardUuid,
                         },
+                    }),
+                );
+            const savedChartUuid =
+                content.type === 'chart' ? content.chartUuids[0] : undefined;
+            const savedChart = savedChartUuid
+                ? await this.savedChartModel.get(savedChartUuid)
+                : undefined;
+            const canUpdateSavedChart =
+                savedChart !== undefined &&
+                savedChart.spaceUuid === writeActions.spaceUuid &&
+                auditedAbility.can(
+                    'update',
+                    subject('SavedChart', {
+                        organizationUuid,
+                        projectUuid,
+                        inheritsFromOrgOrProject:
+                            spaceAccessContext.inheritsFromOrgOrProject,
+                        access: spaceAccessContext.access,
+                        metadata: { savedChartUuid },
                     }),
                 );
             const canCreateSavedChart = auditedAbility.can(
@@ -2699,6 +2719,7 @@ export class EmbedService extends BaseService {
 
             return {
                 canUpdateDashboard,
+                canUpdateSavedChart,
                 canCreateSavedChart,
                 canUseAiAgent,
                 aiAgentErrorMessage: canUseAiAgent
@@ -2717,6 +2738,7 @@ export class EmbedService extends BaseService {
             ) {
                 return {
                     canUpdateDashboard: false,
+                    canUpdateSavedChart: false,
                     canCreateSavedChart: false,
                     canUseAiAgent: false,
                     aiAgentErrorMessage:

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -183,6 +183,7 @@ export type AnonymousAccount = BaseAccountWithHelpers & {
     embedWriteUser?: SessionUser;
     embedWriteContext?: {
         canUpdateDashboard: boolean;
+        canUpdateSavedChart: boolean;
         canCreateSavedChart: boolean;
         canUseAiAgent: boolean;
         aiAgentErrorMessage?: string;

--- a/packages/frontend/sdk/index.test.tsx
+++ b/packages/frontend/sdk/index.test.tsx
@@ -2,10 +2,35 @@ import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+let mockEmbedWriteContext: { canUpdateSavedChart: boolean } | undefined;
+
 vi.mock('../src/components/MonacoEditor', () => ({
     default: () => null,
     Editor: () => null,
     useMonaco: () => null,
+}));
+
+vi.mock('../src/ee/pages/EmbedChart', () => ({
+    default: () => <div data-testid="embed-chart-view" />,
+}));
+
+vi.mock('../src/ee/pages/EmbedExplore', () => ({
+    default: ({
+        allowChartUpdate,
+        isEditMode,
+        chartView,
+    }: {
+        allowChartUpdate?: boolean;
+        isEditMode?: boolean;
+        chartView?: boolean;
+    }) => (
+        <div
+            data-testid="embed-chart-edit"
+            data-allow-chart-update={allowChartUpdate}
+            data-edit-mode={isEditMode}
+            data-chart-view={chartView}
+        />
+    ),
 }));
 
 // Mock react-router hooks
@@ -60,6 +85,7 @@ vi.mock('../src/hooks/dashboard/useDashboard', () => ({
 vi.mock('../src/hooks/user/useAccount', () => ({
     useAccount: () => ({
         data: {
+            embedWriteContext: mockEmbedWriteContext,
             user: {
                 userUuid: 'test-user',
                 email: 'test@example.com',
@@ -144,6 +170,7 @@ vi.mock('../src/pages/MetricsCatalog', async () => {
 import { FilterOperator } from '@lightdash/common';
 import {
     AiAgent,
+    Chart,
     Dashboard,
     MetricsCatalog,
     createLightdashApiClient,
@@ -343,6 +370,87 @@ describe('SDK Dashboard - URL Sync Behavior', () => {
             // Browser URL should not change
             expect(window.location.pathname).toBe('/test');
         });
+    });
+});
+
+describe('SDK Chart edit mode', () => {
+    const mockToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb250ZW50Ijp7InR5cGUiOiJjaGFydCIsInByb2plY3RVdWlkIjoidGVzdC1wcm9qZWN0LXV1aWQiLCJjb250ZW50SWQiOiJ0ZXN0LWNoYXJ0LXV1aWQifX0.test';
+    const mockInstanceUrl = 'http://localhost:3000';
+
+    beforeEach(() => {
+        mockEmbedWriteContext = undefined;
+    });
+
+    it('keeps the minimal chart as the default view', async () => {
+        mockEmbedWriteContext = { canUpdateSavedChart: true };
+        const { findByTestId } = render(
+            <Chart
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                id="test-chart-uuid"
+            />,
+        );
+
+        expect(await findByTestId('embed-chart-view')).toBeInTheDocument();
+    });
+
+    it('renders the saved chart editor when the write actor can update it', async () => {
+        mockEmbedWriteContext = { canUpdateSavedChart: true };
+        const { findByTestId } = render(
+            <Chart
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                id="test-chart-uuid"
+                isEditMode
+            />,
+        );
+
+        expect(await findByTestId('embed-chart-edit')).toHaveAttribute(
+            'data-allow-chart-update',
+            'true',
+        );
+    });
+
+    it('keeps the same explorer mounted while toggling view and edit', async () => {
+        mockEmbedWriteContext = { canUpdateSavedChart: true };
+        const { findByTestId, rerender } = render(
+            <Chart
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                id="test-chart-uuid"
+                isEditMode={false}
+            />,
+        );
+        const explorer = await findByTestId('embed-chart-edit');
+        expect(explorer).toHaveAttribute('data-edit-mode', 'false');
+        expect(explorer).toHaveAttribute('data-chart-view', 'true');
+
+        rerender(
+            <Chart
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                id="test-chart-uuid"
+                isEditMode
+            />,
+        );
+
+        expect(await findByTestId('embed-chart-edit')).toBe(explorer);
+        expect(explorer).toHaveAttribute('data-edit-mode', 'true');
+    });
+
+    it('rejects edit mode when the write actor cannot update the chart', async () => {
+        mockEmbedWriteContext = { canUpdateSavedChart: false };
+        const { findByText } = render(
+            <Chart
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                id="test-chart-uuid"
+                isEditMode
+            />,
+        );
+
+        expect(await findByText('Unable to edit chart')).toBeInTheDocument();
     });
 });
 

--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -18,6 +18,7 @@ import {
     type PropsWithChildren,
 } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
+import SuboptimalState from '../src/components/common/SuboptimalState/SuboptimalState';
 import { type SdkFilter } from '../src/ee/features/embed/EmbedDashboard/types';
 import EmbedChart from '../src/ee/pages/EmbedChart';
 import EmbedDashboard from '../src/ee/pages/EmbedDashboard';
@@ -25,10 +26,10 @@ import EmbedExplore from '../src/ee/pages/EmbedExplore';
 import EmbedProvider from '../src/ee/providers/Embed/EmbedProvider';
 import { type EmbedExploreChart } from '../src/ee/providers/Embed/types';
 import useEmbed from '../src/ee/providers/Embed/useEmbed';
-import SuboptimalState from '../src/components/common/SuboptimalState/SuboptimalState';
 import ErrorBoundary from '../src/features/errorBoundary/ErrorBoundary';
-import ChartColorMappingContextProvider from '../src/hooks/useChartColorConfig/ChartColorMappingContextProvider';
 import { useCreateMutation } from '../src/hooks/dashboard/useDashboard';
+import ChartColorMappingContextProvider from '../src/hooks/useChartColorConfig/ChartColorMappingContextProvider';
+import { useAccount } from '../src/hooks/user/useAccount';
 import MetricsCatalogPage from '../src/pages/MetricsCatalog';
 import AbilityProvider from '../src/providers/Ability/AbilityProvider';
 import ActiveJobProvider from '../src/providers/ActiveJob/ActiveJobProvider';
@@ -76,6 +77,11 @@ type DashboardProps = BaseProps & {
 
 type DashboardBuilderProps = DashboardProps & {
     onDashboardReady?: (dashboard: EmbedDashboardType) => void;
+};
+
+type ChartProps = Omit<BaseProps, 'filters' | 'onExplore'> & {
+    id: string;
+    isEditMode?: boolean;
 };
 
 type AiAgentProps = Omit<
@@ -416,7 +422,9 @@ const DashboardBuilderContent: FC<{
                 spaceUuid: writeActions.spaceUuid,
                 tiles: [],
                 tabs: [],
-            }).then((createdDashboard) => createdDashboard as EmbedDashboardType);
+            }).then(
+                (createdDashboard) => createdDashboard as EmbedDashboardType,
+            );
 
         dashboardBuilderCreatePromises.set(createKey, createPromise);
 
@@ -512,7 +520,9 @@ const DashboardBuilder: FC<DashboardBuilderProps> = ({
     );
 };
 
-const Explore: FC<BaseProps & { exploreId: string; savedChart: SavedChart }> = ({
+const Explore: FC<
+    BaseProps & { exploreId: string; savedChart: SavedChart }
+> = ({
     token: tokenOrTokenPromise,
     instanceUrl,
     styles,
@@ -581,9 +591,7 @@ const Explore: FC<BaseProps & { exploreId: string; savedChart: SavedChart }> = (
                         overflow: 'auto',
                         backgroundColor:
                             styles?.backgroundColor ??
-                            (theme
-                                ? 'var(--mantine-color-body)'
-                                : undefined),
+                            (theme ? 'var(--mantine-color-body)' : undefined),
                     }}
                 />
             </EmbedProvider>
@@ -591,13 +599,66 @@ const Explore: FC<BaseProps & { exploreId: string; savedChart: SavedChart }> = (
     );
 };
 
-const Chart: FC<Omit<BaseProps, 'filters' | 'onExplore'> & { id: string }> = ({
+const EditableChartContent: FC<{
+    containerStyles: React.CSSProperties;
+    isEditMode: boolean;
+}> = ({ containerStyles, isEditMode }) => {
+    const { embedWriteContext } = useEmbed();
+    const account = useAccount();
+
+    if (account.isLoading) {
+        return null;
+    }
+
+    if (embedWriteContext?.canUpdateSavedChart === true) {
+        return (
+            <EmbedExplore
+                containerStyles={containerStyles}
+                allowChartUpdate
+                isEditMode={isEditMode}
+                chartView
+            />
+        );
+    }
+
+    if (isEditMode) {
+        return (
+            <SuboptimalState
+                title="Unable to edit chart"
+                description="The embed write actor does not have permission to update this chart in the configured write space."
+            />
+        );
+    }
+
+    return <EmbedChart containerStyles={containerStyles} />;
+};
+
+const ChartContent: FC<{
+    containerStyles: React.CSSProperties;
+    isEditMode?: boolean;
+}> = ({ containerStyles, isEditMode }) => {
+    // Omitting isEditMode preserves the legacy Chart renderer exactly. Passing
+    // an explicit boolean opts into the mounted view/edit explorer surface.
+    if (isEditMode === undefined) {
+        return <EmbedChart containerStyles={containerStyles} />;
+    }
+
+    return (
+        <EditableChartContent
+            containerStyles={containerStyles}
+            isEditMode={isEditMode}
+        />
+    );
+};
+
+const Chart: FC<ChartProps> = ({
     token: tokenOrTokenPromise,
     instanceUrl,
     styles,
     theme,
     contentOverrides,
     id,
+    isEditMode,
 }) => {
     const [token, setToken] = useState<string | null>(null);
     const [projectUuid, setProjectUuid] = useState<string | null>(null);
@@ -638,6 +699,16 @@ const Chart: FC<Omit<BaseProps, 'filters' | 'onExplore'> & { id: string }> = ({
         return null;
     }
 
+    const containerStyles = {
+        width: '100%',
+        height: '100%',
+        position: 'relative' as const,
+        overflow: 'auto',
+        backgroundColor:
+            styles?.backgroundColor ??
+            (theme ? 'var(--mantine-color-body)' : undefined),
+    };
+
     return (
         <SdkProviders projectUuid={projectUuid} styles={styles} theme={theme}>
             <EmbedProvider
@@ -646,18 +717,9 @@ const Chart: FC<Omit<BaseProps, 'filters' | 'onExplore'> & { id: string }> = ({
                 contentOverrides={contentOverrides}
                 savedQueryUuid={id}
             >
-                <EmbedChart
-                    containerStyles={{
-                        width: '100%',
-                        height: '100%',
-                        position: 'relative',
-                        overflow: 'auto',
-                        backgroundColor:
-                            styles?.backgroundColor ??
-                            (theme
-                                ? 'var(--mantine-color-body)'
-                                : undefined),
-                    }}
+                <ChartContent
+                    containerStyles={containerStyles}
+                    isEditMode={isEditMode}
                 />
             </EmbedProvider>
         </SdkProviders>

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -17,6 +17,7 @@ import { useCallback, useMemo, type FC } from 'react';
 import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
 import { useMergeQuickFilter } from '../../../features/mergeQuery/hooks/useMergeQuickFilter';
 import { useMergeSourceCell } from '../../../features/mergeQuery/hooks/useMergeSourceCell';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { Can } from '../../../providers/Ability';
@@ -44,7 +45,7 @@ const CellContextMenu: FC<
     const merge = useMergeSafe();
     const isMerged = !!merge?.mergeResults;
     const mergeQuickFilter = useMergeQuickFilter();
-    const { openUnderlyingDataModal, metricQuery } =
+    const { openUnderlyingDataModal, metricQuery, tableName } =
         useMetricQueryDataContext();
     const { track } = useTracking();
     const { showToastError, showToastSuccess } = useToaster();
@@ -52,7 +53,10 @@ const CellContextMenu: FC<
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
     const { user } = useApp();
+    const { data: organization } = useOrganization();
     const projectUuid = useProjectUuid();
+    const organizationUuid =
+        user.data?.organizationUuid ?? organization?.organizationUuid;
 
     const value: ResultValue = useMemo(
         () => cell.getValue()?.value || {},
@@ -160,7 +164,7 @@ const CellContextMenu: FC<
                     <Can
                         I="view"
                         this={subject('UnderlyingData', {
-                            organizationUuid: user.data?.organizationUuid,
+                            organizationUuid,
                             projectUuid: projectUuid,
                         })}
                     >
@@ -175,8 +179,9 @@ const CellContextMenu: FC<
             <Can
                 I="manage"
                 this={subject('Explore', {
-                    organizationUuid: user.data?.organizationUuid,
+                    organizationUuid,
                     projectUuid: projectUuid,
+                    exploreNames: [tableName],
                 })}
             >
                 {isEditMode &&
@@ -193,7 +198,15 @@ const CellContextMenu: FC<
                             }
                         />
                     )}
-
+            </Can>
+            <Can
+                I="view"
+                this={subject('Explore', {
+                    organizationUuid,
+                    projectUuid: projectUuid,
+                    exploreNames: [tableName],
+                })}
+            >
                 {(!isMerged || resolvedSourceCell) && (
                     <DrillDownMenuItem
                         item={resolvedSourceCell?.item ?? item}
@@ -202,7 +215,7 @@ const CellContextMenu: FC<
                         }
                         source={resolvedSourceCell?.source}
                         trackingData={{
-                            organizationId: user.data?.organizationUuid,
+                            organizationId: organizationUuid,
                             userId: user.data?.userUuid,
                             projectId: projectUuid,
                         }}

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -17,9 +17,9 @@ import { useCallback, useMemo, type FC } from 'react';
 import { useMergeSafe } from '../../../features/mergeQuery/context/useMerge';
 import { useMergeQuickFilter } from '../../../features/mergeQuery/hooks/useMergeQuickFilter';
 import { useMergeSourceCell } from '../../../features/mergeQuery/hooks/useMergeSourceCell';
-import { useOrganization } from '../../../hooks/organization/useOrganization';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useAccount } from '../../../hooks/user/useAccount';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -53,10 +53,24 @@ const CellContextMenu: FC<
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
     const { user } = useApp();
-    const { data: organization } = useOrganization();
+    const { data: account } = useAccount();
     const projectUuid = useProjectUuid();
+    const isEmbedded = account?.isJwtUser() === true;
     const organizationUuid =
-        user.data?.organizationUuid ?? organization?.organizationUuid;
+        user.data?.organizationUuid ?? account?.organization.organizationUuid;
+    const drillDownPermission = subject(
+        'Explore',
+        isEmbedded
+            ? {
+                  organizationUuid,
+                  projectUuid,
+                  exploreNames: [tableName],
+              }
+            : {
+                  organizationUuid: user.data?.organizationUuid,
+                  projectUuid,
+              },
+    );
 
     const value: ResultValue = useMemo(
         () => cell.getValue()?.value || {},
@@ -179,9 +193,8 @@ const CellContextMenu: FC<
             <Can
                 I="manage"
                 this={subject('Explore', {
-                    organizationUuid,
+                    organizationUuid: user.data?.organizationUuid,
                     projectUuid: projectUuid,
-                    exploreNames: [tableName],
                 })}
             >
                 {isEditMode &&
@@ -199,14 +212,7 @@ const CellContextMenu: FC<
                         />
                     )}
             </Can>
-            <Can
-                I="view"
-                this={subject('Explore', {
-                    organizationUuid,
-                    projectUuid: projectUuid,
-                    exploreNames: [tableName],
-                })}
-            >
+            <Can I={isEmbedded ? 'view' : 'manage'} this={drillDownPermission}>
                 {(!isMerged || resolvedSourceCell) && (
                     <DrillDownMenuItem
                         item={resolvedSourceCell?.item ?? item}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -16,6 +16,7 @@ import {
     useState,
     type FC,
 } from 'react';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { Can } from '../../../providers/Ability';
@@ -39,12 +40,15 @@ export const SeriesContextMenu: FC<{
     const clipboard = useClipboard({ timeout: 200 });
     const { track } = useTracking();
     const { user } = useApp();
+    const { data: organization } = useOrganization();
+    const organizationUuid =
+        user.data?.organizationUuid ?? organization?.organizationUuid;
 
     const context = useVisualizationContext();
     const { resultsData: { metricQuery } = {} } = context;
 
     const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
-    const { openUnderlyingDataModal } = useMetricQueryDataContext();
+    const { openUnderlyingDataModal, tableName } = useMetricQueryDataContext();
 
     const [contextMenuTargetOffset, setContextMenuTargetOffset] = useState<{
         left: number;
@@ -95,7 +99,7 @@ export const SeriesContextMenu: FC<{
         track({
             name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
             properties: {
-                organizationId: user?.data?.organizationUuid,
+                organizationId: organizationUuid,
                 userId: user?.data?.userUuid,
                 projectId: projectUuid,
             },
@@ -110,7 +114,7 @@ export const SeriesContextMenu: FC<{
         dimensions,
         openUnderlyingDataModal,
         track,
-        user?.data?.organizationUuid,
+        organizationUuid,
         user?.data?.userUuid,
         projectUuid,
     ]);
@@ -162,7 +166,7 @@ export const SeriesContextMenu: FC<{
                 <Can
                     I="view"
                     this={subject('UnderlyingData', {
-                        organizationUuid: user.data?.organizationUuid,
+                        organizationUuid,
                         projectUuid: projectUuid,
                     })}
                 >
@@ -179,14 +183,15 @@ export const SeriesContextMenu: FC<{
                 <Can
                     I="view"
                     this={subject('Explore', {
-                        organizationUuid: user.data?.organizationUuid,
+                        organizationUuid,
                         projectUuid: projectUuid,
+                        exploreNames: [tableName],
                     })}
                 >
                     <DrillDownMenuItem
                         {...underlyingData}
                         trackingData={{
-                            organizationId: user?.data?.organizationUuid,
+                            organizationId: organizationUuid,
                             userId: user?.data?.userUuid,
                             projectId: projectUuid,
                         }}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -193,10 +193,7 @@ export const SeriesContextMenu: FC<{
                     )}
                 </Can>
 
-                <Can
-                    I={isEmbedded ? 'view' : 'manage'}
-                    this={drillDownPermission}
-                >
+                <Can I="view" this={drillDownPermission}>
                     <DrillDownMenuItem
                         {...underlyingData}
                         trackingData={{

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -16,9 +16,9 @@ import {
     useState,
     type FC,
 } from 'react';
-import { useOrganization } from '../../../hooks/organization/useOrganization';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useAccount } from '../../../hooks/user/useAccount';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -40,22 +40,35 @@ export const SeriesContextMenu: FC<{
     const clipboard = useClipboard({ timeout: 200 });
     const { track } = useTracking();
     const { user } = useApp();
-    const { data: organization } = useOrganization();
+    const { data: account } = useAccount();
+    const isEmbedded = account?.isJwtUser() === true;
     const organizationUuid =
-        user.data?.organizationUuid ?? organization?.organizationUuid;
+        user.data?.organizationUuid ?? account?.organization.organizationUuid;
+    const projectUuid = useProjectUuid();
 
     const context = useVisualizationContext();
     const { resultsData: { metricQuery } = {} } = context;
 
     const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
     const { openUnderlyingDataModal, tableName } = useMetricQueryDataContext();
+    const drillDownPermission = subject(
+        'Explore',
+        isEmbedded
+            ? {
+                  organizationUuid,
+                  projectUuid,
+                  exploreNames: [tableName],
+              }
+            : {
+                  organizationUuid: user.data?.organizationUuid,
+                  projectUuid,
+              },
+    );
 
     const [contextMenuTargetOffset, setContextMenuTargetOffset] = useState<{
         left: number;
         top: number;
     }>();
-
-    const projectUuid = useProjectUuid();
 
     useEffect(() => {
         if (echartsSeriesClickEvent !== undefined) {
@@ -181,12 +194,8 @@ export const SeriesContextMenu: FC<{
                 </Can>
 
                 <Can
-                    I="view"
-                    this={subject('Explore', {
-                        organizationUuid,
-                        projectUuid: projectUuid,
-                        exploreNames: [tableName],
-                    })}
+                    I={isEmbedded ? 'view' : 'manage'}
+                    this={drillDownPermission}
                 >
                     <DrillDownMenuItem
                         {...underlyingData}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,4 +1,3 @@
-import { subject } from '@casl/ability';
 import {
     derivePivotConfigurationFromChart,
     ECHARTS_DEFAULT_COLORS,
@@ -46,10 +45,8 @@ import { resolveMergeColumnOrder } from '../../../features/mergeQuery/utils/reso
 import { useColorPalettes } from '../../../hooks/appearance/useOrganizationAppearance';
 import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
 import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
-import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
-import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
 import useFullscreen from '../../../providers/Fullscreen/useFullscreen';
@@ -80,6 +77,7 @@ type Props = {
     projectUuid?: string;
     onScreenshotReady?: () => void;
     onScreenshotError?: () => void;
+    minimal?: boolean;
 };
 
 const VisualizationCard: FC<Props> = memo((props) => {
@@ -87,9 +85,9 @@ const VisualizationCard: FC<Props> = memo((props) => {
         projectUuid: fallBackUUid,
         onScreenshotReady,
         onScreenshotError,
+        minimal = false,
     } = props;
     const { health } = useApp();
-    const { data: org } = useOrganization();
     const colorScheme = useComputedColorScheme();
     const dispatch = useExplorerDispatch();
     // In fullscreen the chart card header is hidden so the chart owns the viewport
@@ -255,7 +253,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
         selectIsVisualizationExpanded,
     );
     // Without the heading there is no way to expand the card, so force it open
-    const isOpen = isVisualizationExpanded || isFullscreen;
+    const isOpen = minimal || isVisualizationExpanded || isFullscreen;
     const isEditMode = useExplorerSelector(selectIsEditMode);
     const isVisualizationConfigOpen = useExplorerSelector(
         selectIsVisualizationConfigOpen,
@@ -417,6 +415,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
         <ErrorBoundary>
             <VisualizationProvider
                 key={savedChart?.uuid}
+                minimal={minimal}
                 chartConfig={unsavedChartVersion.chartConfig}
                 initialPivotDimensions={
                     unsavedChartVersion.pivotConfig?.columns
@@ -449,7 +448,8 @@ const VisualizationCard: FC<Props> = memo((props) => {
                     title="Chart"
                     isOpen={isOpen}
                     isVisualizationCard
-                    hideHeading={isFullscreen}
+                    hideHeading={isFullscreen || minimal}
+                    minimal={minimal}
                     onToggle={toggleSection}
                     headerElement={
                         isOpen && (
@@ -541,30 +541,22 @@ const VisualizationCard: FC<Props> = memo((props) => {
                                         portalTarget,
                                     )}
 
-                                <Can
-                                    I="manage"
-                                    this={subject('Explore', {
-                                        organizationUuid: org?.organizationUuid,
-                                        projectUuid,
-                                    })}
-                                >
-                                    {!!projectUuid && (
-                                        <ChartDownloadMenu
-                                            getDownloadQueryUuid={
-                                                mergeResults && merge
-                                                    ? merge.getDownloadQueryUuid
-                                                    : getDownloadQueryUuid
-                                            }
-                                            projectUuid={projectUuid}
-                                            chartName={savedChart?.name}
-                                            getGsheetLink={
-                                                mergeResults
-                                                    ? undefined
-                                                    : getGsheetLink
-                                            }
-                                        />
-                                    )}
-                                </Can>
+                                {!!projectUuid && (
+                                    <ChartDownloadMenu
+                                        getDownloadQueryUuid={
+                                            mergeResults && merge
+                                                ? merge.getDownloadQueryUuid
+                                                : getDownloadQueryUuid
+                                        }
+                                        projectUuid={projectUuid}
+                                        chartName={savedChart?.name}
+                                        getGsheetLink={
+                                            mergeResults
+                                                ? undefined
+                                                : getGsheetLink
+                                        }
+                                    />
+                                )}
 
                                 {import.meta.env.DEV && (
                                     <DevCopyChartDebugData />

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -63,8 +63,8 @@ import { WriteBackModal } from './WriteBackModal';
 
 const EMPTY_PARAMETER_REFERENCES: string[] = [];
 
-const Explorer: FC<{ hideHeader?: boolean }> = memo(
-    ({ hideHeader = false }) => {
+const Explorer: FC<{ hideHeader?: boolean; chartView?: boolean }> = memo(
+    ({ hideHeader = false, chartView = false }) => {
         const tableName = useExplorerSelector(selectTableName);
         const dimensions = useExplorerSelector(selectDimensions);
         const metrics = useExplorerSelector(selectMetrics);
@@ -72,6 +72,8 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
         const sorts = useExplorerSelector(selectSorts);
         const metricQuery = useExplorerSelector(selectMetricQuery);
         const isEditMode = useExplorerSelector(selectIsEditMode);
+        const showQueryBuilder = isEditMode || !chartView;
+        const showMinimalChart = chartView && !isEditMode;
         const parameterReferencesFromRedux = useExplorerSelector(
             selectParameterReferences,
         );
@@ -273,11 +275,14 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                         ))}
 
                     <MergeAutoRun />
-                    {!isFullscreen && <MergeReadOnlyBar />}
+                    {!isFullscreen && showQueryBuilder && <MergeReadOnlyBar />}
 
-                    {!isFullscreen && <MergeRelationshipCard />}
+                    {!isFullscreen && showQueryBuilder && (
+                        <MergeRelationshipCard />
+                    )}
 
                     {!isFullscreen &&
+                        showQueryBuilder &&
                         !!tableName &&
                         hasReferencedUserParameters && (
                             <ParametersCard
@@ -287,15 +292,16 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                             />
                         )}
 
-                    {!isFullscreen && <FiltersCard />}
+                    {!isFullscreen && showQueryBuilder && <FiltersCard />}
 
                     <VisualizationCard
                         projectUuid={projectUuid}
                         onScreenshotReady={handleScreenshotReady}
                         onScreenshotError={handleScreenshotError}
+                        minimal={showMinimalChart}
                     />
 
-                    {!isFullscreen && (
+                    {!isFullscreen && showQueryBuilder && (
                         <>
                             <ResultsCard />
 

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -12,9 +12,9 @@ import { useClipboard } from '@mantine/hooks';
 import { IconCopy, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
-import { useOrganization } from '../../hooks/organization/useOrganization';
 import useToaster from '../../hooks/toaster/useToaster';
 import { useProjectUuid } from '../../hooks/useProjectUuid';
+import { useAccount } from '../../hooks/user/useAccount';
 import { Can } from '../../providers/Ability';
 import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
@@ -46,10 +46,24 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
 
     const { track } = useTracking();
     const { user } = useApp();
-    const { data: organization } = useOrganization();
+    const { data: account } = useAccount();
     const projectUuid = useProjectUuid();
+    const isEmbedded = account?.isJwtUser() === true;
     const organizationUuid =
-        user.data?.organizationUuid ?? organization?.organizationUuid;
+        user.data?.organizationUuid ?? account?.organization.organizationUuid;
+    const drillDownPermission = subject(
+        'Explore',
+        isEmbedded
+            ? {
+                  organizationUuid,
+                  projectUuid,
+                  exploreNames: [tableName],
+              }
+            : {
+                  organizationUuid: user.data?.organizationUuid,
+                  projectUuid,
+              },
+    );
     const clipboard = useClipboard({ timeout: 200 });
 
     const handleCopyToClipboard = useCallback(() => {
@@ -127,9 +141,8 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
             <Can
                 I="manage"
                 this={subject('Explore', {
-                    organizationUuid,
+                    organizationUuid: user.data?.organizationUuid,
                     projectUuid: projectUuid,
-                    exploreNames: [tableName],
                 })}
             >
                 {isEditMode &&
@@ -139,14 +152,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
                         <QuickFilterMenuItems item={item} value={value} />
                     )}
             </Can>
-            <Can
-                I="view"
-                this={subject('Explore', {
-                    organizationUuid,
-                    projectUuid: projectUuid,
-                    exploreNames: [tableName],
-                })}
-            >
+            <Can I={isEmbedded ? 'view' : 'manage'} this={drillDownPermission}>
                 <DrillDownMenuItem
                     item={item}
                     fieldValues={fieldValues}

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -12,6 +12,7 @@ import { useClipboard } from '@mantine/hooks';
 import { IconCopy, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
+import { useOrganization } from '../../hooks/organization/useOrganization';
 import useToaster from '../../hooks/toaster/useToaster';
 import { useProjectUuid } from '../../hooks/useProjectUuid';
 import { Can } from '../../providers/Ability';
@@ -27,7 +28,7 @@ import DrillDownMenuItem from '../MetricQueryData/DrillDownMenuItem';
 import { useMetricQueryDataContext } from '../MetricQueryData/useMetricQueryDataContext';
 
 const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
-    const { openUnderlyingDataModal, metricQuery } =
+    const { openUnderlyingDataModal, metricQuery, tableName } =
         useMetricQueryDataContext();
     const { isEditMode, hasExplorerStore } = useVisualizationContext();
     const { showToastSuccess } = useToaster();
@@ -45,7 +46,10 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
 
     const { track } = useTracking();
     const { user } = useApp();
+    const { data: organization } = useOrganization();
     const projectUuid = useProjectUuid();
+    const organizationUuid =
+        user.data?.organizationUuid ?? organization?.organizationUuid;
     const clipboard = useClipboard({ timeout: 200 });
 
     const handleCopyToClipboard = useCallback(() => {
@@ -62,7 +66,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
         track({
             name: EventName.VIEW_UNDERLYING_DATA_CLICKED,
             properties: {
-                organizationId: user?.data?.organizationUuid,
+                organizationId: organizationUuid,
                 userId: user?.data?.userUuid,
                 projectId: projectUuid,
             },
@@ -73,7 +77,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
         openUnderlyingDataModal,
         projectUuid,
         track,
-        user?.data?.organizationUuid,
+        organizationUuid,
         user?.data?.userUuid,
         value,
     ]);
@@ -105,7 +109,7 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
                     <Can
                         I="view"
                         this={subject('UnderlyingData', {
-                            organizationUuid: user.data?.organizationUuid,
+                            organizationUuid,
                             projectUuid: projectUuid,
                         })}
                     >
@@ -123,8 +127,9 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
             <Can
                 I="manage"
                 this={subject('Explore', {
-                    organizationUuid: user.data?.organizationUuid,
+                    organizationUuid,
                     projectUuid: projectUuid,
+                    exploreNames: [tableName],
                 })}
             >
                 {isEditMode &&
@@ -133,13 +138,21 @@ const CellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({ cell }) => {
                     isFilterableField(item) && (
                         <QuickFilterMenuItems item={item} value={value} />
                     )}
-
+            </Can>
+            <Can
+                I="view"
+                this={subject('Explore', {
+                    organizationUuid,
+                    projectUuid: projectUuid,
+                    exploreNames: [tableName],
+                })}
+            >
                 <DrillDownMenuItem
                     item={item}
                     fieldValues={fieldValues}
                     pivotReference={meta?.pivotReference}
                     trackingData={{
-                        organizationId: user?.data?.organizationUuid,
+                        organizationId: organizationUuid,
                         userId: user?.data?.userUuid,
                         projectId: projectUuid,
                     }}

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -10,9 +10,8 @@ import { ActionIcon, Popover } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback } from 'react';
 import useEchartsCartesianConfig from '../../../hooks/echarts/useEchartsCartesianConfig';
-import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { useAccount } from '../../../hooks/user/useAccount';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
-import useApp from '../../../providers/App/useApp';
 import { type Limit } from '../../ExportResults/types';
 import ExportSelector from '../../ExportSelector';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/types';
@@ -61,41 +60,42 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
             (visualizationConfig.chartType === ChartType.CARTESIAN &&
                 !eChartsOptions);
 
-        const { user } = useApp();
-        const { data: organization } = useOrganization();
+        const { data: account } = useAccount();
         const ability = useAbilityContext();
-        const organizationUuid =
-            user.data?.organizationUuid ?? organization?.organizationUuid;
-        const canExportCsv =
-            ability.can(
-                'manage',
-                subject('ExportCsv', {
-                    organizationUuid,
-                    projectUuid,
-                }),
-            ) ||
-            ability.can(
-                'export',
-                subject('SavedChart', {
-                    organizationUuid,
-                    type: 'csv',
-                }),
-            );
-        const canExportImages =
-            ability.can(
-                'manage',
-                subject('Explore', {
-                    organizationUuid,
-                    projectUuid,
-                }),
-            ) ||
-            ability.can(
-                'export',
-                subject('SavedChart', {
-                    organizationUuid,
-                    type: 'images',
-                }),
-            );
+        const organizationUuid = account?.organization.organizationUuid;
+        const isEmbedded = account?.isJwtUser() === true;
+        const canManageExplore = ability.can(
+            'manage',
+            subject('Explore', {
+                organizationUuid,
+                projectUuid,
+            }),
+        );
+        const canExportCsv = isEmbedded
+            ? ability.can(
+                  'export',
+                  subject('SavedChart', {
+                      organizationUuid,
+                      type: 'csv',
+                  }),
+              )
+            : canManageExplore &&
+              ability.can(
+                  'manage',
+                  subject('ExportCsv', {
+                      organizationUuid,
+                      projectUuid,
+                  }),
+              );
+        const canExportImages = isEmbedded
+            ? ability.can(
+                  'export',
+                  subject('SavedChart', {
+                      organizationUuid,
+                      type: 'images',
+                  }),
+              )
+            : canManageExplore;
 
         const getChartInstance = useCallback(
             () => chartRef.current?.getEchartsInstance(),

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -10,7 +10,8 @@ import { ActionIcon, Popover } from '@mantine/core';
 import { IconShare2 } from '@tabler/icons-react';
 import { memo, useCallback } from 'react';
 import useEchartsCartesianConfig from '../../../hooks/echarts/useEchartsCartesianConfig';
-import { Can } from '../../../providers/Ability';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
 import useApp from '../../../providers/App/useApp';
 import { type Limit } from '../../ExportResults/types';
 import ExportSelector from '../../ExportSelector';
@@ -61,6 +62,40 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                 !eChartsOptions);
 
         const { user } = useApp();
+        const { data: organization } = useOrganization();
+        const ability = useAbilityContext();
+        const organizationUuid =
+            user.data?.organizationUuid ?? organization?.organizationUuid;
+        const canExportCsv =
+            ability.can(
+                'manage',
+                subject('ExportCsv', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            ) ||
+            ability.can(
+                'export',
+                subject('SavedChart', {
+                    organizationUuid,
+                    type: 'csv',
+                }),
+            );
+        const canExportImages =
+            ability.can(
+                'manage',
+                subject('Explore', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            ) ||
+            ability.can(
+                'export',
+                subject('SavedChart', {
+                    organizationUuid,
+                    type: 'images',
+                }),
+            );
 
         const getChartInstance = useCallback(
             () => chartRef.current?.getEchartsInstance(),
@@ -115,13 +150,7 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
         }
         return isTableVisualizationConfig(visualizationConfig) &&
             getChartDownloadQueryUuid ? (
-            <Can
-                I="manage"
-                this={subject('ExportCsv', {
-                    organizationUuid: user.data?.organizationUuid,
-                    projectUuid,
-                })}
-            >
+            canExportCsv ? (
                 <Popover
                     {...COLLAPSABLE_CARD_POPOVER_PROPS}
                     disabled={disabled}
@@ -186,9 +215,9 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                         />
                     </Popover.Dropdown>
                 </Popover>
-            </Can>
+            ) : null
         ) : isTableVisualizationConfig(visualizationConfig) &&
-          !getDownloadQueryUuid ? null : (
+          !getDownloadQueryUuid ? null : canExportImages ? (
             <Popover
                 {...COLLAPSABLE_CARD_POPOVER_PROPS}
                 disabled={disabled}
@@ -214,7 +243,7 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                     ) : null}
                 </Popover.Dropdown>
             </Popover>
-        );
+        ) : null;
     },
 );
 

--- a/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
+++ b/packages/frontend/src/components/common/CollapsableCard/CollapsableCard.tsx
@@ -17,11 +17,13 @@ interface CollapsableCardProps {
     rightHeaderElement?: React.ReactNode;
     isVisualizationCard?: boolean;
     hideHeading?: boolean;
+    minimal?: boolean;
 }
 
 const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
     isVisualizationCard = false,
     hideHeading = false,
+    minimal = false,
     children,
     onToggle,
     isOpen = false,
@@ -48,14 +50,15 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
     return (
         <Card
             component={Flex}
-            p="xxs"
+            p={minimal ? 0 : 'xxs'}
+            shadow={minimal ? undefined : 'subtle'}
+            unstyled={minimal}
             style={{
                 display: 'flex',
                 flexDirection: 'column',
                 overflow: 'visible',
                 ...(shouldExpand ? { flex: 1 } : undefined),
             }}
-            shadow="subtle"
         >
             {!hideHeading && (
                 <Flex
@@ -157,8 +160,12 @@ const CollapsableCard: FC<React.PropsWithChildren<CollapsableCardProps>> = ({
                             >
                                 <div
                                     style={{
-                                        height: COLLAPSIBLE_CARD_GAP_SIZE,
-                                        minHeight: COLLAPSIBLE_CARD_GAP_SIZE,
+                                        height: minimal
+                                            ? 0
+                                            : COLLAPSIBLE_CARD_GAP_SIZE,
+                                        minHeight: minimal
+                                            ? 0
+                                            : COLLAPSIBLE_CARD_GAP_SIZE,
                                     }}
                                 />
                                 {children}

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -4,7 +4,7 @@ import {
     type SavedChart,
 } from '@lightdash/common';
 import { IconUnlink } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { useEffect, useLayoutEffect, useState, type FC } from 'react';
 import { Provider } from 'react-redux';
 import Page from '../../../../../components/common/Page/Page';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
@@ -13,6 +13,7 @@ import ExploreSideBar from '../../../../../components/Explorer/ExploreSideBar';
 import {
     buildInitialExplorerState,
     createExplorerStore,
+    explorerActions,
 } from '../../../../../features/explorer/store';
 import { MergeProvider } from '../../../../../features/mergeQuery/context/MergeContext';
 import { useExplore } from '../../../../../hooks/useExplore';
@@ -25,7 +26,16 @@ const EmbedExploreView: FC<{
     onExploreSelect?: (exploreName: string) => void;
     onBackToTables?: () => void;
     fitContainerHeight?: boolean;
-}> = ({ exploreId, onExploreSelect, onBackToTables, fitContainerHeight }) => {
+    isEditMode: boolean;
+    chartView?: boolean;
+}> = ({
+    exploreId,
+    onExploreSelect,
+    onBackToTables,
+    fitContainerHeight,
+    isEditMode,
+    chartView,
+}) => {
     const { data } = useExplore(exploreId);
 
     // Run the query effects hook
@@ -45,11 +55,13 @@ const EmbedExploreView: FC<{
                     onBackToTables={onBackToTables}
                 />
             }
+            isSidebarOpen={isEditMode}
             withFullHeight
-            withPaddedContent
+            withPaddedContent={!chartView || isEditMode}
+            noContentPadding={chartView && !isEditMode}
         >
-            <MergeProvider>
-                <Explorer />
+            <MergeProvider readOnly={!isEditMode}>
+                <Explorer chartView={chartView} />
             </MergeProvider>
         </Page>
     );
@@ -62,6 +74,8 @@ const EmbedExploreContent: FC<{
     onBackToTables?: () => void;
     fitContainerHeight?: boolean;
     allowChartUpdate?: boolean;
+    isEditMode: boolean;
+    chartView?: boolean;
 }> = ({
     exploreId,
     savedChart,
@@ -69,17 +83,22 @@ const EmbedExploreContent: FC<{
     onBackToTables,
     fitContainerHeight,
     allowChartUpdate,
+    isEditMode,
+    chartView,
 }) => {
     // The store initializes once; the parent key remounts it when inputs change.
     const [store] = useState(() => {
+        const expandedSections = isEditMode
+            ? [
+                  ExplorerSection.FILTERS,
+                  ExplorerSection.VISUALIZATION,
+                  ExplorerSection.RESULTS,
+              ]
+            : [ExplorerSection.VISUALIZATION];
         const initialState = buildInitialExplorerState({
-            isEditMode: true,
-            expandedSections: [
-                ExplorerSection.FILTERS,
-                ExplorerSection.VISUALIZATION,
-                ExplorerSection.RESULTS,
-            ],
+            isEditMode,
             initialState: {
+                expandedSections,
                 // With a full SavedChart in the store the save flow becomes
                 // "Save changes" (new version) instead of create
                 savedChart:
@@ -125,6 +144,30 @@ const EmbedExploreContent: FC<{
         return createExplorerStore({ explorer: initialState });
     });
 
+    useLayoutEffect(() => {
+        store.dispatch(explorerActions.setIsEditMode(isEditMode));
+        if (isEditMode) {
+            const expandedSections = store.getState().explorer.expandedSections;
+            [
+                ExplorerSection.FILTERS,
+                ExplorerSection.VISUALIZATION,
+                ExplorerSection.RESULTS,
+            ].forEach((section) => {
+                if (!expandedSections.includes(section)) {
+                    store.dispatch(
+                        explorerActions.toggleExpandedSection(section),
+                    );
+                }
+            });
+        }
+    }, [isEditMode, store]);
+
+    useEffect(() => {
+        if (savedChart && 'uuid' in savedChart) {
+            store.dispatch(explorerActions.setSavedChart(savedChart));
+        }
+    }, [savedChart, store]);
+
     return (
         <Provider store={store}>
             <EmbedExploreView
@@ -132,6 +175,8 @@ const EmbedExploreContent: FC<{
                 onExploreSelect={onExploreSelect}
                 onBackToTables={onBackToTables}
                 fitContainerHeight={fitContainerHeight}
+                isEditMode={isEditMode}
+                chartView={chartView}
             />
         </Provider>
     );
@@ -149,6 +194,10 @@ type Props = {
     // Treat a full SavedChart as editable: saving creates a new version of it
     // instead of a new chart
     allowChartUpdate?: boolean;
+    // Keep the same explorer mounted while the authoring sidebar transitions.
+    isEditMode?: boolean;
+    // Render the saved-chart surface without read-only query-builder cards.
+    chartView?: boolean;
 };
 
 const EmbedExplore: FC<Props> = ({
@@ -159,6 +208,8 @@ const EmbedExplore: FC<Props> = ({
     onBackToTables,
     fitContainerHeight,
     allowChartUpdate,
+    isEditMode = true,
+    chartView,
 }) => {
     const { projectUuid } = useEmbed();
     const { error: exploreError } = useExplore(exploreId);
@@ -199,6 +250,8 @@ const EmbedExplore: FC<Props> = ({
                 onBackToTables={onBackToTables}
                 fitContainerHeight={fitContainerHeight}
                 allowChartUpdate={allowChartUpdate}
+                isEditMode={isEditMode}
+                chartView={chartView}
             />
         </div>
     );

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -57,8 +57,7 @@ const EmbedExploreView: FC<{
             }
             isSidebarOpen={isEditMode}
             withFullHeight
-            withPaddedContent={!chartView || isEditMode}
-            noContentPadding={chartView && !isEditMode}
+            withPaddedContent
         >
             <MergeProvider readOnly={!isEditMode}>
                 <Explorer chartView={chartView} />

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -1516,7 +1516,7 @@ export const EmbeddedChart = ({ embedJwt }: EmbeddedChartProps) => (
         instanceUrl="${siteUrl}"
         token={embedJwt}
         id="${data.content.contentId || '<CHART_UUID>'}"
-        styles={{
+${data.writeActions ? '        isEditMode\n' : ''}        styles={{
             // Optional: customize supported SDK styles here:
             // backgroundColor: '#fff',
             // fontFamily: 'Inter, sans-serif',

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewChartForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewChartForm.tsx
@@ -32,7 +32,13 @@ import {
     IconTrash,
 } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
-import { useCallback, useState, type FC, type ReactNode } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useState,
+    type FC,
+    type ReactNode,
+} from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { lightdashApi } from '../../../../api';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -80,13 +86,22 @@ type FormValues = {
 const EmbedPreviewChartForm: FC<{
     projectUuid: string;
     siteUrl: string;
-    charts: Pick<SavedChart, 'uuid' | 'name'>[];
+    charts: Pick<SavedChart, 'uuid' | 'name' | 'spaceUuid'>[];
     writeActions?: CreateEmbedJwt['writeActions'];
     writeActionsPanel?: ReactNode;
-}> = ({ projectUuid, siteUrl, charts, writeActions, writeActionsPanel }) => {
+    onChartSpaceChange?: (spaceUuid: string | undefined) => void;
+}> = ({
+    projectUuid,
+    siteUrl,
+    charts,
+    writeActions,
+    writeActionsPanel,
+    onChartSpaceChange,
+}) => {
     const { mutateAsync: createEmbedUrl } =
         useEmbedUrlCreateMutation(projectUuid);
     const colorScheme = useComputedColorScheme();
+
     const { data: user } = useUser(true);
     const [embedMethod, setEmbedMethod] = useState<EmbedMethod>('iframe');
 
@@ -112,6 +127,13 @@ const EmbedPreviewChartForm: FC<{
         },
     });
     const { onSubmit, values: formValues } = form;
+
+    useEffect(() => {
+        onChartSpaceChange?.(
+            charts.find((chart) => chart.uuid === form.values.chartUuid)
+                ?.spaceUuid,
+        );
+    }, [charts, form.values.chartUuid, onChartSpaceChange]);
 
     const convertFormValuesToCreateEmbedJwt = useCallback(
         (
@@ -203,6 +225,13 @@ const EmbedPreviewChartForm: FC<{
                     placeholder="Select a chart..."
                     searchable
                     {...form.getInputProps('chartUuid')}
+                    onChange={(chartUuid) => {
+                        form.setFieldValue('chartUuid', chartUuid ?? undefined);
+                        onChartSpaceChange?.(
+                            charts.find((chart) => chart.uuid === chartUuid)
+                                ?.spaceUuid,
+                        );
+                    }}
                 />
 
                 <Stack gap="xs">

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
@@ -163,6 +163,8 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
         useState<CreateEmbedJwt['writeActions']>();
     const [selectedDashboardSpaceUuid, setSelectedDashboardSpaceUuid] =
         useState<string>();
+    const [selectedChartSpaceUuid, setSelectedChartSpaceUuid] =
+        useState<string>();
     const [activeTab, setActiveTab] = useState<
         'dashboards' | 'charts' | 'apps' | 'aiAgents'
     >('dashboards');
@@ -368,12 +370,16 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                                 siteUrl={health.data.siteUrl}
                                 charts={charts || []}
                                 writeActions={writeActions}
+                                onChartSpaceChange={setSelectedChartSpaceUuid}
                                 writeActionsPanel={
                                     activeTab === 'charts' ? (
                                         <EmbedWriteActionsForm
                                             projectUuid={projectUuid}
                                             value={writeActions}
                                             onChange={setWriteActions}
+                                            fixedSpaceUuid={
+                                                selectedChartSpaceUuid
+                                            }
                                         />
                                     ) : null
                                 }

--- a/packages/frontend/src/ee/pages/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/pages/EmbedExplore.tsx
@@ -19,10 +19,16 @@ const EmbedExplorePage: FC<{
     containerStyles?: React.CSSProperties;
     exploreId?: string;
     savedChart?: EmbedExploreChart;
+    allowChartUpdate?: boolean;
+    isEditMode?: boolean;
+    chartView?: boolean;
 }> = ({
     containerStyles,
     exploreId: exploreIdProps,
     savedChart: savedChartProps,
+    allowChartUpdate,
+    isEditMode,
+    chartView,
 }) => {
     const {
         content,
@@ -92,6 +98,9 @@ const EmbedExplorePage: FC<{
             containerStyles={containerStyles}
             exploreId={exploreId}
             savedChart={savedChart}
+            allowChartUpdate={allowChartUpdate}
+            isEditMode={isEditMode}
+            chartView={chartView}
         />
     );
 };


### PR DESCRIPTION
Closes: PROD-10304
Closes: #27612

## What changed

- adds `isEditMode` to `Lightdash.Chart`, reusing the existing embedded Explore editor for filters, visualization, results, drill/underlying-data actions, exports, and saving
- derives saved-chart update access from the existing `writeActions` service-account role and exact chart space
- locks chart write configuration to the selected chart space and includes edit mode in generated SDK snippets
- preserves the current compact chart view as the default

## Permission model

No new JWT capability flag is introduced. Edit mode is available only when the existing write actor can update the exact saved chart in `writeActions.spaceUuid`; otherwise the SDK fails closed with an explanatory state.

## Validation

- common, backend, and frontend SDK typechecks
- focused backend EmbedService tests (31 passed)
- focused frontend SDK tests (15 passed)
- changed backend/common/frontend source lint
- API generation (no generated diff)
- isolated local stack hot-reloaded successfully at frontend :3090 / API :8170

## Live UI note

The isolated stack is running, but a full visual browser pass still needs an authenticated local browser session.