### PR TITLE
feat: propose drifted content to git retroactively

### DIFF
--- a/packages/backend/src/controllers/CoderControllerUtils.ts
+++ b/packages/backend/src/controllers/CoderControllerUtils.ts
@@ -1,4 +1,6 @@
+import type { ContentAsCodeWritebackSummary } from '@lightdash/common';
 import type { RequestHandler } from 'express';
+import type { ContentAsCodeWriteback } from '../models/ContentAsCodeWritebackModel';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -19,3 +21,17 @@ export const CODE_WRITE_MIDDLEWARES: RequestHandler[] = [
 export const codeSuccess = <Results>(
     results: Results,
 ): { status: 'ok'; results: Results } => ({ status: 'ok', results });
+
+export const toWritebackSummary = (
+    row: ContentAsCodeWriteback,
+): ContentAsCodeWritebackSummary => ({
+    contentType: row.contentType,
+    slug: row.slug,
+    branch: row.branch,
+    prNumber: row.prNumber,
+    prUrl: row.prUrl,
+    status: row.status,
+    error: row.error,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+});

--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -10,6 +10,9 @@ import {
     type ApiAlertAsCodeUpsertResponse,
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
+    type ApiContentAsCodeProposeResponse,
+    type ApiContentAsCodeSettingsResponse,
+    type ApiContentAsCodeWritebacksResponse,
     type ApiDashboardAsCodeListResponse,
     type ApiDashboardAsCodeUpsertResponse,
     type ApiErrorPayload,
@@ -59,6 +62,7 @@ import {
     CODE_READ_MIDDLEWARES,
     CODE_WRITE_MIDDLEWARES,
     codeSuccess,
+    toWritebackSummary,
 } from './CoderControllerUtils';
 
 type AiAgentCoder = {
@@ -116,6 +120,81 @@ export class ProjectCoderController extends BaseController {
             .getCoderService()
             .renameContentSlug(toSessionUser(req.account), projectUuid, body);
         return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * List this instance's content-as-code write-back PRs for the project.
+     * Pass refresh=true to also re-check open PRs against the git provider
+     * (a merged PR then reads as merged instead of a stale pending badge).
+     * @summary List content-as-code write-backs
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_READ_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Get('/code/writebacks')
+    @OperationId('listContentAsCodeWritebacks')
+    async listContentAsCodeWritebacks(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Query() refresh?: boolean,
+    ): Promise<ApiContentAsCodeWritebacksResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const rows = await this.services
+            .getContentAsCodeWritebackService()
+            .listWritebacks(toSessionUser(req.account), projectUuid, {
+                refresh,
+            });
+        return codeSuccess(rows.map(toWritebackSummary));
+    }
+
+    /**
+     * Propose the current instance version of a managed chart back to the
+     * connected repo: opens (or appends to) this instance's write-back PR
+     * for the slug. The retroactive migration path for drifted content.
+     * @summary Propose chart to git
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_WRITE_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Post('/code/writebacks/charts/{slug}/propose')
+    @OperationId('proposeChartToGit')
+    async proposeChartToGit(
+        @Path() projectUuid: string,
+        @Path() slug: string,
+        @Request() req: express.Request,
+    ): Promise<ApiContentAsCodeProposeResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const row = await this.services
+            .getContentAsCodeWritebackService()
+            .proposeChart(toSessionUser(req.account), projectUuid, slug);
+        return codeSuccess(toWritebackSummary(row));
+    }
+
+    /**
+     * The content_as_code flags last stamped on this project by an upload
+     * @summary Get content-as-code settings
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_READ_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Get('/code/sync-settings')
+    @OperationId('getContentAsCodeSettings')
+    async getContentAsCodeSettings(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiContentAsCodeSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return codeSuccess(
+            await this.services
+                .getCoderService()
+                .getContentAsCodeSettings(
+                    toSessionUser(req.account),
+                    projectUuid,
+                ),
+        );
     }
 
     /**

--- a/packages/backend/src/models/ContentAsCodeWritebackModel.ts
+++ b/packages/backend/src/models/ContentAsCodeWritebackModel.ts
@@ -1,3 +1,4 @@
+import type { ContentAsCodeWritebackStatus } from '@lightdash/common';
 import { Knex } from 'knex';
 import {
     ContentAsCodeWritebacksTableName,
@@ -12,7 +13,7 @@ export type ContentAsCodeWriteback = {
     branch: string;
     prNumber: number | null;
     prUrl: string | null;
-    status: string;
+    status: ContentAsCodeWritebackStatus;
     error: string | null;
     createdByUserUuid: string | null;
     createdAt: Date;
@@ -20,12 +21,7 @@ export type ContentAsCodeWriteback = {
 };
 
 // 'pending' = row created, PR not opened yet; 'open' = PR live on the repo.
-// 'closed' rows are history; a new write-back then starts a fresh row.
-export type ContentAsCodeWritebackStatus =
-    | 'pending'
-    | 'open'
-    | 'closed'
-    | 'error';
+// 'merged'/'closed' rows are history; a new write-back then starts a fresh row.
 
 type ContentAsCodeWritebackModelArguments = {
     database: Knex;
@@ -39,7 +35,7 @@ const parseRow = (row: DbContentAsCodeWriteback): ContentAsCodeWriteback => ({
     branch: row.branch,
     prNumber: row.pr_number,
     prUrl: row.pr_url,
-    status: row.status,
+    status: row.status as ContentAsCodeWritebackStatus,
     error: row.error,
     createdByUserUuid: row.created_by_user_uuid,
     createdAt: row.created_at,

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -2881,6 +2881,31 @@ export class CoderService extends BaseService {
         );
     }
 
+    async getContentAsCodeSettings(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<{
+        syncEnabled: boolean;
+        stampedAt: Date;
+    } | null> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        const settings =
+            await this.contentAsCodeProjectSettingsModel.get(projectUuid);
+        return settings ?? null;
+    }
+
     // The repo's content_as_code flags travel with uploads; stamping them as
     // project-level state is how the instance (settings UI, write-back)
     // learns what the repo has opted into.

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -1,5 +1,7 @@
+import { Ability } from '@casl/ability';
 import {
     DbtProjectType,
+    PossibleAbilities,
     PullRequestSource,
     type SessionUser,
 } from '@lightdash/common';
@@ -11,7 +13,10 @@ const user = {
     firstName: 'Demo',
     lastName: 'User',
     email: 'demo@lightdash.com',
-} as SessionUser;
+    ability: new Ability<PossibleAbilities>([
+        { action: 'manage', subject: 'ContentAsCode' },
+    ]),
+} as unknown as SessionUser;
 
 const chartAsCode = {
     name: 'Monthly revenue',
@@ -89,6 +94,10 @@ const buildService = (overrides: Overrides = {}) => {
     const service = new ContentAsCodeWritebackService({
         lightdashConfig: { siteUrl: 'https://app.lightdash.dev' } as never,
         projectModel: {
+            get: vi.fn().mockResolvedValue({
+                projectUuid: 'project-uuid',
+                organizationUuid: 'org-uuid',
+            }),
             getSummary: vi
                 .fn()
                 .mockResolvedValue({ organizationUuid: 'org-uuid' }),

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -6,12 +6,6 @@ import {
 import { describe, expect, it, vi } from 'vitest';
 import { ContentAsCodeWritebackService } from './ContentAsCodeWritebackService';
 
-const args = {
-    projectUuid: 'project-uuid',
-    savedChartUuid: 'chart-uuid',
-    slug: 'monthly-revenue',
-};
-
 const user = {
     userUuid: 'user-uuid',
     firstName: 'Demo',
@@ -27,6 +21,7 @@ const chartAsCode = {
 };
 
 type Overrides = {
+    settings?: object | undefined;
     snapshot?: object | undefined;
     liveRow?: object | undefined;
     existingFile?: object | 'missing';
@@ -55,6 +50,18 @@ const buildService = (overrides: Overrides = {}) => {
     };
     const coderService = {
         getPortableChartAsCode: vi.fn().mockResolvedValue(chartAsCode),
+        getCurrentContentVersionBySlug: vi
+            .fn()
+            .mockResolvedValue({ contentUuid: 'chart-uuid' }),
+    };
+    const contentAsCodeProjectSettingsModel = {
+        get: vi
+            .fn()
+            .mockResolvedValue(
+                'settings' in overrides
+                    ? overrides.settings
+                    : { syncEnabled: true },
+            ),
     };
     const contentAsCodeSnapshotModel = {
         get: vi
@@ -81,8 +88,15 @@ const buildService = (overrides: Overrides = {}) => {
     };
     const service = new ContentAsCodeWritebackService({
         lightdashConfig: { siteUrl: 'https://app.lightdash.dev' } as never,
+        projectModel: {
+            getSummary: vi
+                .fn()
+                .mockResolvedValue({ organizationUuid: 'org-uuid' }),
+        } as never,
         gitIntegrationService: gitIntegrationService as never,
         coderService: coderService as never,
+        contentAsCodeProjectSettingsModel:
+            contentAsCodeProjectSettingsModel as never,
         contentAsCodeSnapshotModel: contentAsCodeSnapshotModel as never,
         contentAsCodeWritebackModel: contentAsCodeWritebackModel as never,
     });
@@ -95,18 +109,10 @@ const buildService = (overrides: Overrides = {}) => {
 };
 
 describe('ContentAsCodeWritebackService', () => {
-    it('does nothing for unmanaged content (no last-applied snapshot)', async () => {
-        const { service, gitIntegrationService } = buildService({
-            snapshot: undefined,
-        });
-        await service.writeChartToWritebackPr(user, args);
-        expect(gitIntegrationService.getProjectRepo).not.toHaveBeenCalled();
-    });
-
     it('first save creates the instance branch, commits the YAML, and opens one PR', async () => {
         const { service, gitIntegrationService, contentAsCodeWritebackModel } =
             buildService();
-        await service.writeChartToWritebackPr(user, args);
+        await service.proposeChart(user, 'project-uuid', 'monthly-revenue');
 
         expect(
             gitIntegrationService.createBranchFromSource,
@@ -152,7 +158,7 @@ describe('ContentAsCodeWritebackService', () => {
 
     it('every commit names the acting user and instance', async () => {
         const { service, gitIntegrationService } = buildService();
-        await service.writeChartToWritebackPr(user, args);
+        await service.proposeChart(user, 'project-uuid', 'monthly-revenue');
         const message = gitIntegrationService.saveFile.mock.calls[0][6];
         expect(message).toContain(
             'Project: https://app.lightdash.dev/projects/project-uuid',
@@ -177,7 +183,7 @@ describe('ContentAsCodeWritebackService', () => {
                 path: 'lightdash/charts/monthly-revenue.yml',
             },
         });
-        await service.writeChartToWritebackPr(user, args);
+        await service.proposeChart(user, 'project-uuid', 'monthly-revenue');
 
         const [, , , , , sha] = gitIntegrationService.saveFile.mock.calls[0];
         expect(sha).toBe('old-sha');
@@ -209,8 +215,24 @@ describe('ContentAsCodeWritebackService', () => {
                 path: 'lightdash/charts/monthly-revenue.yml',
             },
         });
-        await service.writeChartToWritebackPr(user, args);
+        await service.proposeChart(user, 'project-uuid', 'monthly-revenue');
         expect(gitIntegrationService.saveFile).not.toHaveBeenCalled();
+    });
+
+    it('propose requires sync to be stamped on the project', async () => {
+        const { service } = buildService({
+            settings: undefined,
+        });
+        await expect(
+            service.proposeChart(user, 'project-uuid', 'monthly-revenue'),
+        ).rejects.toThrow('content_as_code.sync');
+    });
+
+    it('propose rejects unmanaged content', async () => {
+        const { service } = buildService({ snapshot: undefined });
+        await expect(
+            service.proposeChart(user, 'project-uuid', 'monthly-revenue'),
+        ).rejects.toThrow('not managed as code');
     });
 
     it('marks the row as error and rethrows when git fails', async () => {
@@ -220,7 +242,7 @@ describe('ContentAsCodeWritebackService', () => {
             new Error('github says no'),
         );
         await expect(
-            service.writeChartToWritebackPr(user, args),
+            service.proposeChart(user, 'project-uuid', 'monthly-revenue'),
         ).rejects.toThrow('github says no');
         expect(contentAsCodeWritebackModel.update).toHaveBeenCalledWith(
             'row-uuid',

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -1,10 +1,15 @@
+import { subject } from '@casl/ability';
 import {
     ContentAsCodeType,
+    DbtProjectType,
+    ForbiddenError,
+    ParameterError,
     PullRequestSource,
     type ChartAsCode,
     type SessionUser,
 } from '@lightdash/common';
 import * as yaml from 'js-yaml';
+import * as GithubClient from '../../clients/github/Github';
 import { LightdashConfig } from '../../config/parseConfig';
 import { ContentAsCodeProjectSettingsModel } from '../../models/ContentAsCodeProjectSettingsModel';
 import { ContentAsCodeSnapshotModel } from '../../models/ContentAsCodeSnapshotModel';
@@ -12,22 +17,19 @@ import {
     ContentAsCodeWritebackModel,
     type ContentAsCodeWriteback,
 } from '../../models/ContentAsCodeWritebackModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../BaseService';
 import { CoderService } from '../CoderService/CoderService';
 import { GitIntegrationService } from '../GitIntegrationService/GitIntegrationService';
 
 type ContentAsCodeWritebackServiceArguments = {
     lightdashConfig: LightdashConfig;
+    projectModel: ProjectModel;
     gitIntegrationService: GitIntegrationService;
     coderService: CoderService;
+    contentAsCodeProjectSettingsModel: ContentAsCodeProjectSettingsModel;
     contentAsCodeSnapshotModel: ContentAsCodeSnapshotModel;
     contentAsCodeWritebackModel: ContentAsCodeWritebackModel;
-};
-
-type ChartWritebackArgs = {
-    projectUuid: string;
-    savedChartUuid: string;
-    slug: string;
 };
 
 // Matches the CLI's writeContent (packages/cli/src/handlers/download.ts):
@@ -69,9 +71,13 @@ const buildCommitMessage = (
 export class ContentAsCodeWritebackService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
+    private readonly projectModel: ProjectModel;
+
     private readonly gitIntegrationService: GitIntegrationService;
 
     private readonly coderService: CoderService;
+
+    private readonly contentAsCodeProjectSettingsModel: ContentAsCodeProjectSettingsModel;
 
     private readonly contentAsCodeSnapshotModel: ContentAsCodeSnapshotModel;
 
@@ -80,8 +86,11 @@ export class ContentAsCodeWritebackService extends BaseService {
     constructor(args: ContentAsCodeWritebackServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
+        this.projectModel = args.projectModel;
         this.gitIntegrationService = args.gitIntegrationService;
         this.coderService = args.coderService;
+        this.contentAsCodeProjectSettingsModel =
+            args.contentAsCodeProjectSettingsModel;
         this.contentAsCodeSnapshotModel = args.contentAsCodeSnapshotModel;
         this.contentAsCodeWritebackModel = args.contentAsCodeWritebackModel;
     }
@@ -102,31 +111,136 @@ export class ContentAsCodeWritebackService extends BaseService {
         return prefix === '' ? base : `${prefix}/${base}`;
     }
 
-    /**
-     * Opens (or appends a commit to) this instance's write-back PR for the
-     * chart. One live branch and PR per slug per instance; later calls add
-     * commits to the same PR.
-     */
-    async writeChartToWritebackPr(
+    // The migration path: instances are already ahead today, so drifted
+    // content can be proposed back to the repo on demand using the same
+    // plumbing as save-time write-back. Runs inline (user-initiated).
+    async proposeChart(
         user: SessionUser,
-        args: ChartWritebackArgs,
-    ): Promise<void> {
-        const { projectUuid, savedChartUuid, slug } = args;
-
-        // Managed content only: never write back content that has no
-        // last-applied marker (that's the explicit add-to-git flow)
+        projectUuid: string,
+        slug: string,
+    ): Promise<ContentAsCodeWriteback> {
+        const settings =
+            await this.contentAsCodeProjectSettingsModel.get(projectUuid);
+        if (!settings?.syncEnabled) {
+            throw new ParameterError(
+                'Proposing content to git requires content_as_code.sync to be enabled in the repo and stamped by an upload',
+            );
+        }
+        // Permission (view) and slug resolution in one place
+        const { contentUuid } =
+            await this.coderService.getCurrentContentVersionBySlug(
+                user,
+                projectUuid,
+                'chart',
+                slug,
+            );
         const snapshot = await this.contentAsCodeSnapshotModel.get(
             projectUuid,
             ContentAsCodeType.CHART,
             slug,
         );
         if (snapshot === undefined) {
-            this.logger.debug(
-                `Skipping content-as-code write-back for ${slug}: not managed (no last-applied snapshot)`,
+            throw new ParameterError(
+                `Chart "${slug}" is not managed as code; adding new content to git is an explicit add-to-git action`,
+            );
+        }
+        return this.writeChartToWritebackPr(user, {
+            projectUuid,
+            savedChartUuid: contentUuid,
+            slug,
+        });
+    }
+
+    async listWritebacks(
+        user: SessionUser,
+        projectUuid: string,
+        options: { refresh?: boolean } = {},
+    ): Promise<ContentAsCodeWriteback[]> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        const rows =
+            await this.contentAsCodeWritebackModel.listByProject(projectUuid);
+        if (options.refresh) {
+            await this.refreshOpenPullRequestStates(user, projectUuid, rows);
+            return this.contentAsCodeWritebackModel.listByProject(projectUuid);
+        }
+        return rows;
+    }
+
+    // A merged-but-not-yet-deployed PR should read "merged, applies on the
+    // next deploy" instead of a stale pending badge.
+    private async refreshOpenPullRequestStates(
+        user: SessionUser,
+        projectUuid: string,
+        rows: ContentAsCodeWriteback[],
+    ): Promise<void> {
+        const openRows = rows.filter(
+            (row) => row.status === 'open' && row.prNumber !== null,
+        );
+        if (openRows.length === 0) return;
+        let repo;
+        let creds;
+        try {
+            repo = await this.gitIntegrationService.getProjectRepo(projectUuid);
+            if (repo.type !== DbtProjectType.GITHUB) return;
+            creds = await this.gitIntegrationService.getGitCredentials(
+                user,
+                projectUuid,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `Could not resolve git credentials to refresh write-back PR states on project ${projectUuid}`,
+                error,
             );
             return;
         }
+        await Promise.all(
+            openRows.map(async (row) => {
+                try {
+                    const pr = await GithubClient.getPullRequest({
+                        owner: creds.owner,
+                        repo: creds.repo,
+                        pullNumber: row.prNumber!,
+                        installationId: creds.installationId,
+                        token: creds.token,
+                    });
+                    if (pr.merged) {
+                        await this.contentAsCodeWritebackModel.update(
+                            row.uuid,
+                            { status: 'merged' },
+                        );
+                    } else if (pr.state === 'closed') {
+                        await this.contentAsCodeWritebackModel.update(
+                            row.uuid,
+                            { status: 'closed' },
+                        );
+                    }
+                } catch (error) {
+                    this.logger.warn(
+                        `Could not refresh write-back PR state for ${row.slug} on project ${projectUuid}`,
+                        error,
+                    );
+                }
+            }),
+        );
+    }
 
+    private async writeChartToWritebackPr(
+        user: SessionUser,
+        target: { projectUuid: string; savedChartUuid: string; slug: string },
+    ): Promise<ContentAsCodeWriteback> {
+        const { projectUuid, slug } = target;
         let row = await this.contentAsCodeWritebackModel.findLive(
             projectUuid,
             ContentAsCodeType.CHART,
@@ -156,7 +270,7 @@ export class ContentAsCodeWritebackService extends BaseService {
         }
 
         try {
-            await this.pushChartToBranch(user, args, row);
+            await this.pushChartToBranch(user, target, row);
         } catch (error) {
             const message = error instanceof Error ? error.message : `${error}`;
             this.logger.error(
@@ -168,14 +282,20 @@ export class ContentAsCodeWritebackService extends BaseService {
             });
             throw error;
         }
+        const updated = await this.contentAsCodeWritebackModel.findLive(
+            projectUuid,
+            ContentAsCodeType.CHART,
+            slug,
+        );
+        return updated ?? row;
     }
 
     private async pushChartToBranch(
         user: SessionUser,
-        args: ChartWritebackArgs,
+        target: { projectUuid: string; savedChartUuid: string; slug: string },
         row: ContentAsCodeWriteback,
     ): Promise<void> {
-        const { projectUuid, savedChartUuid, slug } = args;
+        const { projectUuid, savedChartUuid, slug } = target;
         const repo =
             await this.gitIntegrationService.getProjectRepo(projectUuid);
 

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -119,6 +119,7 @@ export class ContentAsCodeWritebackService extends BaseService {
         projectUuid: string,
         slug: string,
     ): Promise<ContentAsCodeWriteback> {
+        await this.assertCanManageContentAsCode(user, projectUuid);
         const settings =
             await this.contentAsCodeProjectSettingsModel.get(projectUuid);
         if (!settings?.syncEnabled) {
@@ -151,24 +152,37 @@ export class ContentAsCodeWritebackService extends BaseService {
         });
     }
 
-    async listWritebacks(
+    // Write-back visibility is a dev/admin surface (the sync panel), never
+    // something business users see; gate on the content-as-code ability.
+    private async assertCanManageContentAsCode(
         user: SessionUser,
         projectUuid: string,
-        options: { refresh?: boolean } = {},
-    ): Promise<ContentAsCodeWriteback[]> {
-        const project = await this.projectModel.getSummary(projectUuid);
+    ): Promise<void> {
+        const project = await this.projectModel.get(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
-                'view',
-                subject('Project', {
+                'manage',
+                subject('ContentAsCode', {
+                    projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
-                    projectUuid,
+                    upstreamProjectUuid: project.upstreamProjectUuid,
+                    type: project.type,
+                    createdByUserUuid: project.createdByUserUuid,
+                    metadata: { slug: '' },
                 }),
             )
         ) {
             throw new ForbiddenError();
         }
+    }
+
+    async listWritebacks(
+        user: SessionUser,
+        projectUuid: string,
+        options: { refresh?: boolean } = {},
+    ): Promise<ContentAsCodeWriteback[]> {
+        await this.assertCanManageContentAsCode(user, projectUuid);
         const rows =
             await this.contentAsCodeWritebackModel.listByProject(projectUuid);
         if (options.refresh) {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1285,8 +1285,11 @@ export class ServiceRepository
             () =>
                 new ContentAsCodeWritebackService({
                     lightdashConfig: this.context.lightdashConfig,
+                    projectModel: this.models.getProjectModel(),
                     gitIntegrationService: this.getGitIntegrationService(),
                     coderService: this.getCoderService(),
+                    contentAsCodeProjectSettingsModel:
+                        this.models.getContentAsCodeProjectSettingsModel(),
                     contentAsCodeSnapshotModel:
                         this.models.getContentAsCodeSnapshotModel(),
                     contentAsCodeWritebackModel:

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -142,6 +142,9 @@ import {
     type ApiAlertAsCodeUpsertResponse,
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
+    type ApiContentAsCodeProposeResponse,
+    type ApiContentAsCodeSettingsResponse,
+    type ApiContentAsCodeWritebacksResponse,
     type ApiDashboardAsCodeListResponse,
     type ApiGoogleSheetsSyncAsCodeListResponse,
     type ApiGoogleSheetsSyncAsCodeUpsertResponse,
@@ -1357,6 +1360,9 @@ type ApiResults =
     | ApiSpaceAsCodeListResponse['results']
     | ApiSpaceAsCodeUpsertResponse['results']
     | ApiChartAsCodeUpsertResponse['results']
+    | ApiContentAsCodeWritebacksResponse['results']
+    | ApiContentAsCodeProposeResponse['results']
+    | ApiContentAsCodeSettingsResponse['results']
     | ApiGetMetricsTree['results']
     | ApiGetMetricsTreeResponse['results']
     | ApiGetMetricsTreesResponse['results']

--- a/packages/common/src/types/contentAsCode/base.ts
+++ b/packages/common/src/types/contentAsCode/base.ts
@@ -68,3 +68,41 @@ export type ApiContentAsCodeUpsertResponse<
     status: 'ok';
     results: { action: ContentAsCodeUpsertAction } & Extra;
 };
+export type ContentAsCodeWritebackStatus =
+    | 'pending'
+    | 'open'
+    | 'merged'
+    | 'closed'
+    | 'error';
+
+export type ContentAsCodeWritebackSummary = {
+    contentType: string;
+    slug: string;
+    branch: string;
+    prNumber: number | null;
+    prUrl: string | null;
+    status: ContentAsCodeWritebackStatus;
+    error: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type ApiContentAsCodeWritebacksResponse = {
+    status: 'ok';
+    results: ContentAsCodeWritebackSummary[];
+};
+
+export type ApiContentAsCodeProposeResponse = {
+    status: 'ok';
+    results: ContentAsCodeWritebackSummary;
+};
+
+export type ContentAsCodeProjectSettings = {
+    syncEnabled: boolean;
+    stampedAt: Date;
+};
+
+export type ApiContentAsCodeSettingsResponse = {
+    status: 'ok';
+    results: ContentAsCodeProjectSettings | null;
+};


### PR DESCRIPTION
## Summary

Stacked on #28004. Existing Lightdash changes can be proposed back to the repo on demand using the write-back primitives.

## API

- `POST /api/v1/projects/{uuid}/code/writebacks/charts/{slug}/propose` opens or appends to the per-slug PR from current instance content. Requires stamped `content_as_code.sync` and a Git-backed snapshot marker. Unmanaged content points to the explicit Add to Git action in #28007.
- `GET /api/v1/projects/{uuid}/code/writebacks` lists this instance's PRs. `refresh=true` best-effort refreshes GitHub PR status.
- `GET /api/v1/projects/{uuid}/code/sync-settings` exposes the stamped sync setting.

## Product note

No business-user-facing UI here. This is the admin/power-user API consumed by the sync panel and draft-review flow. Editor saves do not open PRs.

## Regression analysis

Purely additive routes/status handling. Propose is explicit and never changes upload behavior.

## Verification

Backend/frontend typechecks and touched tests/lints pass.

Closes: PROD-10512
Relates: PROD-2856