### PR TITLE
feat(ai-agents): merged answers render through custom chart types

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -55,6 +55,7 @@ import {
     ApiUpdateEvaluationRequest,
     ApiUpdateUserAgentPreferences,
     assertUnreachable,
+    ChartType,
     CommercialFeatureFlags,
     ConflictError,
     ContentType,
@@ -128,6 +129,7 @@ import {
     type AiAgentEditDbtProjectPipelineJobPayload,
     type AiAgentModelConfig,
     type AiClonedThreadCreatedFrom,
+    type AiCustomChartTypeChartArtifactConfig,
     type AiDeepResearchBudget,
     type AiDeepResearchEventPayloadMap,
     type AiDeepResearchEvidencePack,
@@ -137,6 +139,7 @@ import {
     type AiWebAppThreadCreatedFrom,
     type DataAppVizChart,
     type ItemsMap,
+    type MergeQueryChart,
     type MetricQuery,
     type PivotConfiguration,
     type SessionUser,
@@ -2496,10 +2499,44 @@ export class AiAgentService extends BaseService {
         });
     }
 
+    // Best-effort merge pivot chart from the type's schema: a deleted app
+    // or invalid schema means no pivot, not an error.
+    private async buildCustomChartTypeMergeChart(
+        projectUuid: string,
+        artifactConfig: AiCustomChartTypeChartArtifactConfig,
+    ): Promise<MergeQueryChart | undefined> {
+        const dataAppVizChart = getDataAppVizChartFromArtifact(artifactConfig);
+        if (!dataAppVizChart) return undefined;
+        const app = await this.appModel.findVisualizationApp(
+            dataAppVizChart.dataAppVizUuid,
+            projectUuid,
+        );
+        const parsedSchema = dataAppVizSchema.safeParse(app?.viz_schema);
+        if (!parsedSchema.success) {
+            Logger.warn(
+                `Skipping custom chart type merge pivot for ${dataAppVizChart.dataAppVizUuid}: app missing or viz_schema failed validation`,
+            );
+            return undefined;
+        }
+        return {
+            chartConfig: {
+                type: ChartType.DATA_APP_VIZ,
+                config: dataAppVizChart,
+            },
+            pivotConfig: deriveDataAppVizPivotConfig(
+                parsedSchema.data.fields,
+                dataAppVizChart.fieldMapping,
+            ),
+        };
+    }
+
     private async executeAsyncAiMergeQuery(
         user: SessionUser,
         projectUuid: string,
         toolArgs: ToolRunQueryArgsTransformed,
+        // Set for custom chart type answers: the merge pivot seam derives
+        // series pivots over the merged result from the type's schema.
+        chart?: MergeQueryChart,
     ) {
         const mergeQuery = await this.buildAiMergeQuery(
             user,
@@ -2513,6 +2550,7 @@ export class AiAgentService extends BaseService {
             context: QueryExecutionContext.AI,
             parameters: toolArgs.queryConfig.parameters ?? undefined,
             mode: { type: 'interactive' },
+            chart,
         });
         if (outcome.outcome === 'refused') {
             throw new ParameterError(formatMergeQueryRefusal(outcome.errors), {
@@ -6856,7 +6894,20 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        if (isAiMergeChartArtifactConfig(artifact.chartConfig)) {
+        // Custom envelopes may carry a merge (the stored mergeConfig is the
+        // discriminator) and replay through merge execution like merges.
+        const customChartTypeEnvelope =
+            artifact.chartConfig.source === 'customChartType'
+                ? artifact.chartConfig
+                : null;
+        const customChartTypeParsed = customChartTypeEnvelope
+            ? parsePersistedRunQueryArgs(customChartTypeEnvelope.config)
+            : null;
+
+        if (
+            isAiMergeChartArtifactConfig(artifact.chartConfig) ||
+            customChartTypeParsed?.mergeConfig
+        ) {
             const { enabled: mergeQueriesEnabled } =
                 await this.featureFlagService.get({
                     user,
@@ -6865,16 +6916,23 @@ export class AiAgentService extends BaseService {
             if (!mergeQueriesEnabled) {
                 throw new ForbiddenError('Merge queries are not enabled');
             }
-            const parsed = parsePersistedRunQueryArgs(
-                artifact.chartConfig.config,
-            );
+            const parsed = isAiMergeChartArtifactConfig(artifact.chartConfig)
+                ? parsePersistedRunQueryArgs(artifact.chartConfig.config)
+                : customChartTypeParsed;
             if (!parsed?.mergeConfig) {
                 throw new ParameterError('Invalid merge visualization config');
             }
+            const chart = customChartTypeEnvelope
+                ? await this.buildCustomChartTypeMergeChart(
+                      projectUuid,
+                      customChartTypeEnvelope,
+                  )
+                : undefined;
             const { query, mergeQuery } = await this.executeAsyncAiMergeQuery(
                 user,
                 projectUuid,
                 parsed,
+                chart,
             );
             this.analytics.track({
                 event: 'ai_agent.artifact_viz_query',

--- a/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
@@ -476,81 +476,197 @@ describe('getRunQuery custom chart types', () => {
         expect(runAsyncQuery).not.toHaveBeenCalled();
     });
 
-    it('rejects mergeConfig combined with a custom chart type', async () => {
-        const runAsyncMergeQuery = vi.fn() as RunAsyncMergeQueryFn;
-        const runAsyncQuery = vi.fn() as RunAsyncQueryFn;
-        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
-        const queryTool = getRunQuery({
-            updateProgress: vi.fn().mockResolvedValue(undefined),
-            runAsyncQuery,
-            runAsyncMergeQuery,
-            enableMergeQueries: true,
-            projectParameterDefinitions: {},
-            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
-            sendFile: vi.fn().mockResolvedValue(undefined),
-            createOrUpdateArtifact,
-            maxLimit: 500,
-            maxContextRows: Number.POSITIVE_INFINITY,
-            exposeQueryUuid: false,
-            enableDataAccess: true,
-            resolveCustomChartType: vi.fn().mockResolvedValue({
+    describe('with mergeConfig', () => {
+        const mergeConfig = {
+            primarySourceId: 'primary',
+            additionalSources: [
+                {
+                    id: 'comparison',
+                    queryConfig: {
+                        exploreName: validExplore.name,
+                        dimensions: metricQueryMock.dimensions,
+                        metrics: metricQueryMock.metrics,
+                        sorts: [],
+                        customMetrics: null,
+                        filters: null,
+                    },
+                },
+            ],
+            joinKey: [
+                {
+                    name: 'key',
+                    fields: [
+                        {
+                            sourceId: 'primary',
+                            fieldId: metricQueryMock.dimensions[0],
+                        },
+                        {
+                            sourceId: 'comparison',
+                            fieldId: metricQueryMock.dimensions[0],
+                        },
+                    ],
+                },
+            ],
+            joinType: 'full' as const,
+        };
+
+        const mergedCustomChartConfig = {
+            customChartTypeSlug: 'cohort-waterfall',
+            fieldMapping: { x: 'merge_key', y: 'primary_a_met1' },
+            options: { showLegend: true },
+        };
+
+        const executeMergeCustom = async ({
+            chartConfig = mergedCustomChartConfig,
+            enableMergeQueries = true,
+            resolveCustomChartType = vi.fn().mockResolvedValue({
                 dataAppVizUuid: '4c25c1d5-cbc9-4d76-b58e-b1c9ee399fd9',
                 schema: vizSchema,
             }) as ResolveCustomChartTypeFn,
-        });
-
-        const mergeCustomInput = {
-            ...toolInput,
-            chartConfig: customChartConfig,
-            mergeConfig: {
-                primarySourceId: 'primary',
-                additionalSources: [
-                    {
-                        id: 'comparison',
-                        queryConfig: {
-                            exploreName: validExplore.name,
-                            dimensions: metricQueryMock.dimensions,
-                            metrics: metricQueryMock.metrics,
-                            sorts: [],
-                            customMetrics: null,
-                            filters: null,
-                        },
-                    },
-                ],
-                joinKey: [
-                    {
-                        name: 'key',
-                        fields: [
-                            {
-                                sourceId: 'primary',
-                                fieldId: metricQueryMock.dimensions[0],
-                            },
-                            {
-                                sourceId: 'comparison',
-                                fieldId: metricQueryMock.dimensions[0],
-                            },
-                        ],
-                    },
-                ],
-                joinType: 'full' as const,
-            },
+        }: {
+            chartConfig?: ToolRunQueryCustomChartTypeConfig;
+            enableMergeQueries?: boolean;
+            resolveCustomChartType?: ResolveCustomChartTypeFn;
+        } = {}) => {
+            const runAsyncMergeQuery: RunAsyncMergeQueryFn = vi
+                .fn()
+                .mockResolvedValue({
+                    queryUuid: '22222222-2222-4222-8222-222222222222',
+                    rows: [{ merge_key: 'one', primary_a_met1: 1 }],
+                    cacheMetadata: { cacheHit: false },
+                    fields: {},
+                    metricQuery: metricQueryMock,
+                });
+            const runAsyncQuery = vi.fn() as RunAsyncQueryFn;
+            const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+            const queryTool = getRunQuery({
+                updateProgress: vi.fn().mockResolvedValue(undefined),
+                runAsyncQuery,
+                runAsyncMergeQuery,
+                enableMergeQueries,
+                projectParameterDefinitions: {},
+                getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+                sendFile: vi.fn().mockResolvedValue(undefined),
+                createOrUpdateArtifact,
+                maxLimit: 500,
+                maxContextRows: Number.POSITIVE_INFINITY,
+                exposeQueryUuid: false,
+                enableDataAccess: true,
+                resolveCustomChartType,
+            });
+            const input = { ...toolInput, chartConfig, mergeConfig };
+            const output = await queryTool.execute!(input, {
+                messages: [],
+                toolCallId: 'tool-call-1',
+                experimental_context: new AgentContext([validExplore]),
+            });
+            if (Symbol.asyncIterator in output) {
+                throw new Error('Expected a non-streaming tool result');
+            }
+            return {
+                output,
+                createOrUpdateArtifact,
+                runAsyncMergeQuery,
+                runAsyncQuery,
+                input,
+            };
         };
-        const output = await queryTool.execute!(mergeCustomInput, {
-            messages: [],
-            toolCallId: 'tool-call-1',
-            experimental_context: new AgentContext([validExplore]),
-        });
-        if (Symbol.asyncIterator in output) {
-            throw new Error('Expected a non-streaming tool result');
-        }
 
-        expect(output.metadata).toEqual({ status: 'error' });
-        expect(output.result).toContain(
-            'Custom chart types cannot be combined with mergeConfig',
-        );
-        expect(runAsyncMergeQuery).not.toHaveBeenCalled();
-        expect(runAsyncQuery).not.toHaveBeenCalled();
-        expect(createOrUpdateArtifact).not.toHaveBeenCalled();
+        it('runs the merge and persists the custom envelope with the merge intact', async () => {
+            const {
+                output,
+                createOrUpdateArtifact,
+                runAsyncMergeQuery,
+                runAsyncQuery,
+                input,
+            } = await executeMergeCustom();
+
+            expect(output.metadata).toMatchObject({
+                status: 'success',
+                queryUuid: '22222222-2222-4222-8222-222222222222',
+            });
+            expect(runAsyncQuery).not.toHaveBeenCalled();
+            expect(runAsyncMergeQuery).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    sources: expect.arrayContaining([
+                        expect.objectContaining({ id: 'primary' }),
+                        expect.objectContaining({ id: 'comparison' }),
+                    ]),
+                    joinType: 'full',
+                }),
+                undefined,
+            );
+            expect(createOrUpdateArtifact).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    vizConfig: {
+                        source: 'customChartType',
+                        schemaVersion: 1,
+                        dataAppVizUuid: '4c25c1d5-cbc9-4d76-b58e-b1c9ee399fd9',
+                        config: input,
+                    },
+                }),
+            );
+        });
+
+        it('rejects a fieldMapping bound to source-explore ids listing the merged pools', async () => {
+            const { output, runAsyncMergeQuery } = await executeMergeCustom({
+                chartConfig: {
+                    ...mergedCustomChartConfig,
+                    fieldMapping: { x: 'a_dim1', y: 'a_met1' },
+                },
+            });
+
+            expect(output.metadata).toEqual({ status: 'error' });
+            expect(output.result).toContain('x → a_dim1');
+            expect(output.result).toContain('y → a_met1');
+            expect(output.result).toContain('merge_key');
+            expect(output.result).toContain('primary_a_met1');
+            expect(output.result).toContain('comparison_a_met1');
+            expect(runAsyncMergeQuery).not.toHaveBeenCalled();
+        });
+
+        it('rejects a join key bound to a metric slot via the merged pools', async () => {
+            const { output, runAsyncMergeQuery } = await executeMergeCustom({
+                chartConfig: {
+                    ...mergedCustomChartConfig,
+                    fieldMapping: { x: 'merge_key', y: 'merge_key' },
+                },
+            });
+
+            expect(output.metadata).toEqual({ status: 'error' });
+            expect(output.result).toContain(
+                'Slot "y" (metric) only accepts metrics or table calculations, but "merge_key" is a dimension',
+            );
+            expect(runAsyncMergeQuery).not.toHaveBeenCalled();
+        });
+
+        it('rejects an unknown slug before the merge executes', async () => {
+            const { output, runAsyncMergeQuery, createOrUpdateArtifact } =
+                await executeMergeCustom({
+                    resolveCustomChartType: vi
+                        .fn()
+                        .mockResolvedValue(null) as ResolveCustomChartTypeFn,
+                });
+
+            expect(output.metadata).toEqual({ status: 'error' });
+            expect(output.result).toContain(
+                'Custom chart type "cohort-waterfall" was not found in this project',
+            );
+            expect(runAsyncMergeQuery).not.toHaveBeenCalled();
+            expect(createOrUpdateArtifact).not.toHaveBeenCalled();
+        });
+
+        it('still rejects merge payloads when merge queries are disabled', async () => {
+            const { output, runAsyncMergeQuery, createOrUpdateArtifact } =
+                await executeMergeCustom({ enableMergeQueries: false });
+
+            expect(output.metadata).toEqual({ status: 'error' });
+            expect(output.result).toContain(
+                'Merge queries are not enabled for this organization.',
+            );
+            expect(runAsyncMergeQuery).not.toHaveBeenCalled();
+            expect(createOrUpdateArtifact).not.toHaveBeenCalled();
+        });
     });
 });
 

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -328,15 +328,25 @@ export const getRunQuery = ({
                     );
                 }
 
-                // Merge × custom chart type has no defined contract yet —
-                // reject explicitly rather than silently falling back.
-                if (
-                    queryTool.mergeConfig &&
-                    isCustomChartTypeSlugChartConfig(queryTool.chartConfig)
-                ) {
-                    throw new AiAgentValidatorError(
-                        'Custom chart types cannot be combined with mergeConfig. Either set mergeConfig to null to render this answer through the custom chart type, or keep the merge and use a builtin chartConfig.',
+                // Resolve the custom chart type slug before any query runs
+                // (merged or not); the uuid is persisted in the envelope.
+                const customChartConfig = isCustomChartTypeSlugChartConfig(
+                    queryTool.chartConfig,
+                )
+                    ? queryTool.chartConfig
+                    : null;
+                let resolvedCustomChartType: Awaited<
+                    ReturnType<ResolveCustomChartTypeFn>
+                > = null;
+                if (customChartConfig) {
+                    resolvedCustomChartType = await resolveCustomChartType(
+                        customChartConfig.customChartTypeSlug,
                     );
+                    if (!resolvedCustomChartType) {
+                        throw new AiAgentValidatorError(
+                            `Custom chart type "${customChartConfig.customChartTypeSlug}" was not found in this project. Use findCustomChartTypes to browse the available types and their slugs.`,
+                        );
+                    }
                 }
 
                 const prompt = await getPrompt();
@@ -374,31 +384,42 @@ export const getRunQuery = ({
                         maxQueryLimit: maxLimit,
                     });
 
-                    // Custom chart configs were rejected above; the guard
-                    // narrows chartConfig to the builtin branch.
-                    if (
+                    // Merged output columns are fields of the merge/source
+                    // "tables", so getItemId is the naming authority.
+                    const dimensionIds = queryTool.mergeConfig.joinKey.map(
+                        (part) =>
+                            getItemId({
+                                table: MERGE_TABLE_NAME,
+                                name: part.name,
+                            }),
+                    );
+                    const metricIds = mergeQuery.sources
+                        .filter(isMergeMetricSource)
+                        .flatMap((source) =>
+                            source.metricQuery.metrics.map((metricId) =>
+                                getItemId({
+                                    table: source.id,
+                                    name: metricId,
+                                }),
+                            ),
+                        );
+
+                    // Custom chart types bind against the merged pools: join
+                    // keys as dimensions, per-source metrics as metrics.
+                    if (customChartConfig && resolvedCustomChartType) {
+                        validateCustomChartTypeChartConfig(
+                            customChartConfig,
+                            resolvedCustomChartType.schema,
+                            {
+                                dimensions: dimensionIds,
+                                metrics: metricIds,
+                                tableCalculations: [],
+                            },
+                        );
+                    } else if (
                         queryTool.chartConfig &&
                         !isCustomChartTypeSlugChartConfig(queryTool.chartConfig)
                     ) {
-                        // Merged output columns are fields of the merge/source
-                        // "tables", so getItemId is the naming authority.
-                        const dimensionIds = queryTool.mergeConfig.joinKey.map(
-                            (part) =>
-                                getItemId({
-                                    table: MERGE_TABLE_NAME,
-                                    name: part.name,
-                                }),
-                        );
-                        const metricIds = mergeQuery.sources
-                            .filter(isMergeMetricSource)
-                            .flatMap((source) =>
-                                source.metricQuery.metrics.map((metricId) =>
-                                    getItemId({
-                                        table: source.id,
-                                        name: metricId,
-                                    }),
-                                ),
-                            );
                         const selected = new Set([
                             ...dimensionIds,
                             ...metricIds,
@@ -431,11 +452,21 @@ export const getRunQuery = ({
                             artifactType: 'chart',
                             title: toolArgs.title,
                             description: toolArgs.description,
-                            vizConfig: {
-                                source: 'merge',
-                                schemaVersion: 1,
-                                config: toolArgs,
-                            },
+                            // The stored merge config inside the tool args is
+                            // the merge discriminator for custom envelopes.
+                            vizConfig: resolvedCustomChartType
+                                ? {
+                                      source: 'customChartType',
+                                      schemaVersion: 1,
+                                      dataAppVizUuid:
+                                          resolvedCustomChartType.dataAppVizUuid,
+                                      config: toolArgs,
+                                  }
+                                : {
+                                      source: 'merge',
+                                      schemaVersion: 1,
+                                      config: toolArgs,
+                                  },
                         });
 
                     if (!enableDataAccess && !isSlackPrompt(prompt)) {
@@ -498,27 +529,15 @@ export const getRunQuery = ({
                     };
                 }
 
-                // Custom chart type answers: resolve the slug project-scoped
-                // and validate the field mapping against the type's schema.
-                // The resolved uuid is persisted beside the verbatim tool
-                // args in the artifact envelope.
-                let customChartTypeDataAppVizUuid: string | null = null;
-                if (isCustomChartTypeSlugChartConfig(queryTool.chartConfig)) {
-                    const customChartConfig = queryTool.chartConfig;
-                    const resolved = await resolveCustomChartType(
-                        customChartConfig.customChartTypeSlug,
-                    );
-                    if (!resolved) {
-                        throw new AiAgentValidatorError(
-                            `Custom chart type "${customChartConfig.customChartTypeSlug}" was not found in this project. Use findCustomChartTypes to browse the available types and their slugs.`,
-                        );
-                    }
+                // Validate the field mapping against the type's schema using
+                // this query's field pools.
+                if (customChartConfig && resolvedCustomChartType) {
                     const aggregations = filterAggregationCustomMetrics(
                         queryTool.queryConfig.customMetrics,
                     );
                     validateCustomChartTypeChartConfig(
                         customChartConfig,
-                        resolved.schema,
+                        resolvedCustomChartType.schema,
                         {
                             dimensions: queryTool.queryConfig.dimensions,
                             metrics: [
@@ -530,7 +549,6 @@ export const getRunQuery = ({
                             ).map((tableCalc) => tableCalc.name),
                         },
                     );
-                    customChartTypeDataAppVizUuid = resolved.dataAppVizUuid;
                 }
 
                 const populatedCustomMetrics = populateCustomMetricsSQL(
@@ -574,13 +592,14 @@ export const getRunQuery = ({
                         artifactType: 'chart',
                         title: toolArgs.title,
                         description: toolArgs.description,
-                        vizConfig: customChartTypeDataAppVizUuid
+                        vizConfig: resolvedCustomChartType
                             ? {
                                   // Envelope: model output verbatim, server-
                                   // derived uuid beside it.
                                   source: 'customChartType',
                                   schemaVersion: 1,
-                                  dataAppVizUuid: customChartTypeDataAppVizUuid,
+                                  dataAppVizUuid:
+                                      resolvedCustomChartType.dataAppVizUuid,
                                   config: toolArgs,
                               }
                             : {

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -3,6 +3,7 @@ import {
     DimensionType,
     FilterOperator,
     FilterType,
+    MergeJoinType,
 } from '@lightdash/common';
 import type { AgentSelectOption } from './getSlackBlocks';
 import {
@@ -581,6 +582,121 @@ describe('Slack AI agent blocks', () => {
                 'create_saved_chart_version',
             )!,
         );
+        expect(saved.chartConfig.type).toBe(ChartType.TABLE);
+        expect(saved.pivotConfig).toBeUndefined();
+    });
+
+    it('keeps the merge fallback for merged custom chart type answers', async () => {
+        let sharedParams: string | undefined;
+        const getDataAppVizSchemaFields = vi.fn();
+        await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async (_path, params) => {
+                sharedParams = params;
+                return 'https://lightdash.example.com/share/custom';
+            },
+            async () => ({}) as never,
+            async () => true,
+            'agent-1',
+            [
+                {
+                    artifactUuid: 'artifact-1',
+                    threadUuid: 'thread-1',
+                    promptUuid: 'prompt-1',
+                    artifactType: 'chart',
+                    savedQueryUuid: null,
+                    savedDashboardUuid: null,
+                    createdAt: new Date(),
+                    versionNumber: 1,
+                    versionUuid: 'version-1',
+                    title: 'Orders vs Targets',
+                    description: null,
+                    dashboardConfig: null,
+                    versionCreatedAt: new Date(),
+                    verifiedByUserUuid: null,
+                    verifiedAt: null,
+                    chartConfig: {
+                        source: 'customChartType',
+                        schemaVersion: 1,
+                        dataAppVizUuid: 'data-app-viz-1',
+                        config: {
+                            title: 'Orders vs Targets',
+                            description: 'Orders vs targets by month',
+                            queryConfig: {
+                                exploreName: 'orders',
+                                dimensions: ['orders_order_date_month'],
+                                metrics: ['orders_unique_order_count'],
+                                sorts: [],
+                                limit: 500,
+                                parameters: null,
+                                customMetrics: [],
+                                tableCalculations: [],
+                                filters: null,
+                            },
+                            chartConfig: {
+                                customChartTypeSlug: 'fuzzy-bar',
+                                fieldMapping: {
+                                    x: 'merge_month',
+                                    y: 'primary_orders_unique_order_count',
+                                },
+                                options: null,
+                            },
+                            mergeConfig: {
+                                primarySourceId: 'primary',
+                                additionalSources: [
+                                    {
+                                        id: 'targets',
+                                        queryConfig: {
+                                            exploreName: 'targets',
+                                            dimensions: ['targets_month'],
+                                            metrics: ['targets_target'],
+                                            sorts: [],
+                                            customMetrics: [],
+                                            filters: null,
+                                        },
+                                    },
+                                ],
+                                joinKey: [
+                                    {
+                                        name: 'month',
+                                        fields: [
+                                            {
+                                                sourceId: 'primary',
+                                                fieldId:
+                                                    'orders_order_date_month',
+                                            },
+                                            {
+                                                sourceId: 'targets',
+                                                fieldId: 'targets_month',
+                                            },
+                                        ],
+                                    },
+                                ],
+                                joinType: MergeJoinType.FULL,
+                            },
+                        },
+                    },
+                },
+            ],
+            [],
+            getDataAppVizSchemaFields,
+        );
+
+        // The custom-chart branch is skipped for merged answers: the link
+        // stays the table-configured primary-source explore.
+        expect(getDataAppVizSchemaFields).not.toHaveBeenCalled();
+        const saved = JSON.parse(
+            new URLSearchParams(sharedParams).get(
+                'create_saved_chart_version',
+            )!,
+        );
+        expect(saved.tableName).toBe('orders');
         expect(saved.chartConfig.type).toBe(ChartType.TABLE);
         expect(saved.pivotConfig).toBeUndefined();
     });

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -732,7 +732,12 @@ export async function getModernArtifactCardBlocks(
                     },
                 };
                 let pivotConfig: { columns: string[] } | undefined;
-                if (artifact.chartConfig.source === 'customChartType') {
+                if (
+                    artifact.chartConfig.source === 'customChartType' &&
+                    // Merged custom answers keep the merge fallback while
+                    // Slack rendering of custom chart types stays deferred.
+                    !vizConfig.vizTool.mergeConfig
+                ) {
                     // Mirror the web save flow: DATA_APP_VIZ config plus the
                     // type's schema-derived pivot. Without the schema (app
                     // deleted / invalid) keep the table fallback so the link

--- a/packages/common/src/ee/AiAgent/utils.test.ts
+++ b/packages/common/src/ee/AiAgent/utils.test.ts
@@ -74,6 +74,62 @@ describe('parseAiArtifactChartConfig', () => {
         });
     });
 
+    it('round-trips a customChartType envelope carrying a merge', () => {
+        const config = {
+            source: 'customChartType',
+            schemaVersion: 1,
+            dataAppVizUuid: '4c25c1d5-cbc9-4d76-b58e-b1c9ee399fd9',
+            config: {
+                ...semanticConfig,
+                chartConfig: {
+                    ...customChartTypeSlugChartConfig,
+                    fieldMapping: { x: 'merge_month', y: 'orders_revenue' },
+                },
+                mergeConfig: {
+                    primarySourceId: 'orders',
+                    additionalSources: [
+                        {
+                            id: 'targets',
+                            queryConfig: {
+                                exploreName: 'targets',
+                                dimensions: ['targets_month'],
+                                metrics: ['targets_target'],
+                                sorts: [],
+                                customMetrics: null,
+                                filters: null,
+                            },
+                        },
+                    ],
+                    joinKey: [
+                        {
+                            name: 'month',
+                            fields: [
+                                {
+                                    sourceId: 'orders',
+                                    fieldId: 'orders_created_month',
+                                },
+                                {
+                                    sourceId: 'targets',
+                                    fieldId: 'targets_month',
+                                },
+                            ],
+                        },
+                    ],
+                    joinType: 'full',
+                },
+            },
+        } as const;
+
+        // The V3 schema parse fills defaulted fields the persisted value omits.
+        expect(parseAiArtifactChartConfig(config)).toEqual({
+            ...config,
+            config: {
+                ...config.config,
+                queryConfig: { ...config.config.queryConfig, parameters: null },
+            },
+        });
+    });
+
     it('rejects a customChartType envelope whose config is not the slug branch', () => {
         expect(
             parseAiArtifactChartConfig({

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -110,9 +110,10 @@ export const parseAiArtifactChartConfig = (
         'config' in config
     ) {
         const parsed = toolRunQueryArgsSchemaPersisted.safeParse(config.config);
+        // A merge-shaped config is valid here: the stored mergeConfig inside
+        // the tool args is the merge discriminator for custom envelopes.
         if (
             parsed.success &&
-            !parsed.data.mergeConfig &&
             isCustomChartTypeSlugChartConfig(parsed.data.chartConfig)
         ) {
             return {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -336,6 +336,9 @@ export const AiChartQuickOptions = ({
         // the merge search param, landing in the merge editor fully set up.
         if (merge) {
             if (!canonicalMerge || !projectUuid) return undefined;
+            // Merged custom answers reuse savedData's schema-derived pivot
+            // (already canonical); until the schema loads there is no URL.
+            if (customChartTypeConfig && !savedData) return undefined;
             const { fieldIdByAiFieldId } = canonicalMerge;
             const [primary, additional] = canonicalMerge.mergeQuery.sources;
             const url = getOpenInExploreUrl({
@@ -343,9 +346,11 @@ export const AiChartQuickOptions = ({
                 projectUuid,
                 columnOrder: remapFieldIdsDeep(columnOrder, fieldIdByAiFieldId),
                 chartConfig: remapFieldIdsDeep(chartConfig, fieldIdByAiFieldId),
-                pivotColumns: pivotDimensions?.length
-                    ? remapFieldIdsDeep(pivotDimensions, fieldIdByAiFieldId)
-                    : undefined,
+                pivotColumns: customChartTypeConfig
+                    ? savedData?.pivotConfig?.columns
+                    : pivotDimensions?.length
+                      ? remapFieldIdsDeep(pivotDimensions, fieldIdByAiFieldId)
+                      : undefined,
             });
             const search = new URLSearchParams(url.search);
             search.set(

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiArtifactChart.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiArtifactChart.ts
@@ -42,8 +42,12 @@ export const getAiArtifactChartSource = (
                 customChartType: null,
             };
         case 'customChartType':
+            // Merged custom answers (stored mergeConfig is the discriminator)
+            // carry every merge affordance around the custom chart render.
             return {
-                isMergeArtifact: false,
+                isMergeArtifact:
+                    'mergeConfig' in chartConfig.config &&
+                    !!chartConfig.config.mergeConfig,
                 semanticChartConfig: chartConfig.config,
                 customChartType: getDataAppVizChartFromArtifact(chartConfig),
             };

--- a/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.test.ts
@@ -219,6 +219,70 @@ describe('buildAiSavedChartData', () => {
             expect(result?.merge?.primarySourceId).toBe(PRIMARY_SOURCE_ID);
         });
 
+        describe('rendered through a custom chart type', () => {
+            const mergedCanonicalMerge: CanonicalAiMerge = {
+                ...canonicalMerge,
+                fieldIdByAiFieldId: {
+                    source_1_total: 'a_total',
+                    merge_month: 'merge_join_key_0',
+                    merge_region: 'merge_join_key_1',
+                },
+            };
+            const mergedCustomChartConfig: ChartConfig = {
+                type: ChartType.DATA_APP_VIZ,
+                config: {
+                    dataAppVizUuid: 'viz-uuid',
+                    fieldMapping: {
+                        x: 'merge_month',
+                        y: 'source_1_total',
+                        split: 'merge_region',
+                    },
+                },
+            };
+
+            it('derives the pivot from the schema and remaps everything to canonical ids', () => {
+                const result = buildAiSavedChartData({
+                    ...baseArgs,
+                    chartConfig: mergedCustomChartConfig,
+                    columnOrder: [
+                        'merge_month',
+                        'merge_region',
+                        'source_1_total',
+                    ],
+                    merge: { parameters: undefined },
+                    canonicalMerge: mergedCanonicalMerge,
+                    customChartTypeMetadata: readyMetadata,
+                });
+                expect(result?.metricQuery).toEqual(metricQuery);
+                expect(result?.chartConfig).toEqual({
+                    type: ChartType.DATA_APP_VIZ,
+                    config: {
+                        dataAppVizUuid: 'viz-uuid',
+                        fieldMapping: {
+                            x: 'merge_join_key_0',
+                            y: 'a_total',
+                            split: 'merge_join_key_1',
+                        },
+                    },
+                });
+                expect(result?.pivotConfig).toEqual({
+                    columns: ['merge_join_key_1'],
+                });
+                expect(result?.merge?.primarySourceId).toBe(PRIMARY_SOURCE_ID);
+            });
+
+            it('returns undefined until the schema metadata is ready', () => {
+                expect(
+                    buildAiSavedChartData({
+                        ...baseArgs,
+                        chartConfig: mergedCustomChartConfig,
+                        merge: { parameters: undefined },
+                        canonicalMerge: mergedCanonicalMerge,
+                    }),
+                ).toBeUndefined();
+            });
+        });
+
         it('returns undefined for a merge that could not be canonicalized', () => {
             expect(
                 buildAiSavedChartData({

--- a/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.ts
@@ -50,6 +50,25 @@ export const buildAiSavedChartData = ({
         if (!canonicalMerge) return undefined;
         const { fieldIdByAiFieldId } = canonicalMerge;
         const [primary] = canonicalMerge.mergeQuery.sources;
+        // Merged custom answers persist the schema-derived pivot with the
+        // AI merge ids remapped to the merge editor's canonical ids.
+        const mergedCustomChartTypeConfig =
+            getCustomChartTypeConfig(chartConfig);
+        let pivotConfig: CreateSavedChartVersion['pivotConfig'];
+        if (mergedCustomChartTypeConfig) {
+            if (customChartTypeMetadata?.state !== 'ready') return undefined;
+            pivotConfig = remapFieldIdsDeep(
+                deriveDataAppVizPivotConfig(
+                    customChartTypeMetadata.schema.fields,
+                    mergedCustomChartTypeConfig.fieldMapping,
+                ),
+                fieldIdByAiFieldId,
+            );
+        } else if (pivotDimensions?.length) {
+            pivotConfig = {
+                columns: remapFieldIdsDeep(pivotDimensions, fieldIdByAiFieldId),
+            };
+        }
         return {
             metricQuery: primary.metricQuery,
             tableName: primary.metricQuery.exploreName,
@@ -57,14 +76,7 @@ export const buildAiSavedChartData = ({
             tableConfig: {
                 columnOrder: remapFieldIdsDeep(columnOrder, fieldIdByAiFieldId),
             },
-            pivotConfig: pivotDimensions?.length
-                ? {
-                      columns: remapFieldIdsDeep(
-                          pivotDimensions,
-                          fieldIdByAiFieldId,
-                      ),
-                  }
-                : undefined,
+            pivotConfig,
             merge: toSavedMerge(canonicalMerge.mergeQuery),
             parameters: merge.parameters,
         };


### PR DESCRIPTION
Agent answers can now render a two-source merge query through a project custom chart type, end-to-end on web.

- **Tool**: slug resolution is hoisted ahead of the merge branch (unknown slug fails before the merge executes); fieldMapping validates against the merged output pools — join keys as the dimension pool, per-source metrics (custom metrics expanded) as the metric pool — with errors listing the valid merged ids. Merge-shaped payloads are still rejected when merge queries are disabled.
- **Envelope**: merged custom answers persist under the existing custom-chart-type envelope with the merge intact; the stored mergeConfig inside the tool args is the merge discriminator. The envelope parser stops rejecting merge-shaped custom configs; existing artifacts parse unchanged.
- **Replay**: the artifact viz-query endpoint routes custom envelopes carrying a merge into merge execution (same feature-flag gate as plain merges) and passes the custom chart shape into the merge pivot seam, deriving series pivots server-side from the type's schema. A deleted app or invalid schema means no pivot, not an error.
- **Web**: merged custom answers are flagged as merge artifacts — merged View SQL, no single-explore load, merge quick options — while the custom chart renderer stays merge-agnostic. Save-as-chart / add-to-dashboard store the merge plus the custom chart config and schema-derived pivot remapped to merge-editor canonical ids; explore-from-here opens the merge editor set up with the custom chart.
- **Slack**: the explore-link path takes the custom-chart branch only for non-merge answers; merged custom answers keep the existing merge fallback.

Behavioral tests added at the tool execute, envelope parser, and saved-chart builder seams, plus the Slack explore-link fallback.

Closes: ZAP-933
