### PR TITLE
fix(pgwire): log pre-auth connection failures with peer address

### DIFF
--- a/packages/backend/src/ee/postgresWire/PostgresWireServer.test.ts
+++ b/packages/backend/src/ee/postgresWire/PostgresWireServer.test.ts
@@ -4,7 +4,8 @@ import * as os from 'os';
 import * as path from 'path';
 import { Client, type QueryConfig } from 'pg';
 import * as tls from 'tls';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Logger from '../../logging/logger';
 import {
     PgWireServerError,
     PostgresWireServer,
@@ -395,6 +396,51 @@ describe('PostgresWireServer TLS', () => {
         expect(errorCode(message.payload)).toBe('28000');
         await reader.waitForClose();
         expect(reader.isClosed).toBe(true);
+    });
+
+    it('logs rejected plaintext startups with the peer address', async () => {
+        const info = vi.spyOn(Logger, 'info');
+        try {
+            const port = await startServer({
+                tls: { certPath: CERT_A, keyPath: KEY_A },
+            });
+            const socket = track(await connect(port));
+            const reader = new MessageReader(socket);
+            socket.write(startupMessage({ user: 'alice', database: 'db' }));
+            await reader.readMessage();
+            expect(info).toHaveBeenCalledWith(
+                expect.stringMatching(
+                    /pgwire: rejected plaintext startup from \S+: client did not request TLS/,
+                ),
+            );
+        } finally {
+            info.mockRestore();
+        }
+    });
+
+    it('logs a failed TLS handshake with the peer address', async () => {
+        const info = vi.spyOn(Logger, 'info');
+        try {
+            const port = await startServer({
+                tls: { certPath: CERT_A, keyPath: KEY_A },
+            });
+            const socket = track(await connect(port));
+            const rawReader = new MessageReader(socket);
+            socket.write(sslRequest());
+            expect(await rawReader.readByte()).toBe('S');
+
+            // not a TLS ClientHello: the server-side handshake fails
+            socket.write(Buffer.from('definitely not a tls handshake'));
+            await vi.waitFor(() => {
+                expect(info).toHaveBeenCalledWith(
+                    expect.stringMatching(
+                        /pgwire: TLS handshake failed from \S+: /,
+                    ),
+                );
+            });
+        } finally {
+            info.mockRestore();
+        }
     });
 
     it('upgrades on SSLRequest and authenticates over TLS', async () => {

--- a/packages/backend/src/ee/postgresWire/PostgresWireServer.ts
+++ b/packages/backend/src/ee/postgresWire/PostgresWireServer.ts
@@ -304,6 +304,8 @@ class PgWireConnection<TSession> {
     /** true once the socket has been upgraded to TLS */
     private isSecure = false;
 
+    private tlsHandshakeDone = false;
+
     private statements = new Map<string, PreparedStatement>();
 
     private portals = new Map<string, Portal>();
@@ -323,7 +325,7 @@ class PgWireConnection<TSession> {
             this.drainBuffer();
         } catch (e) {
             Logger.warn(
-                `pgwire: closing connection after protocol error: ${
+                `pgwire: closing connection from ${this.peerAddress} after protocol error: ${
                     e instanceof Error ? e.message : e
                 }`,
             );
@@ -331,12 +333,16 @@ class PgWireConnection<TSession> {
         }
     };
 
+    /** captured at accept time: remoteAddress is undefined once the socket closes */
+    private readonly peerAddress: string;
+
     constructor(
         socket: net.Socket,
         private handlers: PgWireHandlers<TSession>,
         private secureContextProvider: SecureContextProvider | null,
     ) {
         this.socket = socket;
+        this.peerAddress = socket.remoteAddress ?? 'unknown';
         this.attachSocket(socket);
     }
 
@@ -344,7 +350,18 @@ class PgWireConnection<TSession> {
         this.socket = socket;
         socket.on('data', this.onData);
         socket.on('error', (e) => {
-            Logger.debug(`pgwire: socket error: ${e.message}`);
+            // a failed TLS handshake is a client-compatibility signal
+            // (wrong trust store, TLS version, direct-TLS client); routine
+            // disconnects on established connections stay at debug
+            if (this.isSecure && !this.tlsHandshakeDone) {
+                Logger.info(
+                    `pgwire: TLS handshake failed from ${this.peerAddress}: ${e.message}`,
+                );
+            } else {
+                Logger.debug(
+                    `pgwire: socket error from ${this.peerAddress}: ${e.message}`,
+                );
+            }
         });
     }
 
@@ -364,6 +381,9 @@ class PgWireConnection<TSession> {
             secureContext: provider.get(),
         });
         this.isSecure = true;
+        secureSocket.once('secure', () => {
+            this.tlsHandshakeDone = true;
+        });
         this.attachSocket(secureSocket);
     }
 
@@ -412,6 +432,9 @@ class PgWireConnection<TSession> {
                         // Reject before AuthenticationCleartextPassword is ever
                         // sent, so no client is prompted for credentials over
                         // an unencrypted connection.
+                        Logger.info(
+                            `pgwire: rejected plaintext startup from ${this.peerAddress}: client did not request TLS`,
+                        );
                         this.socket.write(
                             errorResponse(
                                 new PgWireServerError(


### PR DESCRIPTION
## Summary

A BI tool that connects to the Metrics SQL API without TLS, or fails the TLS handshake, gets rejected with **zero visible server logs** — which makes a client-side misconfiguration indistinguishable from "no traffic ever reached us" and sends debugging down the wrong path (a real customer investigation concluded "network issue" when the client was simply sending a plaintext startup).

## Root cause

Two pre-auth paths were silent in production:

```
Client                          Server                     Logged?
──────────────────────────────  ─────────────────────────  ─────────────────
plaintext StartupMessage        ErrorResponse 28000,       nothing
  (TLS required)                  socket.end()
SSLRequest → bad TLS handshake  socket error event         debug only
established conn, proto error   warn                       yes (no peer IP)
```

## How it works

- Rejected plaintext startups log at info: `pgwire: rejected plaintext startup from <ip>: client did not request TLS`
- TLS handshake failures (tracked via the TLS socket's `secure` event) log at info with the peer address and OpenSSL reason; socket errors on established connections stay at debug
- The existing protocol-error warn now includes the peer address
- Peer address is captured at accept time (`remoteAddress` is undefined once the socket closes)

No behavior change on the wire — log lines only.

## Test plan

- 2 new raw-socket tests assert both log lines (spying on the logger); all 36 PostgresWireServer tests and the full postgresWire suite pass; typecheck + lint clean
- Verified on a running instance: plaintext startup and garbage-TLS probes produce both info lines with the peer IP, a normal `psql sslmode=require` session produces neither, and `SELECT 1` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)