### PR TITLE
fix(explorer): version sync, run query and header parity in authoring

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -153,6 +153,7 @@ const dataAppViz = {
 const readyVersion = {
     version: 1,
     status: 'ready',
+    createdAt: new Date('2026-08-19T00:00:00Z'),
 } as ApiAppVersionSummary;
 
 const workspaceStub = (

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
@@ -1,6 +1,8 @@
 import {
     ChartType,
+    derivePivotConfigurationFromChart,
     FeatureFlags,
+    getFieldsFromMetricQuery,
     type DataAppVizOptionValues,
     type ItemsMap,
 } from '@lightdash/common';
@@ -14,17 +16,22 @@ import { buildExplorerVizContext } from '../../../features/chartTypes/utils/expl
 import {
     explorerActions,
     selectChartConfig,
+    selectUnsavedChartVersion,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import useHealth from '../../../hooks/health/useHealth';
 import useToaster from '../../../hooks/toaster/useToaster';
+import { useExplore } from '../../../hooks/useExplore';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { type ChartTypeAuthoringState } from '../../../providers/Explorer/types';
 import { CHART_GALLERY_SIDEBAR_TITLE_ID } from '../../common/ChartGallery/ChartGalleryContext';
+import { RefreshButton } from '../../RefreshButton';
 import { useSelectProjectChartType } from '../../VisualizationConfigs/CustomChartType/useSelectProjectChartType';
 import { useExplorerChartColorPalette } from '../VisualizationCard/useExplorerChartColorPalette';
 import { useExplorerResultsData } from '../VisualizationCard/useExplorerResultsData';
+import VisualizationWarning from '../VisualizationCard/VisualizationWarning';
 import ExplorerChartTypeAuthoringView from './ExplorerChartTypeAuthoringView';
 
 // Stable identities, so the workspace does not rebind before results land.
@@ -45,12 +52,43 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
     const selectProjectChartType = useSelectProjectChartType();
     const { mutate: deleteApp } = useDeleteApp();
 
-    const { resultsData } = useExplorerResultsData();
+    const {
+        resultsData,
+        isLoadingQueryResults,
+        mergeResults,
+        suppressPrimaryResults,
+    } = useExplorerResultsData();
     // Every page, so the preview sees what the chart would.
     useEffect(() => {
         resultsData.setFetchAll(true);
     }, [resultsData]);
     const itemsMap = resultsData.fields ?? NO_ITEMS;
+
+    // The same staleness signal the chart card shows: results computed with
+    // pivot settings that no longer match the configuration.
+    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
+    const { data: explore } = useExplore(unsavedChartVersion.tableName);
+    const health = useHealth();
+    const visualizationMetricQuery = suppressPrimaryResults
+        ? undefined
+        : (mergeResults?.metricQuery ?? unsavedChartVersion.metricQuery);
+    const dirtyPivotConfiguration = useMemo(() => {
+        const fields =
+            mergeResults?.fields ??
+            (explore
+                ? getFieldsFromMetricQuery(
+                      unsavedChartVersion.metricQuery,
+                      explore,
+                  )
+                : undefined);
+        return visualizationMetricQuery && fields
+            ? derivePivotConfigurationFromChart(
+                  unsavedChartVersion,
+                  visualizationMetricQuery,
+                  fields,
+              )
+            : undefined;
+    }, [unsavedChartVersion, visualizationMetricQuery, mergeResults, explore]);
 
     const workspace = useChartTypeBuilderWorkspace({
         projectUuid,
@@ -65,6 +103,16 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
             dispatch(explorerActions.claimChartTypeAuthoringViz(build.appUuid));
         }
     }, [authoring.dataAppVizUuid, build.appUuid, dispatch]);
+
+    // The sidebar lives outside this tree, so the pinned version reaches it
+    // through the store and its options follow the previewed version.
+    useEffect(() => {
+        dispatch(
+            explorerActions.viewChartTypeAuthoringVersion(
+                workspace.viewedVersion,
+            ),
+        );
+    }, [workspace.viewedVersion, dispatch]);
 
     const chartConfig = useExplorerSelector(selectChartConfig);
     const chartUsesThisType =
@@ -213,6 +261,18 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
             }
             workspace={workspace}
             previewContext={previewContext}
+            runQuery={
+                <>
+                    <VisualizationWarning
+                        dirtyPivotConfiguration={dirtyPivotConfiguration}
+                        chartConfig={unsavedChartVersion.chartConfig}
+                        resultsData={resultsData}
+                        isLoading={isLoadingQueryResults}
+                        maxColumnLimit={health.data?.pivotTable?.maxColumnLimit}
+                    />
+                    <RefreshButton size="xs" />
+                </>
+            }
             onDetailsSaved={handleDetailsSaved}
             onDone={handleDone}
         />

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.module.css
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.module.css
@@ -6,9 +6,23 @@
     background: var(--mantine-color-background-0);
 }
 
-/* The one element allowed to give way, so the actions never do. */
+/* The title and its byline share a text baseline; the icons between them
+   have none, so they center against the taller title instead. */
+.nameCluster {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    min-width: 0;
+}
+
+.nameCluster > button {
+    align-self: center;
+}
+
+/* Sits by its neighbours and only gives way under pressure, so the gap
+   after it stays the row gap rather than a fixed slot. */
 .title {
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     min-width: 0;
     max-width: 280px;
     overflow: hidden;
@@ -16,11 +30,10 @@
     text-overflow: ellipsis;
 }
 
-.status {
-    flex: 0 0 auto;
-    text-transform: none;
-    letter-spacing: 0;
-    font-weight: 500;
+/* Yields after the title, so the actions never do. */
+.provenance {
+    flex: 0 1 auto;
+    min-width: 0;
 }
 
 .actions {

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.test.tsx
@@ -29,9 +29,12 @@ const renderHeader = (
         titleId: 'title',
         app,
         status: null,
+        provenanceVersion: null,
+        hasOrigin: false,
         upgrade: null,
         hasHistory: true,
         isHistoryOpen: false,
+        runQuery: null,
         onToggleHistory: vi.fn(),
         onUpgradeStarted: vi.fn(),
         onDetailsSaved: vi.fn(),
@@ -101,6 +104,35 @@ describe('ExplorerChartTypeAuthoringHeader', () => {
             screen.getByRole('button', { name: 'Upgrade available' }),
         );
         expect(screen.getByRole('dialog')).toHaveTextContent('Upgrade');
+    });
+
+    it('shows where the type came from and explains it on demand', () => {
+        renderHeader({
+            provenanceVersion: {
+                version: 1,
+                createdAt: new Date().toISOString(),
+                createdByUser: {
+                    userUuid: 'user-1',
+                    firstName: 'David',
+                    lastName: 'Attenborough',
+                },
+            } as never,
+            hasOrigin: true,
+        });
+
+        expect(
+            screen.getByText(/Built by David Attenborough/),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Chart type description' }),
+        ).toBeInTheDocument();
+    });
+
+    it('hosts the run-query control it is given', () => {
+        renderHeader({ runQuery: <button type="button">Run query</button> });
+        expect(
+            screen.getByRole('button', { name: 'Run query' }),
+        ).toBeInTheDocument();
     });
 
     it('always offers Done and reports whether history is open', async () => {

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.tsx
@@ -1,19 +1,28 @@
-import { getAppDisplayName } from '@lightdash/common';
+import {
+    getAppDisplayName,
+    type ApiAppVersionSummary,
+} from '@lightdash/common';
 import {
     ActionIcon,
-    Badge,
+    Box,
     Button,
     Group,
-    Loader,
     Title,
     Tooltip,
     VisuallyHidden,
 } from '@mantine/core';
-import { IconHistory, IconPencil, IconSparkles } from '@tabler/icons-react';
-import { useEffect, useRef, useState, type FC } from 'react';
+import {
+    IconHistory,
+    IconInfoCircle,
+    IconPencil,
+    IconSparkles,
+} from '@tabler/icons-react';
+import { useEffect, useRef, useState, type FC, type ReactNode } from 'react';
 import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
 import AppUpgradeModal from '../../../features/apps/components/AppUpgradeModal';
 import { type SdkUpgradeOffer } from '../../../features/apps/hooks/useSdkUpgradeStatus';
+import { getVersionAuthorName } from '../../../features/apps/utils/versionsToChatMessages';
+import VersionProvenance from '../../../features/chartTypes/builder/VersionProvenance';
 import MantineIcon from '../../common/MantineIcon';
 import { authoringStatusLabel, type AuthoringStatus } from './authoringStatus';
 import classes from './ExplorerChartTypeAuthoringHeader.module.css';
@@ -24,9 +33,15 @@ type Props = {
     /** Null while no app exists yet (a new type before its first build). */
     app: { appUuid: string; name: string; description: string } | null;
     status: AuthoringStatus | null;
+    /** The version the provenance line reports; null while history is empty. */
+    provenanceVersion: ApiAppVersionSummary | null;
+    /** Whether `provenanceVersion` really is the origin (v1 is loaded). */
+    hasOrigin: boolean;
     upgrade: (SdkUpgradeOffer & { disabled: boolean }) | null;
     hasHistory: boolean;
     isHistoryOpen: boolean;
+    /** The host's run-query control; null when no query backs the session. */
+    runQuery: ReactNode;
     onToggleHistory: () => void;
     onUpgradeStarted: () => void;
     onDetailsSaved: () => void;
@@ -38,9 +53,12 @@ const ExplorerChartTypeAuthoringHeader: FC<Props> = ({
     titleId,
     app,
     status,
+    provenanceVersion,
+    hasOrigin,
     upgrade,
     hasHistory,
     isHistoryOpen,
+    runQuery,
     onToggleHistory,
     onUpgradeStarted,
     onDetailsSaved,
@@ -62,50 +80,64 @@ const ExplorerChartTypeAuthoringHeader: FC<Props> = ({
 
     return (
         <Group className={classes.header} gap="sm" wrap="nowrap">
-            <Title
-                ref={titleRef}
-                id={titleId}
-                order={2}
-                className={classes.title}
-                fz="sm"
-                fw={600}
-                title={title}
-                tabIndex={-1}
-            >
-                {title}
-            </Title>
-            {app && (
-                <Tooltip label="Edit details" position="bottom">
-                    <ActionIcon
-                        variant="subtle"
-                        color="gray"
-                        size="sm"
-                        aria-label="Edit chart type details"
-                        onClick={() => setIsEditingDetails(true)}
-                    >
-                        <MantineIcon icon={IconPencil} />
-                    </ActionIcon>
-                </Tooltip>
-            )}
-            {status && (
-                <Badge
-                    className={classes.status}
-                    size="sm"
-                    radius="sm"
-                    variant={status.kind === 'ready' ? 'filled' : 'light'}
-                    leftSection={
-                        status.kind === 'building' ? (
-                            <Loader size={8} color="currentColor" />
-                        ) : undefined
-                    }
+            <Box className={classes.nameCluster}>
+                <Title
+                    ref={titleRef}
+                    id={titleId}
+                    order={2}
+                    className={classes.title}
+                    fz="sm"
+                    fw={600}
+                    title={title}
+                    tabIndex={-1}
                 >
-                    {authoringStatusLabel(status)}
-                </Badge>
-            )}
+                    {title}
+                </Title>
+                {app && app.description && (
+                    <Tooltip
+                        withArrow
+                        multiline
+                        w={280}
+                        label={app.description}
+                        position="bottom"
+                    >
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            size="sm"
+                            aria-label="Chart type description"
+                        >
+                            <MantineIcon icon={IconInfoCircle} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+                {app && (
+                    <Tooltip label="Edit details" position="bottom">
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            size="sm"
+                            aria-label="Edit chart type details"
+                            onClick={() => setIsEditingDetails(true)}
+                        >
+                            <MantineIcon icon={IconPencil} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+                {provenanceVersion && (
+                    <VersionProvenance
+                        className={classes.provenance}
+                        authorName={getVersionAuthorName(provenanceVersion)}
+                        at={new Date(provenanceVersion.createdAt)}
+                        isOrigin={hasOrigin}
+                    />
+                )}
+            </Box>
             <VisuallyHidden role="status">
                 {status ? authoringStatusLabel(status) : ''}
             </VisuallyHidden>
             <Group className={classes.actions} gap="xs" wrap="nowrap">
+                {runQuery}
                 {upgradeAvailable && (
                     <Button
                         size="compact-sm"

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.tsx
@@ -1,6 +1,6 @@
 import { type DataAppVizContext } from '@lightdash/common';
 import { Box } from '@mantine/core';
-import { useId, type FC } from 'react';
+import { useId, type FC, type ReactNode } from 'react';
 import { type SdkUpgradeOffer } from '../../../features/apps/hooks/useSdkUpgradeStatus';
 import ChartTypeBuilderWorkspace from '../../../features/chartTypes/builder/ChartTypeBuilderWorkspace';
 import { type ChartTypeBuilderWorkspaceState } from '../../../features/chartTypes/builder/useChartTypeBuilderWorkspace';
@@ -14,6 +14,8 @@ type Props = {
     upgrade: (SdkUpgradeOffer & { disabled: boolean }) | null;
     workspace: ChartTypeBuilderWorkspaceState;
     previewContext: DataAppVizContext | null;
+    /** The host's run-query control; null when no query backs the session. */
+    runQuery: ReactNode;
     onDetailsSaved: () => void;
     onDone: () => void;
 };
@@ -25,10 +27,14 @@ const ExplorerChartTypeAuthoringView: FC<Props> = ({
     upgrade,
     workspace,
     previewContext,
+    runQuery,
     onDetailsSaved,
     onDone,
 }) => {
     const titleId = useId();
+    const provenanceVersion = workspace.history.hasOrigin
+        ? workspace.history.oldest
+        : workspace.history.latest;
     return (
         <Box
             component="section"
@@ -41,9 +47,12 @@ const ExplorerChartTypeAuthoringView: FC<Props> = ({
                 titleId={titleId}
                 app={app}
                 status={deriveAuthoringStatus(workspace)}
+                provenanceVersion={provenanceVersion}
+                hasOrigin={workspace.history.hasOrigin}
                 upgrade={upgrade}
                 hasHistory={workspace.hasHistory}
                 isHistoryOpen={workspace.isHistoryOpen}
+                runQuery={runQuery}
                 onToggleHistory={workspace.toggleHistory}
                 onUpgradeStarted={workspace.openHistory}
                 onDetailsSaved={onDetailsSaved}

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -54,7 +54,10 @@ const {
     navigate: vi.fn(),
     pickerProps: [] as PickerProps[],
     authoringState: {
-        current: null as { dataAppVizUuid: string | null } | null,
+        current: null as {
+            dataAppVizUuid: string | null;
+            viewedVersion?: number | null;
+        } | null,
     },
 }));
 
@@ -584,6 +587,42 @@ describe('DataAppVizConfigTabs', () => {
 
         expect(screen.getByText('Radial gauge')).toBeInTheDocument();
         await expect(screen.findByText('Edit ↗')).rejects.toThrow();
+    });
+
+    it('fetches the schema of the version the builder previews while authoring', () => {
+        authoringState.current = {
+            dataAppVizUuid: 'data-app-viz-uuid',
+            viewedVersion: 2,
+        };
+        try {
+            renderWithProviders(<ConfigTabs />);
+
+            expect(useDataAppVisualization).toHaveBeenLastCalledWith(
+                'project-1',
+                'data-app-viz-uuid',
+                2,
+            );
+        } finally {
+            authoringState.current = null;
+        }
+    });
+
+    it('stays on the latest schema when authoring a different type', () => {
+        authoringState.current = {
+            dataAppVizUuid: 'another-viz-uuid',
+            viewedVersion: 2,
+        };
+        try {
+            renderWithProviders(<ConfigTabs />);
+
+            expect(useDataAppVisualization).toHaveBeenLastCalledWith(
+                'project-1',
+                'data-app-viz-uuid',
+                null,
+            );
+        } finally {
+            authoringState.current = null;
+        }
     });
 
     it('fires setOption when a control changes', async () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -43,7 +43,8 @@ export const ConfigTabs: FC = memo(() => {
         useVisualizationContext();
     const selectProjectChartType = useSelectProjectChartType();
     const dispatch = useExplorerDispatch();
-    const isAuthoring = useExplorerSelector(selectChartTypeAuthoring) !== null;
+    const authoring = useExplorerSelector(selectChartTypeAuthoring);
+    const isAuthoring = authoring !== null;
 
     const isDataAppViz = isDataAppVizVisualizationConfig(visualizationConfig);
     const dataAppVizUuid = isDataAppViz
@@ -51,11 +52,16 @@ export const ConfigTabs: FC = memo(() => {
         : '';
 
     // A chart renders the viz's latest ready version, so its options come from
-    // that version's declaration.
+    // that version's declaration — unless the builder is previewing an older
+    // version of this same viz, whose own declaration the panel then follows.
+    const authoringVersion =
+        authoring !== null && authoring.dataAppVizUuid === dataAppVizUuid
+            ? authoring.viewedVersion
+            : null;
     const { data: dataAppViz } = useDataAppVisualization(
         projectUuid,
         dataAppVizUuid || undefined,
-        null,
+        authoringVersion,
     );
 
     const configOptions = useMemo(
@@ -138,7 +144,7 @@ export const ConfigTabs: FC = memo(() => {
                 fieldMapping={effectiveMapping}
                 onFieldChange={handleFieldChange}
             />
-            {dataAppViz && (!isInsideChartGallery || isAuthoring) && (
+            {dataAppViz && !isInsideChartGallery && (
                 <Box className={classes.typeCard}>
                     <Text fz="xs" fw={500}>
                         {getAppDisplayName(

--- a/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.module.css
+++ b/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.module.css
@@ -26,10 +26,25 @@
     flex-shrink: 0;
 }
 
+/* The name and its byline share a text baseline; the icons between them
+   have none, so they center against the taller name instead. */
+.nameCluster {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    min-width: 0;
+}
+
+.nameCluster > button {
+    align-self: center;
+}
+
 .name {
     max-width: 280px;
 }
 
+/* Truncates only under real pressure, not at a fixed width. */
 .provenance {
-    max-width: 260px;
+    flex: 0 1 auto;
+    min-width: 0;
 }

--- a/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.tsx
@@ -84,59 +84,66 @@ const ChartTypeBuilderHeader: FC<Props> = ({
                     {backLink.label}
                 </Button>
                 <Box className={classes.divider} />
-                {app ? (
-                    <>
-                        <Title
-                            className={classes.name}
-                            order={6}
-                            c="ldDark.9"
-                            fw={600}
-                            lineClamp={1}
-                        >
-                            {getAppDisplayName(app.name, app.appUuid)}
-                        </Title>
-                        {app.description && (
-                            <Tooltip
-                                withArrow
-                                multiline
-                                w={280}
-                                label={app.description}
+                <Box className={classes.nameCluster}>
+                    {app ? (
+                        <>
+                            <Title
+                                className={classes.name}
+                                order={6}
+                                c="ldDark.9"
+                                fw={600}
+                                lineClamp={1}
                             >
+                                {getAppDisplayName(app.name, app.appUuid)}
+                            </Title>
+                            {app.description && (
+                                <Tooltip
+                                    withArrow
+                                    multiline
+                                    w={280}
+                                    label={app.description}
+                                >
+                                    <ActionIcon
+                                        variant="subtle"
+                                        color="gray"
+                                        size="sm"
+                                        aria-label="Chart type description"
+                                    >
+                                        <MantineIcon icon={IconInfoCircle} />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
+                            <Tooltip withArrow label="Edit details">
                                 <ActionIcon
                                     variant="subtle"
                                     color="gray"
                                     size="sm"
-                                    aria-label="Chart type description"
+                                    aria-label="Edit chart type details"
+                                    onClick={() => setIsEditingDetails(true)}
                                 >
-                                    <MantineIcon icon={IconInfoCircle} />
+                                    <MantineIcon icon={IconPencil} />
                                 </ActionIcon>
                             </Tooltip>
-                        )}
-                        <Tooltip withArrow label="Edit details">
-                            <ActionIcon
-                                variant="subtle"
-                                color="gray"
-                                size="sm"
-                                aria-label="Edit chart type details"
-                                onClick={() => setIsEditingDetails(true)}
-                            >
-                                <MantineIcon icon={IconPencil} />
-                            </ActionIcon>
-                        </Tooltip>
-                    </>
-                ) : (
-                    <Text className={classes.name} fz="sm" fw={600} c="dimmed">
-                        Untitled chart type
-                    </Text>
-                )}
-                {provenanceVersion && (
-                    <VersionProvenance
-                        className={classes.provenance}
-                        authorName={getVersionAuthorName(provenanceVersion)}
-                        at={new Date(provenanceVersion.createdAt)}
-                        isOrigin={hasOrigin}
-                    />
-                )}
+                        </>
+                    ) : (
+                        <Text
+                            className={classes.name}
+                            fz="sm"
+                            fw={600}
+                            c="dimmed"
+                        >
+                            Untitled chart type
+                        </Text>
+                    )}
+                    {provenanceVersion && (
+                        <VersionProvenance
+                            className={classes.provenance}
+                            authorName={getVersionAuthorName(provenanceVersion)}
+                            at={new Date(provenanceVersion.createdAt)}
+                            isOrigin={hasOrigin}
+                        />
+                    )}
+                </Box>
             </Box>
             <Group gap="xs" wrap="nowrap">
                 {upgradeAvailable && (

--- a/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
@@ -103,6 +103,7 @@ describe('explorerSlice chart type authoring', () => {
     it('moves a new type onto the empty custom config and shows Configure', () => {
         expect(authoringNew.chartTypeAuthoring).toEqual({
             dataAppVizUuid: null,
+            viewedVersion: null,
             createdInSession: false,
             previous: {
                 chartSidebarStep: 'choose',
@@ -151,6 +152,27 @@ describe('explorerSlice chart type authoring', () => {
             explorerReducer(
                 undefined,
                 explorerActions.claimChartTypeAuthoringViz('viz-1'),
+            ).chartTypeAuthoring,
+        ).toBeNull();
+    });
+
+    it('tracks the version the builder previews, only while authoring', () => {
+        const pinned = explorerReducer(
+            authoringNew,
+            explorerActions.viewChartTypeAuthoringVersion(2),
+        );
+        expect(pinned.chartTypeAuthoring?.viewedVersion).toBe(2);
+
+        const unpinned = explorerReducer(
+            pinned,
+            explorerActions.viewChartTypeAuthoringVersion(null),
+        );
+        expect(unpinned.chartTypeAuthoring?.viewedVersion).toBeNull();
+
+        expect(
+            explorerReducer(
+                undefined,
+                explorerActions.viewChartTypeAuthoringVersion(2),
             ).chartTypeAuthoring,
         ).toBeNull();
     });

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -361,6 +361,7 @@ const explorerSlice = createSlice({
             const beforePivotConfig = state.unsavedChartVersion.pivotConfig;
             state.chartTypeAuthoring = {
                 dataAppVizUuid: action.payload.dataAppVizUuid,
+                viewedVersion: null,
                 createdInSession: false,
                 previous: {
                     chartSidebarStep: state.chartSidebarStep,
@@ -395,6 +396,15 @@ const explorerSlice = createSlice({
                 };
                 state.unsavedChartVersion.pivotConfig = undefined;
             }
+        },
+        // The builder pinned an older version (or returned to the current
+        // one), so the sidebar configures what the preview renders.
+        viewChartTypeAuthoringVersion: (
+            state,
+            action: PayloadAction<number | null>,
+        ) => {
+            if (state.chartTypeAuthoring === null) return;
+            state.chartTypeAuthoring.viewedVersion = action.payload;
         },
         // A first build claimed an app; the session keeps going under it.
         claimChartTypeAuthoringViz: (state, action: PayloadAction<string>) => {

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -260,6 +260,8 @@ export type ChartSidebarStep = 'choose' | 'configure';
 export type ChartTypeAuthoringState = {
     /** The chart type being revised; null while a new one is authored. */
     dataAppVizUuid: string | null;
+    /** The older version the builder previews; null follows the current one. */
+    viewedVersion: number | null;
     /** The type was created by this session, so cancelling may discard it. */
     createdInSession: boolean;
     /** What the chart and the sidebar showed before, restored on cancel. */


### PR DESCRIPTION
## Summary

Four fixes bringing the embedded chart type builder (behind `explorer-chart-gallery`) in line with the standalone builder page:

- **Configure panel follows the previewed version.** Pinning an older version in the history panel updated the canvas but the sidebar kept fetching the latest schema, so its bindings and option tabs never changed. The pin now reaches the sidebar through the store (`chartTypeAuthoring.viewedVersion`, synced from the workspace), and `DataAppVizConfigTabs` fetches the schema at that version while authoring the same viz — sharing the workspace's react-query entry, so no extra request.
- **Header parity with the standalone builder.** The name cluster now shows the description info icon, the rename pencil, and the "Built by X · time ago" provenance byline instead of the "vN ready" badge (a visually-hidden live region still announces build status). Both headers also get true baseline alignment: title and byline sit in a nested `align-items: baseline` cluster (icons re-centered), fixing the byline riding ~2px off the title's baseline. The standalone header additionally drops the arbitrary 260px byline cap that truncated "about N hours ago" with free space around it, and the embedded title no longer reserves a fixed 280px slot that left a gap before the pencil.
- **Run query while authoring.** The authoring header hosts the Explorer's `RefreshButton` (limit menu, cancel, mod+Enter), so adding a field mid-build no longer requires leaving the builder to re-run and get the field into the mapping pools.
- **Stale-results warning.** The same `VisualizationWarning` the chart card shows ("Results may be incorrect" on a pivot mismatch, e.g. after changing the Series binding) now renders next to Run query.

The type name/description card is also removed from the gallery sidebar's Configure step — the authoring header already carries both.

## How to test

1. Enable `explorer-chart-gallery`, open a chart using a project type with several versions in edit mode, Configure → Change → Edit on the type.
2. Open Version history and view older versions: the sidebar's binding selects and option tabs now swap with the canvas, in both directions; closing the panel returns both to latest.
3. The header reads like the standalone builder page (name · info · pencil · byline) with the byline on the title's baseline; same on `/chart-types/:uuid`.
4. Add a dimension from the field rail, hit **Run query** in the builder header: the field appears in the mapping selects. Set it as Series: "Results may be incorrect" appears; Run query clears it.

Verified live plus 161 tests across the touched areas, typecheck and oxlint clean.

Relates: GLITCH-680
