### PR TITLE
feat(frontend): add content-as-code sync status panel

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -352,6 +352,13 @@ export enum FeatureFlags {
      * still delete threads from the agent admin threads view. Off by default.
      */
     AiDisableThreadDeletion = 'ai-disable-thread-deletion',
+
+    /**
+     * Show content-as-code sync status in project settings and enable
+     * two-way content-as-code sync. Off by default; enable per-org
+     * for gradual rollout.
+     */
+    ContentAsCodeSync = 'content-as-code-sync',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -352,13 +352,6 @@ export enum FeatureFlags {
      * still delete threads from the agent admin threads view. Off by default.
      */
     AiDisableThreadDeletion = 'ai-disable-thread-deletion',
-
-    /**
-     * Show content-as-code sync status in project settings and enable
-     * two-way content-as-code sync. Off by default; enable per-org
-     * for gradual rollout.
-     */
-    ContentAsCodeSync = 'content-as-code-sync',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -17,6 +17,8 @@ import {
 import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import SettingsEmbed from '../../ee/features/embed/SettingsEmbed';
 import ContentAsCodeSyncStatusPanel from '../../features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel';
+import { useContentAsCodeSyncStatus } from '../../features/contentAsCodeSync/hooks/useContentAsCodeSyncStatus';
+import { shouldShowContentAsCodeSync } from '../../features/contentAsCodeSync/types';
 import { ExternalSourcesSettingsPanel } from '../../features/externalSources/components/ExternalSourcesSettingsPanel';
 import PullRequestsPage from '../../features/pullRequests/components/PullRequestsPage';
 import RecentlyDeletedPage from '../../features/recentlyDeleted/components/RecentlyDeletedPage';
@@ -102,12 +104,11 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
     const { data: resultsCacheFlag, isLoading: isResultsCacheFlagLoading } =
         useServerFeatureFlag(FeatureFlags.ResultsCacheEnabled);
     const {
-        data: contentAsCodeSyncFlag,
-        isLoading: isContentAsCodeSyncFlagLoading,
-    } = useServerFeatureFlag(FeatureFlags.ContentAsCodeSync);
+        data: contentAsCodeSyncResult,
+        isInitialLoading: isContentAsCodeSyncStatusLoading,
+    } = useContentAsCodeSyncStatus(projectUuid);
     const isResultsCacheEnabled = resultsCacheFlag?.enabled ?? false;
     const isDataAppsEnabled = dataAppsFlag?.enabled ?? false;
-    const isContentAsCodeSyncEnabled = contentAsCodeSyncFlag?.enabled ?? false;
     const canManageExternalConnections =
         isDataAppsEnabled &&
         !!project &&
@@ -133,7 +134,6 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
             false);
 
     const canViewContentAsCode =
-        isContentAsCodeSyncEnabled &&
         !!project &&
         (user.data?.ability.can(
             'view',
@@ -143,6 +143,9 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
             }),
         ) ??
             false);
+    const canViewContentAsCodeSync =
+        canViewContentAsCode &&
+        shouldShowContentAsCodeSync(contentAsCodeSyncResult);
 
     const routes = useMemo<RouteObject[]>(() => {
         if (!projectUuid) {
@@ -264,14 +267,14 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
                     </ProjectSettingsPage>
                 ),
             },
-            ...(canViewContentAsCode
+            ...(canViewContentAsCodeSync
                 ? [
                       {
                           path: `/contentAsCode`,
                           element: (
                               <ProjectSettingsPage
                                   title="Content as code"
-                                  description="Review when content as code was last applied to this project."
+                                  description="See which managed slugs are in sync, ahead, or UI-only."
                               >
                                   <ContentAsCodeSyncStatusPanel
                                       projectUuid={projectUuid}
@@ -522,7 +525,7 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
         user.data?.ability,
         canManageExternalConnections,
         canManageExternalSources,
-        canViewContentAsCode,
+        canViewContentAsCodeSync,
         isAiCopilotEnabledOrTrial,
     ]);
     const routesElements = useRoutes(routes);
@@ -548,7 +551,7 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
             location.pathname,
         );
     const isAwaitingContentAsCodeRoute =
-        isContentAsCodeSyncFlagLoading &&
+        isContentAsCodeSyncStatusLoading &&
         !!matchPath(
             '/generalSettings/projectManagement/:projectUuid/contentAsCode',
             location.pathname,

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -16,6 +16,7 @@ import {
 } from 'react-router';
 import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import SettingsEmbed from '../../ee/features/embed/SettingsEmbed';
+import ContentAsCodeSyncStatusPanel from '../../features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel';
 import { ExternalSourcesSettingsPanel } from '../../features/externalSources/components/ExternalSourcesSettingsPanel';
 import PullRequestsPage from '../../features/pullRequests/components/PullRequestsPage';
 import RecentlyDeletedPage from '../../features/recentlyDeleted/components/RecentlyDeletedPage';
@@ -100,8 +101,13 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
         useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const { data: resultsCacheFlag, isLoading: isResultsCacheFlagLoading } =
         useServerFeatureFlag(FeatureFlags.ResultsCacheEnabled);
+    const {
+        data: contentAsCodeSyncFlag,
+        isLoading: isContentAsCodeSyncFlagLoading,
+    } = useServerFeatureFlag(FeatureFlags.ContentAsCodeSync);
     const isResultsCacheEnabled = resultsCacheFlag?.enabled ?? false;
     const isDataAppsEnabled = dataAppsFlag?.enabled ?? false;
+    const isContentAsCodeSyncEnabled = contentAsCodeSyncFlag?.enabled ?? false;
     const canManageExternalConnections =
         isDataAppsEnabled &&
         !!project &&
@@ -120,6 +126,18 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
         (user.data?.ability.can(
             'manage',
             subject('ExternalSource', {
+                organizationUuid: project.organizationUuid,
+                projectUuid: project.projectUuid,
+            }),
+        ) ??
+            false);
+
+    const canViewContentAsCode =
+        isContentAsCodeSyncEnabled &&
+        !!project &&
+        (user.data?.ability.can(
+            'view',
+            subject('ContentAsCode', {
                 organizationUuid: project.organizationUuid,
                 projectUuid: project.projectUuid,
             }),
@@ -246,6 +264,23 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
                     </ProjectSettingsPage>
                 ),
             },
+            ...(canViewContentAsCode
+                ? [
+                      {
+                          path: `/contentAsCode`,
+                          element: (
+                              <ProjectSettingsPage
+                                  title="Content as code"
+                                  description="Review when content as code was last applied to this project."
+                              >
+                                  <ContentAsCodeSyncStatusPanel
+                                      projectUuid={projectUuid}
+                                  />
+                              </ProjectSettingsPage>
+                          ),
+                      },
+                  ]
+                : []),
             {
                 path: `/defaultUserSpaces`,
                 element: (
@@ -487,6 +522,7 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
         user.data?.ability,
         canManageExternalConnections,
         canManageExternalSources,
+        canViewContentAsCode,
         isAiCopilotEnabledOrTrial,
     ]);
     const routesElements = useRoutes(routes);
@@ -511,13 +547,20 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
             '/generalSettings/projectManagement/:projectUuid/caching',
             location.pathname,
         );
+    const isAwaitingContentAsCodeRoute =
+        isContentAsCodeSyncFlagLoading &&
+        !!matchPath(
+            '/generalSettings/projectManagement/:projectUuid/contentAsCode',
+            location.pathname,
+        );
 
     if (
         isInitialLoading ||
         !project ||
         !projectUuid ||
         isAwaitingDataAppConnectionsRoute ||
-        isAwaitingCachingRoute
+        isAwaitingCachingRoute ||
+        isAwaitingContentAsCodeRoute
     ) {
         return (
             <div style={{ marginTop: '20px' }}>

--- a/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeSyncStatus.test.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeSyncStatus.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
-import { EMPTY_CONTENT_AS_CODE_SYNC_STATUS } from '../types';
 
 vi.mock('../../../api', () => ({
     lightdashApi: vi.fn(), // pragma: allowlist secret
@@ -11,15 +10,17 @@ import { getContentAsCodeSyncStatus } from './getContentAsCodeSyncStatus';
 const mockApi = api as unknown as Mock;
 
 const populatedStatus = {
+    syncEnabled: true,
     lastAppliedAt: new Date('2026-08-25T09:00:00.000Z'),
-    revisionCount: 1,
-    revisions: [
+    items: [
         {
             contentType: 'chart',
             slug: 'orders-over-time',
-            contentHash: 'abc123def456',
+            state: 'ahead',
             appliedAt: new Date('2026-08-25T09:00:00.000Z'),
-            appliedByUserUuid: null,
+            contentHash: 'abc123',
+            snapshot: { name: 'old' },
+            current: { name: 'new' },
         },
     ],
 };
@@ -34,7 +35,7 @@ describe('getContentAsCodeSyncStatus', () => {
 
         await expect(
             getContentAsCodeSyncStatus('project-uuid'),
-        ).resolves.toEqual(populatedStatus);
+        ).resolves.toEqual({ kind: 'ok', status: populatedStatus });
         expect(mockApi).toHaveBeenCalledWith({
             url: '/projects/project-uuid/code/sync-status',
             method: 'GET',
@@ -42,7 +43,7 @@ describe('getContentAsCodeSyncStatus', () => {
         });
     });
 
-    it('returns an empty status when the endpoint is not deployed yet', async () => {
+    it('returns unavailable when the endpoint is not deployed yet', async () => {
         mockApi.mockRejectedValueOnce({
             status: 'error',
             error: {
@@ -55,10 +56,10 @@ describe('getContentAsCodeSyncStatus', () => {
 
         await expect(
             getContentAsCodeSyncStatus('project-uuid'),
-        ).resolves.toEqual(EMPTY_CONTENT_AS_CODE_SYNC_STATUS);
+        ).resolves.toEqual({ kind: 'unavailable' });
     });
 
-    it('returns an empty status on a network miss', async () => {
+    it('returns unavailable on a network miss', async () => {
         mockApi.mockRejectedValueOnce({
             status: 'error',
             error: {
@@ -71,7 +72,7 @@ describe('getContentAsCodeSyncStatus', () => {
 
         await expect(
             getContentAsCodeSyncStatus('project-uuid'),
-        ).resolves.toEqual(EMPTY_CONTENT_AS_CODE_SYNC_STATUS);
+        ).resolves.toEqual({ kind: 'unavailable' });
     });
 
     it('rethrows unexpected API errors', async () => {

--- a/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeSyncStatus.test.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeSyncStatus.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { EMPTY_CONTENT_AS_CODE_SYNC_STATUS } from '../types';
+
+vi.mock('../../../api', () => ({
+    lightdashApi: vi.fn(), // pragma: allowlist secret
+}));
+
+import { lightdashApi as api } from '../../../api'; // pragma: allowlist secret
+import { getContentAsCodeSyncStatus } from './getContentAsCodeSyncStatus';
+
+const mockApi = api as unknown as Mock;
+
+const populatedStatus = {
+    lastAppliedAt: new Date('2026-08-25T09:00:00.000Z'),
+    revisionCount: 1,
+    revisions: [
+        {
+            contentType: 'chart',
+            slug: 'orders-over-time',
+            contentHash: 'abc123def456',
+            appliedAt: new Date('2026-08-25T09:00:00.000Z'),
+            appliedByUserUuid: null,
+        },
+    ],
+};
+
+describe('getContentAsCodeSyncStatus', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns the sync status when the endpoint succeeds', async () => {
+        mockApi.mockResolvedValueOnce(populatedStatus);
+
+        await expect(
+            getContentAsCodeSyncStatus('project-uuid'),
+        ).resolves.toEqual(populatedStatus);
+        expect(mockApi).toHaveBeenCalledWith({
+            url: '/projects/project-uuid/code/sync-status',
+            method: 'GET',
+            body: undefined,
+        });
+    });
+
+    it('returns an empty status when the endpoint is not deployed yet', async () => {
+        mockApi.mockRejectedValueOnce({
+            status: 'error',
+            error: {
+                name: 'NotFoundError',
+                statusCode: 404,
+                message: 'Not found',
+                data: {},
+            },
+        });
+
+        await expect(
+            getContentAsCodeSyncStatus('project-uuid'),
+        ).resolves.toEqual(EMPTY_CONTENT_AS_CODE_SYNC_STATUS);
+    });
+
+    it('returns an empty status on a network miss', async () => {
+        mockApi.mockRejectedValueOnce({
+            status: 'error',
+            error: {
+                name: 'NetworkError',
+                statusCode: 500,
+                message: 'Unable to reach the server',
+                data: {},
+            },
+        });
+
+        await expect(
+            getContentAsCodeSyncStatus('project-uuid'),
+        ).resolves.toEqual(EMPTY_CONTENT_AS_CODE_SYNC_STATUS);
+    });
+
+    it('rethrows unexpected API errors', async () => {
+        const forbidden = {
+            status: 'error' as const,
+            error: {
+                name: 'ForbiddenError',
+                statusCode: 403,
+                message: 'Forbidden',
+                data: {},
+            },
+        };
+        mockApi.mockRejectedValueOnce(forbidden);
+
+        await expect(
+            getContentAsCodeSyncStatus('project-uuid'),
+        ).rejects.toEqual(forbidden);
+    });
+});

--- a/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeSyncStatus.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeSyncStatus.ts
@@ -1,33 +1,25 @@
-import { isApiError, type AnyType } from '@lightdash/common'; // pragma: allowlist secret
+import { type AnyType } from '@lightdash/common'; // pragma: allowlist secret
 import { lightdashApi as api } from '../../../api'; // pragma: allowlist secret
 import {
-    EMPTY_CONTENT_AS_CODE_SYNC_STATUS,
     type ContentAsCodeSyncStatus,
+    type ContentAsCodeSyncStatusResult,
 } from '../types';
-
-const isMissingSyncStatus = (error: unknown): boolean => {
-    if (!isApiError(error)) {
-        return true;
-    }
-
-    return (
-        error.error.statusCode === 404 || error.error.name === 'NetworkError'
-    );
-};
+import { isMissingSyncStatus } from './isMissingSyncStatus';
 
 export const getContentAsCodeSyncStatus = async (
     projectUuid: string,
-): Promise<ContentAsCodeSyncStatus> => {
+): Promise<ContentAsCodeSyncStatusResult> => {
     try {
-        return (await api<AnyType>({
+        const status = (await api<AnyType>({
             url: `/projects/${projectUuid}/code/sync-status`,
             method: 'GET',
             body: undefined,
         })) as ContentAsCodeSyncStatus;
+
+        return { kind: 'ok', status };
     } catch (error) {
-        // Missing endpoint or a network miss is treated as "not yet synced".
         if (isMissingSyncStatus(error)) {
-            return EMPTY_CONTENT_AS_CODE_SYNC_STATUS;
+            return { kind: 'unavailable' };
         }
 
         throw error;

--- a/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeSyncStatus.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeSyncStatus.ts
@@ -1,0 +1,35 @@
+import { isApiError, type AnyType } from '@lightdash/common'; // pragma: allowlist secret
+import { lightdashApi as api } from '../../../api'; // pragma: allowlist secret
+import {
+    EMPTY_CONTENT_AS_CODE_SYNC_STATUS,
+    type ContentAsCodeSyncStatus,
+} from '../types';
+
+const isMissingSyncStatus = (error: unknown): boolean => {
+    if (!isApiError(error)) {
+        return true;
+    }
+
+    return (
+        error.error.statusCode === 404 || error.error.name === 'NetworkError'
+    );
+};
+
+export const getContentAsCodeSyncStatus = async (
+    projectUuid: string,
+): Promise<ContentAsCodeSyncStatus> => {
+    try {
+        return (await api<AnyType>({
+            url: `/projects/${projectUuid}/code/sync-status`,
+            method: 'GET',
+            body: undefined,
+        })) as ContentAsCodeSyncStatus;
+    } catch (error) {
+        // Missing endpoint or a network miss is treated as "not yet synced".
+        if (isMissingSyncStatus(error)) {
+            return EMPTY_CONTENT_AS_CODE_SYNC_STATUS;
+        }
+
+        throw error;
+    }
+};

--- a/packages/frontend/src/features/contentAsCodeSync/api/isMissingSyncStatus.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/api/isMissingSyncStatus.ts
@@ -1,0 +1,11 @@
+import { isApiError } from '@lightdash/common'; // pragma: allowlist secret
+
+export const isMissingSyncStatus = (error: unknown): boolean => {
+    if (!isApiError(error)) {
+        return true;
+    }
+
+    return (
+        error.error.statusCode === 404 || error.error.name === 'NetworkError'
+    );
+};

--- a/packages/frontend/src/features/contentAsCodeSync/api/restampContentAsCodeRevision.test.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/api/restampContentAsCodeRevision.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+vi.mock('../../../api', () => ({
+    lightdashApi: vi.fn(), // pragma: allowlist secret
+}));
+
+import { lightdashApi as api } from '../../../api'; // pragma: allowlist secret
+import { restampContentAsCodeRevision } from './restampContentAsCodeRevision';
+
+const mockApi = api as unknown as Mock;
+
+describe('restampContentAsCodeRevision', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('posts the slug and content type', async () => {
+        const status = {
+            syncEnabled: true,
+            lastAppliedAt: new Date('2026-08-25T09:00:00.000Z'),
+            items: [],
+        };
+        mockApi.mockResolvedValueOnce(status);
+
+        await expect(
+            restampContentAsCodeRevision({
+                projectUuid: 'project-uuid',
+                contentType: 'chart',
+                slug: 'orders-over-time',
+            }),
+        ).resolves.toEqual(status);
+        expect(mockApi).toHaveBeenCalledWith({
+            url: '/projects/project-uuid/code/applied-revisions/restamp',
+            method: 'POST',
+            body: JSON.stringify({
+                contentType: 'chart',
+                slug: 'orders-over-time',
+            }),
+        });
+    });
+});

--- a/packages/frontend/src/features/contentAsCodeSync/api/restampContentAsCodeRevision.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/api/restampContentAsCodeRevision.ts
@@ -1,0 +1,23 @@
+import { type AnyType } from '@lightdash/common'; // pragma: allowlist secret
+import { lightdashApi as api } from '../../../api'; // pragma: allowlist secret
+import {
+    type ContentAsCodeSyncContentType,
+    type ContentAsCodeSyncStatus,
+} from '../types';
+
+export type RestampContentAsCodeRevisionArgs = {
+    projectUuid: string;
+    contentType: ContentAsCodeSyncContentType;
+    slug: string;
+};
+
+export const restampContentAsCodeRevision = async ({
+    projectUuid,
+    contentType,
+    slug,
+}: RestampContentAsCodeRevisionArgs): Promise<ContentAsCodeSyncStatus> =>
+    (await api<AnyType>({
+        url: `/projects/${projectUuid}/code/applied-revisions/restamp`,
+        method: 'POST',
+        body: JSON.stringify({ contentType, slug }),
+    })) as ContentAsCodeSyncStatus;

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncDiffModal.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncDiffModal.tsx
@@ -1,0 +1,66 @@
+import { Stack, Text } from '@mantine/core';
+import { IconGitCompare } from '@tabler/icons-react';
+import { type FC } from 'react';
+import CodeBlock from '../../../components/common/CodeBlock/CodeBlock';
+import MantineModal from '../../../components/common/MantineModal';
+import { type ContentAsCodeSyncItem } from '../types';
+import { getContentAsCodeTypeLabel } from '../utils/contentAsCodeTypeLabel';
+import { dumpContentAsCodeDocument } from '../utils/dumpContentAsCodeDocument';
+import classes from './ContentAsCodeSyncStatusPanel.module.css';
+
+type ContentAsCodeSyncDiffModalProps = {
+    item: ContentAsCodeSyncItem | null;
+    opened: boolean;
+    onClose: () => void;
+};
+
+const ContentAsCodeSyncDiffModal: FC<ContentAsCodeSyncDiffModalProps> = ({
+    item,
+    opened,
+    onClose,
+}) => {
+    if (!item) {
+        return null;
+    }
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            icon={IconGitCompare}
+            title={item.slug}
+            subtitle={`${getContentAsCodeTypeLabel(item.contentType)} · last applied vs current`}
+            size="xl"
+            cancelLabel="Close"
+        >
+            <div className={classes.diffColumns}>
+                <Stack gap="xs">
+                    <Text fz="sm" c="ldGray.6">
+                        Last applied
+                    </Text>
+                    <CodeBlock
+                        language="yaml"
+                        code={
+                            dumpContentAsCodeDocument(item.snapshot) ||
+                            'No last-applied snapshot'
+                        }
+                    />
+                </Stack>
+                <Stack gap="xs">
+                    <Text fz="sm" c="ldGray.6">
+                        Current
+                    </Text>
+                    <CodeBlock
+                        language="yaml"
+                        code={
+                            dumpContentAsCodeDocument(item.current) ||
+                            'No current document'
+                        }
+                    />
+                </Stack>
+            </div>
+        </MantineModal>
+    );
+};
+
+export default ContentAsCodeSyncDiffModal;

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncItemRow.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncItemRow.tsx
@@ -1,0 +1,148 @@
+import {
+    Badge,
+    Box,
+    Button,
+    Group,
+    Paper,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import { format } from 'date-fns';
+import { type FC } from 'react';
+import TruncatedText from '../../../components/common/TruncatedText';
+import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import { type ContentAsCodeSyncItem } from '../types';
+import {
+    canRestampContentAsCodeSyncItem,
+    CONTENT_AS_CODE_SYNC_STATE_BADGE,
+} from '../utils/contentAsCodeSyncState';
+import { getContentAsCodeTypeLabel } from '../utils/contentAsCodeTypeLabel';
+import { toDate } from '../utils/toDate';
+import classes from './ContentAsCodeSyncStatusPanel.module.css';
+
+type ContentAsCodeSyncItemRowProps = {
+    item: ContentAsCodeSyncItem;
+    canRestamp: boolean;
+    isRestamping: boolean;
+    isRestampAvailable: boolean;
+    onViewDiff: () => void;
+    onRestamp: () => void;
+};
+
+const AppliedTime: FC<{ value: Date | string }> = ({ value }) => {
+    const timeAgo = useTimeAgo(value);
+    return (
+        <Text fz="xs" c="ldGray.6">
+            Last applied {timeAgo} ·{' '}
+            {format(toDate(value), 'MMM d, yyyy HH:mm')}
+        </Text>
+    );
+};
+
+const restampDisabledReason = ({
+    canRestamp,
+    isRestampAvailable,
+    item,
+}: Pick<
+    ContentAsCodeSyncItemRowProps,
+    'canRestamp' | 'isRestampAvailable' | 'item'
+>): string | null => {
+    if (!isRestampAvailable) {
+        return 'The API is not available yet.';
+    }
+
+    if (!canRestamp) {
+        return null;
+    }
+
+    if (!canRestampContentAsCodeSyncItem(item.state)) {
+        return 'This slug is already in sync.';
+    }
+
+    return null;
+};
+
+const ContentAsCodeSyncItemRow: FC<ContentAsCodeSyncItemRowProps> = ({
+    item,
+    canRestamp,
+    isRestamping,
+    isRestampAvailable,
+    onViewDiff,
+    onRestamp,
+}) => {
+    const stateBadge = CONTENT_AS_CODE_SYNC_STATE_BADGE[item.state];
+    const canShowRestamp = canRestamp;
+    const restampDisabled =
+        !isRestampAvailable || !canRestampContentAsCodeSyncItem(item.state);
+    const disabledReason = restampDisabledReason({
+        canRestamp,
+        isRestampAvailable,
+        item,
+    });
+    const canViewDiff = item.state === 'ahead';
+
+    return (
+        <Paper withBorder p="md" radius="md">
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+                <Stack gap="xs" className={classes.itemMeta}>
+                    <Group gap="xs">
+                        <Badge variant="light" size="sm" tt="none">
+                            {getContentAsCodeTypeLabel(item.contentType)}
+                        </Badge>
+                        <Badge
+                            variant="light"
+                            size="sm"
+                            tt="none"
+                            color={stateBadge.color}
+                        >
+                            {stateBadge.label}
+                        </Badge>
+                    </Group>
+                    <TruncatedText maxWidth="100%" fw={500}>
+                        {item.slug}
+                    </TruncatedText>
+                    {item.appliedAt ? (
+                        <AppliedTime value={item.appliedAt} />
+                    ) : (
+                        <Text fz="xs" c="ldGray.6">
+                            No last-applied snapshot
+                        </Text>
+                    )}
+                </Stack>
+                <Group gap="xs" wrap="nowrap" className={classes.itemActions}>
+                    {canViewDiff ? (
+                        <Button
+                            variant="default"
+                            size="xs"
+                            onClick={onViewDiff}
+                        >
+                            View diff
+                        </Button>
+                    ) : null}
+                    {/* Write-back later adds "Propose to git" here. */}
+                    {canShowRestamp ? (
+                        <Tooltip
+                            label={disabledReason}
+                            disabled={!disabledReason}
+                        >
+                            <Box>
+                                <Button
+                                    variant="default"
+                                    size="xs"
+                                    disabled={restampDisabled}
+                                    loading={isRestamping}
+                                    onClick={onRestamp}
+                                >
+                                    Use git version on next deploy
+                                </Button>
+                            </Box>
+                        </Tooltip>
+                    ) : null}
+                </Group>
+            </Group>
+        </Paper>
+    );
+};
+
+export default ContentAsCodeSyncItemRow;

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.module.css
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.module.css
@@ -1,15 +1,19 @@
-.summary {
+.itemMeta {
+    min-width: 0;
+}
+
+.itemActions {
+    flex-shrink: 0;
+}
+
+.diffColumns {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--mantine-spacing-md);
 }
 
-.revisionList {
-    display: flex;
-    flex-direction: column;
-    gap: var(--mantine-spacing-sm);
-}
-
-.revisionMeta {
-    min-width: 0;
+@media (max-width: 48em) {
+    .diffColumns {
+        grid-template-columns: minmax(0, 1fr);
+    }
 }

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.module.css
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.module.css
@@ -1,0 +1,15 @@
+.summary {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--mantine-spacing-md);
+}
+
+.revisionList {
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-sm);
+}
+
+.revisionMeta {
+    min-width: 0;
+}

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.test.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.test.tsx
@@ -61,7 +61,9 @@ const populatedItems = {
 
 const createAbility = {
     user: {
-        abilityRules: [{ action: 'create', subject: 'ContentAsCode' }],
+        abilityRules: [
+            { action: 'create' as const, subject: 'ContentAsCode' as const },
+        ],
     },
 };
 

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.test.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.test.tsx
@@ -1,0 +1,97 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { type ContentAsCodeSyncStatus } from '../types';
+import ContentAsCodeSyncStatusPanel from './ContentAsCodeSyncStatusPanel';
+
+const useContentAsCodeSyncStatus = vi.hoisted(() => vi.fn());
+
+vi.mock('../hooks/useContentAsCodeSyncStatus', () => ({
+    useContentAsCodeSyncStatus,
+}));
+
+const populatedStatus: ContentAsCodeSyncStatus = {
+    lastAppliedAt: new Date('2026-08-25T09:00:00.000Z'),
+    revisionCount: 2,
+    revisions: [
+        {
+            contentType: 'chart',
+            slug: 'orders-over-time',
+            contentHash: 'abc123def4567890',
+            appliedAt: new Date('2026-08-25T09:00:00.000Z'),
+            appliedByUserUuid: null,
+        },
+        {
+            contentType: 'dashboard',
+            slug: 'revenue',
+            contentHash: 'fff0001112223334',
+            appliedAt: new Date('2026-08-24T15:30:00.000Z'),
+            appliedByUserUuid: 'user-1',
+        },
+    ],
+};
+
+describe('ContentAsCodeSyncStatusPanel', () => {
+    it('shows the empty state when there is no sync history', () => {
+        useContentAsCodeSyncStatus.mockReturnValue({
+            data: {
+                lastAppliedAt: null,
+                revisionCount: 0,
+                revisions: [],
+            },
+            isInitialLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        });
+
+        renderWithProviders(
+            <ContentAsCodeSyncStatusPanel projectUuid="project-uuid" />,
+        );
+
+        expect(
+            screen.getByRole('heading', { name: 'No sync history yet' }),
+        ).toBeVisible();
+        expect(screen.queryByText('Last applied')).not.toBeInTheDocument();
+    });
+
+    it('shows last applied, revision count, and revisions without raw hashes as the primary UI', () => {
+        useContentAsCodeSyncStatus.mockReturnValue({
+            data: populatedStatus,
+            isInitialLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        });
+
+        renderWithProviders(
+            <ContentAsCodeSyncStatusPanel projectUuid="project-uuid" />,
+        );
+
+        expect(screen.getByText('Last applied')).toBeVisible();
+        expect(screen.getByText('Revisions')).toBeVisible();
+        expect(screen.getByText('2')).toBeVisible();
+        expect(screen.getByText('Chart')).toBeVisible();
+        expect(screen.getByText('orders-over-time')).toBeVisible();
+        expect(screen.getByText('Dashboard')).toBeVisible();
+        expect(screen.getByText('revenue')).toBeVisible();
+        expect(screen.queryByText('abc123def4567890')).not.toBeInTheDocument();
+        expect(screen.getByText('abc123de')).toBeVisible();
+    });
+
+    it('shows a quiet error state when the request fails unexpectedly', () => {
+        useContentAsCodeSyncStatus.mockReturnValue({
+            data: undefined,
+            isInitialLoading: false,
+            isError: true,
+            refetch: vi.fn(),
+        });
+
+        renderWithProviders(
+            <ContentAsCodeSyncStatusPanel projectUuid="project-uuid" />,
+        );
+
+        expect(
+            screen.getByText('Could not load content as code sync status.'),
+        ).toBeVisible();
+        expect(screen.getByRole('button', { name: 'Retry' })).toBeVisible();
+    });
+});

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.test.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.test.tsx
@@ -1,97 +1,229 @@
 import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
-import { type ContentAsCodeSyncStatus } from '../types';
 import ContentAsCodeSyncStatusPanel from './ContentAsCodeSyncStatusPanel';
 
 const useContentAsCodeSyncStatus = vi.hoisted(() => vi.fn());
+const useRestampContentAsCodeRevision = vi.hoisted(() => vi.fn());
 
 vi.mock('../hooks/useContentAsCodeSyncStatus', () => ({
     useContentAsCodeSyncStatus,
 }));
 
-const populatedStatus: ContentAsCodeSyncStatus = {
-    lastAppliedAt: new Date('2026-08-25T09:00:00.000Z'),
-    revisionCount: 2,
-    revisions: [
-        {
-            contentType: 'chart',
-            slug: 'orders-over-time',
-            contentHash: 'abc123def4567890',
-            appliedAt: new Date('2026-08-25T09:00:00.000Z'),
-            appliedByUserUuid: null,
-        },
-        {
-            contentType: 'dashboard',
-            slug: 'revenue',
-            contentHash: 'fff0001112223334',
-            appliedAt: new Date('2026-08-24T15:30:00.000Z'),
-            appliedByUserUuid: 'user-1',
-        },
-    ],
+vi.mock('../hooks/useRestampContentAsCodeRevision', () => ({
+    useRestampContentAsCodeRevision,
+}));
+
+const restampMock = {
+    mutate: vi.fn(),
+    isLoading: false,
+    isError: false,
+    error: null,
+    variables: undefined,
+};
+
+const populatedItems = {
+    kind: 'ok' as const,
+    status: {
+        syncEnabled: true,
+        lastAppliedAt: new Date('2026-08-25T09:00:00.000Z'),
+        items: [
+            {
+                contentType: 'chart' as const,
+                slug: 'orders-over-time',
+                state: 'in_sync' as const,
+                appliedAt: new Date('2026-08-25T09:00:00.000Z'),
+                contentHash: 'abc123def4567890',
+                snapshot: { name: 'orders' },
+                current: { name: 'orders' },
+            },
+            {
+                contentType: 'dashboard' as const,
+                slug: 'revenue',
+                state: 'ahead' as const,
+                appliedAt: new Date('2026-08-24T15:30:00.000Z'),
+                contentHash: 'fff0001112223334',
+                snapshot: { name: 'old revenue' },
+                current: { name: 'new revenue' },
+            },
+            {
+                contentType: 'chart' as const,
+                slug: 'new-chart',
+                state: 'ui_only' as const,
+                appliedAt: null,
+                contentHash: null,
+                snapshot: null,
+                current: { name: 'new chart' },
+            },
+        ],
+    },
+};
+
+const createAbility = {
+    user: {
+        abilityRules: [{ action: 'create', subject: 'ContentAsCode' }],
+    },
 };
 
 describe('ContentAsCodeSyncStatusPanel', () => {
-    it('shows the empty state when there is no sync history', () => {
+    it('shows a not-available state when the API is missing', () => {
+        useContentAsCodeSyncStatus.mockReturnValue({
+            data: { kind: 'unavailable' },
+            isInitialLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        });
+        useRestampContentAsCodeRevision.mockReturnValue(restampMock);
+
+        renderWithProviders(
+            <ContentAsCodeSyncStatusPanel projectUuid="project-uuid" />,
+        );
+
+        expect(
+            screen.getByRole('heading', {
+                name: 'Content as code sync is not available yet',
+            }),
+        ).toBeVisible();
+    });
+
+    it('shows an empty managed-content state when sync is enabled but there are no slugs', () => {
         useContentAsCodeSyncStatus.mockReturnValue({
             data: {
-                lastAppliedAt: null,
-                revisionCount: 0,
-                revisions: [],
+                kind: 'ok',
+                status: {
+                    syncEnabled: true,
+                    lastAppliedAt: null,
+                    items: [],
+                },
             },
             isInitialLoading: false,
             isError: false,
             refetch: vi.fn(),
         });
+        useRestampContentAsCodeRevision.mockReturnValue(restampMock);
 
         renderWithProviders(
             <ContentAsCodeSyncStatusPanel projectUuid="project-uuid" />,
         );
 
         expect(
-            screen.getByRole('heading', { name: 'No sync history yet' }),
+            screen.getByRole('heading', { name: 'No managed content' }),
         ).toBeVisible();
-        expect(screen.queryByText('Last applied')).not.toBeInTheDocument();
     });
 
-    it('shows last applied, revision count, and revisions without raw hashes as the primary UI', () => {
+    it('renders in sync, ahead, and UI-only rows without raw hashes as the primary UI', async () => {
         useContentAsCodeSyncStatus.mockReturnValue({
-            data: populatedStatus,
+            data: populatedItems,
             isInitialLoading: false,
             isError: false,
             refetch: vi.fn(),
         });
+        useRestampContentAsCodeRevision.mockReturnValue(restampMock);
 
         renderWithProviders(
             <ContentAsCodeSyncStatusPanel projectUuid="project-uuid" />,
+            createAbility,
         );
 
-        expect(screen.getByText('Last applied')).toBeVisible();
-        expect(screen.getByText('Revisions')).toBeVisible();
-        expect(screen.getByText('2')).toBeVisible();
-        expect(screen.getByText('Chart')).toBeVisible();
+        expect(screen.getByText('In sync')).toBeVisible();
+        expect(screen.getByText('Ahead')).toBeVisible();
+        expect(screen.getByText('UI-only')).toBeVisible();
         expect(screen.getByText('orders-over-time')).toBeVisible();
-        expect(screen.getByText('Dashboard')).toBeVisible();
         expect(screen.getByText('revenue')).toBeVisible();
+        expect(screen.getByText('new-chart')).toBeVisible();
+        expect(screen.getByRole('button', { name: 'View diff' })).toBeVisible();
         expect(screen.queryByText('abc123def4567890')).not.toBeInTheDocument();
-        expect(screen.getByText('abc123de')).toBeVisible();
+
+        const restampButtons = await screen.findAllByRole('button', {
+            name: 'Use git version on next deploy',
+        });
+        expect(restampButtons).toHaveLength(3);
+        expect(restampButtons[0]).toBeDisabled();
+        expect(restampButtons[1]).toBeEnabled();
+        expect(restampButtons[2]).toBeEnabled();
     });
 
-    it('shows a quiet error state when the request fails unexpectedly', () => {
+    it('hides restamp when the user cannot create content as code', async () => {
         useContentAsCodeSyncStatus.mockReturnValue({
-            data: undefined,
+            data: populatedItems,
             isInitialLoading: false,
-            isError: true,
+            isError: false,
             refetch: vi.fn(),
         });
+        useRestampContentAsCodeRevision.mockReturnValue(restampMock);
 
         renderWithProviders(
             <ContentAsCodeSyncStatusPanel projectUuid="project-uuid" />,
         );
 
         expect(
-            screen.getByText('Could not load content as code sync status.'),
+            await screen.findByRole('button', { name: 'View diff' }),
         ).toBeVisible();
-        expect(screen.getByRole('button', { name: 'Retry' })).toBeVisible();
+        expect(
+            screen.queryByRole('button', {
+                name: 'Use git version on next deploy',
+            }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows the not-available state when sync is disabled on the project', () => {
+        useContentAsCodeSyncStatus.mockReturnValue({
+            data: {
+                kind: 'ok',
+                status: {
+                    syncEnabled: false,
+                    lastAppliedAt: null,
+                    items: [],
+                },
+            },
+            isInitialLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        });
+        useRestampContentAsCodeRevision.mockReturnValue(restampMock);
+
+        renderWithProviders(
+            <ContentAsCodeSyncStatusPanel projectUuid="project-uuid" />,
+        );
+
+        expect(
+            screen.getByRole('heading', {
+                name: 'Content as code sync is not available yet',
+            }),
+        ).toBeVisible();
+    });
+
+    it('disables restamp when the restamp API is not deployed yet', async () => {
+        useContentAsCodeSyncStatus.mockReturnValue({
+            data: populatedItems,
+            isInitialLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        });
+        useRestampContentAsCodeRevision.mockReturnValue({
+            ...restampMock,
+            isError: true,
+            error: {
+                error: {
+                    name: 'NotFoundError',
+                    statusCode: 404,
+                    message: 'Not found',
+                    data: {},
+                },
+            },
+        });
+
+        renderWithProviders(
+            <ContentAsCodeSyncStatusPanel projectUuid="project-uuid" />,
+            createAbility,
+        );
+
+        const restampButtons = await screen.findAllByRole('button', {
+            name: 'Use git version on next deploy',
+        });
+        expect(restampButtons).toHaveLength(3);
+        expect(restampButtons[0]).toBeDisabled();
+        expect(restampButtons[1]).toBeDisabled();
+        expect(restampButtons[2]).toBeDisabled();
     });
 });

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.tsx
@@ -1,0 +1,152 @@
+import { Badge, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
+import { IconCode } from '@tabler/icons-react';
+import { format } from 'date-fns';
+import { type FC } from 'react';
+import EmptyStateLoader from '../../../components/common/EmptyStateLoader';
+import InlineErrorState from '../../../components/common/InlineErrorState';
+import { SettingsEmptyState } from '../../../components/common/Settings/SettingsEmptyState';
+import TruncatedText from '../../../components/common/TruncatedText';
+import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import { useContentAsCodeSyncStatus } from '../hooks/useContentAsCodeSyncStatus';
+import { type ContentAsCodeAppliedRevision } from '../types';
+import { getContentAsCodeTypeLabel } from '../utils/contentAsCodeTypeLabel';
+import { toDate } from '../utils/toDate';
+import classes from './ContentAsCodeSyncStatusPanel.module.css';
+
+type ContentAsCodeSyncStatusPanelProps = {
+    projectUuid: string;
+};
+
+const isEmptySyncStatus = (
+    lastAppliedAt: Date | string | null | undefined,
+    revisionCount: number,
+    revisions: ContentAsCodeAppliedRevision[],
+): boolean =>
+    lastAppliedAt == null && revisionCount === 0 && revisions.length === 0;
+
+const AppliedTime: FC<{ value: Date | string }> = ({ value }) => {
+    const timeAgo = useTimeAgo(value);
+    const absolute = format(toDate(value), 'MMM d, yyyy HH:mm');
+
+    return (
+        <Stack gap={2} align="flex-end">
+            <Text fz="sm">{timeAgo}</Text>
+            <Text fz="xs" c="ldGray.6">
+                {absolute}
+            </Text>
+        </Stack>
+    );
+};
+
+const LastAppliedValue: FC<{ value: Date | string }> = ({ value }) => {
+    const timeAgo = useTimeAgo(value);
+    const absolute = format(toDate(value), 'MMM d, yyyy HH:mm');
+
+    return (
+        <Stack gap={2}>
+            <Text fw={500}>{timeAgo}</Text>
+            <Text fz="xs" c="ldGray.6">
+                {absolute}
+            </Text>
+        </Stack>
+    );
+};
+
+const ContentAsCodeRevisionRow: FC<{
+    revision: ContentAsCodeAppliedRevision;
+}> = ({ revision }) => {
+    const shortHash = revision.contentHash.slice(0, 8);
+
+    return (
+        <Paper withBorder p="md" radius="md">
+            <Group justify="space-between" wrap="nowrap" gap="md">
+                <Stack gap="xs" className={classes.revisionMeta}>
+                    <Badge variant="light" size="sm" tt="none">
+                        {getContentAsCodeTypeLabel(revision.contentType)}
+                    </Badge>
+                    <TruncatedText maxWidth="100%" fw={500}>
+                        {revision.slug}
+                    </TruncatedText>
+                    <Tooltip label={revision.contentHash}>
+                        <Text fz="xs" c="ldGray.5" ff="monospace">
+                            {shortHash}
+                        </Text>
+                    </Tooltip>
+                </Stack>
+                <AppliedTime value={revision.appliedAt} />
+            </Group>
+        </Paper>
+    );
+};
+
+const ContentAsCodeSyncStatusPanel: FC<ContentAsCodeSyncStatusPanelProps> = ({
+    projectUuid,
+}) => {
+    const { data, isInitialLoading, isError, refetch } =
+        useContentAsCodeSyncStatus(projectUuid);
+
+    if (isInitialLoading) {
+        return <EmptyStateLoader title="Loading sync status" />;
+    }
+
+    if (isError) {
+        return (
+            <InlineErrorState
+                message="Could not load content as code sync status."
+                onRetry={() => {
+                    void refetch();
+                }}
+            />
+        );
+    }
+
+    const revisions = data?.revisions ?? [];
+    const revisionCount = data?.revisionCount ?? 0;
+
+    if (isEmptySyncStatus(data?.lastAppliedAt, revisionCount, revisions)) {
+        return (
+            <SettingsEmptyState
+                icon={IconCode}
+                title="No sync history yet"
+                description="Applied revisions from content as code uploads will appear here."
+            />
+        );
+    }
+
+    return (
+        <Stack gap="lg">
+            <div className={classes.summary}>
+                <Paper withBorder p="md" radius="md">
+                    <Stack gap="xs">
+                        <Text fz="sm" c="ldGray.6">
+                            Last applied
+                        </Text>
+                        {data?.lastAppliedAt ? (
+                            <LastAppliedValue value={data.lastAppliedAt} />
+                        ) : (
+                            <Text c="ldGray.5">—</Text>
+                        )}
+                    </Stack>
+                </Paper>
+                <Paper withBorder p="md" radius="md">
+                    <Stack gap="xs">
+                        <Text fz="sm" c="ldGray.6">
+                            Revisions
+                        </Text>
+                        <Text fw={500}>{revisionCount}</Text>
+                    </Stack>
+                </Paper>
+            </div>
+            <div className={classes.revisionList}>
+                {revisions.map((revision) => (
+                    <ContentAsCodeRevisionRow
+                        key={`${revision.contentType}:${revision.slug}:${revision.contentHash}`}
+                        revision={revision}
+                    />
+                ))}
+            </div>
+        </Stack>
+    );
+};
+
+export default ContentAsCodeSyncStatusPanel;

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.tsx
@@ -1,89 +1,61 @@
-import { Badge, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
+import { subject } from '@casl/ability';
+import { Stack, Text } from '@mantine/core';
 import { IconCode } from '@tabler/icons-react';
 import { format } from 'date-fns';
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
 import EmptyStateLoader from '../../../components/common/EmptyStateLoader';
 import InlineErrorState from '../../../components/common/InlineErrorState';
 import { SettingsEmptyState } from '../../../components/common/Settings/SettingsEmptyState';
-import TruncatedText from '../../../components/common/TruncatedText';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
+import useApp from '../../../providers/App/useApp';
 import { useContentAsCodeSyncStatus } from '../hooks/useContentAsCodeSyncStatus';
-import { type ContentAsCodeAppliedRevision } from '../types';
-import { getContentAsCodeTypeLabel } from '../utils/contentAsCodeTypeLabel';
+import { useRestampContentAsCodeRevision } from '../hooks/useRestampContentAsCodeRevision';
+import { type ContentAsCodeSyncItem } from '../types';
 import { toDate } from '../utils/toDate';
-import classes from './ContentAsCodeSyncStatusPanel.module.css';
+import ContentAsCodeSyncDiffModal from './ContentAsCodeSyncDiffModal';
+import ContentAsCodeSyncItemRow from './ContentAsCodeSyncItemRow';
 
 type ContentAsCodeSyncStatusPanelProps = {
     projectUuid: string;
 };
 
-const isEmptySyncStatus = (
-    lastAppliedAt: Date | string | null | undefined,
-    revisionCount: number,
-    revisions: ContentAsCodeAppliedRevision[],
-): boolean =>
-    lastAppliedAt == null && revisionCount === 0 && revisions.length === 0;
-
-const AppliedTime: FC<{ value: Date | string }> = ({ value }) => {
+const LastAppliedSummary: FC<{ value: Date | string }> = ({ value }) => {
     const timeAgo = useTimeAgo(value);
-    const absolute = format(toDate(value), 'MMM d, yyyy HH:mm');
 
     return (
-        <Stack gap={2} align="flex-end">
-            <Text fz="sm">{timeAgo}</Text>
-            <Text fz="xs" c="ldGray.6">
-                {absolute}
-            </Text>
-        </Stack>
-    );
-};
-
-const LastAppliedValue: FC<{ value: Date | string }> = ({ value }) => {
-    const timeAgo = useTimeAgo(value);
-    const absolute = format(toDate(value), 'MMM d, yyyy HH:mm');
-
-    return (
-        <Stack gap={2}>
-            <Text fw={500}>{timeAgo}</Text>
-            <Text fz="xs" c="ldGray.6">
-                {absolute}
-            </Text>
-        </Stack>
-    );
-};
-
-const ContentAsCodeRevisionRow: FC<{
-    revision: ContentAsCodeAppliedRevision;
-}> = ({ revision }) => {
-    const shortHash = revision.contentHash.slice(0, 8);
-
-    return (
-        <Paper withBorder p="md" radius="md">
-            <Group justify="space-between" wrap="nowrap" gap="md">
-                <Stack gap="xs" className={classes.revisionMeta}>
-                    <Badge variant="light" size="sm" tt="none">
-                        {getContentAsCodeTypeLabel(revision.contentType)}
-                    </Badge>
-                    <TruncatedText maxWidth="100%" fw={500}>
-                        {revision.slug}
-                    </TruncatedText>
-                    <Tooltip label={revision.contentHash}>
-                        <Text fz="xs" c="ldGray.5" ff="monospace">
-                            {shortHash}
-                        </Text>
-                    </Tooltip>
-                </Stack>
-                <AppliedTime value={revision.appliedAt} />
-            </Group>
-        </Paper>
+        <Text fz="sm" c="ldGray.6">
+            Last applied {timeAgo} ·{' '}
+            {format(toDate(value), 'MMM d, yyyy HH:mm')}
+        </Text>
     );
 };
 
 const ContentAsCodeSyncStatusPanel: FC<ContentAsCodeSyncStatusPanelProps> = ({
     projectUuid,
 }) => {
+    const { user } = useApp();
     const { data, isInitialLoading, isError, refetch } =
         useContentAsCodeSyncStatus(projectUuid);
+    const restampMutation = useRestampContentAsCodeRevision(projectUuid);
+    const [diffItem, setDiffItem] = useState<ContentAsCodeSyncItem | null>(
+        null,
+    );
+
+    const canRestamp =
+        user.data?.ability.can(
+            'create',
+            subject('ContentAsCode', {
+                organizationUuid: user.data.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false;
+
+    const isRestampAvailable =
+        data?.kind === 'ok' &&
+        !(
+            restampMutation.isError &&
+            restampMutation.error.error.statusCode === 404
+        );
 
     if (isInitialLoading) {
         return <EmptyStateLoader title="Loading sync status" />;
@@ -100,51 +72,70 @@ const ContentAsCodeSyncStatusPanel: FC<ContentAsCodeSyncStatusPanelProps> = ({
         );
     }
 
-    const revisions = data?.revisions ?? [];
-    const revisionCount = data?.revisionCount ?? 0;
-
-    if (isEmptySyncStatus(data?.lastAppliedAt, revisionCount, revisions)) {
+    if (!data || data.kind === 'unavailable' || !data.status.syncEnabled) {
         return (
             <SettingsEmptyState
                 icon={IconCode}
-                title="No sync history yet"
-                description="Applied revisions from content as code uploads will appear here."
+                title="Content as code sync is not available yet"
+                description="This project has not enabled content as code sync, or the status API is not deployed yet."
             />
         );
     }
 
+    const { status } = data;
+
+    if (status.items.length === 0) {
+        return (
+            <SettingsEmptyState
+                icon={IconCode}
+                title="No managed content"
+                description="Charts and dashboards managed as code will appear here with their sync state."
+            />
+        );
+    }
+
+    const restampingKey = restampMutation.isLoading
+        ? `${restampMutation.variables?.contentType}:${restampMutation.variables?.slug}`
+        : null;
+
     return (
-        <Stack gap="lg">
-            <div className={classes.summary}>
-                <Paper withBorder p="md" radius="md">
-                    <Stack gap="xs">
-                        <Text fz="sm" c="ldGray.6">
-                            Last applied
-                        </Text>
-                        {data?.lastAppliedAt ? (
-                            <LastAppliedValue value={data.lastAppliedAt} />
-                        ) : (
-                            <Text c="ldGray.5">—</Text>
-                        )}
-                    </Stack>
-                </Paper>
-                <Paper withBorder p="md" radius="md">
-                    <Stack gap="xs">
-                        <Text fz="sm" c="ldGray.6">
-                            Revisions
-                        </Text>
-                        <Text fw={500}>{revisionCount}</Text>
-                    </Stack>
-                </Paper>
-            </div>
-            <div className={classes.revisionList}>
-                {revisions.map((revision) => (
-                    <ContentAsCodeRevisionRow
-                        key={`${revision.contentType}:${revision.slug}:${revision.contentHash}`}
-                        revision={revision}
+        <Stack gap="md">
+            {status.lastAppliedAt ? (
+                <LastAppliedSummary value={status.lastAppliedAt} />
+            ) : (
+                <Text fz="sm" c="ldGray.6">
+                    No last-applied snapshot yet
+                </Text>
+            )}
+            <Stack gap="sm">
+                {status.items.map((item) => (
+                    <ContentAsCodeSyncItemRow
+                        key={`${item.contentType}:${item.slug}`}
+                        item={item}
+                        canRestamp={canRestamp}
+                        isRestampAvailable={isRestampAvailable}
+                        isRestamping={
+                            restampingKey === `${item.contentType}:${item.slug}`
+                        }
+                        onViewDiff={() => {
+                            setDiffItem(item);
+                        }}
+                        onRestamp={() => {
+                            restampMutation.mutate({
+                                contentType: item.contentType,
+                                slug: item.slug,
+                            });
+                        }}
                     />
                 ))}
-            </div>
+            </Stack>
+            <ContentAsCodeSyncDiffModal
+                item={diffItem}
+                opened={diffItem !== null}
+                onClose={() => {
+                    setDiffItem(null);
+                }}
+            />
         </Stack>
     );
 };

--- a/packages/frontend/src/features/contentAsCodeSync/hooks/useContentAsCodeSyncStatus.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/hooks/useContentAsCodeSyncStatus.ts
@@ -1,0 +1,12 @@
+import { type ApiError } from '@lightdash/common'; // pragma: allowlist secret
+import { useQuery } from '@tanstack/react-query';
+import { getContentAsCodeSyncStatus } from '../api/getContentAsCodeSyncStatus';
+import { type ContentAsCodeSyncStatus } from '../types';
+
+export const useContentAsCodeSyncStatus = (projectUuid: string | undefined) =>
+    useQuery<ContentAsCodeSyncStatus, ApiError>({
+        queryKey: ['content-as-code-sync-status', projectUuid],
+        queryFn: () => getContentAsCodeSyncStatus(projectUuid!),
+        enabled: !!projectUuid,
+        retry: false,
+    });

--- a/packages/frontend/src/features/contentAsCodeSync/hooks/useContentAsCodeSyncStatus.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/hooks/useContentAsCodeSyncStatus.ts
@@ -1,11 +1,14 @@
 import { type ApiError } from '@lightdash/common'; // pragma: allowlist secret
 import { useQuery } from '@tanstack/react-query';
 import { getContentAsCodeSyncStatus } from '../api/getContentAsCodeSyncStatus';
-import { type ContentAsCodeSyncStatus } from '../types';
+import {
+    CONTENT_AS_CODE_SYNC_STATUS_QUERY_KEY,
+    type ContentAsCodeSyncStatusResult,
+} from '../types';
 
 export const useContentAsCodeSyncStatus = (projectUuid: string | undefined) =>
-    useQuery<ContentAsCodeSyncStatus, ApiError>({
-        queryKey: ['content-as-code-sync-status', projectUuid],
+    useQuery<ContentAsCodeSyncStatusResult, ApiError>({
+        queryKey: [CONTENT_AS_CODE_SYNC_STATUS_QUERY_KEY, projectUuid],
         queryFn: () => getContentAsCodeSyncStatus(projectUuid!),
         enabled: !!projectUuid,
         retry: false,

--- a/packages/frontend/src/features/contentAsCodeSync/hooks/useRestampContentAsCodeRevision.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/hooks/useRestampContentAsCodeRevision.ts
@@ -1,0 +1,48 @@
+import { isApiError, type ApiError } from '@lightdash/common'; // pragma: allowlist secret
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { restampContentAsCodeRevision } from '../api/restampContentAsCodeRevision';
+import {
+    CONTENT_AS_CODE_SYNC_STATUS_QUERY_KEY,
+    type ContentAsCodeSyncContentType,
+    type ContentAsCodeSyncStatus,
+} from '../types';
+
+type RestampVariables = {
+    contentType: ContentAsCodeSyncContentType;
+    slug: string;
+};
+
+export const useRestampContentAsCodeRevision = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<ContentAsCodeSyncStatus, ApiError, RestampVariables>({
+        mutationFn: ({ contentType, slug }) =>
+            restampContentAsCodeRevision({
+                projectUuid,
+                contentType,
+                slug,
+            }),
+        onSuccess: (status) => {
+            queryClient.setQueryData(
+                [CONTENT_AS_CODE_SYNC_STATUS_QUERY_KEY, projectUuid],
+                { kind: 'ok', status },
+            );
+            showToastSuccess({
+                title: 'Marker restamped',
+                subtitle:
+                    'The next upload will apply the incoming version for this slug.',
+            });
+        },
+        onError: (error) => {
+            if (isApiError(error)) {
+                showToastApiError({
+                    title: 'Could not restamp this slug',
+                    apiError: error.error,
+                });
+                return;
+            }
+        },
+    });
+};

--- a/packages/frontend/src/features/contentAsCodeSync/types.test.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/types.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowContentAsCodeSync } from './types';
+
+describe('shouldShowContentAsCodeSync', () => {
+    it('hides the nav until the status query resolves', () => {
+        expect(shouldShowContentAsCodeSync(undefined)).toBe(false);
+    });
+
+    it('shows the nav when the API is not deployed yet', () => {
+        expect(shouldShowContentAsCodeSync({ kind: 'unavailable' })).toBe(true);
+    });
+
+    it('hides the nav when the project has not enabled sync', () => {
+        expect(
+            shouldShowContentAsCodeSync({
+                kind: 'ok',
+                status: {
+                    syncEnabled: false,
+                    lastAppliedAt: null,
+                    items: [],
+                },
+            }),
+        ).toBe(false);
+    });
+
+    it('shows the nav when sync is enabled', () => {
+        expect(
+            shouldShowContentAsCodeSync({
+                kind: 'ok',
+                status: {
+                    syncEnabled: true,
+                    lastAppliedAt: null,
+                    items: [],
+                },
+            }),
+        ).toBe(true);
+    });
+});

--- a/packages/frontend/src/features/contentAsCodeSync/types.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Local copy of the content-as-code sync-status contract until
+ * the shared types are published.
+ */
+
+export type ContentAsCodeAppliedRevision = {
+    contentType: string;
+    slug: string;
+    contentHash: string;
+    appliedAt: Date;
+    appliedByUserUuid: string | null;
+};
+
+export type ContentAsCodeSyncStatus = {
+    lastAppliedAt: Date | null;
+    revisionCount: number;
+    revisions: ContentAsCodeAppliedRevision[];
+};
+
+export type ApiContentAsCodeSyncStatusResponse = {
+    status: 'ok';
+    results: ContentAsCodeSyncStatus;
+};
+
+export const EMPTY_CONTENT_AS_CODE_SYNC_STATUS: ContentAsCodeSyncStatus = {
+    lastAppliedAt: null,
+    revisionCount: 0,
+    revisions: [],
+};

--- a/packages/frontend/src/features/contentAsCodeSync/types.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/types.ts
@@ -3,18 +3,24 @@
  * the shared types are published.
  */
 
-export type ContentAsCodeAppliedRevision = {
-    contentType: string;
+export type ContentAsCodeSyncContentType = 'chart' | 'dashboard';
+
+export type ContentAsCodeSyncItemState = 'in_sync' | 'ahead' | 'ui_only';
+
+export type ContentAsCodeSyncItem = {
+    contentType: ContentAsCodeSyncContentType;
     slug: string;
-    contentHash: string;
-    appliedAt: Date;
-    appliedByUserUuid: string | null;
+    state: ContentAsCodeSyncItemState;
+    appliedAt: Date | null;
+    contentHash: string | null;
+    snapshot: Record<string, unknown> | null;
+    current: Record<string, unknown> | null;
 };
 
 export type ContentAsCodeSyncStatus = {
+    syncEnabled: boolean;
     lastAppliedAt: Date | null;
-    revisionCount: number;
-    revisions: ContentAsCodeAppliedRevision[];
+    items: ContentAsCodeSyncItem[];
 };
 
 export type ApiContentAsCodeSyncStatusResponse = {
@@ -22,8 +28,23 @@ export type ApiContentAsCodeSyncStatusResponse = {
     results: ContentAsCodeSyncStatus;
 };
 
-export const EMPTY_CONTENT_AS_CODE_SYNC_STATUS: ContentAsCodeSyncStatus = {
-    lastAppliedAt: null,
-    revisionCount: 0,
-    revisions: [],
+export type ContentAsCodeSyncStatusResult =
+    | { kind: 'unavailable' }
+    | { kind: 'ok'; status: ContentAsCodeSyncStatus };
+
+export const CONTENT_AS_CODE_SYNC_STATUS_QUERY_KEY =
+    'content-as-code-sync-status';
+
+export const shouldShowContentAsCodeSync = (
+    result: ContentAsCodeSyncStatusResult | undefined,
+): boolean => {
+    if (!result) {
+        return false;
+    }
+
+    if (result.kind === 'unavailable') {
+        return true;
+    }
+
+    return result.status.syncEnabled;
 };

--- a/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeSyncState.test.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeSyncState.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import {
+    canRestampContentAsCodeSyncItem,
+    CONTENT_AS_CODE_SYNC_STATE_BADGE,
+} from './contentAsCodeSyncState';
+
+describe('contentAsCodeSyncState', () => {
+    it('labels the three sync states', () => {
+        expect(CONTENT_AS_CODE_SYNC_STATE_BADGE.in_sync.label).toBe('In sync');
+        expect(CONTENT_AS_CODE_SYNC_STATE_BADGE.ahead.label).toBe('Ahead');
+        expect(CONTENT_AS_CODE_SYNC_STATE_BADGE.ui_only.label).toBe('UI-only');
+    });
+
+    it('allows restamp for ahead and UI-only, not in sync', () => {
+        expect(canRestampContentAsCodeSyncItem('ahead')).toBe(true);
+        expect(canRestampContentAsCodeSyncItem('ui_only')).toBe(true);
+        expect(canRestampContentAsCodeSyncItem('in_sync')).toBe(false);
+    });
+});

--- a/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeSyncState.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeSyncState.ts
@@ -1,0 +1,14 @@
+import { type ContentAsCodeSyncItemState } from '../types';
+
+export const CONTENT_AS_CODE_SYNC_STATE_BADGE: Record<
+    ContentAsCodeSyncItemState,
+    { label: string; color: string }
+> = {
+    in_sync: { label: 'In sync', color: 'teal' },
+    ahead: { label: 'Ahead', color: 'yellow' },
+    ui_only: { label: 'UI-only', color: 'ldGray' },
+};
+
+export const canRestampContentAsCodeSyncItem = (
+    state: ContentAsCodeSyncItemState,
+): boolean => state === 'ahead' || state === 'ui_only';

--- a/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeTypeLabel.test.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeTypeLabel.test.ts
@@ -1,0 +1,23 @@
+import { ContentAsCodeType } from '@lightdash/common'; // pragma: allowlist secret
+import { describe, expect, it } from 'vitest';
+import { getContentAsCodeTypeLabel } from './contentAsCodeTypeLabel';
+
+describe('getContentAsCodeTypeLabel', () => {
+    it('maps known content-as-code types to display labels', () => {
+        expect(getContentAsCodeTypeLabel(ContentAsCodeType.CHART)).toBe(
+            'Chart',
+        );
+        expect(getContentAsCodeTypeLabel(ContentAsCodeType.SQL_CHART)).toBe(
+            'SQL chart',
+        );
+        expect(
+            getContentAsCodeTypeLabel(ContentAsCodeType.GOOGLE_SHEETS_SYNC),
+        ).toBe('Google Sheets sync');
+    });
+
+    it('humanizes unknown content types without inventing a label', () => {
+        expect(getContentAsCodeTypeLabel('custom_resource')).toBe(
+            'custom resource',
+        );
+    });
+});

--- a/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeTypeLabel.test.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeTypeLabel.test.ts
@@ -1,23 +1,9 @@
-import { ContentAsCodeType } from '@lightdash/common'; // pragma: allowlist secret
 import { describe, expect, it } from 'vitest';
 import { getContentAsCodeTypeLabel } from './contentAsCodeTypeLabel';
 
 describe('getContentAsCodeTypeLabel', () => {
-    it('maps known content-as-code types to display labels', () => {
-        expect(getContentAsCodeTypeLabel(ContentAsCodeType.CHART)).toBe(
-            'Chart',
-        );
-        expect(getContentAsCodeTypeLabel(ContentAsCodeType.SQL_CHART)).toBe(
-            'SQL chart',
-        );
-        expect(
-            getContentAsCodeTypeLabel(ContentAsCodeType.GOOGLE_SHEETS_SYNC),
-        ).toBe('Google Sheets sync');
-    });
-
-    it('humanizes unknown content types without inventing a label', () => {
-        expect(getContentAsCodeTypeLabel('custom_resource')).toBe(
-            'custom resource',
-        );
+    it('labels managed content types', () => {
+        expect(getContentAsCodeTypeLabel('chart')).toBe('Chart');
+        expect(getContentAsCodeTypeLabel('dashboard')).toBe('Dashboard');
     });
 });

--- a/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeTypeLabel.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeTypeLabel.ts
@@ -1,25 +1,13 @@
-import { ContentAsCodeType } from '@lightdash/common'; // pragma: allowlist secret
+import { type ContentAsCodeSyncContentType } from '../types';
 
-const CONTENT_AS_CODE_TYPE_LABELS: Record<ContentAsCodeType, string> = {
-    [ContentAsCodeType.CHART]: 'Chart',
-    [ContentAsCodeType.DASHBOARD]: 'Dashboard',
-    [ContentAsCodeType.SQL_CHART]: 'SQL chart',
-    [ContentAsCodeType.SPACE]: 'Space',
-    [ContentAsCodeType.AI_AGENT]: 'AI agent',
-    [ContentAsCodeType.SCHEDULED_DELIVERY]: 'Scheduled delivery',
-    [ContentAsCodeType.ALERT]: 'Alert',
-    [ContentAsCodeType.GOOGLE_SHEETS_SYNC]: 'Google Sheets sync',
-    [ContentAsCodeType.VIRTUAL_VIEW]: 'Virtual view',
-    [ContentAsCodeType.EXTERNAL_CONNECTION]: 'External connection',
+const CONTENT_AS_CODE_TYPE_LABELS: Record<
+    ContentAsCodeSyncContentType,
+    string
+> = {
+    chart: 'Chart',
+    dashboard: 'Dashboard',
 };
 
-const isContentAsCodeType = (value: string): value is ContentAsCodeType =>
-    Object.values(ContentAsCodeType).includes(value as ContentAsCodeType);
-
-export const getContentAsCodeTypeLabel = (contentType: string): string => {
-    if (isContentAsCodeType(contentType)) {
-        return CONTENT_AS_CODE_TYPE_LABELS[contentType];
-    }
-
-    return contentType.replace(/_/g, ' ');
-};
+export const getContentAsCodeTypeLabel = (
+    contentType: ContentAsCodeSyncContentType,
+): string => CONTENT_AS_CODE_TYPE_LABELS[contentType];

--- a/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeTypeLabel.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeTypeLabel.ts
@@ -1,0 +1,25 @@
+import { ContentAsCodeType } from '@lightdash/common'; // pragma: allowlist secret
+
+const CONTENT_AS_CODE_TYPE_LABELS: Record<ContentAsCodeType, string> = {
+    [ContentAsCodeType.CHART]: 'Chart',
+    [ContentAsCodeType.DASHBOARD]: 'Dashboard',
+    [ContentAsCodeType.SQL_CHART]: 'SQL chart',
+    [ContentAsCodeType.SPACE]: 'Space',
+    [ContentAsCodeType.AI_AGENT]: 'AI agent',
+    [ContentAsCodeType.SCHEDULED_DELIVERY]: 'Scheduled delivery',
+    [ContentAsCodeType.ALERT]: 'Alert',
+    [ContentAsCodeType.GOOGLE_SHEETS_SYNC]: 'Google Sheets sync',
+    [ContentAsCodeType.VIRTUAL_VIEW]: 'Virtual view',
+    [ContentAsCodeType.EXTERNAL_CONNECTION]: 'External connection',
+};
+
+const isContentAsCodeType = (value: string): value is ContentAsCodeType =>
+    Object.values(ContentAsCodeType).includes(value as ContentAsCodeType);
+
+export const getContentAsCodeTypeLabel = (contentType: string): string => {
+    if (isContentAsCodeType(contentType)) {
+        return CONTENT_AS_CODE_TYPE_LABELS[contentType];
+    }
+
+    return contentType.replace(/_/g, ' ');
+};

--- a/packages/frontend/src/features/contentAsCodeSync/utils/dumpContentAsCodeDocument.test.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/utils/dumpContentAsCodeDocument.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { dumpContentAsCodeDocument } from './dumpContentAsCodeDocument';
+
+describe('dumpContentAsCodeDocument', () => {
+    it('returns an empty string for a missing document', () => {
+        expect(dumpContentAsCodeDocument(null)).toBe('');
+    });
+
+    it('dumps a stable YAML document', () => {
+        expect(
+            dumpContentAsCodeDocument({
+                name: 'orders',
+                slug: 'orders-over-time',
+            }),
+        ).toBe('name: orders\nslug: orders-over-time\n');
+    });
+});

--- a/packages/frontend/src/features/contentAsCodeSync/utils/dumpContentAsCodeDocument.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/utils/dumpContentAsCodeDocument.ts
@@ -1,0 +1,14 @@
+import yaml from 'js-yaml';
+
+export const dumpContentAsCodeDocument = (
+    document: Record<string, unknown> | null,
+): string => {
+    if (!document) {
+        return '';
+    }
+
+    return yaml.dump(document, {
+        quotingType: '"',
+        sortKeys: true,
+    });
+};

--- a/packages/frontend/src/features/contentAsCodeSync/utils/toDate.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/utils/toDate.ts
@@ -1,0 +1,2 @@
+export const toDate = (value: Date | string): Date =>
+    value instanceof Date ? value : new Date(value);

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -80,6 +80,7 @@ export type SettingsContext = {
     isDataAppsFlagLoading: boolean;
     externalSourcesFlag: FeatureFlag | undefined;
     isResultsCacheEnabled: boolean;
+    isContentAsCodeSyncEnabled: boolean;
     embeddingEnabled: FeatureFlag | undefined;
     allowPasswordAuthentication: boolean;
     hasSocialLogin: boolean | undefined;

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -80,7 +80,8 @@ export type SettingsContext = {
     isDataAppsFlagLoading: boolean;
     externalSourcesFlag: FeatureFlag | undefined;
     isResultsCacheEnabled: boolean;
-    isContentAsCodeSyncEnabled: boolean;
+    shouldShowContentAsCodeSync: boolean;
+    isContentAsCodeSyncStatusLoading: boolean;
     embeddingEnabled: FeatureFlag | undefined;
     allowPasswordAuthentication: boolean;
     hasSocialLogin: boolean | undefined;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -79,6 +79,11 @@ export const useSettingsContext = (): SettingsContext => {
     );
     const isResultsCacheEnabled = resultsCacheFlag?.enabled ?? false;
 
+    const { data: contentAsCodeSyncFlag } = useServerFeatureFlag(
+        FeatureFlags.ContentAsCodeSync,
+    );
+    const isContentAsCodeSyncEnabled = contentAsCodeSyncFlag?.enabled ?? false;
+
     const { data: proLimitsFlag } = useServerFeatureFlag(
         FeatureFlags.ProLimits,
     );
@@ -200,6 +205,7 @@ export const useSettingsContext = (): SettingsContext => {
         isDataAppsFlagLoading: dataAppsFlagQuery.isInitialLoading,
         externalSourcesFlag,
         isResultsCacheEnabled,
+        isContentAsCodeSyncEnabled,
         embeddingEnabled,
         allowPasswordAuthentication,
         hasSocialLogin,

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -2,6 +2,8 @@ import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
 import { useIsGitProject } from '../../components/Explorer/WriteBackModal/hooks';
 import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
+import { useContentAsCodeSyncStatus } from '../../features/contentAsCodeSync/hooks/useContentAsCodeSyncStatus';
+import { shouldShowContentAsCodeSync } from '../../features/contentAsCodeSync/types';
 import useApp from '../../providers/App/useApp';
 import { useOrganization } from '../organization/useOrganization';
 import { useActiveProjectUuid } from '../useActiveProject';
@@ -79,11 +81,6 @@ export const useSettingsContext = (): SettingsContext => {
     );
     const isResultsCacheEnabled = resultsCacheFlag?.enabled ?? false;
 
-    const { data: contentAsCodeSyncFlag } = useServerFeatureFlag(
-        FeatureFlags.ContentAsCodeSync,
-    );
-    const isContentAsCodeSyncEnabled = contentAsCodeSyncFlag?.enabled ?? false;
-
     const { data: proLimitsFlag } = useServerFeatureFlag(
         FeatureFlags.ProLimits,
     );
@@ -125,6 +122,8 @@ export const useSettingsContext = (): SettingsContext => {
     } = useProject(activeProjectUuid);
 
     const isGitProject = useIsGitProject(activeProjectUuid ?? '');
+    const contentAsCodeSyncQuery =
+        useContentAsCodeSyncStatus(activeProjectUuid);
 
     // "Ask AI" settings are visible to org AI admins (all projects) and to
     // project-scoped AI admins (only the projects they can reach). These are
@@ -205,7 +204,11 @@ export const useSettingsContext = (): SettingsContext => {
         isDataAppsFlagLoading: dataAppsFlagQuery.isInitialLoading,
         externalSourcesFlag,
         isResultsCacheEnabled,
-        isContentAsCodeSyncEnabled,
+        shouldShowContentAsCodeSync: shouldShowContentAsCodeSync(
+            contentAsCodeSyncQuery.data,
+        ),
+        isContentAsCodeSyncStatusLoading:
+            contentAsCodeSyncQuery.isInitialLoading,
         embeddingEnabled,
         allowPasswordAuthentication,
         hasSocialLogin,

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -91,7 +91,7 @@ export const useSettingsNavigation = (
         dataAppsFlag,
         externalSourcesFlag,
         isResultsCacheEnabled,
-        isContentAsCodeSyncEnabled,
+        shouldShowContentAsCodeSync,
         isGitProject,
     } = context;
 
@@ -969,7 +969,7 @@ export const useSettingsNavigation = (
             }
 
             if (
-                isContentAsCodeSyncEnabled &&
+                shouldShowContentAsCodeSync &&
                 ability?.can(
                     'view',
                     subject('ContentAsCode', {
@@ -1052,7 +1052,7 @@ export const useSettingsNavigation = (
         isDataAppsEnabled,
         isExternalSourcesEnabled,
         isResultsCacheEnabled,
-        isContentAsCodeSyncEnabled,
+        shouldShowContentAsCodeSync,
         isGitProject,
         track,
     ]);

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -10,6 +10,7 @@ import {
     IconCalendarStats,
     IconChecklist,
     IconClock,
+    IconCode,
     IconBook2,
     IconDatabase,
     IconDatabaseCog,
@@ -90,6 +91,7 @@ export const useSettingsNavigation = (
         dataAppsFlag,
         externalSourcesFlag,
         isResultsCacheEnabled,
+        isContentAsCodeSyncEnabled,
         isGitProject,
     } = context;
 
@@ -967,6 +969,26 @@ export const useSettingsNavigation = (
             }
 
             if (
+                isContentAsCodeSyncEnabled &&
+                ability?.can(
+                    'view',
+                    subject('ContentAsCode', {
+                        organizationUuid: project.organizationUuid,
+                        projectUuid: project.projectUuid,
+                    }),
+                )
+            ) {
+                projectItems.push({
+                    label: 'Content as code',
+                    to: `${base}/contentAsCode`,
+                    icon: IconCode,
+                    keywords: ['sync', 'upload', 'as code', 'git'],
+                    children: [],
+                    exact: true,
+                });
+            }
+
+            if (
                 isGitProject &&
                 ability?.can(
                     'view',
@@ -1030,6 +1052,7 @@ export const useSettingsNavigation = (
         isDataAppsEnabled,
         isExternalSourcesEnabled,
         isResultsCacheEnabled,
+        isContentAsCodeSyncEnabled,
         isGitProject,
         track,
     ]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: PROD-10509
Relates: PROD-2856

**PROD-2856 ship plan: wave 2.** Status panel + explicit propose, after protection (10507 → 10508 → 10510). Prefer rebasing onto #27995 when that snapshot table is the merge base.

### Description:
Adds a project-settings **Content as code** panel that lists managed slugs and their sync state.

- Nav item in Current project, next to Data ops
- Route: `/generalSettings/projectManagement/:projectUuid/contentAsCode`
- Reads `GET /api/v1/projects/{projectUuid}/code/sync-status`
- Shown when the GET 404s (API not deployed yet) or when `syncEnabled` is true. Hidden when GET succeeds with `syncEnabled: false`.
- Gated on persisted `content_as_code.sync`, not Unleash
- `view:ContentAsCode` to see the panel; `create:ContentAsCode` to restamp
- States: **in sync**, **ahead**, **UI-only**
- Ahead rows: **View diff** of last-applied snapshot vs current instance YAML
- **Use git version on next deploy** restamps ahead and UI-only slugs. Disabled for in-sync. POST 404 disables every restamp button.

Depends on the snapshot API from PROD-10507 (https://github.com/lightdash/lightdash/pull/27996). Prefer #27995 as the long-term foundation.

### Risk assessment:
- [ ] This is a high-risk change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8ccfc64-3e19-47b0-ba73-d713ac376003?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8ccfc64-3e19-47b0-ba73-d713ac376003&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

