### PR TITLE
feat(dashboards): apply direct access to queries

### DIFF
--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -155,6 +155,7 @@ Migrate to the v2 async query flow: [Execute dashboard chart](https://docs.light
             invalidateCache?: boolean;
             dashboardSorts: SortField[];
             dashboardUuid: string;
+            tileUuid?: string;
             dateZoom?: DateZoom;
             autoRefresh?: boolean;
         },
@@ -174,6 +175,7 @@ Migrate to the v2 async query flow: [Execute dashboard chart](https://docs.light
                     dashboardSorts: body.dashboardSorts,
                     dateZoom: body.dateZoom,
                     dashboardUuid: body.dashboardUuid,
+                    tileUuid: body.tileUuid,
                     autoRefresh: body.autoRefresh,
                     context: getContextFromQueryOrHeader(req),
                 }),

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -907,6 +907,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     // silent no-op in EE builds.
                     getAppGenerateService: () =>
                         repository.getAppGenerateService<AppGenerateService>(),
+                    getDashboardService: () => repository.getDashboardService(),
                     getDataAppCustomSqlProvenance: (args) =>
                         repository
                             .getAppGenerateService<AppGenerateService>()
@@ -1040,6 +1041,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getPersistentDownloadFileService(),
                     organizationAccessService:
                         repository.getOrganizationAccessService(),
+                    getDashboardService: () => repository.getDashboardService(),
                     externalSourceTableResolver: (
                         projectUuid,
                         tableUuidOrName,

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -517,10 +517,12 @@ export class AppModel {
     async findAppsByUuids(
         projectUuid: string,
         appUuids: string[],
-    ): Promise<Pick<DbApp, 'app_id' | 'slug'>[]> {
+    ): Promise<
+        Pick<DbApp, 'app_id' | 'slug' | 'space_uuid' | 'created_by_user_uuid'>[]
+    > {
         if (appUuids.length === 0) return [];
         return this.database(AppsTableName)
-            .select('app_id', 'slug')
+            .select('app_id', 'slug', 'space_uuid', 'created_by_user_uuid')
             .where('project_uuid', projectUuid)
             .whereIn('app_id', appUuids)
             .whereNull('deleted_at');

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -2629,7 +2629,10 @@ export class SavedChartModel {
     async getInfoForAvailableFilters(savedChartUuids: string[]): Promise<
         ({
             spaceUuid: Space['uuid'];
-        } & Pick<SavedChartDAO, 'uuid' | 'name' | 'tableName'> &
+        } & Pick<
+            SavedChartDAO,
+            'uuid' | 'name' | 'tableName' | 'dashboardUuid'
+        > &
             Pick<Project, 'projectUuid'> &
             Pick<Organization, 'organizationUuid'>)[]
     > {
@@ -2643,6 +2646,7 @@ export class SavedChartModel {
                 name: `${SavedChartsTableName}.name`,
                 spaceUuid: `${SpaceTableName}.space_uuid`,
                 tableName: `${SavedChartVersionsTableName}.explore_name`,
+                dashboardUuid: `${SavedChartsTableName}.dashboard_uuid`,
                 projectUuid: `${SavedChartsTableName}.project_uuid`,
                 organizationUuid: 'organizations.organization_uuid',
             })

--- a/packages/backend/src/models/SavedSqlModel.ts
+++ b/packages/backend/src/models/SavedSqlModel.ts
@@ -305,6 +305,24 @@ export class SavedSqlModel {
         return SavedSqlModel.convertSelectSavedSql(result);
     }
 
+    async getInfoForDashboardDependencies(uuids: string[]): Promise<
+        {
+            savedSqlUuid: string;
+            spaceUuid: string;
+        }[]
+    > {
+        if (uuids.length === 0) {
+            return [];
+        }
+        return this.database(SavedSqlTableName)
+            .select({
+                savedSqlUuid: `${SavedSqlTableName}.saved_sql_uuid`,
+                spaceUuid: `${SavedSqlTableName}.space_uuid`,
+            })
+            .whereIn(`${SavedSqlTableName}.saved_sql_uuid`, uuids)
+            .whereNull(`${SavedSqlTableName}.deleted_at`);
+    }
+
     static async createVersion(
         trx: Knex,
         data: {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -82,6 +82,7 @@ import type { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import type { ICacheService } from '../CacheService/ICacheService';
 import { CacheHitCacheResult, MissCacheResult } from '../CacheService/types';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import { OrganizationAccessService } from '../OrganizationAccessService/OrganizationAccessService';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
@@ -246,6 +247,11 @@ const spaceModel = {
     getAllSpaces: vi.fn(async () => spacesWithSavedCharts),
 };
 
+const dashboardServiceMock = {
+    assertViewAccess: vi.fn(),
+    assertTileViewAccess: vi.fn(),
+};
+
 const userAttributesModel = {
     getAttributeValuesForOrgMember: vi.fn(async () => ({})),
 };
@@ -376,6 +382,8 @@ const getMockedAsyncQueryService = (
                 status: OrganizationAccessStatus.ACTIVE,
             })),
         } as unknown as OrganizationAccessService,
+        getDashboardService: () =>
+            dashboardServiceMock as unknown as DashboardService,
         preAggregateStrategy: new NoOpPreAggregateStrategy(),
         projectCompileLogModel: {} as ProjectCompileLogModel,
         adminNotificationService: {} as AdminNotificationService,
@@ -3047,6 +3055,65 @@ describe('AsyncQueryService', () => {
                     account,
                     projectUuid,
                     queryUuid: 'test-query-uuid',
+                }),
+            ).rejects.toThrow(ForbiddenError);
+        });
+
+        it('reauthorizes dashboard query history against current dashboard access', async () => {
+            dashboardServiceMock.assertViewAccess.mockClear();
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const account = buildAccount();
+            account.user.ability = new Ability<PossibleAbilities>([
+                { action: 'view', subject: 'Project' },
+            ]);
+            const queryHistory = {
+                ...createQueryHistory(),
+                requestParameters: {
+                    dashboardUuid: 'dashboard-uuid',
+                },
+            } as QueryHistory;
+            (
+                service.queryHistoryModel.get as import('vitest').Mock
+            ).mockResolvedValue(queryHistory);
+
+            await service.getAsyncQueryHistory({
+                account,
+                projectUuid,
+                queryUuid: queryHistory.queryUuid,
+            });
+
+            expect(
+                dashboardServiceMock.assertViewAccess,
+            ).toHaveBeenCalledWith(account, 'dashboard-uuid', {
+                projectUuid,
+                includeDependencies: false,
+            });
+        });
+
+        it('fails dashboard query-history reads after dashboard access is revoked', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            const account = buildAccount();
+            account.user.ability = new Ability<PossibleAbilities>([
+                { action: 'view', subject: 'Project' },
+            ]);
+            const queryHistory = {
+                ...createQueryHistory(),
+                requestParameters: {
+                    dashboardUuid: 'dashboard-uuid',
+                },
+            } as QueryHistory;
+            (
+                service.queryHistoryModel.get as import('vitest').Mock
+            ).mockResolvedValue(queryHistory);
+            dashboardServiceMock.assertViewAccess.mockRejectedValueOnce(
+                new ForbiddenError(),
+            );
+
+            await expect(
+                service.getAsyncQueryHistory({
+                    account,
+                    projectUuid,
+                    queryUuid: queryHistory.queryUuid,
                 }),
             ).rejects.toThrow(ForbiddenError);
         });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -3082,12 +3082,14 @@ describe('AsyncQueryService', () => {
                 queryUuid: queryHistory.queryUuid,
             });
 
-            expect(
-                dashboardServiceMock.assertViewAccess,
-            ).toHaveBeenCalledWith(account, 'dashboard-uuid', {
-                projectUuid,
-                includeDependencies: false,
-            });
+            expect(dashboardServiceMock.assertViewAccess).toHaveBeenCalledWith(
+                account,
+                'dashboard-uuid',
+                {
+                    projectUuid,
+                    includeDependencies: false,
+                },
+            );
         });
 
         it('fails dashboard query-history reads after dashboard access is revoked', async () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -45,6 +45,7 @@ import {
     getAvailableFilterFieldIds,
     getColumnTimezone,
     getDashboardFilterRulesForTables,
+    getDashboardUuidFromRequestParameters,
     getDateZoomFromRequestParameters,
     getDimensions,
     getDimensionsWithValidParameters,
@@ -396,7 +397,6 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     permissionsService: PermissionsService;
     persistentDownloadFileService: PersistentDownloadFileService;
     organizationAccessService: OrganizationAccessService;
-    getDashboardService: () => DashboardService;
     preAggregateStrategy?: PreAggregateStrategy;
     /** EE resolver for external tables; absent in OSS. */
     externalSourceTableResolver?: (
@@ -530,8 +530,6 @@ export class AsyncQueryService extends ProjectService {
 
     private readonly organizationAccessService: OrganizationAccessService;
 
-    private readonly getDashboardService: () => DashboardService;
-
     protected readonly preAggregateStrategy: PreAggregateStrategy;
 
     private readonly externalSourceTableResolver: AsyncQueryServiceArguments['externalSourceTableResolver'];
@@ -551,7 +549,6 @@ export class AsyncQueryService extends ProjectService {
         this.permissionsService = args.permissionsService;
         this.persistentDownloadFileService = args.persistentDownloadFileService;
         this.organizationAccessService = args.organizationAccessService;
-        this.getDashboardService = args.getDashboardService;
         this.preAggregateStrategy =
             args.preAggregateStrategy ?? new NoOpPreAggregateStrategy();
         this.externalSourceTableResolver = args.externalSourceTableResolver;
@@ -883,13 +880,9 @@ export class AsyncQueryService extends ProjectService {
             return;
         }
 
-        const { requestParameters } = queryHistory;
-        const dashboardUuid =
-            requestParameters &&
-            'dashboardUuid' in requestParameters &&
-            typeof requestParameters.dashboardUuid === 'string'
-                ? requestParameters.dashboardUuid
-                : undefined;
+        const dashboardUuid = getDashboardUuidFromRequestParameters(
+            queryHistory.requestParameters,
+        );
         if (!dashboardUuid) {
             return;
         }
@@ -899,6 +892,28 @@ export class AsyncQueryService extends ProjectService {
             dashboardUuid,
             { projectUuid, includeDependencies: false },
         );
+    }
+
+    /**
+     * The sanctioned way to read query history in this service: fetches the
+     * entry and re-authorizes any dashboard context it was created under.
+     */
+    private async getAuthorizedQueryHistory(
+        queryUuid: string,
+        projectUuid: string,
+        account: Account,
+    ): Promise<QueryHistory> {
+        const queryHistory = await this.queryHistoryModel.get(
+            queryUuid,
+            projectUuid,
+            account,
+        );
+        await this.assertDashboardQueryHistoryAccess(
+            account,
+            projectUuid,
+            queryHistory,
+        );
+        return queryHistory;
     }
 
     private getPreAggregationRoutingDecision({
@@ -1130,15 +1145,10 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
-        const queryHistory = await this.queryHistoryModel.get(
+        const queryHistory = await this.getAuthorizedQueryHistory(
             queryUuid,
             projectUuid,
             account,
-        );
-        await this.assertDashboardQueryHistoryAccess(
-            account,
-            projectUuid,
-            queryHistory,
         );
 
         const previousStatus = queryHistory.status;
@@ -1602,15 +1612,10 @@ export class AsyncQueryService extends ProjectService {
             }),
         );
 
-        const queryHistory = await this.queryHistoryModel.get(
+        const queryHistory = await this.getAuthorizedQueryHistory(
             queryUuid,
             projectUuid,
             account,
-        );
-        await this.assertDashboardQueryHistoryAccess(
-            account,
-            projectUuid,
-            queryHistory,
         );
 
         if (canViewProject) {
@@ -1665,15 +1670,10 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
-        const queryHistory = await this.queryHistoryModel.get(
+        const queryHistory = await this.getAuthorizedQueryHistory(
             queryUuid,
             projectUuid,
             account,
-        );
-        await this.assertDashboardQueryHistoryAccess(
-            account,
-            projectUuid,
-            queryHistory,
         );
 
         const { status, resultsFileName } = queryHistory;
@@ -1976,15 +1976,10 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
-        const queryHistory = await this.queryHistoryModel.get(
+        const queryHistory = await this.getAuthorizedQueryHistory(
             queryUuid,
             projectUuid,
             account,
-        );
-        await this.assertDashboardQueryHistoryAccess(
-            account,
-            projectUuid,
-            queryHistory,
         );
 
         const displayTimezone = queryHistory.metricQuery.timezone ?? null;
@@ -4111,10 +4106,7 @@ export class AsyncQueryService extends ProjectService {
         } else if (params && 'savedSqlUuid' in params) {
             chartUuid = params.savedSqlUuid;
         }
-        const dashboardUuid =
-            params && 'dashboardUuid' in params
-                ? params.dashboardUuid
-                : undefined;
+        const dashboardUuid = getDashboardUuidFromRequestParameters(params);
 
         return {
             ...actorTags,
@@ -5371,14 +5363,9 @@ export class AsyncQueryService extends ProjectService {
         assertIsAccountWithOrg(account);
 
         const [source, { organizationUuid }] = await Promise.all([
-            this.queryHistoryModel.get(queryUuid, projectUuid, account),
+            this.getAuthorizedQueryHistory(queryUuid, projectUuid, account),
             this.projectModel.getSummary(projectUuid),
         ]);
-        await this.assertDashboardQueryHistoryAccess(
-            account,
-            projectUuid,
-            source,
-        );
 
         const { csvCellsLimit, maxLimit } =
             await resolveOrganizationExportLimits(
@@ -5449,14 +5436,9 @@ export class AsyncQueryService extends ProjectService {
         // this account — that ownership authorizes the totals query, so we skip
         // the explore-level CASL gate (which embed JWT callers can't pass).
         const [source, { organizationUuid }] = await Promise.all([
-            this.queryHistoryModel.get(queryUuid, projectUuid, account),
+            this.getAuthorizedQueryHistory(queryUuid, projectUuid, account),
             this.projectModel.getSummary(projectUuid),
         ]);
-        await this.assertDashboardQueryHistoryAccess(
-            account,
-            projectUuid,
-            source,
-        );
 
         // Reuse the source's parameter values so the totals query sees the
         // same parameter context as the original. The execution path
@@ -8327,15 +8309,10 @@ export class AsyncQueryService extends ProjectService {
         projectUuid: string,
         queryUuid: string,
     ): Promise<{ metricQuery: MetricQuery; fields: ItemsMap }> {
-        const queryHistory = await this.queryHistoryModel.get(
+        const queryHistory = await this.getAuthorizedQueryHistory(
             queryUuid,
             projectUuid,
             account,
-        );
-        await this.assertDashboardQueryHistoryAccess(
-            account,
-            projectUuid,
-            queryHistory,
         );
         if (queryHistory.status !== QueryHistoryStatus.READY) {
             throw new ParameterError(
@@ -9059,15 +9036,10 @@ export class AsyncQueryService extends ProjectService {
         queryUuid: string;
         expiresAt: Date;
     }): Promise<void> {
-        const queryHistory = await this.queryHistoryModel.get(
+        const queryHistory = await this.getAuthorizedQueryHistory(
             queryUuid,
             projectUuid,
             account,
-        );
-        await this.assertDashboardQueryHistoryAccess(
-            account,
-            projectUuid,
-            queryHistory,
         );
         if (
             !queryHistory.resultsFileName ||
@@ -9150,15 +9122,10 @@ export class AsyncQueryService extends ProjectService {
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
         displayTimezone: string | null;
     }> {
-        const queryHistory = await this.queryHistoryModel.get(
+        const queryHistory = await this.getAuthorizedQueryHistory(
             queryUuid,
             projectUuid,
             account,
-        );
-        await this.assertDashboardQueryHistoryAccess(
-            account,
-            projectUuid,
-            queryHistory,
         );
 
         const resultsStream = await this.getResultsStorageClientForContext(

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -222,6 +222,7 @@ import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import type { ICacheService } from '../CacheService/ICacheService';
 import { CreateCacheResult } from '../CacheService/types';
 import { CsvService } from '../CsvService/CsvService';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import { ExcelService } from '../ExcelService/ExcelService';
 import { OrganizationAccessService } from '../OrganizationAccessService/OrganizationAccessService';
 import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
@@ -395,6 +396,7 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     permissionsService: PermissionsService;
     persistentDownloadFileService: PersistentDownloadFileService;
     organizationAccessService: OrganizationAccessService;
+    getDashboardService: () => DashboardService;
     preAggregateStrategy?: PreAggregateStrategy;
     /** EE resolver for external tables; absent in OSS. */
     externalSourceTableResolver?: (
@@ -528,6 +530,8 @@ export class AsyncQueryService extends ProjectService {
 
     private readonly organizationAccessService: OrganizationAccessService;
 
+    private readonly getDashboardService: () => DashboardService;
+
     protected readonly preAggregateStrategy: PreAggregateStrategy;
 
     private readonly externalSourceTableResolver: AsyncQueryServiceArguments['externalSourceTableResolver'];
@@ -547,6 +551,7 @@ export class AsyncQueryService extends ProjectService {
         this.permissionsService = args.permissionsService;
         this.persistentDownloadFileService = args.persistentDownloadFileService;
         this.organizationAccessService = args.organizationAccessService;
+        this.getDashboardService = args.getDashboardService;
         this.preAggregateStrategy =
             args.preAggregateStrategy ?? new NoOpPreAggregateStrategy();
         this.externalSourceTableResolver = args.externalSourceTableResolver;
@@ -841,6 +846,61 @@ export class AsyncQueryService extends ProjectService {
         }
     }
 
+    private async assertDashboardQueryAccess({
+        account,
+        projectUuid,
+        dashboardUuid,
+        tileUuid,
+        dependency,
+    }: {
+        account: Account;
+        projectUuid: string;
+        dashboardUuid: string;
+        tileUuid: string;
+        dependency:
+            | { type: 'savedChart'; uuid: string }
+            | { type: 'savedSql'; uuid: string };
+    }) {
+        if (isJwtUser(account)) {
+            return undefined;
+        }
+
+        return this.getDashboardService().assertTileViewAccess({
+            actor: account,
+            projectUuid,
+            dashboardUuid,
+            tileUuid,
+            dependency,
+        });
+    }
+
+    private async assertDashboardQueryHistoryAccess(
+        account: Account,
+        projectUuid: string,
+        queryHistory: QueryHistory,
+    ): Promise<void> {
+        if (isJwtUser(account)) {
+            return;
+        }
+
+        const { requestParameters } = queryHistory;
+        const dashboardUuid =
+            requestParameters &&
+            'dashboardUuid' in requestParameters &&
+            typeof requestParameters.dashboardUuid === 'string'
+                ? requestParameters.dashboardUuid
+                : undefined;
+        if (!dashboardUuid) {
+            return;
+        }
+
+        await this.getDashboardService().assertViewAccess(
+            account,
+            dashboardUuid,
+            { projectUuid, includeDependencies: false },
+        );
+    }
+
     private getPreAggregationRoutingDecision({
         metricQuery,
         explore,
@@ -1074,6 +1134,11 @@ export class AsyncQueryService extends ProjectService {
             queryUuid,
             projectUuid,
             account,
+        );
+        await this.assertDashboardQueryHistoryAccess(
+            account,
+            projectUuid,
+            queryHistory,
         );
 
         const previousStatus = queryHistory.status;
@@ -1315,6 +1380,11 @@ export class AsyncQueryService extends ProjectService {
             organizationUuid,
             queryHistory,
         );
+        await this.assertDashboardQueryHistoryAccess(
+            account,
+            projectUuid,
+            queryHistory,
+        );
 
         const {
             context,
@@ -1532,15 +1602,20 @@ export class AsyncQueryService extends ProjectService {
             }),
         );
 
-        if (canViewProject) {
-            return this.queryHistoryModel.get(queryUuid, projectUuid, account);
-        }
-
         const queryHistory = await this.queryHistoryModel.get(
             queryUuid,
             projectUuid,
             account,
         );
+        await this.assertDashboardQueryHistoryAccess(
+            account,
+            projectUuid,
+            queryHistory,
+        );
+
+        if (canViewProject) {
+            return queryHistory;
+        }
 
         if (
             auditedAbility.cannot(
@@ -1594,6 +1669,11 @@ export class AsyncQueryService extends ProjectService {
             queryUuid,
             projectUuid,
             account,
+        );
+        await this.assertDashboardQueryHistoryAccess(
+            account,
+            projectUuid,
+            queryHistory,
         );
 
         const { status, resultsFileName } = queryHistory;
@@ -1900,6 +1980,11 @@ export class AsyncQueryService extends ProjectService {
             queryUuid,
             projectUuid,
             account,
+        );
+        await this.assertDashboardQueryHistoryAccess(
+            account,
+            projectUuid,
+            queryHistory,
         );
 
         const displayTimezone = queryHistory.metricQuery.timezone ?? null;
@@ -5289,6 +5374,11 @@ export class AsyncQueryService extends ProjectService {
             this.queryHistoryModel.get(queryUuid, projectUuid, account),
             this.projectModel.getSummary(projectUuid),
         ]);
+        await this.assertDashboardQueryHistoryAccess(
+            account,
+            projectUuid,
+            source,
+        );
 
         const { csvCellsLimit, maxLimit } =
             await resolveOrganizationExportLimits(
@@ -5362,6 +5452,11 @@ export class AsyncQueryService extends ProjectService {
             this.queryHistoryModel.get(queryUuid, projectUuid, account),
             this.projectModel.getSummary(projectUuid),
         ]);
+        await this.assertDashboardQueryHistoryAccess(
+            account,
+            projectUuid,
+            source,
+        );
 
         // Reuse the source's parameter values so the totals query sees the
         // same parameter context as the original. The execution path
@@ -6174,12 +6269,25 @@ export class AsyncQueryService extends ProjectService {
         }
         const resolvedDashboardUuid = effectiveDashboardUuid;
 
-        await this.checkDashboardChartQueryPermissions(
+        const dashboard = await this.assertDashboardQueryAccess({
             account,
             projectUuid,
-            savedChart.uuid,
-            space,
-        );
+            dashboardUuid: resolvedDashboardUuid,
+            tileUuid,
+            dependency: { type: 'savedChart', uuid: savedChart.uuid },
+        });
+        const isDashboardOwnedChart =
+            dashboard !== undefined &&
+            savedChart.dashboardUuid === dashboard.uuid;
+
+        if (!isDashboardOwnedChart) {
+            await this.checkDashboardChartQueryPermissions(
+                account,
+                projectUuid,
+                savedChart.uuid,
+                space,
+            );
+        }
 
         // Fire-and-forget: analytics tracking is non-critical and shouldn't block query execution
         void this.analyticsModel
@@ -8224,6 +8332,11 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             account,
         );
+        await this.assertDashboardQueryHistoryAccess(
+            account,
+            projectUuid,
+            queryHistory,
+        );
         if (queryHistory.status !== QueryHistoryStatus.READY) {
             throw new ParameterError(
                 `its results are not ready (status: ${queryHistory.status}).`,
@@ -8702,6 +8815,14 @@ export class AsyncQueryService extends ProjectService {
         }
         const resolvedDashboardUuid = dashboardUuid;
 
+        await this.assertDashboardQueryAccess({
+            account,
+            projectUuid,
+            dashboardUuid: resolvedDashboardUuid,
+            tileUuid,
+            dependency: { type: 'savedSql', uuid: savedChart.savedSqlUuid },
+        });
+
         if (isJwtUser(account)) {
             const { embedWriteUser } = account;
             const embedWriteActions = account.authentication.data.writeActions;
@@ -8943,6 +9064,11 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             account,
         );
+        await this.assertDashboardQueryHistoryAccess(
+            account,
+            projectUuid,
+            queryHistory,
+        );
         if (
             !queryHistory.resultsFileName ||
             (queryHistory.resultsExpiresAt &&
@@ -9028,6 +9154,11 @@ export class AsyncQueryService extends ProjectService {
             queryUuid,
             projectUuid,
             account,
+        );
+        await this.assertDashboardQueryHistoryAccess(
+            account,
+            projectUuid,
+            queryHistory,
         );
 
         const resultsStream = await this.getResultsStorageClientForContext(

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -59,6 +59,9 @@ describe('Csv service', () => {
         projectService: new ProjectService({
             lightdashConfig,
             analytics: analyticsMock,
+            getDashboardService: () => {
+                throw new Error('DashboardService is not wired in this test');
+            },
             analyticsModel: {} as AnalyticsModel,
             dashboardModel: {} as DashboardModel,
             emailClient: {} as EmailClient,

--- a/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
@@ -9,6 +9,7 @@ import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { SlackClient } from '../../clients/Slack/SlackClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
+import type { AppModel } from '../../models/AppModel';
 import { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
@@ -97,6 +98,7 @@ describe('DashboardService - Content Verification', () => {
         dashboardModel: dashboardModel as unknown as DashboardModel,
         spaceModel: {} as unknown as SpaceModel,
         analyticsModel: {} as unknown as AnalyticsModel,
+        appModel: {} as AppModel,
         pinnedListModel: {} as unknown as PinnedListModel,
         schedulerModel: {} as unknown as SchedulerModel,
         searchModel: {} as unknown as SearchModel,

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -187,21 +187,30 @@ const spaceContexts = {
         projectUuid: publicSpace.projectUuid,
         inheritsFromOrgOrProject: space.inherit_parent_permissions,
         access: [],
-        admins: [],
+        admins: [] as {
+            userUuid: string;
+            source: 'organization' | 'project';
+        }[],
     },
     [privateSpace.uuid]: {
         organizationUuid: privateSpace.organizationUuid,
         projectUuid: privateSpace.projectUuid,
         inheritsFromOrgOrProject: privateSpace.inheritParentPermissions,
         access: [],
-        admins: [],
+        admins: [] as {
+            userUuid: string;
+            source: 'organization' | 'project';
+        }[],
     },
     [publicSpace.uuid]: {
         organizationUuid: publicSpace.organizationUuid,
         projectUuid: publicSpace.projectUuid,
         inheritsFromOrgOrProject: publicSpace.inheritParentPermissions,
         access: publicSpace.access,
-        admins: [],
+        admins: [] as {
+            userUuid: string;
+            source: 'organization' | 'project';
+        }[],
     },
 };
 
@@ -332,11 +341,9 @@ describe('DashboardService', () => {
             ],
         };
         dashboardModel.getByIdOrSlug.mockResolvedValueOnce(privateDashboard);
-        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce(
-            {
-                [privateDashboard.uuid]: SpaceMemberRole.VIEWER,
-            },
-        );
+        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce({
+            [privateDashboard.uuid]: SpaceMemberRole.VIEWER,
+        });
 
         const result = await service.getByIdOrSlug(
             directViewer,
@@ -402,13 +409,13 @@ describe('DashboardService', () => {
         dashboardModel.getByIdOrSlug.mockResolvedValueOnce(privateDashboard);
         spacePermissionService.getSpaceAccessContext.mockResolvedValueOnce({
             ...spaceContexts[privateSpace.uuid],
-            admins: [{ userUuid: user.userUuid, source: 'organization' }],
+            admins: [
+                { userUuid: user.userUuid, source: 'organization' as const },
+            ],
         });
-        directAccessService.resolveUserAccessForSessionUser.mockResolvedValueOnce(
-            {
-                [privateDashboard.uuid]: SpaceMemberRole.ADMIN,
-            },
-        );
+        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce({
+            [privateDashboard.uuid]: SpaceMemberRole.ADMIN,
+        });
 
         const result = await service.getByIdOrSlug(user, privateDashboard.uuid);
 
@@ -463,6 +470,63 @@ describe('DashboardService', () => {
         expect(result.tiles).toEqual(privateDashboard.tiles);
     });
 
+    test('should load a chart-less dashboard through direct access', async () => {
+        const directViewer = {
+            ...user,
+            ability: defineUserAbility(
+                {
+                    ...user,
+                    organizationUuid: 'another-org-uuid',
+                },
+                [
+                    {
+                        projectUuid,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: user.userUuid,
+                        roleUuid: undefined,
+                    },
+                ],
+            ),
+        };
+        const markdownOnlyDashboard = {
+            ...dashboard,
+            spaceUuid: privateSpace.uuid,
+            spaceName: 'Private finance',
+            tiles: [
+                {
+                    uuid: 'markdown-tile-uuid',
+                    type: DashboardTileTypes.MARKDOWN,
+                    properties: { title: 'Notes', content: 'Hello' },
+                    x: 0,
+                    y: 0,
+                    h: 2,
+                    w: 2,
+                    tabUuid: undefined,
+                },
+            ],
+        };
+        dashboardModel.getByIdOrSlug.mockResolvedValueOnce(
+            markdownOnlyDashboard,
+        );
+        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce({
+            [markdownOnlyDashboard.uuid]: SpaceMemberRole.VIEWER,
+        });
+        // Mirror the real model contract: zero matching rows throws.
+        savedChartModel.getInfoForAvailableFilters.mockRejectedValueOnce(
+            new NotFoundError('Saved queries not found'),
+        );
+
+        const result = await service.getByIdOrSlug(
+            directViewer,
+            markdownOnlyDashboard.uuid,
+        );
+
+        expect(result.tiles).toEqual(markdownOnlyDashboard.tiles);
+        expect(
+            savedChartModel.getInfoForAvailableFilters,
+        ).not.toHaveBeenCalled();
+    });
+
     test('should deny the same private dashboard without effective direct access', async () => {
         const directViewer = {
             ...user,
@@ -487,11 +551,9 @@ describe('DashboardService', () => {
             spaceName: 'Private finance',
         };
         dashboardModel.getByIdOrSlug.mockResolvedValueOnce(privateDashboard);
-        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce(
-            {
-                [privateDashboard.uuid]: undefined,
-            },
-        );
+        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce({
+            [privateDashboard.uuid]: undefined,
+        });
 
         await expect(
             service.getByIdOrSlug(directViewer, privateDashboard.uuid),

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -9,6 +9,7 @@ import {
     OrganizationMemberRole,
     PossibleAbilities,
     ProjectMemberRole,
+    ProjectType,
     SCHEDULER_TASKS,
     SchedulerFormat,
     SessionUser,
@@ -25,6 +26,7 @@ import { fromSession } from '../../auth/account/account';
 import { SlackClient } from '../../clients/Slack/SlackClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
+import type { AppModel } from '../../models/AppModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
@@ -82,6 +84,9 @@ const spaceModel = {
 const analyticsModel = {
     addDashboardViewEvent: vi.fn(async () => null),
 };
+const appModel = {
+    findAppsByUuids: vi.fn(async () => []),
+};
 const savedChartModel = {
     get: vi.fn(async () => chart),
     create: vi.fn(async () => ({ ...chart, uuid: 'duplicated-chart-uuid' })),
@@ -89,9 +94,18 @@ const savedChartModel = {
         uuid: 'chart_uuid',
         projectUuid: 'project_uuid',
     })),
-    getInfoForAvailableFilters: vi.fn(async () => []),
+    getInfoForAvailableFilters: vi.fn(
+        async (): ReturnType<
+            SavedChartModel['getInfoForAvailableFilters']
+        > => [],
+    ),
 };
 const savedSqlModel = {
+    getInfoForDashboardDependencies: vi.fn(
+        async (): ReturnType<
+            SavedSqlModel['getInfoForDashboardDependencies']
+        > => [],
+    ),
     getByUuid: vi.fn(async () => ({
         space: {
             uuid: publicSpace.uuid,
@@ -102,6 +116,12 @@ const savedSqlModel = {
 const projectModel = {
     getCachedExploreNames: vi.fn(async () => []),
     get: vi.fn(async () => ({ schedulerTimezone: 'UTC' })),
+    getSummary: vi.fn(async () => ({
+        organizationUuid: dashboard.organizationUuid,
+        type: ProjectType.DEFAULT,
+        createdByUserUuid: user.userUuid,
+        upstreamProjectUuid: null,
+    })),
 };
 
 const schedulerModel = {
@@ -143,7 +163,7 @@ const contentVerificationModel = {
 };
 
 const directAccessService = {
-    resolveUserAccessForSessionUser: vi.fn(
+    resolveUserAccessForUser: vi.fn(
         async ({
             resources,
         }: {
@@ -213,6 +233,7 @@ describe('DashboardService', () => {
         dashboardModel: dashboardModel as unknown as DashboardModel,
         spaceModel: spaceModel as unknown as SpaceModel,
         analyticsModel: analyticsModel as unknown as AnalyticsModel,
+        appModel: appModel as unknown as AppModel,
         pinnedListModel: {} as PinnedListModel,
         schedulerModel: schedulerModel as unknown as SchedulerModel,
         searchModel: searchModel as unknown as SearchModel,
@@ -289,13 +310,29 @@ describe('DashboardService', () => {
                 ],
             ),
         };
-        const privateDashboard = {
+        const privateDashboard: Dashboard = {
             ...dashboard,
             spaceUuid: privateSpace.uuid,
             spaceName: 'Private finance',
+            tiles: [
+                ...dashboard.tiles,
+                {
+                    uuid: 'data-app-tile',
+                    type: DashboardTileTypes.DATA_APP,
+                    x: 0,
+                    y: 0,
+                    h: 2,
+                    w: 2,
+                    tabUuid: undefined,
+                    properties: {
+                        title: 'Private forecast app',
+                        appUuid: 'private-app-uuid',
+                    },
+                },
+            ],
         };
         dashboardModel.getByIdOrSlug.mockResolvedValueOnce(privateDashboard);
-        directAccessService.resolveUserAccessForSessionUser.mockResolvedValueOnce(
+        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce(
             {
                 [privateDashboard.uuid]: SpaceMemberRole.VIEWER,
             },
@@ -317,11 +354,34 @@ describe('DashboardService', () => {
                     hasDirectAccess: false,
                 },
             ],
+            tiles: [
+                {
+                    uuid: 'my-tile',
+                    properties: {
+                        savedChartUuid: null,
+                        dependencyAccess: 'denied',
+                    },
+                },
+                {
+                    uuid: 'data-app-tile',
+                    properties: {
+                        title: '',
+                        appUuid: '',
+                        dependencyAccess: 'denied',
+                    },
+                },
+            ],
         });
+        expect(JSON.stringify(result.tiles)).not.toContain('savedChartName');
+        expect(JSON.stringify(result.tiles)).not.toContain(
+            'Private forecast app',
+        );
+        expect(JSON.stringify(result.tiles)).not.toContain('private-app-uuid');
         expect(
-            directAccessService.resolveUserAccessForSessionUser,
+            directAccessService.resolveUserAccessForUser,
         ).toHaveBeenCalledWith({
-            user: expect.objectContaining({ userUuid: user.userUuid }),
+            userUuid: user.userUuid,
+            organizationUuid: directViewer.organizationUuid,
             resourceType: 'dashboard',
             resources: {
                 [privateDashboard.uuid]: {
@@ -356,6 +416,53 @@ describe('DashboardService', () => {
         expect(result).not.toHaveProperty('admins');
     });
 
+    test('should preserve a dashboard-owned chart for a direct viewer', async () => {
+        const directViewer = {
+            ...user,
+            ability: defineUserAbility(
+                {
+                    ...user,
+                    organizationUuid: 'another-org-uuid',
+                },
+                [
+                    {
+                        projectUuid,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: user.userUuid,
+                        roleUuid: undefined,
+                    },
+                ],
+            ),
+        };
+        const privateDashboard = {
+            ...dashboard,
+            spaceUuid: privateSpace.uuid,
+            spaceName: 'Private finance',
+        };
+        dashboardModel.getByIdOrSlug.mockResolvedValueOnce(privateDashboard);
+        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce({
+            [privateDashboard.uuid]: SpaceMemberRole.VIEWER,
+        });
+        savedChartModel.getInfoForAvailableFilters.mockResolvedValueOnce([
+            {
+                uuid: 'savedChartUuid',
+                name: 'Dashboard-owned chart',
+                tableName: 'orders',
+                spaceUuid: privateSpace.uuid,
+                projectUuid,
+                organizationUuid: privateSpace.organizationUuid,
+                dashboardUuid: privateDashboard.uuid,
+            },
+        ]);
+
+        const result = await service.getByIdOrSlug(
+            directViewer,
+            privateDashboard.uuid,
+        );
+
+        expect(result.tiles).toEqual(privateDashboard.tiles);
+    });
+
     test('should deny the same private dashboard without effective direct access', async () => {
         const directViewer = {
             ...user,
@@ -380,7 +487,7 @@ describe('DashboardService', () => {
             spaceName: 'Private finance',
         };
         dashboardModel.getByIdOrSlug.mockResolvedValueOnce(privateDashboard);
-        directAccessService.resolveUserAccessForSessionUser.mockResolvedValueOnce(
+        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce(
             {
                 [privateDashboard.uuid]: undefined,
             },
@@ -421,6 +528,36 @@ describe('DashboardService', () => {
                 inheritedFrom: inheritedAccess.inheritedFrom,
             }),
         ]);
+    });
+
+    test('should authorize the exact chart dependency for a dashboard tile', async () => {
+        await expect(
+            service.assertTileViewAccess({
+                actor: user,
+                projectUuid: dashboard.projectUuid,
+                dashboardUuid: dashboard.uuid,
+                tileUuid: 'my-tile',
+                dependency: {
+                    type: 'savedChart',
+                    uuid: 'savedChartUuid',
+                },
+            }),
+        ).resolves.toMatchObject({ uuid: dashboard.uuid });
+    });
+
+    test('should reject a dependency that does not belong to the requested tile', async () => {
+        await expect(
+            service.assertTileViewAccess({
+                actor: user,
+                projectUuid: dashboard.projectUuid,
+                dashboardUuid: dashboard.uuid,
+                tileUuid: 'my-tile',
+                dependency: {
+                    type: 'savedChart',
+                    uuid: 'another-saved-chart-uuid',
+                },
+            }),
+        ).rejects.toThrow(ForbiddenError);
     });
 
     test('should forward the applied parameter values when exporting content', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -422,7 +422,7 @@ export class DashboardService
         )[dashboard.uuid];
 
         const isSpaceAdmin = spaceContext.admins.some(
-            ({ userUuid }) => userUuid === user.userUuid,
+            (admin) => admin.userUuid === userUuid,
         );
 
         // `admins` stays internal: it is audit-display data on the space
@@ -809,7 +809,19 @@ export class DashboardService
             .map((tile) => tile.properties.appUuid);
         const [charts, savedSqlCharts, apps, projectSummary] =
             await Promise.all([
-                this.savedChartModel.getInfoForAvailableFilters(chartUuids),
+                // getInfoForAvailableFilters throws NotFoundError when it
+                // matches zero rows (chart-less dashboards, or every chart
+                // soft-deleted); here that simply means nothing is visible.
+                chartUuids.length > 0
+                    ? this.savedChartModel
+                          .getInfoForAvailableFilters(chartUuids)
+                          .catch((error) => {
+                              if (error instanceof NotFoundError) {
+                                  return [];
+                              }
+                              throw error;
+                          })
+                    : [],
                 this.savedSqlModel.getInfoForDashboardDependencies(
                     savedSqlUuids,
                 ),
@@ -2878,7 +2890,7 @@ export class DashboardService
         }
 
         // Construct a full dashboard object from the version
-        const fullDashboard: Dashboard = {
+        const versionedDashboard: Dashboard = {
             ...dashboardDao,
             tiles: dashboard.tiles,
             filters: dashboard.filters,
@@ -2890,6 +2902,14 @@ export class DashboardService
             ...accessContext,
             spaceName: isDirectOnly ? '' : dashboardDao.spaceName,
         };
+        // Historical tiles carry the same private dependency metadata as the
+        // live read, so direct-only readers get the same redaction.
+        const fullDashboard = isDirectOnly
+            ? await this.redactInaccessibleDependencies(
+                  user,
+                  versionedDashboard,
+              )
+            : versionedDashboard;
 
         // Check if this is the current version
         const isCurrentVersion = dashboardDao.versionUuid === versionUuid;

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -22,7 +22,9 @@ import {
     getSchedulerResourceTypeAndId,
     hasChartsInDashboard,
     isDashboardChartTileType,
+    isDashboardDataAppTileType,
     isDashboardScheduler,
+    isDashboardSqlChartTile,
     isDashboardUnversionedFields,
     isDashboardVersionedFields,
     isJwtUser,
@@ -78,6 +80,7 @@ import { LightdashConfig } from '../../config/parseConfig';
 import { getSchedulerTargetType } from '../../database/entities/scheduler';
 // CaslAuditWrapper is now used via this.createAuditedAbility() from BaseService
 import { AnalyticsModel } from '../../models/AnalyticsModel';
+import type { AppModel } from '../../models/AppModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { getChartFieldUsageChanges } from '../../models/CatalogModel/utils';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
@@ -109,6 +112,7 @@ type DashboardServiceArguments = {
     dashboardModel: DashboardModel;
     spaceModel: SpaceModel;
     analyticsModel: AnalyticsModel;
+    appModel: AppModel;
     pinnedListModel: PinnedListModel;
     schedulerModel: SchedulerModel;
     searchModel: SearchModel;
@@ -126,6 +130,12 @@ type DashboardServiceArguments = {
     directAccessService: DirectAccessService;
 };
 
+type DashboardAccessActor = Account | SessionUser;
+
+export type DashboardTileDependency =
+    | { type: 'savedChart'; uuid: string }
+    | { type: 'savedSql'; uuid: string };
+
 export class DashboardService
     extends BaseService
     implements BulkActionable<Knex>, SoftDeletableService
@@ -139,6 +149,8 @@ export class DashboardService
     spaceModel: SpaceModel;
 
     analyticsModel: AnalyticsModel;
+
+    appModel: AppModel;
 
     pinnedListModel: PinnedListModel;
 
@@ -270,6 +282,7 @@ export class DashboardService
         dashboardModel,
         spaceModel,
         analyticsModel,
+        appModel,
         pinnedListModel,
         schedulerModel,
         searchModel,
@@ -292,6 +305,7 @@ export class DashboardService
         this.dashboardModel = dashboardModel;
         this.spaceModel = spaceModel;
         this.analyticsModel = analyticsModel;
+        this.appModel = appModel;
         this.pinnedListModel = pinnedListModel;
         this.schedulerModel = schedulerModel;
         this.searchModel = searchModel;
@@ -310,13 +324,13 @@ export class DashboardService
     }
 
     private static getAccessForRole(
-        user: SessionUser,
+        actor: DashboardAccessActor,
         logicalAccess: SpaceAccess | undefined,
         role: SpaceMemberRole,
     ): SpaceAccess[] {
         return [
             {
-                userUuid: user.userUuid,
+                userUuid: DashboardService.getActorUserUuid(actor),
                 role,
                 hasDirectAccess: false,
                 projectRole: logicalAccess?.projectRole,
@@ -326,15 +340,19 @@ export class DashboardService
         ];
     }
 
+    private static getActorUserUuid(actor: DashboardAccessActor): string {
+        return 'user' in actor ? actor.user.id : actor.userUuid;
+    }
+
     private getDashboardCapabilityCeiling(
-        user: SessionUser,
+        actor: DashboardAccessActor,
         dashboard: DashboardDAO,
         spaceContext: Awaited<
             ReturnType<SpacePermissionService['getSpaceAccessContext']>
         >,
         logicalAccess: SpaceAccess | undefined,
     ): SpaceMemberRole | null {
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(actor);
         const can = (action: AbilityAction, role: SpaceMemberRole) =>
             auditedAbility.can(
                 action,
@@ -342,7 +360,7 @@ export class DashboardService
                     ...dashboard,
                     ...spaceContext,
                     access: DashboardService.getAccessForRole(
-                        user,
+                        actor,
                         logicalAccess,
                         role,
                     ),
@@ -362,31 +380,37 @@ export class DashboardService
     }
 
     private async getDashboardReadContext(
-        user: SessionUser,
+        actor: DashboardAccessActor,
         dashboard: DashboardDAO,
     ) {
+        const userUuid = DashboardService.getActorUserUuid(actor);
+        const organizationUuid =
+            'user' in actor
+                ? actor.organization.organizationUuid
+                : actor.organizationUuid;
         const spaceContext =
             await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
+                userUuid,
                 dashboard.spaceUuid,
             );
         const logicalAccess = spaceContext.access.find(
-            ({ userUuid }) => userUuid === user.userUuid,
+            (access) => access.userUuid === userUuid,
         );
         const logicalRole = getHighestSpaceRole(
             spaceContext.access
-                .filter(({ userUuid }) => userUuid === user.userUuid)
+                .filter((access) => access.userUuid === userUuid)
                 .map(({ role }) => role),
         );
         const capabilityCeiling = this.getDashboardCapabilityCeiling(
-            user,
+            actor,
             dashboard,
             spaceContext,
             logicalAccess,
         );
         const effectiveRole = (
-            await this.directAccessService.resolveUserAccessForSessionUser({
-                user,
+            await this.directAccessService.resolveUserAccessForUser({
+                userUuid,
+                organizationUuid,
                 resourceType: 'dashboard',
                 resources: {
                     [dashboard.uuid]: {
@@ -409,7 +433,7 @@ export class DashboardService
             inheritsFromOrgOrProject: spaceContext.inheritsFromOrgOrProject,
             access: effectiveRole
                 ? DashboardService.getAccessForRole(
-                      user,
+                      actor,
                       logicalAccess,
                       effectiveRole,
                   )
@@ -715,7 +739,21 @@ export class DashboardService
     async getByIdOrSlug(
         user: SessionUser,
         dashboardUuidOrSlug: UuidOrSlug,
-        options?: { projectUuid?: string },
+        options?: { projectUuid?: string; includeDependencies?: boolean },
+    ): Promise<Dashboard> {
+        const dashboard = await this.assertViewAccess(
+            user,
+            dashboardUuidOrSlug,
+            options,
+        );
+        this.recordDashboardView(user.userUuid, dashboard);
+        return dashboard;
+    }
+
+    async assertViewAccess(
+        actor: DashboardAccessActor,
+        dashboardUuidOrSlug: UuidOrSlug,
+        options?: { projectUuid?: string; includeDependencies?: boolean },
     ): Promise<Dashboard> {
         const dashboardDao = await this.dashboardModel.getByIdOrSlug(
             dashboardUuidOrSlug,
@@ -723,16 +761,14 @@ export class DashboardService
                 projectUuid: options?.projectUuid,
             },
         );
-
         const { isDirectOnly, ...accessContext } =
-            await this.getDashboardReadContext(user, dashboardDao);
+            await this.getDashboardReadContext(actor, dashboardDao);
         const dashboard = {
             ...dashboardDao,
             ...accessContext,
             spaceName: isDirectOnly ? '' : dashboardDao.spaceName,
         };
-
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(actor);
 
         if (
             auditedAbility.cannot(
@@ -751,7 +787,184 @@ export class DashboardService
             );
         }
 
-        this.recordDashboardView(user.userUuid, dashboard);
+        return isDirectOnly && options?.includeDependencies !== false
+            ? this.redactInaccessibleDependencies(actor, dashboard)
+            : dashboard;
+    }
+
+    private async redactInaccessibleDependencies(
+        actor: DashboardAccessActor,
+        dashboard: Dashboard,
+    ): Promise<Dashboard> {
+        const chartUuids = dashboard.tiles
+            .filter(isDashboardChartTileType)
+            .map((tile) => tile.properties.savedChartUuid)
+            .filter((uuid): uuid is string => uuid !== null);
+        const savedSqlUuids = dashboard.tiles
+            .filter(isDashboardSqlChartTile)
+            .map((tile) => tile.properties.savedSqlUuid)
+            .filter((uuid): uuid is string => uuid !== null);
+        const appUuids = dashboard.tiles
+            .filter(isDashboardDataAppTileType)
+            .map((tile) => tile.properties.appUuid);
+        const [charts, savedSqlCharts, apps, projectSummary] =
+            await Promise.all([
+                this.savedChartModel.getInfoForAvailableFilters(chartUuids),
+                this.savedSqlModel.getInfoForDashboardDependencies(
+                    savedSqlUuids,
+                ),
+                this.appModel.findAppsByUuids(dashboard.projectUuid, appUuids),
+                this.projectModel.getSummary(dashboard.projectUuid),
+            ]);
+        const chartByUuid = new Map(charts.map((chart) => [chart.uuid, chart]));
+        const savedSqlByUuid = new Map(
+            savedSqlCharts.map((savedSql) => [savedSql.savedSqlUuid, savedSql]),
+        );
+        const appByUuid = new Map(apps.map((app) => [app.app_id, app]));
+        const dependencySpaceUuids = [
+            ...charts
+                .filter((chart) => chart.dashboardUuid !== dashboard.uuid)
+                .map((chart) => chart.spaceUuid),
+            ...savedSqlCharts.map((savedSql) => savedSql.spaceUuid),
+            ...apps
+                .map((app) => app.space_uuid)
+                .filter((uuid): uuid is string => uuid !== null),
+        ];
+        const spaceContexts =
+            dependencySpaceUuids.length > 0
+                ? await this.spacePermissionService.getSpacesAccessContext(
+                      DashboardService.getActorUserUuid(actor),
+                      [...new Set(dependencySpaceUuids)],
+                  )
+                : {};
+        const auditedAbility = this.createAuditedAbility(actor);
+        const canViewInSpace = (
+            spaceUuid: string,
+            metadata: Record<string, string>,
+        ) => {
+            const spaceContext = spaceContexts[spaceUuid];
+            return (
+                spaceContext !== undefined &&
+                auditedAbility.can(
+                    'view',
+                    subject('SavedChart', { ...spaceContext, metadata }),
+                )
+            );
+        };
+
+        return {
+            ...dashboard,
+            tiles: dashboard.tiles.map((tile) => {
+                if (isDashboardChartTileType(tile)) {
+                    const { savedChartUuid } = tile.properties;
+                    const chart = savedChartUuid
+                        ? chartByUuid.get(savedChartUuid)
+                        : undefined;
+                    const canView =
+                        chart?.dashboardUuid === dashboard.uuid ||
+                        (chart !== undefined &&
+                            canViewInSpace(chart.spaceUuid, {
+                                savedChartUuid: chart.uuid,
+                            }));
+                    return canView
+                        ? tile
+                        : {
+                              ...tile,
+                              properties: {
+                                  savedChartUuid: null,
+                                  dependencyAccess: 'denied' as const,
+                              },
+                          };
+                }
+                if (isDashboardSqlChartTile(tile)) {
+                    const { savedSqlUuid } = tile.properties;
+                    const savedSql = savedSqlUuid
+                        ? savedSqlByUuid.get(savedSqlUuid)
+                        : undefined;
+                    const canView =
+                        savedSql !== undefined &&
+                        canViewInSpace(savedSql.spaceUuid, {
+                            savedSqlUuid: savedSql.savedSqlUuid,
+                        });
+                    return canView
+                        ? tile
+                        : {
+                              ...tile,
+                              properties: {
+                                  savedSqlUuid: null,
+                                  chartName: '',
+                                  dependencyAccess: 'denied' as const,
+                              },
+                          };
+                }
+                if (isDashboardDataAppTileType(tile)) {
+                    const app = appByUuid.get(tile.properties.appUuid);
+                    const spaceContext = app?.space_uuid
+                        ? spaceContexts[app.space_uuid]
+                        : {};
+                    const canView =
+                        app !== undefined &&
+                        auditedAbility.can(
+                            'view',
+                            subject('DataApp', {
+                                organizationUuid:
+                                    projectSummary.organizationUuid,
+                                projectUuid: dashboard.projectUuid,
+                                projectType: projectSummary.type,
+                                projectCreatedByUserUuid:
+                                    projectSummary.createdByUserUuid,
+                                upstreamProjectUuid:
+                                    projectSummary.upstreamProjectUuid ?? null,
+                                ...spaceContext,
+                                createdByUserUuid:
+                                    app.created_by_user_uuid ?? undefined,
+                            }),
+                        );
+                    return canView
+                        ? tile
+                        : {
+                              ...tile,
+                              properties: {
+                                  title: '',
+                                  appUuid: '',
+                                  dependencyAccess: 'denied' as const,
+                              },
+                          };
+                }
+                return tile;
+            }),
+        };
+    }
+
+    async assertTileViewAccess({
+        actor,
+        projectUuid,
+        dashboardUuid,
+        tileUuid,
+        dependency,
+    }: {
+        actor: DashboardAccessActor;
+        projectUuid: string;
+        dashboardUuid: string;
+        tileUuid: string;
+        dependency: DashboardTileDependency;
+    }): Promise<Dashboard> {
+        const dashboard = await this.assertViewAccess(actor, dashboardUuid, {
+            projectUuid,
+            includeDependencies: false,
+        });
+        const tile = dashboard.tiles.find(({ uuid }) => uuid === tileUuid);
+        const matchesDependency =
+            tile !== undefined &&
+            (dependency.type === 'savedChart'
+                ? isDashboardChartTileType(tile) &&
+                  tile.properties.savedChartUuid === dependency.uuid
+                : isDashboardSqlChartTile(tile) &&
+                  tile.properties.savedSqlUuid === dependency.uuid);
+
+        if (!matchesDependency) {
+            throw new ForbiddenError('Dashboard tile is not accessible');
+        }
 
         return dashboard;
     }

--- a/packages/backend/src/services/DirectAccess/DirectAccessFeatureGate.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessFeatureGate.ts
@@ -3,7 +3,6 @@ import {
     ForbiddenError,
     getErrorMessage,
     type RegisteredAccount,
-    type SessionUser,
 } from '@lightdash/common';
 import Logger from '../../logging/logger';
 import { type FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
@@ -43,7 +42,10 @@ export class DirectAccessFeatureGate {
         }
     }
 
-    async isEnabledForSessionUser(user: SessionUser): Promise<boolean> {
+    async isEnabledForUser(user: {
+        userUuid: string;
+        organizationUuid: string | undefined;
+    }): Promise<boolean> {
         if (
             user.organizationUuid === undefined ||
             !this.licenseService.getLicenseStatus().valid

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.ts
@@ -1,7 +1,6 @@
 import {
     ForbiddenError,
     type RegisteredAccount,
-    type SessionUser,
     type SpaceMemberRole,
     type UUID,
 } from '@lightdash/common';
@@ -252,25 +251,29 @@ export class DirectAccessService extends BaseService {
         });
     }
 
-    async resolveUserAccessForSessionUser({
-        user,
+    async resolveUserAccessForUser({
+        userUuid,
+        organizationUuid,
         resourceType,
         resources,
     }: {
-        user: SessionUser;
+        userUuid: UUID;
+        organizationUuid: UUID | undefined;
         resourceType: DirectAccessResourceType;
         resources: DirectAccessResources;
     }): Promise<Record<string, SpaceMemberRole | undefined>> {
-        const { organizationUuid } = user;
         if (
             organizationUuid === undefined ||
-            !(await this.featureGate.isEnabledForSessionUser(user))
+            !(await this.featureGate.isEnabledForUser({
+                userUuid,
+                organizationUuid,
+            }))
         ) {
             return getLogicalAccessBatch(resources);
         }
         const directAccess = await this.getModel(resourceType).getUserAccess(
             Object.keys(resources),
-            user.userUuid,
+            userUuid,
             { organizationUuid },
         );
         return resolveDirectAccessBatch({

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -397,6 +397,9 @@ const getMockedProjectService = (
     new ProjectService({
         lightdashConfig,
         analytics: analyticsMock,
+        getDashboardService: () => {
+            throw new Error('DashboardService is not wired in this test');
+        },
         projectModel: projectModel as unknown as ProjectModel,
         projectDbtSourcesModel:
             overrides.projectDbtSourcesModel ??

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -53,6 +53,7 @@ import {
     CustomFormatType,
     CustomSqlQueryForbiddenError,
     DashboardAvailableFilters,
+    DashboardAvailableFiltersRequest,
     DashboardBasicDetails,
     DashboardFilters,
     DatabricksAuthenticationType,
@@ -116,6 +117,7 @@ import {
     isCartesianChartConfig,
     isCustomDimension,
     isCustomSqlDimension,
+    isDashboardChartTileType,
     isDateItem,
     isDimension,
     isExploreError,
@@ -343,6 +345,7 @@ import { applyLimitToSqlQuery } from '../../utils/QueryBuilder/utils';
 import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import { BaseService } from '../BaseService';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import {
@@ -445,6 +448,7 @@ export type ProjectServiceArguments = {
     // AppGenerateService depends on ProjectService, so eager injection would
     // create a construction cycle. Resolves undefined in core (non-EE) builds.
     getAppGenerateService?: () => AppGenerateService | undefined;
+    getDashboardService?: () => DashboardService;
     getDataAppCustomSqlProvenance: (args: {
         account: Account;
         projectUuid: string;
@@ -587,6 +591,8 @@ export class ProjectService extends BaseService {
 
     getAppGenerateService: (() => AppGenerateService | undefined) | undefined;
 
+    getDashboardServiceResolver: (() => DashboardService) | undefined;
+
     getDataAppCustomSqlProvenance: ProjectServiceArguments['getDataAppCustomSqlProvenance'];
 
     getAiAgentService: (() => AiAgentService | undefined) | undefined;
@@ -637,6 +643,7 @@ export class ProjectService extends BaseService {
         projectContextModel,
         isProjectContextEnabled,
         getAppGenerateService,
+        getDashboardService,
         getDataAppCustomSqlProvenance,
         getAiAgentService,
         onProjectCreated,
@@ -686,6 +693,7 @@ export class ProjectService extends BaseService {
         this.projectContextModel = projectContextModel;
         this.isProjectContextEnabled = isProjectContextEnabled;
         this.getAppGenerateService = getAppGenerateService;
+        this.getDashboardServiceResolver = getDashboardService;
         this.getDataAppCustomSqlProvenance = getDataAppCustomSqlProvenance;
         this.getAiAgentService = getAiAgentService;
         this.onProjectCreated = onProjectCreated;
@@ -6658,12 +6666,14 @@ export class ProjectService extends BaseService {
         dashboardSorts,
         dateZoom,
         dashboardUuid,
+        tileUuid,
         autoRefresh,
         context = QueryExecutionContext.DASHBOARD,
     }: {
         account: Account;
         chartUuid: string;
         dashboardUuid: string;
+        tileUuid?: string;
         dashboardFilters: DashboardFilters;
         invalidateCache?: boolean;
         dashboardSorts: SortField[];
@@ -6676,11 +6686,32 @@ export class ProjectService extends BaseService {
         const savedChart = await this.savedChartModel.get(chartUuid);
         const { organizationUuid, projectUuid } = savedChart;
 
+        const dashboard =
+            tileUuid && this.getDashboardServiceResolver && !isJwtUser(account)
+                ? await this.getDashboardServiceResolver().assertTileViewAccess(
+                      {
+                          actor: account,
+                          projectUuid,
+                          dashboardUuid,
+                          tileUuid,
+                          dependency: {
+                              type: 'savedChart',
+                              uuid: savedChart.uuid,
+                          },
+                      },
+                  )
+                : undefined;
+        const isDashboardOwnedChart =
+            dashboard !== undefined &&
+            savedChart.dashboardUuid === dashboard.uuid;
+
         const [spaceCtx, explore] = await Promise.all([
-            this.spacePermissionService.getSpaceAccessContext(
-                account.user.id,
-                savedChart.spaceUuid,
-            ),
+            isDashboardOwnedChart
+                ? undefined
+                : this.spacePermissionService.getSpaceAccessContext(
+                      account.user.id,
+                      savedChart.spaceUuid,
+                  ),
             this.getExplore(
                 account,
                 projectUuid,
@@ -6691,20 +6722,23 @@ export class ProjectService extends BaseService {
 
         const auditedAbility = this.createAuditedAbility(account);
         if (
-            auditedAbility.cannot(
-                'view',
-                subject('SavedChart', {
-                    organizationUuid: spaceCtx.organizationUuid,
-                    projectUuid: spaceCtx.projectUuid,
-                    inheritsFromOrgOrProject: spaceCtx.inheritsFromOrgOrProject,
-                    access: spaceCtx.access,
-                    metadata: {
-                        savedChartUuid: chartUuid,
-                        savedChartName: savedChart.name,
-                        dashboardUuid,
-                    },
-                }),
-            ) ||
+            (!isDashboardOwnedChart &&
+                (!spaceCtx ||
+                    auditedAbility.cannot(
+                        'view',
+                        subject('SavedChart', {
+                            organizationUuid: spaceCtx.organizationUuid,
+                            projectUuid: spaceCtx.projectUuid,
+                            inheritsFromOrgOrProject:
+                                spaceCtx.inheritsFromOrgOrProject,
+                            access: spaceCtx.access,
+                            metadata: {
+                                savedChartUuid: chartUuid,
+                                savedChartName: savedChart.name,
+                                dashboardUuid,
+                            },
+                        }),
+                    ))) ||
             auditedAbility.cannot(
                 'view',
                 subject('Project', {
@@ -6714,6 +6748,10 @@ export class ProjectService extends BaseService {
                 }),
             )
         ) {
+            throw new ForbiddenError();
+        }
+        const chartAccessContext = dashboard ?? spaceCtx;
+        if (!chartAccessContext) {
             throw new ForbiddenError();
         }
 
@@ -6812,8 +6850,9 @@ export class ProjectService extends BaseService {
         return {
             chart: {
                 ...savedChart,
-                inheritsFromOrgOrProject: spaceCtx.inheritsFromOrgOrProject,
-                access: spaceCtx.access,
+                inheritsFromOrgOrProject:
+                    chartAccessContext.inheritsFromOrgOrProject,
+                access: chartAccessContext.access ?? [],
             },
             explore,
             metricQuery: metricQueryWithDashboardOverrides,
@@ -9741,7 +9780,9 @@ export class ProjectService extends BaseService {
 
     async getAvailableFiltersForSavedQueries(
         account: Account,
-        savedChartUuidsAndTileUuids: SavedChartsInfoForDashboardAvailableFilters,
+        request:
+            | SavedChartsInfoForDashboardAvailableFilters
+            | DashboardAvailableFiltersRequest,
     ): Promise<DashboardAvailableFilters> {
         type ChartFilters = {
             uuid: string;
@@ -9750,6 +9791,12 @@ export class ProjectService extends BaseService {
         };
 
         let allFilters: ChartFilters[] = [];
+        const dashboardUuid = Array.isArray(request)
+            ? undefined
+            : request.dashboardUuid;
+        const savedChartUuidsAndTileUuids = Array.isArray(request)
+            ? request
+            : request.charts;
 
         allFilters = await traceSpan(
             {
@@ -9772,6 +9819,39 @@ export class ProjectService extends BaseService {
                 if (savedCharts.length === 0) {
                     return [];
                 }
+
+                const dashboard =
+                    dashboardUuid &&
+                    this.getDashboardServiceResolver &&
+                    !isJwtUser(account)
+                        ? await this.getDashboardServiceResolver().assertViewAccess(
+                              account,
+                              dashboardUuid,
+                              {
+                                  projectUuid: savedCharts[0].projectUuid,
+                                  includeDependencies: false,
+                              },
+                          )
+                        : undefined;
+                const requestedChartByTileUuid = new Map(
+                    savedChartUuidsAndTileUuids.map(
+                        ({ tileUuid, savedChartUuid }) => [
+                            tileUuid,
+                            savedChartUuid,
+                        ],
+                    ),
+                );
+                const dashboardOwnedChartUuids = new Set(
+                    dashboard?.tiles
+                        .filter(isDashboardChartTileType)
+                        .filter(
+                            (tile) =>
+                                requestedChartByTileUuid.get(tile.uuid) ===
+                                tile.properties.savedChartUuid,
+                        )
+                        .map((tile) => tile.properties.savedChartUuid)
+                        .filter((uuid): uuid is string => uuid !== null),
+                );
 
                 const [spacesCtx, exploresMap] = await Promise.all([
                     this.spacePermissionService.getSpacesAccessContext(
@@ -9819,7 +9899,13 @@ export class ProjectService extends BaseService {
                 );
 
                 return savedCharts.map((savedChart) => {
-                    if (!chartAccess.get(savedChart.uuid)) {
+                    const inheritsDashboardAccess =
+                        savedChart.dashboardUuid === dashboard?.uuid &&
+                        dashboardOwnedChartUuids.has(savedChart.uuid);
+                    if (
+                        !inheritsDashboardAccess &&
+                        !chartAccess.get(savedChart.uuid)
+                    ) {
                         return {
                             uuid: savedChart.uuid,
                             filters: [],

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -448,7 +448,9 @@ export type ProjectServiceArguments = {
     // AppGenerateService depends on ProjectService, so eager injection would
     // create a construction cycle. Resolves undefined in core (non-EE) builds.
     getAppGenerateService?: () => AppGenerateService | undefined;
-    getDashboardService?: () => DashboardService;
+    // Lazy thunk for the same construction-cycle reason as above; always
+    // wired by both OSS and EE composition.
+    getDashboardService: () => DashboardService;
     getDataAppCustomSqlProvenance: (args: {
         account: Account;
         projectUuid: string;
@@ -591,7 +593,7 @@ export class ProjectService extends BaseService {
 
     getAppGenerateService: (() => AppGenerateService | undefined) | undefined;
 
-    getDashboardServiceResolver: (() => DashboardService) | undefined;
+    protected readonly getDashboardService: () => DashboardService;
 
     getDataAppCustomSqlProvenance: ProjectServiceArguments['getDataAppCustomSqlProvenance'];
 
@@ -693,7 +695,7 @@ export class ProjectService extends BaseService {
         this.projectContextModel = projectContextModel;
         this.isProjectContextEnabled = isProjectContextEnabled;
         this.getAppGenerateService = getAppGenerateService;
-        this.getDashboardServiceResolver = getDashboardService;
+        this.getDashboardService = getDashboardService;
         this.getDataAppCustomSqlProvenance = getDataAppCustomSqlProvenance;
         this.getAiAgentService = getAiAgentService;
         this.onProjectCreated = onProjectCreated;
@@ -6687,19 +6689,17 @@ export class ProjectService extends BaseService {
         const { organizationUuid, projectUuid } = savedChart;
 
         const dashboard =
-            tileUuid && this.getDashboardServiceResolver && !isJwtUser(account)
-                ? await this.getDashboardServiceResolver().assertTileViewAccess(
-                      {
-                          actor: account,
-                          projectUuid,
-                          dashboardUuid,
-                          tileUuid,
-                          dependency: {
-                              type: 'savedChart',
-                              uuid: savedChart.uuid,
-                          },
+            tileUuid && !isJwtUser(account)
+                ? await this.getDashboardService().assertTileViewAccess({
+                      actor: account,
+                      projectUuid,
+                      dashboardUuid,
+                      tileUuid,
+                      dependency: {
+                          type: 'savedChart',
+                          uuid: savedChart.uuid,
                       },
-                  )
+                  })
                 : undefined;
         const isDashboardOwnedChart =
             dashboard !== undefined &&
@@ -9821,10 +9821,8 @@ export class ProjectService extends BaseService {
                 }
 
                 const dashboard =
-                    dashboardUuid &&
-                    this.getDashboardServiceResolver &&
-                    !isJwtUser(account)
-                        ? await this.getDashboardServiceResolver().assertViewAccess(
+                    dashboardUuid && !isJwtUser(account)
+                        ? await this.getDashboardService().assertViewAccess(
                               account,
                               dashboardUuid,
                               {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -428,6 +428,7 @@ export class ServiceRepository
                     dashboardModel: this.models.getDashboardModel(),
                     spaceModel: this.models.getSpaceModel(),
                     analyticsModel: this.models.getAnalyticsModel(),
+                    appModel: this.models.getAppModel(),
                     pinnedListModel: this.models.getPinnedListModel(),
                     schedulerModel: this.models.getSchedulerModel(),
                     searchModel: this.models.getSearchModel(),
@@ -914,6 +915,7 @@ export class ServiceRepository
                         this.providers.appGenerateService
                             ? this.getAppGenerateService<AppGenerateService>()
                             : undefined,
+                    getDashboardService: () => this.getDashboardService(),
                     // Core has no data apps. EE replaces this provider with a
                     // capability resolver backed by AppGenerateService.
                     getDataAppCustomSqlProvenance: async () => ({
@@ -991,6 +993,7 @@ export class ServiceRepository
                         this.getPersistentDownloadFileService(),
                     organizationAccessService:
                         this.getOrganizationAccessService(),
+                    getDashboardService: () => this.getDashboardService(),
                     projectCompileLogModel:
                         this.models.getProjectCompileLogModel(),
                     adminNotificationService:

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -218,6 +218,13 @@ export const getDateZoomFromRequestParameters = (
 ): DateZoom | undefined =>
     params && 'dateZoom' in params ? params.dateZoom : undefined;
 
+// Recovers the dashboard context from a persisted request-parameters union
+// without duck-typing at call sites.
+export const getDashboardUuidFromRequestParameters = (
+    params: ExecuteAsyncQueryRequestParams | undefined,
+): string | undefined =>
+    params && 'dashboardUuid' in params ? params.dashboardUuid : undefined;
+
 /**
  * Kinds of totals derivable from an executed pivot query.
  */

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -24,6 +24,8 @@ export enum DashboardTileTypes {
     DATA_APP = 'data_app',
 }
 
+export type DashboardDependencyAccess = 'denied';
+
 type CreateDashboardTileBase = {
     uuid?: string;
     type: DashboardTileTypes;
@@ -64,6 +66,7 @@ export type DashboardChartTileProperties = {
         chartName?: string | null;
         lastVersionChartKind?: ChartKind | null;
         chartSlug?: string | null;
+        dependencyAccess?: DashboardDependencyAccess;
     };
 };
 
@@ -75,6 +78,7 @@ export type DashboardSqlChartTileProperties = {
         chartName: string;
         hideTitle?: boolean;
         chartSlug?: string | null;
+        dependencyAccess?: DashboardDependencyAccess;
     };
 };
 
@@ -100,6 +104,7 @@ export type DashboardDataAppTileProperties = {
         // so the frontend can render a placeholder instead of trying to load
         // a missing iframe.
         appDeletedAt?: string | null;
+        dependencyAccess?: DashboardDependencyAccess;
     };
 };
 
@@ -184,6 +189,10 @@ export const isDashboardHeadingTileType = (
 export const isDashboardDataAppTileType = (
     tile: DashboardTile,
 ): tile is DashboardDataAppTile => tile.type === DashboardTileTypes.DATA_APP;
+
+export const isDashboardDependencyDenied = (tile: DashboardTile): boolean =>
+    'dependencyAccess' in tile.properties &&
+    tile.properties.dependencyAccess === 'denied';
 
 export type DashboardTab = {
     uuid: string;
@@ -346,6 +355,11 @@ export type SavedChartsInfoForDashboardAvailableFilters = {
     tileUuid: string;
     savedChartUuid: string;
 }[];
+
+export type DashboardAvailableFiltersRequest = {
+    dashboardUuid: string;
+    charts: SavedChartsInfoForDashboardAvailableFilters;
+};
 
 export const isDashboardUnversionedFields = (
     data: UpdateDashboard,

--- a/packages/frontend/src/components/DashboardTiles/DashboardDependencyDeniedTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDependencyDeniedTile.tsx
@@ -1,0 +1,25 @@
+import type { DashboardTile } from '@lightdash/common';
+import { IconLock } from '@tabler/icons-react';
+import type { ComponentProps, FC } from 'react';
+import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
+import TileBase from './TileBase';
+
+type Props = Pick<
+    ComponentProps<typeof TileBase>,
+    'onDelete' | 'onEdit' | 'isEditMode'
+> & {
+    tile: DashboardTile;
+};
+
+const DashboardDependencyDeniedTile: FC<Props> = (props) => (
+    <TileBase {...props} title="" hasError>
+        <SuboptimalState
+            adaptive
+            icon={IconLock}
+            title="Content unavailable"
+            description="You don't have access to this dashboard tile."
+        />
+    </TileBase>
+);
+
+export default DashboardDependencyDeniedTile;

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
@@ -87,6 +87,9 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
 
     const { data: availableTileFilters } = useDashboardsAvailableFilters(
         savedChartUuidsAndTileUuids,
+        undefined,
+        undefined,
+        dashboard?.uuid,
     );
 
     const fieldsWithSuggestions = useMemo(() => {

--- a/packages/frontend/src/features/dashboardTabs/GridTile.test.tsx
+++ b/packages/frontend/src/features/dashboardTabs/GridTile.test.tsx
@@ -105,4 +105,27 @@ describe('GridTile (locked)', () => {
             screen.queryByTestId('unmet-requirements-placeholder'),
         ).toBeNull();
     });
+
+    it('renders a generic denied state without dependency metadata', () => {
+        renderWithProviders(
+            <GridTile
+                tile={{
+                    ...chartTile,
+                    properties: {
+                        savedChartUuid: null,
+                        dependencyAccess: 'denied',
+                    },
+                }}
+                index={0}
+                isEditMode={false}
+                locked={false}
+                onEdit={vi.fn()}
+                onDelete={vi.fn()}
+                onAddTiles={vi.fn(async () => {})}
+            />,
+        );
+
+        expect(screen.getByText('Content unavailable')).toBeInTheDocument();
+        expect(screen.queryByText('Sales')).toBeNull();
+    });
 });

--- a/packages/frontend/src/features/dashboardTabs/GridTile.tsx
+++ b/packages/frontend/src/features/dashboardTabs/GridTile.tsx
@@ -1,6 +1,7 @@
 import {
     assertUnreachable,
     DashboardTileTypes,
+    isDashboardDependencyDenied,
     type DashboardTab,
     type Dashboard as IDashboard,
 } from '@lightdash/common';
@@ -8,6 +9,7 @@ import { Box } from '@mantine/core';
 import { memo, type FC } from 'react';
 import ChartTile from '../../components/DashboardTiles/DashboardChartTile';
 import DataAppTile from '../../components/DashboardTiles/DashboardDataAppTile';
+import DashboardDependencyDeniedTile from '../../components/DashboardTiles/DashboardDependencyDeniedTile';
 import HeadingTile from '../../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../../components/DashboardTiles/DashboardMarkdownTile';
@@ -32,6 +34,10 @@ type GridTileProps = Pick<
 
 const GridTileInner: FC<GridTileProps> = memo((props) => {
     const { tile } = props;
+
+    if (isDashboardDependencyDenied(tile)) {
+        return <DashboardDependencyDeniedTile {...props} tile={tile} />;
+    }
 
     if (props.locked) {
         // Allow non-filterable tiles to show even when locked.

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -15,6 +15,7 @@ import {
     type ExportContentFormat,
     type ParametersValuesMap,
     type SavedChartsInfoForDashboardAvailableFilters,
+    type DashboardAvailableFiltersRequest,
     type SchedulerCsvOptions,
     type SchedulerImageOptions,
     type UpdateDashboard,
@@ -95,12 +96,12 @@ const deleteDashboard = async (id: string, projectUuid: string) =>
     });
 
 const postDashboardsAvailableFilters = async (
-    savedChartUuidsAndTileUuids: SavedChartsInfoForDashboardAvailableFilters,
+    request: DashboardAvailableFiltersRequest,
 ) =>
     lightdashApi<DashboardAvailableFilters>({
         url: `/dashboards/availableFilters`,
         method: 'POST',
-        body: JSON.stringify(savedChartUuidsAndTileUuids),
+        body: JSON.stringify(request),
     });
 
 const postEmbedDashboardsAvailableFilters = async (
@@ -117,18 +118,29 @@ export const useDashboardsAvailableFilters = (
     savedChartUuidsAndTileUuids: SavedChartsInfoForDashboardAvailableFilters,
     projectUuid?: string,
     embedToken?: string,
+    dashboardUuid?: string,
 ) =>
     useQuery<DashboardAvailableFilters, ApiError>(
-        ['dashboards', 'availableFilters', ...savedChartUuidsAndTileUuids],
+        [
+            'dashboards',
+            'availableFilters',
+            dashboardUuid,
+            ...savedChartUuidsAndTileUuids,
+        ],
         () =>
             embedToken && projectUuid
                 ? postEmbedDashboardsAvailableFilters(
                       projectUuid,
                       savedChartUuidsAndTileUuids,
                   )
-                : postDashboardsAvailableFilters(savedChartUuidsAndTileUuids),
+                : postDashboardsAvailableFilters({
+                      dashboardUuid: dashboardUuid!,
+                      charts: savedChartUuidsAndTileUuids,
+                  }),
         {
-            enabled: savedChartUuidsAndTileUuids.length > 0,
+            enabled:
+                savedChartUuidsAndTileUuids.length > 0 &&
+                (!!embedToken || !!dashboardUuid),
         },
     );
 

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -11,6 +11,7 @@ import {
     DashboardTileTypes,
     EXPORT_TAB_PAGE_CLASS,
     getPagedExportOrphanHomeTabUuid,
+    isDashboardDependencyDenied,
     isDashboardScheduler,
     isTileInSelectedTabs,
     SessionStorageKeys,
@@ -33,6 +34,7 @@ import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndica
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ChartTile from '../components/DashboardTiles/DashboardChartTile';
 import DataAppTile from '../components/DashboardTiles/DashboardDataAppTile';
+import DashboardDependencyDeniedTile from '../components/DashboardTiles/DashboardDependencyDeniedTile';
 import HeadingTile from '../components/DashboardTiles/DashboardHeadingTile';
 import LoomTile from '../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../components/DashboardTiles/DashboardMarkdownTile';
@@ -81,6 +83,18 @@ type MinimalDashboardContentProps = {
 };
 
 const renderDashboardTile = (tile: Dashboard['tiles'][number]) => {
+    if (isDashboardDependencyDenied(tile)) {
+        return (
+            <DashboardDependencyDeniedTile
+                key={tile.uuid}
+                tile={tile}
+                isEditMode={false}
+                onDelete={() => {}}
+                onEdit={() => {}}
+            />
+        );
+    }
+
     switch (tile.type) {
         case DashboardTileTypes.SAVED_CHART:
             return (

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -885,6 +885,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         savedChartUuidsAndTileUuids ?? [],
         projectUuid,
         embedToken,
+        dashboardUuid,
     );
 
     const filterableFieldsByTileUuid = useMemo(() => {

--- a/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
@@ -1,5 +1,6 @@
 import {
     isDashboardChartTileType,
+    isDashboardDependencyDenied,
     isDashboardSqlChartTile,
     isTileInPagedExport,
     type CacheMetadata,
@@ -135,8 +136,9 @@ const DashboardTileStatusProvider: React.FC<
                 return dashboardTiles
                     .filter(
                         (tile) =>
-                            isDashboardChartTileType(tile) ||
-                            isDashboardSqlChartTile(tile),
+                            (isDashboardChartTileType(tile) ||
+                                isDashboardSqlChartTile(tile)) &&
+                            !isDashboardDependencyDenied(tile),
                     )
                     .filter((tile) =>
                         isTileInPagedExport(tile, resolvedTabUuids),
@@ -148,8 +150,11 @@ const DashboardTileStatusProvider: React.FC<
             return dashboardTiles
                 .filter(
                     (tile) =>
-                        isDashboardChartTileType(tile) ||
-                        isDashboardSqlChartTile(tile),
+                        (isDashboardChartTileType(tile) ||
+                            isDashboardSqlChartTile(tile)) &&
+                        // Denied tiles render a static placeholder and never
+                        // report screenshot readiness.
+                        !isDashboardDependencyDenied(tile),
                 )
                 .filter((tile) =>
                     schedulerTabsSelected.includes(tile.tabUuid ?? null),
@@ -162,8 +167,9 @@ const DashboardTileStatusProvider: React.FC<
         return dashboardTiles
             .filter(
                 (tile) =>
-                    isDashboardChartTileType(tile) ||
-                    isDashboardSqlChartTile(tile),
+                    (isDashboardChartTileType(tile) ||
+                        isDashboardSqlChartTile(tile)) &&
+                    !isDashboardDependencyDenied(tile),
             )
             .filter((tile) => {
                 if (!activeTab) return true;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1250

## Summary

PR 2 of 5 authorizes dashboard query and result paths against the exact tile or dependency being used, including asynchronous result, cancel, and download flows.

Stacks on [#28018](https://github.com/lightdash/lightdash/pull/28018), which adds direct-aware dashboard reads.

## Query path

```
dashboard tile -> bind exact dependency -> authorize current dashboard access
                                      ├─> execute / enqueue
                                      └─> result / cancel / download recheck
```

## Scope

- Binds dashboard tiles to their exact chart, SQL chart, or data-app dependency.
- Preserves independent access checks for reusable saved content.
- Reauthorizes asynchronous result, cancellation, and download operations.
- Returns a generic denial for inaccessible or mismatched tiles.
- Batches dependency resolution to avoid per-tile reads.

## Test plan

- [x] Common, backend, and frontend typecheck
- [x] Common, backend, and frontend lint
- [x] 122 focused backend tests
- [x] 6 AppModel tests
- [x] 3 GridTile tests

## Credit

Thanks @hrx-joseph-fahnestock for the initial direct-access exploration in [houserx/lightdash-hrx#25](https://github.com/houserx/lightdash-hrx/pull/25), which informed this stack.
