### PR TITLE
fix(filters): suggest values for hidden joined dimensions

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -564,6 +564,30 @@ describe('ProjectModel', () => {
         });
     });
 
+    describe('findExploreContainingTable', () => {
+        test('returns an explore containing a joined-only table', async () => {
+            tracker.on
+                .select(
+                    queryMatcher(CachedExploreTableName, [
+                        'orders',
+                        'orders',
+                        projectUuid,
+                        1,
+                    ]),
+                )
+                .response([
+                    {
+                        explore: exploreWithMetricFilters,
+                        baseMatch: false,
+                    },
+                ]);
+
+            await expect(
+                model.findExploreContainingTable(projectUuid, 'orders'),
+            ).resolves.toEqual(exploreWithMetricFilters);
+        });
+    });
+
     describe('saveExploresToCache', () => {
         test('preserves cached explores when the payload is not explicitly complete', async () => {
             const cachedExplore = exploresWithSameName[0];

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1800,6 +1800,58 @@ export class ProjectModel {
         return cachedExplores[tableName];
     }
 
+    private async findExploreCacheContainingTable(
+        projectUuid: string,
+        tableName: string,
+    ): Promise<
+        | {
+              explore: Explore | ExploreError;
+              baseMatch: boolean;
+          }
+        | undefined
+    > {
+        return this.database(CachedExploreTableName)
+            .columns({
+                explore: 'explore',
+                baseMatch: this.database.raw("? = explore->>'baseTable'", [
+                    tableName,
+                ]),
+            })
+            .select<{
+                explore: Explore | ExploreError;
+                baseMatch: boolean;
+            }>()
+            .whereRaw('? = ANY(table_names)', tableName)
+            .andWhere('project_uuid', projectUuid)
+            .orderBy('baseMatch', 'desc')
+            .first();
+    }
+
+    async findExploreContainingTable(
+        projectUuid: string,
+        tableName: string,
+    ): Promise<Explore | ExploreError | undefined> {
+        return wrapSentryTransaction(
+            'ProjectModel.findExploreContainingTable',
+            {},
+            async (span) => {
+                const exploreCache = await this.findExploreCacheContainingTable(
+                    projectUuid,
+                    tableName,
+                );
+                span.setAttribute(
+                    'foundExploreContainingTable',
+                    !!exploreCache,
+                );
+                return exploreCache
+                    ? ProjectModel.convertMetricFiltersFieldIdsToFieldRef(
+                          exploreCache.explore,
+                      )
+                    : undefined;
+            },
+        );
+    }
+
     // Returns explore based on the join original name rather than the explore with the join.
     async findJoinAliasExplore(
         projectUuid: string,
@@ -1809,24 +1861,11 @@ export class ProjectModel {
             'ProjectModel.findExploreFromJoinAlias',
             {},
             async (span) => {
-                const exploreWithJoinAlias = await this.database(
-                    CachedExploreTableName,
-                )
-                    .columns({
-                        explore: 'explore',
-                        baseMatch: this.database.raw(
-                            "? = explore->>'baseTable'",
-                            [joinAliasName],
-                        ),
-                    })
-                    .select<{
-                        explore: Explore | ExploreError;
-                        baseMatch: boolean;
-                    }>()
-                    .whereRaw('? = ANY(table_names)', joinAliasName)
-                    .andWhere('project_uuid', projectUuid)
-                    .orderBy('baseMatch', 'desc')
-                    .first();
+                const exploreWithJoinAlias =
+                    await this.findExploreCacheContainingTable(
+                        projectUuid,
+                        joinAliasName,
+                    );
                 if (exploreWithJoinAlias) {
                     const originalTableName =
                         exploreWithJoinAlias.explore.tables?.[joinAliasName]

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -92,6 +92,7 @@ const lookupExplore: Explore = {
 const mockExploreResolver = {
     findExploreByTableName: vi.fn(),
     findJoinAliasExplore: vi.fn(),
+    findExploreContainingTable: vi.fn(),
 };
 
 describe('getFieldValuesMetricQuery', () => {
@@ -101,6 +102,9 @@ describe('getFieldValuesMetricQuery', () => {
             validExplore,
         );
         mockExploreResolver.findJoinAliasExplore.mockResolvedValue(undefined);
+        mockExploreResolver.findExploreContainingTable.mockResolvedValue(
+            undefined,
+        );
     });
 
     test('builds a MetricQuery with correct structure', async () => {
@@ -494,6 +498,33 @@ describe('getFieldValuesMetricQuery', () => {
         );
         // fieldId should be remapped from alias_table to base table
         expect(result.fieldId).toBe('a_dim1');
+    });
+
+    test('falls back to an explore containing a joined-only table', async () => {
+        mockExploreResolver.findExploreByTableName.mockResolvedValue(undefined);
+        mockExploreResolver.findJoinAliasExplore.mockResolvedValue(undefined);
+        mockExploreResolver.findExploreContainingTable.mockResolvedValue(
+            validExplore,
+        );
+
+        const result = await getFieldValuesMetricQuery({
+            projectUuid: 'project-uuid',
+            table: 'b',
+            initialFieldId: 'b_dim1',
+            search: '',
+            limit: 10,
+            maxLimit: 5000,
+            filters: undefined,
+            exploreResolver: mockExploreResolver,
+        });
+
+        expect(
+            mockExploreResolver.findExploreContainingTable,
+        ).toHaveBeenCalledWith('project-uuid', 'b');
+        expect(result.explore).toBe(validExplore);
+        expect(result.fieldId).toBe('b_dim1');
+        expect(result.metricQuery.exploreName).toBe(validExplore.name);
+        expect(result.metricQuery.dimensions).toEqual(['b_dim1']);
     });
 
     test('throws NotFoundError when explore not found', async () => {

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -28,6 +28,10 @@ type ExploreResolver = {
         projectUuid: string,
         table: string,
     ): Promise<Explore | ExploreError | undefined>;
+    findExploreContainingTable(
+        projectUuid: string,
+        table: string,
+    ): Promise<Explore | ExploreError | undefined>;
 };
 
 const parseFieldValuesLimit = (limit: unknown, maxLimit: number): number => {
@@ -96,6 +100,12 @@ export async function getFieldValuesMetricQuery({
         if (explore && !isExploreError(explore)) {
             fieldId = initialFieldId.replace(table, explore.baseTable);
         }
+    }
+    if (!explore) {
+        explore = await exploreResolver.findExploreContainingTable(
+            projectUuid,
+            table,
+        );
     }
 
     if (!explore) {


### PR DESCRIPTION
Closes: PROD-10260

### Description:

- Resolve field value suggestion requests for dimensions that belong to hidden, joined-only tables.
- Fall back to a cached parent explore containing the requested table when neither a standalone explore nor a join-alias explore can be resolved.
- Preserve the joined field ID when building the suggestion query while keeping existing join-alias behavior unchanged.
- Add focused ProjectModel and field-values query-builder coverage.

Before this change, requesting suggestions for Stg circuits -> Circuit ref sent table=stg_circuits and returned 404 Explore stg_circuits does not exist, even though the field worked in queries through Race Results.

### Validation:

- pnpm -F backend exec vitest run --config vitest.config.ts src/services/ProjectService/fieldValuesQueryBuilder.test.ts src/models/ProjectModel/ProjectModel.test.ts (79 passed, 1 skipped)
- pnpm -F backend typecheck
- Focused backend lint and formatting checks
- git diff --check
- Browser: Race Results filter suggestions returned 24 circuit values plus null, including silverstone, with no false warning
- Browser: saved dashboard editor and viewer Add filter flows both returned silverstone and applied it successfully to the Race Winners by Round tile

### Risk assessment:

- [ ] This is a high-risk change

Low risk. The fallback only runs after direct explore and join-alias resolution fail, and it uses existing cached explore metadata scoped to the project.