### PR TITLE
feat(dashboards): apply direct access to reads

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
@@ -21,6 +21,7 @@ import { SchedulerModel } from '../../models/SchedulerModel';
 import { SearchModel } from '../../models/SearchModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import type { DirectAccessService } from '../DirectAccess/DirectAccessService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import { SchedulerService } from '../SchedulerService/SchedulerService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
@@ -115,6 +116,7 @@ describe('DashboardService - Content Verification', () => {
         spacePermissionService: {} as unknown as SpacePermissionService,
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
+        directAccessService: {} as unknown as DirectAccessService,
     });
 
     afterEach(() => {

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -167,18 +167,21 @@ const spaceContexts = {
         projectUuid: publicSpace.projectUuid,
         inheritsFromOrgOrProject: space.inherit_parent_permissions,
         access: [],
+        admins: [],
     },
     [privateSpace.uuid]: {
         organizationUuid: privateSpace.organizationUuid,
         projectUuid: privateSpace.projectUuid,
         inheritsFromOrgOrProject: privateSpace.inheritParentPermissions,
         access: [],
+        admins: [],
     },
     [publicSpace.uuid]: {
         organizationUuid: publicSpace.organizationUuid,
         projectUuid: publicSpace.projectUuid,
         inheritsFromOrgOrProject: publicSpace.inheritParentPermissions,
         access: publicSpace.access,
+        admins: [],
     },
 };
 
@@ -327,6 +330,30 @@ describe('DashboardService', () => {
                 },
             },
         });
+        expect(result).not.toHaveProperty('admins');
+    });
+
+    test('should keep the space name for an admin who also holds a direct grant', async () => {
+        const privateDashboard = {
+            ...dashboard,
+            spaceUuid: privateSpace.uuid,
+            spaceName: 'Private finance',
+        };
+        dashboardModel.getByIdOrSlug.mockResolvedValueOnce(privateDashboard);
+        spacePermissionService.getSpaceAccessContext.mockResolvedValueOnce({
+            ...spaceContexts[privateSpace.uuid],
+            admins: [{ userUuid: user.userUuid, source: 'organization' }],
+        });
+        directAccessService.resolveUserAccessForSessionUser.mockResolvedValueOnce(
+            {
+                [privateDashboard.uuid]: SpaceMemberRole.ADMIN,
+            },
+        );
+
+        const result = await service.getByIdOrSlug(user, privateDashboard.uuid);
+
+        expect(result.spaceName).toBe('Private finance');
+        expect(result).not.toHaveProperty('admins');
     });
 
     test('should deny the same private dashboard without effective direct access', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -12,6 +12,7 @@ import {
     SCHEDULER_TASKS,
     SchedulerFormat,
     SessionUser,
+    SpaceMemberRole,
     type Account,
     type ContentVerificationInfo,
     type Dashboard,
@@ -36,6 +37,7 @@ import { SchedulerModel } from '../../models/SchedulerModel';
 import { SearchModel } from '../../models/SearchModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import type { DirectAccessService } from '../DirectAccess/DirectAccessService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import type { SchedulerService } from '../SchedulerService/SchedulerService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
@@ -140,6 +142,25 @@ const contentVerificationModel = {
     unverify: vi.fn(async () => undefined),
 };
 
+const directAccessService = {
+    resolveUserAccessForSessionUser: vi.fn(
+        async ({
+            resources,
+        }: {
+            resources: Record<
+                string,
+                { logicalRole: SpaceMemberRole | undefined }
+            >;
+        }) =>
+            Object.fromEntries(
+                Object.entries(resources).map(([resourceUuid, resource]) => [
+                    resourceUuid,
+                    resource.logicalRole,
+                ]),
+            ),
+    ),
+};
+
 const spaceContexts = {
     [space.space_uuid]: {
         organizationUuid: space.organization_uuid,
@@ -207,6 +228,8 @@ describe('DashboardService', () => {
             spacePermissionService as unknown as SpacePermissionService,
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
+        directAccessService:
+            directAccessService as unknown as DirectAccessService,
     });
     afterEach(() => {
         vi.clearAllMocks();
@@ -243,6 +266,134 @@ describe('DashboardService', () => {
             dashboard.uuid,
             { projectUuid: undefined },
         );
+    });
+
+    test('should load a private dashboard through direct access without exposing its space name', async () => {
+        const directViewer = {
+            ...user,
+            ability: defineUserAbility(
+                {
+                    ...user,
+                    organizationUuid: 'another-org-uuid',
+                },
+                [
+                    {
+                        projectUuid,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: user.userUuid,
+                        roleUuid: undefined,
+                    },
+                ],
+            ),
+        };
+        const privateDashboard = {
+            ...dashboard,
+            spaceUuid: privateSpace.uuid,
+            spaceName: 'Private finance',
+        };
+        dashboardModel.getByIdOrSlug.mockResolvedValueOnce(privateDashboard);
+        directAccessService.resolveUserAccessForSessionUser.mockResolvedValueOnce(
+            {
+                [privateDashboard.uuid]: SpaceMemberRole.VIEWER,
+            },
+        );
+
+        const result = await service.getByIdOrSlug(
+            directViewer,
+            privateDashboard.uuid,
+        );
+
+        expect(result).toMatchObject({
+            uuid: privateDashboard.uuid,
+            spaceUuid: privateSpace.uuid,
+            spaceName: '',
+            access: [
+                {
+                    userUuid: user.userUuid,
+                    role: SpaceMemberRole.VIEWER,
+                    hasDirectAccess: false,
+                },
+            ],
+        });
+        expect(
+            directAccessService.resolveUserAccessForSessionUser,
+        ).toHaveBeenCalledWith({
+            user: expect.objectContaining({ userUuid: user.userUuid }),
+            resourceType: 'dashboard',
+            resources: {
+                [privateDashboard.uuid]: {
+                    logicalRole: undefined,
+                    capabilityCeiling: SpaceMemberRole.VIEWER,
+                },
+            },
+        });
+    });
+
+    test('should deny the same private dashboard without effective direct access', async () => {
+        const directViewer = {
+            ...user,
+            ability: defineUserAbility(
+                {
+                    ...user,
+                    organizationUuid: 'another-org-uuid',
+                },
+                [
+                    {
+                        projectUuid,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: user.userUuid,
+                        roleUuid: undefined,
+                    },
+                ],
+            ),
+        };
+        const privateDashboard = {
+            ...dashboard,
+            spaceUuid: privateSpace.uuid,
+            spaceName: 'Private finance',
+        };
+        dashboardModel.getByIdOrSlug.mockResolvedValueOnce(privateDashboard);
+        directAccessService.resolveUserAccessForSessionUser.mockResolvedValueOnce(
+            {
+                [privateDashboard.uuid]: undefined,
+            },
+        );
+
+        await expect(
+            service.getByIdOrSlug(directViewer, privateDashboard.uuid),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    test('should keep the space name when dashboard access is inherited', async () => {
+        const inheritedAccess = {
+            userUuid: user.userUuid,
+            role: SpaceMemberRole.VIEWER,
+            hasDirectAccess: false,
+            projectRole: ProjectMemberRole.VIEWER,
+            inheritedRole: ProjectMemberRole.VIEWER,
+            inheritedFrom: 'project' as const,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            email: user.email!,
+            isInternal: false,
+            avatarUrl: null,
+            avatarGradient: null,
+        };
+        spacePermissionService.getSpaceAccessContext.mockResolvedValueOnce({
+            ...spaceContexts[publicSpace.uuid],
+            access: [inheritedAccess],
+        });
+
+        const result = await service.getByIdOrSlug(user, dashboard.uuid);
+
+        expect(result.spaceName).toBe(dashboard.spaceName);
+        expect(result.access).toEqual([
+            expect.objectContaining({
+                userUuid: inheritedAccess.userUuid,
+                role: inheritedAccess.role,
+                inheritedFrom: inheritedAccess.inheritedFrom,
+            }),
+        ]);
     });
 
     test('should forward the applied parameter values when exporting content', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -397,8 +397,16 @@ export class DashboardService
             })
         )[dashboard.uuid];
 
+        const isSpaceAdmin = spaceContext.admins.some(
+            ({ userUuid }) => userUuid === user.userUuid,
+        );
+
+        // `admins` stays internal: it is audit-display data on the space
+        // context and must not serialize into dashboard API responses.
         return {
-            ...spaceContext,
+            organizationUuid: spaceContext.organizationUuid,
+            projectUuid: spaceContext.projectUuid,
+            inheritsFromOrgOrProject: spaceContext.inheritsFromOrgOrProject,
             access: effectiveRole
                 ? DashboardService.getAccessForRole(
                       user,
@@ -407,7 +415,9 @@ export class DashboardService
                   )
                 : [],
             isDirectOnly:
-                logicalRole === undefined && effectiveRole !== undefined,
+                !isSpaceAdmin &&
+                logicalRole === undefined &&
+                effectiveRole !== undefined,
         };
     }
 

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -18,6 +18,7 @@ import {
     ExportContentRequest,
     ForbiddenError,
     generateSlug,
+    getHighestSpaceRole,
     getSchedulerResourceTypeAndId,
     hasChartsInDashboard,
     isDashboardChartTileType,
@@ -41,6 +42,7 @@ import {
     SchedulerRun,
     SchedulerRunStatus,
     SessionUser,
+    SpaceMemberRole,
     TogglePinnedItemInfo,
     UpdateDashboard,
     UpdateMultipleDashboards,
@@ -57,6 +59,7 @@ import {
     type DuplicateDashboardParams,
     type Explore,
     type ExploreError,
+    type SpaceAccess,
     type UUID,
     type UuidOrSlug,
 } from '@lightdash/common';
@@ -90,6 +93,7 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { createTwoColumnTiles } from '../../utils/dashboardTileUtils';
 import { BaseService } from '../BaseService';
+import { DirectAccessService } from '../DirectAccess/DirectAccessService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import type { SchedulerService } from '../SchedulerService/SchedulerService';
 import type {
@@ -119,6 +123,7 @@ type DashboardServiceArguments = {
     organizationModel: OrganizationModel;
     spacePermissionService: SpacePermissionService;
     contentVerificationModel: ContentVerificationModel;
+    directAccessService: DirectAccessService;
 };
 
 export class DashboardService
@@ -162,6 +167,8 @@ export class DashboardService
     spacePermissionService: SpacePermissionService;
 
     contentVerificationModel: ContentVerificationModel;
+
+    directAccessService: DirectAccessService;
 
     async scheduleExportContent(
         account: Account,
@@ -277,6 +284,7 @@ export class DashboardService
         organizationModel,
         spacePermissionService,
         contentVerificationModel,
+        directAccessService,
     }: DashboardServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -298,6 +306,109 @@ export class DashboardService
         this.slackClient = slackClient;
         this.spacePermissionService = spacePermissionService;
         this.contentVerificationModel = contentVerificationModel;
+        this.directAccessService = directAccessService;
+    }
+
+    private static getAccessForRole(
+        user: SessionUser,
+        logicalAccess: SpaceAccess | undefined,
+        role: SpaceMemberRole,
+    ): SpaceAccess[] {
+        return [
+            {
+                userUuid: user.userUuid,
+                role,
+                hasDirectAccess: false,
+                projectRole: logicalAccess?.projectRole,
+                inheritedRole: logicalAccess?.inheritedRole,
+                inheritedFrom: logicalAccess?.inheritedFrom,
+            },
+        ];
+    }
+
+    private getDashboardCapabilityCeiling(
+        user: SessionUser,
+        dashboard: DashboardDAO,
+        spaceContext: Awaited<
+            ReturnType<SpacePermissionService['getSpaceAccessContext']>
+        >,
+        logicalAccess: SpaceAccess | undefined,
+    ): SpaceMemberRole | null {
+        const auditedAbility = this.createAuditedAbility(user);
+        const can = (action: AbilityAction, role: SpaceMemberRole) =>
+            auditedAbility.can(
+                action,
+                subject('Dashboard', {
+                    ...dashboard,
+                    ...spaceContext,
+                    access: DashboardService.getAccessForRole(
+                        user,
+                        logicalAccess,
+                        role,
+                    ),
+                }),
+            );
+
+        if (can('manage', SpaceMemberRole.ADMIN)) {
+            return SpaceMemberRole.ADMIN;
+        }
+        if (can('manage', SpaceMemberRole.EDITOR)) {
+            return SpaceMemberRole.EDITOR;
+        }
+        if (can('view', SpaceMemberRole.VIEWER)) {
+            return SpaceMemberRole.VIEWER;
+        }
+        return null;
+    }
+
+    private async getDashboardReadContext(
+        user: SessionUser,
+        dashboard: DashboardDAO,
+    ) {
+        const spaceContext =
+            await this.spacePermissionService.getSpaceAccessContext(
+                user.userUuid,
+                dashboard.spaceUuid,
+            );
+        const logicalAccess = spaceContext.access.find(
+            ({ userUuid }) => userUuid === user.userUuid,
+        );
+        const logicalRole = getHighestSpaceRole(
+            spaceContext.access
+                .filter(({ userUuid }) => userUuid === user.userUuid)
+                .map(({ role }) => role),
+        );
+        const capabilityCeiling = this.getDashboardCapabilityCeiling(
+            user,
+            dashboard,
+            spaceContext,
+            logicalAccess,
+        );
+        const effectiveRole = (
+            await this.directAccessService.resolveUserAccessForSessionUser({
+                user,
+                resourceType: 'dashboard',
+                resources: {
+                    [dashboard.uuid]: {
+                        logicalRole,
+                        capabilityCeiling,
+                    },
+                },
+            })
+        )[dashboard.uuid];
+
+        return {
+            ...spaceContext,
+            access: effectiveRole
+                ? DashboardService.getAccessForRole(
+                      user,
+                      logicalAccess,
+                      effectiveRole,
+                  )
+                : [],
+            isDirectOnly:
+                logicalRole === undefined && effectiveRole !== undefined,
+        };
     }
 
     async verifyDashboard(
@@ -603,15 +714,12 @@ export class DashboardService
             },
         );
 
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                dashboardDao.spaceUuid,
-            );
+        const { isDirectOnly, ...accessContext } =
+            await this.getDashboardReadContext(user, dashboardDao);
         const dashboard = {
             ...dashboardDao,
-            inheritsFromOrgOrProject,
-            access,
+            ...accessContext,
+            spaceName: isDirectOnly ? '' : dashboardDao.spaceName,
         };
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -633,8 +741,14 @@ export class DashboardService
             );
         }
 
+        this.recordDashboardView(user.userUuid, dashboard);
+
+        return dashboard;
+    }
+
+    private recordDashboardView(userUuid: UUID, dashboard: Dashboard): void {
         void this.analyticsModel
-            .addDashboardViewEvent(dashboard.uuid, user.userUuid)
+            .addDashboardViewEvent(dashboard.uuid, userUuid)
             .catch((err) => {
                 this.logger.warn('dashboard view event failed', {
                     dashboardUuid: dashboard.uuid,
@@ -644,7 +758,7 @@ export class DashboardService
 
         this.analytics.track({
             event: 'dashboard.view',
-            userId: user.userUuid,
+            userId: userUuid,
             properties: {
                 dashboardId: dashboard.uuid,
                 organizationId: dashboard.organizationUuid,
@@ -661,8 +775,6 @@ export class DashboardService
                 err: err instanceof Error ? err.message : String(err),
             });
         });
-
-        return dashboard;
     }
 
     async getDashboardCharts(
@@ -2461,19 +2573,15 @@ export class DashboardService
     ): Promise<DashboardHistory> {
         const dashboardDao =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                dashboardDao.spaceUuid,
-            );
+        const { isDirectOnly: _isDirectOnly, ...accessContext } =
+            await this.getDashboardReadContext(user, dashboardDao);
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
                 'manage',
                 subject('Dashboard', {
                     ...dashboardDao,
-                    inheritsFromOrgOrProject,
-                    access,
+                    ...accessContext,
                     metadata: {
                         dashboardUuid: dashboardDao.uuid,
                         dashboardName: dashboardDao.name,
@@ -2510,19 +2618,15 @@ export class DashboardService
     ): Promise<DashboardVersion> {
         const dashboardDao =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                dashboardDao.spaceUuid,
-            );
+        const { isDirectOnly, ...accessContext } =
+            await this.getDashboardReadContext(user, dashboardDao);
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
                 'view',
                 subject('Dashboard', {
                     ...dashboardDao,
-                    inheritsFromOrgOrProject,
-                    access,
+                    ...accessContext,
                     metadata: {
                         dashboardUuid: dashboardDao.uuid,
                         dashboardName: dashboardDao.name,
@@ -2560,8 +2664,8 @@ export class DashboardService
             config: dashboard.config,
             updatedAt: dashboard.updatedAt,
             updatedByUser: dashboard.updatedByUser,
-            inheritsFromOrgOrProject,
-            access,
+            ...accessContext,
+            spaceName: isDirectOnly ? '' : dashboardDao.spaceName,
         };
 
         // Check if this is the current version

--- a/packages/backend/src/services/DirectAccess/DirectAccessFeatureGate.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessFeatureGate.ts
@@ -3,6 +3,7 @@ import {
     ForbiddenError,
     getErrorMessage,
     type RegisteredAccount,
+    type SessionUser,
 } from '@lightdash/common';
 import Logger from '../../logging/logger';
 import { type FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
@@ -33,6 +34,32 @@ export class DirectAccessFeatureGate {
         } catch (error) {
             // Fail closed, but keep fault-denials distinguishable from
             // policy denials in the logs.
+            Logger.warn(
+                `Direct access flag resolution failed; failing closed: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+            return false;
+        }
+    }
+
+    async isEnabledForSessionUser(user: SessionUser): Promise<boolean> {
+        if (
+            user.organizationUuid === undefined ||
+            !this.licenseService.getLicenseStatus().valid
+        ) {
+            return false;
+        }
+        try {
+            const featureFlag = await this.featureFlagModel.get({
+                featureFlagId: CommercialFeatureFlags.DirectAccess,
+                user: {
+                    userUuid: user.userUuid,
+                    organizationUuid: user.organizationUuid,
+                },
+            });
+            return featureFlag.enabled;
+        } catch (error) {
             Logger.warn(
                 `Direct access flag resolution failed; failing closed: ${getErrorMessage(
                     error,

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.ts
@@ -1,6 +1,7 @@
 import {
     ForbiddenError,
     type RegisteredAccount,
+    type SessionUser,
     type SpaceMemberRole,
     type UUID,
 } from '@lightdash/common';
@@ -242,6 +243,34 @@ export class DirectAccessService extends BaseService {
         const directAccess = await this.getModel(resourceType).getUserAccess(
             Object.keys(resources),
             account.user.userUuid,
+            { organizationUuid },
+        );
+        return resolveDirectAccessBatch({
+            resources,
+            directAccess,
+            organizationUuid,
+        });
+    }
+
+    async resolveUserAccessForSessionUser({
+        user,
+        resourceType,
+        resources,
+    }: {
+        user: SessionUser;
+        resourceType: DirectAccessResourceType;
+        resources: DirectAccessResources;
+    }): Promise<Record<string, SpaceMemberRole | undefined>> {
+        const { organizationUuid } = user;
+        if (
+            organizationUuid === undefined ||
+            !(await this.featureGate.isEnabledForSessionUser(user))
+        ) {
+            return getLogicalAccessBatch(resources);
+        }
+        const directAccess = await this.getModel(resourceType).getUserAccess(
+            Object.keys(resources),
+            user.userUuid,
             { organizationUuid },
         );
         return resolveDirectAccessBatch({

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -30,6 +30,8 @@ import { ContentVerificationService } from './ContentVerificationService';
 import { CsvService } from './CsvService/CsvService';
 import { DashboardService } from './DashboardService/DashboardService';
 import { DeployService } from './DeployService';
+import { DirectAccessFeatureGate } from './DirectAccess/DirectAccessFeatureGate';
+import { DirectAccessService } from './DirectAccess/DirectAccessService';
 import { DownloadFileService } from './DownloadFileService/DownloadFileService';
 import { EmailWhitelabelService } from './EmailWhitelabelService/EmailWhitelabelService';
 import { FavoritesService } from './FavoritesService/FavoritesService';
@@ -97,6 +99,7 @@ interface ServiceManifest {
     commentService: CommentService;
     csvService: CsvService;
     dashboardService: DashboardService;
+    directAccessService: DirectAccessService;
     deployService: DeployService;
     downloadFileService: DownloadFileService;
     favoritesService: FavoritesService;
@@ -440,6 +443,30 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
+                    directAccessService: this.getDirectAccessService(),
+                }),
+        );
+    }
+
+    public getDirectAccessService(): DirectAccessService {
+        return this.getService(
+            'directAccessService',
+            () =>
+                new DirectAccessService({
+                    models: {
+                        dashboard: this.models.getDashboardAccessModel(),
+                        savedChart: this.models.getSavedChartAccessModel(),
+                        savedSql: this.models.getSavedSqlAccessModel(),
+                        app: this.models.getAppAccessModel(),
+                    },
+                    featureGate: new DirectAccessFeatureGate(
+                        this.models.getFeatureFlagModel(),
+                        this.getLicenseService(),
+                    ),
+                    // Read paths are available before Stack 5 wires the
+                    // authoritative transactional mutation resolver. Returning
+                    // no actor role keeps every write fail-closed meanwhile.
+                    actorRoleResolver: async () => undefined,
                 }),
         );
     }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1250

## Summary

PR 1 of 5 adds direct-access-aware dashboard metadata, history, version, and restoration reads. It preserves logical space behavior and hides private parent-space names from grant-only readers.

Builds on the direct-access foundation from [#27925](https://github.com/lightdash/lightdash/pull/27925).

## Read path

```
dashboard request
  ├─ logical space access ──────────────┐
  └─ direct user/group dashboard role ─┼─> additive role -> existing capability scopes
                                       └─> dashboard response
```

## Scope

- Resolves direct dashboard roles alongside existing space access.
- Applies the additive role to dashboard, history, version, and restoration reads.
- Keeps the real space UUID while suppressing private parent names and hierarchy.
- Leaves public, embed, and disabled-flag behavior unchanged.

## Test plan

- [x] Common and backend typecheck
- [x] Common and backend lint
- [x] 41 focused dashboard read tests

## Credit

Thanks @hrx-joseph-fahnestock for the initial direct-access exploration in [houserx/lightdash-hrx#25](https://github.com/houserx/lightdash-hrx/pull/25), which informed this stack.
