### PR TITLE
feat: skip instance-ahead content on upload with content_as_code.sync

### DIFF
--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -562,18 +562,28 @@ export class ProjectCoderController extends BaseController {
     ): Promise<ApiChartAsCodeUpsertResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
+        // Options must not travel inside the document: the drift gate hashes
+        // it against the instance's canonical form.
+        const {
+            skipSpaceCreate,
+            publicSpaceCreate,
+            force,
+            spaceNames,
+            syncEnabled,
+            ...chartDoc
+        } = chart;
         return codeSuccess(
             await this.services.getCoderService().upsertChart(
                 toSessionUser(req.account),
                 projectUuid,
                 slug,
-                { ...chart, description: chart.description ?? undefined },
+                { ...chartDoc, description: chart.description ?? undefined },
                 {
-                    skipSpaceCreate: chart.skipSpaceCreate,
-                    publicSpaceCreate: chart.publicSpaceCreate,
-                    force: chart.force,
-                    spaceNames: chart.spaceNames,
-                    syncEnabled: chart.syncEnabled,
+                    skipSpaceCreate,
+                    publicSpaceCreate,
+                    force,
+                    spaceNames,
+                    syncEnabled,
                 },
             ),
         );
@@ -646,21 +656,31 @@ export class ProjectCoderController extends BaseController {
     ): Promise<ApiDashboardAsCodeUpsertResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
+        // Options must not travel inside the document: the drift gate hashes
+        // it against the instance's canonical form.
+        const {
+            skipSpaceCreate,
+            publicSpaceCreate,
+            force,
+            spaceNames,
+            syncEnabled,
+            ...dashboardDoc
+        } = dashboard;
         return codeSuccess(
             await this.services.getCoderService().upsertDashboard(
                 toSessionUser(req.account),
                 projectUuid,
                 slug,
                 {
-                    ...dashboard,
+                    ...dashboardDoc,
                     description: dashboard.description ?? undefined,
                 },
                 {
-                    skipSpaceCreate: dashboard.skipSpaceCreate,
-                    publicSpaceCreate: dashboard.publicSpaceCreate,
-                    force: dashboard.force,
-                    spaceNames: dashboard.spaceNames,
-                    syncEnabled: dashboard.syncEnabled,
+                    skipSpaceCreate,
+                    publicSpaceCreate,
+                    force,
+                    spaceNames,
+                    syncEnabled,
                 },
             ),
         );

--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -554,8 +554,7 @@ export class ProjectCoderController extends BaseController {
             publicSpaceCreate?: boolean;
             force?: boolean;
             spaceNames?: Record<string, string>;
-            syncEnforced?: boolean;
-            overwriteDrifted?: boolean;
+            syncEnabled?: boolean;
             chartConfig: AnyType;
             description?: string | null;
         },
@@ -574,8 +573,7 @@ export class ProjectCoderController extends BaseController {
                     publicSpaceCreate: chart.publicSpaceCreate,
                     force: chart.force,
                     spaceNames: chart.spaceNames,
-                    syncEnforced: chart.syncEnforced,
-                    overwriteDrifted: chart.overwriteDrifted,
+                    syncEnabled: chart.syncEnabled,
                 },
             ),
         );
@@ -640,8 +638,7 @@ export class ProjectCoderController extends BaseController {
             publicSpaceCreate?: boolean;
             force?: boolean;
             spaceNames?: Record<string, string>;
-            syncEnforced?: boolean;
-            overwriteDrifted?: boolean;
+            syncEnabled?: boolean;
             tiles: AnyType;
             description?: string | null;
         },
@@ -663,8 +660,7 @@ export class ProjectCoderController extends BaseController {
                     publicSpaceCreate: dashboard.publicSpaceCreate,
                     force: dashboard.force,
                     spaceNames: dashboard.spaceNames,
-                    syncEnforced: dashboard.syncEnforced,
-                    overwriteDrifted: dashboard.overwriteDrifted,
+                    syncEnabled: dashboard.syncEnabled,
                 },
             ),
         );

--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -554,6 +554,8 @@ export class ProjectCoderController extends BaseController {
             publicSpaceCreate?: boolean;
             force?: boolean;
             spaceNames?: Record<string, string>;
+            syncEnforced?: boolean;
+            overwriteDrifted?: boolean;
             chartConfig: AnyType;
             description?: string | null;
         },
@@ -572,6 +574,8 @@ export class ProjectCoderController extends BaseController {
                     publicSpaceCreate: chart.publicSpaceCreate,
                     force: chart.force,
                     spaceNames: chart.spaceNames,
+                    syncEnforced: chart.syncEnforced,
+                    overwriteDrifted: chart.overwriteDrifted,
                 },
             ),
         );
@@ -636,6 +640,8 @@ export class ProjectCoderController extends BaseController {
             publicSpaceCreate?: boolean;
             force?: boolean;
             spaceNames?: Record<string, string>;
+            syncEnforced?: boolean;
+            overwriteDrifted?: boolean;
             tiles: AnyType;
             description?: string | null;
         },
@@ -657,6 +663,8 @@ export class ProjectCoderController extends BaseController {
                     publicSpaceCreate: dashboard.publicSpaceCreate,
                     force: dashboard.force,
                     spaceNames: dashboard.spaceNames,
+                    syncEnforced: dashboard.syncEnforced,
+                    overwriteDrifted: dashboard.overwriteDrifted,
                 },
             ),
         );

--- a/packages/backend/src/models/ContentAsCodeSnapshotModel.ts
+++ b/packages/backend/src/models/ContentAsCodeSnapshotModel.ts
@@ -11,11 +11,37 @@ type ContentAsCodeSnapshotModelArguments = {
     database: Knex;
 };
 
+export type ContentAsCodeSnapshot = {
+    snapshot: object;
+    snapshotHash: string;
+    appliedAt: Date;
+};
+
 export class ContentAsCodeSnapshotModel {
     private readonly database: Knex;
 
     constructor({ database }: ContentAsCodeSnapshotModelArguments) {
         this.database = database;
+    }
+
+    async get(
+        projectUuid: string,
+        contentType: ContentAsCodeSnapshotType,
+        slug: string,
+    ): Promise<ContentAsCodeSnapshot | undefined> {
+        const row = await this.database(ContentAsCodeSnapshotsTableName)
+            .where({
+                project_uuid: projectUuid,
+                content_type: contentType,
+                slug,
+            })
+            .first();
+        if (row === undefined) return undefined;
+        return {
+            snapshot: row.snapshot,
+            snapshotHash: row.snapshot_hash,
+            appliedAt: row.applied_at,
+        };
     }
 
     async upsert({

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -19,6 +19,7 @@ import {
     ChartAsCode,
     ChartAsCodeConfig,
     ChartAsCodeInternalization,
+    ChartAsCodeUpsertResult,
     ChartConfig,
     ChartGoogleSheetsSyncAsCode,
     ChartScheduledDeliveryAsCode,
@@ -134,6 +135,9 @@ import {
 } from './chartPermissions';
 import {
     buildContentAsCodeSnapshot,
+    resolveDriftGate,
+    resolveDriftVerdict,
+    type DriftGateOutcome,
     type SnapshotAsCodeContent,
 } from './contentAsCodeSnapshot';
 import {
@@ -199,6 +203,9 @@ type UpsertContentAsCodeOptions = {
     // Gates snapshot recording: a project that never opts into sync has no
     // use for a last-applied baseline.
     syncEnabled?: boolean;
+    // content_as_code.sync in lightdash.config.yml: skip instance-ahead content
+    syncEnforced?: boolean;
+    overwriteDrifted?: boolean;
 };
 
 export class CoderService extends BaseService {
@@ -2808,6 +2815,103 @@ export class CoderService extends BaseService {
         });
     }
 
+    // The instance content in its canonical as-code form — the same document
+    // an upload of the current state would have applied.
+    private async getCurrentChartAsCode(
+        chartUuid: string,
+    ): Promise<ChartAsCode> {
+        const chart = await this.savedChartModel.get(chartUuid);
+        const spaces = await this.spaceModel.find({
+            spaceUuids: chart.spaceUuid ? [chart.spaceUuid] : [],
+        });
+        const dashboardSlugs = chart.dashboardUuid
+            ? await this.dashboardModel.getSlugsForUuids([chart.dashboardUuid])
+            : {};
+        const verificationMap =
+            await this.contentVerificationModel.getByContentUuids(
+                ContentType.CHART,
+                [chart.uuid],
+            );
+        return CoderService.transformChart(
+            chart,
+            spaces,
+            dashboardSlugs,
+            verificationMap,
+        );
+    }
+
+    private async getCurrentDashboardAsCode(
+        dashboardUuid: string,
+    ): Promise<DashboardAsCode> {
+        const dashboard =
+            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const spaces = await this.spaceModel.find({
+            spaceUuids: dashboard.spaceUuid ? [dashboard.spaceUuid] : [],
+        });
+        const verificationMap =
+            await this.contentVerificationModel.getByContentUuids(
+                ContentType.DASHBOARD,
+                [dashboard.uuid],
+            );
+        return CoderService.transformDashboard(
+            dashboard,
+            spaces,
+            verificationMap,
+        );
+    }
+
+    // Drift detection is best-effort: a failure here must not block uploads,
+    // so any error falls back to today's behavior (proceed, no gate).
+    private async runDriftGate(args: {
+        projectUuid: string;
+        contentType: ContentAsCodeSnapshotType;
+        slug: string;
+        getCurrentContent: () => Promise<SnapshotAsCodeContent>;
+        incomingContent: SnapshotAsCodeContent;
+        options: UpsertContentAsCodeOptions;
+    }): Promise<DriftGateOutcome | undefined> {
+        const {
+            projectUuid,
+            contentType,
+            slug,
+            getCurrentContent,
+            incomingContent,
+            options,
+        } = args;
+        try {
+            const currentContent = await getCurrentContent();
+            const lastApplied = await this.contentAsCodeSnapshotModel.get(
+                projectUuid,
+                contentType,
+                slug,
+            );
+            const verdict = resolveDriftVerdict({
+                currentHash:
+                    buildContentAsCodeSnapshot(currentContent).snapshotHash,
+                incomingHash:
+                    buildContentAsCodeSnapshot(incomingContent).snapshotHash,
+                lastAppliedHash: lastApplied?.snapshotHash ?? null,
+            });
+            return resolveDriftGate({
+                verdict,
+                contentType:
+                    contentType === ContentAsCodeType.DASHBOARD
+                        ? 'dashboard'
+                        : 'chart',
+                slug,
+                force: options.force,
+                syncEnforced: options.syncEnforced,
+                overwriteDrifted: options.overwriteDrifted,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Failed to evaluate as-code drift for ${contentType} ${slug} on project ${projectUuid}`,
+                error,
+            );
+            return undefined;
+        }
+    }
+
     // Snapshot stamping is bookkeeping for drift detection; it must never
     // fail an upload, so each stamp method swallows and logs its errors.
     // Recording only happens for repos that opted into content_as_code.sync
@@ -2820,29 +2924,10 @@ export class CoderService extends BaseService {
     ): Promise<void> {
         if (!syncEnabled) return;
         try {
-            const chart = await this.savedChartModel.get(chartUuid);
-            const spaces = await this.spaceModel.find({
-                spaceUuids: chart.spaceUuid ? [chart.spaceUuid] : [],
-            });
-            const dashboardSlugs = chart.dashboardUuid
-                ? await this.dashboardModel.getSlugsForUuids([
-                      chart.dashboardUuid,
-                  ])
-                : {};
-            const verificationMap =
-                await this.contentVerificationModel.getByContentUuids(
-                    ContentType.CHART,
-                    [chart.uuid],
-                );
             await this.recordAppliedSnapshot(
                 projectUuid,
                 ContentAsCodeType.CHART,
-                CoderService.transformChart(
-                    chart,
-                    spaces,
-                    dashboardSlugs,
-                    verificationMap,
-                ),
+                await this.getCurrentChartAsCode(chartUuid),
                 user.userUuid,
             );
         } catch (error) {
@@ -2861,24 +2946,10 @@ export class CoderService extends BaseService {
     ): Promise<void> {
         if (!syncEnabled) return;
         try {
-            const dashboard =
-                await this.dashboardModel.getByIdOrSlug(dashboardUuid);
-            const spaces = await this.spaceModel.find({
-                spaceUuids: dashboard.spaceUuid ? [dashboard.spaceUuid] : [],
-            });
-            const verificationMap =
-                await this.contentVerificationModel.getByContentUuids(
-                    ContentType.DASHBOARD,
-                    [dashboard.uuid],
-                );
             await this.recordAppliedSnapshot(
                 projectUuid,
                 ContentAsCodeType.DASHBOARD,
-                CoderService.transformDashboard(
-                    dashboard,
-                    spaces,
-                    verificationMap,
-                ),
+                await this.getCurrentDashboardAsCode(dashboardUuid),
                 user.userUuid,
             );
         } catch (error) {
@@ -2980,7 +3051,7 @@ export class CoderService extends BaseService {
         slug: string,
         chartAsCode: ChartAsCode,
         options: UpsertContentAsCodeOptions = {},
-    ) {
+    ): Promise<ChartAsCodeUpsertResult> {
         const {
             skipSpaceCreate,
             publicSpaceCreate,
@@ -3293,6 +3364,27 @@ export class CoderService extends BaseService {
             });
         }
 
+        const driftGate =
+            mode === 'upsert'
+                ? await this.runDriftGate({
+                      projectUuid,
+                      contentType: ContentAsCodeType.CHART,
+                      slug: chart.slug,
+                      getCurrentContent: () =>
+                          this.getCurrentChartAsCode(chart.uuid),
+                      incomingContent: chartWithDefaults,
+                      options,
+                  })
+                : undefined;
+        if (driftGate?.outcome === 'skip') {
+            return {
+                spaces: [],
+                charts: [],
+                dashboards: [],
+                skips: [driftGate.skip],
+            };
+        }
+
         const { promotedChart, upstreamChart } =
             await this.promoteService.getPromoteCharts(
                 user,
@@ -3329,6 +3421,38 @@ export class CoderService extends BaseService {
                 ),
             };
         }
+
+        // Instance already matches the incoming document: nothing to write,
+        // just realign the applied snapshot.
+        if (driftGate?.outcome === 'fast_forward') {
+            promotionChanges = {
+                ...promotionChanges,
+                charts: promotionChanges.charts.map((c) => ({
+                    ...c,
+                    action: PromotionAction.NO_CHANGES,
+                })),
+            };
+            await this.stampAppliedChartSnapshot(user, projectUuid, chart.uuid);
+            console.info(
+                `Fast-forwarded chart "${chartWithDefaults.name}" on project ${projectUuid}: instance already matches incoming content`,
+            );
+            return promotionChanges;
+        }
+
+        // The snapshot comparison replaces the updatedAt heuristic: past this
+        // point the incoming document differs from the instance, so it must
+        // be written even when updatedAt makes it look unchanged.
+        if (driftGate?.outcome === 'proceed') {
+            promotionChanges = {
+                ...promotionChanges,
+                charts: promotionChanges.charts.map((c) =>
+                    c.action === PromotionAction.NO_CHANGES
+                        ? { ...c, action: PromotionAction.UPDATE }
+                        : c,
+                ),
+            };
+        }
+
         promotionChanges = await this.promoteService.upsertCharts(
             user,
             promotionChanges,
@@ -3356,7 +3480,9 @@ export class CoderService extends BaseService {
             `Finished updating chart "${chartWithDefaults.name}" on project ${projectUuid}: ${promotionChanges.charts[0].action}`,
         );
 
-        return promotionChanges;
+        return driftGate?.outcome === 'proceed' && driftGate.driftWarning
+            ? { ...promotionChanges, driftWarnings: [driftGate.driftWarning] }
+            : promotionChanges;
     }
 
     async renameContentSlug(
@@ -4270,6 +4396,27 @@ export class CoderService extends BaseService {
             });
         }
 
+        const driftGate =
+            mode === 'upsert'
+                ? await this.runDriftGate({
+                      projectUuid,
+                      contentType: ContentAsCodeType.DASHBOARD,
+                      slug: dashboard.slug,
+                      getCurrentContent: () =>
+                          this.getCurrentDashboardAsCode(dashboard.uuid),
+                      incomingContent: dashboardWithDefaults,
+                      options,
+                  })
+                : undefined;
+        if (driftGate?.outcome === 'skip') {
+            return {
+                spaces: [],
+                charts: [],
+                dashboards: [],
+                skips: [driftGate.skip],
+            };
+        }
+
         const dashboardWithUuids = {
             ...dashboardWithResolvedTabs,
             tiles: tilesWithUuids,
@@ -4338,6 +4485,31 @@ export class CoderService extends BaseService {
         // DB rows, so a forced update writes an identical duplicate chart
         // version. Chart file changes are applied by the chart upload path.
 
+        // Instance already matches the incoming document: nothing to write,
+        // just realign the applied snapshot.
+        if (driftGate?.outcome === 'fast_forward') {
+            promotionChanges = {
+                ...promotionChanges,
+                dashboards: promotionChanges.dashboards.map((d) => ({
+                    ...d,
+                    action: PromotionAction.NO_CHANGES,
+                })),
+                charts: promotionChanges.charts.map((c) => ({
+                    ...c,
+                    action: PromotionAction.NO_CHANGES,
+                })),
+            };
+            await this.stampAppliedDashboardSnapshot(
+                user,
+                projectUuid,
+                dashboard.uuid,
+            );
+            console.info(
+                `Fast-forwarded dashboard "${dashboard.name}" on project ${projectUuid}: instance already matches incoming content`,
+            );
+            return withTileWarnings(promotionChanges, tileWarnings);
+        }
+
         promotionChanges = await this.promoteService.getOrCreateDashboard(
             user,
             promotionChanges,
@@ -4385,6 +4557,9 @@ export class CoderService extends BaseService {
         return withTileWarnings(promotionChanges, [
             ...tileWarnings,
             ...ownerWarnings,
+            ...(driftGate?.outcome === 'proceed' && driftGate.driftWarning
+                ? [driftGate.driftWarning]
+                : []),
         ]);
     }
 }

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -3338,27 +3338,8 @@ export class CoderService extends BaseService {
             });
         }
 
-        const { space } = await this.getOrCreateSpace(
-            projectUuid,
-            chartWithDefaults.spaceSlug,
-            user,
-            skipSpaceCreate,
-            undefined,
-            spaceNames,
-            allowSpaceCreate,
-        );
-        if (!canUploadAnyContent && space.uuid !== targetSpace?.uuid) {
-            await this.assertSpaceContentAccess({
-                userUuid: user.userUuid,
-                auditedAbility,
-                action: 'update',
-                subjectType: 'SavedChart',
-                spaceUuids: [space.uuid],
-                metadata: { savedChartUuid: chart.uuid },
-                errorMessage: `You don't have access to update chart "${slug}"`,
-            });
-        }
-
+        // Gate before getOrCreateSpace: a skipped upload must not create a
+        // space as a side effect (mirrors the dashboard path's ordering)
         const driftGate =
             mode === 'upsert' && options.syncEnabled
                 ? await this.runDriftGate({
@@ -3378,6 +3359,27 @@ export class CoderService extends BaseService {
                 dashboards: [],
                 skips: [driftGate.skip],
             };
+        }
+
+        const { space } = await this.getOrCreateSpace(
+            projectUuid,
+            chartWithDefaults.spaceSlug,
+            user,
+            skipSpaceCreate,
+            undefined,
+            spaceNames,
+            allowSpaceCreate,
+        );
+        if (!canUploadAnyContent && space.uuid !== targetSpace?.uuid) {
+            await this.assertSpaceContentAccess({
+                userUuid: user.userUuid,
+                auditedAbility,
+                action: 'update',
+                subjectType: 'SavedChart',
+                spaceUuids: [space.uuid],
+                metadata: { savedChartUuid: chart.uuid },
+                errorMessage: `You don't have access to update chart "${slug}"`,
+            });
         }
 
         const { promotedChart, upstreamChart } =

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -200,12 +200,9 @@ type UpsertContentAsCodeOptions = {
     spaceNames?: Record<string, string>;
     mode?: 'upsert' | 'create';
     // Mirrors content_as_code.sync from the caller's lightdash.config.yml.
-    // Gates snapshot recording: a project that never opts into sync has no
-    // use for a last-applied baseline.
+    // Gates the whole sync contract: snapshot recording and instance-ahead
+    // skip enforcement. Off means uploads behave as before the feature.
     syncEnabled?: boolean;
-    // content_as_code.sync in lightdash.config.yml: skip instance-ahead content
-    syncEnforced?: boolean;
-    overwriteDrifted?: boolean;
 };
 
 export class CoderService extends BaseService {
@@ -2900,8 +2897,6 @@ export class CoderService extends BaseService {
                         : 'chart',
                 slug,
                 force: options.force,
-                syncEnforced: options.syncEnforced,
-                overwriteDrifted: options.overwriteDrifted,
             });
         } catch (error) {
             this.logger.warn(
@@ -3365,7 +3360,7 @@ export class CoderService extends BaseService {
         }
 
         const driftGate =
-            mode === 'upsert'
+            mode === 'upsert' && options.syncEnabled
                 ? await this.runDriftGate({
                       projectUuid,
                       contentType: ContentAsCodeType.CHART,
@@ -3432,7 +3427,13 @@ export class CoderService extends BaseService {
                     action: PromotionAction.NO_CHANGES,
                 })),
             };
-            await this.stampAppliedChartSnapshot(user, projectUuid, chart.uuid);
+            // The gate only runs with sync enabled, so always restamp here
+            await this.stampAppliedChartSnapshot(
+                user,
+                projectUuid,
+                chart.uuid,
+                true,
+            );
             console.info(
                 `Fast-forwarded chart "${chartWithDefaults.name}" on project ${projectUuid}: instance already matches incoming content`,
             );
@@ -3480,9 +3481,7 @@ export class CoderService extends BaseService {
             `Finished updating chart "${chartWithDefaults.name}" on project ${projectUuid}: ${promotionChanges.charts[0].action}`,
         );
 
-        return driftGate?.outcome === 'proceed' && driftGate.driftWarning
-            ? { ...promotionChanges, driftWarnings: [driftGate.driftWarning] }
-            : promotionChanges;
+        return promotionChanges;
     }
 
     async renameContentSlug(
@@ -4397,7 +4396,7 @@ export class CoderService extends BaseService {
         }
 
         const driftGate =
-            mode === 'upsert'
+            mode === 'upsert' && options.syncEnabled
                 ? await this.runDriftGate({
                       projectUuid,
                       contentType: ContentAsCodeType.DASHBOARD,
@@ -4499,10 +4498,12 @@ export class CoderService extends BaseService {
                     action: PromotionAction.NO_CHANGES,
                 })),
             };
+            // The gate only runs with sync enabled, so always restamp here
             await this.stampAppliedDashboardSnapshot(
                 user,
                 projectUuid,
                 dashboard.uuid,
+                true,
             );
             console.info(
                 `Fast-forwarded dashboard "${dashboard.name}" on project ${projectUuid}: instance already matches incoming content`,
@@ -4557,9 +4558,6 @@ export class CoderService extends BaseService {
         return withTileWarnings(promotionChanges, [
             ...tileWarnings,
             ...ownerWarnings,
-            ...(driftGate?.outcome === 'proceed' && driftGate.driftWarning
-                ? [driftGate.driftWarning]
-                : []),
         ]);
     }
 }

--- a/packages/backend/src/services/CoderService/contentAsCodeSnapshot.test.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeSnapshot.test.ts
@@ -176,13 +176,6 @@ describe('resolveDriftGate', () => {
         expect(resolveDriftGate({ ...base, verdict: 'in_sync' })).toEqual({
             outcome: 'proceed',
         });
-        expect(
-            resolveDriftGate({
-                ...base,
-                verdict: 'in_sync',
-                syncEnforced: true,
-            }),
-        ).toEqual({ outcome: 'proceed' });
     });
 
     it('fast-forwards when instance matches incoming, unless forced', () => {
@@ -194,51 +187,33 @@ describe('resolveDriftGate', () => {
         ).toEqual({ outcome: 'proceed' });
     });
 
-    it.each(['ahead', 'no_marker'] as const)(
-        'skips %s content when sync is enforced',
-        (verdict) => {
-            const gate = resolveDriftGate({
-                ...base,
-                verdict,
-                syncEnforced: true,
+    it.each(['ahead', 'no_marker'] as const)('skips %s content', (verdict) => {
+        const gate = resolveDriftGate({ ...base, verdict });
+        expect(gate.outcome).toBe('skip');
+        if (gate.outcome === 'skip') {
+            expect(gate.skip).toMatchObject({
+                contentType: 'chart',
+                slug: 'monthly-revenue',
+                reason: ContentAsCodeSkipReason.SKIPPED_AHEAD,
             });
-            expect(gate.outcome).toBe('skip');
-            if (gate.outcome === 'skip') {
-                expect(gate.skip).toMatchObject({
-                    contentType: 'chart',
-                    slug: 'monthly-revenue',
-                    reason: ContentAsCodeSkipReason.SKIPPED_AHEAD,
-                });
-            }
-        },
-    );
+        }
+    });
 
-    it('force does not bypass the ahead skip; only --overwrite-drifted does', () => {
+    it('force does not bypass the ahead skip', () => {
         expect(
             resolveDriftGate({
                 ...base,
                 verdict: 'ahead',
-                syncEnforced: true,
                 force: true,
             }).outcome,
         ).toBe('skip');
-        const gate = resolveDriftGate({
-            ...base,
-            verdict: 'ahead',
-            syncEnforced: true,
-            overwriteDrifted: true,
-        });
-        expect(gate.outcome).toBe('proceed');
-        if (gate.outcome === 'proceed') {
-            expect(gate.driftWarning).toContain('--overwrite-drifted');
-        }
     });
 
-    it('proceeds with a warning when sync is not enforced', () => {
+    it('skip messages point at resolving in Lightdash, not a CLI override', () => {
         const gate = resolveDriftGate({ ...base, verdict: 'ahead' });
-        expect(gate.outcome).toBe('proceed');
-        if (gate.outcome === 'proceed') {
-            expect(gate.driftWarning).toContain('content_as_code.sync');
+        if (gate.outcome === 'skip') {
+            expect(gate.skip.message).toContain('Review the changes');
+            expect(gate.skip.message).not.toContain('--');
         }
     });
 });

--- a/packages/backend/src/services/CoderService/contentAsCodeSnapshot.test.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeSnapshot.test.ts
@@ -1,9 +1,14 @@
 import {
     ChartType,
+    ContentAsCodeSkipReason,
     ContentAsCodeType,
     type ChartAsCode,
 } from '@lightdash/common';
-import { buildContentAsCodeSnapshot } from './contentAsCodeSnapshot';
+import {
+    buildContentAsCodeSnapshot,
+    resolveDriftGate,
+    resolveDriftVerdict,
+} from './contentAsCodeSnapshot';
 
 const chartAsCode = (overrides: Partial<ChartAsCode> = {}): ChartAsCode =>
     ({
@@ -112,5 +117,128 @@ describe('buildContentAsCodeSnapshot', () => {
         expect(buildContentAsCodeSnapshot(withSorts).snapshotHash).not.toEqual(
             buildContentAsCodeSnapshot(reversedSorts).snapshotHash,
         );
+    });
+});
+
+describe('resolveDriftVerdict', () => {
+    it('is fast_forward when instance already matches incoming, marker or not', () => {
+        expect(
+            resolveDriftVerdict({
+                currentHash: 'aaa',
+                incomingHash: 'aaa',
+                lastAppliedHash: 'bbb',
+            }),
+        ).toBe('fast_forward');
+        expect(
+            resolveDriftVerdict({
+                currentHash: 'aaa',
+                incomingHash: 'aaa',
+                lastAppliedHash: null,
+            }),
+        ).toBe('fast_forward');
+    });
+
+    it('is no_marker when content was never uploaded and differs from incoming', () => {
+        expect(
+            resolveDriftVerdict({
+                currentHash: 'aaa',
+                incomingHash: 'bbb',
+                lastAppliedHash: null,
+            }),
+        ).toBe('no_marker');
+    });
+
+    it('is in_sync when instance matches the last upload', () => {
+        expect(
+            resolveDriftVerdict({
+                currentHash: 'aaa',
+                incomingHash: 'bbb',
+                lastAppliedHash: 'aaa',
+            }),
+        ).toBe('in_sync');
+    });
+
+    it('is ahead when instance differs from both', () => {
+        expect(
+            resolveDriftVerdict({
+                currentHash: 'aaa',
+                incomingHash: 'bbb',
+                lastAppliedHash: 'ccc',
+            }),
+        ).toBe('ahead');
+    });
+});
+
+describe('resolveDriftGate', () => {
+    const base = { contentType: 'chart' as const, slug: 'monthly-revenue' };
+
+    it('proceeds silently when in sync', () => {
+        expect(resolveDriftGate({ ...base, verdict: 'in_sync' })).toEqual({
+            outcome: 'proceed',
+        });
+        expect(
+            resolveDriftGate({
+                ...base,
+                verdict: 'in_sync',
+                syncEnforced: true,
+            }),
+        ).toEqual({ outcome: 'proceed' });
+    });
+
+    it('fast-forwards when instance matches incoming, unless forced', () => {
+        expect(resolveDriftGate({ ...base, verdict: 'fast_forward' })).toEqual({
+            outcome: 'fast_forward',
+        });
+        expect(
+            resolveDriftGate({ ...base, verdict: 'fast_forward', force: true }),
+        ).toEqual({ outcome: 'proceed' });
+    });
+
+    it.each(['ahead', 'no_marker'] as const)(
+        'skips %s content when sync is enforced',
+        (verdict) => {
+            const gate = resolveDriftGate({
+                ...base,
+                verdict,
+                syncEnforced: true,
+            });
+            expect(gate.outcome).toBe('skip');
+            if (gate.outcome === 'skip') {
+                expect(gate.skip).toMatchObject({
+                    contentType: 'chart',
+                    slug: 'monthly-revenue',
+                    reason: ContentAsCodeSkipReason.SKIPPED_AHEAD,
+                });
+            }
+        },
+    );
+
+    it('force does not bypass the ahead skip; only --overwrite-drifted does', () => {
+        expect(
+            resolveDriftGate({
+                ...base,
+                verdict: 'ahead',
+                syncEnforced: true,
+                force: true,
+            }).outcome,
+        ).toBe('skip');
+        const gate = resolveDriftGate({
+            ...base,
+            verdict: 'ahead',
+            syncEnforced: true,
+            overwriteDrifted: true,
+        });
+        expect(gate.outcome).toBe('proceed');
+        if (gate.outcome === 'proceed') {
+            expect(gate.driftWarning).toContain('--overwrite-drifted');
+        }
+    });
+
+    it('proceeds with a warning when sync is not enforced', () => {
+        const gate = resolveDriftGate({ ...base, verdict: 'ahead' });
+        expect(gate.outcome).toBe('proceed');
+        if (gate.outcome === 'proceed') {
+            expect(gate.driftWarning).toContain('content_as_code.sync');
+        }
     });
 });

--- a/packages/backend/src/services/CoderService/contentAsCodeSnapshot.test.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeSnapshot.test.ts
@@ -76,6 +76,20 @@ describe('buildContentAsCodeSnapshot', () => {
         );
     });
 
+    it('hashes identically when upload options ride the same body', () => {
+        const base = buildContentAsCodeSnapshot(chartAsCode());
+        const polluted = buildContentAsCodeSnapshot({
+            ...chartAsCode(),
+            needsUpdating: true,
+            skipSpaceCreate: false,
+            publicSpaceCreate: true,
+            force: true,
+            spaceNames: { finance: 'Finance' },
+            syncEnabled: true,
+        } as unknown as ChartAsCode);
+        expect(polluted.snapshotHash).toEqual(base.snapshotHash);
+    });
+
     it('hashes identically for different timestamps', () => {
         const first = buildContentAsCodeSnapshot(
             chartAsCode({ updatedAt: new Date('2026-01-01T00:00:00Z') }),

--- a/packages/backend/src/services/CoderService/contentAsCodeSnapshot.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeSnapshot.ts
@@ -1,5 +1,8 @@
 import {
+    assertUnreachable,
+    ContentAsCodeSkipReason,
     type ChartAsCode,
+    type ContentAsCodeSkip,
     type DashboardAsCode,
     type SqlChartAsCode,
 } from '@lightdash/common';
@@ -74,4 +77,85 @@ export const buildContentAsCodeSnapshot = (
         .update(JSON.stringify(snapshot))
         .digest('hex');
     return { snapshot, snapshotHash };
+};
+
+// How the instance content relates to the last-applied snapshot and the
+// incoming as-code document.
+export type ContentDriftVerdict =
+    | 'in_sync' // instance matches last-applied: safe to apply incoming
+    | 'fast_forward' // instance already matches incoming: just restamp
+    | 'no_marker' // content exists but was never uploaded: treat as ahead
+    | 'ahead'; // instance changed since last-applied: unsafe to overwrite
+
+export const resolveDriftVerdict = (args: {
+    currentHash: string;
+    incomingHash: string;
+    lastAppliedHash: string | null;
+}): ContentDriftVerdict => {
+    const { currentHash, incomingHash, lastAppliedHash } = args;
+    if (currentHash === incomingHash) return 'fast_forward';
+    if (lastAppliedHash === null) return 'no_marker';
+    if (currentHash === lastAppliedHash) return 'in_sync';
+    return 'ahead';
+};
+
+export type DriftGateOutcome =
+    | { outcome: 'proceed'; driftWarning?: string }
+    | { outcome: 'fast_forward' }
+    | { outcome: 'skip'; skip: ContentAsCodeSkip };
+
+export const resolveDriftGate = (args: {
+    verdict: ContentDriftVerdict;
+    contentType: 'chart' | 'dashboard';
+    slug: string;
+    force?: boolean;
+    syncEnforced?: boolean;
+    overwriteDrifted?: boolean;
+}): DriftGateOutcome => {
+    const {
+        verdict,
+        contentType,
+        slug,
+        force,
+        syncEnforced,
+        overwriteDrifted,
+    } = args;
+    switch (verdict) {
+        case 'in_sync':
+            return { outcome: 'proceed' };
+        case 'fast_forward':
+            // force means "upload even if unchanged", so it still applies
+            return force ? { outcome: 'proceed' } : { outcome: 'fast_forward' };
+        case 'ahead':
+        case 'no_marker': {
+            const label = contentType === 'chart' ? 'Chart' : 'Dashboard';
+            const cause =
+                verdict === 'ahead'
+                    ? `changed on the instance since the last upload`
+                    : `exists on the instance but has no record of a previous upload`;
+            if (overwriteDrifted) {
+                return {
+                    outcome: 'proceed',
+                    driftWarning: `${label} "${slug}" ${cause}; overwritten because --overwrite-drifted is set.`,
+                };
+            }
+            if (syncEnforced) {
+                return {
+                    outcome: 'skip',
+                    skip: {
+                        contentType,
+                        slug,
+                        reason: ContentAsCodeSkipReason.SKIPPED_AHEAD,
+                        message: `${label} "${slug}" ${cause}; skipped to avoid overwriting instance changes. Use --overwrite-drifted to make git win.`,
+                    },
+                };
+            }
+            return {
+                outcome: 'proceed',
+                driftWarning: `${label} "${slug}" ${cause} and was overwritten. Set content_as_code.sync: true in lightdash.config.yml to protect instance changes.`,
+            };
+        }
+        default:
+            return assertUnreachable(verdict, 'Unknown drift verdict');
+    }
 };

--- a/packages/backend/src/services/CoderService/contentAsCodeSnapshot.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeSnapshot.ts
@@ -100,26 +100,19 @@ export const resolveDriftVerdict = (args: {
 };
 
 export type DriftGateOutcome =
-    | { outcome: 'proceed'; driftWarning?: string }
+    | { outcome: 'proceed' }
     | { outcome: 'fast_forward' }
     | { outcome: 'skip'; skip: ContentAsCodeSkip };
 
+// Only evaluated for repos with content_as_code.sync enabled; without sync
+// there is no snapshot baseline, so uploads apply unconditionally.
 export const resolveDriftGate = (args: {
     verdict: ContentDriftVerdict;
     contentType: 'chart' | 'dashboard';
     slug: string;
     force?: boolean;
-    syncEnforced?: boolean;
-    overwriteDrifted?: boolean;
 }): DriftGateOutcome => {
-    const {
-        verdict,
-        contentType,
-        slug,
-        force,
-        syncEnforced,
-        overwriteDrifted,
-    } = args;
+    const { verdict, contentType, slug, force } = args;
     switch (verdict) {
         case 'in_sync':
             return { outcome: 'proceed' };
@@ -133,26 +126,14 @@ export const resolveDriftGate = (args: {
                 verdict === 'ahead'
                     ? `changed in the Lightdash project since the last upload`
                     : `exists in the Lightdash project but has no record of a previous upload`;
-            if (overwriteDrifted) {
-                return {
-                    outcome: 'proceed',
-                    driftWarning: `${label} "${slug}" ${cause}; overwritten because --overwrite-drifted is set.`,
-                };
-            }
-            if (syncEnforced) {
-                return {
-                    outcome: 'skip',
-                    skip: {
-                        contentType,
-                        slug,
-                        reason: ContentAsCodeSkipReason.SKIPPED_AHEAD,
-                        message: `${label} "${slug}" ${cause}; skipped to avoid overwriting those changes. Use --overwrite-drifted to make git win.`,
-                    },
-                };
-            }
             return {
-                outcome: 'proceed',
-                driftWarning: `${label} "${slug}" ${cause} and was overwritten. Set content_as_code.sync: true in lightdash.config.yml to protect changes made in Lightdash.`,
+                outcome: 'skip',
+                skip: {
+                    contentType,
+                    slug,
+                    reason: ContentAsCodeSkipReason.SKIPPED_AHEAD,
+                    message: `${label} "${slug}" ${cause}; skipped to avoid overwriting those changes. Review the changes in Lightdash and propose them to git, or update the file to match the Lightdash project.`,
+                },
             };
         }
         default:

--- a/packages/backend/src/services/CoderService/contentAsCodeSnapshot.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeSnapshot.ts
@@ -22,11 +22,21 @@ type CanonicalJsonValue =
     | { [key: string]: CanonicalJsonValue };
 
 // updatedAt/downloadedAt are transport metadata and verification is runtime
-// instance state; the snapshot records only the declarative document.
+// instance state; the snapshot records only the declarative document. The
+// remaining keys are upload options and CLI bookkeeping that ride the same
+// POST body as the document — the controller strips them, but hashing must
+// stay correct for any direct API caller too, or fast_forward/in_sync
+// verdicts become unreachable and every upload reads as drifted.
 const STRIPPED_KEYS: ReadonlySet<string> = new Set([
     'updatedAt',
     'downloadedAt',
     'verification',
+    'needsUpdating',
+    'skipSpaceCreate',
+    'publicSpaceCreate',
+    'force',
+    'spaceNames',
+    'syncEnabled',
 ]);
 
 // Deep-sorts keys, drops undefined values, and serialises dates so that

--- a/packages/backend/src/services/CoderService/contentAsCodeSnapshot.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeSnapshot.ts
@@ -131,8 +131,8 @@ export const resolveDriftGate = (args: {
             const label = contentType === 'chart' ? 'Chart' : 'Dashboard';
             const cause =
                 verdict === 'ahead'
-                    ? `changed on the instance since the last upload`
-                    : `exists on the instance but has no record of a previous upload`;
+                    ? `changed in the Lightdash project since the last upload`
+                    : `exists in the Lightdash project but has no record of a previous upload`;
             if (overwriteDrifted) {
                 return {
                     outcome: 'proceed',
@@ -146,13 +146,13 @@ export const resolveDriftGate = (args: {
                         contentType,
                         slug,
                         reason: ContentAsCodeSkipReason.SKIPPED_AHEAD,
-                        message: `${label} "${slug}" ${cause}; skipped to avoid overwriting instance changes. Use --overwrite-drifted to make git win.`,
+                        message: `${label} "${slug}" ${cause}; skipped to avoid overwriting those changes. Use --overwrite-drifted to make git win.`,
                     },
                 };
             }
             return {
                 outcome: 'proceed',
-                driftWarning: `${label} "${slug}" ${cause} and was overwritten. Set content_as_code.sync: true in lightdash.config.yml to protect instance changes.`,
+                driftWarning: `${label} "${slug}" ${cause} and was overwritten. Set content_as_code.sync: true in lightdash.config.yml to protect changes made in Lightdash.`,
             };
         }
         default:

--- a/packages/cli/src/handlers/contentDiff.test.ts
+++ b/packages/cli/src/handlers/contentDiff.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { renderContentDiff } from './contentDiff';
+
+// eslint-disable-next-line no-control-regex
+const strip = (s: string) => s.replace(/\[[0-9;]*m/g, '');
+
+describe('renderContentDiff', () => {
+    it('returns empty for identical documents (transport fields ignored)', () => {
+        const doc = { name: 'A', slug: 'a', metricQuery: { limit: 500 } };
+        expect(
+            renderContentDiff(
+                { ...doc, updatedAt: new Date('2026-01-01') },
+                { ...doc, downloadedAt: new Date('2026-02-02') },
+                { current: 'instance', incoming: 'git' },
+            ),
+        ).toBe('');
+    });
+
+    it('shows removed instance lines and added git lines with context', () => {
+        const current = {
+            name: 'A',
+            slug: 'a',
+            description: 'edited on the instance',
+            metricQuery: { limit: 500 },
+        };
+        const incoming = {
+            name: 'A',
+            slug: 'a',
+            description: 'what git wants',
+            metricQuery: { limit: 500 },
+        };
+        const out = strip(
+            renderContentDiff(current, incoming, {
+                current: 'instance (current)',
+                incoming: 'git (this upload)',
+            }),
+        );
+        expect(out).toContain('--- instance (current)');
+        expect(out).toContain('+++ git (this upload)');
+        expect(out).toContain('- description: edited on the instance');
+        expect(out).toContain('+ description: what git wants');
+        expect(out).toContain('metricQuery:');
+    });
+
+    it('truncates very large diffs', () => {
+        const current = Object.fromEntries(
+            Array.from({ length: 120 }, (_, i) => [`key${i}`, 'old']),
+        );
+        const incoming = Object.fromEntries(
+            Array.from({ length: 120 }, (_, i) => [`key${i}`, 'new']),
+        );
+        const out = strip(
+            renderContentDiff(current, incoming, {
+                current: 'instance',
+                incoming: 'git',
+            }),
+        );
+        expect(out).toContain('more changed lines');
+    });
+});

--- a/packages/cli/src/handlers/contentDiff.test.ts
+++ b/packages/cli/src/handlers/contentDiff.test.ts
@@ -31,11 +31,11 @@ describe('renderContentDiff', () => {
         };
         const out = strip(
             renderContentDiff(current, incoming, {
-                current: 'instance (current)',
+                current: 'project (current)',
                 incoming: 'git (this upload)',
             }),
         );
-        expect(out).toContain('--- instance (current)');
+        expect(out).toContain('--- project (current)');
         expect(out).toContain('+++ git (this upload)');
         expect(out).toContain('- description: edited on the instance');
         expect(out).toContain('+ description: what git wants');

--- a/packages/cli/src/handlers/contentDiff.ts
+++ b/packages/cli/src/handlers/contentDiff.ts
@@ -1,0 +1,112 @@
+import * as yaml from 'js-yaml';
+import * as styles from '../styles';
+
+// Longest-common-subsequence line diff; small documents only (as-code YAML),
+// so the quadratic table is fine and avoids a runtime dependency.
+const diffLines = (
+    oldLines: string[],
+    newLines: string[],
+): { sign: '-' | '+' | ' '; line: string }[] => {
+    const n = oldLines.length;
+    const m = newLines.length;
+    const lcs: number[][] = Array.from({ length: n + 1 }, () =>
+        new Array<number>(m + 1).fill(0),
+    );
+    for (let i = n - 1; i >= 0; i -= 1) {
+        for (let j = m - 1; j >= 0; j -= 1) {
+            lcs[i][j] =
+                oldLines[i] === newLines[j]
+                    ? lcs[i + 1][j + 1] + 1
+                    : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+        }
+    }
+    const out: { sign: '-' | '+' | ' '; line: string }[] = [];
+    let i = 0;
+    let j = 0;
+    while (i < n && j < m) {
+        if (oldLines[i] === newLines[j]) {
+            out.push({ sign: ' ', line: oldLines[i] });
+            i += 1;
+            j += 1;
+        } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+            out.push({ sign: '-', line: oldLines[i] });
+            i += 1;
+        } else {
+            out.push({ sign: '+', line: newLines[j] });
+            j += 1;
+        }
+    }
+    while (i < n) {
+        out.push({ sign: '-', line: oldLines[i] });
+        i += 1;
+    }
+    while (j < m) {
+        out.push({ sign: '+', line: newLines[j] });
+        j += 1;
+    }
+    return out;
+};
+
+const CONTEXT_LINES = 2;
+const MAX_DIFF_LINES = 60;
+
+/**
+ * Unified-style diff of two as-code documents, changed hunks with a little
+ * context. Empty string when the rendered documents are identical.
+ */
+export const renderContentDiff = (
+    currentDoc: object,
+    incomingDoc: object,
+    labels: { current: string; incoming: string },
+): string => {
+    const dump = (doc: object) => {
+        const { updatedAt, downloadedAt, needsUpdating, ...clean } =
+            doc as Record<string, unknown>;
+        return yaml.dump(clean, { quotingType: '"', sortKeys: true });
+    };
+    const entries = diffLines(
+        dump(currentDoc).split('\n'),
+        dump(incomingDoc).split('\n'),
+    );
+    if (!entries.some((entry) => entry.sign !== ' ')) return '';
+
+    const keep = new Set<number>();
+    entries.forEach((entry, index) => {
+        if (entry.sign === ' ') return;
+        for (
+            let k = Math.max(0, index - CONTEXT_LINES);
+            k <= Math.min(entries.length - 1, index + CONTEXT_LINES);
+            k += 1
+        ) {
+            keep.add(k);
+        }
+    });
+
+    const lines: string[] = [
+        styles.error(`    --- ${labels.current}`),
+        styles.success(`    +++ ${labels.incoming}`),
+    ];
+    let truncated = 0;
+    let lastPrinted = -1;
+    Array.from(keep)
+        .sort((a, b) => a - b)
+        .forEach((index) => {
+            if (lines.length - 2 >= MAX_DIFF_LINES) {
+                truncated += 1;
+                return;
+            }
+            if (lastPrinted !== -1 && index > lastPrinted + 1) {
+                lines.push(styles.secondary('    ⋮'));
+            }
+            lastPrinted = index;
+            const { sign, line } = entries[index];
+            const text = `    ${sign} ${line}`;
+            if (sign === '-') lines.push(styles.error(text));
+            else if (sign === '+') lines.push(styles.success(text));
+            else lines.push(styles.secondary(text));
+        });
+    if (truncated > 0) {
+        lines.push(styles.secondary(`    … ${truncated} more changed lines`));
+    }
+    return lines.join('\n');
+};

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -4522,7 +4522,6 @@ export const uploadHandler = async (
                     concurrency,
                     looseFiles.charts,
                     spaceNames,
-                    spaceNames,
                     undefined,
                     syncEnabled,
                 );
@@ -4578,7 +4577,6 @@ export const uploadHandler = async (
                     options.validate,
                     concurrency,
                     looseFiles.dashboards,
-                    spaceNames,
                     spaceNames,
                     dashboardsToSkip,
                     syncEnabled,

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -48,6 +48,7 @@ import {
     SqlChartAsCode,
     validateDataAppDependencies,
     VirtualViewAsCode,
+    type AnyType,
     type DashboardAsCodeUpsertResult,
     type DataAppCodeDownload,
     type SpaceAsCode,
@@ -124,6 +125,7 @@ import {
     type CodeResourceDefinition,
 } from './contentAsCode/resource';
 import { getDownloadFolder } from './contentAsCodePaths';
+import { renderContentDiff } from './contentDiff';
 import {
     checkLightdashVersion,
     getContentAsCodeUploadPermissions,
@@ -2999,6 +3001,35 @@ const runUploadChangesPhase = async ({
     return updatedChanges;
 };
 
+// Decorates a SKIPPED_AHEAD message with what actually differs: the
+// instance's current document vs what this upload wanted to apply.
+const printSkipDiff = async (
+    item: ChartAsCode | DashboardAsCode,
+    type: 'charts' | 'dashboards',
+    projectId: string,
+): Promise<void> => {
+    try {
+        const listData = await lightdashApi<AnyType>({
+            method: 'GET',
+            url: `/api/v1/projects/${projectId}/code/${type}?ids=${encodeURIComponent(
+                item.slug,
+            )}`,
+            body: undefined,
+        });
+        const current = (
+            type === 'charts' ? listData?.charts : listData?.dashboards
+        )?.[0];
+        if (!current) return;
+        const diff = renderContentDiff(current, item, {
+            current: 'instance (current)',
+            incoming: 'git (this upload)',
+        });
+        if (diff) GlobalState.log(diff);
+    } catch {
+        // The diff is best-effort decoration on the skip message
+    }
+};
+
 type UploadSyncOptions = {
     syncEnforced?: boolean;
     overwriteDrifted?: boolean;
@@ -3059,6 +3090,7 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
             upsertData.skips.forEach((skip) => {
                 GlobalState.log(styles.error(`  ✖ ${skip.message}`));
             });
+            await printSkipDiff(item, type, projectId);
             changes[`${type} skipped (instance ahead)`] =
                 (changes[`${type} skipped (instance ahead)`] ?? 0) +
                 upsertData.skips.length;

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -66,6 +66,7 @@ import {
 import { getConfig, setAnswer } from '../config';
 import { CLI_VERSION } from '../env';
 import GlobalState from '../globalState';
+import { readAndLoadLightdashProjectConfig } from '../lightdash-config';
 import * as styles from '../styles';
 import {
     createContentAsCodeOutput,
@@ -210,6 +211,7 @@ export type DownloadHandlerOptions = {
     chartTypesOnly?: boolean; // download: implies skipCharts + skipDashboards + skipSpaces; upload: chart-types-only filtered run
     stripPivotSeries: boolean; // Strip per-value pivot series config for portable chart YAML
     validate?: boolean; // Validate charts and dashboards after upload
+    overwriteDrifted?: boolean; // Upload only: overwrite content the instance is ahead on (git wins)
     concurrency: number;
     gzip?: boolean;
     organization: boolean;
@@ -2926,6 +2928,7 @@ const UPLOAD_CHANGE_SUFFIXES = [
     'created',
     'updated',
     'deleted',
+    'skipped (instance ahead)',
     'skipped',
     'failed',
 ] as const;
@@ -2959,7 +2962,10 @@ const summarizeUploadChanges = (
         .map(([label, total]) => `${total} ${label}`)
         .join(', ');
     const hasFailures = [...totals.keys()].some(
-        (label) => label === 'with errors' || label === 'failed',
+        (label) =>
+            label === 'with errors' ||
+            label === 'failed' ||
+            label === 'skipped (instance ahead)',
     );
     return { detail, variant: hasFailures ? 'warning' : undefined };
 };
@@ -2993,6 +2999,11 @@ const runUploadChangesPhase = async ({
     return updatedChanges;
 };
 
+type UploadSyncOptions = {
+    syncEnforced?: boolean;
+    overwriteDrifted?: boolean;
+};
+
 const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
     item: T & { needsUpdating: boolean },
     type: 'charts' | 'dashboards',
@@ -3004,6 +3015,8 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
     publicSpaceCreate?: boolean,
     validate?: boolean,
     spaceNames?: Record<string, string>,
+    spaceNames?: Record<string, string>,
+    syncOptions?: UploadSyncOptions,
 ): Promise<'upserted' | 'skipped' | 'failed'> => {
     try {
         if (!force && !item.needsUpdating) {
@@ -3032,13 +3045,31 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
                 skipSpaceCreate,
                 publicSpaceCreate,
                 force,
+                // The sqlCharts route doesn't support drift detection yet
+                ...(!isSqlChartItem && {
+                    syncEnforced: syncOptions?.syncEnforced,
+                    overwriteDrifted: syncOptions?.overwriteDrifted,
+                }),
                 ...(spaceNames &&
                     Object.keys(spaceNames).length > 0 && { spaceNames }),
             }),
         });
 
+        if (upsertData.skips && upsertData.skips.length > 0) {
+            upsertData.skips.forEach((skip) => {
+                GlobalState.log(styles.error(`  ✖ ${skip.message}`));
+            });
+            changes[`${type} skipped (instance ahead)`] =
+                (changes[`${type} skipped (instance ahead)`] ?? 0) +
+                upsertData.skips.length;
+            return 'skipped';
+        }
+        (upsertData.driftWarnings ?? []).forEach((warning) =>
+            GlobalState.log(styles.warning(`  ⚠ ${warning}`)),
+        );
+
         GlobalState.debug(
-            `${type} "${item.name}": ${upsertData[type]?.[0].action}`,
+            `${type} "${item.name}": ${upsertData[type]?.[0]?.action}`,
         );
         (upsertData.warnings ?? []).forEach((warning) =>
             GlobalState.log(styles.warning(`  ⚠ ${item.slug}: ${warning}`)),
@@ -3180,7 +3211,9 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
     concurrency: number = 1,
     extraItems: (T & { needsUpdating: boolean })[] = [],
     spaceNames?: Record<string, string>,
+    spaceNames?: Record<string, string>,
     skipSlugs?: ReadonlySet<string>,
+    syncOptions?: UploadSyncOptions,
 ): Promise<{
     changes: Record<string, number>;
     total: number;
@@ -3265,6 +3298,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 publicSpaceCreate,
                 validate,
                 spaceNames,
+                syncOptions,
             );
             trackOutcome(item, outcome);
         }
@@ -3348,6 +3382,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 publicSpaceCreate,
                 validate,
                 spaceNames,
+                syncOptions,
             );
             trackOutcome(item, outcome);
         }
@@ -3368,6 +3403,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                         publicSpaceCreate,
                         validate,
                         spaceNames,
+                        syncOptions,
                     );
                     trackOutcome(item, outcome);
                 }),
@@ -3606,6 +3642,17 @@ export const uploadHandler = async (
 
     // Log current project info
     logSelectedProject(projectSelection, config, 'Uploading to');
+
+    // content_as_code.sync in lightdash.config.yml opts this repo into
+    // instance-ahead protection; the flag travels with the repo like force.
+    const projectConfig = await readAndLoadLightdashProjectConfig(
+        process.cwd(),
+        projectId,
+    );
+    const syncOptions: UploadSyncOptions = {
+        syncEnforced: projectConfig.content_as_code?.sync === true,
+        overwriteDrifted: options.overwriteDrifted === true,
+    };
 
     let changes: Record<string, number> = {};
     const counts: ProjectContentAsCodeCounts = {};
@@ -4440,6 +4487,8 @@ export const uploadHandler = async (
                     concurrency,
                     looseFiles.charts,
                     spaceNames,
+                    undefined,
+                    syncOptions,
                 );
                 result.failedSlugs.forEach((slug) =>
                     failedChartSlugs.add(slug),
@@ -4495,6 +4544,7 @@ export const uploadHandler = async (
                     looseFiles.dashboards,
                     spaceNames,
                     dashboardsToSkip,
+                    syncOptions,
                 );
                 counts.dashboardsNum = result.total;
                 return result.changes;
@@ -4628,6 +4678,18 @@ export const uploadHandler = async (
                 timeToCompleted: (end - start) / 1000, // in seconds
             },
         });
+
+        const skippedAhead = Object.entries(changes)
+            .filter(([key]) => key.endsWith('skipped (instance ahead)'))
+            .reduce((acc, [, count]) => acc + count, 0);
+        if (skippedAhead > 0) {
+            GlobalState.log(
+                styles.error(
+                    `${skippedAhead} item(s) skipped because the instance is ahead of git — see messages above. Use --overwrite-drifted to make git win.`,
+                ),
+            );
+            process.exitCode = 1;
+        }
 
         completeUpload();
     } catch (error) {

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -2930,7 +2930,7 @@ const UPLOAD_CHANGE_SUFFIXES = [
     'created',
     'updated',
     'deleted',
-    'skipped (instance ahead)',
+    'skipped (project ahead)',
     'skipped',
     'failed',
 ] as const;
@@ -2967,7 +2967,7 @@ const summarizeUploadChanges = (
         (label) =>
             label === 'with errors' ||
             label === 'failed' ||
-            label === 'skipped (instance ahead)',
+            label === 'skipped (project ahead)',
     );
     return { detail, variant: hasFailures ? 'warning' : undefined };
 };
@@ -3021,7 +3021,7 @@ const printSkipDiff = async (
         )?.[0];
         if (!current) return;
         const diff = renderContentDiff(current, item, {
-            current: 'instance (current)',
+            current: 'project (current)',
             incoming: 'git (this upload)',
         });
         if (diff) GlobalState.log(diff);
@@ -3091,8 +3091,8 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
                 GlobalState.log(styles.error(`  ✖ ${skip.message}`));
             });
             await printSkipDiff(item, type, projectId);
-            changes[`${type} skipped (instance ahead)`] =
-                (changes[`${type} skipped (instance ahead)`] ?? 0) +
+            changes[`${type} skipped (project ahead)`] =
+                (changes[`${type} skipped (project ahead)`] ?? 0) +
                 upsertData.skips.length;
             return 'skipped';
         }
@@ -4712,12 +4712,12 @@ export const uploadHandler = async (
         });
 
         const skippedAhead = Object.entries(changes)
-            .filter(([key]) => key.endsWith('skipped (instance ahead)'))
+            .filter(([key]) => key.endsWith('skipped (project ahead)'))
             .reduce((acc, [, count]) => acc + count, 0);
         if (skippedAhead > 0) {
             GlobalState.log(
                 styles.error(
-                    `${skippedAhead} item(s) skipped because the instance is ahead of git — see messages above. Use --overwrite-drifted to make git win.`,
+                    `${skippedAhead} item(s) skipped because the Lightdash project is ahead of git — see messages above. Use --overwrite-drifted to make git win.`,
                 ),
             );
             process.exitCode = 1;

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -3058,6 +3058,8 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
             ? `/api/v1/projects/${projectId}/code/sqlCharts/${item.slug}`
             : `/api/v1/projects/${projectId}/code/${type}/${item.slug}`;
 
+        // needsUpdating is local CLI bookkeeping, not part of the document
+        const { needsUpdating, ...itemDoc } = item;
         const upsertData = await lightdashApi<
             ApiChartAsCodeUpsertResponse['results'] &
                 Pick<DashboardAsCodeUpsertResult, 'warnings'>
@@ -3065,7 +3067,7 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
             method: 'POST',
             url: endpoint,
             body: JSON.stringify({
-                ...item,
+                ...itemDoc,
                 skipSpaceCreate,
                 publicSpaceCreate,
                 force,
@@ -3662,11 +3664,30 @@ export const uploadHandler = async (
 
     // content_as_code.sync in lightdash.config.yml opts this repo into
     // instance-ahead protection; the flag travels with the repo like force.
-    const projectConfig = await readAndLoadLightdashProjectConfig(
-        process.cwd(),
-        projectId,
-    );
-    const syncEnabled = projectConfig.content_as_code?.sync === true;
+    // No file here (e.g. running from outside the repo root) means the
+    // opt-in state is unknown, not an opt-out: send nothing so the server
+    // decides from the project's stamped settings.
+    let syncEnabled: boolean | undefined;
+    const configExists = await fs
+        .access(path.join(process.cwd(), 'lightdash.config.yml'))
+        .then(() => true)
+        .catch(() => false);
+    if (configExists) {
+        try {
+            const projectConfig = await readAndLoadLightdashProjectConfig(
+                process.cwd(),
+                projectId,
+            );
+            syncEnabled = projectConfig.content_as_code?.sync === true;
+        } catch (error) {
+            throw new LightdashError({
+                message: `Upload aborted: lightdash.config.yml exists but could not be read, so the repo's content_as_code.sync opt-in cannot be honoured. Fix the config and retry. ${getErrorMessage(error)}`,
+                name: 'ParseError',
+                statusCode: 400,
+                data: {},
+            });
+        }
+    }
 
     let changes: Record<string, number> = {};
     const counts: ProjectContentAsCodeCounts = {};

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -213,7 +213,6 @@ export type DownloadHandlerOptions = {
     chartTypesOnly?: boolean; // download: implies skipCharts + skipDashboards + skipSpaces; upload: chart-types-only filtered run
     stripPivotSeries: boolean; // Strip per-value pivot series config for portable chart YAML
     validate?: boolean; // Validate charts and dashboards after upload
-    overwriteDrifted?: boolean; // Upload only: overwrite content the instance is ahead on (git wins)
     concurrency: number;
     gzip?: boolean;
     organization: boolean;
@@ -3030,11 +3029,6 @@ const printSkipDiff = async (
     }
 };
 
-type UploadSyncOptions = {
-    syncEnforced?: boolean;
-    overwriteDrifted?: boolean;
-};
-
 const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
     item: T & { needsUpdating: boolean },
     type: 'charts' | 'dashboards',
@@ -3046,8 +3040,7 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
     publicSpaceCreate?: boolean,
     validate?: boolean,
     spaceNames?: Record<string, string>,
-    spaceNames?: Record<string, string>,
-    syncOptions?: UploadSyncOptions,
+    syncEnabled?: boolean,
 ): Promise<'upserted' | 'skipped' | 'failed'> => {
     try {
         if (!force && !item.needsUpdating) {
@@ -3077,10 +3070,7 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
                 publicSpaceCreate,
                 force,
                 // The sqlCharts route doesn't support drift detection yet
-                ...(!isSqlChartItem && {
-                    syncEnforced: syncOptions?.syncEnforced,
-                    overwriteDrifted: syncOptions?.overwriteDrifted,
-                }),
+                ...(!isSqlChartItem && { syncEnabled }),
                 ...(spaceNames &&
                     Object.keys(spaceNames).length > 0 && { spaceNames }),
             }),
@@ -3096,10 +3086,6 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
                 upsertData.skips.length;
             return 'skipped';
         }
-        (upsertData.driftWarnings ?? []).forEach((warning) =>
-            GlobalState.log(styles.warning(`  ⚠ ${warning}`)),
-        );
-
         GlobalState.debug(
             `${type} "${item.name}": ${upsertData[type]?.[0]?.action}`,
         );
@@ -3243,9 +3229,8 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
     concurrency: number = 1,
     extraItems: (T & { needsUpdating: boolean })[] = [],
     spaceNames?: Record<string, string>,
-    spaceNames?: Record<string, string>,
     skipSlugs?: ReadonlySet<string>,
-    syncOptions?: UploadSyncOptions,
+    syncEnabled?: boolean,
 ): Promise<{
     changes: Record<string, number>;
     total: number;
@@ -3330,7 +3315,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 publicSpaceCreate,
                 validate,
                 spaceNames,
-                syncOptions,
+                syncEnabled,
             );
             trackOutcome(item, outcome);
         }
@@ -3414,7 +3399,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 publicSpaceCreate,
                 validate,
                 spaceNames,
-                syncOptions,
+                syncEnabled,
             );
             trackOutcome(item, outcome);
         }
@@ -3435,7 +3420,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                         publicSpaceCreate,
                         validate,
                         spaceNames,
-                        syncOptions,
+                        syncEnabled,
                     );
                     trackOutcome(item, outcome);
                 }),
@@ -3681,10 +3666,7 @@ export const uploadHandler = async (
         process.cwd(),
         projectId,
     );
-    const syncOptions: UploadSyncOptions = {
-        syncEnforced: projectConfig.content_as_code?.sync === true,
-        overwriteDrifted: options.overwriteDrifted === true,
-    };
+    const syncEnabled = projectConfig.content_as_code?.sync === true;
 
     let changes: Record<string, number> = {};
     const counts: ProjectContentAsCodeCounts = {};
@@ -4519,8 +4501,9 @@ export const uploadHandler = async (
                     concurrency,
                     looseFiles.charts,
                     spaceNames,
+                    spaceNames,
                     undefined,
-                    syncOptions,
+                    syncEnabled,
                 );
                 result.failedSlugs.forEach((slug) =>
                     failedChartSlugs.add(slug),
@@ -4575,8 +4558,9 @@ export const uploadHandler = async (
                     concurrency,
                     looseFiles.dashboards,
                     spaceNames,
+                    spaceNames,
                     dashboardsToSkip,
-                    syncOptions,
+                    syncEnabled,
                 );
                 counts.dashboardsNum = result.total;
                 return result.changes;
@@ -4717,7 +4701,7 @@ export const uploadHandler = async (
         if (skippedAhead > 0) {
             GlobalState.log(
                 styles.error(
-                    `${skippedAhead} item(s) skipped because the Lightdash project is ahead of git — see messages above. Use --overwrite-drifted to make git win.`,
+                    `${skippedAhead} item(s) skipped because the Lightdash project is ahead of git — see messages above. Review and publish those changes in Lightdash, or update the files to match.`,
                 ),
             );
             process.exitCode = 1;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1065,6 +1065,11 @@ const uploadCommand = program
         false,
     )
     .option(
+        '--overwrite-drifted',
+        'Overwrite content that changed on the instance since the last upload (git wins). Only relevant with content_as_code.sync enabled in lightdash.config.yml',
+        false,
+    )
+    .option(
         '-p, --path <path>',
         'specify a custom path to upload content from',
         undefined,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1065,11 +1065,6 @@ const uploadCommand = program
         false,
     )
     .option(
-        '--overwrite-drifted',
-        'Overwrite content that changed on the instance since the last upload (git wins). Only relevant with content_as_code.sync enabled in lightdash.config.yml',
-        false,
-    )
-    .option(
         '-p, --path <path>',
         'specify a custom path to upload content from',
         undefined,

--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -4,6 +4,18 @@
     "type": ["object", "null"],
     "required": ["spotlight"],
     "properties": {
+        "content_as_code": {
+            "type": ["object", "null"],
+            "description": "Settings for content-as-code sync between this repo and Lightdash instances",
+            "properties": {
+                "sync": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, uploads refuse to overwrite content that changed on the instance since the last upload (skipped, exit 1). When false, drift is reported as warnings only."
+                }
+            },
+            "additionalProperties": false
+        },
         "spotlight": {
             "type": ["object", "null"],
             "properties": {

--- a/packages/common/src/types/contentAsCode/base.ts
+++ b/packages/common/src/types/contentAsCode/base.ts
@@ -81,11 +81,9 @@ export type ContentAsCodeSkip = {
 };
 
 /**
- * Drift outcome of an upsert against the last-applied snapshot.
- * `skips` is populated when sync enforcement rejected the write;
- * `driftWarnings` when enforcement is off and the write proceeded.
+ * Drift outcome of an upsert against the last-applied snapshot: `skips` is
+ * populated when content_as_code.sync enforcement rejected the write.
  */
 export type ContentAsCodeSyncStatus = {
     skips?: ContentAsCodeSkip[];
-    driftWarnings?: string[];
 };

--- a/packages/common/src/types/contentAsCode/base.ts
+++ b/packages/common/src/types/contentAsCode/base.ts
@@ -68,3 +68,24 @@ export type ApiContentAsCodeUpsertResponse<
     status: 'ok';
     results: { action: ContentAsCodeUpsertAction } & Extra;
 };
+
+export enum ContentAsCodeSkipReason {
+    SKIPPED_AHEAD = 'skipped_ahead',
+}
+
+export type ContentAsCodeSkip = {
+    contentType: 'chart' | 'dashboard';
+    slug: string;
+    reason: ContentAsCodeSkipReason;
+    message: string;
+};
+
+/**
+ * Drift outcome of an upsert against the last-applied snapshot.
+ * `skips` is populated when sync enforcement rejected the write;
+ * `driftWarnings` when enforcement is off and the write proceeded.
+ */
+export type ContentAsCodeSyncStatus = {
+    skips?: ContentAsCodeSkip[];
+    driftWarnings?: string[];
+};

--- a/packages/common/src/types/contentAsCode/charts.ts
+++ b/packages/common/src/types/contentAsCode/charts.ts
@@ -19,6 +19,7 @@ import type {
     TreemapChartConfig,
 } from '../savedCharts';
 import type { SqlChart } from '../sqlRunner';
+import type { ContentAsCodeSyncStatus } from './base';
 import type { ContentAsCodeType, FiltersInput } from './core';
 import type { SpaceAsCode } from './spaces';
 
@@ -135,9 +136,12 @@ export type ApiChartAsCodeListResponse = {
     };
 };
 
+export type ChartAsCodeUpsertResult = PromotionChanges &
+    ContentAsCodeSyncStatus;
+
 export type ApiChartAsCodeUpsertResponse = {
     status: 'ok';
-    results: PromotionChanges;
+    results: ChartAsCodeUpsertResult;
 };
 
 export type ApiSqlChartAsCodeUpsertResponse = {

--- a/packages/common/src/types/contentAsCode/charts.ts
+++ b/packages/common/src/types/contentAsCode/charts.ts
@@ -136,8 +136,10 @@ export type ApiChartAsCodeListResponse = {
     };
 };
 
-export type ChartAsCodeUpsertResult = PromotionChanges &
-    ContentAsCodeSyncStatus;
+// Interface extension (not intersection) so TSOA emits a flat object schema:
+// an allOf here erases the response's required properties in the OpenAPI spec.
+export interface ChartAsCodeUpsertResult
+    extends PromotionChanges, ContentAsCodeSyncStatus {}
 
 export type ApiChartAsCodeUpsertResponse = {
     status: 'ok';

--- a/packages/common/src/types/contentAsCode/dashboards.ts
+++ b/packages/common/src/types/contentAsCode/dashboards.ts
@@ -15,6 +15,7 @@ import type {
 } from '../dashboard';
 import type { DashboardFilterRule } from '../filter';
 import type { PromotionChanges } from '../promotion';
+import type { ContentAsCodeSyncStatus } from './base';
 import type { ContentAsCodeType } from './core';
 import type { SpaceAsCode } from './spaces';
 
@@ -184,10 +185,11 @@ export type ApiDashboardAsCodeListResponse = {
         offset: number;
     };
 };
-export type DashboardAsCodeUpsertResult = PromotionChanges & {
-    /** Non-fatal issues, e.g. a data app tile whose app is not in this project. */
-    warnings?: string[];
-};
+export type DashboardAsCodeUpsertResult = PromotionChanges &
+    ContentAsCodeSyncStatus & {
+        /** Non-fatal issues, e.g. a data app tile whose app is not in this project. */
+        warnings?: string[];
+    };
 
 export type ApiDashboardAsCodeUpsertResponse = {
     status: 'ok';

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -101,8 +101,18 @@ export type CustomGranularity = {
     type?: DimensionType.DATE | DimensionType.TIMESTAMP | DimensionType.STRING;
 };
 
+export type ContentAsCodeConfig = {
+    /**
+     * When true, `lightdash upload` refuses to overwrite content that has
+     * changed on the instance since the last upload (reported as skipped,
+     * exit 1). When false or omitted, drift is only reported as warnings.
+     */
+    sync?: boolean;
+};
+
 export type LightdashProjectConfig = {
     spotlight: SpotlightConfig;
+    content_as_code?: ContentAsCodeConfig;
     parameters?: Record<string, LightdashProjectParameter>; // keys must be ^[a-zA-Z0-9_-]+$
     warehouse?: WarehouseConfig; // Required for Lightdash-only projects (no dbt)
     defaults?: ProjectDefaults; // Project-wide defaults for various settings


### PR DESCRIPTION
## Summary

Second slice of content-as-code sync safeguards, stacked on #27995. With `content_as_code.sync: true` in `lightdash.config.yml`, upload compares the instance's canonical as-code form against the last-applied snapshot before writing, so a deploy can no longer silently overwrite content that changed on the instance. With sync off, uploads behave exactly as before this feature — no drift computation, no snapshot reads, no warnings.

## Contract (per slug, sync on)

- instance == last-applied → apply incoming, restamp (the `updatedAt` heuristic is retired on this path: a real difference always writes, even when timestamps make it look unchanged)
- instance == incoming → fast-forward: no write, just restamp (how a merged write-back PR settles later)
- instance differs from both → **skipped**, reported `skipped_ahead`, CLI exits 1
- content exists with no snapshot marker → treated as ahead (conservative first protected deploy; content matching the repo fast-forwards and stamps, so onboarding converges)

There is deliberately **no CLI override to make git win**: resolving drift goes through the app (review the pending changes, propose them to git) or by updating the repo file to match. `--force` keeps its existing meaning (upload even if unchanged) and does not bypass the skip.

## Gating and flags

- One boolean: `content_as_code.sync` in `lightdash.config.yml`, sent to the API as `syncEnabled` — versioned in the repo, so enabling protection is itself a reviewed PR.
- If `lightdash.config.yml` is absent where upload runs, the CLI sends nothing (opt-in state unknown ≠ opt-out); a malformed config aborts the upload with a clear error rather than silently dropping the repo's opt-in.
- Skips ride a new `skips` field on the upsert responses (`ContentAsCodeSkip`, reason `skipped_ahead`). No changes to `PromotionAction`.

## Regression analysis

- Drift evaluation is wrapped so any internal failure logs and falls back to today's behavior (proceed, no gate) — it can never block an upload by malfunctioning.
- Upload options and CLI bookkeeping (`syncEnabled`, `force`, `needsUpdating`, `skipSpaceCreate`, `publicSpaceCreate`, `spaceNames`) are stripped from the document before hashing at three layers (controller destructure, CLI body, hasher strip-list), so transport keys can never contaminate the drift verdict.
- The chart drift gate runs before `getOrCreateSpace`, so a skipped upload cannot create a space as a side effect (matches the dashboard path).
- Sync off is a true no-op path: no snapshot reads, no behavior change for any project that hasn't opted in.
- SQL charts are out of scope (their upsert has no options object yet); the CLI doesn't send the new field to that route.
- Fixed a pre-existing CLI bug: `successHandler` called `process.exit(0)` unconditionally, clobbering `process.exitCode = 1` (this also silently broke the failed-data-apps exit path).

Also in this PR: a skip prints a unified diff of the instance document vs what the upload wanted to apply (two context lines, capped at 60 lines, best-effort) — the operator sees exactly what was protected from the CI log itself.

## Verification

- Backend tests pass, including a verdict/gate matrix (pure functions, no mocks) and a hash-stability test proving option keys don't affect the drift hash.
- Live-verified against a dev GitHub-backed project (pre-rework): enforced upload skipped instance-ahead content and exited 1 without touching it; in-sync re-upload passed clean.

Closes: PROD-10508
Relates: PROD-2856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ML5B2E8MVem8Nsa4fHLxVx
