### PR TITLE
feat(ai-reviews): send new review findings to Linear

### DIFF
--- a/packages/backend/src/ee/database/entities/aiReviewNotifications.ts
+++ b/packages/backend/src/ee/database/entities/aiReviewNotifications.ts
@@ -13,6 +13,9 @@ export type DbAiReviewNotificationSettings = {
     organization_uuid: string;
     enabled: boolean;
     slack_channel_id: string | null;
+    linear_enabled: boolean;
+    linear_team_id: string | null;
+    linear_project_id: string | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -36,7 +39,12 @@ export type AiReviewNotificationSettingsTable = Knex.CompositeTableType<
     DbAiReviewNotificationSettings,
     Pick<
         DbAiReviewNotificationSettings,
-        'organization_uuid' | 'enabled' | 'slack_channel_id'
+        | 'organization_uuid'
+        | 'enabled'
+        | 'slack_channel_id'
+        | 'linear_enabled'
+        | 'linear_team_id'
+        | 'linear_project_id'
     > &
         Partial<
             Pick<DbAiReviewNotificationSettings, 'created_at' | 'updated_at'>
@@ -44,7 +52,12 @@ export type AiReviewNotificationSettingsTable = Knex.CompositeTableType<
     Partial<
         Pick<
             DbAiReviewNotificationSettings,
-            'enabled' | 'slack_channel_id' | 'updated_at'
+            | 'enabled'
+            | 'slack_channel_id'
+            | 'linear_enabled'
+            | 'linear_team_id'
+            | 'linear_project_id'
+            | 'updated_at'
         >
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260825140001_add_linear_to_review_notification_settings.ts
+++ b/packages/backend/src/ee/database/migrations/20260825140001_add_linear_to_review_notification_settings.ts
@@ -1,0 +1,23 @@
+import type { Knex } from 'knex';
+
+const settingsTable = 'ai_agent_review_notification_settings';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+
+    await knex.schema.alterTable(settingsTable, (table) => {
+        table.boolean('linear_enabled').notNullable().defaultTo(false);
+        table.text('linear_team_id').nullable();
+        table.text('linear_project_id').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+
+    await knex.schema.alterTable(settingsTable, (table) => {
+        table.dropColumn('linear_enabled');
+        table.dropColumn('linear_team_id');
+        table.dropColumn('linear_project_id');
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1320,7 +1320,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.models.getAiAgentReviewNotificationModel<AiAgentReviewNotificationModel>(),
                 aiAgentReviewNotificationService:
                     context.serviceRepository.getAiAgentReviewNotificationService<AiAgentReviewNotificationService>(),
-                linearAppService: context.serviceRepository.getLinearAppService(),
+                linearAppService:
+                    context.serviceRepository.getLinearAppService(),
                 aiAgentAdminService:
                     context.serviceRepository.getAiAgentAdminService<AiAgentAdminService>(),
                 projectContextService:

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1320,6 +1320,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.models.getAiAgentReviewNotificationModel<AiAgentReviewNotificationModel>(),
                 aiAgentReviewNotificationService:
                     context.serviceRepository.getAiAgentReviewNotificationService<AiAgentReviewNotificationService>(),
+                linearAppService: context.serviceRepository.getLinearAppService(),
                 aiAgentAdminService:
                     context.serviceRepository.getAiAgentAdminService<AiAgentAdminService>(),
                 projectContextService:

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -2546,6 +2546,20 @@ export class AiAgentReviewClassifierModel {
             .ignore();
     }
 
+    async updateReviewItemLinkedIssueUrl(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        linkedIssueUrl: string;
+    }): Promise<void> {
+        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+            .where('fingerprint', args.fingerprint)
+            .where('organization_uuid', args.organizationUuid)
+            .update({
+                linked_issue_url: args.linkedIssueUrl,
+                updated_at: this.database.fn.now() as never,
+            });
+    }
+
     async updateReviewItemAssignee(args: {
         fingerprint: string;
         organizationUuid: string;

--- a/packages/backend/src/ee/models/AiAgentReviewNotificationModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewNotificationModel.test.ts
@@ -31,6 +31,9 @@ describe('AiAgentReviewNotificationModel', () => {
             organizationUuid: 'org-1',
             enabled: false,
             slackChannelId: null,
+            linearEnabled: false,
+            linearTeamId: null,
+            linearProjectId: null,
         });
     });
 

--- a/packages/backend/src/ee/models/AiAgentReviewNotificationModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewNotificationModel.ts
@@ -38,6 +38,9 @@ export class AiAgentReviewNotificationModel {
             organizationUuid: row.organization_uuid,
             enabled: row.enabled,
             slackChannelId: row.slack_channel_id,
+            linearEnabled: row.linear_enabled,
+            linearTeamId: row.linear_team_id,
+            linearProjectId: row.linear_project_id,
         };
     }
 
@@ -53,6 +56,9 @@ export class AiAgentReviewNotificationModel {
                 organizationUuid,
                 enabled: false,
                 slackChannelId: null,
+                linearEnabled: false,
+                linearTeamId: null,
+                linearProjectId: null,
             };
         }
 
@@ -67,12 +73,18 @@ export class AiAgentReviewNotificationModel {
                 organization_uuid: settings.organizationUuid,
                 enabled: settings.enabled,
                 slack_channel_id: settings.slackChannelId,
+                linear_enabled: settings.linearEnabled,
+                linear_team_id: settings.linearTeamId,
+                linear_project_id: settings.linearProjectId,
                 updated_at: new Date(),
             })
             .onConflict('organization_uuid')
             .merge({
                 enabled: settings.enabled,
                 slack_channel_id: settings.slackChannelId,
+                linear_enabled: settings.linearEnabled,
+                linear_team_id: settings.linearTeamId,
+                linear_project_id: settings.linearProjectId,
                 updated_at: new Date(),
             })
             .returning('*');

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -26,6 +26,8 @@ import { type McpToolCallModel } from '../models/McpToolCallModel';
 import { AiAgentAdminService } from '../services/AiAgentAdminService';
 import { AiAgentMemoryService } from '../services/AiAgentMemoryService/AiAgentMemoryService';
 import { AiAgentReviewClassifierService } from '../services/AiAgentReviewClassifierService';
+import { type LinearAppService } from '../../services/LinearAppService/LinearAppService';
+import { createReviewLinearIssue } from './tasks/createReviewLinearIssue';
 import { type AiAgentReviewNotificationService } from '../services/AiAgentReviewNotificationService';
 import { AiAgentService } from '../services/AiAgentService/AiAgentService';
 import { type AiDeepResearchService } from '../services/AiDeepResearchService/AiDeepResearchService';
@@ -112,6 +114,7 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
     aiAgentReviewNotificationModel: AiAgentReviewNotificationModel;
     aiAgentReviewNotificationService: AiAgentReviewNotificationService;
+    linearAppService: LinearAppService;
     aiAgentAdminService: AiAgentAdminService;
     embedService: EmbedService;
     managedAgentService: ManagedAgentService;
@@ -149,6 +152,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
 
     protected readonly aiAgentReviewNotificationService: AiAgentReviewNotificationService;
 
+    protected readonly linearAppService: LinearAppService;
+
     protected readonly aiAgentAdminService: AiAgentAdminService;
 
     protected readonly embedService: EmbedService;
@@ -185,6 +190,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             args.aiAgentReviewNotificationModel;
         this.aiAgentReviewNotificationService =
             args.aiAgentReviewNotificationService;
+        this.linearAppService = args.linearAppService;
         this.aiAgentAdminService = args.aiAgentAdminService;
         this.embedService = args.embedService;
         this.managedAgentService = args.managedAgentService;
@@ -951,6 +957,17 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     projectModel: this.projectModel,
                     openIdIdentityModel: this.openIdIdentityModel,
                     slackClient: this.slackClient,
+                    analytics: this.analytics,
+                })(payload);
+            },
+            [EE_SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: async (payload) => {
+                await createReviewLinearIssue({
+                    siteUrl: this.lightdashConfig.siteUrl, // pragma: allowlist secret
+                    model: this.aiAgentReviewNotificationModel,
+                    aiAgentReviewClassifierModel:
+                        this.aiAgentReviewClassifierModel,
+                    projectModel: this.projectModel,
+                    linearAppService: this.linearAppService,
                     analytics: this.analytics,
                 })(payload);
             },

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -20,14 +20,13 @@ import {
     SchedulerWorkerArguments,
 } from '../../scheduler/SchedulerWorker';
 import { TypedEETaskList } from '../../scheduler/types';
+import { type LinearAppService } from '../../services/LinearAppService/LinearAppService';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
 import { type AiAgentReviewNotificationModel } from '../models/AiAgentReviewNotificationModel';
 import { type McpToolCallModel } from '../models/McpToolCallModel';
 import { AiAgentAdminService } from '../services/AiAgentAdminService';
 import { AiAgentMemoryService } from '../services/AiAgentMemoryService/AiAgentMemoryService';
 import { AiAgentReviewClassifierService } from '../services/AiAgentReviewClassifierService';
-import { type LinearAppService } from '../../services/LinearAppService/LinearAppService';
-import { createReviewLinearIssue } from './tasks/createReviewLinearIssue';
 import { type AiAgentReviewNotificationService } from '../services/AiAgentReviewNotificationService';
 import { AiAgentService } from '../services/AiAgentService/AiAgentService';
 import { type AiDeepResearchService } from '../services/AiDeepResearchService/AiDeepResearchService';
@@ -39,6 +38,7 @@ import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgen
 import { type OnboardingAgentService } from '../services/OnboardingAgentService/OnboardingAgentService';
 import { ProjectContextService } from '../services/ProjectContextService/ProjectContextService';
 import type { ProjectHomepageService } from '../services/ProjectHomepageService';
+import { createReviewLinearIssue } from './tasks/createReviewLinearIssue';
 import { sendReviewNotification } from './tasks/sendReviewNotification';
 
 const MCP_TOOL_CALL_RETENTION_DAYS = 90;
@@ -960,7 +960,9 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     analytics: this.analytics,
                 })(payload);
             },
-            [EE_SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: async (payload) => {
+            [EE_SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: async (
+                payload,
+            ) => {
                 await createReviewLinearIssue({
                     siteUrl: this.lightdashConfig.siteUrl, // pragma: allowlist secret
                     model: this.aiAgentReviewNotificationModel,

--- a/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.test.ts
+++ b/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.test.ts
@@ -1,0 +1,120 @@
+import { createReviewLinearIssue } from './createReviewLinearIssue';
+
+const ORGANIZATION_UUID = 'org-1';
+const PROJECT_UUID = 'project-1';
+const FINGERPRINT = 'fp-1';
+
+const payload = {
+    organizationUuid: ORGANIZATION_UUID,
+    projectUuid: PROJECT_UUID,
+    fingerprints: [FINGERPRINT],
+    reviewRunUuid: 'run-1',
+};
+
+const makeDeps = (overrides: Record<string, unknown> = {}) => {
+    const createIssueForOrganization = vi.fn().mockResolvedValue({
+        id: 'issue-1',
+        identifier: 'PRD-12',
+        url: 'https://linear.app/acme/issue/PRD-12',
+        title: 'Broken metric',
+    });
+    const updateReviewItemLinkedIssueUrl = vi.fn().mockResolvedValue(undefined);
+
+    return {
+        siteUrl: 'https://app.example.com',
+        model: {
+            getSettings: vi.fn().mockResolvedValue({
+                organizationUuid: ORGANIZATION_UUID,
+                enabled: false,
+                slackChannelId: null,
+                linearEnabled: true,
+                linearTeamId: 'team-1',
+                linearProjectId: 'project-linear-1',
+            }),
+        },
+        aiAgentReviewClassifierModel: {
+            getReviewItem: vi.fn().mockResolvedValue({
+                title: 'Broken metric',
+                description: 'Count is wrong',
+                primaryRootCause: 'semantic_layer',
+                linkedIssueUrl: null,
+                latestFinding: {
+                    threadUuid: 'thread-1',
+                    agentUuid: 'agent-1',
+                },
+                agentUuid: 'agent-1',
+            }),
+            updateReviewItemLinkedIssueUrl,
+        },
+        projectModel: {
+            get: vi.fn().mockResolvedValue({ name: 'Jaffle shop' }),
+        },
+        linearAppService: {
+            createIssueForOrganization,
+        },
+        analytics: {
+            track: vi.fn(),
+        },
+        createIssueForOrganization,
+        updateReviewItemLinkedIssueUrl,
+        ...overrides,
+    };
+};
+
+describe('createReviewLinearIssue', () => {
+    it('does nothing when Linear export is disabled', async () => {
+        const deps = makeDeps({
+            model: {
+                getSettings: vi.fn().mockResolvedValue({
+                    linearEnabled: false,
+                    linearTeamId: 'team-1',
+                    linearProjectId: null,
+                }),
+            },
+        });
+
+        await createReviewLinearIssue(deps)(payload);
+
+        expect(deps.createIssueForOrganization).not.toHaveBeenCalled();
+    });
+
+    it('creates a Linear issue and stores the linked URL', async () => {
+        const deps = makeDeps();
+
+        await createReviewLinearIssue(deps)(payload);
+
+        expect(deps.createIssueForOrganization).toHaveBeenCalledWith(
+            ORGANIZATION_UUID,
+            expect.objectContaining({
+                title: 'Broken metric',
+                teamId: 'team-1',
+                projectId: 'project-linear-1',
+            }),
+        );
+        expect(deps.updateReviewItemLinkedIssueUrl).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            fingerprint: FINGERPRINT,
+            linkedIssueUrl: 'https://linear.app/acme/issue/PRD-12',
+        });
+    });
+
+    it('skips review items that already have a linked issue', async () => {
+        const deps = makeDeps({
+            aiAgentReviewClassifierModel: {
+                getReviewItem: vi.fn().mockResolvedValue({
+                    title: 'Broken metric',
+                    description: 'Count is wrong',
+                    primaryRootCause: 'semantic_layer',
+                    linkedIssueUrl: 'https://linear.app/acme/issue/PRD-1',
+                    latestFinding: null,
+                    agentUuid: null,
+                }),
+                updateReviewItemLinkedIssueUrl: vi.fn(),
+            },
+        });
+
+        await createReviewLinearIssue(deps)(payload);
+
+        expect(deps.createIssueForOrganization).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.test.ts
+++ b/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.test.ts
@@ -1,4 +1,7 @@
+import { type Mock } from 'vitest';
 import { createReviewLinearIssue } from './createReviewLinearIssue';
+
+type Deps = Parameters<typeof createReviewLinearIssue>[0];
 
 const ORGANIZATION_UUID = 'org-1';
 const PROJECT_UUID = 'project-1';
@@ -58,6 +61,9 @@ const makeDeps = (overrides: Record<string, unknown> = {}) => {
         createIssueForOrganization,
         updateReviewItemLinkedIssueUrl,
         ...overrides,
+    } as unknown as Deps & {
+        createIssueForOrganization: Mock;
+        updateReviewItemLinkedIssueUrl: Mock;
     };
 };
 
@@ -96,6 +102,21 @@ describe('createReviewLinearIssue', () => {
             fingerprint: FINGERPRINT,
             linkedIssueUrl: 'https://linear.app/acme/issue/PRD-12',
         });
+    });
+
+    it('fails the job when Linear rejects an item so it is retried', async () => {
+        const deps = makeDeps({
+            linearAppService: {
+                createIssueForOrganization: vi
+                    .fn()
+                    .mockRejectedValue(new Error('Linear is down')),
+            },
+        });
+
+        await expect(createReviewLinearIssue(deps)(payload)).rejects.toThrow(
+            FINGERPRINT,
+        );
+        expect(deps.updateReviewItemLinkedIssueUrl).not.toHaveBeenCalled();
     });
 
     it('skips review items that already have a linked issue', async () => {

--- a/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.ts
+++ b/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.ts
@@ -1,0 +1,124 @@
+import {
+    getErrorMessage,
+    type CreateReviewLinearIssuePayload,
+} from '@lightdash/common'; // pragma: allowlist secret
+import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics'; // pragma: allowlist secret
+import Logger from '../../../logging/logger';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { type LinearAppService } from '../../../services/LinearAppService/LinearAppService';
+import { type AiAgentReviewClassifierModel } from '../../models/AiAgentReviewClassifierModel';
+import { type AiAgentReviewNotificationModel } from '../../models/AiAgentReviewNotificationModel';
+import {
+    buildReviewDrawerSearchParams,
+    REVIEWS_BOARD_PATH,
+} from '../../services/AiAgentReviewNotificationService';
+
+type CreateReviewLinearIssueDeps = {
+    siteUrl: string;
+    model: AiAgentReviewNotificationModel;
+    aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    projectModel: ProjectModel;
+    linearAppService: LinearAppService;
+    analytics: LightdashAnalytics; // pragma: allowlist secret
+};
+
+const buildIssueDescription = (args: {
+    description: string;
+    rootCause: string;
+    projectName: string;
+    reviewUrl: string;
+}): string =>
+    [
+        args.description,
+        '',
+        `**Root cause:** ${args.rootCause}`,
+        `**Project:** ${args.projectName}`,
+        '',
+        `[Open in Lightdash](${args.reviewUrl})`, // pragma: allowlist secret
+    ]
+        .filter((line, index, lines) => line !== '' || lines[index - 1] !== '')
+        .join('\n')
+        .trim();
+
+export const createReviewLinearIssue =
+    (deps: CreateReviewLinearIssueDeps) =>
+    async (payload: CreateReviewLinearIssuePayload): Promise<void> => {
+        const settings = await deps.model.getSettings(payload.organizationUuid);
+        if (!settings.linearEnabled || !settings.linearTeamId) {
+            return;
+        }
+
+        const project = await deps.projectModel.get(payload.projectUuid);
+
+        for (const fingerprint of payload.fingerprints) {
+            try {
+                const reviewItem =
+                    await deps.aiAgentReviewClassifierModel.getReviewItem(
+                        payload.organizationUuid,
+                        fingerprint,
+                    );
+                if (!reviewItem) {
+                    Logger.warn(
+                        'Skipping Linear issue creation for missing review item',
+                        { fingerprint },
+                    );
+                    continue;
+                }
+                if (reviewItem.linkedIssueUrl) {
+                    continue;
+                }
+
+                const reviewUrl = `${deps.siteUrl}${REVIEWS_BOARD_PATH}?${buildReviewDrawerSearchParams(
+                    payload.projectUuid,
+                    fingerprint,
+                    reviewItem,
+                )}`;
+                const created = await deps.linearAppService.createIssueForOrganization(
+                    payload.organizationUuid,
+                    {
+                        title: reviewItem.title,
+                        description: buildIssueDescription({
+                            description: reviewItem.description,
+                            rootCause: reviewItem.primaryRootCause,
+                            projectName: project.name,
+                            reviewUrl,
+                        }),
+                        teamId: settings.linearTeamId,
+                        projectId: settings.linearProjectId,
+                    },
+                );
+
+                await deps.aiAgentReviewClassifierModel.updateReviewItemLinkedIssueUrl(
+                    {
+                        organizationUuid: payload.organizationUuid,
+                        fingerprint,
+                        linkedIssueUrl: created.url,
+                    },
+                );
+
+                deps.analytics.track({
+                    event: 'ai_review_linear_issue.created',
+                    anonymousId: payload.organizationUuid,
+                    properties: {
+                        organizationId: payload.organizationUuid,
+                        projectId: payload.projectUuid,
+                    },
+                });
+            } catch (error) {
+                Logger.error(
+                    `Failed to create Linear issue for review item ${fingerprint}: ${getErrorMessage(
+                        error,
+                    )}`,
+                );
+                deps.analytics.track({
+                    event: 'ai_review_linear_issue.errored',
+                    anonymousId: payload.organizationUuid,
+                    properties: {
+                        organizationId: payload.organizationUuid,
+                        projectId: payload.projectUuid,
+                        error: getErrorMessage(error),
+                    },
+                });
+            }
+        }
+    };

--- a/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.ts
+++ b/packages/backend/src/ee/scheduler/tasks/createReviewLinearIssue.ts
@@ -29,16 +29,15 @@ const buildIssueDescription = (args: {
     reviewUrl: string;
 }): string =>
     [
-        args.description,
-        '',
-        `**Root cause:** ${args.rootCause}`,
-        `**Project:** ${args.projectName}`,
-        '',
+        args.description.trim(),
+        [
+            `**Root cause:** ${args.rootCause}`,
+            `**Project:** ${args.projectName}`,
+        ].join('\n'),
         `[Open in Lightdash](${args.reviewUrl})`, // pragma: allowlist secret
     ]
-        .filter((line, index, lines) => line !== '' || lines[index - 1] !== '')
-        .join('\n')
-        .trim();
+        .filter((section) => section !== '')
+        .join('\n\n');
 
 export const createReviewLinearIssue =
     (deps: CreateReviewLinearIssueDeps) =>
@@ -49,7 +48,11 @@ export const createReviewLinearIssue =
         }
 
         const project = await deps.projectModel.get(payload.projectUuid);
+        const failedFingerprints: string[] = [];
 
+        // Issues are created one at a time on purpose: Linear rate limits the
+        // API, and a partial failure must not lose the items already created.
+        /* eslint-disable no-await-in-loop */
         for (const fingerprint of payload.fingerprints) {
             try {
                 const reviewItem =
@@ -57,54 +60,53 @@ export const createReviewLinearIssue =
                         payload.organizationUuid,
                         fingerprint,
                     );
+
                 if (!reviewItem) {
                     Logger.warn(
                         'Skipping Linear issue creation for missing review item',
                         { fingerprint },
                     );
-                    continue;
-                }
-                if (reviewItem.linkedIssueUrl) {
-                    continue;
-                }
-
-                const reviewUrl = `${deps.siteUrl}${REVIEWS_BOARD_PATH}?${buildReviewDrawerSearchParams(
-                    payload.projectUuid,
-                    fingerprint,
-                    reviewItem,
-                )}`;
-                const created = await deps.linearAppService.createIssueForOrganization(
-                    payload.organizationUuid,
-                    {
-                        title: reviewItem.title,
-                        description: buildIssueDescription({
-                            description: reviewItem.description,
-                            rootCause: reviewItem.primaryRootCause,
-                            projectName: project.name,
-                            reviewUrl,
-                        }),
-                        teamId: settings.linearTeamId,
-                        projectId: settings.linearProjectId,
-                    },
-                );
-
-                await deps.aiAgentReviewClassifierModel.updateReviewItemLinkedIssueUrl(
-                    {
-                        organizationUuid: payload.organizationUuid,
+                } else if (reviewItem.linkedIssueUrl === null) {
+                    const reviewUrl = `${deps.siteUrl}${REVIEWS_BOARD_PATH}?${buildReviewDrawerSearchParams(
+                        payload.projectUuid,
                         fingerprint,
-                        linkedIssueUrl: created.url,
-                    },
-                );
+                        reviewItem,
+                    )}`;
+                    const created =
+                        await deps.linearAppService.createIssueForOrganization(
+                            payload.organizationUuid,
+                            {
+                                title: reviewItem.title,
+                                description: buildIssueDescription({
+                                    description: reviewItem.description,
+                                    rootCause: reviewItem.primaryRootCause,
+                                    projectName: project.name,
+                                    reviewUrl,
+                                }),
+                                teamId: settings.linearTeamId,
+                                projectId: settings.linearProjectId,
+                            },
+                        );
 
-                deps.analytics.track({
-                    event: 'ai_review_linear_issue.created',
-                    anonymousId: payload.organizationUuid,
-                    properties: {
-                        organizationId: payload.organizationUuid,
-                        projectId: payload.projectUuid,
-                    },
-                });
+                    await deps.aiAgentReviewClassifierModel.updateReviewItemLinkedIssueUrl(
+                        {
+                            organizationUuid: payload.organizationUuid,
+                            fingerprint,
+                            linkedIssueUrl: created.url,
+                        },
+                    );
+
+                    deps.analytics.track({
+                        event: 'ai_review_linear_issue.created',
+                        anonymousId: payload.organizationUuid,
+                        properties: {
+                            organizationId: payload.organizationUuid,
+                            projectId: payload.projectUuid,
+                        },
+                    });
+                }
             } catch (error) {
+                failedFingerprints.push(fingerprint);
                 Logger.error(
                     `Failed to create Linear issue for review item ${fingerprint}: ${getErrorMessage(
                         error,
@@ -120,5 +122,16 @@ export const createReviewLinearIssue =
                     },
                 });
             }
+        }
+        /* eslint-enable no-await-in-loop */
+
+        // Fail the job so Graphile retries. Items that succeeded already carry a
+        // linked issue URL, so a retry only reattempts the ones that failed.
+        if (failedFingerprints.length > 0) {
+            throw new Error(
+                `Failed to create Linear issues for review items: ${failedFingerprints.join(
+                    ', ',
+                )}`,
+            );
         }
     };

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -351,11 +351,17 @@ const makeService = ({
                 organizationUuid: ORGANIZATION_UUID,
                 enabled: false,
                 slackChannelId: null,
+                linearEnabled: false,
+                linearTeamId: null,
+                linearProjectId: null,
             }),
             upsertSettings: vi.fn().mockResolvedValue({
                 organizationUuid: ORGANIZATION_UUID,
                 enabled: true,
                 slackChannelId: 'C123',
+                linearEnabled: false,
+                linearTeamId: null,
+                linearProjectId: null,
             }),
             ...aiAgentReviewNotificationModel,
         },
@@ -442,6 +448,7 @@ const makeService = ({
         },
         aiAgentReviewNotificationService: {
             notifyAssigned: vi.fn().mockResolvedValue(undefined),
+            createLinearIssues: vi.fn().mockResolvedValue(undefined),
             ...aiAgentReviewNotificationService,
         },
         slackClient: {
@@ -1346,6 +1353,9 @@ describe('AiAgentAdminService review notification settings', () => {
             organizationUuid: ORGANIZATION_UUID,
             enabled: true,
             slackChannelId: 'C123',
+            linearEnabled: false,
+            linearTeamId: null,
+            linearProjectId: null,
         });
         const service = makeService({
             aiAgentReviewNotificationModel: { getSettings },
@@ -1357,6 +1367,9 @@ describe('AiAgentAdminService review notification settings', () => {
             organizationUuid: ORGANIZATION_UUID,
             enabled: true,
             slackChannelId: 'C123',
+            linearEnabled: false,
+            linearTeamId: null,
+            linearProjectId: null,
         });
         expect(getSettings).toHaveBeenCalledWith(ORGANIZATION_UUID);
     });
@@ -1371,6 +1384,9 @@ describe('AiAgentAdminService review notification settings', () => {
             service.updateReviewNotificationSettings(makeDeveloperUser(), {
                 enabled: true,
                 slackChannelId: 'C123',
+                linearEnabled: false,
+                linearTeamId: null,
+                linearProjectId: null,
             }),
         ).rejects.toThrow(
             'Insufficient permissions to access organization-wide AI agent data',
@@ -1385,6 +1401,9 @@ describe('AiAgentAdminService review notification settings', () => {
         await service.updateReviewNotificationSettings(makeAdminUser(), {
             enabled: true,
             slackChannelId: 'C123',
+            linearEnabled: false,
+            linearTeamId: null,
+            linearProjectId: null,
         });
 
         expect(joinChannels).toHaveBeenCalledWith(ORGANIZATION_UUID, ['C123']);
@@ -1399,6 +1418,9 @@ describe('AiAgentAdminService review notification settings', () => {
                     organizationUuid: ORGANIZATION_UUID,
                     enabled: false,
                     slackChannelId: 'C123',
+                    linearEnabled: false,
+                    linearTeamId: null,
+                    linearProjectId: null,
                 }),
             },
         });
@@ -1406,9 +1428,26 @@ describe('AiAgentAdminService review notification settings', () => {
         await service.updateReviewNotificationSettings(makeAdminUser(), {
             enabled: false,
             slackChannelId: 'C123',
+            linearEnabled: false,
+            linearTeamId: null,
+            linearProjectId: null,
         });
 
         expect(joinChannels).not.toHaveBeenCalled();
+    });
+
+    it('requires a Linear team when Linear issue creation is enabled', async () => {
+        const service = makeService();
+
+        await expect(
+            service.updateReviewNotificationSettings(makeAdminUser(), {
+                enabled: false,
+                slackChannelId: null,
+                linearEnabled: true,
+                linearTeamId: null,
+                linearProjectId: null,
+            }),
+        ).rejects.toThrow('A Linear team is required to create review issues');
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -1436,6 +1436,44 @@ describe('AiAgentAdminService review notification settings', () => {
         expect(joinChannels).not.toHaveBeenCalled();
     });
 
+    it('preserves Linear settings for legacy update requests', async () => {
+        const upsertSettings = vi.fn().mockResolvedValue({
+            organizationUuid: ORGANIZATION_UUID,
+            enabled: true,
+            slackChannelId: 'C123',
+            linearEnabled: true,
+            linearTeamId: 'team-1',
+            linearProjectId: 'project-1',
+        });
+        const service = makeService({
+            aiAgentReviewNotificationModel: {
+                getSettings: vi.fn().mockResolvedValue({
+                    organizationUuid: ORGANIZATION_UUID,
+                    enabled: false,
+                    slackChannelId: null,
+                    linearEnabled: true,
+                    linearTeamId: 'team-1',
+                    linearProjectId: 'project-1',
+                }),
+                upsertSettings,
+            },
+        });
+
+        await service.updateReviewNotificationSettings(makeAdminUser(), {
+            enabled: true,
+            slackChannelId: 'C123',
+        });
+
+        expect(upsertSettings).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            enabled: true,
+            slackChannelId: 'C123',
+            linearEnabled: true,
+            linearTeamId: 'team-1',
+            linearProjectId: 'project-1',
+        });
+    });
+
     it('requires a Linear team when Linear issue creation is enabled', async () => {
         const service = makeService();
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -1039,6 +1039,12 @@ export class AiAgentAdminService extends BaseService {
         }
         this.checkOrganizationAdminAccess(user);
 
+        if (settings.linearEnabled && !settings.linearTeamId) {
+            throw new ParameterError(
+                'A Linear team is required to create review issues',
+            );
+        }
+
         const updated =
             await this.aiAgentReviewNotificationModel.upsertSettings({
                 organizationUuid,
@@ -1232,6 +1238,16 @@ export class AiAgentAdminService extends BaseService {
                 priority: item.priority,
             },
         });
+
+        if (item.projectUuid) {
+            await this.aiAgentReviewNotificationService.createLinearIssues({
+                organizationUuid,
+                projectUuid: item.projectUuid,
+                fingerprints: [item.fingerprint],
+                reviewRunUuid: null,
+                userUuid: user.userUuid,
+            });
+        }
 
         return item;
     }

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -1039,17 +1039,25 @@ export class AiAgentAdminService extends BaseService {
         }
         this.checkOrganizationAdminAccess(user);
 
-        if (settings.linearEnabled && !settings.linearTeamId) {
+        const currentSettings =
+            await this.aiAgentReviewNotificationModel.getSettings(
+                organizationUuid,
+            );
+        const updatedSettings = {
+            ...currentSettings,
+            ...settings,
+        };
+
+        if (updatedSettings.linearEnabled && !updatedSettings.linearTeamId) {
             throw new ParameterError(
                 'A Linear team is required to create review issues',
             );
         }
 
         const updated =
-            await this.aiAgentReviewNotificationModel.upsertSettings({
-                organizationUuid,
-                ...settings,
-            });
+            await this.aiAgentReviewNotificationModel.upsertSettings(
+                updatedSettings,
+            );
 
         // Slack rejects chat.postMessage with not_in_channel unless the app is
         // a member, so join on save the same way scheduled deliveries do.

--- a/packages/backend/src/ee/services/AiAgentReviewNotificationService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewNotificationService.test.ts
@@ -113,4 +113,31 @@ describe('AiAgentReviewNotificationService', () => {
             }),
         );
     });
+
+    it('enqueues Slack and Linear tasks for new review findings', async () => {
+        const { service, schedulerClient } = makeService();
+
+        await service.notifyNeedsReview({
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            reviewRunUuid: 'run-1',
+            fingerprints: ['fingerprint-1'],
+        });
+
+        expect(schedulerClient.scheduleTask).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION,
+            expect.objectContaining({
+                event: AiReviewNotificationEvent.NeedsReview,
+                fingerprints: ['fingerprint-1'],
+            }),
+        );
+        expect(schedulerClient.scheduleTask).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE,
+            expect.objectContaining({
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+                fingerprints: ['fingerprint-1'],
+            }),
+        );
+    });
 });

--- a/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
@@ -180,5 +180,35 @@ export class AiAgentReviewNotificationService {
                 reviewRunUuid: args.reviewRunUuid,
             },
         );
+
+        await this.createLinearIssues({
+            organizationUuid: args.organizationUuid,
+            projectUuid: args.projectUuid,
+            fingerprints: args.fingerprints,
+            reviewRunUuid: args.reviewRunUuid,
+        });
+    }
+
+    async createLinearIssues(args: {
+        organizationUuid: string;
+        projectUuid: string;
+        fingerprints: string[];
+        reviewRunUuid: string | null;
+        userUuid?: string;
+    }): Promise<void> {
+        if (args.fingerprints.length === 0) {
+            return;
+        }
+
+        await this.schedulerClient.scheduleTask(
+            EE_SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE,
+            {
+                organizationUuid: args.organizationUuid,
+                projectUuid: args.projectUuid,
+                fingerprints: args.fingerprints,
+                reviewRunUuid: args.reviewRunUuid,
+                userUuid: args.userUuid,
+            },
+        );
     }
 }

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -216,6 +216,12 @@ const getTagsForTask: {
         'user.uuid': payload.userUuid ?? '',
     }),
 
+    [SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'user.uuid': payload.userUuid ?? '',
+    }),
+
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/common/src/ee/types/aiReviewNotification.ts
+++ b/packages/common/src/ee/types/aiReviewNotification.ts
@@ -22,11 +22,14 @@ export type AiReviewNotificationSettings = {
     organizationUuid: string;
     enabled: boolean;
     slackChannelId: string | null;
+    linearEnabled: boolean;
+    linearTeamId: string | null;
+    linearProjectId: string | null;
 };
 
 export type UpdateAiReviewNotificationSettings = Pick<
     AiReviewNotificationSettings,
-    'enabled' | 'slackChannelId'
+    'enabled' | 'slackChannelId' | 'linearEnabled' | 'linearTeamId' | 'linearProjectId'
 >;
 
 export type ApiAiReviewNotificationSettingsResponse =

--- a/packages/common/src/ee/types/aiReviewNotification.ts
+++ b/packages/common/src/ee/types/aiReviewNotification.ts
@@ -27,16 +27,13 @@ export type AiReviewNotificationSettings = {
     linearProjectId: string | null;
 };
 
-export type UpdateAiReviewNotificationSettings = Pick<
-    AiReviewNotificationSettings,
-    'enabled' | 'slackChannelId'
-> &
-    Partial<
-        Pick<
-            AiReviewNotificationSettings,
-            'linearEnabled' | 'linearTeamId' | 'linearProjectId'
-        >
-    >;
+export type UpdateAiReviewNotificationSettings = {
+    enabled: boolean;
+    slackChannelId: string | null;
+    linearEnabled?: boolean;
+    linearTeamId?: string | null;
+    linearProjectId?: string | null;
+};
 
 export type ApiAiReviewNotificationSettingsResponse =
     ApiSuccess<AiReviewNotificationSettings>;

--- a/packages/common/src/ee/types/aiReviewNotification.ts
+++ b/packages/common/src/ee/types/aiReviewNotification.ts
@@ -29,8 +29,14 @@ export type AiReviewNotificationSettings = {
 
 export type UpdateAiReviewNotificationSettings = Pick<
     AiReviewNotificationSettings,
-    'enabled' | 'slackChannelId' | 'linearEnabled' | 'linearTeamId' | 'linearProjectId'
->;
+    'enabled' | 'slackChannelId'
+> &
+    Partial<
+        Pick<
+            AiReviewNotificationSettings,
+            'linearEnabled' | 'linearTeamId' | 'linearProjectId'
+        >
+    >;
 
 export type ApiAiReviewNotificationSettingsResponse =
     ApiSuccess<AiReviewNotificationSettings>;

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -955,3 +955,12 @@ export type SendReviewNotificationPayload = {
     schedulerUuid?: string;
     userUuid?: string;
 };
+
+export type CreateReviewLinearIssuePayload = {
+    organizationUuid: string;
+    projectUuid: string;
+    fingerprints: string[];
+    reviewRunUuid: string | null;
+    schedulerUuid?: string;
+    userUuid?: string;
+};

--- a/packages/common/src/types/schedulerTaskList.test.ts
+++ b/packages/common/src/types/schedulerTaskList.test.ts
@@ -6,6 +6,12 @@ test('SEND_REVIEW_NOTIFICATION task is registered', () => {
     );
 });
 
+test('CREATE_REVIEW_LINEAR_ISSUE task is registered', () => {
+    expect(EE_SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE).toBe(
+        'createReviewLinearIssue',
+    );
+});
+
 test('AI_DEEP_RESEARCH tasks are registered', () => {
     expect(EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH).toBe('aiDeepResearch');
     expect(EE_SCHEDULER_TASKS.SWEEP_STALE_AI_DEEP_RESEARCH_RUNS).toBe(

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -44,6 +44,7 @@ import {
     type ReplaceCustomFieldsPayload,
     type ScheduledDeliveryPayload,
     type SchedulerCreateProjectWithCompilePayload,
+    type CreateReviewLinearIssuePayload,
     type SendReviewNotificationPayload,
     type SlackBatchNotificationPayload,
     type SlackNotificationPayload,
@@ -163,6 +164,7 @@ export const EE_SCHEDULER_TASKS = {
     AI_AGENT_REVIEW_REMEDIATION_COMPILE: 'aiAgentReviewRemediationCompile',
     AI_AGENT_REVIEW_REMEDIATION_RUN: 'aiAgentReviewRemediationRun',
     SEND_REVIEW_NOTIFICATION: 'sendReviewNotification',
+    CREATE_REVIEW_LINEAR_ISSUE: 'createReviewLinearIssue',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
@@ -283,6 +285,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: AiAgentReviewRemediationCompileJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
     [SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: SendReviewNotificationPayload;
+    [SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: CreateReviewLinearIssuePayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
@@ -317,6 +320,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: AiAgentReviewRemediationCompileJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
     [EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: SendReviewNotificationPayload;
+    [EE_SCHEDULER_TASKS.CREATE_REVIEW_LINEAR_ISSUE]: CreateReviewLinearIssuePayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -27,6 +27,7 @@ import { type RenameResourcesPayload } from './rename';
 import {
     type BackfillDefaultUserSpacesPayload,
     type CompileProjectPayload,
+    type CreateReviewLinearIssuePayload,
     type DownloadAsyncQueryResultsPayload,
     type EmailBatchNotificationPayload,
     type EmailNotificationPayload,
@@ -44,7 +45,6 @@ import {
     type ReplaceCustomFieldsPayload,
     type ScheduledDeliveryPayload,
     type SchedulerCreateProjectWithCompilePayload,
-    type CreateReviewLinearIssuePayload,
     type SendReviewNotificationPayload,
     type SlackBatchNotificationPayload,
     type SlackNotificationPayload,

--- a/packages/frontend/src/components/common/LinearIntegration/hooks/useLinearIntegration.tsx
+++ b/packages/frontend/src/components/common/LinearIntegration/hooks/useLinearIntegration.tsx
@@ -1,6 +1,7 @@
 import {
     type ApiError,
     type LinearInstallation,
+    type LinearProject,
     type LinearTeam,
 } from '@lightdash/common'; // pragma: allowlist secret
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -9,6 +10,7 @@ import useToaster from '../../../../hooks/toaster/useToaster';
 
 const LINEAR_INSTALLATION_QUERY_KEY = ['linear_installation'];
 const LINEAR_TEAMS_QUERY_KEY = ['linear_teams'];
+const LINEAR_PROJECTS_QUERY_KEY = ['linear_projects'];
 
 const getLinearInstallation = async (): Promise<LinearInstallation> =>
     lightdashApi<LinearInstallation>({
@@ -64,6 +66,37 @@ export const useLinearTeams = (options?: { enabled?: boolean }) => {
     });
 };
 
+const getLinearProjects = async (teamId: string): Promise<LinearProject[]> =>
+    lightdashApi<LinearProject[]>({
+        // pragma: allowlist secret
+        url: `/linear/projects?teamId=${encodeURIComponent(teamId)}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useLinearProjects = (options: {
+    enabled?: boolean;
+    teamId: string | null;
+}) => {
+    const { showToastApiError } = useToaster();
+    const { teamId } = options;
+
+    return useQuery<LinearProject[], ApiError>({
+        queryKey: [...LINEAR_PROJECTS_QUERY_KEY, teamId],
+        queryFn: () => getLinearProjects(teamId!),
+        retry: false,
+        enabled: !!teamId && (options.enabled ?? true),
+        onError: ({ error }) => {
+            if (error.statusCode === 404 || error.statusCode === 401) return;
+
+            showToastApiError({
+                title: 'Failed to get Linear projects',
+                apiError: error,
+            });
+        },
+    });
+};
+
 const deleteLinearInstallation = async (): Promise<void> =>
     lightdashApi<undefined>({
         // pragma: allowlist secret
@@ -81,6 +114,7 @@ export const useDeleteLinearInstallationMutation = () => {
         onSuccess: async () => {
             await queryClient.invalidateQueries(LINEAR_INSTALLATION_QUERY_KEY);
             await queryClient.invalidateQueries(LINEAR_TEAMS_QUERY_KEY);
+            await queryClient.invalidateQueries(LINEAR_PROJECTS_QUERY_KEY);
             showToastSuccess({
                 title: 'Success! Linear integration was deleted.',
             });

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ReviewNotificationsSettings.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ReviewNotificationsSettings.tsx
@@ -1,14 +1,24 @@
 import {
+    Anchor,
     Box,
     Divider,
     Group,
     Loader,
+    Select,
+    Stack,
     Switch,
     Text,
     Title,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { Link } from 'react-router';
 import { SlackChannelSelect } from '../../../../../../components/common/SlackChannelSelect';
+import {
+    useLinearInstallation,
+    useLinearProjects,
+    useLinearTeams,
+} from '../../../../../../components/common/LinearIntegration/hooks/useLinearIntegration';
 import { useGetSlack } from '../../../../../../hooks/slack/useSlack';
+import useHealth from '../../../../../../hooks/health/useHealth';
 import useApp from '../../../../../../providers/App/useApp';
 import {
     useReviewNotificationSettings,
@@ -16,74 +26,232 @@ import {
 } from '../../../hooks/useReviewNotificationSettings';
 
 /**
- * Slack channel notifications for AI review runs. Rendered inside the
- * "Review AI agent turns" card, only when reviews are enabled and the org has
- * a Slack integration. The in-app bell + assignment DMs fire independently.
+ * Slack and Linear destinations for AI review runs. Rendered inside the
+ * "Review AI agent turns" card when reviews are enabled.
  */
 export const ReviewNotificationsSettings = () => {
     const { user } = useApp();
     const canEdit = user.data?.ability?.can('manage', 'Organization') ?? false;
+    const { data: health } = useHealth();
+    const hasLinearConfig = !!health?.hasLinear;
 
     const { data: slackInstallation } = useGetSlack();
     const hasSlack = !!slackInstallation?.organizationUuid;
+
+    const linearInstallationQuery = useLinearInstallation({
+        enabled: hasLinearConfig,
+    });
+    const hasLinear = !!linearInstallationQuery.data;
+    const { data: linearTeams, isInitialLoading: isLinearTeamsLoading } =
+        useLinearTeams({
+            enabled: hasLinear,
+        });
 
     const { data: settings, isInitialLoading } =
         useReviewNotificationSettings();
     const { mutate: updateSettings, isLoading: isUpdating } =
         useUpdateReviewNotificationSettings();
+    const { data: linearProjects, isInitialLoading: isLinearProjectsLoading } =
+        useLinearProjects({
+            enabled: hasLinear && !!settings?.linearTeamId,
+            teamId: settings?.linearTeamId ?? undefined,
+        });
 
-    if (!hasSlack) {
+    if (!hasSlack && !hasLinearConfig) {
         return null;
     }
 
     return (
         <>
-            <Divider mx="calc(var(--mantine-spacing-md) * -1)" />
-            <Group
-                justify="space-between"
-                wrap="nowrap"
-                align="flex-start"
-                gap="md"
-            >
-                <Box maw={620}>
-                    <Title order={6} mb={4}>
-                        Slack notifications
-                    </Title>
-                    <Text c="dimmed" fz="xs">
-                        Post to a Slack channel when a review run surfaces
-                        findings that need review. Assignment notifications are
-                        always sent as a direct message and in the in-app bell,
-                        regardless of this setting.
-                    </Text>
-                </Box>
-                {isInitialLoading || !settings ? (
-                    <Loader size="sm" />
-                ) : (
-                    <Switch
-                        size="md"
-                        checked={settings.enabled}
-                        disabled={!canEdit || isUpdating}
-                        onChange={(event) =>
-                            updateSettings({
-                                enabled: event.currentTarget.checked,
-                                slackChannelId: settings.slackChannelId,
-                            })
-                        }
-                    />
-                )}
-            </Group>
+            {hasSlack && (
+                <>
+                    <Divider mx="calc(var(--mantine-spacing-md) * -1)" />
+                    <Group
+                        justify="space-between"
+                        wrap="nowrap"
+                        align="flex-start"
+                        gap="md"
+                    >
+                        <Box maw={620}>
+                            <Title order={6} mb={4}>
+                                Slack notifications
+                            </Title>
+                            <Text c="dimmed" fz="xs">
+                                Post to a Slack channel when a review run
+                                surfaces findings that need review. Assignment
+                                notifications are always sent as a direct
+                                message and in the in-app bell, regardless of
+                                this setting.
+                            </Text>
+                        </Box>
+                        {isInitialLoading || !settings ? (
+                            <Loader size="sm" />
+                        ) : (
+                            <Switch
+                                size="md"
+                                checked={settings.enabled}
+                                disabled={!canEdit || isUpdating}
+                                onChange={(event) =>
+                                    updateSettings({
+                                        enabled: event.currentTarget.checked,
+                                        slackChannelId:
+                                            settings.slackChannelId,
+                                        linearEnabled: settings.linearEnabled,
+                                        linearTeamId: settings.linearTeamId,
+                                        linearProjectId:
+                                            settings.linearProjectId,
+                                    })
+                                }
+                            />
+                        )}
+                    </Group>
 
-            {settings?.enabled && (
-                <SlackChannelSelect
-                    label="Slack channel"
-                    value={settings.slackChannelId}
-                    disabled={!canEdit || isUpdating}
-                    withRefresh
-                    placeholder="Select a channel"
-                    onChange={(slackChannelId) =>
-                        updateSettings({ enabled: true, slackChannelId })
-                    }
-                />
+                    {settings?.enabled && (
+                        <SlackChannelSelect
+                            label="Slack channel"
+                            value={settings.slackChannelId}
+                            disabled={!canEdit || isUpdating}
+                            withRefresh
+                            placeholder="Select a channel"
+                            onChange={(slackChannelId) =>
+                                updateSettings({
+                                    enabled: true,
+                                    slackChannelId,
+                                    linearEnabled: settings.linearEnabled,
+                                    linearTeamId: settings.linearTeamId,
+                                    linearProjectId: settings.linearProjectId,
+                                })
+                            }
+                        />
+                    )}
+                </>
+            )}
+
+            {hasLinearConfig && (
+                <>
+                    <Divider mx="calc(var(--mantine-spacing-md) * -1)" />
+                    <Group
+                        justify="space-between"
+                        wrap="nowrap"
+                        align="flex-start"
+                        gap="md"
+                    >
+                        <Box maw={620}>
+                            <Title order={6} mb={4}>
+                                Linear issues
+                            </Title>
+                            <Text c="dimmed" fz="xs">
+                                Create a Linear issue when a review run
+                                surfaces a new finding. Choose a team and
+                                optionally a project.
+                            </Text>
+                            {!hasLinear && !linearInstallationQuery.isInitialLoading && (
+                                <Text c="dimmed" fz="xs" mt="xs">
+                                    Connect Linear in{' '}
+                                    <Anchor
+                                        component={Link}
+                                        to="/generalSettings/integrations"
+                                    >
+                                        Integrations
+                                    </Anchor>{' '}
+                                    to send new issues there.
+                                </Text>
+                            )}
+                        </Box>
+                        {isInitialLoading ||
+                        !settings ||
+                        linearInstallationQuery.isInitialLoading ? (
+                            <Loader size="sm" />
+                        ) : (
+                            <Switch
+                                size="md"
+                                checked={settings.linearEnabled}
+                                disabled={
+                                    !canEdit ||
+                                    isUpdating ||
+                                    !hasLinear ||
+                                    (!settings.linearTeamId &&
+                                        !settings.linearEnabled)
+                                }
+                                onChange={(event) =>
+                                    updateSettings({
+                                        enabled: settings.enabled,
+                                        slackChannelId:
+                                            settings.slackChannelId,
+                                        linearEnabled:
+                                            event.currentTarget.checked,
+                                        linearTeamId: settings.linearTeamId,
+                                        linearProjectId:
+                                            settings.linearProjectId,
+                                    })
+                                }
+                            />
+                        )}
+                    </Group>
+
+                    {hasLinear && settings && (
+                        <Stack gap="sm">
+                            <Select
+                                label="Linear team"
+                                placeholder={
+                                    isLinearTeamsLoading
+                                        ? 'Loading teams'
+                                        : 'Select a team'
+                                }
+                                data={(linearTeams ?? []).map((team) => ({
+                                    value: team.id,
+                                    label: `${team.name} (${team.key})`,
+                                }))}
+                                value={settings.linearTeamId}
+                                disabled={
+                                    !canEdit ||
+                                    isUpdating ||
+                                    isLinearTeamsLoading
+                                }
+                                onChange={(linearTeamId) =>
+                                    updateSettings({
+                                        enabled: settings.enabled,
+                                        slackChannelId:
+                                            settings.slackChannelId,
+                                        linearEnabled: true,
+                                        linearTeamId,
+                                        linearProjectId: null,
+                                    })
+                                }
+                            />
+                            <Select
+                                label="Linear project"
+                                placeholder={
+                                    isLinearProjectsLoading
+                                        ? 'Loading projects'
+                                        : 'Optional project'
+                                }
+                                data={(linearProjects ?? []).map((project) => ({
+                                    value: project.id,
+                                    label: project.name,
+                                }))}
+                                value={settings.linearProjectId}
+                                disabled={
+                                    !canEdit ||
+                                    isUpdating ||
+                                    !settings.linearTeamId ||
+                                    isLinearProjectsLoading
+                                }
+                                clearable
+                                onChange={(linearProjectId) =>
+                                    updateSettings({
+                                        enabled: settings.enabled,
+                                        slackChannelId:
+                                            settings.slackChannelId,
+                                        linearEnabled: true,
+                                        linearTeamId: settings.linearTeamId,
+                                        linearProjectId,
+                                    })
+                                }
+                            />
+                        </Stack>
+                    )}
+                </>
             )}
         </>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ReviewNotificationsSettings.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ReviewNotificationsSettings.tsx
@@ -11,14 +11,14 @@ import {
     Title,
 } from '@mantine/core';
 import { Link } from 'react-router';
-import { SlackChannelSelect } from '../../../../../../components/common/SlackChannelSelect';
 import {
     useLinearInstallation,
     useLinearProjects,
     useLinearTeams,
 } from '../../../../../../components/common/LinearIntegration/hooks/useLinearIntegration';
-import { useGetSlack } from '../../../../../../hooks/slack/useSlack';
+import { SlackChannelSelect } from '../../../../../../components/common/SlackChannelSelect';
 import useHealth from '../../../../../../hooks/health/useHealth';
+import { useGetSlack } from '../../../../../../hooks/slack/useSlack';
 import useApp from '../../../../../../providers/App/useApp';
 import {
     useReviewNotificationSettings,
@@ -94,8 +94,7 @@ export const ReviewNotificationsSettings = () => {
                                 onChange={(event) =>
                                     updateSettings({
                                         enabled: event.currentTarget.checked,
-                                        slackChannelId:
-                                            settings.slackChannelId,
+                                        slackChannelId: settings.slackChannelId,
                                         linearEnabled: settings.linearEnabled,
                                         linearTeamId: settings.linearTeamId,
                                         linearProjectId:
@@ -141,22 +140,23 @@ export const ReviewNotificationsSettings = () => {
                                 Linear issues
                             </Title>
                             <Text c="dimmed" fz="xs">
-                                Create a Linear issue when a review run
-                                surfaces a new finding. Choose a team and
-                                optionally a project.
+                                Create a Linear issue when a review run surfaces
+                                a new finding. Choose a team and optionally a
+                                project.
                             </Text>
-                            {!hasLinear && !linearInstallationQuery.isInitialLoading && (
-                                <Text c="dimmed" fz="xs" mt="xs">
-                                    Connect Linear in{' '}
-                                    <Anchor
-                                        component={Link}
-                                        to="/generalSettings/integrations"
-                                    >
-                                        Integrations
-                                    </Anchor>{' '}
-                                    to send new issues there.
-                                </Text>
-                            )}
+                            {!hasLinear &&
+                                !linearInstallationQuery.isInitialLoading && (
+                                    <Text c="dimmed" fz="xs" mt="xs">
+                                        Connect Linear in{' '}
+                                        <Anchor
+                                            component={Link}
+                                            to="/generalSettings/integrations"
+                                        >
+                                            Integrations
+                                        </Anchor>{' '}
+                                        to send new issues there.
+                                    </Text>
+                                )}
                         </Box>
                         {isInitialLoading ||
                         !settings ||
@@ -176,8 +176,7 @@ export const ReviewNotificationsSettings = () => {
                                 onChange={(event) =>
                                     updateSettings({
                                         enabled: settings.enabled,
-                                        slackChannelId:
-                                            settings.slackChannelId,
+                                        slackChannelId: settings.slackChannelId,
                                         linearEnabled:
                                             event.currentTarget.checked,
                                         linearTeamId: settings.linearTeamId,
@@ -211,8 +210,7 @@ export const ReviewNotificationsSettings = () => {
                                 onChange={(linearTeamId) =>
                                     updateSettings({
                                         enabled: settings.enabled,
-                                        slackChannelId:
-                                            settings.slackChannelId,
+                                        slackChannelId: settings.slackChannelId,
                                         linearEnabled: true,
                                         linearTeamId,
                                         linearProjectId: null,
@@ -241,8 +239,7 @@ export const ReviewNotificationsSettings = () => {
                                 onChange={(linearProjectId) =>
                                     updateSettings({
                                         enabled: settings.enabled,
-                                        slackChannelId:
-                                            settings.slackChannelId,
+                                        slackChannelId: settings.slackChannelId,
                                         linearEnabled: true,
                                         linearTeamId: settings.linearTeamId,
                                         linearProjectId,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ReviewNotificationsSettings.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ReviewNotificationsSettings.tsx
@@ -9,7 +9,7 @@ import {
     Switch,
     Text,
     Title,
-} from '@mantine-8/core';
+} from '@mantine/core';
 import { Link } from 'react-router';
 import { SlackChannelSelect } from '../../../../../../components/common/SlackChannelSelect';
 import {
@@ -53,8 +53,8 @@ export const ReviewNotificationsSettings = () => {
         useUpdateReviewNotificationSettings();
     const { data: linearProjects, isInitialLoading: isLinearProjectsLoading } =
         useLinearProjects({
-            enabled: hasLinear && !!settings?.linearTeamId,
-            teamId: settings?.linearTeamId ?? undefined,
+            enabled: hasLinear,
+            teamId: settings?.linearTeamId ?? null,
         });
 
     if (!hasSlack && !hasLinearConfig) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No ticket yet — started from an internal product request to send AI review findings to Linear. Add `Closes:` / `Relates:` once a GitHub issue or Linear ticket exists.

This is the top of a Graphite stack. It depends on the Linear OAuth integration PR.

### Description:
Lets Ask AI admins send newly classified review findings to Linear.

- Review notification settings include a Linear team (required) and optional project, next to the existing Slack channel.
- The classifier and manual review-item creation schedule a background job that creates a Linear issue for new items only, then stores the issue URL on `linked_issue_url`.
- Recurrences and items that already have a linked issue are skipped.

### Changes since the previous revision

Rebased onto the updated OAuth branch, plus three cleanup commits.

- **`fix: trace the Linear issue scheduler task`** — backend typecheck failed because the new task had no entry in the `SchedulerTaskTracer` tag map, so its errors would also not have been filterable in Sentry. Payload import ordering restored.
- **`fix: retry Linear issue creation after a failure`** — the task logged and swallowed every per-item error, so a Linear outage silently dropped findings while the job still reported success. It now fails the job; items that succeeded already carry a `linked_issue_url` and are skipped on retry. The loop also used `continue` and un-annotated `await`-in-loop, which failed backend lint.
- **`refactor: follow the team-scoped Linear project hook`** — imports Mantine from the workspace package (the settings component previously used an unresolvable path, which broke the frontend dependency scan) and lets the project hook gate itself on the selected team.

### Testing
`typecheck` and `lint` pass for `common`, `backend`, and `frontend`; 117 tests pass across the Linear and AI-review suites. A new test covers the retry-on-failure path.

### Known follow-ups (not in this PR)
- The reviews board never surfaces `linked_issue_url`, so admins cannot see that a finding already became an issue.
- Selecting a team implicitly enables the toggle, which is the inverse of the Slack channel interaction.
- Manual review items without a `projectUuid` skip Linear with no indication in the UI.

### Risk assessment:
- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lightdash.slack.com/archives/C0BC1LFAH35/p1787605953459929?thread_ts=1787605953.459929&cid=C0BC1LFAH35)

<div><a href="https://cursor.com/agents/bc-c0b81f2d-346b-572e-b1a4-2d841c62e438?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0b81f2d-346b-572e-b1a4-2d841c62e438&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

