### PR TITLE
chore(cursor): enable pstack plugin for this repository

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,5 @@
+{
+	"plugins": {
+		"pstack": { "enabled": true }
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No GitHub issue or Linear ticket was attached to this request.

### Description:

Enable the pstack Cursor plugin for this repository.

`.cursor/settings.json` turns pstack on at project scope so agents in this checkout load `poteto-mode` and the rest of the pstack skills without a per-user marketplace install.

This session already has pstack 0.14.3 loaded (44 skills, poteto-agent + Comment Sicko). After merge, a new chat in the repo should see the same set.

Next step after this lands: run `/setup-pstack` to pick models per role. That writes a user-level rule, not this file.

### Risk assessment:

- [ ] This is a high-risk change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-975fa2c5-87da-42d3-a4a7-4bd03168d957?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-975fa2c5-87da-42d3-a4a7-4bd03168d957&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

