### PR TITLE
feat: conflict resolution for skipped content (instance vs git)

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -41,6 +41,10 @@ import {
     DashboardTileCommentsTableName,
 } from '../database/entities/comments';
 import {
+    ContentAsCodeIncomingStashTable,
+    ContentAsCodeIncomingStashTableName,
+} from '../database/entities/contentAsCodeIncomingStash';
+import {
     ContentAsCodeSnapshotsTableName,
     ContentAsCodeSnapshotTable,
 } from '../database/entities/contentAsCodeSnapshots';
@@ -785,6 +789,7 @@ declare module 'knex/types/tables' {
         [ManagedAgentProtectionsTableName]: ManagedAgentProtectionsTable;
         [UserFavoritesTableName]: UserFavoritesTable;
         [ContentAsCodeSnapshotsTableName]: ContentAsCodeSnapshotTable;
+        [ContentAsCodeIncomingStashTableName]: ContentAsCodeIncomingStashTable;
         [ContentAsCodeProjectSettingsTableName]: ContentAsCodeProjectSettingsTable;
         [ContentAsCodeWritebacksTableName]: ContentAsCodeWritebackTable;
         [ContentVerificationTableName]: ContentVerificationTable;

--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -10,6 +10,8 @@ import {
     type ApiAlertAsCodeUpsertResponse,
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
+    type ApiContentAsCodeConflictResponse,
+    type ApiContentAsCodeConflictsResponse,
     type ApiContentAsCodeProposeResponse,
     type ApiContentAsCodeSettingsResponse,
     type ApiContentAsCodeWritebacksResponse,
@@ -31,6 +33,8 @@ import {
     type ApiVirtualViewAsCodeListResponse,
     type ApiVirtualViewAsCodeUpsertResponse,
     type ChartAsCode,
+    type ContentAsCodeConflictResolution,
+    type ContentAsCodeSyncedContentType,
     type ContentSlugRenameRequest,
     type DashboardAsCode,
     type ExternalConnectionAsCode,
@@ -229,6 +233,93 @@ export class ProjectCoderController extends BaseController {
                     projectUuid,
                 ),
         );
+    }
+
+    /**
+     * Skipped uploads stashed for later conflict resolution
+     * @summary List content-as-code conflicts
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_READ_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Get('/code/conflicts')
+    @OperationId('listContentAsCodeConflicts')
+    async listContentAsCodeConflicts(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiContentAsCodeConflictsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return codeSuccess(
+            await this.services
+                .getCoderService()
+                .listContentAsCodeConflicts(
+                    toSessionUser(req.account),
+                    projectUuid,
+                ),
+        );
+    }
+
+    /**
+     * Three-way view of a skipped slug: base (last applied), current
+     * (instance), incoming (rejected from git at skip time)
+     * @summary Get content-as-code conflict
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_READ_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Get('/code/conflicts/{contentType}/{slug}')
+    @OperationId('getContentAsCodeConflict')
+    async getContentAsCodeConflict(
+        @Path() projectUuid: string,
+        @Path() contentType: ContentAsCodeSyncedContentType,
+        @Path() slug: string,
+        @Request() req: express.Request,
+    ): Promise<ApiContentAsCodeConflictResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return codeSuccess(
+            await this.services
+                .getCoderService()
+                .getContentAsCodeConflict(
+                    toSessionUser(req.account),
+                    projectUuid,
+                    contentType,
+                    slug,
+                ),
+        );
+    }
+
+    /**
+     * Resolve a stashed conflict: take_git applies the stashed incoming
+     * document and restamps; keep_mine clears the stash and leaves the slug
+     * ahead (propose-to-git remains the path back to the repo)
+     * @summary Resolve content-as-code conflict
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_WRITE_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Post('/code/conflicts/{contentType}/{slug}/resolve')
+    @OperationId('resolveContentAsCodeConflict')
+    async resolveContentAsCodeConflict(
+        @Path() projectUuid: string,
+        @Path() contentType: ContentAsCodeSyncedContentType,
+        @Path() slug: string,
+        @Request() req: express.Request,
+        @Body() body: { resolution: ContentAsCodeConflictResolution },
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        await this.services
+            .getCoderService()
+            .resolveContentAsCodeConflict(
+                toSessionUser(req.account),
+                projectUuid,
+                contentType,
+                slug,
+                body.resolution,
+            );
+        return { status: 'ok', results: undefined };
     }
 
     /**

--- a/packages/backend/src/database/entities/contentAsCodeIncomingStash.ts
+++ b/packages/backend/src/database/entities/contentAsCodeIncomingStash.ts
@@ -1,0 +1,32 @@
+import { Knex } from 'knex';
+
+export const ContentAsCodeIncomingStashTableName =
+    'content_as_code_incoming_stash';
+
+export type DbContentAsCodeIncomingStash = {
+    content_as_code_incoming_stash_uuid: string;
+    project_uuid: string;
+    content_type: string;
+    slug: string;
+    incoming_snapshot: object;
+    incoming_hash: string;
+    rejected_at: Date;
+};
+
+export type CreateDbContentAsCodeIncomingStash = Pick<
+    DbContentAsCodeIncomingStash,
+    | 'project_uuid'
+    | 'content_type'
+    | 'slug'
+    | 'incoming_snapshot'
+    | 'incoming_hash'
+>;
+
+export type ContentAsCodeIncomingStashTable = Knex.CompositeTableType<
+    DbContentAsCodeIncomingStash,
+    CreateDbContentAsCodeIncomingStash,
+    Pick<
+        DbContentAsCodeIncomingStash,
+        'incoming_snapshot' | 'incoming_hash' | 'rejected_at'
+    >
+>;

--- a/packages/backend/src/database/migrations/20260825120000_create_content_as_code_incoming_stash.ts
+++ b/packages/backend/src/database/migrations/20260825120000_create_content_as_code_incoming_stash.ts
@@ -1,0 +1,45 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Creates an empty stash table without touching existing rows',
+} as const;
+
+const INCOMING_STASH_TABLE = 'content_as_code_incoming_stash';
+const PROJECTS_TABLE = 'projects';
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.createTable(INCOMING_STASH_TABLE, (table) => {
+        table
+            .uuid('content_as_code_incoming_stash_uuid')
+            .notNullable()
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable(PROJECTS_TABLE)
+            .onDelete('CASCADE')
+            .index();
+        table.string('content_type').notNullable();
+        table.string('slug', 255).notNullable();
+        table.jsonb('incoming_snapshot').notNullable();
+        table.string('incoming_hash', 64).notNullable();
+        table
+            .timestamp('rejected_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.unique(['project_uuid', 'content_type', 'slug']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.dropTableIfExists(INCOMING_STASH_TABLE);
+}

--- a/packages/backend/src/models/ContentAsCodeSnapshotModel.ts
+++ b/packages/backend/src/models/ContentAsCodeSnapshotModel.ts
@@ -1,5 +1,6 @@
 import { ContentAsCodeType } from '@lightdash/common';
 import { Knex } from 'knex';
+import { ContentAsCodeIncomingStashTableName } from '../database/entities/contentAsCodeIncomingStash';
 import { ContentAsCodeSnapshotsTableName } from '../database/entities/contentAsCodeSnapshots';
 
 export type ContentAsCodeSnapshotType =
@@ -15,6 +16,14 @@ export type ContentAsCodeSnapshot = {
     snapshot: object;
     snapshotHash: string;
     appliedAt: Date;
+};
+
+export type ContentAsCodeIncomingStash = {
+    contentType: string;
+    slug: string;
+    incomingSnapshot: object;
+    incomingHash: string;
+    rejectedAt: Date;
 };
 
 export class ContentAsCodeSnapshotModel {
@@ -75,5 +84,82 @@ export class ContentAsCodeSnapshotModel {
                 applied_at: this.database.fn.now(),
                 applied_by_user_uuid: appliedByUserUuid,
             });
+    }
+
+    // The rejected incoming doc stashed at skip time: without it, post-deploy
+    // conflict resolution in the UI would be impossible (upload discards what
+    // it skipped)
+    async stashIncoming(args: {
+        projectUuid: string;
+        contentType: ContentAsCodeSnapshotType;
+        slug: string;
+        incomingSnapshot: object;
+        incomingHash: string;
+    }): Promise<void> {
+        await this.database(ContentAsCodeIncomingStashTableName)
+            .insert({
+                project_uuid: args.projectUuid,
+                content_type: args.contentType,
+                slug: args.slug,
+                incoming_snapshot: args.incomingSnapshot,
+                incoming_hash: args.incomingHash,
+            })
+            .onConflict(['project_uuid', 'content_type', 'slug'])
+            .merge({
+                incoming_snapshot: args.incomingSnapshot,
+                incoming_hash: args.incomingHash,
+                rejected_at: this.database.fn.now(),
+            });
+    }
+
+    async getIncomingStash(
+        projectUuid: string,
+        contentType: ContentAsCodeSnapshotType,
+        slug: string,
+    ): Promise<ContentAsCodeIncomingStash | undefined> {
+        const row = await this.database(ContentAsCodeIncomingStashTableName)
+            .where({
+                project_uuid: projectUuid,
+                content_type: contentType,
+                slug,
+            })
+            .first();
+        if (row === undefined) return undefined;
+        return {
+            contentType: row.content_type,
+            slug: row.slug,
+            incomingSnapshot: row.incoming_snapshot,
+            incomingHash: row.incoming_hash,
+            rejectedAt: row.rejected_at,
+        };
+    }
+
+    async listIncomingStash(
+        projectUuid: string,
+    ): Promise<ContentAsCodeIncomingStash[]> {
+        const rows = await this.database(ContentAsCodeIncomingStashTableName)
+            .where({ project_uuid: projectUuid })
+            .orderBy('rejected_at', 'desc');
+        return rows.map((row) => ({
+            contentType: row.content_type,
+            slug: row.slug,
+            incomingSnapshot: row.incoming_snapshot,
+            incomingHash: row.incoming_hash,
+            rejectedAt: row.rejected_at,
+        }));
+    }
+
+    async clearIncomingStash(
+        projectUuid: string,
+        contentType: ContentAsCodeSnapshotType,
+        slug: string,
+    ): Promise<void> {
+        await this.database(ContentAsCodeIncomingStashTableName)
+            .where({
+                project_uuid: projectUuid,
+                content_type: contentType,
+                slug,
+            })
+            .delete();
     }
 }

--- a/packages/backend/src/services/CoderService/CoderService.conflicts.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.conflicts.test.ts
@@ -1,0 +1,174 @@
+import { type AnyType, type SessionUser } from '@lightdash/common';
+import { describe, expect, it, vi } from 'vitest';
+import { CoderService } from './CoderService';
+
+const user = {
+    userUuid: 'user-uuid',
+    ability: {
+        can: () => true,
+        cannot: () => false,
+        relevantRuleFor: () => ({ inverted: false }),
+    },
+} as unknown as SessionUser;
+
+const stash = {
+    contentType: 'chart',
+    slug: 'monthly-revenue',
+    incomingSnapshot: { name: 'Monthly revenue', slug: 'monthly-revenue' },
+    incomingHash: 'incoming-hash',
+    rejectedAt: new Date('2026-08-25T09:00:00Z'),
+};
+
+const buildService = (
+    overrides: {
+        stash?: object | undefined;
+        base?: object | undefined;
+    } = {},
+) => {
+    const contentAsCodeSnapshotModel = {
+        upsert: vi.fn(),
+        get: vi.fn().mockResolvedValue(
+            'base' in overrides
+                ? overrides.base
+                : {
+                      snapshot: { name: 'Base' },
+                      snapshotHash: 'base-hash',
+                      appliedAt: new Date('2026-08-24T09:00:00Z'),
+                  },
+        ),
+        getIncomingStash: vi
+            .fn()
+            .mockResolvedValue('stash' in overrides ? overrides.stash : stash),
+        listIncomingStash: vi.fn().mockResolvedValue([stash]),
+        clearIncomingStash: vi.fn(),
+        stashIncoming: vi.fn(),
+    };
+    const service = new CoderService({
+        analytics: {} as AnyType,
+        contentAsCodeSnapshotModel: contentAsCodeSnapshotModel as AnyType,
+        contentAsCodeProjectSettingsModel: { upsert: vi.fn() } as AnyType,
+        contentVerificationModel: {} as AnyType,
+        dashboardModel: {} as AnyType,
+        lightdashConfig: {} as AnyType,
+        projectModel: {
+            get: vi.fn().mockResolvedValue({
+                projectUuid: 'project-uuid',
+                organizationUuid: 'org-uuid',
+            }),
+            getSummary: vi.fn().mockResolvedValue({
+                organizationUuid: 'org-uuid',
+            }),
+        } as AnyType,
+        promoteService: {} as AnyType,
+        savedChartModel: { find: vi.fn() } as AnyType,
+        savedSqlModel: { find: vi.fn() } as AnyType,
+        appModel: {} as AnyType,
+        schedulerModel: {} as AnyType,
+        schedulerService: {} as AnyType,
+        savedChartService: {} as AnyType,
+        dashboardService: {} as AnyType,
+        schedulerClient: {} as AnyType,
+        spaceModel: {} as AnyType,
+        spacePermissionService: {} as AnyType,
+        groupsModel: {} as AnyType,
+        organizationMemberProfileModel: {} as AnyType,
+        userModel: {} as AnyType,
+    });
+    return { service, contentAsCodeSnapshotModel };
+};
+
+describe('CoderService content-as-code conflicts', () => {
+    it('lists stashed conflicts', async () => {
+        const { service } = buildService();
+        const conflicts = await service.listContentAsCodeConflicts(
+            user,
+            'project-uuid',
+        );
+        expect(conflicts).toEqual([
+            {
+                contentType: 'chart',
+                slug: 'monthly-revenue',
+                incomingHash: 'incoming-hash',
+                rejectedAt: stash.rejectedAt,
+            },
+        ]);
+    });
+
+    it('returns the three-way view for a stashed slug', async () => {
+        const { service } = buildService();
+        vi.spyOn(service, 'getCurrentContentVersionBySlug').mockResolvedValue({
+            contentUuid: 'chart-uuid',
+            versionUuid: null,
+        });
+        vi.spyOn(service, 'getCurrentChartAsCode').mockResolvedValue({
+            name: 'Current',
+            slug: 'monthly-revenue',
+        } as AnyType);
+
+        const conflict = await service.getContentAsCodeConflict(
+            user,
+            'project-uuid',
+            'chart',
+            'monthly-revenue',
+        );
+        expect(conflict.base).toEqual({ name: 'Base' });
+        expect(conflict.baseHash).toBe('base-hash');
+        expect(conflict.current).toEqual({
+            name: 'Current',
+            slug: 'monthly-revenue',
+        });
+        expect(conflict.incoming).toEqual(stash.incomingSnapshot);
+        expect(conflict.incomingHash).toBe('incoming-hash');
+    });
+
+    it('404s when nothing is stashed', async () => {
+        const { service } = buildService({ stash: undefined });
+        await expect(
+            service.getContentAsCodeConflict(
+                user,
+                'project-uuid',
+                'chart',
+                'monthly-revenue',
+            ),
+        ).rejects.toThrow('No skipped upload is stashed');
+    });
+
+    it('take_git applies the stashed incoming doc with git-wins semantics', async () => {
+        const { service } = buildService();
+        const upsertSpy = vi
+            .spyOn(service, 'upsertChart')
+            .mockResolvedValue({} as AnyType);
+        await service.resolveContentAsCodeConflict(
+            user,
+            'project-uuid',
+            'chart',
+            'monthly-revenue',
+            'take_git',
+        );
+        expect(upsertSpy).toHaveBeenCalledWith(
+            user,
+            'project-uuid',
+            'monthly-revenue',
+            stash.incomingSnapshot,
+            { overwriteDrifted: true },
+        );
+    });
+
+    it('keep_mine clears the stash and applies nothing', async () => {
+        const { service, contentAsCodeSnapshotModel } = buildService();
+        const upsertSpy = vi
+            .spyOn(service, 'upsertChart')
+            .mockResolvedValue({} as AnyType);
+        await service.resolveContentAsCodeConflict(
+            user,
+            'project-uuid',
+            'chart',
+            'monthly-revenue',
+            'keep_mine',
+        );
+        expect(upsertSpy).not.toHaveBeenCalled();
+        expect(
+            contentAsCodeSnapshotModel.clearIncomingStash,
+        ).toHaveBeenCalledWith('project-uuid', 'chart', 'monthly-revenue');
+    });
+});

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -25,6 +25,10 @@ import {
     ChartScheduledDeliveryAsCode,
     ChartSummary,
     ChartType,
+    ContentAsCodeConflict,
+    ContentAsCodeConflictResolution,
+    ContentAsCodeConflictSummary,
+    ContentAsCodeSyncedContentType,
     ContentAsCodeType,
     ContentSlugRenameRequest,
     ContentType,
@@ -2788,6 +2792,12 @@ export class CoderService extends BaseService {
             snapshotHash,
             appliedByUserUuid,
         });
+        // A successful apply supersedes any conflict stashed at skip time
+        await this.contentAsCodeSnapshotModel.clearIncomingStash(
+            projectUuid,
+            contentType,
+            content.slug,
+        );
     }
 
     // The instance content in its canonical as-code form — the same document
@@ -2858,6 +2868,176 @@ export class CoderService extends BaseService {
         return settings ?? null;
     }
 
+    private async assertProjectViewAccess(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    async listContentAsCodeConflicts(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ContentAsCodeConflictSummary[]> {
+        await this.assertProjectViewAccess(user, projectUuid);
+        const rows =
+            await this.contentAsCodeSnapshotModel.listIncomingStash(
+                projectUuid,
+            );
+        return rows.map((row) => ({
+            contentType: row.contentType,
+            slug: row.slug,
+            incomingHash: row.incomingHash,
+            rejectedAt: row.rejectedAt,
+        }));
+    }
+
+    // Three-way view: base = last-applied snapshot (merge base), current =
+    // instance content, incoming = the git document rejected at skip time
+    async getContentAsCodeConflict(
+        user: SessionUser,
+        projectUuid: string,
+        contentType: ContentAsCodeSyncedContentType,
+        slug: string,
+    ): Promise<ContentAsCodeConflict> {
+        const snapshotType =
+            contentType === 'chart'
+                ? ContentAsCodeType.CHART
+                : ContentAsCodeType.DASHBOARD;
+        const stash = await this.contentAsCodeSnapshotModel.getIncomingStash(
+            projectUuid,
+            snapshotType,
+            slug,
+        );
+        if (stash === undefined) {
+            throw new NotFoundError(
+                `No skipped upload is stashed for ${contentType} "${slug}"`,
+            );
+        }
+        // Also carries the project view permission check
+        const { contentUuid } = await this.getCurrentContentVersionBySlug(
+            user,
+            projectUuid,
+            contentType,
+            slug,
+        );
+        const currentContent =
+            contentType === 'chart'
+                ? await this.getCurrentChartAsCode(contentUuid)
+                : await this.getCurrentDashboardAsCode(contentUuid);
+        const current = buildContentAsCodeSnapshot(currentContent);
+        const base = await this.contentAsCodeSnapshotModel.get(
+            projectUuid,
+            snapshotType,
+            slug,
+        );
+        return {
+            contentType,
+            slug,
+            base: base?.snapshot ?? null,
+            baseHash: base?.snapshotHash ?? null,
+            appliedAt: base?.appliedAt ?? null,
+            current: current.snapshot,
+            currentHash: current.snapshotHash,
+            incoming: stash.incomingSnapshot,
+            incomingHash: stash.incomingHash,
+            rejectedAt: stash.rejectedAt,
+        };
+    }
+
+    // "Take git" applies the stashed incoming doc and restamps (which also
+    // clears the stash); "keep mine" clears the stash and leaves the slug
+    // ahead — propose-to-git remains the path back to the repo.
+    async resolveContentAsCodeConflict(
+        user: SessionUser,
+        projectUuid: string,
+        contentType: ContentAsCodeSyncedContentType,
+        slug: string,
+        resolution: ContentAsCodeConflictResolution,
+    ): Promise<void> {
+        const snapshotType =
+            contentType === 'chart'
+                ? ContentAsCodeType.CHART
+                : ContentAsCodeType.DASHBOARD;
+        const stash = await this.contentAsCodeSnapshotModel.getIncomingStash(
+            projectUuid,
+            snapshotType,
+            slug,
+        );
+        if (stash === undefined) {
+            throw new NotFoundError(
+                `No skipped upload is stashed for ${contentType} "${slug}"`,
+            );
+        }
+        switch (resolution) {
+            case 'take_git': {
+                // The stash is the canonical as-code document rejected at
+                // skip time; apply it with git-wins semantics
+                if (contentType === 'chart') {
+                    await this.upsertChart(
+                        user,
+                        projectUuid,
+                        slug,
+                        stash.incomingSnapshot as ChartAsCode,
+                        { overwriteDrifted: true },
+                    );
+                } else {
+                    await this.upsertDashboard(
+                        user,
+                        projectUuid,
+                        slug,
+                        stash.incomingSnapshot as DashboardAsCode,
+                        { overwriteDrifted: true },
+                    );
+                }
+                return;
+            }
+            case 'keep_mine': {
+                // Clearing the stash mutates sync state: require the same
+                // full content-as-code access as settings stamping
+                const project = await this.projectModel.get(projectUuid);
+                const auditedAbility = this.createAuditedAbility(user);
+                if (
+                    auditedAbility.cannot(
+                        'manage',
+                        subject('ContentAsCode', {
+                            projectUuid: project.projectUuid,
+                            organizationUuid: project.organizationUuid,
+                            upstreamProjectUuid: project.upstreamProjectUuid,
+                            type: project.type,
+                            createdByUserUuid: project.createdByUserUuid,
+                            metadata: { slug },
+                        }),
+                    )
+                ) {
+                    throw new ForbiddenError(
+                        `You don't have permission to resolve content-as-code conflicts on this project`,
+                    );
+                }
+                await this.contentAsCodeSnapshotModel.clearIncomingStash(
+                    projectUuid,
+                    snapshotType,
+                    slug,
+                );
+                return;
+            }
+            default:
+                assertUnreachable(resolution, 'Unknown conflict resolution');
+        }
+    }
+
     // The repo's content_as_code flags travel with uploads; stamping them as
     // project-level state is how the instance (settings UI, write-back)
     // learns what the repo has opted into.
@@ -2889,6 +3069,32 @@ export class CoderService extends BaseService {
             projectUuid,
             syncEnabled: settings.sync,
         });
+    }
+
+    // Stashing what a skip rejected is what makes post-deploy conflict
+    // resolution possible; best-effort, a stash failure never fails the skip.
+    private async stashRejectedIncoming(
+        projectUuid: string,
+        contentType: ContentAsCodeSnapshotType,
+        slug: string,
+        incomingContent: SnapshotAsCodeContent,
+    ): Promise<void> {
+        try {
+            const { snapshot, snapshotHash } =
+                buildContentAsCodeSnapshot(incomingContent);
+            await this.contentAsCodeSnapshotModel.stashIncoming({
+                projectUuid,
+                contentType,
+                slug,
+                incomingSnapshot: snapshot,
+                incomingHash: snapshotHash,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Failed to stash rejected incoming ${contentType} ${slug} on project ${projectUuid}`,
+                error,
+            );
+        }
     }
 
     // Drift detection is best-effort: a failure here must not block uploads,
@@ -3353,6 +3559,12 @@ export class CoderService extends BaseService {
                   })
                 : undefined;
         if (driftGate?.outcome === 'skip') {
+            await this.stashRejectedIncoming(
+                projectUuid,
+                ContentAsCodeType.CHART,
+                chart.slug,
+                chartWithDefaults,
+            );
             return {
                 spaces: [],
                 charts: [],
@@ -4368,6 +4580,12 @@ export class CoderService extends BaseService {
                   })
                 : undefined;
         if (driftGate?.outcome === 'skip') {
+            await this.stashRejectedIncoming(
+                projectUuid,
+                ContentAsCodeType.DASHBOARD,
+                dashboard.slug,
+                dashboardWithDefaults,
+            );
             return {
                 spaces: [],
                 charts: [],

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -142,6 +142,8 @@ import {
     type ApiAlertAsCodeUpsertResponse,
     type ApiChartAsCodeListResponse,
     type ApiChartAsCodeUpsertResponse,
+    type ApiContentAsCodeConflictResponse,
+    type ApiContentAsCodeConflictsResponse,
     type ApiContentAsCodeProposeResponse,
     type ApiContentAsCodeSettingsResponse,
     type ApiContentAsCodeWritebacksResponse,
@@ -1356,6 +1358,8 @@ type ApiResults =
     | ApiSpaceAsCodeUpsertResponse['results']
     | ApiChartAsCodeUpsertResponse['results']
     | ApiContentAsCodeWritebacksResponse['results']
+    | ApiContentAsCodeConflictsResponse['results']
+    | ApiContentAsCodeConflictResponse['results']
     | ApiContentAsCodeProposeResponse['results']
     | ApiContentAsCodeSettingsResponse['results']
     | ApiGetMetricsTree['results']

--- a/packages/common/src/types/contentAsCode/base.ts
+++ b/packages/common/src/types/contentAsCode/base.ts
@@ -128,3 +128,42 @@ export type ApiContentAsCodeSettingsResponse = {
     status: 'ok';
     results: ContentAsCodeProjectSettings | null;
 };
+
+export type ContentAsCodeSyncedContentType = 'chart' | 'dashboard';
+
+export type ContentAsCodeConflictSummary = {
+    contentType: string;
+    slug: string;
+    incomingHash: string;
+    rejectedAt: Date;
+};
+
+/**
+ * Three-way view of a skipped slug: base is the last-applied snapshot
+ * (merge base), current is the instance content, incoming is the git
+ * document rejected at skip time.
+ */
+export type ContentAsCodeConflict = {
+    contentType: string;
+    slug: string;
+    base: object | null;
+    baseHash: string | null;
+    appliedAt: Date | null;
+    current: object;
+    currentHash: string;
+    incoming: object;
+    incomingHash: string;
+    rejectedAt: Date;
+};
+
+export type ContentAsCodeConflictResolution = 'take_git' | 'keep_mine';
+
+export type ApiContentAsCodeConflictsResponse = {
+    status: 'ok';
+    results: ContentAsCodeConflictSummary[];
+};
+
+export type ApiContentAsCodeConflictResponse = {
+    status: 'ok';
+    results: ContentAsCodeConflict;
+};


### PR DESCRIPTION
## Summary

Final slice of the content-as-code sync stack, stacked on #28007. The skip contract (#28002) protects instance edits but leaves the conflict unresolved — the only options were whole-fleet-coarse (`--overwrite-drifted` or propose-to-git). This makes per-slug resolution possible.

## How it works

- **Stash at skip time**: when the drift gate skips a slug, the rejected incoming document (canonical form + hash) is stashed in a new `content_as_code_incoming_stash` table (one row per project/type/slug, upserted). Best-effort — a stash failure never fails the skip. Without this, upload discards what it skipped and post-deploy resolution would be impossible.
- **Three-way view**: `GET /code/conflicts/{contentType}/{slug}` returns base (last-applied snapshot — the merge base the snapshot foundation gives us), current (instance content in canonical form), incoming (the stashed git doc), with hashes and timestamps. `GET /code/conflicts` lists stashed slugs.
- **Resolve**: `POST /code/conflicts/{contentType}/{slug}/resolve` with `take_git` applies the stashed incoming doc through the normal upsert with git-wins semantics (which restamps and clears the stash via the shared apply funnel), or `keep_mine` which clears the stash and leaves the slug ahead — propose-to-git (#28006) remains the path back to the repo. `keep_mine` requires full content-as-code access; `take_git` inherits the upsert's own permission checks.
- **Any successful apply clears the stash** (wired into `recordAppliedSnapshot`, the single funnel), so a later `--overwrite-drifted` or in-sync upload self-heals stale conflicts.

## Scope decisions (per ticket's open questions)

- Whole-document per slug; field-level auto-merge is out of scope.
- Backend + API only: the three-way diff UI belongs to the admin sync panel (PROD-10509) — no business-user-facing surface, per the write-back product direction.
- Interactive CLI resolution out of scope.

## Verification

- 5 new unit tests: list, three-way shape, 404 without stash, take_git delegates to upsert with `overwriteDrifted`, keep_mine clears without applying. Full CoderService suite green (163 tests).
- Migration is additive (empty table, classified safe).

Closes: PROD-10515
Relates: PROD-2856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGS7Sze6P5jGHyeUphu3vi