### PR TITLE
feat(cli): add --dry-run to lightdash upload

### DIFF
--- a/docs/content-as-code.md
+++ b/docs/content-as-code.md
@@ -94,6 +94,10 @@ the resource returned by the backend.
 7. The backend returns a `CREATE`, `UPDATE`, or `NO_CHANGES` action.
 8. The CLI aggregates those actions and reports any per-file failures.
 
+`--dry-run` on upload discovers the same local files and prints which slugs
+would be uploaded, grouped by content type, without calling upsert APIs,
+writing files, or recording a last-applied snapshot.
+
 Sending resources individually is useful when files are independent. A bad
 file can fail without preventing valid sibling files from being processed. The
 backend still owns the transaction and atomicity of each individual resource.

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -137,6 +137,7 @@ const makeDownloadHandlerOptions = (
     stripPivotSeries: false,
     concurrency: 1,
     organization: false,
+    dryRun: false,
     ...overrides,
 });
 
@@ -1468,6 +1469,183 @@ describe('uploadHandler failures', () => {
                 }),
             ),
         ).rejects.toBe(fatalError);
+    });
+});
+
+describe('uploadHandler dry-run', () => {
+    let tmpDir: string;
+    let output: string[];
+
+    const writeProjectContent = async () => {
+        await fs.mkdir(path.join(tmpDir, 'spaces'), { recursive: true });
+        await fs.mkdir(path.join(tmpDir, 'charts'), { recursive: true });
+        await fs.mkdir(path.join(tmpDir, 'dashboards'), { recursive: true });
+        await fs.writeFile(
+            path.join(tmpDir, 'spaces', 'finance.space.yml'),
+            [
+                'contentType: space',
+                'version: 1',
+                'spaceName: Finance',
+                'slug: finance',
+                '',
+            ].join('\n'),
+        );
+        await fs.writeFile(
+            path.join(tmpDir, 'charts', 'orders.yml'),
+            [
+                'contentType: chart',
+                'name: Orders over time',
+                'slug: orders-over-time',
+                'spaceSlug: finance',
+                '',
+            ].join('\n'),
+        );
+        await fs.writeFile(
+            path.join(tmpDir, 'dashboards', 'weekly.yml'),
+            [
+                'contentType: dashboard',
+                'name: Weekly KPIs',
+                'slug: weekly-kpis',
+                'spaceSlug: finance',
+                'tiles: []',
+                'version: 1',
+                '',
+            ].join('\n'),
+        );
+    };
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'upload-dry-run-'));
+        output = [];
+        vi.spyOn(console, 'info').mockImplementation((message?: unknown) => {
+            output.push(String(message ?? ''));
+        });
+        vi.mocked(lightdashApi).mockReset(); // pragma: allowlist secret
+        vi.mocked(getContentAsCodeUploadPermissions).mockReset();
+        vi.mocked(lightdashApi).mockImplementation(async ({ method, url }) => { // pragma: allowlist secret
+            if (url.includes('/health')) {
+                return { version: '0.0.0' } as never;
+            }
+            throw new Error(`Unexpected API call: ${method} ${url}`);
+        });
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('accepts dryRun and prints slugs without calling upsert APIs', async () => {
+        await writeProjectContent();
+        const chartPath = path.join(tmpDir, 'charts', 'orders.yml');
+        const before = await fs.readFile(chartPath, 'utf-8');
+
+        await expect(
+            uploadHandler(
+                makeDownloadHandlerOptions({
+                    dryRun: true,
+                    path: tmpDir,
+                    project: 'project-uuid',
+                    skipSpaces: false,
+                    skipVirtualViews: true,
+                    skipAgents: true,
+                    skipAlerts: true,
+                    skipGoogleSheets: true,
+                    skipScheduledDeliveries: true,
+                    skipExternalConnections: true,
+                }),
+            ),
+        ).resolves.toBeUndefined();
+
+        const printed = output.join('\n');
+        expect(printed).toContain('Dry run — no changes will be made.');
+        expect(printed).toContain('would upload space finance');
+        expect(printed).toContain('would upload chart orders-over-time');
+        expect(printed).toContain('would upload dashboard weekly-kpis');
+        expect(printed).toContain(
+            'No files were written and no content was uploaded.',
+        );
+
+        const mutatingCalls = vi
+            .mocked(lightdashApi) // pragma: allowlist secret
+            .mock.calls.filter(([request]) => request.method !== 'GET');
+        expect(mutatingCalls).toEqual([]);
+        expect(getContentAsCodeUploadPermissions).not.toHaveBeenCalled();
+        await expect(fs.readFile(chartPath, 'utf-8')).resolves.toBe(before);
+    });
+
+    it('previews organization uploads without calling upsert APIs', async () => {
+        await fs.mkdir(path.join(tmpDir, 'custom-roles'), { recursive: true });
+        await fs.writeFile(
+            path.join(tmpDir, 'custom-roles', 'developer.yml'),
+            [
+                'version: 1',
+                'name: Developer view only',
+                'description: null',
+                'level: project',
+                'scopes:',
+                '  - view:Dashboard',
+                '',
+            ].join('\n'),
+        );
+
+        await expect(
+            uploadHandler(
+                makeDownloadHandlerOptions({
+                    dryRun: true,
+                    organization: true,
+                    path: tmpDir,
+                }),
+            ),
+        ).resolves.toBeUndefined();
+
+        expect(output.join('\n')).toContain(
+            'would upload custom role Developer view only',
+        );
+        expect(
+            vi
+                .mocked(lightdashApi) // pragma: allowlist secret
+                .mock.calls.filter(([request]) => request.method !== 'GET'),
+        ).toEqual([]);
+    });
+
+    it('still errors when conflicting flags are combined with dry-run', async () => {
+        await expect(
+            uploadHandler(
+                makeDownloadHandlerOptions({
+                    dryRun: true,
+                    spacesOnly: true,
+                    skipSpaces: true,
+                    project: 'project-uuid',
+                }),
+            ),
+        ).rejects.toThrow(
+            'Nothing to upload: --spaces-only cannot be combined with --skip-spaces.',
+        );
+        await expect(
+            uploadHandler(
+                makeDownloadHandlerOptions({
+                    dryRun: true,
+                    appsOnly: true,
+                    spacesOnly: true,
+                    skipSpaces: false,
+                    project: 'project-uuid',
+                }),
+            ),
+        ).rejects.toThrow('--apps-only cannot be combined with --spaces-only.');
+        await expect(
+            uploadHandler(
+                makeDownloadHandlerOptions({
+                    dryRun: true,
+                    appsOnly: true,
+                    charts: ['orders-over-time'],
+                    project: 'project-uuid',
+                }),
+            ),
+        ).rejects.toThrow(
+            '--apps-only cannot be combined with --charts or --dashboards.',
+        );
+        expect(vi.mocked(lightdashApi)).not.toHaveBeenCalled(); // pragma: allowlist secret
     });
 });
 

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -1522,7 +1522,8 @@ describe('uploadHandler dry-run', () => {
         });
         vi.mocked(lightdashApi).mockReset(); // pragma: allowlist secret
         vi.mocked(getContentAsCodeUploadPermissions).mockReset();
-        vi.mocked(lightdashApi).mockImplementation(async ({ method, url }) => { // pragma: allowlist secret
+        vi.mocked(lightdashApi).mockImplementation(async ({ method, url }) => {
+            // pragma: allowlist secret
             if (url.includes('/health')) {
                 return { version: '0.0.0' } as never;
             }

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -157,6 +157,12 @@ import {
     writeSpaceFiles,
     type SpaceCodeFile,
 } from './spacesAsCode';
+import {
+    collectOrganizationUploadPlan,
+    createUploadDryRunGroup,
+    printUploadDryRunPlan,
+    type UploadDryRunGroup,
+} from './uploadDryRun';
 
 export type DownloadHandlerOptions = {
     verbose: boolean;
@@ -208,6 +214,7 @@ export type DownloadHandlerOptions = {
     gzip?: boolean;
     organization: boolean;
     sendInvites?: boolean;
+    dryRun?: boolean;
 };
 
 type FolderScheme = 'flat' | 'nested';
@@ -3060,6 +3067,355 @@ const isFilteredWithNoDashboards = (
     dashboardSlugs: string[],
 ): boolean => hasFilters && dashboardSlugs.length === 0;
 
+const toUploadPlanItems = (
+    items: Array<{ slug: string; needsUpdating?: boolean }>,
+    force: boolean,
+): { slugs: string[]; unchangedSlugs: string[] } => {
+    const slugs: string[] = [];
+    const unchangedSlugs: string[] = [];
+    items.forEach((item) => {
+        if (!force && item.needsUpdating === false) {
+            unchangedSlugs.push(item.slug);
+            return;
+        }
+        slugs.push(item.slug);
+    });
+    return { slugs, unchangedSlugs };
+};
+
+const collectAppPlanSlugs = async ({
+    options,
+    hasFilters,
+    dashboardItems,
+}: {
+    options: DownloadHandlerOptions;
+    hasFilters: boolean;
+    dashboardItems: DashboardAsCode[];
+}): Promise<string[]> => {
+    const explicitAppReferences = Array.isArray(options.apps)
+        ? options.apps
+        : [];
+    const isExplicitAppSelection =
+        options.includeApps === true || explicitAppReferences.length > 0;
+    const autoPushAppSlugs = isFilteredWithNoDashboards(
+        hasFilters,
+        options.dashboards,
+    )
+        ? []
+        : selectDashboardAppSlugs(dashboardItems, options.dashboards);
+    if (!isExplicitAppSelection && autoPushAppSlugs.length === 0) {
+        return [];
+    }
+
+    const uploadFilter = isExplicitAppSelection
+        ? getDataAppUploadFilter(
+              explicitAppReferences,
+              options.includeApps === true,
+          )
+        : null;
+
+    const appsDir = path.join(getDownloadFolder(options.path), 'apps');
+    let appFolderEntries: Dirent[];
+    try {
+        appFolderEntries = await fs.readdir(appsDir, { withFileTypes: true });
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return [];
+        }
+        throw error;
+    }
+
+    const slugs: string[] = [];
+    for (const subDir of appFolderEntries.filter((entry) =>
+        entry.isDirectory(),
+    )) {
+        try {
+            const code = await readBundleFromDir(
+                path.join(appsDir, subDir.name),
+            );
+            const matchesFilter = uploadFilterMatches(
+                uploadFilter,
+                code.manifest,
+            );
+            const isAutoPushCandidate =
+                code.manifest.slug !== undefined &&
+                autoPushAppSlugs.includes(code.manifest.slug);
+            if (
+                matchesFilter &&
+                (isExplicitAppSelection || isAutoPushCandidate)
+            ) {
+                slugs.push(code.manifest.slug ?? subDir.name);
+            }
+        } catch {
+            slugs.push(subDir.name);
+        }
+    }
+    return slugs;
+};
+
+const collectProjectUploadPlan = async ({
+    options,
+    hasFilters,
+    shouldReconcileSpaces,
+    spaceFiles,
+}: {
+    options: DownloadHandlerOptions;
+    hasFilters: boolean;
+    shouldReconcileSpaces: boolean;
+    spaceFiles: SpaceCodeFile[];
+}): Promise<UploadDryRunGroup[]> => {
+    const groups: UploadDryRunGroup[] = [];
+    const pushGroup = (group: UploadDryRunGroup | null) => {
+        if (group !== null) {
+            groups.push(group);
+        }
+    };
+
+    if (shouldReconcileSpaces) {
+        pushGroup(
+            createUploadDryRunGroup({
+                label: 'Spaces',
+                singular: 'space',
+                slugs: spaceFiles.map(({ space }) => space.slug),
+            }),
+        );
+    }
+    if (options.spacesOnly) {
+        return groups;
+    }
+
+    const looseFiles = await readLooseCodeFiles(options.path);
+    let dashboardItemsPromise: Promise<DashboardAsCode[]> | undefined;
+    const loadDashboardItems = () => {
+        dashboardItemsPromise =
+            dashboardItemsPromise ??
+            readDashboardItems(options.path, looseFiles.dashboards);
+        return dashboardItemsPromise;
+    };
+
+    if (!options.skipVirtualViews) {
+        let virtualViewCandidates: string[] = [];
+        if (
+            options.includeVirtualViews === true &&
+            hasFilters &&
+            (options.charts.length > 0 || options.dashboards.length > 0)
+        ) {
+            virtualViewCandidates = selectVirtualViewCandidates({
+                chartItems: [
+                    ...(await readCodeFiles<ChartAsCode>(
+                        'charts',
+                        options.path,
+                    )),
+                    ...looseFiles.charts,
+                ],
+                chartSlugs: options.charts,
+                dashboardItems:
+                    options.dashboards.length > 0
+                        ? await loadDashboardItems()
+                        : [],
+                dashboardSlugs: options.dashboards,
+            });
+        }
+        if (
+            !(
+                hasFilters &&
+                options.virtualViews.length === 0 &&
+                virtualViewCandidates.length === 0
+            )
+        ) {
+            const virtualViews = await readVirtualViewFiles(options.path);
+            const candidateSet = new Set(virtualViewCandidates);
+            const selected =
+                options.virtualViews.length > 0 || candidateSet.size > 0
+                    ? virtualViews.filter(
+                          ({ slug }) =>
+                              options.virtualViews.includes(slug) ||
+                              candidateSet.has(slug),
+                      )
+                    : virtualViews;
+            pushGroup(
+                createUploadDryRunGroup({
+                    label: 'Virtual views',
+                    singular: 'virtual view',
+                    slugs: selected.map(({ slug }) => slug),
+                }),
+            );
+        }
+    }
+
+    if (
+        !options.skipExternalConnections &&
+        !(hasFilters && options.externalConnections.length === 0)
+    ) {
+        const connections = await readExternalConnectionFiles(options.path);
+        const selected = options.externalConnections.length
+            ? connections.filter(({ slug }) =>
+                  options.externalConnections.includes(slug),
+              )
+            : connections;
+        pushGroup(
+            createUploadDryRunGroup({
+                label: 'External connections',
+                singular: 'external connection',
+                slugs: selected.map(({ slug }) => slug),
+            }),
+        );
+    }
+
+    pushGroup(
+        createUploadDryRunGroup({
+            label: 'Data apps',
+            singular: 'data app',
+            slugs: await collectAppPlanSlugs({
+                options,
+                hasFilters,
+                dashboardItems: await loadDashboardItems(),
+            }),
+        }),
+    );
+
+    const chartSlugs = options.includeCharts
+        ? Array.from(
+              new Set([
+                  ...options.charts,
+                  ...selectDashboardChartSlugs(
+                      await loadDashboardItems(),
+                      options.dashboards,
+                  ),
+              ]),
+          )
+        : options.charts;
+    if (!(hasFilters && chartSlugs.length === 0)) {
+        const folderCharts = await readCodeFiles<ChartAsCode>(
+            'charts',
+            options.path,
+        );
+        const charts = [...folderCharts, ...looseFiles.charts];
+        const selectedCharts =
+            chartSlugs.length > 0
+                ? charts.filter((chart) => chartSlugs.includes(chart.slug))
+                : charts;
+        const savedCharts = selectedCharts.filter(
+            (chart) => !isSqlChartContent(chart),
+        );
+        const sqlCharts = selectedCharts.filter((chart) =>
+            isSqlChartContent(chart),
+        );
+        pushGroup(
+            createUploadDryRunGroup({
+                label: 'Charts',
+                singular: 'chart',
+                ...toUploadPlanItems(savedCharts, options.force),
+            }),
+        );
+        pushGroup(
+            createUploadDryRunGroup({
+                label: 'SQL charts',
+                singular: 'SQL chart',
+                ...toUploadPlanItems(sqlCharts, options.force),
+            }),
+        );
+    }
+
+    if (!(hasFilters && options.dashboards.length === 0)) {
+        const folderDashboards = await readCodeFiles<DashboardAsCode>(
+            'dashboards',
+            options.path,
+        );
+        const dashboards = [...folderDashboards, ...looseFiles.dashboards];
+        const selectedDashboards =
+            options.dashboards.length > 0
+                ? dashboards.filter((dashboard) =>
+                      options.dashboards.includes(dashboard.slug),
+                  )
+                : dashboards;
+        pushGroup(
+            createUploadDryRunGroup({
+                label: 'Dashboards',
+                singular: 'dashboard',
+                ...toUploadPlanItems(selectedDashboards, options.force),
+            }),
+        );
+    }
+
+    if (!options.skipAgents && !(hasFilters && options.agents.length === 0)) {
+        const agents = await readAiAgentFiles(options.path);
+        const selected = options.agents.length
+            ? agents.filter((agent) => options.agents.includes(agent.slug))
+            : agents;
+        pushGroup(
+            createUploadDryRunGroup({
+                label: 'AI agents',
+                singular: 'AI agent',
+                slugs: selected.map(({ slug }) => slug),
+            }),
+        );
+    }
+
+    if (!options.skipAlerts && !(hasFilters && options.alerts.length === 0)) {
+        const alerts = await readScheduledContentFiles(
+            ContentAsCodeTypeEnum.ALERT,
+            options.path,
+        );
+        const selected = options.alerts.length
+            ? alerts.filter((item) => options.alerts.includes(item.slug))
+            : alerts;
+        pushGroup(
+            createUploadDryRunGroup({
+                label: 'Alerts',
+                singular: 'alert',
+                slugs: selected.map(({ slug }) => slug),
+            }),
+        );
+    }
+
+    if (
+        !options.skipScheduledDeliveries &&
+        !(hasFilters && options.scheduledDeliveries.length === 0)
+    ) {
+        const deliveries = await readScheduledContentFiles(
+            ContentAsCodeTypeEnum.SCHEDULED_DELIVERY,
+            options.path,
+        );
+        const selected = options.scheduledDeliveries.length
+            ? deliveries.filter((item) =>
+                  options.scheduledDeliveries.includes(item.slug),
+              )
+            : deliveries;
+        pushGroup(
+            createUploadDryRunGroup({
+                label: 'Scheduled deliveries',
+                singular: 'scheduled delivery',
+                slugs: selected.map(({ slug }) => slug),
+            }),
+        );
+    }
+
+    if (
+        !options.skipGoogleSheets &&
+        !(hasFilters && options.googleSheets.length === 0)
+    ) {
+        const googleSheets = await readScheduledContentFiles(
+            ContentAsCodeTypeEnum.GOOGLE_SHEETS_SYNC,
+            options.path,
+        );
+        const selected = options.googleSheets.length
+            ? googleSheets.filter((item) =>
+                  options.googleSheets.includes(item.slug),
+              )
+            : googleSheets;
+        pushGroup(
+            createUploadDryRunGroup({
+                label: 'Google Sheets syncs',
+                singular: 'Google Sheets sync',
+                slugs: selected.map(({ slug }) => slug),
+            }),
+        );
+    }
+
+    return groups;
+};
+
 export const uploadHandler = async (
     options: DownloadHandlerOptions,
 ): Promise<void> => {
@@ -3119,6 +3475,12 @@ export const uploadHandler = async (
     }
 
     if (isOrganizationUpload) {
+        if (options.dryRun === true) {
+            printUploadDryRunPlan(
+                await collectOrganizationUploadPlan(options.path),
+            );
+            return;
+        }
         await uploadOrganizationContent({
             customPath: options.path,
             config,
@@ -3139,7 +3501,24 @@ export const uploadHandler = async (
     const projectId = projectSelection.projectUuid;
 
     // Log current project info
-    logSelectedProject(projectSelection, config, 'Uploading to');
+    logSelectedProject(
+        projectSelection,
+        config,
+        options.dryRun === true ? 'Previewing upload to' : 'Uploading to',
+    );
+
+    if (options.dryRun === true) {
+        // Skip upserts, file writes, and any last-applied snapshot PUT.
+        printUploadDryRunPlan(
+            await collectProjectUploadPlan({
+                options,
+                hasFilters,
+                shouldReconcileSpaces,
+                spaceFiles: preflightSpaceFiles,
+            }),
+        );
+        return;
+    }
 
     let changes: Record<string, number> = {};
     const counts: ProjectContentAsCodeCounts = {};
@@ -4056,6 +4435,7 @@ export const testHelpers = {
     shouldDownloadAiAgents,
     sortSpaceFilesParentFirst,
     summarizeUploadChanges,
+    collectProjectUploadPlan,
     upsertAiAgents,
     upsertExternalConnections,
     upsertSpaces,

--- a/packages/cli/src/handlers/uploadDryRun.test.ts
+++ b/packages/cli/src/handlers/uploadDryRun.test.ts
@@ -1,0 +1,142 @@
+import { Command } from 'commander';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    addUploadDryRunOption,
+    collectOrganizationUploadPlan,
+    createUploadDryRunGroup,
+    printUploadDryRunPlan,
+} from './uploadDryRun';
+
+describe('addUploadDryRunOption', () => {
+    it('accepts --dry-run', () => {
+        const command = new Command();
+        addUploadDryRunOption(command);
+        command.parse(['--dry-run'], { from: 'user' });
+
+        expect(command.opts().dryRun).toBe(true);
+    });
+
+    it('defaults --dry-run to false', () => {
+        const command = new Command();
+        addUploadDryRunOption(command);
+        command.parse([], { from: 'user' });
+
+        expect(command.opts().dryRun).toBe(false);
+    });
+});
+
+describe('createUploadDryRunGroup', () => {
+    it('omits empty groups and sorts slugs', () => {
+        expect(
+            createUploadDryRunGroup({
+                label: 'Charts',
+                singular: 'chart',
+                slugs: [],
+            }),
+        ).toBeNull();
+
+        expect(
+            createUploadDryRunGroup({
+                label: 'Charts',
+                singular: 'chart',
+                slugs: ['zeta', 'alpha'],
+                unchangedSlugs: ['unchanged-chart'],
+            }),
+        ).toEqual({
+            label: 'Charts',
+            singular: 'chart',
+            items: [
+                { slug: 'alpha', action: 'UPLOAD' },
+                { slug: 'zeta', action: 'UPLOAD' },
+                { slug: 'unchanged-chart', action: 'NO_CHANGES' },
+            ],
+        });
+    });
+});
+
+describe('printUploadDryRunPlan', () => {
+    let output: string[];
+
+    beforeEach(() => {
+        output = [];
+        vi.spyOn(console, 'info').mockImplementation((message?: unknown) => {
+            output.push(String(message ?? ''));
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('prints a grouped would-upload plan', () => {
+        printUploadDryRunPlan([
+            {
+                label: 'Charts',
+                singular: 'chart',
+                items: [
+                    { slug: 'orders-over-time', action: 'UPLOAD' },
+                    { slug: 'stale-chart', action: 'NO_CHANGES' },
+                ],
+            },
+        ]);
+
+        const printed = output.join('\n');
+        expect(printed).toContain('Dry run — no changes will be made.');
+        expect(printed).toContain('would upload chart orders-over-time');
+        expect(printed).toContain(
+            'would skip chart stale-chart (no local changes)',
+        );
+        expect(printed).toContain(
+            'No files were written and no content was uploaded.',
+        );
+    });
+
+    it('prints an empty plan', () => {
+        printUploadDryRunPlan([]);
+
+        const printed = output.join('\n');
+        expect(printed).toContain('Dry run — no changes will be made.');
+        expect(printed).toContain('Nothing would be uploaded.');
+    });
+});
+
+describe('collectOrganizationUploadPlan', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'org-upload-dry-run-'),
+        );
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('lists organization files without requiring an API', async () => {
+        await fs.mkdir(path.join(tmpDir, 'custom-roles'), { recursive: true });
+        await fs.writeFile(
+            path.join(tmpDir, 'custom-roles', 'developer.yml'),
+            [
+                'version: 1',
+                'name: Developer view only',
+                'description: null',
+                'level: project',
+                'scopes:',
+                '  - view:Dashboard',
+                '',
+            ].join('\n'),
+        );
+
+        await expect(collectOrganizationUploadPlan(tmpDir)).resolves.toEqual([
+            {
+                label: 'Custom roles',
+                singular: 'custom role',
+                items: [{ slug: 'Developer view only', action: 'UPLOAD' }],
+            },
+        ]);
+    });
+});

--- a/packages/cli/src/handlers/uploadDryRun.ts
+++ b/packages/cli/src/handlers/uploadDryRun.ts
@@ -1,0 +1,158 @@
+import { Command } from 'commander';
+import { promises as fs } from 'fs';
+import * as styles from '../styles';
+import {
+    assertCodeResourceFilesValid,
+    readCodeResourceFiles,
+} from './contentAsCode/resource';
+import { getDownloadFolder } from './contentAsCodePaths';
+import { CUSTOM_ROLE_CODE_RESOURCE } from './organizationContent/customRoles';
+import { GROUP_CODE_RESOURCE } from './organizationContent/groups';
+import { getThemesFolder } from './organizationContent/themePackage';
+import { USER_CODE_RESOURCE } from './organizationContent/users';
+
+export type UploadDryRunAction = 'UPLOAD' | 'NO_CHANGES';
+
+export type UploadDryRunItem = {
+    slug: string;
+    action: UploadDryRunAction;
+};
+
+export type UploadDryRunGroup = {
+    label: string;
+    singular: string;
+    items: UploadDryRunItem[];
+};
+
+export const addUploadDryRunOption = (command: Command): Command =>
+    command.option(
+        '--dry-run',
+        'Preview the upload without writing to the instance or recording a last-applied snapshot',
+        false,
+    );
+
+const toPlanItems = (
+    slugs: string[],
+    action: UploadDryRunAction = 'UPLOAD',
+): UploadDryRunItem[] =>
+    [...new Set(slugs)]
+        .sort((left, right) => left.localeCompare(right))
+        .map((slug) => ({ slug, action }));
+
+export const createUploadDryRunGroup = ({
+    label,
+    singular,
+    slugs,
+    unchangedSlugs = [],
+}: {
+    label: string;
+    singular: string;
+    slugs: string[];
+    unchangedSlugs?: string[];
+}): UploadDryRunGroup | null => {
+    const unchanged = new Set(unchangedSlugs);
+    const items = [
+        ...toPlanItems(
+            slugs.filter((slug) => !unchanged.has(slug)),
+            'UPLOAD',
+        ),
+        ...toPlanItems(unchangedSlugs, 'NO_CHANGES'),
+    ];
+    if (items.length === 0) {
+        return null;
+    }
+    return { label, singular, items };
+};
+
+export const printUploadDryRunPlan = (groups: UploadDryRunGroup[]): void => {
+    console.info(styles.success('Dry run — no changes will be made.'));
+    if (groups.length === 0) {
+        console.info(styles.secondary('Nothing would be uploaded.'));
+        return;
+    }
+
+    console.info('');
+    groups.forEach((group) => {
+        console.info(styles.bold(group.label));
+        group.items.forEach((item) => {
+            if (item.action === 'NO_CHANGES') {
+                console.info(
+                    `  would skip ${group.singular} ${item.slug} (no local changes)`,
+                );
+                return;
+            }
+            console.info(`  would upload ${group.singular} ${item.slug}`);
+        });
+        console.info('');
+    });
+    console.info(
+        styles.secondary('No files were written and no content was uploaded.'),
+    );
+};
+
+const readThemeSlugs = async (customPath?: string): Promise<string[]> => {
+    const themesFolder = getThemesFolder(getDownloadFolder(customPath));
+    try {
+        const entries = await fs.readdir(themesFolder, {
+            withFileTypes: true,
+        });
+        return entries
+            .filter(
+                (entry) => entry.isDirectory() && !entry.name.startsWith('.'),
+            )
+            .map((entry) => entry.name)
+            .sort((left, right) => left.localeCompare(right));
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return [];
+        }
+        throw error;
+    }
+};
+
+export const collectOrganizationUploadPlan = async (
+    customPath?: string,
+): Promise<UploadDryRunGroup[]> => {
+    const basePath = getDownloadFolder(customPath);
+
+    const customRoles = await readCodeResourceFiles({
+        definition: CUSTOM_ROLE_CODE_RESOURCE,
+        basePath,
+    });
+    assertCodeResourceFilesValid(customRoles);
+
+    const users = await readCodeResourceFiles({
+        definition: USER_CODE_RESOURCE,
+        basePath,
+    });
+    assertCodeResourceFilesValid(users);
+
+    const groups = await readCodeResourceFiles({
+        definition: GROUP_CODE_RESOURCE,
+        basePath,
+    });
+    assertCodeResourceFilesValid(groups);
+
+    return [
+        createUploadDryRunGroup({
+            label: 'Custom roles',
+            singular: 'custom role',
+            slugs: customRoles.files.map(({ document }) => document.name),
+        }),
+        createUploadDryRunGroup({
+            label: 'Users',
+            singular: 'user',
+            slugs: users.files.map(({ document }) => document.email),
+        }),
+        createUploadDryRunGroup({
+            label: 'Groups',
+            singular: 'group',
+            slugs: groups.files.map(({ document }) => document.name),
+        }),
+        createUploadDryRunGroup({
+            label: 'Themes',
+            singular: 'theme',
+            slugs: await readThemeSlugs(customPath),
+        }),
+    ].filter((group): group is UploadDryRunGroup => group !== null);
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,6 +55,7 @@ import { setWarehouseHandler } from './handlers/setWarehouse';
 import { slugUpdateHandler } from './handlers/slugUpdate';
 import { sqlHandler } from './handlers/sql';
 import { registerUpgradeCheckCommand } from './handlers/upgradeCheck';
+import { addUploadDryRunOption } from './handlers/uploadDryRun';
 import { validateHandler } from './handlers/validate';
 import { warehouseCatalogHandler } from './handlers/warehouseCatalog';
 import * as styles from './styles';
@@ -785,6 +786,7 @@ program
     .action(stopPreviewHandler);
 
 const ORGANIZATION_MODE_OPTIONS = new Set([
+    'dryRun',
     'organization',
     'path',
     'sendInvites',
@@ -1107,6 +1109,8 @@ const uploadCommand = program
         'send invitations to eligible pending users during organization upload',
         false,
     );
+
+addUploadDryRunOption(uploadCommand);
 
 uploadCommand.action(withOrganizationMode(uploadHandler));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: PROD-10510
Relates: PROD-2856

**PROD-2856 ship plan: wave 1 — protection.** Merge with 10507 → 10508. This is the deploy-safe preview; it does not change upload writes.

### Description:
Adds `--dry-run` to `lightdash upload` so operators can see what would be uploaded without writing to the instance or recording a last-applied snapshot.

- CLI-only: discovers the same files as a real upload, prints a plan, does not POST upserts
- Covered by CLI unit tests for the flag and the no-write path
- Documents the flag next to the existing upload help

Does not own the snapshot table or sync-status APIs (PROD-10507).

### Risk assessment:
- [ ] This is a high-risk change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8ccfc64-3e19-47b0-ba73-d713ac376003?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8ccfc64-3e19-47b0-ba73-d713ac376003&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

