### PR TITLE
fix(explorer): colorize the chart gallery icons and selection

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
@@ -80,19 +80,22 @@
     );
 }
 
-/* Selected reads like the join-type control's active segment: lifted under a
-   soft shadow with the hairline on the border, where the scroll viewport
-   cannot clip it. Light lifts onto the body surface; dark lifts a step past
-   the hover shade instead, since body sits level with the panel there — both
-   the join-type control and Mantine's segmented indicator go lighter in dark. */
+/* Selection owns the blue at full strength: accent border over a tint of the
+   same hue. Dark mixes the tint into the card surface explicitly so it reads
+   as a lit tile, never a darker cut-out. The hairline stays on the border,
+   where the scroll viewport cannot clip it. */
 .card[data-selected='true'] {
     border-color: light-dark(
-        var(--mantine-color-ldGray-3),
-        var(--mantine-color-ldGray-4)
+        var(--mantine-color-blue-5),
+        var(--mantine-color-blue-7)
     );
     background: light-dark(
-        var(--mantine-color-body),
-        var(--mantine-color-ldGray-2)
+        var(--mantine-color-blue-0),
+        color-mix(
+            in srgb,
+            var(--mantine-color-blue-9) 30%,
+            var(--mantine-color-ldDark-3)
+        )
     );
     box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
 }
@@ -128,6 +131,15 @@
     opacity: 0.5;
 }
 
+/* Resting glyphs stay gray; only selection earns the blue fill. */
+.card .icon {
+    color: var(--mantine-color-ldGray-7);
+}
+
+.card[data-selected='true'] .icon {
+    color: light-dark(var(--mantine-color-blue-7), var(--mantine-color-blue-4));
+}
+
 .thumbnail {
     display: grid;
     width: 86px;
@@ -142,6 +154,7 @@
         var(--mantine-color-ldGray-0),
         var(--mantine-color-ldDark-3)
     );
+    color: var(--mantine-color-ldGray-7);
 }
 
 .thumbnail[data-small='true'] {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -69,8 +69,7 @@ const ChartTypeIcon: FC<ChartTypeIconProps> = ({
         data-rotated={rotatedIcon}
         icon={icon}
         size={small ? 'md' : 'xl'}
-        stroke={1.5}
-        color="ldGray.7"
+        stroke={1.25}
     />
 );
 


### PR DESCRIPTION
Part of https://linear.app/lightdash/issue/GLITCH-680/embed-the-existing-chart-type-builder-in-explorer

Design feedback on the gray gallery pass: selection read too mute, but a first iteration that tinted every glyph with a blue chip read noisy. This layer keeps the resting grid gray and spends the blue only where it means something:

- **Selected card**: `blue-5` border over `blue-0` in light; in dark a `blue-7` border over a 30% `blue-9` `color-mix` into the card surface, so the selected card reads as a lit tile rather than a darker cut-out. The glyph fills blue to match (`blue-7` light / `blue-4` dark). The join-type gray-lift recipe from the previous layer is superseded here.
- **Resting cards** are untouched: gray surfaces, gray glyphs, gray hover deepen.
- **Stroke** thins from 1.5 to 1.25 on the chart glyphs.
- The create and "+N more" tiles stay gray; keeping everything else neutral is what lets blue mean "this is the chosen type".

Verified live in light and dark (Bar chart selected, project + built-in sections, create/more tiles). 21 gallery tests, typecheck, oxlint, oxfmt clean.

