### PR TITLE
feat(content-as-code): write managed chart UI saves back to git

### DIFF
--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -1100,6 +1100,44 @@ export const createPullRequest = async ({
     }
 };
 
+export const findOpenPullRequestByHead = async ({
+    owner,
+    repo,
+    head,
+    installationId,
+    token,
+}: {
+    owner: string;
+    repo: string;
+    head: string;
+    installationId?: string;
+    token?: string;
+}): Promise<{ number: number; html_url: string; title: string } | null> => {
+    const { octokit, headers } = getOctokit(installationId, token);
+
+    try {
+        const response = await octokit.rest.pulls.list({
+            owner,
+            repo,
+            state: 'open',
+            head: `${owner}:${head}`,
+            per_page: 1,
+            headers,
+        });
+        const pullRequest = response.data[0];
+        if (!pullRequest) {
+            return null;
+        }
+        return {
+            number: pullRequest.number,
+            html_url: pullRequest.html_url,
+            title: pullRequest.title,
+        };
+    } catch (e) {
+        throw toGitWriteError(e);
+    }
+};
+
 export const updatePullRequest = async ({
     owner,
     repo,

--- a/packages/backend/src/clients/gitlab/Gitlab.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.ts
@@ -339,6 +339,40 @@ export const createPullRequest = async ({
     };
 };
 
+export const findOpenMergeRequestBySourceBranch = async ({
+    owner,
+    repo,
+    sourceBranch,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: GitlabApiParams & { sourceBranch: string }): Promise<{
+    number: number;
+    html_url: string;
+    title: string;
+} | null> => {
+    const projectId = getProjectId(owner, repo);
+    const url = getApiUrl(
+        hostDomain,
+        `/projects/${projectId}/merge_requests?state=opened&source_branch=${encodeURIComponent(
+            sourceBranch,
+        )}&per_page=1`,
+    );
+    const mergeRequests = (await makeGitlabRequest(url, token)) as Array<{
+        iid: number;
+        web_url: string;
+        title: string;
+    }>;
+    const mergeRequest = mergeRequests[0];
+    if (!mergeRequest) {
+        return null;
+    }
+    return {
+        number: mergeRequest.iid,
+        html_url: mergeRequest.web_url,
+        title: mergeRequest.title,
+    };
+};
+
 const GITLAB_MR_BATCH_SIZE = 100;
 
 const mapGitlabMrState = (state: string): PullRequestState => {

--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -49,6 +49,7 @@ export type DbProject = {
     provisioning_source: string | null;
     agent_sql_scope: AgentSqlScope | null;
     content_as_code_sync_enabled: boolean | null;
+    content_as_code_write_back_enabled: boolean | null;
 };
 
 type CreateDbProject = Pick<
@@ -98,6 +99,7 @@ type UpdateDbProject = Partial<
         | 'provisioning_source'
         | 'agent_sql_scope'
         | 'content_as_code_sync_enabled'
+        | 'content_as_code_write_back_enabled'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260825140000_add_content_as_code_write_back_enabled_to_projects.ts
+++ b/packages/backend/src/database/migrations/20260825140000_add_content_as_code_write_back_enabled_to_projects.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+const ProjectTableName = 'projects';
+const ColumnName = 'content_as_code_write_back_enabled';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds an expand-only nullable boolean for content-as-code write-back',
+} as const;
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(ProjectTableName, (table) => {
+        table.boolean(ColumnName).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.alterTable(ProjectTableName, (table) => {
+        table.dropColumn(ColumnName);
+    });
+}

--- a/packages/backend/src/models/ContentAsCodeAppliedRevisionModel.ts
+++ b/packages/backend/src/models/ContentAsCodeAppliedRevisionModel.ts
@@ -88,4 +88,21 @@ export class ContentAsCodeAppliedRevisionModel {
 
         return rows.map(mapDbRevision);
     }
+
+    async findBySlug(
+        projectUuid: string,
+        contentType: ContentAsCodeSnapshotType,
+        slug: string,
+    ): Promise<ContentAsCodeAppliedRevision | undefined> {
+        const row = await this.database(ContentAsCodeAppliedRevisionsTableName)
+            .select('*')
+            .where({
+                project_uuid: projectUuid,
+                content_type: contentType,
+                slug,
+            })
+            .first();
+
+        return row ? mapDbRevision(row) : undefined;
+    }
 }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -853,6 +853,26 @@ export class ProjectModel {
             .where('project_uuid', projectUuid);
     }
 
+    async getContentAsCodeWriteBackEnabled(
+        projectUuid: string,
+    ): Promise<boolean> {
+        const [row] = await this.database(ProjectTableName)
+            .select('content_as_code_write_back_enabled')
+            .where('project_uuid', projectUuid);
+        return row?.content_as_code_write_back_enabled === true;
+    }
+
+    async setContentAsCodeWriteBackEnabled(
+        projectUuid: string,
+        enabled: boolean,
+    ): Promise<void> {
+        await this.database(ProjectTableName)
+            .update({
+                content_as_code_write_back_enabled: enabled,
+            })
+            .where('project_uuid', projectUuid);
+    }
+
     async getPreviewExpirationSettings(projectUuid: string): Promise<{
         defaultPreviewExpirationHours: number;
         maxPreviewExpirationHours: number;

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1091,6 +1091,14 @@ export class SpaceModel {
         return rows.map((r: { space_uuid: string }) => r.space_uuid);
     }
 
+    async isDefaultUserSpace(spaceUuid: string): Promise<boolean> {
+        const [row] = await this.database(SpaceTableName)
+            .select('is_default_user_space')
+            .where('space_uuid', spaceUuid)
+            .whereNull('deleted_at');
+        return row?.is_default_user_space === true;
+    }
+
     async find(
         filters: {
             projectUuid?: string;

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -159,6 +159,7 @@ import {
     getScheduledDeliveryTargetKey,
     getScheduledDeliveryTargetsAsCode,
 } from './scheduledContent';
+import { transformChartAsCode } from './transformChartAsCode';
 
 type ContentAsCodeSpaceContentMetadata = {
     savedChartUuid?: string;
@@ -1410,56 +1411,7 @@ export class CoderService extends BaseService {
         };
     }
 
-    private static transformChart(
-        chart: SavedChartDAO,
-        spaceSummary: Pick<SpaceSummaryBase, 'uuid' | 'name' | 'path'>[],
-        dashboardSlugs: Record<string, string>,
-        verificationMap: Map<string, ContentVerificationInfo>,
-    ): ChartAsCode {
-        const contentSpace = spaceSummary.find(
-            (space) => space.uuid === chart.spaceUuid,
-        );
-        if (!contentSpace) {
-            throw new NotFoundError(`Space ${chart.spaceUuid} not found`);
-        }
-
-        const spaceSlug = getContentAsCodePathFromLtreePath(contentSpace.path);
-
-        const additionalMetrics = chart.metricQuery.additionalMetrics?.map(
-            ({ uuid: _uuid, ...metric }) => metric,
-        );
-        const dimensionOverrides =
-            chart.metricQuery.dimensionOverrides &&
-            Object.keys(chart.metricQuery.dimensionOverrides).length > 0
-                ? chart.metricQuery.dimensionOverrides
-                : undefined;
-
-        return {
-            name: chart.name,
-            description: chart.description,
-            tableName: chart.tableName,
-            updatedAt: chart.updatedAt,
-            metricQuery: {
-                ...chart.metricQuery,
-                additionalMetrics,
-                dimensionOverrides,
-            },
-            chartConfig: chart.chartConfig,
-            pivotConfig: chart.pivotConfig,
-            dashboardSlug: chart.dashboardUuid
-                ? dashboardSlugs[chart.dashboardUuid]
-                : undefined,
-            slug: chart.slug,
-            tableConfig: chart.tableConfig,
-            spaceSlug,
-            version: currentVersion,
-            contentType: ContentAsCodeType.CHART,
-            downloadedAt: new Date(),
-            parameters: chart.parameters,
-            verified: verificationMap.has(chart.uuid) ? true : undefined,
-            verification: verificationMap.get(chart.uuid) ?? null,
-        };
-    }
+    private static transformChart = transformChartAsCode;
 
     private static transformSqlChart(
         sqlChart: {

--- a/packages/backend/src/services/CoderService/ContentAsCodeWriteBackService.ts
+++ b/packages/backend/src/services/CoderService/ContentAsCodeWriteBackService.ts
@@ -5,10 +5,12 @@ import {
     getErrorMessage,
     SavedChartDAO,
     SessionUser,
-} from '@lightdash/common'; // pragma: allowlist secret
+} from '@lightdash/common';
+import { LightdashConfig } from '../../config/parseConfig';
 import { ContentAsCodeAppliedRevisionModel } from '../../models/ContentAsCodeAppliedRevisionModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { BaseService } from '../BaseService';
 import { GitIntegrationService } from '../GitIntegrationService/GitIntegrationService';
@@ -21,6 +23,8 @@ import { dumpCanonicalContentAsCodeYaml } from './contentAsCodeYaml';
 import { transformChartAsCode } from './transformChartAsCode';
 
 type ContentAsCodeWriteBackServiceArguments = {
+    lightdashConfig: LightdashConfig;
+    projectModel: ProjectModel;
     contentAsCodeAppliedRevisionModel: ContentAsCodeAppliedRevisionModel;
     contentVerificationModel: ContentVerificationModel;
     dashboardModel: DashboardModel;
@@ -29,6 +33,10 @@ type ContentAsCodeWriteBackServiceArguments = {
 };
 
 export class ContentAsCodeWriteBackService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly projectModel: ProjectModel;
+
     private readonly contentAsCodeAppliedRevisionModel: ContentAsCodeAppliedRevisionModel;
 
     private readonly contentVerificationModel: ContentVerificationModel;
@@ -41,6 +49,8 @@ export class ContentAsCodeWriteBackService extends BaseService {
 
     constructor(args: ContentAsCodeWriteBackServiceArguments) {
         super({ serviceName: 'ContentAsCodeWriteBackService' });
+        this.lightdashConfig = args.lightdashConfig;
+        this.projectModel = args.projectModel;
         this.contentAsCodeAppliedRevisionModel =
             args.contentAsCodeAppliedRevisionModel;
         this.contentVerificationModel = args.contentVerificationModel;
@@ -59,6 +69,25 @@ export class ContentAsCodeWriteBackService extends BaseService {
         }
 
         try {
+            const [syncEnabled, writeBackEnabled] = await Promise.all([
+                this.projectModel.getContentAsCodeSyncEnabled(projectUuid),
+                this.projectModel.getContentAsCodeWriteBackEnabled(projectUuid),
+            ]);
+            if (!syncEnabled || !writeBackEnabled) {
+                return;
+            }
+
+            if (await this.spaceModel.isDefaultUserSpace(chart.spaceUuid)) {
+                return;
+            }
+
+            const spaces = await this.spaceModel.find({
+                spaceUuids: [chart.spaceUuid],
+            });
+            if (spaces.length === 0) {
+                return;
+            }
+
             const revision =
                 await this.contentAsCodeAppliedRevisionModel.findBySlug(
                     projectUuid,
@@ -92,21 +121,27 @@ export class ContentAsCodeWriteBackService extends BaseService {
                 return;
             }
 
-            const chartAsCode = await this.buildChartAsCode(chart);
+            const chartAsCode = await this.buildChartAsCode(chart, spaces);
             const canonical = toCanonicalContentAsCodeSnapshot(chartAsCode);
             if (hashContentAsCodeDocument(canonical) === revision.contentHash) {
                 return;
             }
 
             const yaml = dumpCanonicalContentAsCodeYaml(canonical);
+            const instanceUrl = this.lightdashConfig.siteUrl;
+            const chartUrl = `${instanceUrl}/projects/${projectUuid}/saved/${slug}`;
             await this.gitIntegrationService.writeBackContentAsCodeFile(
                 user,
                 projectUuid,
                 {
+                    slug,
                     filePath: getContentAsCodeChartRelativePath(slug),
                     content: yaml,
                     title: `Update chart \`${slug}\``,
-                    description: `Updates the content-as-code YAML for chart \`${slug}\` after a UI save.`,
+                    description: `Updates the content-as-code YAML for chart \`${slug}\` after a UI save.
+
+Instance: ${instanceUrl}
+Chart: ${chartUrl}`,
                 },
             );
         } catch (error) {
@@ -123,10 +158,10 @@ export class ContentAsCodeWriteBackService extends BaseService {
         }
     }
 
-    private async buildChartAsCode(chart: SavedChartDAO) {
-        const spaces = await this.spaceModel.find({
-            spaceUuids: [chart.spaceUuid],
-        });
+    private async buildChartAsCode(
+        chart: SavedChartDAO,
+        spaces: Awaited<ReturnType<SpaceModel['find']>>,
+    ) {
         const dashboardSlugs = chart.dashboardUuid
             ? await this.dashboardModel.getSlugsForUuids([chart.dashboardUuid])
             : {};

--- a/packages/backend/src/services/CoderService/ContentAsCodeWriteBackService.ts
+++ b/packages/backend/src/services/CoderService/ContentAsCodeWriteBackService.ts
@@ -1,0 +1,146 @@
+import { subject } from '@casl/ability';
+import {
+    ContentAsCodeType,
+    ContentType,
+    getErrorMessage,
+    SavedChartDAO,
+    SessionUser,
+} from '@lightdash/common'; // pragma: allowlist secret
+import { ContentAsCodeAppliedRevisionModel } from '../../models/ContentAsCodeAppliedRevisionModel';
+import { ContentVerificationModel } from '../../models/ContentVerificationModel';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { BaseService } from '../BaseService';
+import { GitIntegrationService } from '../GitIntegrationService/GitIntegrationService';
+import {
+    hashContentAsCodeDocument,
+    toCanonicalContentAsCodeSnapshot,
+} from './contentAsCodeHash';
+import { getContentAsCodeChartRelativePath } from './contentAsCodePaths';
+import { dumpCanonicalContentAsCodeYaml } from './contentAsCodeYaml';
+import { transformChartAsCode } from './transformChartAsCode';
+
+type ContentAsCodeWriteBackServiceArguments = {
+    contentAsCodeAppliedRevisionModel: ContentAsCodeAppliedRevisionModel;
+    contentVerificationModel: ContentVerificationModel;
+    dashboardModel: DashboardModel;
+    spaceModel: SpaceModel;
+    gitIntegrationService: GitIntegrationService;
+};
+
+export class ContentAsCodeWriteBackService extends BaseService {
+    private readonly contentAsCodeAppliedRevisionModel: ContentAsCodeAppliedRevisionModel;
+
+    private readonly contentVerificationModel: ContentVerificationModel;
+
+    private readonly dashboardModel: DashboardModel;
+
+    private readonly spaceModel: SpaceModel;
+
+    private readonly gitIntegrationService: GitIntegrationService;
+
+    constructor(args: ContentAsCodeWriteBackServiceArguments) {
+        super({ serviceName: 'ContentAsCodeWriteBackService' });
+        this.contentAsCodeAppliedRevisionModel =
+            args.contentAsCodeAppliedRevisionModel;
+        this.contentVerificationModel = args.contentVerificationModel;
+        this.dashboardModel = args.dashboardModel;
+        this.spaceModel = args.spaceModel;
+        this.gitIntegrationService = args.gitIntegrationService;
+    }
+
+    async writeBackManagedChartIfNeeded(
+        user: SessionUser,
+        chart: SavedChartDAO,
+    ): Promise<void> {
+        const { projectUuid, slug, organizationUuid } = chart;
+        if (!projectUuid || !slug) {
+            return;
+        }
+
+        try {
+            const revision =
+                await this.contentAsCodeAppliedRevisionModel.findBySlug(
+                    projectUuid,
+                    ContentAsCodeType.CHART,
+                    slug,
+                );
+            if (!revision) {
+                return;
+            }
+
+            const ability = this.createAuditedAbility(user);
+            if (
+                ability.cannot(
+                    'manage',
+                    subject('SourceCode', {
+                        organizationUuid,
+                        projectUuid,
+                        isProtectedBranch: false,
+                        metadata: { slug, chartUuid: chart.uuid },
+                    }),
+                )
+            ) {
+                this.logger.warn(
+                    'Skipping content-as-code write-back; user cannot manage SourceCode',
+                    {
+                        userUuid: user.userUuid,
+                        projectUuid,
+                        slug,
+                    },
+                );
+                return;
+            }
+
+            const chartAsCode = await this.buildChartAsCode(chart);
+            const canonical = toCanonicalContentAsCodeSnapshot(chartAsCode);
+            if (hashContentAsCodeDocument(canonical) === revision.contentHash) {
+                return;
+            }
+
+            const yaml = dumpCanonicalContentAsCodeYaml(canonical);
+            await this.gitIntegrationService.writeBackContentAsCodeFile(
+                user,
+                projectUuid,
+                {
+                    filePath: getContentAsCodeChartRelativePath(slug),
+                    content: yaml,
+                    title: `Update chart \`${slug}\``,
+                    description: `Updates the content-as-code YAML for chart \`${slug}\` after a UI save.`,
+                },
+            );
+        } catch (error) {
+            this.logger.warn(
+                'Content-as-code write-back failed after managed chart save',
+                {
+                    userUuid: user.userUuid,
+                    projectUuid,
+                    slug,
+                    chartUuid: chart.uuid,
+                    error: getErrorMessage(error),
+                },
+            );
+        }
+    }
+
+    private async buildChartAsCode(chart: SavedChartDAO) {
+        const spaces = await this.spaceModel.find({
+            spaceUuids: [chart.spaceUuid],
+        });
+        const dashboardSlugs = chart.dashboardUuid
+            ? await this.dashboardModel.getSlugsForUuids([chart.dashboardUuid])
+            : {};
+        const verificationMap =
+            await this.contentVerificationModel.getByContentUuids(
+                ContentType.CHART,
+                [chart.uuid],
+            );
+
+        return transformChartAsCode(
+            chart,
+            spaces,
+            dashboardSlugs,
+            verificationMap,
+        );
+    }
+}

--- a/packages/backend/src/services/CoderService/ContentAsCodeWriteBackService.ts
+++ b/packages/backend/src/services/CoderService/ContentAsCodeWriteBackService.ts
@@ -1,4 +1,3 @@
-import { subject } from '@casl/ability';
 import {
     ContentAsCodeType,
     ContentType,
@@ -59,11 +58,16 @@ export class ContentAsCodeWriteBackService extends BaseService {
         this.gitIntegrationService = args.gitIntegrationService;
     }
 
+    /**
+     * Propose a managed-chart UI save as a git PR. The instance save already
+     * succeeded; git failures are logged and never returned to the saver.
+     * Editors do not need SourceCode — power users review the PR in git.
+     */
     async writeBackManagedChartIfNeeded(
         user: SessionUser,
         chart: SavedChartDAO,
     ): Promise<void> {
-        const { projectUuid, slug, organizationUuid } = chart;
+        const { projectUuid, slug } = chart;
         if (!projectUuid || !slug) {
             return;
         }
@@ -95,29 +99,6 @@ export class ContentAsCodeWriteBackService extends BaseService {
                     slug,
                 );
             if (!revision) {
-                return;
-            }
-
-            const ability = this.createAuditedAbility(user);
-            if (
-                ability.cannot(
-                    'manage',
-                    subject('SourceCode', {
-                        organizationUuid,
-                        projectUuid,
-                        isProtectedBranch: false,
-                        metadata: { slug, chartUuid: chart.uuid },
-                    }),
-                )
-            ) {
-                this.logger.warn(
-                    'Skipping content-as-code write-back; user cannot manage SourceCode',
-                    {
-                        userUuid: user.userUuid,
-                        projectUuid,
-                        slug,
-                    },
-                );
                 return;
             }
 

--- a/packages/backend/src/services/CoderService/contentAsCodePaths.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodePaths.ts
@@ -1,0 +1,5 @@
+const CONTENT_AS_CODE_ROOT_FOLDER = 'lightdash'; // pragma: allowlist secret
+const CONTENT_AS_CODE_CHARTS_FOLDER = 'charts';
+
+export const getContentAsCodeChartRelativePath = (slug: string): string =>
+    `${CONTENT_AS_CODE_ROOT_FOLDER}/${CONTENT_AS_CODE_CHARTS_FOLDER}/${slug}.yml`;

--- a/packages/backend/src/services/CoderService/contentAsCodeWriteBack.test.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeWriteBack.test.ts
@@ -1,0 +1,23 @@
+import {
+    getContentAsCodeWriteBackBranchName,
+    getContentAsCodeWriteBackInstanceId,
+} from './contentAsCodeWriteBack';
+
+describe('content-as-code write-back branch names', () => {
+    it('uses the SITE_URL host as the instance id', () => {
+        expect(
+            getContentAsCodeWriteBackInstanceId(
+                'https://analytics.lightdash.cloud',
+            ),
+        ).toBe('analytics.lightdash.cloud');
+    });
+
+    it('builds an instance-scoped branch per slug', () => {
+        expect(
+            getContentAsCodeWriteBackBranchName(
+                'analytics.lightdash.cloud',
+                'orders',
+            ),
+        ).toBe('lightdash/write-back/analytics.lightdash.cloud/orders');
+    });
+});

--- a/packages/backend/src/services/CoderService/contentAsCodeWriteBack.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeWriteBack.ts
@@ -1,0 +1,14 @@
+export const getContentAsCodeWriteBackInstanceId = (
+    siteUrl: string,
+): string => {
+    try {
+        return new URL(siteUrl).host.replace(/[^a-zA-Z0-9.-]/g, '-');
+    } catch {
+        return 'unknown';
+    }
+};
+
+export const getContentAsCodeWriteBackBranchName = (
+    instanceId: string,
+    slug: string,
+): string => `lightdash/write-back/${instanceId}/${slug}`;

--- a/packages/backend/src/services/CoderService/contentAsCodeYaml.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodeYaml.ts
@@ -1,0 +1,8 @@
+import * as yaml from 'js-yaml';
+import { toCanonicalContentAsCodeSnapshot } from './contentAsCodeHash';
+
+export const dumpCanonicalContentAsCodeYaml = (document: unknown): string =>
+    yaml.dump(toCanonicalContentAsCodeSnapshot(document), {
+        quotingType: '"',
+        sortKeys: true,
+    });

--- a/packages/backend/src/services/CoderService/transformChartAsCode.ts
+++ b/packages/backend/src/services/CoderService/transformChartAsCode.ts
@@ -1,0 +1,61 @@
+import {
+    ChartAsCode,
+    ContentAsCodeType,
+    currentVersion,
+    getContentAsCodePathFromLtreePath,
+    NotFoundError,
+    SavedChartDAO,
+    type ContentVerificationInfo,
+    type SpaceSummaryBase,
+} from '@lightdash/common'; // pragma: allowlist secret
+
+export const transformChartAsCode = (
+    chart: SavedChartDAO,
+    spaceSummary: Pick<SpaceSummaryBase, 'uuid' | 'name' | 'path'>[],
+    dashboardSlugs: Record<string, string>,
+    verificationMap: Map<string, ContentVerificationInfo>,
+): ChartAsCode => {
+    const contentSpace = spaceSummary.find(
+        (space) => space.uuid === chart.spaceUuid,
+    );
+    if (!contentSpace) {
+        throw new NotFoundError(`Space ${chart.spaceUuid} not found`);
+    }
+
+    const spaceSlug = getContentAsCodePathFromLtreePath(contentSpace.path);
+
+    const additionalMetrics = chart.metricQuery.additionalMetrics?.map(
+        ({ uuid: _uuid, ...metric }) => metric,
+    );
+    const dimensionOverrides =
+        chart.metricQuery.dimensionOverrides &&
+        Object.keys(chart.metricQuery.dimensionOverrides).length > 0
+            ? chart.metricQuery.dimensionOverrides
+            : undefined;
+
+    return {
+        name: chart.name,
+        description: chart.description,
+        tableName: chart.tableName,
+        updatedAt: chart.updatedAt,
+        metricQuery: {
+            ...chart.metricQuery,
+            additionalMetrics,
+            dimensionOverrides,
+        },
+        chartConfig: chart.chartConfig,
+        pivotConfig: chart.pivotConfig,
+        dashboardSlug: chart.dashboardUuid
+            ? dashboardSlugs[chart.dashboardUuid]
+            : undefined,
+        slug: chart.slug,
+        tableConfig: chart.tableConfig,
+        spaceSlug,
+        version: currentVersion,
+        contentType: ContentAsCodeType.CHART,
+        downloadedAt: new Date(),
+        parameters: chart.parameters,
+        verified: verificationMap.has(chart.uuid) ? true : undefined,
+        verification: verificationMap.get(chart.uuid) ?? null,
+    };
+};

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -1150,6 +1150,180 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
     }
 
     /**
+     * Create a feature-branch pull request that writes a content-as-code YAML
+     * file into the project's git-backed dbt repo. Updates the file when it
+     * already exists on the project's configured branch; otherwise creates it.
+     */
+    async writeBackContentAsCodeFile(
+        user: SessionUser,
+        projectUuid: string,
+        {
+            filePath,
+            content,
+            title,
+            description,
+        }: {
+            filePath: string;
+            content: string;
+            title: string;
+            description: string;
+        },
+    ): Promise<PullRequestCreated> {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('SourceCode', {
+                    organizationUuid: user.organizationUuid!,
+                    projectUuid,
+                    isProtectedBranch: false,
+                    metadata: { filePath },
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const gitProps = await this.getGitProps(user, projectUuid, '"');
+        const fileName = GitIntegrationService.removeExtraSlashes(
+            `${gitProps.path}/${filePath}`,
+        );
+        const eventProperties: WriteBackEvent['properties'] = {
+            name: fileName,
+            projectId: projectUuid,
+            organizationId: user.organizationUuid!,
+            context: QueryExecutionContext.CHART,
+        };
+
+        await GitIntegrationService.createBranch(gitProps);
+
+        const getFileContent =
+            gitProps.type === DbtProjectType.GITHUB
+                ? GithubClient.getFileContent
+                : GitlabClient.getFileContent;
+
+        let existingSha: string | undefined;
+        try {
+            ({ sha: existingSha } = await getFileContent({
+                fileName,
+                owner: gitProps.owner,
+                repo: gitProps.repo,
+                branch: gitProps.branch,
+                installationId: gitProps.installationId,
+                token: gitProps.token,
+                hostDomain: gitProps.hostDomain,
+            }));
+        } catch (error) {
+            if (!(error instanceof NotFoundError)) {
+                throw error;
+            }
+        }
+
+        const commitMessage = existingSha
+            ? `Update ${fileName}`
+            : `Create ${fileName}`;
+
+        if (existingSha) {
+            const updateFile =
+                gitProps.type === DbtProjectType.GITHUB
+                    ? GithubClient.updateFile
+                    : GitlabClient.updateFile;
+            await updateFile({
+                owner: gitProps.owner,
+                repo: gitProps.repo,
+                fileName,
+                content,
+                fileSha: existingSha,
+                branch: gitProps.branch,
+                installationId: gitProps.installationId,
+                token: gitProps.token,
+                hostDomain: gitProps.hostDomain,
+                message: commitMessage,
+            });
+        } else {
+            const createFile =
+                gitProps.type === DbtProjectType.GITHUB
+                    ? GithubClient.createFile
+                    : GitlabClient.createFile;
+            await createFile({
+                owner: gitProps.owner,
+                repo: gitProps.repo,
+                fileName,
+                content,
+                branch: gitProps.branch,
+                installationId: gitProps.installationId,
+                token: gitProps.token,
+                hostDomain: gitProps.hostDomain,
+                message: commitMessage,
+            });
+        }
+
+        try {
+            const createPullRequest =
+                gitProps.type === DbtProjectType.GITHUB
+                    ? GithubClient.createPullRequest
+                    : GitlabClient.createPullRequest;
+
+            const fullDescription = `${description}
+
+Triggered by user ${user.firstName} ${user.lastName} (${user.email})
+
+🤖 Created with Lightdash`; // pragma: allowlist secret
+
+            const pullRequest = await createPullRequest({
+                ...gitProps,
+                title,
+                body: fullDescription,
+                head: gitProps.branch,
+                base: gitProps.mainBranch,
+            });
+
+            this.analytics.track({
+                event: 'write_back.created',
+                userId: user.userUuid,
+                properties: eventProperties,
+            });
+            this.analytics.track({
+                event: 'source_code.pull_request_created',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: user.organizationUuid!,
+                    projectId: projectUuid,
+                    filePath: fileName,
+                    fileSize: content.length,
+                    gitProvider: gitProps.type,
+                },
+            });
+
+            await this.recordPullRequest({
+                user,
+                projectUuid,
+                type: gitProps.type,
+                owner: gitProps.owner,
+                repo: gitProps.repo,
+                prNumber: pullRequest.number,
+                prUrl: pullRequest.html_url,
+                source: PullRequestSource.CONTENT_AS_CODE,
+            });
+
+            return {
+                prTitle: pullRequest.title,
+                prUrl: pullRequest.html_url,
+            };
+        } catch (error) {
+            this.analytics.track({
+                event: 'write_back.error',
+                userId: user.userUuid,
+                properties: {
+                    ...eventProperties,
+                    error: getErrorMessage(error),
+                },
+            });
+            throw error;
+        }
+    }
+
+    /**
      * Create a pull request with arbitrary file changes
      * @deprecated Only used by the deprecated file-change PR endpoint; use createPullRequestFromBranch instead.
      */

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -48,6 +48,10 @@ import { PullRequestsModel } from '../../models/PullRequestsModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { BaseService } from '../BaseService';
+import {
+    getContentAsCodeWriteBackBranchName,
+    getContentAsCodeWriteBackInstanceId,
+} from '../CoderService/contentAsCodeWriteBack';
 import type { GithubAppService } from '../GithubAppService/GithubAppService';
 
 type GitIntegrationServiceArguments = {
@@ -1150,19 +1154,21 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
     }
 
     /**
-     * Create a feature-branch pull request that writes a content-as-code YAML
-     * file into the project's git-backed dbt repo. Updates the file when it
-     * already exists on the project's configured branch; otherwise creates it.
+     * Write a content-as-code YAML file onto an instance-scoped branch and
+     * open (or append to) one PR per slug. Uses saveFile / createBranchFromSource
+     * / createPullRequestFromBranch. Never force-pushes.
      */
     async writeBackContentAsCodeFile(
         user: SessionUser,
         projectUuid: string,
         {
+            slug,
             filePath,
             content,
             title,
             description,
         }: {
+            slug: string;
             filePath: string;
             content: string;
             title: string;
@@ -1177,7 +1183,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch: false,
-                    metadata: { filePath },
+                    metadata: { filePath, slug },
                 }),
             )
         ) {
@@ -1188,6 +1194,10 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         const fileName = GitIntegrationService.removeExtraSlashes(
             `${gitProps.path}/${filePath}`,
         );
+        const branchName = getContentAsCodeWriteBackBranchName(
+            getContentAsCodeWriteBackInstanceId(this.lightdashConfig.siteUrl),
+            slug,
+        );
         const eventProperties: WriteBackEvent['properties'] = {
             name: fileName,
             projectId: projectUuid,
@@ -1195,121 +1205,60 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             context: QueryExecutionContext.CHART,
         };
 
-        await GitIntegrationService.createBranch(gitProps);
-
-        const getFileContent =
-            gitProps.type === DbtProjectType.GITHUB
-                ? GithubClient.getFileContent
-                : GitlabClient.getFileContent;
+        try {
+            await this.createBranchFromSource(
+                user,
+                projectUuid,
+                branchName,
+                gitProps.mainBranch,
+            );
+        } catch {
+            // Branch already exists from a previous save — append a commit.
+        }
 
         let existingSha: string | undefined;
         try {
-            ({ sha: existingSha } = await getFileContent({
+            const file = await this.getFileOrDirectory(
+                user,
+                projectUuid,
+                branchName,
                 fileName,
-                owner: gitProps.owner,
-                repo: gitProps.repo,
-                branch: gitProps.branch,
-                installationId: gitProps.installationId,
-                token: gitProps.token,
-                hostDomain: gitProps.hostDomain,
-            }));
-        } catch (error) {
-            if (!(error instanceof NotFoundError)) {
-                throw error;
+            );
+            if (file.type === 'file') {
+                existingSha = file.sha;
             }
+        } catch {
+            existingSha = undefined;
         }
 
-        const commitMessage = existingSha
-            ? `Update ${fileName}`
-            : `Create ${fileName}`;
+        await this.saveFile(
+            user,
+            projectUuid,
+            branchName,
+            fileName,
+            content,
+            existingSha,
+            existingSha ? `Update ${fileName}` : `Create ${fileName}`,
+        );
 
-        if (existingSha) {
-            const updateFile =
-                gitProps.type === DbtProjectType.GITHUB
-                    ? GithubClient.updateFile
-                    : GitlabClient.updateFile;
-            await updateFile({
-                owner: gitProps.owner,
-                repo: gitProps.repo,
-                fileName,
-                content,
-                fileSha: existingSha,
-                branch: gitProps.branch,
-                installationId: gitProps.installationId,
-                token: gitProps.token,
-                hostDomain: gitProps.hostDomain,
-                message: commitMessage,
-            });
-        } else {
-            const createFile =
-                gitProps.type === DbtProjectType.GITHUB
-                    ? GithubClient.createFile
-                    : GitlabClient.createFile;
-            await createFile({
-                owner: gitProps.owner,
-                repo: gitProps.repo,
-                fileName,
-                content,
-                branch: gitProps.branch,
-                installationId: gitProps.installationId,
-                token: gitProps.token,
-                hostDomain: gitProps.hostDomain,
-                message: commitMessage,
-            });
+        const openPullRequest = await this.findOpenPullRequestForHead(
+            user,
+            projectUuid,
+            branchName,
+        );
+        if (openPullRequest) {
+            return openPullRequest;
         }
 
         try {
-            const createPullRequest =
-                gitProps.type === DbtProjectType.GITHUB
-                    ? GithubClient.createPullRequest
-                    : GitlabClient.createPullRequest;
-
-            const fullDescription = `${description}
-
-Triggered by user ${user.firstName} ${user.lastName} (${user.email})
-
-🤖 Created with Lightdash`; // pragma: allowlist secret
-
-            const pullRequest = await createPullRequest({
-                ...gitProps,
-                title,
-                body: fullDescription,
-                head: gitProps.branch,
-                base: gitProps.mainBranch,
-            });
-
-            this.analytics.track({
-                event: 'write_back.created',
-                userId: user.userUuid,
-                properties: eventProperties,
-            });
-            this.analytics.track({
-                event: 'source_code.pull_request_created',
-                userId: user.userUuid,
-                properties: {
-                    organizationId: user.organizationUuid!,
-                    projectId: projectUuid,
-                    filePath: fileName,
-                    fileSize: content.length,
-                    gitProvider: gitProps.type,
-                },
-            });
-
-            await this.recordPullRequest({
+            return await this.createPullRequestFromBranch(
                 user,
                 projectUuid,
-                type: gitProps.type,
-                owner: gitProps.owner,
-                repo: gitProps.repo,
-                prNumber: pullRequest.number,
-                prUrl: pullRequest.html_url,
-                source: PullRequestSource.CONTENT_AS_CODE,
-            });
-
-            return {
-                prTitle: pullRequest.title,
-                prUrl: pullRequest.html_url,
-            };
+                branchName,
+                title,
+                description,
+                PullRequestSource.CONTENT_AS_CODE,
+            );
         } catch (error) {
             this.analytics.track({
                 event: 'write_back.error',
@@ -1321,6 +1270,39 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             });
             throw error;
         }
+    }
+
+    private async findOpenPullRequestForHead(
+        user: SessionUser,
+        projectUuid: string,
+        head: string,
+    ): Promise<PullRequestCreated | null> {
+        const creds = await this.getGitCredentials(user, projectUuid, {
+            preferUserToken: true,
+        });
+        const openPullRequest =
+            creds.type === DbtProjectType.GITHUB
+                ? await GithubClient.findOpenPullRequestByHead({
+                      owner: creds.owner,
+                      repo: creds.repo,
+                      head,
+                      installationId: creds.installationId,
+                      token: creds.token,
+                  })
+                : await GitlabClient.findOpenMergeRequestBySourceBranch({
+                      owner: creds.owner,
+                      repo: creds.repo,
+                      sourceBranch: head,
+                      token: creds.token,
+                      hostDomain: creds.hostDomain,
+                  });
+        if (!openPullRequest) {
+            return null;
+        }
+        return {
+            prTitle: openPullRequest.title,
+            prUrl: openPullRequest.html_url,
+        };
     }
 
     /**
@@ -1915,6 +1897,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         branch: string,
         title: string,
         description: string,
+        source: PullRequestSource = PullRequestSource.SOURCE_EDITOR,
     ): Promise<PullRequestCreated> {
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -1986,7 +1969,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             repo: creds.repo,
             prNumber: pullRequest.number,
             prUrl: pullRequest.html_url,
-            source: PullRequestSource.SOURCE_EDITOR,
+            source,
         });
 
         return {

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -80,6 +80,15 @@ type GitProps = {
     dbtVersion?: SupportedDbtVersions;
 };
 
+type GitOperationOptions = {
+    /**
+     * Content-as-code write-back is a project-configured side effect of a
+     * permitted UI save. Editors must not need SourceCode, and they must not
+     * need a linked GitHub account — use the project installation / PAT.
+     */
+    asSystemWriteBack?: boolean;
+};
+
 // Keep backward compatibility
 type GithubProps = GitProps;
 
@@ -1157,6 +1166,10 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
      * Write a content-as-code YAML file onto an instance-scoped branch and
      * open (or append to) one PR per slug. Uses saveFile / createBranchFromSource
      * / createPullRequestFromBranch. Never force-pushes.
+     *
+     * This is a silent system write after a permitted UI save. The saver does
+     * not need SourceCode or a linked git account; power users review the PR
+     * in the repo or Project settings → Pull requests.
      */
     async writeBackContentAsCodeFile(
         user: SessionUser,
@@ -1175,24 +1188,11 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             description: string;
         },
     ): Promise<PullRequestCreated> {
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('SourceCode', {
-                    organizationUuid: user.organizationUuid!,
-                    projectUuid,
-                    isProtectedBranch: false,
-                    metadata: { filePath, slug },
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
+        await this.assertSameOrganizationAsProject(user, projectUuid);
 
-        const gitProps = await this.getGitProps(user, projectUuid, '"');
+        const repo = await this.getProjectRepo(projectUuid);
         const fileName = GitIntegrationService.removeExtraSlashes(
-            `${gitProps.path}/${filePath}`,
+            `${repo.path}/${filePath}`,
         );
         const branchName = getContentAsCodeWriteBackBranchName(
             getContentAsCodeWriteBackInstanceId(this.lightdashConfig.siteUrl),
@@ -1204,13 +1204,15 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             organizationId: user.organizationUuid!,
             context: QueryExecutionContext.CHART,
         };
+        const systemWrite: GitOperationOptions = { asSystemWriteBack: true };
 
         try {
             await this.createBranchFromSource(
                 user,
                 projectUuid,
                 branchName,
-                gitProps.mainBranch,
+                repo.branch,
+                systemWrite,
             );
         } catch {
             // Branch already exists from a previous save — append a commit.
@@ -1223,6 +1225,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
                 projectUuid,
                 branchName,
                 fileName,
+                systemWrite,
             );
             if (file.type === 'file') {
                 existingSha = file.sha;
@@ -1239,12 +1242,14 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             content,
             existingSha,
             existingSha ? `Update ${fileName}` : `Create ${fileName}`,
+            systemWrite,
         );
 
         const openPullRequest = await this.findOpenPullRequestForHead(
             user,
             projectUuid,
             branchName,
+            systemWrite,
         );
         if (openPullRequest) {
             return openPullRequest;
@@ -1258,6 +1263,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
                 title,
                 description,
                 PullRequestSource.CONTENT_AS_CODE,
+                systemWrite,
             );
         } catch (error) {
             this.analytics.track({
@@ -1272,13 +1278,24 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         }
     }
 
+    private async assertSameOrganizationAsProject(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        if (project.organizationUuid !== user.organizationUuid) {
+            throw new ForbiddenError();
+        }
+    }
+
     private async findOpenPullRequestForHead(
         user: SessionUser,
         projectUuid: string,
         head: string,
+        options?: GitOperationOptions,
     ): Promise<PullRequestCreated | null> {
         const creds = await this.getGitCredentials(user, projectUuid, {
-            preferUserToken: true,
+            preferUserToken: options?.asSystemWriteBack !== true,
         });
         const openPullRequest =
             creds.type === DbtProjectType.GITHUB
@@ -1576,22 +1593,29 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         projectUuid: string,
         branch: string,
         path?: string,
+        options?: GitOperationOptions,
     ): Promise<GitFileOrDirectory> {
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('SourceCode', {
-                    organizationUuid: user.organizationUuid!,
-                    projectUuid,
-                    metadata: { branch, path },
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
+        if (options?.asSystemWriteBack === true) {
+            await this.assertSameOrganizationAsProject(user, projectUuid);
+        } else {
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'view',
+                    subject('SourceCode', {
+                        organizationUuid: user.organizationUuid!,
+                        projectUuid,
+                        metadata: { branch, path },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
         }
 
-        const creds = await this.getGitCredentials(user, projectUuid);
+        const creds = await this.getGitCredentials(user, projectUuid, {
+            preferUserToken: options?.asSystemWriteBack !== true,
+        });
         const targetPath = path || '';
 
         // Try to get file content first
@@ -1664,30 +1688,35 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         content: string,
         sha?: string,
         message?: string,
+        options?: GitOperationOptions,
     ): Promise<{ sha: string; path: string }> {
-        const auditedAbility = this.createAuditedAbility(user);
         const protectedBranch = await this.getProtectedBranch(projectUuid);
         const isProtectedBranch = branch === protectedBranch;
 
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('SourceCode', {
-                    organizationUuid: user.organizationUuid!,
-                    projectUuid,
-                    isProtectedBranch,
-                    metadata: { branch, path, sha },
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                `Cannot write to protected branch "${protectedBranch}". ` +
-                    `Please use a feature branch and submit changes via pull request.`,
-            );
+        if (options?.asSystemWriteBack === true) {
+            await this.assertSameOrganizationAsProject(user, projectUuid);
+        } else {
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'manage',
+                    subject('SourceCode', {
+                        organizationUuid: user.organizationUuid!,
+                        projectUuid,
+                        isProtectedBranch,
+                        metadata: { branch, path, sha },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    `Cannot write to protected branch "${protectedBranch}". ` +
+                        `Please use a feature branch and submit changes via pull request.`,
+                );
+            }
         }
 
         const creds = await this.getGitCredentials(user, projectUuid, {
-            preferUserToken: true,
+            preferUserToken: options?.asSystemWriteBack !== true,
         });
         const commitMessage =
             message || (sha ? `Update ${path}` : `Create ${path}`);
@@ -1823,24 +1852,29 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         projectUuid: string,
         branchName: string,
         sourceBranch: string,
+        options?: GitOperationOptions,
     ): Promise<GitBranch> {
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('SourceCode', {
-                    organizationUuid: user.organizationUuid!,
-                    projectUuid,
-                    isProtectedBranch: false,
-                    metadata: { branchName, sourceBranch },
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
+        if (options?.asSystemWriteBack === true) {
+            await this.assertSameOrganizationAsProject(user, projectUuid);
+        } else {
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'manage',
+                    subject('SourceCode', {
+                        organizationUuid: user.organizationUuid!,
+                        projectUuid,
+                        isProtectedBranch: false,
+                        metadata: { branchName, sourceBranch },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
         }
 
         const creds = await this.getGitCredentials(user, projectUuid, {
-            preferUserToken: true,
+            preferUserToken: options?.asSystemWriteBack !== true,
         });
 
         // Get the latest commit from the source branch
@@ -1898,24 +1932,29 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         title: string,
         description: string,
         source: PullRequestSource = PullRequestSource.SOURCE_EDITOR,
+        options?: GitOperationOptions,
     ): Promise<PullRequestCreated> {
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('SourceCode', {
-                    organizationUuid: user.organizationUuid!,
-                    projectUuid,
-                    isProtectedBranch: false,
-                    metadata: { branch },
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
+        if (options?.asSystemWriteBack === true) {
+            await this.assertSameOrganizationAsProject(user, projectUuid);
+        } else {
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'manage',
+                    subject('SourceCode', {
+                        organizationUuid: user.organizationUuid!,
+                        projectUuid,
+                        isProtectedBranch: false,
+                        metadata: { branch },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
         }
 
         const creds = await this.getGitCredentials(user, projectUuid, {
-            preferUserToken: true,
+            preferUserToken: options?.asSystemWriteBack !== true,
         });
         const protectedBranch = await this.getProtectedBranch(projectUuid);
 

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -234,6 +234,7 @@ const projectModel = {
     saveExploresToCache: vi.fn(async () => ({ cachedExploreUuids: [] })),
     setTableGroups: vi.fn(async () => undefined),
     setContentAsCodeSyncEnabled: vi.fn(async () => undefined),
+    setContentAsCodeWriteBackEnabled: vi.fn(async () => undefined),
     updateProjectDefaults: vi.fn(async () => undefined),
     updateDefaultUserSpaces: vi.fn(async () => undefined),
     tryAcquireProjectLock: vi.fn(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3229,6 +3229,11 @@ export class ProjectService extends BaseService {
                         newProjectUuid,
                         lightdashProjectConfig.content_as_code?.sync === true,
                     );
+                    await this.projectModel.setContentAsCodeWriteBackEnabled(
+                        newProjectUuid,
+                        lightdashProjectConfig.content_as_code?.write_back ===
+                            true,
+                    );
                     // Mirrors CLI deploy semantics: only overwrite stored
                     // defaults when the config file defines them
                     if (lightdashProjectConfig.defaults) {
@@ -3929,6 +3934,11 @@ export class ProjectService extends BaseService {
                                 projectUuid,
                                 lightdashProjectConfig.content_as_code?.sync ===
                                     true,
+                            );
+                            await this.projectModel.setContentAsCodeWriteBackEnabled(
+                                projectUuid,
+                                lightdashProjectConfig.content_as_code
+                                    ?.write_back === true,
                             );
                             // Mirrors CLI deploy semantics: only overwrite
                             // stored defaults when the config file defines them
@@ -8769,6 +8779,11 @@ export class ProjectService extends BaseService {
                             projectUuid,
                             lightdashProjectConfig.content_as_code?.sync ===
                                 true,
+                        );
+                        await this.projectModel.setContentAsCodeWriteBackEnabled(
+                            projectUuid,
+                            lightdashProjectConfig.content_as_code
+                                ?.write_back === true,
                         );
                         // Mirrors CLI deploy semantics: only overwrite stored
                         // defaults when the config file defines them

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentAsCodeWriteBack.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentAsCodeWriteBack.test.ts
@@ -166,10 +166,13 @@ describe('SavedChartService - content-as-code write-back', () => {
             organizationUuid: 'org-uuid',
             projectUuid: 'project-uuid',
         })),
+        getContentAsCodeSyncEnabled: vi.fn(async () => true),
+        getContentAsCodeWriteBackEnabled: vi.fn(async () => true),
     };
     const spaceModel = {
         find: vi.fn(async () => spaces),
         getSpaceSummary: vi.fn(async () => ({ uuid: 'space-uuid' })),
+        isDefaultUserSpace: vi.fn(async () => false),
     };
     const dashboardModel = {
         getSlugsForUuids: vi.fn(async () => ({})),
@@ -182,6 +185,8 @@ describe('SavedChartService - content-as-code write-back', () => {
     };
 
     const writeBackService = new ContentAsCodeWriteBackService({
+        lightdashConfig: lightdashConfigMock,
+        projectModel: projectModel as unknown as ProjectModel,
         contentAsCodeAppliedRevisionModel:
             appliedRevisionModel as unknown as ContentAsCodeAppliedRevisionModel,
         contentVerificationModel:
@@ -222,6 +227,9 @@ describe('SavedChartService - content-as-code write-back', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         appliedRevisionModel.findBySlug.mockResolvedValue(undefined);
+        projectModel.getContentAsCodeSyncEnabled.mockResolvedValue(true);
+        projectModel.getContentAsCodeWriteBackEnabled.mockResolvedValue(true);
+        spaceModel.isDefaultUserSpace.mockResolvedValue(false);
         gitIntegrationService.writeBackContentAsCodeFile.mockResolvedValue({
             prTitle: 'Update chart `orders`',
             prUrl: 'https://example.com/pull/1',
@@ -252,8 +260,12 @@ describe('SavedChartService - content-as-code write-back', () => {
             expect.objectContaining({ userUuid: 'user-uuid' }),
             'project-uuid',
             expect.objectContaining({
-                filePath: 'lightdash/charts/orders.yml', // pragma: allowlist secret
+                slug: 'orders',
+                filePath: 'lightdash/charts/orders.yml',
                 title: 'Update chart `orders`',
+                description: expect.stringContaining(
+                    '/projects/project-uuid/saved/orders',
+                ),
             }),
         );
         const [{ content }] =
@@ -264,6 +276,36 @@ describe('SavedChartService - content-as-code write-back', () => {
         expect(content).toContain('slug: orders');
         expect(content).not.toContain('updatedAt');
         expect(content).not.toContain('downloadedAt');
+    });
+
+    it('does not write back when write_back is not enabled', async () => {
+        appliedRevisionModel.findBySlug.mockResolvedValue(appliedRevision);
+        projectModel.getContentAsCodeWriteBackEnabled.mockResolvedValue(false);
+
+        await service.createVersion(
+            fromSession(developerUser, 'session-cookie'),
+            'chart-uuid',
+            versionPayload,
+        );
+
+        expect(
+            gitIntegrationService.writeBackContentAsCodeFile,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('does not write back charts in personal spaces', async () => {
+        appliedRevisionModel.findBySlug.mockResolvedValue(appliedRevision);
+        spaceModel.isDefaultUserSpace.mockResolvedValue(true);
+
+        await service.createVersion(
+            fromSession(developerUser, 'session-cookie'),
+            'chart-uuid',
+            versionPayload,
+        );
+
+        expect(
+            gitIntegrationService.writeBackContentAsCodeFile,
+        ).not.toHaveBeenCalled();
     });
 
     it('does not write unmanaged charts back to git', async () => {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentAsCodeWriteBack.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentAsCodeWriteBack.test.ts
@@ -117,6 +117,21 @@ const developerUser = {
     updatedAt: new Date(),
 };
 
+const editorUser = {
+    ...developerUser,
+    userUuid: 'editor-uuid',
+    email: 'editor@test.com',
+    firstName: 'Biz',
+    lastName: 'User',
+    role: OrganizationMemberRole.EDITOR,
+    ability: new Ability<PossibleAbilities>([
+        {
+            subject: 'SavedChart',
+            action: ['view', 'update', 'delete', 'create'],
+        },
+    ]),
+};
+
 const appliedRevision = {
     contentType: ContentAsCodeType.CHART,
     slug: 'orders',
@@ -324,6 +339,29 @@ describe('SavedChartService - content-as-code write-back', () => {
         expect(
             gitIntegrationService.writeBackContentAsCodeFile,
         ).not.toHaveBeenCalled();
+    });
+
+    it('writes back editor saves without requiring SourceCode', async () => {
+        appliedRevisionModel.findBySlug.mockResolvedValue(appliedRevision);
+
+        const result = await service.createVersion(
+            fromSession(editorUser, 'session-cookie'),
+            'chart-uuid',
+            versionPayload,
+        );
+
+        expect(result.uuid).toBe('chart-uuid');
+        expect(result).not.toHaveProperty('prUrl');
+        expect(
+            gitIntegrationService.writeBackContentAsCodeFile,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+            gitIntegrationService.writeBackContentAsCodeFile,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({ userUuid: 'editor-uuid' }),
+            'project-uuid',
+            expect.objectContaining({ slug: 'orders' }),
+        );
     });
 
     it('does not fail the UI save when write-back fails', async () => {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentAsCodeWriteBack.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentAsCodeWriteBack.test.ts
@@ -1,0 +1,304 @@
+import { Ability } from '@casl/ability';
+import {
+    ChartType,
+    ContentAsCodeType,
+    OrganizationMemberRole,
+    PossibleAbilities,
+} from '@lightdash/common'; // pragma: allowlist secret
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock'; // pragma: allowlist secret
+import { fromSession } from '../../auth/account';
+import { GoogleDriveClient } from '../../clients/Google/GoogleDriveClient';
+import { SlackClient } from '../../clients/Slack/SlackClient';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock'; // pragma: allowlist secret
+import { AnalyticsModel } from '../../models/AnalyticsModel';
+import { CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { ContentAsCodeAppliedRevisionModel } from '../../models/ContentAsCodeAppliedRevisionModel';
+import { ContentVerificationModel } from '../../models/ContentVerificationModel';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { OrganizationModel } from '../../models/OrganizationModel';
+import { PinnedListModel } from '../../models/PinnedListModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SchedulerModel } from '../../models/SchedulerModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import { hashContentAsCodeDocument } from '../CoderService/contentAsCodeHash';
+import { ContentAsCodeWriteBackService } from '../CoderService/ContentAsCodeWriteBackService';
+import { GitIntegrationService } from '../GitIntegrationService/GitIntegrationService';
+import { PermissionsService } from '../PermissionsService/PermissionsService';
+import { SchedulerService } from '../SchedulerService/SchedulerService';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { UserService } from '../UserService';
+import { SavedChartService } from './SavedChartService';
+
+const chartSummary = {
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    uuid: 'chart-uuid',
+    spaceUuid: 'space-uuid',
+    metricQuery: {
+        metrics: [],
+        dimensions: [],
+        customDimensions: [],
+        tableCalculations: [],
+    },
+};
+
+const savedChartData = {
+    ...chartSummary,
+    name: 'Orders',
+    slug: 'orders',
+    description: 'Orders chart',
+    tableName: 'test_table',
+    dashboardUuid: null,
+    updatedAt: new Date('2026-08-25T12:00:00.000Z'),
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: { eChartsConfig: { xAxis: [], yAxis: [], series: [] } },
+    },
+    tableConfig: { columnOrder: [] },
+    metricQuery: {
+        exploreName: 'test',
+        metrics: [],
+        dimensions: [],
+        filters: { dimensions: {}, metrics: {}, tableCalculations: {} },
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+        additionalMetrics: [],
+    },
+};
+
+const versionPayload = {
+    tableName: 'test_table',
+    metricQuery: {
+        exploreName: 'test',
+        dimensions: [],
+        metrics: [],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+    },
+    chartConfig: { type: ChartType.CARTESIAN },
+    tableConfig: { columnOrder: [] },
+};
+
+const developerUser = {
+    userUuid: 'user-uuid',
+    email: 'dev@test.com',
+    firstName: 'Dev',
+    lastName: 'User',
+    organizationUuid: 'org-uuid',
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    timezone: null,
+    isSetupComplete: true,
+    userId: 1,
+    role: OrganizationMemberRole.DEVELOPER,
+    ability: new Ability<PossibleAbilities>([
+        {
+            subject: 'SavedChart',
+            action: ['view', 'update', 'delete', 'create'],
+        },
+        {
+            subject: 'SourceCode',
+            action: 'manage',
+            conditions: { isProtectedBranch: false },
+        },
+    ]),
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const appliedRevision = {
+    contentType: ContentAsCodeType.CHART,
+    slug: 'orders',
+    contentHash: hashContentAsCodeDocument({
+        slug: 'orders',
+        name: 'Orders yesterday',
+    }),
+    snapshot: { slug: 'orders', name: 'Orders yesterday' },
+    appliedAt: new Date('2026-08-25T11:00:00.000Z'),
+    appliedByUserUuid: 'user-uuid',
+};
+
+const spaces = [
+    {
+        uuid: 'space-uuid',
+        name: 'Jaffle shop',
+        path: 'jaffle_shop',
+    },
+];
+
+describe('SavedChartService - content-as-code write-back', () => {
+    const savedChartModel = {
+        getSummary: vi.fn(async () => chartSummary),
+        get: vi.fn(async () => savedChartData),
+        createVersion: vi.fn(async () => savedChartData),
+        update: vi.fn(async () => savedChartData),
+        create: vi.fn(async () => savedChartData),
+    };
+    const contentVerificationModel = {
+        verify: vi.fn(async () => undefined),
+        unverify: vi.fn(async () => undefined),
+        getByContent: vi.fn(async () => null),
+        getByContentUuids: vi.fn(async () => new Map()),
+    };
+    const spacePermissionService = {
+        getSpaceAccessContext: vi.fn(async () => ({
+            organizationUuid: 'org-uuid',
+            projectUuid: 'project-uuid',
+            inheritsFromOrgOrProject: true,
+            access: [],
+        })),
+        getFirstViewableSpaceUuid: vi.fn(async () => 'space-uuid'),
+    };
+    const projectModel = {
+        getExploreFromCache: vi.fn(async () => null),
+        getSummary: vi.fn(async () => ({
+            organizationUuid: 'org-uuid',
+            projectUuid: 'project-uuid',
+        })),
+    };
+    const spaceModel = {
+        find: vi.fn(async () => spaces),
+        getSpaceSummary: vi.fn(async () => ({ uuid: 'space-uuid' })),
+    };
+    const dashboardModel = {
+        getSlugsForUuids: vi.fn(async () => ({})),
+    };
+    const appliedRevisionModel = {
+        findBySlug: vi.fn(),
+    };
+    const gitIntegrationService = {
+        writeBackContentAsCodeFile: vi.fn(),
+    };
+
+    const writeBackService = new ContentAsCodeWriteBackService({
+        contentAsCodeAppliedRevisionModel:
+            appliedRevisionModel as unknown as ContentAsCodeAppliedRevisionModel,
+        contentVerificationModel:
+            contentVerificationModel as unknown as ContentVerificationModel,
+        dashboardModel: dashboardModel as unknown as DashboardModel,
+        spaceModel: spaceModel as unknown as SpaceModel,
+        gitIntegrationService:
+            gitIntegrationService as unknown as GitIntegrationService,
+    });
+
+    const service = new SavedChartService({
+        analytics: analyticsMock,
+        lightdashConfig: lightdashConfigMock, // pragma: allowlist secret
+        projectModel: projectModel as unknown as ProjectModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        spaceModel: spaceModel as unknown as SpaceModel,
+        analyticsModel: {
+            addChartViewEvent: vi.fn(),
+        } as unknown as AnalyticsModel,
+        pinnedListModel: {} as unknown as PinnedListModel,
+        schedulerModel: {} as unknown as SchedulerModel,
+        schedulerService: {} as unknown as SchedulerService,
+        schedulerClient: {} as unknown as SchedulerClient,
+        slackClient: {} as unknown as SlackClient,
+        dashboardModel: dashboardModel as unknown as DashboardModel,
+        catalogModel: {} as unknown as CatalogModel,
+        permissionsService: {} as unknown as PermissionsService,
+        googleDriveClient: {} as unknown as GoogleDriveClient,
+        userService: {} as unknown as UserService,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+        contentVerificationModel:
+            contentVerificationModel as unknown as ContentVerificationModel,
+        organizationModel: {} as unknown as OrganizationModel,
+        contentAsCodeWriteBackService: writeBackService,
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        appliedRevisionModel.findBySlug.mockResolvedValue(undefined);
+        gitIntegrationService.writeBackContentAsCodeFile.mockResolvedValue({
+            prTitle: 'Update chart `orders`',
+            prUrl: 'https://example.com/pull/1',
+        });
+    });
+
+    it('writes managed chart YAML back to git after a UI save', async () => {
+        appliedRevisionModel.findBySlug.mockResolvedValue(appliedRevision);
+
+        const result = await service.createVersion(
+            fromSession(developerUser, 'session-cookie'),
+            'chart-uuid',
+            versionPayload,
+        );
+
+        expect(result.uuid).toBe('chart-uuid');
+        expect(appliedRevisionModel.findBySlug).toHaveBeenCalledWith(
+            'project-uuid',
+            ContentAsCodeType.CHART,
+            'orders',
+        );
+        expect(
+            gitIntegrationService.writeBackContentAsCodeFile,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+            gitIntegrationService.writeBackContentAsCodeFile,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({ userUuid: 'user-uuid' }),
+            'project-uuid',
+            expect.objectContaining({
+                filePath: 'lightdash/charts/orders.yml', // pragma: allowlist secret
+                title: 'Update chart `orders`',
+            }),
+        );
+        const [{ content }] =
+            gitIntegrationService.writeBackContentAsCodeFile.mock.calls[0].slice(
+                2,
+            );
+        expect(content).toContain('name: Orders');
+        expect(content).toContain('slug: orders');
+        expect(content).not.toContain('updatedAt');
+        expect(content).not.toContain('downloadedAt');
+    });
+
+    it('does not write unmanaged charts back to git', async () => {
+        const result = await service.createVersion(
+            fromSession(developerUser, 'session-cookie'),
+            'chart-uuid',
+            versionPayload,
+        );
+
+        expect(result.uuid).toBe('chart-uuid');
+        expect(appliedRevisionModel.findBySlug).toHaveBeenCalledWith(
+            'project-uuid',
+            ContentAsCodeType.CHART,
+            'orders',
+        );
+        expect(
+            gitIntegrationService.writeBackContentAsCodeFile,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('does not fail the UI save when write-back fails', async () => {
+        appliedRevisionModel.findBySlug.mockResolvedValue(appliedRevision);
+        gitIntegrationService.writeBackContentAsCodeFile.mockRejectedValue(
+            new Error('git unavailable'),
+        );
+
+        await expect(
+            service.createVersion(
+                fromSession(developerUser, 'session-cookie'),
+                'chart-uuid',
+                versionPayload,
+            ),
+        ).resolves.toMatchObject({ uuid: 'chart-uuid' });
+        expect(
+            gitIntegrationService.writeBackContentAsCodeFile,
+        ).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -20,6 +20,7 @@ import {
     ExploreType,
     ForbiddenError,
     generateSlug,
+    getErrorMessage,
     getSchedulerResourceTypeAndId,
     getTimezoneLabel,
     GoogleSheetsTransientError,
@@ -86,6 +87,7 @@ import { SchedulerModel } from '../../models/SchedulerModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { BaseService } from '../BaseService';
+import type { ContentAsCodeWriteBackService } from '../CoderService/ContentAsCodeWriteBackService';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import type { SchedulerService } from '../SchedulerService/SchedulerService';
 import type {
@@ -115,6 +117,7 @@ type SavedChartServiceArguments = {
     spacePermissionService: SpacePermissionService;
     contentVerificationModel: ContentVerificationModel;
     organizationModel: OrganizationModel;
+    contentAsCodeWriteBackService?: ContentAsCodeWriteBackService;
 };
 
 type GoogleSheetValidationOptions = {
@@ -174,6 +177,10 @@ export class SavedChartService
 
     private readonly organizationModel: OrganizationModel;
 
+    private readonly contentAsCodeWriteBackService:
+        | ContentAsCodeWriteBackService
+        | undefined;
+
     constructor(args: SavedChartServiceArguments) {
         super();
         this.analytics = args.analytics;
@@ -195,6 +202,34 @@ export class SavedChartService
         this.spacePermissionService = args.spacePermissionService;
         this.contentVerificationModel = args.contentVerificationModel;
         this.organizationModel = args.organizationModel;
+        this.contentAsCodeWriteBackService = args.contentAsCodeWriteBackService;
+    }
+
+    private async writeBackManagedChartAfterSave(
+        user: SessionUser,
+        savedChart: SavedChartDAO,
+    ): Promise<void> {
+        if (!this.contentAsCodeWriteBackService) {
+            return;
+        }
+
+        try {
+            await this.contentAsCodeWriteBackService.writeBackManagedChartIfNeeded(
+                user,
+                savedChart,
+            );
+        } catch (error) {
+            this.logger.warn(
+                'Content-as-code write-back failed after chart save',
+                {
+                    userUuid: user.userUuid,
+                    chartUuid: savedChart.uuid,
+                    projectUuid: savedChart.projectUuid,
+                    slug: savedChart.slug,
+                    error: getErrorMessage(error),
+                },
+            );
+        }
     }
 
     private async checkUpdateAccess(
@@ -818,6 +853,8 @@ export class SavedChartService
             );
         }
 
+        await this.writeBackManagedChartAfterSave(user, savedChart);
+
         return {
             ...savedChart,
             verification: verificationAfterUpdate,
@@ -927,6 +964,9 @@ export class SavedChartService
                 },
             });
         }
+
+        await this.writeBackManagedChartAfterSave(user, savedChart);
+
         return {
             ...savedChart,
             verification: verificationAfterUpdate,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -205,6 +205,11 @@ export class SavedChartService
         this.contentAsCodeWriteBackService = args.contentAsCodeWriteBackService;
     }
 
+    /**
+     * Fire-and-forget git proposal after a successful chart save. Never attach
+     * PR details to the save response — business users should only see the
+     * usual "chart saved" confirmation.
+     */
     private async writeBackManagedChartAfterSave(
         user: SessionUser,
         savedChart: SavedChartDAO,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -24,6 +24,7 @@ import { BaseService } from './BaseService';
 import { CatalogService } from './CatalogService/CatalogService';
 import { CiService } from './CiService/CiService';
 import { CoderService } from './CoderService/CoderService';
+import { ContentAsCodeWriteBackService } from './CoderService/ContentAsCodeWriteBackService';
 import { CommentService } from './CommentService/CommentService';
 import { ContentService } from './ContentService/ContentService';
 import { ContentVerificationService } from './ContentVerificationService';
@@ -1021,6 +1022,17 @@ export class ServiceRepository
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
                     organizationModel: this.models.getOrganizationModel(),
+                    contentAsCodeWriteBackService:
+                        new ContentAsCodeWriteBackService({
+                            contentAsCodeAppliedRevisionModel:
+                                this.models.getContentAsCodeAppliedRevisionModel(),
+                            contentVerificationModel:
+                                this.models.getContentVerificationModel(),
+                            dashboardModel: this.models.getDashboardModel(),
+                            spaceModel: this.models.getSpaceModel(),
+                            gitIntegrationService:
+                                this.getGitIntegrationService(),
+                        }),
                 }),
         );
     }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1024,6 +1024,8 @@ export class ServiceRepository
                     organizationModel: this.models.getOrganizationModel(),
                     contentAsCodeWriteBackService:
                         new ContentAsCodeWriteBackService({
+                            lightdashConfig: this.context.lightdashConfig,
+                            projectModel: this.models.getProjectModel(),
                             contentAsCodeAppliedRevisionModel:
                                 this.models.getContentAsCodeAppliedRevisionModel(),
                             contentVerificationModel:

--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -54,6 +54,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "When true, uploads refuse to overwrite content that changed on the instance since the last upload (skipped, exit 1). When false, drift is reported as warnings only."
+                },
+                "write_back": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, UI saves of managed content open a reviewable git PR. Requires sync and a GitHub/GitLab connection."
                 }
             },
             "additionalProperties": false

--- a/packages/common/src/types/gitIntegration.ts
+++ b/packages/common/src/types/gitIntegration.ts
@@ -37,6 +37,7 @@ export enum PullRequestSource {
     SQL_RUNNER = 'sql_runner',
     SOURCE_EDITOR = 'source_editor',
     AI_AGENT = 'ai_agent',
+    CONTENT_AS_CODE = 'content_as_code',
 }
 
 export enum PullRequestState {

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -108,6 +108,11 @@ export type ContentAsCodeConfig = {
      * settings panel is shown. When false or omitted, sync is off.
      */
     sync?: boolean;
+    /**
+     * When true, UI saves of managed content open a reviewable git PR.
+     * Requires `sync` and a GitHub/GitLab project connection.
+     */
+    write_back?: boolean;
 };
 
 export type LightdashProjectConfig = {

--- a/packages/frontend/src/features/pullRequests/utils.ts
+++ b/packages/frontend/src/features/pullRequests/utils.ts
@@ -26,6 +26,8 @@ export const getSourceLabel = (source: PullRequestSource): string => {
             return 'Source editor';
         case PullRequestSource.AI_AGENT:
             return 'AI agent';
+        case PullRequestSource.CONTENT_AS_CODE:
+            return 'Content as code';
         default:
             return assertUnreachable(source, `Unknown source ${source}`);
     }
@@ -62,6 +64,8 @@ export const getSourceColor = (source: PullRequestSource): string => {
             return 'orange';
         case PullRequestSource.AI_AGENT:
             return 'indigo';
+        case PullRequestSource.CONTENT_AS_CODE:
+            return 'teal';
         default:
             return assertUnreachable(source, `Unknown source ${source}`);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: PROD-10511
Relates: PROD-2856

**PROD-2856 ship plan: hold.** Auto write-back on every UI save is unvalidated. Explicit propose (10512) is the day-one path from instance → repo. Ship this only if propose usage shows people doing it constantly. Code stays reviewable as a draft.

### Description:
After a successful UI save of an existing **managed** chart, open a reviewable git PR with the new canonical chart-as-code YAML. The instance save always succeeds; git failures are logged and never block the user.

Business users (editors) keep the normal "chart saved" confirmation. They do not need SourceCode or a linked GitHub account, and the save API does not return a PR URL. Power users review proposals in the repo or in Project settings → Pull requests.

- Opt-in via `content_as_code.write_back` in `lightdash.config.yml`, persisted at compile. Requires `content_as_code.sync` and a GitHub/GitLab connection.
- Managed means a last-applied snapshot exists for `(project, chart, slug)`. UI-only charts and personal spaces never write back.
- One open PR per slug per instance. Branch: `lightdash/write-back/{SITE_URL host}/{slug}`.
- Saves append commits to the open PR. No force-push. A new PR is opened only when none is open.
- Reuses `saveFile`, `createBranchFromSource`, and `createPullRequestFromBranch` with the project installation / PAT (not the saver's personal token).
- PR body includes the acting user, instance URL, and a deep link to the chart.
- Charts first. Dashboards and explicit add-to-git are PROD-10513.

Stacked on last-applied snapshot recording.

### Risk assessment:
- [ ] This is a high-risk change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8ccfc64-3e19-47b0-ba73-d713ac376003?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8ccfc64-3e19-47b0-ba73-d713ac376003&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

