### PR TITLE
fix(frontend): reset connection form on project switch

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
@@ -230,7 +230,13 @@ const UpdateProjectConnectionWrapper: FC<{
         return null;
     }
 
-    return <UpdateProjectConnection projectUuid={projectUuid} project={data} />;
+    return (
+        <UpdateProjectConnection
+            key={projectUuid}
+            projectUuid={projectUuid}
+            project={data}
+        />
+    );
 };
 
 export default UpdateProjectConnectionWrapper;


### PR DESCRIPTION
## Summary

- remount the project connection form when the project UUID changes
- prevent warehouse and dbt settings from carrying over from the previously selected project
- preserve normal form state across refetches for the same project

## Verification

- reproduced before the fix: selecting F1 updated the route and navigation while the form still showed Jaffle shop and its PostgreSQL settings
- verified live on `http://localhost:3000`: F1 -> Jaffle shop -> F1 -> Jaffle shop consistently switched between the correct BigQuery and PostgreSQL forms
- `pnpm -F frontend typecheck`
- targeted `oxlint` and `oxfmt --check`
- `git diff --check`

Closes #27833