### PR TITLE
chore(dev): opt-in memory cap for tsc watchers (LD_WATCHER_MEMORY_CAP)

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -542,6 +542,11 @@ LDPAT=ldpat_deadbeefdeadbeefdeadbeefdeadbeef
 # Allow registering fresh users/orgs (signup flow testing). Always on by default
 # in dev — without it, POST /api/v1/user 403s once the seed org exists.
 ALLOW_MULTIPLE_ORGS=true
+
+# Restart PM2 tsc watchers above this memory cap — they hold memory after big
+# rebuilds (branch switches), and multiple instances can exhaust the machine.
+# See ecosystem.config.js. Uncomment on smaller (e.g. 16GB) machines:
+# LD_WATCHER_MEMORY_CAP=1500M
 EOF
 echo "DBT_DEMO_DIR=$(pwd)/examples/full-jaffle-shop-demo" >> .env.development.local
 ```

--- a/.env.development
+++ b/.env.development
@@ -77,6 +77,11 @@ INTERCOM_APP_ID=zppxyjpp
 # GITHUB_REDIRECT_DOMAIN=
 
 # LIGHTDASH_LICENSE_KEY=
+
+# Restart PM2 tsc watchers when their memory exceeds this cap — they hold
+# memory after big rebuilds (e.g. branch switches). Recommended on 16GB
+# machines, especially with multiple checkouts: 1500M
+# LD_WATCHER_MEMORY_CAP=
 # Users who run Lightdash with Docker should use the following settings
 HEADLESS_BROWSER_HOST=headless-browser
 HEADLESS_BROWSER_PORT=3000

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -100,6 +100,16 @@ if (!mapleBin) {
 
 const frontendArgs = fePort ? `--port ${fePort}` : undefined;
 
+// Opt-in via LD_WATCHER_MEMORY_CAP (e.g. 1500M in .env.development.local):
+// bounce a tsc watcher whose RSS exceeds the cap. Watchers recompile the
+// world on branch switches and never release the memory; the post-restart
+// incremental rebuild is cheap. Unset = no cap, today's behavior.
+const watcherMemoryCap =
+    process.env.LD_WATCHER_MEMORY_CAP ?? env.LD_WATCHER_MEMORY_CAP;
+const watcherMemoryCapConfig = watcherMemoryCap
+    ? { max_memory_restart: watcherMemoryCap }
+    : {};
+
 module.exports = {
     apps: [
         // Backend API Server
@@ -191,6 +201,7 @@ module.exports = {
             cwd: path.join(__dirname, 'packages/common'),
             watch: false,
             autorestart: false,
+            ...watcherMemoryCapConfig,
             kill_timeout: 3000,
             merge_logs: true,
             time: true,
@@ -205,6 +216,7 @@ module.exports = {
             cwd: path.join(__dirname, 'packages/formula'),
             watch: false,
             autorestart: false,
+            ...watcherMemoryCapConfig,
             kill_timeout: 3000,
             merge_logs: true,
             time: true,
@@ -219,6 +231,7 @@ module.exports = {
             cwd: path.join(__dirname, 'packages/warehouses'),
             watch: false,
             autorestart: false,
+            ...watcherMemoryCapConfig,
             kill_timeout: 3000,
             merge_logs: true,
             time: true,


### PR DESCRIPTION
Each dev checkout's PM2 stack runs three \`tsc --build --watch\` processes (common, warehouses, formula). A branch switch — or an agent restacking a branch stack — invalidates most of the program; the watcher recompiles everything and **never releases the memory**. Observed on a 16GB machine: one checkout's common-watch at 1.5GB RSS and warehouses-watch at 1.2GB, indefinitely. Two checkouts doing this at once makes the machine unusable.

This adds an **opt-in, per-machine** cap: set \`LD_WATCHER_MEMORY_CAP=1500M\` in \`.env.development.local\` (gitignored) and PM2 bounces any tsc watcher whose RSS crosses the cap — the post-restart incremental rebuild (\`.tsbuildinfo\`) is cheap and RSS returns to a ~200MB baseline, converting swap-death into a ~10s rebuild.

**Unset (the default), nothing changes for anyone** — no cap is applied, so machines with plenty of RAM keep exactly today's behavior and never pay a restart pause they don't need.

Notes: Node heap flags are not an option here (these run the native TS compiler binaries, not Node); PM2's memory monitor operates independently of \`autorestart\`, which only governs crash-exits. Dev-tooling only; no runtime code touched.

Closes: GLITCH-691

🤖 Generated with [Claude Code](https://claude.com/claude-code)