### PR TITLE
fix(dashboards): clear chart dirty state after save

### DIFF
--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -506,6 +506,7 @@ export const useAddVersionMutation = (options?: {
     const redirectOnSuccess = options?.redirectOnSuccess ?? true;
     const navigate = useNavigate();
     const queryClient = useQueryClient();
+    const params = useParams();
     const dashboardUuid = useSearchParams('fromDashboard');
 
     const { showToastSuccess, showToastError, showToastApiError } =
@@ -530,6 +531,10 @@ export const useAddVersionMutation = (options?: {
 
             queryClient.setQueryData(
                 ['saved_query', data.uuid, data.projectUuid],
+                data,
+            );
+            queryClient.setQueryData(
+                ['saved_query', params.savedQueryUuid, data.projectUuid],
                 data,
             );
             await queryClient.resetQueries(['savedChartResults', data.uuid]);


### PR DESCRIPTION
## Summary

- update the active saved-chart query cache after saving a new chart version
- keep the slug-based editor saved baseline in sync with the successful API response
- prevent the unsaved-changes prompt from persisting after dashboard-origin chart saves

## Root cause

The editor is loaded from the chart slug and subscribes to a slug-keyed saved_query cache entry. The version-save mutation only updated the canonical UUID-keyed entry, so the backend save succeeded while the editor retained a stale saved baseline.

## Verification

- reproduced the exact warning from a dashboard tile on localhost:3000 before the fix
- verified the success confirmation appears and Save changes becomes disabled after the fix
- verified navigation completes without the unsaved-changes dialog
- restored the temporary Show row numbers setting used during reproduction
- pnpm -F frontend typecheck
- pnpm -F frontend lint
- pnpm -F frontend exec oxfmt --check ./src/hooks/useSavedQuery.ts
- git diff --check origin/main...HEAD

Linear: https://linear.app/lightdash/issue/PROD-10535/dashboards-unsaved-changes-prompt-persists-after-successfully-saving-a