### PR TITLE
fix(explorer): fold project chart types into the gallery grid

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
@@ -16,44 +16,32 @@
     min-width: 0;
 }
 
-.rowWrapper {
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+    gap: var(--mantine-spacing-xs);
+}
+
+.cardWrapper {
     position: relative;
+    display: grid;
+    min-width: 0;
 }
 
-.row {
-    width: 100%;
-    padding: var(--mantine-spacing-sm);
-    border: 1px solid transparent;
-    text-align: left;
-}
-
-/* Reserve space for the hover-revealed Edit so text never runs under it. */
-.row[data-has-edit='true'] {
-    padding-right: calc(var(--mantine-spacing-sm) * 2 + 24px);
-}
-
-/* Edit fades in on hover/focus so resting rows stay clean. */
-.rowEdit {
+/* Edit fades in on hover/focus so resting cards stay clean. */
+.cardEdit {
     position: absolute;
-    top: 50%;
-    right: var(--mantine-spacing-sm);
-    translate: 0 -50%;
-    font-family: inherit;
+    top: 4px;
+    right: 4px;
     opacity: 0;
     pointer-events: none;
     transition: opacity 100ms ease-out;
 }
 
-.rowWrapper:hover .rowEdit,
-.rowWrapper:focus-within .rowEdit {
+.cardWrapper:hover .cardEdit,
+.cardWrapper:focus-within .cardEdit {
     opacity: 1;
     pointer-events: auto;
-}
-
-.grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
-    gap: var(--mantine-spacing-xs);
 }
 
 .card {
@@ -70,27 +58,15 @@
         var(--mantine-color-ldDark-3)
     );
     text-align: center;
-}
-
-/* Interactive states shared by the rows and grid layouts. Kept after the
-   base rules: light-dark() compiles to a scheme-prefixed selector with the
-   same specificity, so source order decides the selected border. */
-.row,
-.card {
     border-radius: var(--mantine-radius-md);
     /* User-defined names can be one long unbroken word; break rather than
        forcing the gallery to scroll horizontally at min sidebar width. */
     overflow-wrap: anywhere;
     min-width: 0;
-}
-
-/* One step off the panel in each scheme: the dark panel already sits on
-   ldGray-0, so the same shade there would hide the hover. */
-.row:hover:not(:disabled):not([data-selected='true']) {
-    background: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldGray-1)
-    );
+    transition:
+        transform 120ms cubic-bezier(0.23, 1, 0.32, 1),
+        background-color 120ms ease,
+        box-shadow 120ms ease;
 }
 
 .card:hover:not(:disabled):not([data-selected='true']) {
@@ -104,19 +80,16 @@
     );
 }
 
-/* Selected reads like the join-type control's active segment: lifted onto
-   the body surface under a soft shadow and a hairline. The hairline lives on
-   the border, not a shadow ring: rows run flush to the scroll viewport, which
-   would clip a ring drawn outside the box. */
-.row[data-selected='true'],
+/* Selected reads like the join-type control's active segment: lifted under a
+   soft shadow with the hairline on the border, where the scroll viewport
+   cannot clip it. Light lifts onto the body surface; dark lifts a step past
+   the hover shade instead, since body sits level with the panel there — both
+   the join-type control and Mantine's segmented indicator go lighter in dark. */
 .card[data-selected='true'] {
     border-color: light-dark(
         var(--mantine-color-ldGray-3),
         var(--mantine-color-ldGray-4)
     );
-    /* Light lifts onto the body surface; dark lifts a step past the hover
-       shade instead, since body sits level with the panel there — both the
-       join-type control and Mantine's segmented indicator go lighter in dark. */
     background: light-dark(
         var(--mantine-color-body),
         var(--mantine-color-ldGray-2)
@@ -124,11 +97,17 @@
     box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
 }
 
-.card {
-    transition:
-        transform 120ms cubic-bezier(0.23, 1, 0.32, 1),
-        background-color 120ms ease,
-        box-shadow 120ms ease;
+/* An action tile among content tiles: outlined, not filled. */
+.createCard {
+    border-style: dashed;
+    background: transparent;
+    color: var(--mantine-color-ldGray-7);
+}
+
+/* Keeps the content cards' material — it stands for hidden cards — with
+   muted ink marking it as an affordance rather than a chart type. */
+.moreCard {
+    color: var(--mantine-color-ldGray-7);
 }
 
 .card:active:not(:disabled) {
@@ -145,7 +124,6 @@
     }
 }
 
-.row:disabled,
 .card:disabled {
     opacity: 0.5;
 }

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
@@ -8,7 +8,8 @@ import { useDataAppVisualizations } from '../../../features/chartTypes/hooks/use
 import { renderWithProviders } from '../../../testing/testUtils';
 import ExplorerChartTypeGallery, {
     ChartTypeGallery,
-    type ChartTypeGalleryRowItem,
+    type ChartTypeGalleryItem,
+    type ChartTypeGallerySection,
 } from './ChartTypeGallery';
 
 const { mocks } = vi.hoisted(() => ({
@@ -84,8 +85,8 @@ vi.mock('react-router', async (importOriginal) => ({
 
 const galleryItem = (
     label: string,
-    description: string,
-): ChartTypeGalleryRowItem => ({
+    description: string | null = null,
+): ChartTypeGalleryItem => ({
     key: label,
     label,
     description,
@@ -97,22 +98,34 @@ const galleryItem = (
     onEdit: null,
 });
 
+const gallerySection = (
+    overrides: Partial<ChartTypeGallerySection> = {},
+): ChartTypeGallerySection => ({
+    label: 'Built in',
+    items: [],
+    emptyMessage: 'Nothing here',
+    loading: false,
+    errorMessage: null,
+    onRetry: null,
+    onLoadMore: null,
+    moreCount: 0,
+    loadingMore: false,
+    onCreateNew: null,
+    ...overrides,
+});
+
 describe('ChartTypeGallery', () => {
-    it('renders grid sections as icon+label cards and rows sections with descriptions', () => {
+    it('renders every section as cards, with Edit only where it is offered', () => {
         renderWithProviders(
             <ChartTypeGallery
                 search=""
                 onSearchChange={vi.fn()}
                 sections={[
-                    {
-                        label: 'Built in',
-                        layout: 'grid',
-                        items: [galleryItem('Bar chart', 'Compare categories')],
-                        emptyMessage: 'Nothing here',
-                    },
-                    {
+                    gallerySection({
+                        items: [galleryItem('Bar chart')],
+                    }),
+                    gallerySection({
                         label: 'Project',
-                        layout: 'rows',
                         items: [
                             {
                                 ...galleryItem(
@@ -122,31 +135,23 @@ describe('ChartTypeGallery', () => {
                                 onEdit: vi.fn(),
                             },
                         ],
-                        emptyMessage: 'Nothing here',
-                        loading: false,
-                        errorMessage: null,
-                        onRetry: null,
-                        onLoadMore: null,
-                        loadingMore: false,
-                        onCreateNew: null,
-                    },
+                    }),
                 ]}
             />,
         );
 
-        // Grid cards keep the label as the accessible name, drop the description.
+        // Cards keep the label as the accessible name; the description lives
+        // in a tooltip rather than the card face.
         expect(
             screen.getByRole('button', { name: 'Bar chart' }),
         ).toBeInTheDocument();
         expect(
-            screen.queryByText('Compare categories'),
-        ).not.toBeInTheDocument();
-
-        expect(
-            screen.getByRole('button', { name: /^Event pulse/ }),
+            screen.getByRole('button', { name: 'Event pulse' }),
         ).toBeInTheDocument();
-        expect(screen.getByText('Reusable ranked bars')).toBeInTheDocument();
-        // Edit names its row so repeated Edit links stay distinguishable.
+        expect(
+            screen.queryByText('Reusable ranked bars'),
+        ).not.toBeInTheDocument();
+        // Edit names its card so repeated pencils stay distinguishable.
         expect(
             screen.getByRole('button', { name: 'Edit Event pulse' }),
         ).toBeInTheDocument();
@@ -158,21 +163,12 @@ describe('ChartTypeGallery', () => {
                 search=""
                 onSearchChange={vi.fn()}
                 sections={[
-                    {
-                        label: 'Built in',
-                        layout: 'grid',
+                    gallerySection({
                         items: [
-                            {
-                                ...galleryItem('Bar chart', ''),
-                                selected: true,
-                            },
-                            {
-                                ...galleryItem('Line chart', ''),
-                                disabled: true,
-                            },
+                            { ...galleryItem('Bar chart'), selected: true },
+                            { ...galleryItem('Line chart'), disabled: true },
                         ],
-                        emptyMessage: 'Nothing here',
-                    },
+                    }),
                 ]}
             />,
         );
@@ -185,19 +181,40 @@ describe('ChartTypeGallery', () => {
         expect(lineChart).toBeDisabled();
     });
 
-    it('shows the empty message when a grid section has no items', () => {
+    it('offers the create tile even when the section is empty', () => {
+        const onCreateNew = vi.fn();
+        renderWithProviders(
+            <ChartTypeGallery
+                search=""
+                onSearchChange={vi.fn()}
+                sections={[
+                    gallerySection({
+                        label: 'Project',
+                        emptyMessage: 'No project chart types yet',
+                        onCreateNew,
+                    }),
+                ]}
+            />,
+        );
+
+        expect(
+            screen.getByText('No project chart types yet'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Create new chart type' }),
+        ).toBeInTheDocument();
+    });
+
+    it('shows the empty message when a section has no items', () => {
         renderWithProviders(
             <ChartTypeGallery
                 search="zzz"
                 onSearchChange={vi.fn()}
                 sections={[
-                    {
-                        label: 'Built in',
-                        layout: 'grid',
-                        items: [],
+                    gallerySection({
                         emptyMessage:
                             'No built-in chart types match your search',
-                    },
+                    }),
                 ]}
             />,
         );
@@ -350,7 +367,7 @@ describe('ExplorerChartTypeGallery', () => {
         ).toBeInTheDocument();
     });
 
-    it('caps the initial project list and reveals the rest on Load more', async () => {
+    it('caps the initial project list and reveals the rest via the "+N more" tile', async () => {
         const many = Array.from({ length: 8 }, (_, i) => ({
             ...projectChartType,
             dataAppVizUuid: `project-chart-type-${i}`,
@@ -381,20 +398,67 @@ describe('ExplorerChartTypeGallery', () => {
         renderGallery();
 
         expect(
-            screen.getByRole('button', { name: /Event pulse 4/ }),
+            screen.getByRole('button', { name: 'Event pulse 4' }),
         ).toBeInTheDocument();
         expect(
-            screen.queryByRole('button', { name: /Event pulse 5/ }),
+            screen.queryByRole('button', { name: 'Event pulse 5' }),
         ).not.toBeInTheDocument();
 
         await userEvent.click(
-            screen.getByRole('button', { name: 'Load more' }),
+            screen.getByRole('button', { name: 'Show 3 more chart types' }),
         );
 
         expect(
-            screen.getByRole('button', { name: /Event pulse 7/ }),
+            screen.getByRole('button', { name: 'Event pulse 7' }),
         ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: /more chart types/ }),
+        ).not.toBeInTheDocument();
+        // Focus lands on the first revealed card once the tile unmounts.
+        expect(
+            screen.getByRole('button', { name: 'Event pulse 5' }),
+        ).toHaveFocus();
         expect(mocks.fetchNextPage).not.toHaveBeenCalled();
+    });
+
+    it('fetches the next page from the "+N more" tile once every loaded item shows', async () => {
+        const loaded = Array.from({ length: 6 }, (_, i) => ({
+            ...projectChartType,
+            dataAppVizUuid: `project-chart-type-${i}`,
+            name: `Event pulse ${i}`,
+        }));
+        mockedUseDataAppVisualizations.mockReturnValue({
+            data: {
+                pages: [
+                    {
+                        data: loaded,
+                        pagination: {
+                            page: 1,
+                            pageSize: 6,
+                            totalPageCount: 2,
+                            totalResults: 10,
+                        },
+                    },
+                ],
+                pageParams: [1],
+            },
+            isInitialLoading: false,
+            error: null,
+            refetch: mocks.refetch,
+            hasNextPage: true,
+            fetchNextPage: mocks.fetchNextPage,
+            isFetchingNextPage: false,
+        } as unknown as ReturnType<typeof useDataAppVisualizations>);
+        renderGallery();
+
+        expect(
+            screen.getByRole('button', { name: 'Event pulse 5' }),
+        ).toBeInTheDocument();
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Show 4 more chart types' }),
+        );
+
+        expect(mocks.fetchNextPage).toHaveBeenCalled();
     });
 
     it('keeps built-in choices usable when project types fail to load', async () => {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -1,10 +1,6 @@
+import { FeatureFlags, type DataAppViz } from '@lightdash/common';
 import {
-    assertUnreachable,
-    FeatureFlags,
-    type DataAppViz,
-} from '@lightdash/common';
-import {
-    Anchor,
+    ActionIcon,
     Box,
     Button,
     Group,
@@ -17,8 +13,13 @@ import {
     UnstyledButton,
 } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
-import { IconPlus, IconSearch } from '@tabler/icons-react';
-import { useCallback, useMemo, useRef, useState, type FC } from 'react';
+import {
+    IconDots,
+    IconFilePencil,
+    IconPlus,
+    IconSearch,
+} from '@tabler/icons-react';
+import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataAppChecker } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualizations } from '../../../features/chartTypes/hooks/useDataAppVisualizations';
@@ -39,17 +40,17 @@ import {
 } from '../VisualizationCardOptions/useChartTypeOptions';
 import classes from './ChartTypeGallery.module.css';
 
-/** Rows shown before "Load more", keeping built-ins visible at first glance. */
-const INITIAL_PROJECT_TYPES_SHOWN = 5;
+/** Grid slots the project section may fill before collapsing; when it does,
+    the last slot becomes the "+N more" tile, so the collapse never trades a
+    single hidden card for a tile. */
+const MAX_UNCOLLAPSED_PROJECT_TYPES = 6;
+const COLLAPSED_PROJECT_TYPES_SHOWN = MAX_UNCOLLAPSED_PROJECT_TYPES - 1;
 
 export type ChartTypeGalleryItem = Omit<ChartTypeOption, 'id'> & {
     key: string;
     disabled: boolean;
-};
-
-/** Rows show per-item text and actions that grid cards deliberately drop. */
-export type ChartTypeGalleryRowItem = ChartTypeGalleryItem & {
-    description: string;
+    /** Shown as the card's tooltip; null shows none. */
+    description: string | null;
     /** Opens the chart type builder for this item; null hides the action. */
     onEdit: (() => void) | null;
 };
@@ -82,109 +83,64 @@ export const ChartTypeThumbnail: FC<ChartTypeIconProps> = ({
     </Box>
 );
 
-type ChartTypeGallerySectionBase = {
+export type ChartTypeGallerySection = {
     label: string;
-    emptyMessage: string;
-};
-
-/** A static set of built-ins: a compact card grid, no remote-list states. */
-type ChartTypeGalleryGridSection = ChartTypeGallerySectionBase & {
-    layout: 'grid';
     items: ChartTypeGalleryItem[];
-};
-
-/** A remote list of project chart types: richer rows with list states. */
-type ChartTypeGalleryRowsSection = ChartTypeGallerySectionBase & {
-    layout: 'rows';
-    items: ChartTypeGalleryRowItem[];
+    emptyMessage: string;
+    /* Remote-list states; a static section passes them inert. */
     loading: boolean;
     errorMessage: string | null;
     onRetry: (() => void) | null;
     onLoadMore: (() => void) | null;
+    /** Hidden items behind the "+N more" tile; 0 when onLoadMore is null. */
+    moreCount: number;
     loadingMore: boolean;
-    /** Opens the chart type builder; null hides the create action. */
+    /** Opens the chart type builder; null hides the create tile. */
     onCreateNew: (() => void) | null;
 };
 
-export type ChartTypeGallerySection =
-    | ChartTypeGalleryGridSection
-    | ChartTypeGalleryRowsSection;
-
-// Observes the clamped description and reports whether it is actually cut
-// off; ResizeObserver fires on observe and on any later size change.
-const useIsClamped = () => {
-    const [isClamped, setIsClamped] = useState(false);
-    const observerRef = useRef<ResizeObserver | null>(null);
-    const ref = useCallback((node: HTMLParagraphElement | null) => {
-        observerRef.current?.disconnect();
-        observerRef.current = null;
-        if (!node) return;
-        observerRef.current = new ResizeObserver(() => {
-            setIsClamped(node.scrollHeight > node.clientHeight);
-        });
-        observerRef.current.observe(node);
-    }, []);
-    return { ref, isClamped };
-};
-
-const GalleryRow: FC<{ item: ChartTypeGalleryRowItem }> = ({ item }) => {
-    // The description is clamped to two lines; surface the full text on hover
-    // only when it is actually cut off.
-    const { ref, isClamped } = useIsClamped();
-
-    return (
-        <Box className={classes.rowWrapper}>
-            <Tooltip
-                label={item.description}
-                withinPortal
-                position="left"
-                withArrow
-                openDelay={500}
-                color="dark"
-                events={{ hover: true, focus: true, touch: false }}
-                disabled={!isClamped}
-                maw={300}
-                multiline
+const GalleryCard: FC<{ item: ChartTypeGalleryItem }> = ({ item }) => (
+    <Box className={classes.cardWrapper}>
+        <Tooltip
+            label={item.description}
+            withinPortal
+            position="top"
+            withArrow
+            openDelay={500}
+            color="dark"
+            events={{ hover: true, focus: true, touch: false }}
+            disabled={item.description === null}
+            maw={300}
+            multiline
+        >
+            <UnstyledButton
+                className={classes.card}
+                data-selected={item.selected}
+                disabled={item.disabled}
+                onClick={item.select}
             >
-                <UnstyledButton
-                    className={classes.row}
-                    data-selected={item.selected}
-                    data-has-edit={item.onEdit !== null}
-                    disabled={item.disabled}
-                    onClick={item.select}
-                >
-                    <Group wrap="nowrap" gap="sm">
-                        <ChartTypeThumbnail
-                            icon={item.icon}
-                            rotatedIcon={item.rotatedIcon}
-                        />
-                        <Stack gap={2} flex={1} miw={0}>
-                            <Text size="sm" fw={500}>
-                                {item.label}
-                            </Text>
-                            <Text ref={ref} fz="xs" c="dimmed" lineClamp={2}>
-                                {item.description}
-                            </Text>
-                        </Stack>
-                    </Group>
-                </UnstyledButton>
-            </Tooltip>
-            {item.onEdit !== null ? (
-                <Anchor
-                    component="button"
-                    type="button"
-                    className={classes.rowEdit}
-                    aria-label={`Edit ${item.label}`}
-                    fz="xs"
-                    fw={500}
-                    onClick={item.onEdit}
-                >
-                    Edit
-                </Anchor>
-            ) : null}
-        </Box>
-    );
-};
+                <ChartTypeIcon
+                    icon={item.icon}
+                    rotatedIcon={item.rotatedIcon}
+                />
+                <Text fz="xs" fw={500} lh={1.2} lineClamp={2}>
+                    {item.label}
+                </Text>
+            </UnstyledButton>
+        </Tooltip>
+        {item.onEdit !== null ? (
+            <ActionIcon
+                className={classes.cardEdit}
+                variant="default"
+                size="sm"
+                aria-label={`Edit ${item.label}`}
+                onClick={item.onEdit}
+            >
+                <MantineIcon icon={IconFilePencil} size={14} />
+            </ActionIcon>
+        ) : null}
+    </Box>
+);
 
 const SectionEmpty: FC<{ message: string }> = ({ message }) => (
     <Text fz="xs" c="dimmed">
@@ -193,117 +149,114 @@ const SectionEmpty: FC<{ message: string }> = ({ message }) => (
 );
 
 const SectionBody: FC<{ section: ChartTypeGallerySection }> = ({ section }) => {
-    switch (section.layout) {
-        case 'grid':
-            if (section.items.length === 0) {
-                return <SectionEmpty message={section.emptyMessage} />;
-            }
-            return (
-                <Box className={classes.grid}>
-                    {section.items.map((item) => (
-                        <UnstyledButton
-                            key={item.key}
-                            className={classes.card}
-                            data-selected={item.selected}
-                            disabled={item.disabled}
-                            onClick={item.select}
-                        >
-                            <ChartTypeIcon
-                                icon={item.icon}
-                                rotatedIcon={item.rotatedIcon}
-                            />
-                            <Text fz="xs" fw={500} lh={1.2}>
-                                {item.label}
-                            </Text>
-                        </UnstyledButton>
-                    ))}
-                </Box>
-            );
-        case 'rows':
-            if (section.loading) {
-                return (
-                    <Group gap="xs">
-                        <Loader size="xs" />
-                        <Text fz="xs" c="dimmed">
-                            Loading chart types…
-                        </Text>
-                    </Group>
-                );
-            }
-            if (section.errorMessage !== null) {
-                return (
-                    <Group justify="space-between" wrap="nowrap">
-                        <Text fz="xs" c="red">
-                            {section.errorMessage}
-                        </Text>
-                        {section.onRetry !== null ? (
-                            <Button
-                                variant="subtle"
-                                size="compact-xs"
-                                onClick={section.onRetry}
-                            >
-                                Retry
-                            </Button>
-                        ) : null}
-                    </Group>
-                );
-            }
-            if (section.items.length === 0) {
-                return <SectionEmpty message={section.emptyMessage} />;
-            }
-            return (
-                <>
-                    {section.items.map((item) => (
-                        <GalleryRow key={item.key} item={item} />
-                    ))}
-                </>
-            );
-        default:
-            return assertUnreachable(
-                section,
-                'Unknown chart type gallery section layout',
-            );
+    const gridRef = useRef<HTMLDivElement | null>(null);
+    const pendingFocusIndex = useRef<number | null>(null);
+    const itemCount = section.items.length;
+
+    // The "+N more" tile can unmount on reveal; move focus to the first new
+    // card so keyboard users are not dropped back to the body.
+    useEffect(() => {
+        const index = pendingFocusIndex.current;
+        if (index === null || itemCount <= index) return;
+        pendingFocusIndex.current = null;
+        gridRef.current
+            ?.querySelectorAll<HTMLButtonElement>(`.${classes.card}`)
+            [index]?.focus();
+    }, [itemCount]);
+
+    if (section.loading) {
+        return (
+            <Group gap="xs">
+                <Loader size="xs" />
+                <Text fz="xs" c="dimmed">
+                    Loading chart types…
+                </Text>
+            </Group>
+        );
     }
+    if (section.errorMessage !== null) {
+        return (
+            <Group justify="space-between" wrap="nowrap">
+                <Text fz="xs" c="red">
+                    {section.errorMessage}
+                </Text>
+                {section.onRetry !== null ? (
+                    <Button
+                        variant="subtle"
+                        size="compact-xs"
+                        onClick={section.onRetry}
+                    >
+                        Retry
+                    </Button>
+                ) : null}
+            </Group>
+        );
+    }
+    if (section.items.length === 0 && section.onCreateNew === null) {
+        return <SectionEmpty message={section.emptyMessage} />;
+    }
+    return (
+        <>
+            {section.items.length === 0 ? (
+                <SectionEmpty message={section.emptyMessage} />
+            ) : null}
+            <Box ref={gridRef} className={classes.grid}>
+                {section.items.map((item) => (
+                    <GalleryCard key={item.key} item={item} />
+                ))}
+                {/* Stands in for the hidden cards, so it keeps the card
+                    material; the count is the informative part. Covers both
+                    revealing capped items and fetching the next page. */}
+                {section.onLoadMore !== null ? (
+                    <UnstyledButton
+                        className={`${classes.card} ${classes.moreCard}`}
+                        aria-label={`Show ${section.moreCount} more chart types`}
+                        disabled={section.loadingMore}
+                        onClick={() => {
+                            pendingFocusIndex.current = section.items.length;
+                            section.onLoadMore?.();
+                        }}
+                    >
+                        {section.loadingMore ? (
+                            <Loader size="sm" color="ldGray.6" />
+                        ) : (
+                            <MantineIcon
+                                className={classes.icon}
+                                icon={IconDots}
+                                size="xl"
+                                stroke={1.5}
+                                color="ldGray.6"
+                            />
+                        )}
+                        <Text fz="xs" fw={500} lh={1.2}>
+                            +{section.moreCount} more
+                        </Text>
+                    </UnstyledButton>
+                ) : null}
+                {/* An action, not a chart type; a tile so it lives where the
+                    eye already is. */}
+                {section.onCreateNew !== null ? (
+                    <UnstyledButton
+                        className={`${classes.card} ${classes.createCard}`}
+                        aria-label="Create new chart type"
+                        onClick={section.onCreateNew}
+                    >
+                        <MantineIcon
+                            className={classes.icon}
+                            icon={IconPlus}
+                            size="xl"
+                            stroke={1.5}
+                            color="ldGray.6"
+                        />
+                        <Text fz="xs" fw={500} lh={1.2}>
+                            New chart type
+                        </Text>
+                    </UnstyledButton>
+                ) : null}
+            </Box>
+        </>
+    );
 };
-
-const RowsSectionActions: FC<{ section: ChartTypeGalleryRowsSection }> = ({
-    section,
-}) => (
-    <>
-        {section.onLoadMore !== null ? (
-            <Button
-                variant="subtle"
-                size="xs"
-                loading={section.loadingMore}
-                onClick={section.onLoadMore}
-            >
-                Load more
-            </Button>
-        ) : null}
-    </>
-);
-
-/* An action, not a chart type; beside the label so it is never below the fold. */
-const SectionHeader: FC<{ section: ChartTypeGallerySection }> = ({
-    section,
-}) => (
-    <Group justify="space-between" wrap="nowrap" gap="xs">
-        <Text fz="xs" fw={600} c="dimmed">
-            {section.label}
-        </Text>
-        {section.layout === 'rows' && section.onCreateNew !== null ? (
-            <Button
-                variant="subtle"
-                size="compact-xs"
-                leftSection={<MantineIcon icon={IconPlus} />}
-                aria-label="Create new chart type"
-                onClick={section.onCreateNew}
-            >
-                New
-            </Button>
-        ) : null}
-    </Group>
-);
 
 type GalleryProps = {
     search: string;
@@ -337,13 +290,11 @@ export const ChartTypeGallery: FC<GalleryProps> = ({
             <Stack gap="lg" pb="xs">
                 {sections.map((section) => (
                     <Stack key={section.label} gap="xs">
-                        <SectionHeader section={section} />
+                        <Text fz="xs" fw={600} c="dimmed">
+                            {section.label}
+                        </Text>
 
                         <SectionBody section={section} />
-
-                        {section.layout === 'rows' ? (
-                            <RowsSectionActions section={section} />
-                        ) : null}
                     </Stack>
                 ))}
             </Stack>
@@ -402,13 +353,15 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
             ...option,
             key: id,
             disabled,
+            description: null,
+            onEdit: null,
             select: () => {
                 option.select();
                 onSelected();
             },
         }));
     const projectItems = projectTypes.map(
-        (dataAppViz: DataAppViz): ChartTypeGalleryRowItem => {
+        (dataAppViz: DataAppViz): ChartTypeGalleryItem => {
             const { label, icon, rotatedIcon } =
                 projectChartTypeItem(dataAppViz);
             return {
@@ -437,24 +390,32 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
         },
     );
 
-    // Cap the initial list so built-ins stay in view; searching shows every
+    // Cap the initial grid so built-ins stay in view; searching shows every
     // match, and a selection deeper in the list is never hidden.
     const selectedProjectIdx = projectItems.findIndex((item) => item.selected);
     const collapseProjectTypes =
         !showAllProjectTypes &&
         debouncedSearch === '' &&
-        projectItems.length > INITIAL_PROJECT_TYPES_SHOWN &&
-        selectedProjectIdx < INITIAL_PROJECT_TYPES_SHOWN;
+        projectItems.length > MAX_UNCOLLAPSED_PROJECT_TYPES &&
+        selectedProjectIdx < COLLAPSED_PROJECT_TYPES_SHOWN;
     const visibleProjectItems = collapseProjectTypes
-        ? projectItems.slice(0, INITIAL_PROJECT_TYPES_SHOWN)
+        ? projectItems.slice(0, COLLAPSED_PROJECT_TYPES_SHOWN)
         : projectItems;
+    // Server total for the current search, so the tile counts pages that are
+    // not fetched yet.
+    const totalProjectTypes =
+        data?.pages.at(-1)?.pagination?.totalResults ?? projectItems.length;
+    const hiddenProjectTypes = collapseProjectTypes
+        ? totalProjectTypes - visibleProjectItems.length
+        : hasNextPage
+          ? Math.max(totalProjectTypes - projectItems.length, 1)
+          : 0;
 
     const sections: ChartTypeGallerySection[] = [
         ...(dataAppsEnabled
             ? [
                   {
                       label: 'Project',
-                      layout: 'rows' as const,
                       items: visibleProjectItems,
                       loading: isInitialLoading,
                       errorMessage: error
@@ -469,6 +430,7 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
                           : hasNextPage
                             ? () => void fetchNextPage()
                             : null,
+                      moreCount: hiddenProjectTypes,
                       loadingMore: isFetchingNextPage,
                       onCreateNew: canCreateChartType
                           ? () =>
@@ -483,9 +445,15 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
             : []),
         {
             label: 'Built in',
-            layout: 'grid',
             items: builtInItems,
             emptyMessage: 'No built-in chart types match your search',
+            loading: false,
+            errorMessage: null,
+            onRetry: null,
+            onLoadMore: null,
+            moreCount: 0,
+            loadingMore: false,
+            onCreateNew: null,
         },
     ];
 


### PR DESCRIPTION
## Summary

Two different shapes for one choice: built-ins were a card grid while project chart types were rows, so the sidebar read as two unrelated pickers. Project types now use the exact same card as built-ins, in one visual system:

- One `ChartTypeGallerySection` shape for both sections (the remote-list states — loading, error, retry, load more — stay, passed inert by the built-in section). The rows layout, `GalleryRow`, the clamped-description machinery and the row CSS are gone.
- A project card keeps its description behind a tooltip (hover/focus, 500ms delay) instead of on the card face.
- Editing a type is the gallery's own affordance: `IconFilePencil` in the card's corner, revealed on hover/focus exactly like the row link was (and like the standalone gallery card's edit action), named `Edit <type>` for assistive tech.
- Creating a type is a dashed **New chart type** tile closing the Project grid — an action tile among content tiles — replacing the section-header button. It stays available when the section is empty, next to the empty message.
- The project section collapses past 6 grid slots: 5 cards plus an in-grid **"+N more" tile** (dots glyph, exact hidden count from `pagination.totalResults`) in the last slot, following the photo-grid/avatar-group overflow convention. The same tile fetches the next server page (inline loader) once everything loaded is shown, replacing the old Load more button. On reveal, focus moves to the first newly shown card. Search and a selection deeper in the list still expand as before.

Styling, selection (lift), hover and press behaviour are the ldGray treatment from #27990, now shared by every card.

## Follow-up feasibility (from the same feedback thread, not in this PR)

- **Custom icons from the icon library**: the `apps` table has no icon column, so this needs a nullable column + the update endpoint/type plumbing (the `AppUpdateModal` path already exists to carry it) + a Tabler icon picker in that modal. Moderate, well-bounded; no new infrastructure.
- **Preview snapshots on the cards**: two existing pipelines to choose from. (a) The standalone gallery card already renders a live sample preview (`ChartTypeSamplePreview`, sample data through the real viz bundle) — heavy for a sidebar grid: one iframe per card. (b) A stored PNG pipeline also exists end-to-end (`apps/{uuid}/thumbnail.png` in S3, upload/delete/fetch endpoints, `useAppThumbnailUrl`, used by the homepage resources block) — cards could show it with a plain `img` and the icon as fallback; the missing piece is capturing a thumbnail automatically when a version builds (today it is user-uploaded). (b) is the practical route.

## How to test

1. Enable `explorer-chart-gallery`, open a chart in edit mode → Configure → Change.
2. Project and Built in render as one continuous card system; hover a project card for its description and the corner edit pencil; the dashed **New chart type** tile ends the Project grid.
3. With more than 6 project types, the **"+N more" tile** reveals the rest (then pages from the server if needed); searching bypasses the cap.
4. Light and dark: selection, hover and press behave identically across both sections.

Relates: GLITCH-680

