### PR TITLE
feat(content-as-code): record last-applied snapshot on upload

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -41,6 +41,10 @@ import {
     DashboardTileCommentsTableName,
 } from '../database/entities/comments';
 import {
+    ContentAsCodeAppliedRevisionsTable,
+    ContentAsCodeAppliedRevisionsTableName,
+} from '../database/entities/contentAsCodeAppliedRevisions';
+import {
     ContentVerificationTable,
     ContentVerificationTableName,
 } from '../database/entities/contentVerification';
@@ -774,6 +778,7 @@ declare module 'knex/types/tables' {
         [ManagedAgentRunsTableName]: ManagedAgentRunsTable;
         [ManagedAgentProtectionsTableName]: ManagedAgentProtectionsTable;
         [UserFavoritesTableName]: UserFavoritesTable;
+        [ContentAsCodeAppliedRevisionsTableName]: ContentAsCodeAppliedRevisionsTable;
         [ContentVerificationTableName]: ContentVerificationTable;
         [AppsTableName]: AppsTable;
         [AppUserAccessTableName]: AppUserAccessTable;

--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -10,6 +10,7 @@ import {
     type ApiAlertAsCodeUpsertResponse,
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
+    type ApiContentAsCodeSyncStatusResponse,
     type ApiDashboardAsCodeListResponse,
     type ApiDashboardAsCodeUpsertResponse,
     type ApiErrorPayload,
@@ -25,20 +26,20 @@ import {
     type ApiSqlChartAsCodeListResponse,
     type ApiSqlChartAsCodeUpsertResponse,
     type ApiSuccessEmpty,
+    type ApiUpsertContentAsCodeAppliedRevisionsResponse,
     type ApiVirtualViewAsCodeListResponse,
     type ApiVirtualViewAsCodeUpsertResponse,
-    type ApiContentAsCodeSyncStatusResponse,
-    type ApiUpsertContentAsCodeAppliedRevisionsResponse,
     type ChartAsCode,
-    type UpsertContentAsCodeAppliedRevisionsRequest,
     type ContentSlugRenameRequest,
     type DashboardAsCode,
     type ExternalConnectionAsCode,
     type GoogleSheetsSyncAsCode,
     type RegisteredAccount,
+    type RestampContentAsCodeRevisionRequest,
     type ScheduledDeliveryAsCode,
     type SpaceAsCode,
     type SqlChartAsCode,
+    type UpsertContentAsCodeAppliedRevisionsRequest,
     type VirtualViewAsCode,
 } from '@lightdash/common';
 import {
@@ -143,6 +144,33 @@ export class ProjectCoderController extends BaseController {
                 .getContentAsCodeSyncStatus(
                     toSessionUser(req.account),
                     projectUuid,
+                ),
+        );
+    }
+
+    /**
+     * Restamp last-applied snapshot to the current instance document so the next upload applies git
+     * @summary Restamp content-as-code applied revision
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_WRITE_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Post('/code/applied-revisions/restamp')
+    @OperationId('restampContentAsCodeAppliedRevision')
+    async restampContentAsCodeAppliedRevision(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Body() body: RestampContentAsCodeRevisionRequest,
+    ): Promise<ApiContentAsCodeSyncStatusResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return codeSuccess(
+            await this.services
+                .getCoderService()
+                .restampContentAsCodeAppliedRevision(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    body,
                 ),
         );
     }

--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -27,7 +27,10 @@ import {
     type ApiSuccessEmpty,
     type ApiVirtualViewAsCodeListResponse,
     type ApiVirtualViewAsCodeUpsertResponse,
+    type ApiContentAsCodeSyncStatusResponse,
+    type ApiUpsertContentAsCodeAppliedRevisionsResponse,
     type ChartAsCode,
+    type UpsertContentAsCodeAppliedRevisionsRequest,
     type ContentSlugRenameRequest,
     type DashboardAsCode,
     type ExternalConnectionAsCode,
@@ -45,6 +48,7 @@ import {
     OperationId,
     Path,
     Post,
+    Put,
     Query,
     Request,
     Response,
@@ -116,6 +120,58 @@ export class ProjectCoderController extends BaseController {
             .getCoderService()
             .renameContentSlug(toSessionUser(req.account), projectUuid, body);
         return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * Get the last-applied content-as-code snapshot for a project
+     * @summary Get content-as-code sync status
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_READ_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Get('/code/sync-status')
+    @OperationId('getContentAsCodeSyncStatus')
+    async getContentAsCodeSyncStatus(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiContentAsCodeSyncStatusResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return codeSuccess(
+            await this.services
+                .getCoderService()
+                .getContentAsCodeSyncStatus(
+                    toSessionUser(req.account),
+                    projectUuid,
+                ),
+        );
+    }
+
+    /**
+     * Record last-applied content-as-code revisions after a successful upload
+     * @summary Upsert content-as-code applied revisions
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_WRITE_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Put('/code/applied-revisions')
+    @OperationId('upsertContentAsCodeAppliedRevisions')
+    async upsertContentAsCodeAppliedRevisions(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Body() body: UpsertContentAsCodeAppliedRevisionsRequest,
+    ): Promise<ApiUpsertContentAsCodeAppliedRevisionsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return codeSuccess(
+            await this.services
+                .getCoderService()
+                .upsertContentAsCodeAppliedRevisions(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    body.revisions,
+                ),
+        );
     }
 
     /**

--- a/packages/backend/src/database/entities/contentAsCodeAppliedRevisions.ts
+++ b/packages/backend/src/database/entities/contentAsCodeAppliedRevisions.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+
+export const ContentAsCodeAppliedRevisionsTableName =
+    'content_as_code_applied_revisions';
+
+export type DbContentAsCodeAppliedRevision = {
+    content_as_code_applied_revision_uuid: string;
+    project_uuid: string;
+    content_type: string;
+    slug: string;
+    content_hash: string;
+    applied_at: Date;
+    applied_by_user_uuid: string | null;
+};
+
+export type ContentAsCodeAppliedRevisionsTable = Knex.CompositeTableType<
+    DbContentAsCodeAppliedRevision,
+    Pick<
+        DbContentAsCodeAppliedRevision,
+        | 'project_uuid'
+        | 'content_type'
+        | 'slug'
+        | 'content_hash'
+        | 'applied_at'
+        | 'applied_by_user_uuid'
+    >
+>;

--- a/packages/backend/src/database/entities/contentAsCodeAppliedRevisions.ts
+++ b/packages/backend/src/database/entities/contentAsCodeAppliedRevisions.ts
@@ -8,7 +8,8 @@ export type DbContentAsCodeAppliedRevision = {
     project_uuid: string;
     content_type: string;
     slug: string;
-    content_hash: string;
+    snapshot: Record<string, unknown>;
+    snapshot_hash: string;
     applied_at: Date;
     applied_by_user_uuid: string | null;
 };
@@ -20,7 +21,8 @@ export type ContentAsCodeAppliedRevisionsTable = Knex.CompositeTableType<
         | 'project_uuid'
         | 'content_type'
         | 'slug'
-        | 'content_hash'
+        | 'snapshot'
+        | 'snapshot_hash'
         | 'applied_at'
         | 'applied_by_user_uuid'
     >

--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -48,6 +48,7 @@ export type DbProject = {
     results_cache_ttl_seconds: number | null;
     provisioning_source: string | null;
     agent_sql_scope: AgentSqlScope | null;
+    content_as_code_sync_enabled: boolean | null;
 };
 
 type CreateDbProject = Pick<
@@ -96,6 +97,7 @@ type UpdateDbProject = Partial<
         | 'results_cache_ttl_seconds'
         | 'provisioning_source'
         | 'agent_sql_scope'
+        | 'content_as_code_sync_enabled'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260825120000_create_content_as_code_applied_revisions.ts
+++ b/packages/backend/src/database/migrations/20260825120000_create_content_as_code_applied_revisions.ts
@@ -27,7 +27,8 @@ export async function up(knex: Knex): Promise<void> {
                 .index();
             table.text('content_type').notNullable();
             table.text('slug').notNullable();
-            table.text('content_hash').notNullable();
+            table.jsonb('snapshot').notNullable();
+            table.text('snapshot_hash').notNullable();
             table
                 .timestamp('applied_at', { useTz: true })
                 .notNullable()

--- a/packages/backend/src/database/migrations/20260825120000_create_content_as_code_applied_revisions.ts
+++ b/packages/backend/src/database/migrations/20260825120000_create_content_as_code_applied_revisions.ts
@@ -47,7 +47,5 @@ export async function up(knex: Knex): Promise<void> {
 
 export async function down(knex: Knex): Promise<void> {
     await knex.raw("SET LOCAL lock_timeout = '5s'");
-    await knex.schema.dropTableIfExists(
-        ContentAsCodeAppliedRevisionsTableName,
-    );
+    await knex.schema.dropTableIfExists(ContentAsCodeAppliedRevisionsTableName);
 }

--- a/packages/backend/src/database/migrations/20260825120000_create_content_as_code_applied_revisions.ts
+++ b/packages/backend/src/database/migrations/20260825120000_create_content_as_code_applied_revisions.ts
@@ -1,0 +1,52 @@
+import { Knex } from 'knex';
+
+const ContentAsCodeAppliedRevisionsTableName =
+    'content_as_code_applied_revisions';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds an expand-only table for last-applied content-as-code revisions',
+} as const;
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+
+    await knex.schema.createTable(
+        ContentAsCodeAppliedRevisionsTableName,
+        (table) => {
+            table
+                .uuid('content_as_code_applied_revision_uuid')
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+            table
+                .uuid('project_uuid')
+                .notNullable()
+                .references('project_uuid')
+                .inTable('projects')
+                .onDelete('CASCADE')
+                .index();
+            table.text('content_type').notNullable();
+            table.text('slug').notNullable();
+            table.text('content_hash').notNullable();
+            table
+                .timestamp('applied_at', { useTz: true })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .uuid('applied_by_user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('SET NULL')
+                .index();
+            table.unique(['project_uuid', 'content_type', 'slug']);
+        },
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.dropTableIfExists(
+        ContentAsCodeAppliedRevisionsTableName,
+    );
+}

--- a/packages/backend/src/database/migrations/20260825130000_add_content_as_code_sync_enabled_to_projects.ts
+++ b/packages/backend/src/database/migrations/20260825130000_add_content_as_code_sync_enabled_to_projects.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+const ProjectTableName = 'projects';
+const ColumnName = 'content_as_code_sync_enabled';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds an expand-only nullable boolean for persisted content-as-code sync',
+} as const;
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(ProjectTableName, (table) => {
+        table.boolean(ColumnName).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(ProjectTableName, (table) => {
+        table.dropColumn(ColumnName);
+    });
+}

--- a/packages/backend/src/models/ContentAsCodeAppliedRevisionModel.ts
+++ b/packages/backend/src/models/ContentAsCodeAppliedRevisionModel.ts
@@ -1,4 +1,9 @@
-import { type ContentAsCodeAppliedRevision } from '@lightdash/common';
+import {
+    isContentAsCodeSnapshotType,
+    type ContentAsCodeAppliedRevision,
+    type ContentAsCodeSnapshot,
+    type ContentAsCodeSnapshotType,
+} from '@lightdash/common';
 import { Knex } from 'knex';
 import {
     ContentAsCodeAppliedRevisionsTableName,
@@ -10,21 +15,29 @@ type ContentAsCodeAppliedRevisionModelArguments = {
 };
 
 type AppliedRevisionInput = {
-    contentType: ContentAsCodeAppliedRevision['contentType'];
+    contentType: ContentAsCodeSnapshotType;
     slug: string;
+    snapshot: ContentAsCodeSnapshot;
     contentHash: string;
 };
 
 const mapDbRevision = (
     row: DbContentAsCodeAppliedRevision,
-): ContentAsCodeAppliedRevision => ({
-    contentType:
-        row.content_type as ContentAsCodeAppliedRevision['contentType'],
-    slug: row.slug,
-    contentHash: row.content_hash,
-    appliedAt: row.applied_at,
-    appliedByUserUuid: row.applied_by_user_uuid,
-});
+): ContentAsCodeAppliedRevision => {
+    if (!isContentAsCodeSnapshotType(row.content_type)) {
+        throw new Error(
+            `Stored content-as-code revision has unsupported type ${row.content_type}`,
+        );
+    }
+    return {
+        contentType: row.content_type,
+        slug: row.slug,
+        contentHash: row.snapshot_hash,
+        snapshot: row.snapshot,
+        appliedAt: row.applied_at,
+        appliedByUserUuid: row.applied_by_user_uuid,
+    };
+};
 
 export class ContentAsCodeAppliedRevisionModel {
     readonly database: Knex;
@@ -49,21 +62,25 @@ export class ContentAsCodeAppliedRevisionModel {
                     project_uuid: projectUuid,
                     content_type: revision.contentType,
                     slug: revision.slug,
-                    content_hash: revision.contentHash,
+                    snapshot: revision.snapshot,
+                    snapshot_hash: revision.contentHash,
                     applied_at: appliedAt,
                     applied_by_user_uuid: appliedByUserUuid,
                 })),
             )
             .onConflict(['project_uuid', 'content_type', 'slug'])
-            .merge(['content_hash', 'applied_at', 'applied_by_user_uuid']);
+            .merge([
+                'snapshot',
+                'snapshot_hash',
+                'applied_at',
+                'applied_by_user_uuid',
+            ]);
     }
 
     async listByProject(
         projectUuid: string,
     ): Promise<ContentAsCodeAppliedRevision[]> {
-        const rows = await this.database(
-            ContentAsCodeAppliedRevisionsTableName,
-        )
+        const rows = await this.database(ContentAsCodeAppliedRevisionsTableName)
             .select('*')
             .where('project_uuid', projectUuid)
             .orderBy('applied_at', 'desc')

--- a/packages/backend/src/models/ContentAsCodeAppliedRevisionModel.ts
+++ b/packages/backend/src/models/ContentAsCodeAppliedRevisionModel.ts
@@ -1,0 +1,74 @@
+import { type ContentAsCodeAppliedRevision } from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    ContentAsCodeAppliedRevisionsTableName,
+    type DbContentAsCodeAppliedRevision,
+} from '../database/entities/contentAsCodeAppliedRevisions';
+
+type ContentAsCodeAppliedRevisionModelArguments = {
+    database: Knex;
+};
+
+type AppliedRevisionInput = {
+    contentType: ContentAsCodeAppliedRevision['contentType'];
+    slug: string;
+    contentHash: string;
+};
+
+const mapDbRevision = (
+    row: DbContentAsCodeAppliedRevision,
+): ContentAsCodeAppliedRevision => ({
+    contentType:
+        row.content_type as ContentAsCodeAppliedRevision['contentType'],
+    slug: row.slug,
+    contentHash: row.content_hash,
+    appliedAt: row.applied_at,
+    appliedByUserUuid: row.applied_by_user_uuid,
+});
+
+export class ContentAsCodeAppliedRevisionModel {
+    readonly database: Knex;
+
+    constructor(args: ContentAsCodeAppliedRevisionModelArguments) {
+        this.database = args.database;
+    }
+
+    async upsertMany(
+        projectUuid: string,
+        appliedByUserUuid: string | null,
+        revisions: AppliedRevisionInput[],
+    ): Promise<void> {
+        if (revisions.length === 0) {
+            return;
+        }
+
+        const appliedAt = new Date();
+        await this.database(ContentAsCodeAppliedRevisionsTableName)
+            .insert(
+                revisions.map((revision) => ({
+                    project_uuid: projectUuid,
+                    content_type: revision.contentType,
+                    slug: revision.slug,
+                    content_hash: revision.contentHash,
+                    applied_at: appliedAt,
+                    applied_by_user_uuid: appliedByUserUuid,
+                })),
+            )
+            .onConflict(['project_uuid', 'content_type', 'slug'])
+            .merge(['content_hash', 'applied_at', 'applied_by_user_uuid']);
+    }
+
+    async listByProject(
+        projectUuid: string,
+    ): Promise<ContentAsCodeAppliedRevision[]> {
+        const rows = await this.database(
+            ContentAsCodeAppliedRevisionsTableName,
+        )
+            .select('*')
+            .where('project_uuid', projectUuid)
+            .orderBy('applied_at', 'desc')
+            .orderBy('slug', 'asc');
+
+        return rows.map(mapDbRevision);
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -8,6 +8,7 @@ import { AppAccessModel } from './AppAccessModel';
 import { AppModel } from './AppModel';
 import { CatalogModel } from './CatalogModel/CatalogModel';
 import { CommentModel } from './CommentModel/CommentModel';
+import { ContentAsCodeAppliedRevisionModel } from './ContentAsCodeAppliedRevisionModel';
 import { ContentModel } from './ContentModel/ContentModel';
 import { ContentVerificationModel } from './ContentVerificationModel';
 import { DashboardAccessModel } from './DashboardAccessModel';
@@ -150,6 +151,7 @@ export type ModelManifest = {
     catalogModel: CatalogModel;
     savedSqlModel: SavedSqlModel;
     savedSqlAccessModel: SavedSqlAccessModel;
+    contentAsCodeAppliedRevisionModel: ContentAsCodeAppliedRevisionModel;
     contentModel: ContentModel;
     contentVerificationModel: ContentVerificationModel;
     tagsModel: TagsModel;
@@ -839,6 +841,16 @@ export class ModelRepository
         return this.getModel(
             'savedSqlAccessModel',
             () => new SavedSqlAccessModel(this.database),
+        );
+    }
+
+    public getContentAsCodeAppliedRevisionModel(): ContentAsCodeAppliedRevisionModel {
+        return this.getModel(
+            'contentAsCodeAppliedRevisionModel',
+            () =>
+                new ContentAsCodeAppliedRevisionModel({
+                    database: this.database,
+                }),
         );
     }
 

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -835,6 +835,24 @@ export class ProjectModel {
             .where('project_uuid', projectUuid);
     }
 
+    async getContentAsCodeSyncEnabled(projectUuid: string): Promise<boolean> {
+        const [row] = await this.database(ProjectTableName)
+            .select('content_as_code_sync_enabled')
+            .where('project_uuid', projectUuid);
+        return row?.content_as_code_sync_enabled === true;
+    }
+
+    async setContentAsCodeSyncEnabled(
+        projectUuid: string,
+        enabled: boolean,
+    ): Promise<void> {
+        await this.database(ProjectTableName)
+            .update({
+                content_as_code_sync_enabled: enabled,
+            })
+            .where('project_uuid', projectUuid);
+    }
+
     async getPreviewExpirationSettings(projectUuid: string): Promise<{
         defaultPreviewExpirationHours: number;
         maxPreviewExpirationHours: number;

--- a/packages/backend/src/services/CoderService/CoderService.appliedRevisions.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.appliedRevisions.test.ts
@@ -47,12 +47,10 @@ const makeSessionUser = (
         abilityRules: [],
     }) as unknown as SessionUser;
 
-const buildService = (
-    appliedRevisionModel: {
-        upsertMany: ReturnType<typeof vi.fn>;
-        listByProject: ReturnType<typeof vi.fn>;
-    },
-) =>
+const buildService = (appliedRevisionModel: {
+    upsertMany: ReturnType<typeof vi.fn>;
+    listByProject: ReturnType<typeof vi.fn>;
+}) =>
     new CoderService({
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
@@ -88,10 +86,7 @@ describe('CoderService applied revisions', () => {
         const service = buildService(appliedRevisionModel);
 
         await expect(
-            service.getContentAsCodeSyncStatus(
-                makeSessionUser(),
-                PROJECT_UUID,
-            ),
+            service.getContentAsCodeSyncStatus(makeSessionUser(), PROJECT_UUID),
         ).resolves.toEqual({
             lastAppliedAt: null,
             revisionCount: 0,
@@ -107,7 +102,10 @@ describe('CoderService applied revisions', () => {
         const service = buildService(appliedRevisionModel);
 
         await expect(
-            service.getContentAsCodeSyncStatus(makeSessionUser([]), PROJECT_UUID),
+            service.getContentAsCodeSyncStatus(
+                makeSessionUser([]),
+                PROJECT_UUID,
+            ),
         ).rejects.toBeInstanceOf(ForbiddenError);
         expect(appliedRevisionModel.listByProject).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/services/CoderService/CoderService.appliedRevisions.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.appliedRevisions.test.ts
@@ -2,6 +2,7 @@ import { Ability, type RawRuleOf } from '@casl/ability';
 import {
     ContentAsCodeType,
     ForbiddenError,
+    NotFoundError,
     OrganizationMemberRole,
     ParameterError,
     PossibleAbilities,
@@ -47,6 +48,31 @@ const makeSessionUser = (
         abilityRules: [],
     }) as unknown as SessionUser;
 
+const emptyListPage = {
+    missingIds: [],
+    spaces: [],
+    languageMap: undefined,
+};
+
+const mockCurrentContent = (
+    service: CoderService,
+    charts: Array<{ slug: string; name: string }> = [],
+    dashboards: Array<{ slug: string; name: string }> = [],
+) => {
+    vi.spyOn(service, 'getCharts').mockResolvedValue({
+        ...emptyListPage,
+        charts: charts as never,
+        total: charts.length,
+        offset: 0,
+    });
+    vi.spyOn(service, 'getDashboards').mockResolvedValue({
+        ...emptyListPage,
+        dashboards: dashboards as never,
+        total: dashboards.length,
+        offset: 0,
+    });
+};
+
 const buildService = (appliedRevisionModel: {
     upsertMany: ReturnType<typeof vi.fn>;
     listByProject: ReturnType<typeof vi.fn>;
@@ -78,19 +104,89 @@ const buildService = (appliedRevisionModel: {
     });
 
 describe('CoderService applied revisions', () => {
-    it('returns an empty sync status when no revisions exist', async () => {
+    it('returns an empty sync status when no revisions or instance content exist', async () => {
         const appliedRevisionModel = {
             upsertMany: vi.fn(),
             listByProject: vi.fn(async () => []),
         };
         const service = buildService(appliedRevisionModel);
+        mockCurrentContent(service);
 
         await expect(
             service.getContentAsCodeSyncStatus(makeSessionUser(), PROJECT_UUID),
         ).resolves.toEqual({
+            syncEnabled: true,
             lastAppliedAt: null,
-            revisionCount: 0,
-            revisions: [],
+            items: [],
+        });
+    });
+
+    it('classifies instance charts as ui_only, in_sync, or ahead', async () => {
+        const appliedAt = new Date('2026-08-25T12:00:00.000Z');
+        const inSyncSnapshot = { slug: 'orders', name: 'Orders' };
+        const driftedSnapshot = { slug: 'revenue', name: 'Revenue yesterday' };
+        const appliedRevisionModel = {
+            upsertMany: vi.fn(),
+            listByProject: vi.fn(async () => [
+                {
+                    contentType: ContentAsCodeType.CHART,
+                    slug: 'orders',
+                    contentHash: hashContentAsCodeDocument(inSyncSnapshot),
+                    snapshot: inSyncSnapshot,
+                    appliedAt,
+                    appliedByUserUuid: USER_UUID,
+                },
+                {
+                    contentType: ContentAsCodeType.CHART,
+                    slug: 'revenue',
+                    contentHash: hashContentAsCodeDocument(driftedSnapshot),
+                    snapshot: driftedSnapshot,
+                    appliedAt,
+                    appliedByUserUuid: USER_UUID,
+                },
+            ]),
+        };
+        const service = buildService(appliedRevisionModel);
+        mockCurrentContent(service, [
+            { slug: 'new-from-ui', name: 'New from UI' },
+            { slug: 'orders', name: 'Orders' },
+            { slug: 'revenue', name: 'Revenue today' },
+        ]);
+
+        await expect(
+            service.getContentAsCodeSyncStatus(makeSessionUser(), PROJECT_UUID),
+        ).resolves.toEqual({
+            syncEnabled: true,
+            lastAppliedAt: appliedAt,
+            items: [
+                {
+                    contentType: ContentAsCodeType.CHART,
+                    slug: 'new-from-ui',
+                    state: 'ui_only',
+                    appliedAt: null,
+                    contentHash: null,
+                    snapshot: null,
+                    current: { slug: 'new-from-ui', name: 'New from UI' },
+                },
+                {
+                    contentType: ContentAsCodeType.CHART,
+                    slug: 'orders',
+                    state: 'in_sync',
+                    appliedAt,
+                    contentHash: hashContentAsCodeDocument(inSyncSnapshot),
+                    snapshot: inSyncSnapshot,
+                    current: { slug: 'orders', name: 'Orders' },
+                },
+                {
+                    contentType: ContentAsCodeType.CHART,
+                    slug: 'revenue',
+                    state: 'ahead',
+                    appliedAt,
+                    contentHash: hashContentAsCodeDocument(driftedSnapshot),
+                    snapshot: driftedSnapshot,
+                    current: { slug: 'revenue', name: 'Revenue today' },
+                },
+            ],
         });
     });
 
@@ -126,6 +222,7 @@ describe('CoderService applied revisions', () => {
             listByProject: vi.fn(async () => [revision]),
         };
         const service = buildService(appliedRevisionModel);
+        mockCurrentContent(service, [{ slug: 'orders', name: 'Orders' }]);
 
         await expect(
             service.upsertContentAsCodeAppliedRevisions(
@@ -143,9 +240,19 @@ describe('CoderService applied revisions', () => {
                 ],
             ),
         ).resolves.toEqual({
+            syncEnabled: true,
             lastAppliedAt: appliedAt,
-            revisionCount: 1,
-            revisions: [revision],
+            items: [
+                {
+                    contentType: ContentAsCodeType.CHART,
+                    slug: 'orders',
+                    state: 'in_sync',
+                    appliedAt,
+                    contentHash: revision.contentHash,
+                    snapshot,
+                    current: { slug: 'orders', name: 'Orders' },
+                },
+            ],
         });
         expect(appliedRevisionModel.upsertMany).toHaveBeenCalledWith(
             PROJECT_UUID,
@@ -181,6 +288,85 @@ describe('CoderService applied revisions', () => {
                 ],
             ),
         ).rejects.toBeInstanceOf(ParameterError);
+        expect(appliedRevisionModel.upsertMany).not.toHaveBeenCalled();
+    });
+
+    it('restamps last-applied to the current instance document', async () => {
+        const appliedAt = new Date('2026-08-25T13:00:00.000Z');
+        const current = { slug: 'orders', name: 'Orders edited in UI' };
+        const revision = {
+            contentType: ContentAsCodeType.CHART,
+            slug: 'orders',
+            contentHash: hashContentAsCodeDocument(current),
+            snapshot: current,
+            appliedAt,
+            appliedByUserUuid: USER_UUID,
+        };
+        const appliedRevisionModel = {
+            upsertMany: vi.fn(async () => undefined),
+            listByProject: vi.fn(async () => [revision]),
+        };
+        const service = buildService(appliedRevisionModel);
+        mockCurrentContent(service, [
+            { slug: 'orders', name: 'Orders edited in UI' },
+        ]);
+
+        await expect(
+            service.restampContentAsCodeAppliedRevision(
+                makeSessionUser(),
+                PROJECT_UUID,
+                {
+                    contentType: ContentAsCodeType.CHART,
+                    slug: 'orders',
+                },
+            ),
+        ).resolves.toEqual({
+            syncEnabled: true,
+            lastAppliedAt: appliedAt,
+            items: [
+                {
+                    contentType: ContentAsCodeType.CHART,
+                    slug: 'orders',
+                    state: 'in_sync',
+                    appliedAt,
+                    contentHash: revision.contentHash,
+                    snapshot: current,
+                    current,
+                },
+            ],
+        });
+        expect(appliedRevisionModel.upsertMany).toHaveBeenCalledWith(
+            PROJECT_UUID,
+            USER_UUID,
+            [
+                {
+                    contentType: ContentAsCodeType.CHART,
+                    slug: 'orders',
+                    snapshot: current,
+                    contentHash: revision.contentHash,
+                },
+            ],
+        );
+    });
+
+    it('rejects restamp when the chart does not exist', async () => {
+        const appliedRevisionModel = {
+            upsertMany: vi.fn(),
+            listByProject: vi.fn(),
+        };
+        const service = buildService(appliedRevisionModel);
+        mockCurrentContent(service);
+
+        await expect(
+            service.restampContentAsCodeAppliedRevision(
+                makeSessionUser(),
+                PROJECT_UUID,
+                {
+                    contentType: ContentAsCodeType.CHART,
+                    slug: 'missing',
+                },
+            ),
+        ).rejects.toBeInstanceOf(NotFoundError);
         expect(appliedRevisionModel.upsertMany).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/CoderService/CoderService.appliedRevisions.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.appliedRevisions.test.ts
@@ -1,0 +1,182 @@
+import { Ability, type RawRuleOf } from '@casl/ability';
+import {
+    ContentAsCodeType,
+    ForbiddenError,
+    OrganizationMemberRole,
+    ParameterError,
+    PossibleAbilities,
+    ProjectType,
+    SessionUser,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { CoderService } from './CoderService';
+import { hashContentAsCodeDocument } from './contentAsCodeHash';
+
+const PROJECT_UUID = 'project-uuid';
+const ORGANIZATION_UUID = 'organization-uuid';
+const USER_UUID = 'user-uuid';
+
+const project = {
+    projectUuid: PROJECT_UUID,
+    organizationUuid: ORGANIZATION_UUID,
+    upstreamProjectUuid: null,
+    type: ProjectType.DEFAULT,
+    createdByUserUuid: USER_UUID,
+};
+
+const makeSessionUser = (
+    rules: RawRuleOf<Ability<PossibleAbilities>>[] = [
+        {
+            subject: 'ContentAsCode',
+            action: ['view', 'create'],
+            conditions: { projectUuid: PROJECT_UUID },
+        },
+    ],
+): SessionUser =>
+    ({
+        userUuid: USER_UUID,
+        userId: 1,
+        email: 'owner@example.com',
+        firstName: 'Sync',
+        lastName: 'Owner',
+        organizationUuid: ORGANIZATION_UUID,
+        role: OrganizationMemberRole.MEMBER,
+        isActive: true,
+        ability: new Ability<PossibleAbilities>(rules),
+        abilityRules: [],
+    }) as unknown as SessionUser;
+
+const buildService = (
+    appliedRevisionModel: {
+        upsertMany: ReturnType<typeof vi.fn>;
+        listByProject: ReturnType<typeof vi.fn>;
+    },
+) =>
+    new CoderService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: {
+            get: vi.fn(async () => project),
+            getSummary: vi.fn(async () => project),
+        } as never,
+        savedChartModel: {} as never,
+        savedSqlModel: {} as never,
+        appModel: {} as never,
+        dashboardModel: {} as never,
+        spaceModel: {} as never,
+        schedulerModel: {} as never,
+        schedulerService: {} as never,
+        savedChartService: {} as never,
+        dashboardService: {} as never,
+        schedulerClient: {} as never,
+        promoteService: {} as never,
+        spacePermissionService: {} as never,
+        contentVerificationModel: {} as never,
+        contentAsCodeAppliedRevisionModel: appliedRevisionModel as never,
+        groupsModel: {} as never,
+        organizationMemberProfileModel: {} as never,
+        userModel: {} as never,
+    });
+
+describe('CoderService applied revisions', () => {
+    it('returns an empty sync status when no revisions exist', async () => {
+        const appliedRevisionModel = {
+            upsertMany: vi.fn(),
+            listByProject: vi.fn(async () => []),
+        };
+        const service = buildService(appliedRevisionModel);
+
+        await expect(
+            service.getContentAsCodeSyncStatus(
+                makeSessionUser(),
+                PROJECT_UUID,
+            ),
+        ).resolves.toEqual({
+            lastAppliedAt: null,
+            revisionCount: 0,
+            revisions: [],
+        });
+    });
+
+    it('rejects sync status for viewers without content-as-code access', async () => {
+        const appliedRevisionModel = {
+            upsertMany: vi.fn(),
+            listByProject: vi.fn(async () => []),
+        };
+        const service = buildService(appliedRevisionModel);
+
+        await expect(
+            service.getContentAsCodeSyncStatus(makeSessionUser([]), PROJECT_UUID),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(appliedRevisionModel.listByProject).not.toHaveBeenCalled();
+    });
+
+    it('stores valid revisions and returns the latest applied timestamp', async () => {
+        const appliedAt = new Date('2026-08-25T12:00:00.000Z');
+        const revision = {
+            contentType: ContentAsCodeType.CHART,
+            slug: 'orders',
+            contentHash: hashContentAsCodeDocument({ slug: 'orders' }),
+            appliedAt,
+            appliedByUserUuid: USER_UUID,
+        };
+        const appliedRevisionModel = {
+            upsertMany: vi.fn(async () => undefined),
+            listByProject: vi.fn(async () => [revision]),
+        };
+        const service = buildService(appliedRevisionModel);
+
+        await expect(
+            service.upsertContentAsCodeAppliedRevisions(
+                makeSessionUser(),
+                PROJECT_UUID,
+                [
+                    {
+                        contentType: ContentAsCodeType.CHART,
+                        slug: 'orders',
+                        contentHash: revision.contentHash,
+                    },
+                ],
+            ),
+        ).resolves.toEqual({
+            lastAppliedAt: appliedAt,
+            revisionCount: 1,
+            revisions: [revision],
+        });
+        expect(appliedRevisionModel.upsertMany).toHaveBeenCalledWith(
+            PROJECT_UUID,
+            USER_UUID,
+            [
+                {
+                    contentType: ContentAsCodeType.CHART,
+                    slug: 'orders',
+                    contentHash: revision.contentHash,
+                },
+            ],
+        );
+    });
+
+    it('rejects invalid content hashes on write', async () => {
+        const appliedRevisionModel = {
+            upsertMany: vi.fn(),
+            listByProject: vi.fn(),
+        };
+        const service = buildService(appliedRevisionModel);
+
+        await expect(
+            service.upsertContentAsCodeAppliedRevisions(
+                makeSessionUser(),
+                PROJECT_UUID,
+                [
+                    {
+                        contentType: ContentAsCodeType.CHART,
+                        slug: 'orders',
+                        contentHash: 'not-a-hash',
+                    },
+                ],
+            ),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(appliedRevisionModel.upsertMany).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/CoderService/CoderService.appliedRevisions.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.appliedRevisions.test.ts
@@ -83,6 +83,7 @@ const buildService = (appliedRevisionModel: {
         projectModel: {
             get: vi.fn(async () => project),
             getSummary: vi.fn(async () => project),
+            getContentAsCodeSyncEnabled: vi.fn(async () => true),
         } as never,
         savedChartModel: {} as never,
         savedSqlModel: {} as never,
@@ -347,6 +348,47 @@ describe('CoderService applied revisions', () => {
                 },
             ],
         );
+    });
+
+    it('returns syncEnabled false when the compiled project config has not opted in', async () => {
+        const appliedRevisionModel = {
+            upsertMany: vi.fn(),
+            listByProject: vi.fn(async () => []),
+        };
+        const service = new CoderService({
+            lightdashConfig: lightdashConfigMock,
+            analytics: analyticsMock,
+            projectModel: {
+                get: vi.fn(async () => project),
+                getSummary: vi.fn(async () => project),
+                getContentAsCodeSyncEnabled: vi.fn(async () => false),
+            } as never,
+            savedChartModel: {} as never,
+            savedSqlModel: {} as never,
+            appModel: {} as never,
+            dashboardModel: {} as never,
+            spaceModel: {} as never,
+            schedulerModel: {} as never,
+            schedulerService: {} as never,
+            savedChartService: {} as never,
+            dashboardService: {} as never,
+            schedulerClient: {} as never,
+            promoteService: {} as never,
+            spacePermissionService: {} as never,
+            contentVerificationModel: {} as never,
+            contentAsCodeAppliedRevisionModel: appliedRevisionModel as never,
+            groupsModel: {} as never,
+            organizationMemberProfileModel: {} as never,
+            userModel: {} as never,
+        });
+        mockCurrentContent(service);
+
+        await expect(
+            service.getContentAsCodeSyncStatus(makeSessionUser(), PROJECT_UUID),
+        ).resolves.toMatchObject({
+            syncEnabled: false,
+            items: [],
+        });
     });
 
     it('rejects restamp when the chart does not exist', async () => {

--- a/packages/backend/src/services/CoderService/CoderService.appliedRevisions.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.appliedRevisions.test.ts
@@ -112,12 +112,14 @@ describe('CoderService applied revisions', () => {
         expect(appliedRevisionModel.listByProject).not.toHaveBeenCalled();
     });
 
-    it('stores valid revisions and returns the latest applied timestamp', async () => {
+    it('stores the canonical snapshot and hash, then returns the latest applied timestamp', async () => {
         const appliedAt = new Date('2026-08-25T12:00:00.000Z');
+        const snapshot = { slug: 'orders', name: 'Orders' };
         const revision = {
             contentType: ContentAsCodeType.CHART,
             slug: 'orders',
-            contentHash: hashContentAsCodeDocument({ slug: 'orders' }),
+            contentHash: hashContentAsCodeDocument(snapshot),
+            snapshot,
             appliedAt,
             appliedByUserUuid: USER_UUID,
         };
@@ -135,7 +137,10 @@ describe('CoderService applied revisions', () => {
                     {
                         contentType: ContentAsCodeType.CHART,
                         slug: 'orders',
-                        contentHash: revision.contentHash,
+                        snapshot: {
+                            ...snapshot,
+                            updatedAt: new Date('2026-08-24T00:00:00.000Z'),
+                        },
                     },
                 ],
             ),
@@ -151,13 +156,14 @@ describe('CoderService applied revisions', () => {
                 {
                     contentType: ContentAsCodeType.CHART,
                     slug: 'orders',
+                    snapshot,
                     contentHash: revision.contentHash,
                 },
             ],
         );
     });
 
-    it('rejects invalid content hashes on write', async () => {
+    it('rejects snapshots that are not charts or dashboards', async () => {
         const appliedRevisionModel = {
             upsertMany: vi.fn(),
             listByProject: vi.fn(),
@@ -170,10 +176,10 @@ describe('CoderService applied revisions', () => {
                 PROJECT_UUID,
                 [
                     {
-                        contentType: ContentAsCodeType.CHART,
-                        slug: 'orders',
-                        contentHash: 'not-a-hash',
-                    },
+                        contentType: ContentAsCodeType.SPACE,
+                        slug: 'finance',
+                        snapshot: { slug: 'finance' },
+                    } as never,
                 ],
             ),
         ).rejects.toBeInstanceOf(ParameterError);

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -22,7 +22,9 @@ import {
     ChartScheduledDeliveryAsCode,
     ChartSummary,
     ContentAsCodeAppliedRevisionInput,
+    ContentAsCodeSnapshot,
     ContentAsCodeSnapshotType,
+    ContentAsCodeSyncItem,
     ContentAsCodeSyncStatus,
     ContentAsCodeType,
     ContentSlugRenameRequest,
@@ -73,6 +75,7 @@ import {
     ProjectType,
     PromotionAction,
     PromotionChanges,
+    RestampContentAsCodeRevisionRequest,
     SavedChartDAO,
     ScheduledDeliveryAsCode,
     ScheduledDeliveryFormatAsCode,
@@ -2582,7 +2585,49 @@ export class CoderService extends BaseService {
             );
         }
 
-        return this.buildContentAsCodeSyncStatus(projectUuid);
+        return this.buildContentAsCodeSyncStatus(user, projectUuid);
+    }
+
+    async restampContentAsCodeAppliedRevision(
+        user: SessionUser,
+        projectUuid: string,
+        request: RestampContentAsCodeRevisionRequest,
+    ): Promise<ContentAsCodeSyncStatus> {
+        const project = await this.projectModel.get(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        CoderService.checkContentAsCodeWriteAccess({
+            auditedAbility,
+            project,
+            slug: request.slug,
+        });
+        if (!isContentAsCodeSnapshotType(request.contentType)) {
+            throw new ParameterError('contentType must be chart or dashboard');
+        }
+        if (!request.slug || request.slug.trim().length === 0) {
+            throw new ParameterError('slug must not be empty');
+        }
+
+        const current = await this.getCurrentAsCodeDocument(
+            user,
+            projectUuid,
+            request.contentType,
+            request.slug,
+        );
+        if (!current) {
+            throw new NotFoundError(
+                `No ${request.contentType} with slug "${request.slug}" in this project`,
+            );
+        }
+
+        await this.recordAppliedRevision({
+            userUuid: user.userUuid,
+            projectUuid,
+            contentType: request.contentType,
+            slug: request.slug,
+            document: current,
+        });
+
+        return this.buildContentAsCodeSyncStatus(user, projectUuid);
     }
 
     async upsertContentAsCodeAppliedRevisions(
@@ -2635,7 +2680,7 @@ export class CoderService extends BaseService {
             normalized,
         );
 
-        return this.buildContentAsCodeSyncStatus(projectUuid);
+        return this.buildContentAsCodeSyncStatus(user, projectUuid);
     }
 
     private async syncVerification({
@@ -3473,17 +3518,165 @@ export class CoderService extends BaseService {
         );
     }
 
+    private async getCurrentAsCodeDocument(
+        user: SessionUser,
+        projectUuid: string,
+        contentType: ContentAsCodeSnapshotType,
+        slug: string,
+    ): Promise<ContentAsCodeSnapshot | null> {
+        if (contentType === ContentAsCodeType.CHART) {
+            const page = await this.getCharts(user, projectUuid, [slug]);
+            const chart = page.charts.find(
+                (candidate) => candidate.slug === slug,
+            );
+            return chart ? toCanonicalContentAsCodeSnapshot(chart) : null;
+        }
+
+        const page = await this.getDashboards(user, projectUuid, [slug]);
+        const dashboard = page.dashboards.find(
+            (candidate) => candidate.slug === slug,
+        );
+        return dashboard ? toCanonicalContentAsCodeSnapshot(dashboard) : null;
+    }
+
+    private async listCurrentAsCodeDocuments(
+        user: SessionUser,
+        projectUuid: string,
+        contentType: ContentAsCodeSnapshotType,
+        offset = 0,
+        documents = new Map<string, ContentAsCodeSnapshot>(),
+    ): Promise<Map<string, ContentAsCodeSnapshot>> {
+        if (contentType === ContentAsCodeType.CHART) {
+            const page = await this.getCharts(
+                user,
+                projectUuid,
+                undefined,
+                offset,
+            );
+            if (page.charts.length === 0) {
+                return documents;
+            }
+            for (const chart of page.charts) {
+                documents.set(
+                    chart.slug,
+                    toCanonicalContentAsCodeSnapshot(chart),
+                );
+            }
+            if (documents.size >= page.total) {
+                return documents;
+            }
+            return this.listCurrentAsCodeDocuments(
+                user,
+                projectUuid,
+                contentType,
+                page.offset + page.charts.length,
+                documents,
+            );
+        }
+
+        const page = await this.getDashboards(
+            user,
+            projectUuid,
+            undefined,
+            offset,
+        );
+        if (page.dashboards.length === 0) {
+            return documents;
+        }
+        for (const dashboard of page.dashboards) {
+            documents.set(
+                dashboard.slug,
+                toCanonicalContentAsCodeSnapshot(dashboard),
+            );
+        }
+        if (documents.size >= page.total) {
+            return documents;
+        }
+        return this.listCurrentAsCodeDocuments(
+            user,
+            projectUuid,
+            contentType,
+            page.offset + page.dashboards.length,
+            documents,
+        );
+    }
+
     private async buildContentAsCodeSyncStatus(
+        user: SessionUser,
         projectUuid: string,
     ): Promise<ContentAsCodeSyncStatus> {
         const revisions =
             (await this.contentAsCodeAppliedRevisionModel?.listByProject(
                 projectUuid,
             )) ?? [];
+        const [charts, dashboards] = await Promise.all([
+            this.listCurrentAsCodeDocuments(
+                user,
+                projectUuid,
+                ContentAsCodeType.CHART,
+            ),
+            this.listCurrentAsCodeDocuments(
+                user,
+                projectUuid,
+                ContentAsCodeType.DASHBOARD,
+            ),
+        ]);
+        const currentByKey = new Map<string, ContentAsCodeSnapshot>();
+        for (const [slug, document] of charts) {
+            currentByKey.set(`${ContentAsCodeType.CHART}:${slug}`, document);
+        }
+        for (const [slug, document] of dashboards) {
+            currentByKey.set(
+                `${ContentAsCodeType.DASHBOARD}:${slug}`,
+                document,
+            );
+        }
+
+        const revisionByKey = new Map(
+            revisions.map((revision) => [
+                `${revision.contentType}:${revision.slug}`,
+                revision,
+            ]),
+        );
+
+        const items: ContentAsCodeSyncItem[] = [...currentByKey.entries()]
+            .map(([contentKey, current]) => {
+                const separatorIndex = contentKey.indexOf(':');
+                const contentType = contentKey.slice(
+                    0,
+                    separatorIndex,
+                ) as ContentAsCodeSnapshotType;
+                const slug = contentKey.slice(separatorIndex + 1);
+                const revision = revisionByKey.get(contentKey);
+                const currentHash = hashContentAsCodeDocument(current);
+                let state: ContentAsCodeSyncItem['state'] = 'ui_only';
+                if (revision) {
+                    state =
+                        revision.contentHash === currentHash
+                            ? 'in_sync'
+                            : 'ahead';
+                }
+                return {
+                    contentType,
+                    slug,
+                    state,
+                    appliedAt: revision?.appliedAt ?? null,
+                    contentHash: revision?.contentHash ?? null,
+                    snapshot: revision?.snapshot ?? null,
+                    current,
+                };
+            })
+            .sort((left, right) => {
+                if (left.contentType === right.contentType) {
+                    return left.slug.localeCompare(right.slug);
+                }
+                return left.contentType.localeCompare(right.contentType);
+            });
+
         return {
+            syncEnabled: true,
             lastAppliedAt: revisions[0]?.appliedAt ?? null,
-            revisionCount: revisions.length,
-            revisions,
+            items,
         };
     }
 

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -3673,8 +3673,11 @@ export class CoderService extends BaseService {
                 return left.contentType.localeCompare(right.contentType);
             });
 
+        const syncEnabled =
+            await this.projectModel.getContentAsCodeSyncEnabled(projectUuid);
+
         return {
-            syncEnabled: true,
+            syncEnabled,
             lastAppliedAt: revisions[0]?.appliedAt ?? null,
             items,
         };

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -21,6 +21,8 @@ import {
     ChartGoogleSheetsSyncAsCode,
     ChartScheduledDeliveryAsCode,
     ChartSummary,
+    ContentAsCodeAppliedRevisionInput,
+    ContentAsCodeSyncStatus,
     ContentAsCodeType,
     ContentSlugRenameRequest,
     ContentType,
@@ -50,6 +52,7 @@ import {
     getContentAsCodePathFromLtreePath,
     getLtreePathFromContentAsCodePath,
     getParameterReferences,
+    isAccount,
     isChartScheduler,
     isDashboardScheduler,
     isEmailTarget,
@@ -98,6 +101,7 @@ import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { getAccountApiAccessContext } from '../../auth/account';
 import { LightdashConfig } from '../../config/parseConfig';
 import { AppModel } from '../../models/AppModel';
+import { ContentAsCodeAppliedRevisionModel } from '../../models/ContentAsCodeAppliedRevisionModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { GroupsModel } from '../../models/GroupsModel';
@@ -135,6 +139,10 @@ import {
     withTileWarnings,
 } from './dashboardReferences';
 import { normalizeFilterIds, stripFilterIds } from './filterIds';
+import {
+    hashContentAsCodeDocument,
+    isContentAsCodeContentHash,
+} from './contentAsCodeHash';
 import { ScheduledContentCoder } from './handlers/ScheduledContentCoder';
 import { VirtualViewCoder } from './handlers/VirtualViewCoder';
 import { paginateAsCode } from './pagination';
@@ -171,6 +179,7 @@ type CoderServiceArguments = {
     promoteService: PromoteService;
     spacePermissionService: SpacePermissionService;
     contentVerificationModel: ContentVerificationModel;
+    contentAsCodeAppliedRevisionModel?: ContentAsCodeAppliedRevisionModel;
     projectService?: ProjectService;
     groupsModel: GroupsModel;
     organizationMemberProfileModel: OrganizationMemberProfileModel;
@@ -218,6 +227,8 @@ export class CoderService extends BaseService {
 
     contentVerificationModel: ContentVerificationModel;
 
+    contentAsCodeAppliedRevisionModel?: ContentAsCodeAppliedRevisionModel;
+
     projectService?: ProjectService;
 
     groupsModel: GroupsModel;
@@ -254,6 +265,7 @@ export class CoderService extends BaseService {
         promoteService,
         spacePermissionService,
         contentVerificationModel,
+        contentAsCodeAppliedRevisionModel,
         projectService,
         groupsModel,
         organizationMemberProfileModel,
@@ -276,6 +288,8 @@ export class CoderService extends BaseService {
         this.promoteService = promoteService;
         this.spacePermissionService = spacePermissionService;
         this.contentVerificationModel = contentVerificationModel;
+        this.contentAsCodeAppliedRevisionModel =
+            contentAsCodeAppliedRevisionModel;
         this.projectService = projectService;
         this.groupsModel = groupsModel;
         this.organizationMemberProfileModel = organizationMemberProfileModel;
@@ -310,13 +324,23 @@ export class CoderService extends BaseService {
         virtualView: VirtualViewAsCode,
         force = false,
     ): Promise<ApiVirtualViewAsCodeUpsertResponse['results']> {
-        return this.virtualViewCoder.upsert(
+        const result = await this.virtualViewCoder.upsert(
             account,
             projectUuid,
             slug,
             virtualView,
             force,
         );
+        await this.recordAppliedRevision({
+            userUuid: isAccount(account)
+                ? account.user.userUuid
+                : (account as unknown as SessionUser).userUuid,
+            projectUuid,
+            contentType: ContentAsCodeType.VIRTUAL_VIEW,
+            slug,
+            document: virtualView,
+        });
+        return result;
     }
 
     private static handleContentAsCodeSqlPermissionChecks({
@@ -1172,6 +1196,13 @@ export class CoderService extends BaseService {
                     `You don't have permission to view space "${desiredSpace.slug}"`,
                 );
             }
+            await this.recordAppliedRevision({
+                userUuid: user.userUuid,
+                projectUuid,
+                contentType: ContentAsCodeType.SPACE,
+                slug: desiredSpace.slug,
+                document: desiredSpace,
+            });
             return { action: SpaceAsCodeAction.NO_CHANGES };
         }
 
@@ -1271,6 +1302,13 @@ export class CoderService extends BaseService {
             accessChanged = !isEqual(currentAccess, desiredSpace.access);
         }
         if (existingSpace && !metadataChanged && !accessChanged) {
+            await this.recordAppliedRevision({
+                userUuid: user.userUuid,
+                projectUuid,
+                contentType: ContentAsCodeType.SPACE,
+                slug: desiredSpace.slug,
+                document: desiredSpace,
+            });
             return { action: SpaceAsCodeAction.NO_CHANGES };
         }
 
@@ -1384,6 +1422,13 @@ export class CoderService extends BaseService {
             },
         });
 
+        await this.recordAppliedRevision({
+            userUuid: user.userUuid,
+            projectUuid,
+            contentType: ContentAsCodeType.SPACE,
+            slug: desiredSpace.slug,
+            document: desiredSpace,
+        });
         return {
             action: existingSpace
                 ? SpaceAsCodeAction.UPDATE
@@ -2538,13 +2583,91 @@ export class CoderService extends BaseService {
         | ApiAlertAsCodeUpsertResponse['results']
         | ApiGoogleSheetsSyncAsCodeUpsertResponse['results']
     > {
-        return this.scheduledContentCoder.upsertScheduledDelivery(
-            user,
+        const result =
+            await this.scheduledContentCoder.upsertScheduledDelivery(
+                user,
+                projectUuid,
+                slug,
+                delivery,
+                force,
+            );
+        await this.recordAppliedRevision({
+            userUuid: user.userUuid,
             projectUuid,
+            contentType: delivery.contentType,
             slug,
-            delivery,
-            force,
+            document: delivery,
+        });
+        return result;
+    }
+
+    async getContentAsCodeSyncStatus(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ContentAsCodeSyncStatus> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('ContentAsCode', {
+                    projectUuid,
+                    organizationUuid: project.organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You are not allowed to view content-as-code sync status',
+            );
+        }
+
+        return this.buildContentAsCodeSyncStatus(projectUuid);
+    }
+
+    async upsertContentAsCodeAppliedRevisions(
+        user: SessionUser,
+        projectUuid: string,
+        revisions: ContentAsCodeAppliedRevisionInput[],
+    ): Promise<ContentAsCodeSyncStatus> {
+        const project = await this.projectModel.get(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        CoderService.checkContentAsCodeWriteAccess({
+            auditedAbility,
+            project,
+            slug: 'applied-revisions',
+        });
+
+        const uniqueTypes = new Set(Object.values(ContentAsCodeType));
+        const normalized = revisions.map((revision, index) => {
+            if (!uniqueTypes.has(revision.contentType)) {
+                throw new ParameterError(
+                    `revisions[${index}].contentType is not a valid content-as-code type`,
+                );
+            }
+            if (!revision.slug || revision.slug.trim().length === 0) {
+                throw new ParameterError(
+                    `revisions[${index}].slug must not be empty`,
+                );
+            }
+            if (!isContentAsCodeContentHash(revision.contentHash)) {
+                throw new ParameterError(
+                    `revisions[${index}].contentHash must be a sha256 hex digest`,
+                );
+            }
+            return {
+                contentType: revision.contentType,
+                slug: revision.slug,
+                contentHash: revision.contentHash,
+            };
+        });
+
+        await this.contentAsCodeAppliedRevisionModel?.upsertMany(
+            projectUuid,
+            user.userUuid,
+            normalized,
         );
+
+        return this.buildContentAsCodeSyncStatus(projectUuid);
     }
 
     private async syncVerification({
@@ -2854,6 +2977,13 @@ export class CoderService extends BaseService {
                     : [],
                 dashboards: [],
             };
+            await this.recordAppliedRevision({
+                userUuid: user.userUuid,
+                projectUuid,
+                contentType: ContentAsCodeType.CHART,
+                slug,
+                document: chartAsCode,
+            });
             return promotionChanges;
         }
         console.info(
@@ -2985,6 +3115,13 @@ export class CoderService extends BaseService {
             `Finished updating chart "${chartWithDefaults.name}" on project ${projectUuid}: ${promotionChanges.charts[0].action}`,
         );
 
+        await this.recordAppliedRevision({
+            userUuid: user.userUuid,
+            projectUuid,
+            contentType: ContentAsCodeType.CHART,
+            slug,
+            document: chartAsCode,
+        });
         return promotionChanges;
     }
 
@@ -3200,6 +3337,13 @@ export class CoderService extends BaseService {
                     : [],
                 dashboards: [],
             };
+            await this.recordAppliedRevision({
+                userUuid: user.userUuid,
+                projectUuid,
+                contentType: ContentAsCodeType.SQL_CHART,
+                slug,
+                document: sqlChartAsCode,
+            });
             return promotionChanges;
         }
 
@@ -3246,6 +3390,13 @@ export class CoderService extends BaseService {
                 : [],
             dashboards: [],
         };
+        await this.recordAppliedRevision({
+            userUuid: user.userUuid,
+            projectUuid,
+            contentType: ContentAsCodeType.SQL_CHART,
+            slug,
+            document: sqlChartAsCode,
+        });
         return promotionChanges;
     }
 
@@ -3335,6 +3486,49 @@ export class CoderService extends BaseService {
                 }),
             );
         return { canUploadAnyContent, allowSpaceCreate };
+    }
+
+    private async recordAppliedRevision({
+        userUuid,
+        projectUuid,
+        contentType,
+        slug,
+        document,
+    }: {
+        userUuid: string;
+        projectUuid: string;
+        contentType: ContentAsCodeType;
+        slug: string;
+        document: unknown;
+    }): Promise<void> {
+        if (!this.contentAsCodeAppliedRevisionModel) {
+            return;
+        }
+        await this.contentAsCodeAppliedRevisionModel.upsertMany(
+            projectUuid,
+            userUuid,
+            [
+                {
+                    contentType,
+                    slug,
+                    contentHash: hashContentAsCodeDocument(document),
+                },
+            ],
+        );
+    }
+
+    private async buildContentAsCodeSyncStatus(
+        projectUuid: string,
+    ): Promise<ContentAsCodeSyncStatus> {
+        const revisions =
+            (await this.contentAsCodeAppliedRevisionModel?.listByProject(
+                projectUuid,
+            )) ?? [];
+        return {
+            lastAppliedAt: revisions[0]?.appliedAt ?? null,
+            revisionCount: revisions.length,
+            revisions,
+        };
     }
 
     private async assertSpaceContentAccess({
@@ -3816,6 +4010,13 @@ export class CoderService extends BaseService {
                 verified: dashboardAsCode.verified,
             });
 
+            await this.recordAppliedRevision({
+                userUuid: user.userUuid,
+                projectUuid,
+                contentType: ContentAsCodeType.DASHBOARD,
+                slug,
+                document: dashboardAsCode,
+            });
             return withTileWarnings(
                 {
                     dashboards: [
@@ -3973,6 +4174,13 @@ export class CoderService extends BaseService {
         console.info(
             `Finished updating dashboard "${dashboard.name}" on project ${projectUuid}: ${promotionChanges.dashboards[0].action}`,
         );
+        await this.recordAppliedRevision({
+            userUuid: user.userUuid,
+            projectUuid,
+            contentType: ContentAsCodeType.DASHBOARD,
+            slug,
+            document: dashboardAsCode,
+        });
         return withTileWarnings(promotionChanges, tileWarnings);
     }
 }

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -22,6 +22,7 @@ import {
     ChartScheduledDeliveryAsCode,
     ChartSummary,
     ContentAsCodeAppliedRevisionInput,
+    ContentAsCodeSnapshotType,
     ContentAsCodeSyncStatus,
     ContentAsCodeType,
     ContentSlugRenameRequest,
@@ -52,8 +53,8 @@ import {
     getContentAsCodePathFromLtreePath,
     getLtreePathFromContentAsCodePath,
     getParameterReferences,
-    isAccount,
     isChartScheduler,
+    isContentAsCodeSnapshotType,
     isDashboardScheduler,
     isEmailTarget,
     isExploreError,
@@ -141,7 +142,7 @@ import {
 import { normalizeFilterIds, stripFilterIds } from './filterIds';
 import {
     hashContentAsCodeDocument,
-    isContentAsCodeContentHash,
+    toCanonicalContentAsCodeSnapshot,
 } from './contentAsCodeHash';
 import { ScheduledContentCoder } from './handlers/ScheduledContentCoder';
 import { VirtualViewCoder } from './handlers/VirtualViewCoder';
@@ -324,23 +325,13 @@ export class CoderService extends BaseService {
         virtualView: VirtualViewAsCode,
         force = false,
     ): Promise<ApiVirtualViewAsCodeUpsertResponse['results']> {
-        const result = await this.virtualViewCoder.upsert(
+        return this.virtualViewCoder.upsert(
             account,
             projectUuid,
             slug,
             virtualView,
             force,
         );
-        await this.recordAppliedRevision({
-            userUuid: isAccount(account)
-                ? account.user.userUuid
-                : (account as unknown as SessionUser).userUuid,
-            projectUuid,
-            contentType: ContentAsCodeType.VIRTUAL_VIEW,
-            slug,
-            document: virtualView,
-        });
-        return result;
     }
 
     private static handleContentAsCodeSqlPermissionChecks({
@@ -1196,13 +1187,6 @@ export class CoderService extends BaseService {
                     `You don't have permission to view space "${desiredSpace.slug}"`,
                 );
             }
-            await this.recordAppliedRevision({
-                userUuid: user.userUuid,
-                projectUuid,
-                contentType: ContentAsCodeType.SPACE,
-                slug: desiredSpace.slug,
-                document: desiredSpace,
-            });
             return { action: SpaceAsCodeAction.NO_CHANGES };
         }
 
@@ -1302,13 +1286,6 @@ export class CoderService extends BaseService {
             accessChanged = !isEqual(currentAccess, desiredSpace.access);
         }
         if (existingSpace && !metadataChanged && !accessChanged) {
-            await this.recordAppliedRevision({
-                userUuid: user.userUuid,
-                projectUuid,
-                contentType: ContentAsCodeType.SPACE,
-                slug: desiredSpace.slug,
-                document: desiredSpace,
-            });
             return { action: SpaceAsCodeAction.NO_CHANGES };
         }
 
@@ -1422,13 +1399,6 @@ export class CoderService extends BaseService {
             },
         });
 
-        await this.recordAppliedRevision({
-            userUuid: user.userUuid,
-            projectUuid,
-            contentType: ContentAsCodeType.SPACE,
-            slug: desiredSpace.slug,
-            document: desiredSpace,
-        });
         return {
             action: existingSpace
                 ? SpaceAsCodeAction.UPDATE
@@ -2583,22 +2553,13 @@ export class CoderService extends BaseService {
         | ApiAlertAsCodeUpsertResponse['results']
         | ApiGoogleSheetsSyncAsCodeUpsertResponse['results']
     > {
-        const result =
-            await this.scheduledContentCoder.upsertScheduledDelivery(
-                user,
-                projectUuid,
-                slug,
-                delivery,
-                force,
-            );
-        await this.recordAppliedRevision({
-            userUuid: user.userUuid,
+        return this.scheduledContentCoder.upsertScheduledDelivery(
+            user,
             projectUuid,
-            contentType: delivery.contentType,
             slug,
-            document: delivery,
-        });
-        return result;
+            delivery,
+            force,
+        );
     }
 
     async getContentAsCodeSyncStatus(
@@ -2637,11 +2598,10 @@ export class CoderService extends BaseService {
             slug: 'applied-revisions',
         });
 
-        const uniqueTypes = new Set(Object.values(ContentAsCodeType));
         const normalized = revisions.map((revision, index) => {
-            if (!uniqueTypes.has(revision.contentType)) {
+            if (!isContentAsCodeSnapshotType(revision.contentType)) {
                 throw new ParameterError(
-                    `revisions[${index}].contentType is not a valid content-as-code type`,
+                    `revisions[${index}].contentType must be chart or dashboard`,
                 );
             }
             if (!revision.slug || revision.slug.trim().length === 0) {
@@ -2649,15 +2609,21 @@ export class CoderService extends BaseService {
                     `revisions[${index}].slug must not be empty`,
                 );
             }
-            if (!isContentAsCodeContentHash(revision.contentHash)) {
+            if (
+                revision.snapshot === null ||
+                typeof revision.snapshot !== 'object' ||
+                Array.isArray(revision.snapshot)
+            ) {
                 throw new ParameterError(
-                    `revisions[${index}].contentHash must be a sha256 hex digest`,
+                    `revisions[${index}].snapshot must be an object`,
                 );
             }
+            const snapshot = toCanonicalContentAsCodeSnapshot(revision.snapshot);
             return {
                 contentType: revision.contentType,
                 slug: revision.slug,
-                contentHash: revision.contentHash,
+                snapshot,
+                contentHash: hashContentAsCodeDocument(snapshot),
             };
         });
 
@@ -3337,13 +3303,6 @@ export class CoderService extends BaseService {
                     : [],
                 dashboards: [],
             };
-            await this.recordAppliedRevision({
-                userUuid: user.userUuid,
-                projectUuid,
-                contentType: ContentAsCodeType.SQL_CHART,
-                slug,
-                document: sqlChartAsCode,
-            });
             return promotionChanges;
         }
 
@@ -3390,13 +3349,6 @@ export class CoderService extends BaseService {
                 : [],
             dashboards: [],
         };
-        await this.recordAppliedRevision({
-            userUuid: user.userUuid,
-            projectUuid,
-            contentType: ContentAsCodeType.SQL_CHART,
-            slug,
-            document: sqlChartAsCode,
-        });
         return promotionChanges;
     }
 
@@ -3497,13 +3449,14 @@ export class CoderService extends BaseService {
     }: {
         userUuid: string;
         projectUuid: string;
-        contentType: ContentAsCodeType;
+        contentType: ContentAsCodeSnapshotType;
         slug: string;
         document: unknown;
     }): Promise<void> {
         if (!this.contentAsCodeAppliedRevisionModel) {
             return;
         }
+        const snapshot = toCanonicalContentAsCodeSnapshot(document);
         await this.contentAsCodeAppliedRevisionModel.upsertMany(
             projectUuid,
             userUuid,
@@ -3511,7 +3464,8 @@ export class CoderService extends BaseService {
                 {
                     contentType,
                     slug,
-                    contentHash: hashContentAsCodeDocument(document),
+                    snapshot,
+                    contentHash: hashContentAsCodeDocument(snapshot),
                 },
             ],
         );

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -131,6 +131,10 @@ import {
     type CurrentChartSqlItems,
 } from './chartPermissions';
 import {
+    hashContentAsCodeDocument,
+    toCanonicalContentAsCodeSnapshot,
+} from './contentAsCodeHash';
+import {
     getConfigWithDateZoomTileSlugs,
     getConfigWithDateZoomTileUuids,
     getFiltersWithTileSlugs,
@@ -140,10 +144,6 @@ import {
     withTileWarnings,
 } from './dashboardReferences';
 import { normalizeFilterIds, stripFilterIds } from './filterIds';
-import {
-    hashContentAsCodeDocument,
-    toCanonicalContentAsCodeSnapshot,
-} from './contentAsCodeHash';
 import { ScheduledContentCoder } from './handlers/ScheduledContentCoder';
 import { VirtualViewCoder } from './handlers/VirtualViewCoder';
 import { paginateAsCode } from './pagination';
@@ -2618,7 +2618,9 @@ export class CoderService extends BaseService {
                     `revisions[${index}].snapshot must be an object`,
                 );
             }
-            const snapshot = toCanonicalContentAsCodeSnapshot(revision.snapshot);
+            const snapshot = toCanonicalContentAsCodeSnapshot(
+                revision.snapshot,
+            );
             return {
                 contentType: revision.contentType,
                 slug: revision.slug,

--- a/packages/backend/src/services/CoderService/contentAsCodeHash.test.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeHash.test.ts
@@ -2,6 +2,7 @@ import {
     hashContentAsCodeDocument,
     isContentAsCodeContentHash,
     stableStringifyContentAsCode,
+    toCanonicalContentAsCodeSnapshot,
 } from './contentAsCodeHash';
 
 describe('contentAsCodeHash', () => {
@@ -11,7 +12,7 @@ describe('contentAsCodeHash', () => {
         );
     });
 
-    it('omits instance-local fields so download and upload hashes can match', () => {
+    it('strips downloadedAt and updatedAt the same way CLI download does', () => {
         const uploaded = {
             slug: 'orders',
             name: 'Orders',
@@ -21,10 +22,9 @@ describe('contentAsCodeHash', () => {
             ...uploaded,
             downloadedAt: new Date('2026-08-25T00:00:00.000Z'),
             updatedAt: new Date('2026-08-24T00:00:00.000Z'),
-            verification: { verified: true },
-            uuid: 'chart-uuid',
         };
 
+        expect(toCanonicalContentAsCodeSnapshot(downloaded)).toEqual(uploaded);
         expect(hashContentAsCodeDocument(uploaded)).toBe(
             hashContentAsCodeDocument(downloaded),
         );

--- a/packages/backend/src/services/CoderService/contentAsCodeHash.test.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeHash.test.ts
@@ -1,0 +1,47 @@
+import {
+    hashContentAsCodeDocument,
+    isContentAsCodeContentHash,
+    stableStringifyContentAsCode,
+} from './contentAsCodeHash';
+
+describe('contentAsCodeHash', () => {
+    it('stringifies objects with sorted keys', () => {
+        expect(stableStringifyContentAsCode({ b: 1, a: 2 })).toBe(
+            '{"a":2,"b":1}',
+        );
+    });
+
+    it('omits instance-local fields so download and upload hashes can match', () => {
+        const uploaded = {
+            slug: 'orders',
+            name: 'Orders',
+            spaceSlug: 'jaffle-shop',
+        };
+        const downloaded = {
+            ...uploaded,
+            downloadedAt: new Date('2026-08-25T00:00:00.000Z'),
+            updatedAt: new Date('2026-08-24T00:00:00.000Z'),
+            verification: { verified: true },
+            uuid: 'chart-uuid',
+        };
+
+        expect(hashContentAsCodeDocument(uploaded)).toBe(
+            hashContentAsCodeDocument(downloaded),
+        );
+    });
+
+    it('changes the hash when portable content changes', () => {
+        expect(
+            hashContentAsCodeDocument({ slug: 'orders', name: 'Orders' }),
+        ).not.toBe(
+            hashContentAsCodeDocument({ slug: 'orders', name: 'Orders v2' }),
+        );
+    });
+
+    it('accepts sha256 hex hashes and rejects other strings', () => {
+        const hash = hashContentAsCodeDocument({ slug: 'orders' });
+        expect(isContentAsCodeContentHash(hash)).toBe(true);
+        expect(isContentAsCodeContentHash('not-a-hash')).toBe(false);
+        expect(isContentAsCodeContentHash(hash.toUpperCase())).toBe(false);
+    });
+});

--- a/packages/backend/src/services/CoderService/contentAsCodeHash.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeHash.ts
@@ -1,0 +1,50 @@
+import { createHash } from 'crypto';
+
+const CONTENT_AS_CODE_VOLATILE_KEYS = new Set([
+    'downloadedAt',
+    'updatedAt',
+    'verification',
+    'uuid',
+]);
+
+const CONTENT_AS_CODE_HASH_PATTERN = /^[a-f0-9]{64}$/;
+
+export const isContentAsCodeContentHash = (value: string): boolean =>
+    CONTENT_AS_CODE_HASH_PATTERN.test(value);
+
+export const stableStringifyContentAsCode = (value: unknown): string => {
+    if (value instanceof Date) {
+        return JSON.stringify(value.toISOString());
+    }
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+        return `[${value
+            .map((item) => stableStringifyContentAsCode(item))
+            .join(',')}]`;
+    }
+
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record)
+        .filter(
+            (key) =>
+                !CONTENT_AS_CODE_VOLATILE_KEYS.has(key) &&
+                record[key] !== undefined,
+        )
+        .sort();
+
+    return `{${keys
+        .map(
+            (key) =>
+                `${JSON.stringify(key)}:${stableStringifyContentAsCode(
+                    record[key],
+                )}`,
+        )
+        .join(',')}}`;
+};
+
+export const hashContentAsCodeDocument = (document: unknown): string =>
+    createHash('sha256')
+        .update(stableStringifyContentAsCode(document))
+        .digest('hex');

--- a/packages/backend/src/services/CoderService/contentAsCodeHash.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeHash.ts
@@ -1,48 +1,53 @@
 import { createHash } from 'crypto';
 
-const CONTENT_AS_CODE_VOLATILE_KEYS = new Set([
-    'downloadedAt',
-    'updatedAt',
-    'verification',
-    'uuid',
-]);
+const CONTENT_AS_CODE_TIMESTAMP_KEYS = new Set(['downloadedAt', 'updatedAt']);
 
 const CONTENT_AS_CODE_HASH_PATTERN = /^[a-f0-9]{64}$/;
 
 export const isContentAsCodeContentHash = (value: string): boolean =>
     CONTENT_AS_CODE_HASH_PATTERN.test(value);
 
-export const stableStringifyContentAsCode = (value: unknown): string => {
+const toCanonicalValue = (value: unknown): unknown => {
     if (value instanceof Date) {
-        return JSON.stringify(value.toISOString());
+        return value.toISOString();
     }
     if (value === null || typeof value !== 'object') {
-        return JSON.stringify(value);
+        return value;
     }
     if (Array.isArray(value)) {
-        return `[${value
-            .map((item) => stableStringifyContentAsCode(item))
-            .join(',')}]`;
+        return value.map((item) => toCanonicalValue(item));
     }
 
     const record = value as Record<string, unknown>;
-    const keys = Object.keys(record)
+    const canonical: Record<string, unknown> = {};
+    for (const key of Object.keys(record)
         .filter(
             (key) =>
-                !CONTENT_AS_CODE_VOLATILE_KEYS.has(key) &&
+                !CONTENT_AS_CODE_TIMESTAMP_KEYS.has(key) &&
                 record[key] !== undefined,
         )
-        .sort();
-
-    return `{${keys
-        .map(
-            (key) =>
-                `${JSON.stringify(key)}:${stableStringifyContentAsCode(
-                    record[key],
-                )}`,
-        )
-        .join(',')}}`;
+        .sort()) {
+        canonical[key] = toCanonicalValue(record[key]);
+    }
+    return canonical;
 };
+
+export const toCanonicalContentAsCodeSnapshot = (
+    document: unknown,
+): Record<string, unknown> => {
+    const canonical = toCanonicalValue(document);
+    if (
+        canonical === null ||
+        typeof canonical !== 'object' ||
+        Array.isArray(canonical)
+    ) {
+        throw new Error('Content-as-code snapshot must be an object');
+    }
+    return canonical as Record<string, unknown>;
+};
+
+export const stableStringifyContentAsCode = (value: unknown): string =>
+    JSON.stringify(toCanonicalValue(value));
 
 export const hashContentAsCodeDocument = (document: unknown): string =>
     createHash('sha256')

--- a/packages/backend/src/services/CoderService/contentAsCodeHash.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeHash.ts
@@ -20,14 +20,14 @@ const toCanonicalValue = (value: unknown): unknown => {
 
     const record = value as Record<string, unknown>;
     const canonical: Record<string, unknown> = {};
-    for (const key of Object.keys(record)
+    for (const fieldName of Object.keys(record)
         .filter(
-            (key) =>
-                !CONTENT_AS_CODE_TIMESTAMP_KEYS.has(key) &&
-                record[key] !== undefined,
+            (candidate) =>
+                !CONTENT_AS_CODE_TIMESTAMP_KEYS.has(candidate) &&
+                record[candidate] !== undefined,
         )
         .sort()) {
-        canonical[key] = toCanonicalValue(record[key]);
+        canonical[fieldName] = toCanonicalValue(record[fieldName]);
     }
     return canonical;
 };

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -233,6 +233,7 @@ const projectModel = {
     saveWarehouseToCache: vi.fn(async () => undefined),
     saveExploresToCache: vi.fn(async () => ({ cachedExploreUuids: [] })),
     setTableGroups: vi.fn(async () => undefined),
+    setContentAsCodeSyncEnabled: vi.fn(async () => undefined),
     updateProjectDefaults: vi.fn(async () => undefined),
     updateDefaultUserSpaces: vi.fn(async () => undefined),
     tryAcquireProjectLock: vi.fn(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3225,6 +3225,10 @@ export class ProjectService extends BaseService {
                         newProjectUuid,
                         lightdashProjectConfig.table_groups,
                     );
+                    await this.projectModel.setContentAsCodeSyncEnabled(
+                        newProjectUuid,
+                        lightdashProjectConfig.content_as_code?.sync === true,
+                    );
                     // Mirrors CLI deploy semantics: only overwrite stored
                     // defaults when the config file defines them
                     if (lightdashProjectConfig.defaults) {
@@ -3920,6 +3924,11 @@ export class ProjectService extends BaseService {
                             await this.projectModel.setTableGroups(
                                 projectUuid,
                                 lightdashProjectConfig.table_groups,
+                            );
+                            await this.projectModel.setContentAsCodeSyncEnabled(
+                                projectUuid,
+                                lightdashProjectConfig.content_as_code?.sync ===
+                                    true,
                             );
                             // Mirrors CLI deploy semantics: only overwrite
                             // stored defaults when the config file defines them
@@ -8755,6 +8764,11 @@ export class ProjectService extends BaseService {
                         await this.projectModel.setTableGroups(
                             projectUuid,
                             lightdashProjectConfig.table_groups,
+                        );
+                        await this.projectModel.setContentAsCodeSyncEnabled(
+                            projectUuid,
+                            lightdashProjectConfig.content_as_code?.sync ===
+                                true,
                         );
                         // Mirrors CLI deploy semantics: only overwrite stored
                         // defaults when the config file defines them

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1274,6 +1274,8 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
+                    contentAsCodeAppliedRevisionModel:
+                        this.models.getContentAsCodeAppliedRevisionModel(),
                     projectService: this.getProjectService(),
                     groupsModel: this.models.getGroupsModel(),
                     organizationMemberProfileModel:

--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -46,6 +46,18 @@
                 }
             }
         },
+        "content_as_code": {
+            "type": ["object", "null"],
+            "description": "Settings for content-as-code sync between this repo and Lightdash instances",
+            "properties": {
+                "sync": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, uploads refuse to overwrite content that changed on the instance since the last upload (skipped, exit 1). When false, drift is reported as warnings only."
+                }
+            },
+            "additionalProperties": false
+        },
         "parameters": {
             "type": ["object", "null"],
             "description": "Define parameters that can be used in SQL queries",

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -142,6 +142,7 @@ import {
     type ApiAlertAsCodeUpsertResponse,
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
+    type ApiContentAsCodeSyncStatusResponse,
     type ApiDashboardAsCodeListResponse,
     type ApiGoogleSheetsSyncAsCodeListResponse,
     type ApiGoogleSheetsSyncAsCodeUpsertResponse,
@@ -152,7 +153,6 @@ import {
     type ApiSqlChartAsCodeListResponse,
     type ApiVirtualViewAsCodeListResponse,
     type ApiVirtualViewAsCodeUpsertResponse,
-    type ApiContentAsCodeSyncStatusResponse,
 } from './coder';
 import {
     type ApiChartContentResponse,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -152,6 +152,7 @@ import {
     type ApiSqlChartAsCodeListResponse,
     type ApiVirtualViewAsCodeListResponse,
     type ApiVirtualViewAsCodeUpsertResponse,
+    type ApiContentAsCodeSyncStatusResponse,
 } from './coder';
 import {
     type ApiChartContentResponse,
@@ -1341,6 +1342,7 @@ type ApiResults =
     | ApiExternalConnectionAsCodeUpsertResponse['results']
     | ApiSpaceAsCodeListResponse['results']
     | ApiSpaceAsCodeUpsertResponse['results']
+    | ApiContentAsCodeSyncStatusResponse['results']
     | ApiChartAsCodeUpsertResponse['results']
     | ApiGetMetricsTree['results']
     | ApiGetMetricsTreeResponse['results']

--- a/packages/common/src/types/contentAsCode/index.ts
+++ b/packages/common/src/types/contentAsCode/index.ts
@@ -5,4 +5,5 @@ export * from './dashboards';
 export * from './parsers';
 export * from './scheduledContent';
 export * from './spaces';
+export * from './sync';
 export * from './virtualViews';

--- a/packages/common/src/types/contentAsCode/sync.ts
+++ b/packages/common/src/types/contentAsCode/sync.ts
@@ -1,0 +1,35 @@
+import type { ContentAsCodeType } from './core';
+
+export type ContentAsCodeAppliedRevision = {
+    contentType: ContentAsCodeType;
+    slug: string;
+    contentHash: string;
+    appliedAt: Date;
+    appliedByUserUuid: string | null;
+};
+
+export type ContentAsCodeAppliedRevisionInput = {
+    contentType: ContentAsCodeType;
+    slug: string;
+    contentHash: string;
+};
+
+export type UpsertContentAsCodeAppliedRevisionsRequest = {
+    revisions: ContentAsCodeAppliedRevisionInput[];
+};
+
+export type ContentAsCodeSyncStatus = {
+    lastAppliedAt: Date | null;
+    revisionCount: number;
+    revisions: ContentAsCodeAppliedRevision[];
+};
+
+export type ApiContentAsCodeSyncStatusResponse = {
+    status: 'ok';
+    results: ContentAsCodeSyncStatus;
+};
+
+export type ApiUpsertContentAsCodeAppliedRevisionsResponse = {
+    status: 'ok';
+    results: ContentAsCodeSyncStatus;
+};

--- a/packages/common/src/types/contentAsCode/sync.ts
+++ b/packages/common/src/types/contentAsCode/sync.ts
@@ -10,6 +10,8 @@ export type ContentAsCodeSnapshotType =
 
 export type ContentAsCodeSnapshot = Record<string, unknown>;
 
+export type ContentAsCodeSyncItemState = 'in_sync' | 'ahead' | 'ui_only';
+
 export type ContentAsCodeAppliedRevision = {
     contentType: ContentAsCodeSnapshotType;
     slug: string;
@@ -29,10 +31,25 @@ export type UpsertContentAsCodeAppliedRevisionsRequest = {
     revisions: ContentAsCodeAppliedRevisionInput[];
 };
 
+export type RestampContentAsCodeRevisionRequest = {
+    contentType: ContentAsCodeSnapshotType;
+    slug: string;
+};
+
+export type ContentAsCodeSyncItem = {
+    contentType: ContentAsCodeSnapshotType;
+    slug: string;
+    state: ContentAsCodeSyncItemState;
+    appliedAt: Date | null;
+    contentHash: string | null;
+    snapshot: ContentAsCodeSnapshot | null;
+    current: ContentAsCodeSnapshot | null;
+};
+
 export type ContentAsCodeSyncStatus = {
+    syncEnabled: boolean;
     lastAppliedAt: Date | null;
-    revisionCount: number;
-    revisions: ContentAsCodeAppliedRevision[];
+    items: ContentAsCodeSyncItem[];
 };
 
 export type ApiContentAsCodeSyncStatusResponse = {

--- a/packages/common/src/types/contentAsCode/sync.ts
+++ b/packages/common/src/types/contentAsCode/sync.ts
@@ -1,17 +1,28 @@
-import type { ContentAsCodeType } from './core';
+import { ContentAsCodeType } from './core';
+
+export const CONTENT_AS_CODE_SNAPSHOT_TYPES = [
+    ContentAsCodeType.CHART,
+    ContentAsCodeType.DASHBOARD,
+] as const;
+
+export type ContentAsCodeSnapshotType =
+    (typeof CONTENT_AS_CODE_SNAPSHOT_TYPES)[number];
+
+export type ContentAsCodeSnapshot = Record<string, unknown>;
 
 export type ContentAsCodeAppliedRevision = {
-    contentType: ContentAsCodeType;
+    contentType: ContentAsCodeSnapshotType;
     slug: string;
     contentHash: string;
+    snapshot: ContentAsCodeSnapshot;
     appliedAt: Date;
     appliedByUserUuid: string | null;
 };
 
 export type ContentAsCodeAppliedRevisionInput = {
-    contentType: ContentAsCodeType;
+    contentType: ContentAsCodeSnapshotType;
     slug: string;
-    contentHash: string;
+    snapshot: ContentAsCodeSnapshot;
 };
 
 export type UpsertContentAsCodeAppliedRevisionsRequest = {
@@ -33,3 +44,8 @@ export type ApiUpsertContentAsCodeAppliedRevisionsResponse = {
     status: 'ok';
     results: ContentAsCodeSyncStatus;
 };
+
+export const isContentAsCodeSnapshotType = (
+    value: string,
+): value is ContentAsCodeSnapshotType =>
+    (CONTENT_AS_CODE_SNAPSHOT_TYPES as readonly string[]).includes(value);

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -352,6 +352,13 @@ export enum FeatureFlags {
      * still delete threads from the agent admin threads view. Off by default.
      */
     AiDisableThreadDeletion = 'ai-disable-thread-deletion',
+
+    /**
+     * Two-way content-as-code sync: last-applied snapshot, skip instance-ahead
+     * uploads, conflict UI, and the project settings sync status panel.
+     * Off by default.
+     */
+    ContentAsCodeSync = 'content-as-code-sync',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -101,8 +101,18 @@ export type CustomGranularity = {
     type?: DimensionType.DATE | DimensionType.TIMESTAMP | DimensionType.STRING;
 };
 
+export type ContentAsCodeConfig = {
+    /**
+     * When true, content-as-code sync is enabled for this project.
+     * Uploads can refuse to overwrite instance-ahead content, and the
+     * settings panel is shown. When false or omitted, sync is off.
+     */
+    sync?: boolean;
+};
+
 export type LightdashProjectConfig = {
     spotlight: SpotlightConfig;
+    content_as_code?: ContentAsCodeConfig;
     parameters?: Record<string, LightdashProjectParameter>; // keys must be ^[a-zA-Z0-9_-]+$
     warehouse?: WarehouseConfig; // Required for Lightdash-only projects (no dbt)
     defaults?: ProjectDefaults; // Project-wide defaults for various settings


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: PROD-10507
Relates: PROD-2856

**PROD-2856 ship plan: hold / superseded.** Use #27995 as the 10507 foundation. This competing snapshot table should not merge.

### Description:
Foundation for two-way content-as-code sync. After every successful chart or dashboard as-code upsert, the backend stamps the last-applied snapshot so later skip-instance-ahead, drift, and write-back work have a merge base.

- New `content_as_code_applied_revisions` table: one row per `(project, chart|dashboard, slug)`
- Stores the **full canonical as-code document** in `snapshot` (jsonb) plus `snapshot_hash`
- Canonicalization matches CLI download: strip `updatedAt` / `downloadedAt`, sort keys
- Stamped only from `CoderService.upsertChart` and `upsertDashboard`, and only after a successful upsert (including `NO_CHANGES`)
- Recording is always on — not gated by `content_as_code.sync`. That flag is for later enforcement/UI so baselines exist before anyone opts in
- `content_as_code.sync` in `lightdash.config.yml` is persisted onto the project at compile as `content_as_code_sync_enabled`
- `GET /api/v1/projects/{projectUuid}/code/sync-status` returns `syncEnabled`, `lastAppliedAt`, and per-slug `items` (`in_sync` / `ahead` / `ui_only`) with last-applied snapshot vs current instance document
- `POST /api/v1/projects/{projectUuid}/code/applied-revisions/restamp` restamps last-applied to the current instance document so the next upload applies git
- `PUT /api/v1/projects/{projectUuid}/code/applied-revisions` remains available for explicit writes

No upload behavior change: results are identical, the marker is written silently.

This does not skip instance-ahead uploads, resolve conflicts, or add CLI `--dry-run` / settings UI. Those are PROD-10508, PROD-10515, PROD-10510, and PROD-10509.

### Risk assessment:
- [ ] This is a high-risk change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8ccfc64-3e19-47b0-ba73-d713ac376003?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8ccfc64-3e19-47b0-ba73-d713ac376003&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

