### PR TITLE
fix(embedding): allow filter values without dashboard

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -584,6 +584,38 @@ describe('EmbedService', () => {
     });
 
     describe('searchFilterValues', () => {
+        const buildChartEmbedAccount = (authorizedExplores: string[]) =>
+            ({
+                authentication: { type: 'jwt', source: 'embed-token' },
+                access: {
+                    content: {
+                        type: 'chart',
+                        chartUuids: ['chart-1'],
+                        explores: authorizedExplores,
+                    },
+                    controls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                },
+                user: {
+                    id: mockUserUuid,
+                    ability: new Ability<PossibleAbilities>([
+                        {
+                            subject: 'Explore',
+                            action: ['view'],
+                            conditions: {
+                                organizationUuid: mockOrganizationUuid,
+                                projectUuid: mockProjectUuid,
+                                exploreNames: { $all: authorizedExplores },
+                            },
+                        },
+                    ]),
+                },
+                organization: { organizationUuid: mockOrganizationUuid },
+                isAnonymousUser: vi.fn().mockReturnValue(true),
+            }) as unknown as AnonymousAccount;
+
         test('searches values for an authorized embedded Explore without a dashboard', async () => {
             const field = validExplore.tables.a.dimensions.dim1;
             const scopedService = new EmbedService({
@@ -602,54 +634,31 @@ describe('EmbedService', () => {
                     }),
                 },
                 projectService: {
-                    _getFieldValuesMetricQuery: vi.fn().mockResolvedValue({
-                        metricQuery: {
-                            exploreName: validExplore.name,
-                            dimensions: ['a_dim1'],
-                            metrics: [],
-                            filters: {},
-                            sorts: [],
-                            limit: 50,
-                            tableCalculations: [],
-                        },
-                        explore: validExplore,
-                        field,
-                        initialExplore: validExplore,
-                        initialField: field,
-                        staticResults: [{ value: 'available value' }],
-                    }),
+                    _getFieldValuesMetricQuery: vi
+                        .fn()
+                        .mockImplementation(({ authorizeInitialExplore }) => {
+                            authorizeInitialExplore?.(validExplore);
+                            return {
+                                metricQuery: {
+                                    exploreName: validExplore.name,
+                                    dimensions: ['a_dim1'],
+                                    metrics: [],
+                                    filters: {},
+                                    sorts: [],
+                                    limit: 50,
+                                    tableCalculations: [],
+                                },
+                                explore: validExplore,
+                                field,
+                                initialExplore: validExplore,
+                                initialField: field,
+                                labelFieldId: null,
+                                staticResults: [{ value: 'available value' }],
+                            };
+                        }),
                 },
             } as unknown as ConstructorParameters<typeof EmbedService>[0]);
-            const account = {
-                authentication: { type: 'jwt', source: 'embed-token' },
-                access: {
-                    content: {
-                        type: 'chart',
-                        chartUuids: ['chart-1'],
-                        explores: [validExplore.name],
-                    },
-                    controls: {
-                        userAttributes: {},
-                        intrinsicUserAttributes: {},
-                    },
-                },
-                user: {
-                    id: mockUserUuid,
-                    ability: new Ability<PossibleAbilities>([
-                        {
-                            subject: 'Explore',
-                            action: ['view'],
-                            conditions: {
-                                organizationUuid: mockOrganizationUuid,
-                                projectUuid: mockProjectUuid,
-                                exploreNames: { $all: [validExplore.name] },
-                            },
-                        },
-                    ]),
-                },
-                organization: { organizationUuid: mockOrganizationUuid },
-                isAnonymousUser: vi.fn().mockReturnValue(true),
-            } as unknown as AnonymousAccount;
+            const account = buildChartEmbedAccount([validExplore.name]);
 
             await expect(
                 scopedService.searchFilterValues({
@@ -664,6 +673,129 @@ describe('EmbedService', () => {
                     fieldId: 'a_dim1',
                 }),
             ).resolves.toMatchObject({ results: ['available value'] });
+        });
+
+        test('authorizes an embedded Explore before resolving its requested field', async () => {
+            const resolveFieldValues = vi
+                .fn()
+                .mockImplementation(({ authorizeInitialExplore }) => {
+                    authorizeInitialExplore?.(validExplore);
+                    throw new Error('reached field resolution');
+                });
+            const scopedService = new EmbedService({
+                ...EmbedServiceArgumentsMock,
+                embedModel: {
+                    get: vi.fn().mockResolvedValue({
+                        dashboardUuids: [],
+                        allowAllDashboards: false,
+                        user: { userUuid: mockUserUuid },
+                    }),
+                },
+                projectModel: {
+                    getSummary: vi.fn().mockResolvedValue({
+                        projectUuid: mockProjectUuid,
+                        organizationUuid: mockOrganizationUuid,
+                    }),
+                },
+                projectService: {
+                    _getFieldValuesMetricQuery: resolveFieldValues,
+                },
+            } as unknown as ConstructorParameters<typeof EmbedService>[0]);
+
+            await expect(
+                scopedService.searchFilterValues({
+                    account: buildChartEmbedAccount(['another_explore']),
+                    projectUuid: mockProjectUuid,
+                    filterUuid: 'filter-uuid',
+                    search: '',
+                    limit: 50,
+                    filters: undefined,
+                    forceRefresh: false,
+                    tableName: 'a',
+                    fieldId: 'a_dim1',
+                }),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(resolveFieldValues).toHaveBeenCalledOnce();
+        });
+
+        test('runs a warehouse value search for an embedded Explore without a dashboard', async () => {
+            const field = validExplore.tables.a.dimensions.dim1;
+            const combineParameters = vi.fn().mockResolvedValue({});
+            const runEmbedQuery = vi.fn().mockResolvedValue({
+                rows: [{ a_dim1: 'warehouse value' }],
+                cacheMetadata: { cacheHit: false },
+            });
+            const scopedService = new EmbedService({
+                ...EmbedServiceArgumentsMock,
+                embedModel: {
+                    get: vi.fn().mockResolvedValue({
+                        dashboardUuids: [],
+                        allowAllDashboards: false,
+                        user: { userUuid: mockUserUuid },
+                    }),
+                },
+                projectModel: {
+                    getSummary: vi.fn().mockResolvedValue({
+                        projectUuid: mockProjectUuid,
+                        organizationUuid: mockOrganizationUuid,
+                    }),
+                },
+                projectService: {
+                    _getFieldValuesMetricQuery: vi
+                        .fn()
+                        .mockImplementation(({ authorizeInitialExplore }) => {
+                            authorizeInitialExplore?.(validExplore);
+                            return {
+                                metricQuery: {
+                                    exploreName: validExplore.name,
+                                    dimensions: ['a_dim1'],
+                                    metrics: [],
+                                    filters: {},
+                                    sorts: [],
+                                    limit: 50,
+                                    tableCalculations: [],
+                                },
+                                explore: validExplore,
+                                field,
+                                initialExplore: validExplore,
+                                initialField: field,
+                                labelFieldId: null,
+                                staticResults: null,
+                            };
+                        }),
+                    combineParameters,
+                    isTimezoneSupportEnabled: vi.fn().mockResolvedValue(false),
+                    getQueryTimezoneForProject: vi
+                        .fn()
+                        .mockResolvedValue('UTC'),
+                },
+            } as unknown as ConstructorParameters<typeof EmbedService>[0]);
+            Object.assign(scopedService, { _runEmbedQuery: runEmbedQuery });
+
+            await expect(
+                scopedService.searchFilterValues({
+                    account: buildChartEmbedAccount([validExplore.name]),
+                    projectUuid: mockProjectUuid,
+                    filterUuid: 'filter-uuid',
+                    search: '',
+                    limit: 50,
+                    filters: undefined,
+                    forceRefresh: false,
+                    tableName: 'a',
+                    fieldId: 'a_dim1',
+                }),
+            ).resolves.toMatchObject({ results: ['warehouse value'] });
+
+            expect(combineParameters).toHaveBeenCalledWith(
+                mockProjectUuid,
+                validExplore,
+                {},
+                {},
+            );
+            expect(runEmbedQuery.mock.calls[0][0].queryTags).not.toHaveProperty(
+                'dashboard_uuid',
+            );
         });
 
         test('rejects autocomplete source fields hidden by embed user attributes', async () => {
@@ -702,42 +834,80 @@ describe('EmbedService', () => {
                         field,
                         initialExplore: validExplore,
                         initialField,
+                        labelFieldId: null,
                         staticResults: null,
                     }),
                 },
             } as unknown as ConstructorParameters<typeof EmbedService>[0]);
-            const account = {
-                authentication: { type: 'jwt', source: 'embed-token' },
-                access: {
-                    content: { type: 'chart' },
-                    controls: {
-                        userAttributes: {},
-                        intrinsicUserAttributes: {},
-                    },
-                },
-                user: {
-                    id: mockUserUuid,
-                    ability: new Ability<PossibleAbilities>([
-                        {
-                            subject: 'Explore',
-                            action: ['view'],
-                            conditions: {
-                                organizationUuid: mockOrganizationUuid,
-                                projectUuid: mockProjectUuid,
-                                exploreNames: {
-                                    $all: [validExplore.name],
-                                },
-                            },
-                        },
-                    ]),
-                },
-                organization: { organizationUuid: mockOrganizationUuid },
-                isAnonymousUser: vi.fn().mockReturnValue(true),
-            } as unknown as AnonymousAccount;
+            const account = buildChartEmbedAccount([validExplore.name]);
 
             await expect(
                 scopedService.searchFilterValues({
                     account,
+                    projectUuid: mockProjectUuid,
+                    filterUuid: 'filter-uuid',
+                    search: '',
+                    limit: 50,
+                    filters: undefined,
+                    forceRefresh: false,
+                    tableName: 'a',
+                    fieldId: 'a_dim1',
+                }),
+            ).rejects.toThrow(ForbiddenError);
+        });
+
+        test('rejects autocomplete label fields hidden by embed user attributes', async () => {
+            const initialField = validExplore.tables.a.dimensions.dim1;
+            const field = validExplore.tables.b.dimensions.dim1;
+            const restrictedSourceExplore = {
+                ...validExplore,
+                name: 'autocomplete_source',
+                tables: {
+                    ...validExplore.tables,
+                    b: {
+                        ...validExplore.tables.b,
+                        dimensions: {
+                            ...validExplore.tables.b.dimensions,
+                            label: {
+                                ...validExplore.tables.b.dimensions.dim1,
+                                name: 'label',
+                                requiredAttributes: { region: 'allowed' },
+                            },
+                        },
+                    },
+                },
+            };
+            const scopedService = new EmbedService({
+                ...EmbedServiceArgumentsMock,
+                embedModel: {
+                    get: vi.fn().mockResolvedValue({
+                        dashboardUuids: [],
+                        allowAllDashboards: false,
+                        user: { userUuid: mockUserUuid },
+                    }),
+                },
+                projectModel: {
+                    getSummary: vi.fn().mockResolvedValue({
+                        projectUuid: mockProjectUuid,
+                        organizationUuid: mockOrganizationUuid,
+                    }),
+                },
+                projectService: {
+                    _getFieldValuesMetricQuery: vi.fn().mockResolvedValue({
+                        metricQuery: {},
+                        explore: restrictedSourceExplore,
+                        field,
+                        initialExplore: validExplore,
+                        initialField,
+                        labelFieldId: 'b_label',
+                        staticResults: null,
+                    }),
+                },
+            } as unknown as ConstructorParameters<typeof EmbedService>[0]);
+
+            await expect(
+                scopedService.searchFilterValues({
+                    account: buildChartEmbedAccount([validExplore.name]),
                     projectUuid: mockProjectUuid,
                     filterUuid: 'filter-uuid',
                     search: '',
@@ -882,6 +1052,7 @@ describe('EmbedService', () => {
                             field,
                             initialExplore: validExplore,
                             initialField: field,
+                            labelFieldId: null,
                             staticResults: null,
                         }),
                         combineParameters,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -584,6 +584,172 @@ describe('EmbedService', () => {
     });
 
     describe('searchFilterValues', () => {
+        test('searches values for an authorized embedded Explore without a dashboard', async () => {
+            const field = validExplore.tables.a.dimensions.dim1;
+            const scopedService = new EmbedService({
+                ...EmbedServiceArgumentsMock,
+                embedModel: {
+                    get: vi.fn().mockResolvedValue({
+                        dashboardUuids: [],
+                        allowAllDashboards: false,
+                        user: { userUuid: mockUserUuid },
+                    }),
+                },
+                projectModel: {
+                    getSummary: vi.fn().mockResolvedValue({
+                        projectUuid: mockProjectUuid,
+                        organizationUuid: mockOrganizationUuid,
+                    }),
+                },
+                projectService: {
+                    _getFieldValuesMetricQuery: vi.fn().mockResolvedValue({
+                        metricQuery: {
+                            exploreName: validExplore.name,
+                            dimensions: ['a_dim1'],
+                            metrics: [],
+                            filters: {},
+                            sorts: [],
+                            limit: 50,
+                            tableCalculations: [],
+                        },
+                        explore: validExplore,
+                        field,
+                        initialExplore: validExplore,
+                        initialField: field,
+                        staticResults: [{ value: 'available value' }],
+                    }),
+                },
+            } as unknown as ConstructorParameters<typeof EmbedService>[0]);
+            const account = {
+                authentication: { type: 'jwt', source: 'embed-token' },
+                access: {
+                    content: {
+                        type: 'chart',
+                        chartUuids: ['chart-1'],
+                        explores: [validExplore.name],
+                    },
+                    controls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                },
+                user: {
+                    id: mockUserUuid,
+                    ability: new Ability<PossibleAbilities>([
+                        {
+                            subject: 'Explore',
+                            action: ['view'],
+                            conditions: {
+                                organizationUuid: mockOrganizationUuid,
+                                projectUuid: mockProjectUuid,
+                                exploreNames: { $all: [validExplore.name] },
+                            },
+                        },
+                    ]),
+                },
+                organization: { organizationUuid: mockOrganizationUuid },
+                isAnonymousUser: vi.fn().mockReturnValue(true),
+            } as unknown as AnonymousAccount;
+
+            await expect(
+                scopedService.searchFilterValues({
+                    account,
+                    projectUuid: mockProjectUuid,
+                    filterUuid: 'filter-uuid',
+                    search: '',
+                    limit: 50,
+                    filters: undefined,
+                    forceRefresh: false,
+                    tableName: 'a',
+                    fieldId: 'a_dim1',
+                }),
+            ).resolves.toMatchObject({ results: ['available value'] });
+        });
+
+        test('rejects autocomplete source fields hidden by embed user attributes', async () => {
+            const initialField = validExplore.tables.a.dimensions.dim1;
+            const field = validExplore.tables.b.dimensions.dim1;
+            const restrictedSourceExplore = {
+                ...validExplore,
+                name: 'autocomplete_source',
+                tables: {
+                    ...validExplore.tables,
+                    b: {
+                        ...validExplore.tables.b,
+                        requiredAttributes: { region: 'allowed' },
+                    },
+                },
+            };
+            const scopedService = new EmbedService({
+                ...EmbedServiceArgumentsMock,
+                embedModel: {
+                    get: vi.fn().mockResolvedValue({
+                        dashboardUuids: [],
+                        allowAllDashboards: false,
+                        user: { userUuid: mockUserUuid },
+                    }),
+                },
+                projectModel: {
+                    getSummary: vi.fn().mockResolvedValue({
+                        projectUuid: mockProjectUuid,
+                        organizationUuid: mockOrganizationUuid,
+                    }),
+                },
+                projectService: {
+                    _getFieldValuesMetricQuery: vi.fn().mockResolvedValue({
+                        metricQuery: {},
+                        explore: restrictedSourceExplore,
+                        field,
+                        initialExplore: validExplore,
+                        initialField,
+                        staticResults: null,
+                    }),
+                },
+            } as unknown as ConstructorParameters<typeof EmbedService>[0]);
+            const account = {
+                authentication: { type: 'jwt', source: 'embed-token' },
+                access: {
+                    content: { type: 'chart' },
+                    controls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                },
+                user: {
+                    id: mockUserUuid,
+                    ability: new Ability<PossibleAbilities>([
+                        {
+                            subject: 'Explore',
+                            action: ['view'],
+                            conditions: {
+                                organizationUuid: mockOrganizationUuid,
+                                projectUuid: mockProjectUuid,
+                                exploreNames: {
+                                    $all: [validExplore.name],
+                                },
+                            },
+                        },
+                    ]),
+                },
+                organization: { organizationUuid: mockOrganizationUuid },
+                isAnonymousUser: vi.fn().mockReturnValue(true),
+            } as unknown as AnonymousAccount;
+
+            await expect(
+                scopedService.searchFilterValues({
+                    account,
+                    projectUuid: mockProjectUuid,
+                    filterUuid: 'filter-uuid',
+                    search: '',
+                    limit: 50,
+                    filters: undefined,
+                    forceRefresh: false,
+                    tableName: 'a',
+                    fieldId: 'a_dim1',
+                }),
+            ).rejects.toThrow(ForbiddenError);
+        });
+
         test('scopes dashboard lookup to the requested project', async () => {
             const dashboardUuid = 'dashboard-1';
             const dashboardModel = {
@@ -714,6 +880,8 @@ describe('EmbedService', () => {
                             },
                             explore: validExplore,
                             field,
+                            initialExplore: validExplore,
+                            initialField: field,
                             staticResults: null,
                         }),
                         combineParameters,
@@ -732,6 +900,10 @@ describe('EmbedService', () => {
                     access: {
                         content: { dashboardUuid },
                         parameters: { enabled: isInteractivityEnabled },
+                        controls: {
+                            userAttributes: {},
+                            intrinsicUserAttributes: {},
+                        },
                     },
                     user: { id: mockUserUuid },
                     organization: {

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -2342,8 +2342,8 @@ export class EmbedService extends BaseService {
         limit,
         filters,
         forceRefresh,
-        tableName: fallbackTableName,
-        fieldId: fallbackFieldId,
+        tableName: requestedTableName,
+        fieldId: requestedFieldId,
         timezone: sessionTimezoneParam,
         parameters,
     }: {
@@ -2362,92 +2362,149 @@ export class EmbedService extends BaseService {
         const { dashboardUuids, allowAllDashboards, user } =
             await this.embedModel.get(projectUuid);
         const { dashboardUuid } = account.access.content;
+        let dashboard: DashboardDAO | undefined;
+        let resolvedTableName: string;
+        let resolvedFieldId: string;
+        let organizationUuid: string;
 
-        if (!dashboardUuid) {
-            throw new ParameterError(
-                'Dashboard ID is required for this operation',
+        if (dashboardUuid) {
+            this.checkDashboardPermissions(
+                {
+                    dashboardUuids,
+                    allowAllDashboards,
+                },
+                dashboardUuid,
             );
-        }
+            dashboard = await this.dashboardModel.getByIdOrSlug(dashboardUuid, {
+                projectUuid,
+            });
+            organizationUuid = dashboard.organizationUuid;
+            const filter = dashboard.filters.dimensions.find(
+                (dashboardFilter) => dashboardFilter.id === filterUuid,
+            );
 
-        this.checkDashboardPermissions(
-            {
-                dashboardUuids,
-                allowAllDashboards,
-            },
-            dashboardUuid,
-        );
-        const dashboard = await this.dashboardModel.getByIdOrSlug(
-            dashboardUuid,
-            { projectUuid },
-        );
-        const dashboardFilters = dashboard.filters.dimensions;
-        const filter = dashboardFilters.find((f) => f.id === filterUuid);
+            // For SDK-injected filters, the UUID is dynamically generated and
+            // won't exist in saved dashboard filters. Fall back to tableName/fieldId
+            // from the request body, but only if the field is within the dashboard's
+            // explores (to prevent arbitrary field enumeration).
+            resolvedTableName = filter?.target.tableName ?? '';
+            resolvedFieldId = filter?.target.fieldId ?? '';
 
-        // For SDK-injected filters, the UUID is dynamically generated and
-        // won't exist in saved dashboard filters. Fall back to tableName/fieldId
-        // from the request body, but only if the field is within the dashboard's
-        // explores (to prevent arbitrary field enumeration).
-        let resolvedTableName = filter?.target.tableName;
-        let resolvedFieldId = filter?.target.fieldId;
+            if (!resolvedTableName || !resolvedFieldId) {
+                if (!requestedTableName || !requestedFieldId) {
+                    throw new ParameterError(
+                        `Filter ${filterUuid} not found and no fallback field provided`,
+                    );
+                }
 
-        if (!resolvedTableName || !resolvedFieldId) {
-            if (!fallbackTableName || !fallbackFieldId) {
-                throw new ParameterError(
-                    `Filter ${filterUuid} not found and no fallback field provided`,
+                // Validate the fallback field is within the dashboard's explores
+                const chartTiles = dashboard.tiles.filter(
+                    isDashboardChartTileType,
                 );
-            }
-
-            // Validate the fallback field is within the dashboard's explores
-            const chartTiles = dashboard.tiles.filter(isDashboardChartTileType);
-            const savedChartUuids = [
-                ...new Set(
-                    chartTiles
-                        .map((tile) => tile.properties.savedChartUuid)
-                        .filter(Boolean),
-                ),
-            ];
-            const savedCharts =
-                await this.savedChartModel.getInfoForAvailableFilters(
-                    savedChartUuids as string[],
-                );
-            const explores = await Promise.all(
-                [...new Set(savedCharts.map((chart) => chart.tableName))].map(
-                    (tableName) =>
+                const savedChartUuids = [
+                    ...new Set(
+                        chartTiles
+                            .map((tile) => tile.properties.savedChartUuid)
+                            .filter(Boolean),
+                    ),
+                ];
+                const savedCharts =
+                    await this.savedChartModel.getInfoForAvailableFilters(
+                        savedChartUuids as string[],
+                    );
+                const explores = await Promise.all(
+                    [
+                        ...new Set(savedCharts.map((chart) => chart.tableName)),
+                    ].map((tableName) =>
                         this.projectModel.getExploreFromCache(
                             projectUuid,
                             tableName,
                         ),
-                ),
-            );
+                    ),
+                );
 
-            const isFieldInDashboardExplores = explores.some(
-                (explore) =>
-                    !isExploreError(explore) &&
-                    fallbackTableName in explore.tables &&
-                    fallbackFieldId in
-                        getDimensionMapFromTables(explore.tables),
-            );
+                const isFieldInDashboardExplores = explores.some(
+                    (explore) =>
+                        !isExploreError(explore) &&
+                        requestedTableName in explore.tables &&
+                        requestedFieldId in
+                            getDimensionMapFromTables(explore.tables),
+                );
 
-            if (!isFieldInDashboardExplores) {
+                if (!isFieldInDashboardExplores) {
+                    throw new ParameterError(
+                        `Field ${requestedFieldId} is not available on this dashboard`,
+                    );
+                }
+
+                resolvedTableName = requestedTableName;
+                resolvedFieldId = requestedFieldId;
+            }
+        } else {
+            if (!requestedTableName || !requestedFieldId) {
                 throw new ParameterError(
-                    `Field ${fallbackFieldId} is not available on this dashboard`,
+                    'Table and field are required for embedded Explore filters',
                 );
             }
-
-            resolvedTableName = fallbackTableName;
-            resolvedFieldId = fallbackFieldId;
+            resolvedTableName = requestedTableName;
+            resolvedFieldId = requestedFieldId;
+            ({ organizationUuid } =
+                await this.projectModel.getSummary(projectUuid));
         }
 
-        const { metricQuery, explore, field, staticResults } =
-            await this.projectService._getFieldValuesMetricQuery({
+        const {
+            metricQuery,
+            explore,
+            field,
+            initialExplore,
+            initialField,
+            staticResults,
+        } = await this.projectService._getFieldValuesMetricQuery({
+            projectUuid,
+            table: resolvedTableName,
+            initialFieldId: resolvedFieldId,
+            search,
+            limit,
+            filters,
+            organizationUuid,
+        });
+
+        if (!dashboard) {
+            this.assertCanQueryExplore(
+                account,
+                organizationUuid,
                 projectUuid,
-                table: resolvedTableName,
-                initialFieldId: resolvedFieldId,
-                search,
-                limit,
-                filters,
-                organizationUuid: dashboard.organizationUuid,
-            });
+                initialExplore.name,
+            );
+
+            const { userAttributes } = this.getAccessControls(account);
+            const filteredInitialExplore = getFilteredExplore(
+                initialExplore,
+                userAttributes,
+            );
+            const filteredSourceExplore = getFilteredExplore(
+                explore,
+                userAttributes,
+            );
+            const initialFieldId = getItemId(initialField);
+            const sourceFieldId = getItemId(field);
+            if (
+                !(initialField.table in filteredInitialExplore.tables) ||
+                !(
+                    initialFieldId in
+                    getDimensionMapFromTables(filteredInitialExplore.tables)
+                ) ||
+                !(field.table in filteredSourceExplore.tables) ||
+                !(
+                    sourceFieldId in
+                    getDimensionMapFromTables(filteredSourceExplore.tables)
+                )
+            ) {
+                throw new ForbiddenError(
+                    'You do not have permission to search values for this field',
+                );
+            }
+        }
 
         // The field's config turns warehouse fetching off: serve curated
         // values (empty when none) instead of running a distinct-value scan.
@@ -2469,13 +2526,13 @@ export class EmbedService extends BaseService {
             projectUuid,
             explore,
             acceptedUserParameters,
-            getDashboardParametersValuesMap(dashboard),
+            dashboard ? getDashboardParametersValuesMap(dashboard) : {},
         );
 
         const useTimezoneAwareDateTrunc =
             await this.projectService.isTimezoneSupportEnabled({
                 userUuid: user?.userUuid ?? account.user.id,
-                organizationUuid: dashboard.organizationUuid,
+                organizationUuid,
             });
 
         const projectTimezone =
@@ -2492,15 +2549,15 @@ export class EmbedService extends BaseService {
         });
 
         const { rows, cacheMetadata } = await this._runEmbedQuery({
-            projectUuid: dashboard.projectUuid,
+            projectUuid,
             metricQuery,
             explore,
             queryTags: {
                 embed: 'true',
                 external_id: account.user.id,
                 project_uuid: projectUuid,
-                organization_uuid: dashboard.organizationUuid,
-                dashboard_uuid: dashboardUuid,
+                organization_uuid: organizationUuid,
+                ...(dashboardUuid ? { dashboard_uuid: dashboardUuid } : {}),
                 explore_name: explore.name,
                 query_context: QueryExecutionContext.FILTER_AUTOCOMPLETE,
             },

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -2458,6 +2458,7 @@ export class EmbedService extends BaseService {
             field,
             initialExplore,
             initialField,
+            labelFieldId,
             staticResults,
         } = await this.projectService._getFieldValuesMetricQuery({
             projectUuid,
@@ -2467,16 +2468,18 @@ export class EmbedService extends BaseService {
             limit,
             filters,
             organizationUuid,
+            authorizeInitialExplore: dashboard
+                ? undefined
+                : (initialExploreForAuthorization) =>
+                      this.assertCanQueryExplore(
+                          account,
+                          organizationUuid,
+                          projectUuid,
+                          initialExploreForAuthorization.name,
+                      ),
         });
 
         if (!dashboard) {
-            this.assertCanQueryExplore(
-                account,
-                organizationUuid,
-                projectUuid,
-                initialExplore.name,
-            );
-
             const { userAttributes } = this.getAccessControls(account);
             const filteredInitialExplore = getFilteredExplore(
                 initialExplore,
@@ -2488,6 +2491,9 @@ export class EmbedService extends BaseService {
             );
             const initialFieldId = getItemId(initialField);
             const sourceFieldId = getItemId(field);
+            const sourceDimensions = getDimensionMapFromTables(
+                filteredSourceExplore.tables,
+            );
             if (
                 !(initialField.table in filteredInitialExplore.tables) ||
                 !(
@@ -2495,10 +2501,8 @@ export class EmbedService extends BaseService {
                     getDimensionMapFromTables(filteredInitialExplore.tables)
                 ) ||
                 !(field.table in filteredSourceExplore.tables) ||
-                !(
-                    sourceFieldId in
-                    getDimensionMapFromTables(filteredSourceExplore.tables)
-                )
+                !(sourceFieldId in sourceDimensions) ||
+                (labelFieldId !== null && !(labelFieldId in sourceDimensions))
             ) {
                 throw new ForbiddenError(
                     'You do not have permission to search values for this field',

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -7852,6 +7852,7 @@ export class ProjectService extends BaseService {
         limit,
         filters,
         organizationUuid: organizationUuidArg,
+        authorizeInitialExplore,
     }: {
         projectUuid: string;
         table: string;
@@ -7860,6 +7861,7 @@ export class ProjectService extends BaseService {
         limit: unknown;
         filters: AndFilterGroup | undefined;
         organizationUuid?: string;
+        authorizeInitialExplore?: (explore: Explore) => void;
     }) {
         const { organizationUuid } = organizationUuidArg
             ? { organizationUuid: organizationUuidArg }
@@ -7878,6 +7880,7 @@ export class ProjectService extends BaseService {
             maxLimit,
             filters,
             exploreResolver: this.projectModel,
+            authorizeInitialExplore,
         });
     }
 

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -143,6 +143,28 @@ describe('getFieldValuesMetricQuery', () => {
         });
     });
 
+    test('authorizes the resolved Explore before resolving the requested field', async () => {
+        const authorizeInitialExplore = vi.fn(() => {
+            throw new Error('not authorized');
+        });
+
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: 'a',
+                initialFieldId: 'a_missing',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+                authorizeInitialExplore,
+            }),
+        ).rejects.toThrow('not authorized');
+
+        expect(authorizeInitialExplore).toHaveBeenCalledWith(validExplore);
+    });
+
     test('returns null staticResults when warehouse fetching is on', async () => {
         const { staticResults } = await getFieldValuesMetricQuery({
             projectUuid: 'project-uuid',

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -72,6 +72,8 @@ export async function getFieldValuesMetricQuery({
     metricQuery: MetricQuery;
     explore: Explore;
     field: Dimension;
+    initialExplore: Explore;
+    initialField: Dimension;
     fieldId: string;
     labelFieldId: string | null;
     /** Non-null when the field's config turns warehouse fetching off: the
@@ -114,7 +116,8 @@ export async function getFieldValuesMetricQuery({
         throw new NotFoundError(`Explore ${table} has errors`);
     }
 
-    const initialField = findFieldByIdInExplore(explore, fieldId);
+    const initialExplore = explore;
+    const initialField = findFieldByIdInExplore(initialExplore, fieldId);
 
     if (!initialField) {
         throw new NotFoundError(`Can't dimension with id: ${fieldId}`);
@@ -296,6 +299,8 @@ export async function getFieldValuesMetricQuery({
         metricQuery,
         explore,
         field,
+        initialExplore,
+        initialField,
         fieldId,
         labelFieldId,
         staticResults,

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -59,6 +59,7 @@ export async function getFieldValuesMetricQuery({
     maxLimit,
     filters,
     exploreResolver,
+    authorizeInitialExplore,
 }: {
     projectUuid: string;
     table: string;
@@ -68,6 +69,7 @@ export async function getFieldValuesMetricQuery({
     maxLimit: number;
     filters: AndFilterGroup | undefined;
     exploreResolver: ExploreResolver;
+    authorizeInitialExplore?: (explore: Explore) => void;
 }): Promise<{
     metricQuery: MetricQuery;
     explore: Explore;
@@ -117,6 +119,7 @@ export async function getFieldValuesMetricQuery({
     }
 
     const initialExplore = explore;
+    authorizeInitialExplore?.(initialExplore);
     const initialField = findFieldByIdInExplore(initialExplore, fieldId);
 
     if (!initialField) {


### PR DESCRIPTION
## What changed

Allow embedded Explore filter-value searches to resolve the requested table and field when no dashboard is present, authorize the target Explore, and enforce user-attribute visibility for both target and configured autocomplete-source fields. Preserve the existing dashboard-bound path and expose original target metadata alongside resolved autocomplete-source metadata.

### Validation
- `pnpm -F backend exec vitest run src/ee/services/EmbedService/EmbedService.test.ts` — passed (30 tests)
- `pnpm -F backend exec vitest run --config vitest.config.ts src/ee/services/EmbedService/EmbedService.test.ts src/services/ProjectService/fieldValuesQueryBuilder.test.ts --reporter=verbose` — passed (55 tests)
- `pnpm -F backend exec oxfmt 'src/ee/services/EmbedService/EmbedService.test.ts' 'src/ee/services/EmbedService/EmbedService.ts' 'src/services/ProjectService/fieldValuesQueryBuilder.ts'` — passed
- `pnpm -F backend run --if-present lint` — passed
- `pnpm -F backend run --if-present typecheck` — passed
- `pnpm -F backend run --if-present test` — passed

## Preview

[Open the public Lightdash preview](https://ld-runner-prod-10506-fe183afa29b5.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10506

