### PR TITLE
fix(explorer): gray out the chart gallery's cards and selection

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
@@ -64,10 +64,10 @@
     gap: var(--mantine-spacing-xs);
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-xs);
     border: 1px solid
-        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-5));
+        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-5));
     background: light-dark(
-        var(--mantine-color-white),
-        var(--mantine-color-ldDark-2)
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-3)
     );
     text-align: center;
 }
@@ -86,21 +86,63 @@
 
 /* One step off the panel in each scheme: the dark panel already sits on
    ldGray-0, so the same shade there would hide the hover. */
-.row:hover:not(:disabled),
-.card:hover:not(:disabled) {
+.row:hover:not(:disabled):not([data-selected='true']) {
     background: light-dark(
         var(--mantine-color-ldGray-0),
         var(--mantine-color-ldGray-1)
     );
 }
 
+.card:hover:not(:disabled):not([data-selected='true']) {
+    border-color: light-dark(
+        var(--mantine-color-ldGray-4),
+        var(--mantine-color-ldDark-6)
+    );
+    background: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-ldDark-4)
+    );
+}
+
+/* Selected reads like the join-type control's active segment: lifted onto
+   the body surface under a soft shadow and a hairline. The hairline lives on
+   the border, not a shadow ring: rows run flush to the scroll viewport, which
+   would clip a ring drawn outside the box. */
 .row[data-selected='true'],
 .card[data-selected='true'] {
-    border-color: var(--mantine-color-blue-5);
-    background: light-dark(
-        var(--mantine-color-blue-0),
-        color-mix(in srgb, var(--mantine-color-blue-9) 26%, transparent)
+    border-color: light-dark(
+        var(--mantine-color-ldGray-3),
+        var(--mantine-color-ldGray-4)
     );
+    /* Light lifts onto the body surface; dark lifts a step past the hover
+       shade instead, since body sits level with the panel there — both the
+       join-type control and Mantine's segmented indicator go lighter in dark. */
+    background: light-dark(
+        var(--mantine-color-body),
+        var(--mantine-color-ldGray-2)
+    );
+    box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
+}
+
+.card {
+    transition:
+        transform 120ms cubic-bezier(0.23, 1, 0.32, 1),
+        background-color 120ms ease,
+        box-shadow 120ms ease;
+}
+
+.card:active:not(:disabled) {
+    transform: scale(0.98);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .card {
+        transition: none;
+    }
+
+    .card:active:not(:disabled) {
+        transform: none;
+    }
 }
 
 .row:disabled,
@@ -116,11 +158,11 @@
     place-items: center;
     overflow: hidden;
     border: 1px solid
-        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-5));
+        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-5));
     border-radius: var(--mantine-radius-sm);
     background: light-dark(
-        var(--mantine-color-white),
-        var(--mantine-color-ldDark-2)
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-3)
     );
 }
 

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -69,7 +69,7 @@ const ChartTypeIcon: FC<ChartTypeIconProps> = ({
         icon={icon}
         size={small ? 'md' : 'xl'}
         stroke={1.5}
-        color="blue"
+        color="ldGray.7"
     />
 );
 


### PR DESCRIPTION
## Summary

The chart gallery leaned on blue for its icons, card accents and the selected state, so every project row competed with the actual selection. This moves the gallery onto the gray ramp:

- Cards and thumbnails sit on `ldGray-0` with `ldGray-3` borders; icons are `ldGray.7`.
- Built-in card hover deepens (border and fill one step) instead of tinting; the row hover keeps the scheme-aware shade from #27942 (one step off the panel in dark, where the panel already sits on `ldGray-0`).
- The selected row or card borrows the join-type control's active-segment treatment (`MergeJoinBar.module.css`): lifted onto the body surface under a soft `0 1px 2px` shadow with an `ldGray-3` hairline in light; in dark it lifts a step past the hover shade (`ldGray-2`, with an `ldGray-4` hairline), since the body surface sits level with the panel there — the direction both that control and Mantine's segmented indicator take in dark. The hairline lives on the border rather than a shadow ring, since rows run flush to the scroll viewport, which would clip a ring drawn outside the box. Cards pick up the same 120ms transition and press scale (guarded for reduced motion).

Styling only; no behaviour, markup or test changes beyond the CSS and one icon color prop.

## How to test

1. Enable `explorer-chart-gallery` and open a chart in edit mode → Configure → Change.
2. Light and dark: cards are gray, the selected type is the one lifted body-surface card with a soft shadow (compare the Join type control in merged queries), hovers read clearly in both schemes, and the selected row's edge is never cut off against the scrollbar.

Relates: GLITCH-680
