### PR TITLE
chore: add verify-lightdash skill driven by agent-browser

### DIFF
--- a/.cursor/skills/verify-lightdash/SKILL.md
+++ b/.cursor/skills/verify-lightdash/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: verify-lightdash
+description: Drive the Lightdash web app as a user (login, home, explorer, saved charts, dashboards) against a local Vite+API stack and capture proof. Use when proving a UI change works, reproducing a user path, or after implementing frontend behavior.
+---
+
+# Verify Lightdash
+
+Agents read this cold. Drive the **web UI**, not internal Redux setters or Cypress-only helpers. Primary surface is the Vite app; the Express API is the same stack (`/api/v1/*`). Also present but out of scope for this skill: `@lightdash/cli`, headless unfurl, MCP warehouse tools.
+
+Repo helpers live in `.cursor/skills/verify-lightdash/scripts/`. Feature recipes live in `features/`.
+
+Harness is the **agent-browser** CLI (`npm` package `agent-browser`, commands `agent-browser …` or this repo’s wrapper). Do not drive with Playwright MCP, Cursor IDE browser MCP, or Cypress. If `agent-browser` is missing, install once: `npm i -g agent-browser && agent-browser install` (or use the wrapper, which falls back to `npx --yes agent-browser`). First machine also needs `agent-browser install` to fetch Chrome.
+
+Before any drive command, load the version-matched guide: `agent-browser skills get core` (or `--full` when you need the command reference).
+
+## Launch
+
+Default local stack is **per worktree**, claimed by `./scripts/dev-ports.sh`. Shared Docker (Postgres base image, MinIO, mailpit, NATS, headless browser) is shared across instances. App ports and Postgres are per instance.
+
+**Prefer attaching.** `resolve-env.sh` uses the first healthy pair among: claimed `dev-ports.sh` slot, `PORT`/`FE_PORT` in `.env.development.local`, then `http://localhost:3000` + `http://localhost:8080`. This worktree may have a claimed slot that is down while a default 3000/8080 stack is up — attach to the live pair. Do not start a second copy of the same `LD_INSTANCE_ID`. Two checkouts can run side by side only after each has its own claimed slot.
+
+Cold start via `./scripts/dev-fast-start.sh` needs `venv/bin/dbt1.12`. If that shim is missing, do not fight the venv from this skill: attach to an already-healthy UI instead, or fix the machine venv outside verification.
+
+```bash
+# From repo root. Prints VERIFY_RUN_ID and EVIDENCE_DIR.
+.cursor/skills/verify-lightdash/scripts/launch.sh
+eval "$(.cursor/skills/verify-lightdash/scripts/resolve-env.sh)"
+export VERIFY_RUN_ID   # from launch.sh stdout if not already set
+export EVIDENCE_DIR
+export AGENT_BROWSER_SESSION="ld-verify-${VERIFY_RUN_ID}"
+```
+
+Ready when doctor prints `READY:` and `GET ${API_URL}/api/v1/health` is 200. `./scripts/dev-fast-start.sh` is the only start command if doctor fails; it is idempotent and can take several minutes.
+
+Seeded login (always, unless the user named another account): `demo@lightdash.com` / `demo_password!`. Seeded project name `Jaffle shop`, uuid `3675b69e-8324-4110-bdca-059031aa8da3` (still resolve via UI or `GET ${API_URL}/api/v1/org/projects` if the DB was re-seeded).
+
+Isolation rules:
+
+- Never `docker compose down` on shared compose from a verification run.
+- Never `pkill` by process name (`node`, `vite`, `pm2`, `chrome`).
+- Cursor Cloud / agent-harness / Okteto / exe.dev already own a stack; attach and skip launch. Ports may not be 3000/8080 — trust `resolve-env.sh` or the environment’s `READY:` URL.
+- Always set `AGENT_BROWSER_SESSION`. The unnamed default session is shared with every other agent and the human’s leftover browser. Never `agent-browser close --all`.
+
+## Doctor
+
+Run first whenever anything looks off:
+
+```bash
+.cursor/skills/verify-lightdash/scripts/doctor.sh
+```
+
+It checks: a resolvable healthy frontend+API, API health 200, frontend `/login` 200, seed user API login 200. PM2 `${LD_INSTANCE_ID}-api` online is reported when present; missing PM2 is a warning if HTTP is healthy. Fail the run if HTTP or seed login fails; do not drive a sick instance.
+
+## Drive
+
+Wrapper (sets nothing; requires `AGENT_BROWSER_SESSION`):
+
+```bash
+AB=".cursor/skills/verify-lightdash/scripts/ab.sh"
+$AB skills get core          # once per agent, if you have not read it
+$AB open "${FRONTEND_URL}/login"
+$AB snapshot -i
+```
+
+Core loop: `open` → `snapshot -i` → act on `@eN` refs or `find role|text|label|testid` → `wait --text` / `wait --url` / `wait --load networkidle` → `snapshot -i` again. Refs go stale after every page change.
+
+Prefer `find` locators from this repo when you already know the name:
+
+```bash
+$AB find role button click --name "Continue"
+$AB find label "Work email" fill "demo@lightdash.com"
+$AB find testid "ExploreMenu/NewButton" click
+$AB find text "Orders" click
+```
+
+**Session:**
+
+1. `eval "$(.cursor/skills/verify-lightdash/scripts/resolve-env.sh)"` and set `AGENT_BROWSER_SESSION` as above.
+2. `$AB open "${FRONTEND_URL}/login"` then `$AB snapshot -i`.
+3. If already authenticated (`Browse` / `New`, or a heading containing `David`), skip login unless the feature file requires a logged-out start.
+4. Login (two-step form, `name="login"`, card `#lightdash-login-page`):
+   - Heading `Log in` (or legacy `Sign in`).
+   - `$AB find label "Work email" fill "demo@lightdash.com"` (or label `Email address`).
+   - `$AB find role button click --name "Continue"` (`data-cy="signin-button"`).
+   - `$AB find label "Password" fill "demo_password!"`.
+   - `$AB find role button click --name "Sign in"`.
+   - `$AB wait --text "David"` or `$AB wait --text "Browse"`.
+5. Follow the matching file under `features/`. Do not mark an entry point verified by using a different path.
+
+Stable handles from this repo:
+
+| What | Handle |
+|---|---|
+| Login card | `#lightdash-login-page` |
+| Continue / Sign in | `data-cy="signin-button"` or button name `Continue` / `Sign in` |
+| Home | link/button name `Home` → `/projects/:projectUuid/home` |
+| New chart | `data-testid="ExploreMenu/NewButton"` then text `Chart` → `/tables` |
+| Browse | button `Browse` → `All dashboards`, `All saved charts`, `All Spaces` |
+| Tables list ready | `wait --text "Orders"` after `/tables` |
+| Explore `Orders` | text `Orders` |
+| Run explorer query | button name containing `Run query` |
+| Seed dashboard | text/link `Jaffle dashboard` |
+| Seed chart | `How much revenue do we have per payment method?` |
+| Logout | user avatar → menuitem `Logout` |
+
+Do not `$AB wait 2000` except when debugging. After a warehouse query, `$AB wait --text` that is not `Loading results` / `Loading chart`, then assert row or chart content.
+
+## Evidence
+
+Directory: `.cursor/skills/verify-lightdash/evidence/<VERIFY_RUN_ID>/` (gitignored except `.gitignore`). Cleanup must not delete it. Do not write screenshots or snapshots into the repo root.
+
+Proof standards:
+
+- Exercise the real user path. Do not POST `/api/v1/login` and call the UI done.
+- Capture the action and the resulting state: snapshot before click, snapshot after, screenshot of the result with Lightdash chrome visible (logo or `Browse`).
+- Mutations: reopen from a list or a second URL.
+- Record feature ID and entry point in `evidence/<id>/proof.md`.
+- Do not stub the Lightdash API.
+
+Minimum artifacts per driven feature:
+
+```bash
+$AB snapshot -i > "${EVIDENCE_DIR}/home.aria.md"
+$AB screenshot "${EVIDENCE_DIR}/home.png"
+```
+
+Plus `proof.md` (feature ID, URL, commands, what was observed).
+
+## Cleanup
+
+```bash
+# Close only this run's agent-browser session, then stack teardown if owned.
+.cursor/skills/verify-lightdash/scripts/ab.sh close
+.cursor/skills/verify-lightdash/scripts/cleanup.sh "$VERIFY_RUN_ID"
+```
+
+If `run.env` has `OWNED=0` (attached), cleanup is a no-op for PM2/Docker. Leave the user’s Lightdash stack running. Never `close --all`.
+
+If `OWNED=1`, cleanup deletes that instance’s PM2 names one by one. It does not release the port slot and does not stop shared Docker.
+
+## Helpers
+
+All are executable; run from any cwd:
+
+```bash
+.cursor/skills/verify-lightdash/scripts/resolve-env.sh   # export FRONTEND_URL API_URL …
+.cursor/skills/verify-lightdash/scripts/doctor.sh        # read-only health
+.cursor/skills/verify-lightdash/scripts/launch.sh        # attach or start; prints VERIFY_RUN_ID
+.cursor/skills/verify-lightdash/scripts/ab.sh <cmd>      # agent-browser (needs AGENT_BROWSER_SESSION)
+.cursor/skills/verify-lightdash/scripts/cleanup.sh <id>  # teardown if owned
+```

--- a/.cursor/skills/verify-lightdash/evidence/.gitignore
+++ b/.cursor/skills/verify-lightdash/evidence/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.cursor/skills/verify-lightdash/features/README.md
+++ b/.cursor/skills/verify-lightdash/features/README.md
@@ -1,0 +1,48 @@
+# Lightdash verification map
+
+This directory is the maintained source for verifying user-facing Lightdash web behavior. Read the index before driving the app, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Launch or attach with `.cursor/skills/verify-lightdash/scripts/launch.sh`.
+- `eval "$(.cursor/skills/verify-lightdash/scripts/resolve-env.sh)"`.
+- `.cursor/skills/verify-lightdash/scripts/doctor.sh` prints `READY:`.
+- Seeded org **Jaffle Shop**, project **Jaffle shop**, user **David Attenborough** (`demo@lightdash.com` / `demo_password!`).
+- `export AGENT_BROWSER_SESSION="ld-verify-${VERIFY_RUN_ID}"`.
+- Drive the Vite UI at `$FRONTEND_URL` with `.cursor/skills/verify-lightdash/scripts/ab.sh` (agent-browser). Do not use Playwright MCP, Cypress, or curl as the user path.
+- Do not start a second stack on the same `LD_INSTANCE_ID`.
+
+## Driving conventions
+
+- Start every recipe from the baseline state unless its preconditions say otherwise.
+- Prefer `ab.sh snapshot -i` plus `@eN` refs, then `find role|text|label|testid`. Treat quoted names as literal.
+- Re-snapshot after every navigation or submit. Refs go stale immediately.
+- After mutations, restore seeded data if you created extra charts/dashboards. Keep proof artifacts.
+- Record the feature ID and entry point with every artifact under `.cursor/skills/verify-lightdash/evidence/<VERIFY_RUN_ID>/`.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the final screen.
+- UI proof includes an `ab.sh snapshot -i` dump and an `ab.sh screenshot` with the Lightdash navbar or login card visible.
+- Mutation proof includes a second user-facing view of the stored value.
+- Report an unreachable path with the attempted URL and the unmet precondition.
+- Do not report a skipped entry point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features`
+2. `How to get to it (user POV)`
+3. `Driving it with agent-browser`
+4. `Gotchas`
+
+`AB` means `.cursor/skills/verify-lightdash/scripts/ab.sh` with `AGENT_BROWSER_SESSION` set.
+
+## Features
+
+- [Log in](./login.md) covers email precheck, password sign-in, already-authenticated redirect, and logout.
+- [Home](./home.md) covers the project home welcome and jumping into tables.
+- [Explore a table](./explore.md) covers the tables list, opening Orders, selecting fields, and running a query.
+- [Saved charts](./saved-charts.md) covers Browse → All saved charts and opening a seeded chart.
+- [Dashboards](./dashboards.md) covers Browse → All dashboards and opening Jaffle dashboard.

--- a/.cursor/skills/verify-lightdash/features/dashboards.md
+++ b/.cursor/skills/verify-lightdash/features/dashboards.md
@@ -1,0 +1,31 @@
+# Dashboards
+
+Dashboards is the project list of dashboards and the view of a seeded dashboard with its tiles.
+
+## Sub-features
+
+- `dash-list` shows `Jaffle dashboard` on `/dashboards`.
+- `dash-open` opens that dashboard and shows tiles (including the revenue chart) after load.
+
+## How to get to it (user POV)
+
+- Navbar `Browse` → `All dashboards`.
+- Direct URL `${FRONTEND_URL}/projects/${SEED_PROJECT_UUID}/dashboards`.
+- Click the `Jaffle dashboard` link in that list (view URL under `/dashboards/:uuidOrSlug`).
+
+## Driving it with agent-browser
+
+Preconditions:
+
+- Authenticated as the seed admin.
+- Seed includes `Jaffle dashboard`.
+
+- **Open list.** `$AB find role button click --name "Browse"`. `$AB snapshot -i`. `$AB find text "All dashboards" click`. `$AB wait --url "**/dashboards"`. `$AB wait --text "Jaffle dashboard"`.
+- **Open dashboard.** `$AB find text "Jaffle dashboard" click`. `$AB wait --load networkidle`. `$AB snapshot -i` includes `How much revenue` or other seeded tile titles and navbar `Browse`.
+- **Proof.** List artifacts (`dash-list.aria.md`, `dash-list.png`) and opened dashboard (`dash-open.aria.md`, `dash-open.png`) with at least one tile readable.
+
+## Gotchas
+
+- Minimal/embed routes (`/minimal/projects/.../dashboards/...`) are not this feature.
+- Do not apply dashboard filters unless asserting filter behavior in a later map file.
+- Do not create a dashboard from `New` during a read-only verify.

--- a/.cursor/skills/verify-lightdash/features/explore.md
+++ b/.cursor/skills/verify-lightdash/features/explore.md
@@ -1,0 +1,37 @@
+# Explore a table
+
+Explore lets a user pick a dbt-modeled table, add dimensions and metrics, run a warehouse query, and see results in the explorer.
+
+## Sub-features
+
+- `explore-list` shows seeded explores on `/tables`.
+- `explore-open-orders` opens the Orders explore with a field tree (`Dimensions`).
+- `explore-run` runs a query after selecting at least one field and shows result rows.
+
+## How to get to it (user POV)
+
+- Navbar `New` (`data-testid="ExploreMenu/NewButton"`) → menu item titled `Chart`.
+- Home `Run a query`.
+- Direct URL `${FRONTEND_URL}/projects/${SEED_PROJECT_UUID}/tables`.
+- From `/tables`, click explore name `Orders` (also `/tables/orders`).
+
+## Driving it with agent-browser
+
+Preconditions:
+
+- Authenticated as the seed admin.
+- Jaffle shop project is compiled (tables list is not empty).
+
+- **Open tables.** `$AB open "${FRONTEND_URL}/projects/${SEED_PROJECT_UUID}/tables"`. `$AB wait --text "Orders"`. `$AB snapshot -i`.
+- **Open Orders.** `$AB find text "Orders" click`. `$AB wait --url "**/tables/orders"`. `$AB wait --text "Dimensions"`. `$AB snapshot -i`.
+- **Select fields.** `$AB find text "Order id" click` (or another Orders dimension). If the tree is virtualized, `$AB scrollintoview` after `$AB snapshot -i` finds the row.
+- **Run.** `$AB find text "Run query" click` (name may include a limit, e.g. `Run query (500)`). `$AB wait --load networkidle`. Confirm `$AB snapshot` no longer shows `Loading results` and a results table has cells.
+- **Proof.** `$AB snapshot -i > "${EVIDENCE_DIR}/explore-orders.aria.md"` and `$AB screenshot "${EVIDENCE_DIR}/explore-orders.png"`. `proof.md` lists the field names clicked.
+
+## Gotchas
+
+- Auto-fetch may run a query as soon as a field is selected. Still click `Run query` when asserting `explore-run`, or note auto-fetch in `proof.md` if the button stayed disabled.
+- Virtualized explore list: `Orders` may be off-screen. Snapshot, scroll, snapshot again.
+- Stay on Orders. Mixing fields from another explore is invalid.
+- Empty results after run is a failure for this seed.
+- Do not save a chart in this feature. Leftover `My chart` pollutes Browse.

--- a/.cursor/skills/verify-lightdash/features/home.md
+++ b/.cursor/skills/verify-lightdash/features/home.md
@@ -1,0 +1,35 @@
+# Home
+
+Home is the project landing after login. It greets the signed-in user and is the hub for Browse, New, and recent content.
+
+## Sub-features
+
+- `home-welcome` shows a David greeting on `/projects/:projectUuid/home` (classic `Welcome, David!` or custom `Good morning, David.` / time-of-day equivalent).
+- `home-tables` opens the tables list. Classic homepage uses `Run a query`. Custom homepage uses navbar `New` → `Chart` (do not flip the homepage mode).
+- `home-logo` returns to home from the navbar control named `Home`.
+
+## How to get to it (user POV)
+
+- Finish log in (see [login](./login.md)); the app routes to project home.
+- Click the Lightdash logo in the top-left navbar (`Home`).
+- Open `${FRONTEND_URL}/projects/3675b69e-8324-4110-bdca-059031aa8da3/home`.
+
+## Driving it with agent-browser
+
+Preconditions:
+
+- Authenticated as `demo@lightdash.com` in this `AGENT_BROWSER_SESSION`.
+- Doctor is `READY:`.
+
+- **Open home.** `$AB open "${FRONTEND_URL}/projects/${SEED_PROJECT_UUID}/home"`. `$AB wait --text "David"`. `$AB snapshot -i`. Navbar includes `Browse` and `New`. Project switcher includes `Jaffle shop`.
+- **Jump to tables.** If `$AB snapshot -i` shows `Run a query`, `$AB find role button click --name "Run a query"`. Otherwise `$AB find testid "ExploreMenu/NewButton" click`, `$AB snapshot -i`, `$AB find text "Chart" click`. `$AB wait --url "**/tables"`. `$AB wait --text "Orders"`.
+- **Return via logo.** `$AB find role link click --name "Home"` (or button named `Home`). `$AB wait --url "**/home"`. `$AB wait --text "David"`.
+- **Proof.** `$AB snapshot -i > "${EVIDENCE_DIR}/home.aria.md"` and `$AB screenshot "${EVIDENCE_DIR}/home.png"`. After tables, `home-tables.aria.md` / `home-tables.png`.
+
+## Gotchas
+
+- Custom homepage builder is on for many local seeds. `Switch back to classic homepage` / `Customize homepage` mutate user preference — skip them on a read-only verify.
+- `Welcome to Lightdash` (no first name) is not seed-user proof.
+- If you see org setup instead of Jaffle, the DB is not the seeded demo — stop and doctor.
+- Time-of-day greetings (`Good morning` / `Good afternoon` / `Good evening`) all count for `home-welcome` when they include `David`.
+- On `/tables`, `Orders` is often below the fold in a virtualized list. `$AB wait --text "Orders"` can time out while the page is healthy. Treat `Select a table` plus `Search tables` as `home-tables` proof; scroll or search for `Orders` only when driving [explore](./explore.md).

--- a/.cursor/skills/verify-lightdash/features/login.md
+++ b/.cursor/skills/verify-lightdash/features/login.md
@@ -1,0 +1,41 @@
+# Log in
+
+Log in lets a seeded user reach the project home from a logged-out browser using email then password, and lets them log out again from the user menu.
+
+## Sub-features
+
+- `login-precheck` submits a work email and reveals the password field.
+- `login-signin` authenticates with the seed password and lands on home.
+- `login-already` redirects `/login` to home when a session already exists.
+- `login-logout` signs out from the avatar menu and returns to `/login`.
+
+## How to get to it (user POV)
+
+- Open `${FRONTEND_URL}/login` while logged out.
+- After a session exists, open `${FRONTEND_URL}/login` again (redirect).
+- Open the user avatar in the top-right navbar and choose `Logout`.
+
+## Driving it with agent-browser
+
+Preconditions:
+
+- Doctor is `READY:`.
+- `AGENT_BROWSER_SESSION` is set. This session must not already be logged in for `login-precheck` / `login-signin`. If `Browse` is visible, run `login-logout` first.
+- Evidence dir exists for this `VERIFY_RUN_ID`.
+
+- **Open login.** `$AB open "${FRONTEND_URL}/login"` then `$AB snapshot -i`. Page shows `#lightdash-login-page` (or heading `Log in` / `Sign in`) and button `Continue`.
+- **Precheck email.** `$AB find label "Work email" fill "demo@lightdash.com"` (or `Email address`). `$AB find role button click --name "Continue"`. `$AB wait --text "Password"`. `$AB snapshot -i`. Button `Sign in` is present.
+- **Sign in.** `$AB find label "Password" fill "demo_password!"`. `$AB find role button click --name "Sign in"`. `$AB wait --text "David"` (or `Browse`). `$AB get url` is under `/projects/` (usually `/projects/3675b69e-8324-4110-bdca-059031aa8da3/home`).
+- **Already authenticated.** `$AB open "${FRONTEND_URL}/login"`. `$AB wait --load networkidle`. `$AB get url` is not stuck on `/login` with the form.
+- **Logout.** `$AB snapshot -i`. Click the user avatar (`DA` or avatar control). `$AB find role menuitem click --name "Logout"`. `$AB wait --url "**/login"`.
+- **Proof.** `$AB snapshot -i > "${EVIDENCE_DIR}/login-home.aria.md"` and `$AB screenshot "${EVIDENCE_DIR}/login-home.png"` after sign-in. After logout, `login-form.aria.md` / `login-form.png`. `proof.md` names `login-signin` and the URL.
+
+## Gotchas
+
+- Login is two submits. Password is not mounted until after `Continue`.
+- Layout A uses `Work email` + `Log in`; layout B uses `Email address` + `Sign in`. Both share `data-cy="signin-button"`.
+- A reused `AGENT_BROWSER_SESSION` often starts already logged in. That proves `login-already`, not `login-signin`. Start a new session name for a logged-out proof.
+- Demo mode auto-logs in; local seed is not demo mode. If the spinner never yields a form, doctor the API `mode` field.
+- API `POST /api/v1/login` 200 is doctor-only. It is not UI proof.
+- The split login layout’s left brand panel can intercept `find text` clicks. Prefer `snapshot -i` then `$AB click @eN` on the form refs, or `$AB find role button click --name "Continue"`.
+- A toast `We are currently unable to reach the Lightdash server` means the Vite app cannot talk to the API (wrong proxy/port). Dismiss it only after doctoring `$API_URL`; do not treat a failed login as a UI bug.

--- a/.cursor/skills/verify-lightdash/features/saved-charts.md
+++ b/.cursor/skills/verify-lightdash/features/saved-charts.md
@@ -1,0 +1,31 @@
+# Saved charts
+
+Saved charts is the project list of charts the user can open from Browse without building a query from scratch.
+
+## Sub-features
+
+- `charts-list` shows seeded charts on `/saved`.
+- `charts-open` opens `How much revenue do we have per payment method?` and renders a chart or results, not an error empty state.
+
+## How to get to it (user POV)
+
+- Navbar `Browse` → `All saved charts`.
+- Direct URL `${FRONTEND_URL}/projects/${SEED_PROJECT_UUID}/saved`.
+- Home or space lists that link the same chart name.
+
+## Driving it with agent-browser
+
+Preconditions:
+
+- Authenticated as the seed admin.
+- Seed data includes the revenue chart (standard Jaffle seed).
+
+- **Open list.** `$AB find role button click --name "Browse"`. `$AB snapshot -i`. `$AB find text "All saved charts" click`. `$AB wait --url "**/saved"`. `$AB wait --text "How much revenue do we have per payment method?"`.
+- **Open chart.** `$AB find text "How much revenue do we have per payment method?" click`. `$AB wait --load networkidle`. `$AB snapshot -i` shows that title and no blocking error dialog. `Loading chart` is gone.
+- **Proof.** `$AB snapshot -i > "${EVIDENCE_DIR}/saved-list.aria.md"` on the list, `$AB screenshot "${EVIDENCE_DIR}/saved-open.png"` on the opened chart.
+
+## Gotchas
+
+- Opening from a space UUID is a different entry point; if you only used `/saved`, do not claim space browser coverage.
+- Chart slugs in the URL are not the display name. Assert the visible title.
+- Do not click `Edit chart` unless the task is editing.

--- a/.cursor/skills/verify-lightdash/scripts/ab.sh
+++ b/.cursor/skills/verify-lightdash/scripts/ab.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Invoke agent-browser (PATH binary, else npx). Requires AGENT_BROWSER_SESSION.
+set -euo pipefail
+
+if [ -z "${AGENT_BROWSER_SESSION:-}" ]; then
+    echo "FAIL: set AGENT_BROWSER_SESSION before driving (see verify-lightdash SKILL.md)." >&2
+    exit 2
+fi
+
+if command -v agent-browser >/dev/null 2>&1; then
+    exec agent-browser "$@"
+fi
+exec npx --yes agent-browser "$@"

--- a/.cursor/skills/verify-lightdash/scripts/cleanup.sh
+++ b/.cursor/skills/verify-lightdash/scripts/cleanup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Tear down only a stack this verification run started. Never deletes evidence.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "$REPO_ROOT"
+
+RUN_ID="${1:-${VERIFY_RUN_ID:-}}"
+if [ -z "$RUN_ID" ]; then
+    echo "usage: cleanup.sh <VERIFY_RUN_ID>" >&2
+    echo "or set VERIFY_RUN_ID" >&2
+    exit 2
+fi
+
+RUN_ENV="${REPO_ROOT}/.cursor/skills/verify-lightdash/evidence/${RUN_ID}/run.env"
+if [ ! -f "$RUN_ENV" ]; then
+    echo "FAIL: no run.env at ${RUN_ENV}" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$RUN_ENV"
+
+if [ -n "${AGENT_BROWSER_SESSION:-}" ]; then
+    AGENT_BROWSER_SESSION="${AGENT_BROWSER_SESSION}" \
+        "$REPO_ROOT/.cursor/skills/verify-lightdash/scripts/ab.sh" close >/dev/null 2>&1 || true
+    echo "CLOSED agent-browser session ${AGENT_BROWSER_SESSION}"
+fi
+
+if [ "${OWNED:-0}" != "1" ]; then
+    echo "SKIP: this run attached to an existing instance; not stopping PM2 or Docker."
+    echo "Evidence remains under ${EVIDENCE_DIR:-.cursor/skills/verify-lightdash/evidence/${RUN_ID}}"
+    exit 0
+fi
+
+: "${LD_INSTANCE_ID:?run.env missing LD_INSTANCE_ID}"
+
+for suffix in api api-routes-watch scheduler frontend common-watch formula-watch warehouses-watch spotlight maple sdk-test; do
+    pnpm exec pm2 delete "${LD_INSTANCE_ID}-${suffix}" >/dev/null 2>&1 || true
+done
+
+echo "STOPPED PM2 processes for ${LD_INSTANCE_ID} (not shared Docker services, not the port slot)."
+echo "Evidence remains under ${EVIDENCE_DIR}"

--- a/.cursor/skills/verify-lightdash/scripts/doctor.sh
+++ b/.cursor/skills/verify-lightdash/scripts/doctor.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Read-only: is a Lightdash instance worth driving?
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "$REPO_ROOT"
+
+ok() { echo "OK: $1"; }
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+if ! RESOLVED="$("$REPO_ROOT/.cursor/skills/verify-lightdash/scripts/resolve-env.sh")"; then
+    fail "no healthy frontend+API (resolve-env.sh failed)"
+fi
+eval "$RESOLVED"
+: "${FRONTEND_URL:?}" "${API_URL:?}"
+
+API_HEALTH="$(curl -sS -o /tmp/ld-verify-health.json -w '%{http_code}' --max-time 5 "${API_URL}/api/v1/health" || true)"
+[ "$API_HEALTH" = "200" ] || fail "API health ${API_HEALTH:-no response} at ${API_URL}/api/v1/health"
+ok "API ${API_URL}/api/v1/health 200"
+
+FE_CODE="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "${FRONTEND_URL}/login" || true)"
+[ "$FE_CODE" = "200" ] || fail "frontend ${FE_CODE:-no response} at ${FRONTEND_URL}/login"
+ok "frontend ${FRONTEND_URL}/login 200"
+
+if command -v pnpm >/dev/null 2>&1 && [ -n "${LD_INSTANCE_ID:-}" ]; then
+    API_STATUS="$(pnpm exec pm2 jlist 2>/dev/null | python3 -c "
+import json, sys
+try:
+    procs = json.load(sys.stdin)
+except Exception:
+    print('UNREADABLE')
+    raise SystemExit
+name = '${LD_INSTANCE_ID}-api'
+hits = [p for p in procs if p.get('name') == name]
+print('MISSING' if not hits else hits[0].get('pm2_env', {}).get('status', 'unknown'))
+" 2>/dev/null || echo "UNREADABLE")"
+    if [ "$API_STATUS" = "online" ]; then
+        ok "PM2 ${LD_INSTANCE_ID}-api online"
+    else
+        echo "WARN: PM2 ${LD_INSTANCE_ID}-api status=${API_STATUS}; API HTTP is healthy so doctor continues"
+    fi
+fi
+
+LOGIN_CODE="$(curl -sS -o /tmp/ld-verify-login.json -w '%{http_code}' --max-time 10 \
+    -X POST "${API_URL}/api/v1/login" \
+    -H 'Content-Type: application/json' \
+    -d '{"email":"demo@lightdash.com","password":"demo_password!"}' || true)"
+[ "$LOGIN_CODE" = "200" ] || fail "seed login HTTP ${LOGIN_CODE:-no response} (need demo@lightdash.com / demo_password!)"
+ok "seed user demo@lightdash.com can log in via API"
+
+python3 - <<'PY'
+import json
+health = json.load(open("/tmp/ld-verify-health.json"))
+results = health.get("results") or {}
+print(f"OK: health.status={health.get('status')} mode={results.get('mode')} healthy={results.get('healthy')}")
+PY
+
+echo "READY: instance=${LD_INSTANCE_ID:-unknown} source=${VERIFY_URL_SOURCE:-unknown} frontend=${FRONTEND_URL} api=${API_URL}"
+echo "SEED_PROJECT_UUID=3675b69e-8324-4110-bdca-059031aa8da3"
+echo "SEED_PROJECT_NAME=Jaffle shop"

--- a/.cursor/skills/verify-lightdash/scripts/launch.sh
+++ b/.cursor/skills/verify-lightdash/scripts/launch.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Attach to a healthy instance, or start one. Records whether this run owns teardown.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "$REPO_ROOT"
+
+RUN_ID="${VERIFY_RUN_ID:-$(date +%Y%m%dT%H%M%S)-$$}"
+EVIDENCE_DIR="${REPO_ROOT}/.cursor/skills/verify-lightdash/evidence/${RUN_ID}"
+mkdir -p "$EVIDENCE_DIR"
+
+if "$REPO_ROOT/.cursor/skills/verify-lightdash/scripts/doctor.sh"; then
+    eval "$("$REPO_ROOT/.cursor/skills/verify-lightdash/scripts/resolve-env.sh")"
+    echo "OWNED=0" > "${EVIDENCE_DIR}/run.env"
+    echo "ATTACHED=1" >> "${EVIDENCE_DIR}/run.env"
+    echo "VERIFY_RUN_ID=${RUN_ID}" >> "${EVIDENCE_DIR}/run.env"
+    echo "EVIDENCE_DIR=${EVIDENCE_DIR}" >> "${EVIDENCE_DIR}/run.env"
+    echo "LD_INSTANCE_ID=${LD_INSTANCE_ID:-unknown}" >> "${EVIDENCE_DIR}/run.env"
+    echo "FRONTEND_URL=${FRONTEND_URL}" >> "${EVIDENCE_DIR}/run.env"
+    echo "API_URL=${API_URL}" >> "${EVIDENCE_DIR}/run.env"
+    echo "VERIFY_URL_SOURCE=${VERIFY_URL_SOURCE:-unknown}" >> "${EVIDENCE_DIR}/run.env"
+    echo "AGENT_BROWSER_SESSION=ld-verify-${RUN_ID}" >> "${EVIDENCE_DIR}/run.env"
+    echo "ATTACHED existing healthy stack source=${VERIFY_URL_SOURCE} frontend=${FRONTEND_URL}; cleanup will not stop it."
+    echo "VERIFY_RUN_ID=${RUN_ID}"
+    echo "EVIDENCE_DIR=${EVIDENCE_DIR}"
+    exit 0
+fi
+
+echo "Doctor failed; starting ./scripts/dev-fast-start.sh (idempotent, can take several minutes)."
+./scripts/dev-fast-start.sh
+"$REPO_ROOT/.cursor/skills/verify-lightdash/scripts/doctor.sh" || {
+    echo "FAIL: stack still unhealthy after launch" >&2
+    exit 1
+}
+
+echo "OWNED=1" > "${EVIDENCE_DIR}/run.env"
+echo "ATTACHED=0" >> "${EVIDENCE_DIR}/run.env"
+echo "VERIFY_RUN_ID=${RUN_ID}" >> "${EVIDENCE_DIR}/run.env"
+echo "EVIDENCE_DIR=${EVIDENCE_DIR}" >> "${EVIDENCE_DIR}/run.env"
+eval "$(./scripts/dev-ports.sh env)"
+echo "LD_INSTANCE_ID=${LD_INSTANCE_ID}" >> "${EVIDENCE_DIR}/run.env"
+echo "AGENT_BROWSER_SESSION=ld-verify-${RUN_ID}" >> "${EVIDENCE_DIR}/run.env"
+echo "OWNED launch of ${LD_INSTANCE_ID}; cleanup will stop this instance's PM2 processes only."
+echo "VERIFY_RUN_ID=${RUN_ID}"
+echo "EVIDENCE_DIR=${EVIDENCE_DIR}"

--- a/.cursor/skills/verify-lightdash/scripts/resolve-env.sh
+++ b/.cursor/skills/verify-lightdash/scripts/resolve-env.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Print frontend/API URLs for a live Lightdash stack serving this checkout.
+# Prefers the claimed port slot; falls back to .env.development.local then 3000/8080.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+cd "$REPO_ROOT"
+
+probe() {
+    local api="$1" fe="$2"
+    local api_code fe_code
+    api_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 "${api}/api/v1/health" || true)"
+    fe_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 "${fe}/login" || true)"
+    [ "$api_code" = "200" ] && [ "$fe_code" = "200" ]
+}
+
+emit() {
+    local id="$1" api_port="$2" fe_port="$3" source="$4"
+    echo "export LD_INSTANCE_ID=${id}"
+    echo "export PORT=${api_port}"
+    echo "export FE_PORT=${fe_port}"
+    echo "export FRONTEND_URL=http://localhost:${fe_port}"
+    echo "export API_URL=http://localhost:${api_port}"
+    echo "export SITE_URL=http://localhost:${fe_port}"
+    echo "export VERIFY_URL_SOURCE=${source}"
+    echo "export SEED_EMAIL=demo@lightdash.com"
+    echo "export SEED_PASSWORD='demo_password!'"
+    echo "export SEED_PROJECT_UUID=3675b69e-8324-4110-bdca-059031aa8da3"
+    echo "export SEED_PROJECT_NAME='Jaffle shop'"
+}
+
+CLAIMED_ID=""
+if ENV_EXPORTS="$(./scripts/dev-ports.sh env 2>/dev/null)"; then
+    eval "$ENV_EXPORTS"
+    CLAIMED_ID="${LD_INSTANCE_ID:-}"
+    if probe "http://localhost:${PORT}" "http://localhost:${FE_PORT}"; then
+        emit "${LD_INSTANCE_ID}" "${PORT}" "${FE_PORT}" "claimed-slot"
+        exit 0
+    fi
+fi
+
+ENV_API=""
+ENV_FE=""
+if [ -f .env.development.local ]; then
+    ENV_API="$(grep -E '^PORT=' .env.development.local | head -1 | cut -d= -f2- || true)"
+    ENV_FE="$(grep -E '^FE_PORT=' .env.development.local | head -1 | cut -d= -f2- || true)"
+    ENV_ID="$(grep -E '^LD_INSTANCE_ID=' .env.development.local | head -1 | cut -d= -f2- || true)"
+    if [ -n "$ENV_API" ] && [ -n "$ENV_FE" ] && probe "http://localhost:${ENV_API}" "http://localhost:${ENV_FE}"; then
+        emit "${ENV_ID:-${CLAIMED_ID:-unknown}}" "$ENV_API" "$ENV_FE" "env-file"
+        exit 0
+    fi
+fi
+
+if probe "http://localhost:8080" "http://localhost:3000"; then
+    emit "${CLAIMED_ID:-lightdash}" "8080" "3000" "default-ports"
+    exit 0
+fi
+
+echo "FAIL: no healthy Lightdash UI+API. Tried claimed slot, .env.development.local, and http://localhost:3000 + :8080." >&2
+exit 1


### PR DESCRIPTION
## Summary
- Adds a project-local `verify-lightdash` skill so agents can attach to a live Vite+API stack and drive the UI as a user.
- Harness is **agent-browser** (`scripts/ab.sh`), with launch/doctor/cleanup helpers and a first feature map (login, home, explore, saved charts, dashboards).
- Home was proven against the seeded Jaffle project; run artifacts stay gitignored.

## Test plan
- [ ] From repo root, run `.cursor/skills/verify-lightdash/scripts/doctor.sh` against a healthy local app
- [ ] Follow `features/home.md` with `scripts/ab.sh` and a named `AGENT_BROWSER_SESSION`
- [ ] Confirm cleanup does not stop an attached (`OWNED=0`) stack and does not delete evidence

Relates: PROD-10507

Made with [Cursor](https://cursor.com)