### PR TITLE
refactor(explorer): share the dirty pivot configuration hook

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
@@ -1,8 +1,6 @@
 import {
     ChartType,
-    derivePivotConfigurationFromChart,
     FeatureFlags,
-    getFieldsFromMetricQuery,
     type DataAppVizOptionValues,
     type ItemsMap,
 } from '@lightdash/common';
@@ -16,19 +14,18 @@ import { buildExplorerVizContext } from '../../../features/chartTypes/utils/expl
 import {
     explorerActions,
     selectChartConfig,
-    selectUnsavedChartVersion,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
 import useHealth from '../../../hooks/health/useHealth';
 import useToaster from '../../../hooks/toaster/useToaster';
-import { useExplore } from '../../../hooks/useExplore';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { type ChartTypeAuthoringState } from '../../../providers/Explorer/types';
 import { CHART_GALLERY_SIDEBAR_TITLE_ID } from '../../common/ChartGallery/ChartGalleryContext';
 import { RefreshButton } from '../../RefreshButton';
 import { useSelectProjectChartType } from '../../VisualizationConfigs/CustomChartType/useSelectProjectChartType';
+import { useDirtyPivotConfiguration } from '../VisualizationCard/useDirtyPivotConfiguration';
 import { useExplorerChartColorPalette } from '../VisualizationCard/useExplorerChartColorPalette';
 import { useExplorerResultsData } from '../VisualizationCard/useExplorerResultsData';
 import VisualizationWarning from '../VisualizationCard/VisualizationWarning';
@@ -52,12 +49,7 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
     const selectProjectChartType = useSelectProjectChartType();
     const { mutate: deleteApp } = useDeleteApp();
 
-    const {
-        resultsData,
-        isLoadingQueryResults,
-        mergeResults,
-        suppressPrimaryResults,
-    } = useExplorerResultsData();
+    const { resultsData, isLoadingQueryResults } = useExplorerResultsData();
     // Every page, so the preview sees what the chart would.
     useEffect(() => {
         resultsData.setFetchAll(true);
@@ -66,29 +58,8 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
 
     // The same staleness signal the chart card shows: results computed with
     // pivot settings that no longer match the configuration.
-    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
-    const { data: explore } = useExplore(unsavedChartVersion.tableName);
     const health = useHealth();
-    const visualizationMetricQuery = suppressPrimaryResults
-        ? undefined
-        : (mergeResults?.metricQuery ?? unsavedChartVersion.metricQuery);
-    const dirtyPivotConfiguration = useMemo(() => {
-        const fields =
-            mergeResults?.fields ??
-            (explore
-                ? getFieldsFromMetricQuery(
-                      unsavedChartVersion.metricQuery,
-                      explore,
-                  )
-                : undefined);
-        return visualizationMetricQuery && fields
-            ? derivePivotConfigurationFromChart(
-                  unsavedChartVersion,
-                  visualizationMetricQuery,
-                  fields,
-              )
-            : undefined;
-    }, [unsavedChartVersion, visualizationMetricQuery, mergeResults, explore]);
+    const dirtyPivotConfiguration = useDirtyPivotConfiguration();
 
     const workspace = useChartTypeBuilderWorkspace({
         projectUuid,
@@ -265,7 +236,7 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
                 <>
                     <VisualizationWarning
                         dirtyPivotConfiguration={dirtyPivotConfiguration}
-                        chartConfig={unsavedChartVersion.chartConfig}
+                        chartConfig={chartConfig}
                         resultsData={resultsData}
                         isLoading={isLoadingQueryResults}
                         maxColumnLimit={health.data?.pivotTable?.maxColumnLimit}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -1,6 +1,4 @@
 import {
-    derivePivotConfigurationFromChart,
-    getFieldsFromMetricQuery,
     getHiddenTableFields,
     getPivotConfig,
     NotFoundError,
@@ -58,6 +56,7 @@ import { useIsChartGalleryEnabled } from '../ChartGallery/useIsChartGalleryEnabl
 import { DevCopyChartDebugData } from '../ExplorerHeader/DevCopyChartDebugData';
 import VisualizationConfig from '../VisualizationCard/VisualizationConfig';
 import { SeriesContextMenu } from './SeriesContextMenu';
+import { useDirtyPivotConfiguration } from './useDirtyPivotConfiguration';
 import { useExplorerChartColorPalette } from './useExplorerChartColorPalette';
 import { useExplorerResultsData } from './useExplorerResultsData';
 import useVisualizationConfigPortalTarget from './useVisualizationConfigPortalTarget';
@@ -264,29 +263,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
         merge?.runErrors,
     ]);
 
-    const dirtyPivotConfiguration = useMemo(() => {
-        const fields =
-            mergeResults?.fields ??
-            (explore
-                ? getFieldsFromMetricQuery(
-                      unsavedChartVersion.metricQuery,
-                      explore,
-                  )
-                : undefined);
-
-        return visualizationMetricQuery && fields
-            ? derivePivotConfigurationFromChart(
-                  unsavedChartVersion,
-                  visualizationMetricQuery,
-                  fields,
-              )
-            : undefined;
-    }, [
-        unsavedChartVersion,
-        explore,
-        mergeResults?.fields,
-        visualizationMetricQuery,
-    ]);
+    const dirtyPivotConfiguration = useDirtyPivotConfiguration();
 
     if (!unsavedChartVersion.tableName) {
         return <CollapsableCard title="Charts" disabled />;

--- a/packages/frontend/src/components/Explorer/VisualizationCard/useDirtyPivotConfiguration.ts
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/useDirtyPivotConfiguration.ts
@@ -1,0 +1,48 @@
+import {
+    derivePivotConfigurationFromChart,
+    getFieldsFromMetricQuery,
+    type PivotConfiguration,
+} from '@lightdash/common';
+import { useMemo } from 'react';
+import {
+    selectUnsavedChartVersion,
+    useExplorerSelector,
+} from '../../../features/explorer/store';
+import { useExplore } from '../../../hooks/useExplore';
+import { useExplorerResultsData } from './useExplorerResultsData';
+
+/**
+ * The pivot the Explorer's dirty configuration implies — derived the way the
+ * next run will derive it. Compared against the pivot behind the results on
+ * screen, a difference means those results are stale. One reader for the
+ * chart card's warning and the chart type builder's.
+ */
+export const useDirtyPivotConfiguration = ():
+    | PivotConfiguration
+    | undefined => {
+    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
+    const { data: explore } = useExplore(unsavedChartVersion.tableName);
+    const { mergeResults, suppressPrimaryResults } = useExplorerResultsData();
+    const visualizationMetricQuery = suppressPrimaryResults
+        ? undefined
+        : (mergeResults?.metricQuery ?? unsavedChartVersion.metricQuery);
+
+    return useMemo(() => {
+        const fields =
+            mergeResults?.fields ??
+            (explore
+                ? getFieldsFromMetricQuery(
+                      unsavedChartVersion.metricQuery,
+                      explore,
+                  )
+                : undefined);
+
+        return visualizationMetricQuery && fields
+            ? derivePivotConfigurationFromChart(
+                  unsavedChartVersion,
+                  visualizationMetricQuery,
+                  fields,
+              )
+            : undefined;
+    }, [unsavedChartVersion, visualizationMetricQuery, mergeResults, explore]);
+};


### PR DESCRIPTION
## Summary

Follow-up to #28013: `VisualizationCard` and `ExplorerChartTypeAuthoring` each rebuilt the dirty pivot configuration from the store, merge state and explore fields to feed their `VisualizationWarning`. Two copies of that derivation would eventually drift and split what "stale results" means between the chart card's warning and the builder's.

The derivation now lives in one self-wiring hook, `useDirtyPivotConfiguration` (beside `useExplorerResultsData`): it reads the unsaved chart version, resolves the explore, respects a configured merge (its metric query and fields replace the primary's, and suppressed primary results yield no pivot), and memoizes `derivePivotConfigurationFromChart` over them. Both callers drop their inline copies; the authoring container also sheds the explore/merge plumbing it only had for this.

No behavior change — same inputs, same memo, one home.

## How to test

Covered by the existing suites (37 tests across `VisualizationCard` and `ChartTypeAuthoring`). Live: both warnings still appear on a group-by change without a re-run, in the chart card and in the embedded builder header.

Relates: GLITCH-680
