### PR TITLE
feat(dashboards): apply direct access to lifecycle

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -74,6 +74,8 @@ const dashboardModel = {
 
     addVersion: vi.fn(async () => dashboard),
 
+    getVersionByUuid: vi.fn(async () => dashboard),
+
     getOrphanedCharts: vi.fn(async () => []),
 };
 
@@ -94,6 +96,10 @@ const savedChartModel = {
         uuid: 'chart_uuid',
         projectUuid: 'project_uuid',
     })),
+    transaction: vi.fn(
+        async (callback: (transaction: unknown) => Promise<unknown>) =>
+            callback({}),
+    ),
     getInfoForAvailableFilters: vi.fn(
         async (): ReturnType<
             SavedChartModel['getInfoForAvailableFilters']
@@ -179,6 +185,27 @@ const directAccessService = {
                 ]),
             ),
     ),
+};
+
+const createDirectUser = (role: ProjectMemberRole) => ({
+    ...user,
+    ability: defineUserAbility(
+        { ...user, organizationUuid: 'another-org-uuid' },
+        [
+            {
+                projectUuid: 'projectUuid',
+                role,
+                userUuid: user.userUuid,
+                roleUuid: undefined,
+            },
+        ],
+    ),
+});
+
+const directPrivateDashboard: Dashboard = {
+    ...dashboard,
+    spaceUuid: privateSpace.uuid,
+    spaceName: 'Private finance',
 };
 
 const spaceContexts = {
@@ -865,6 +892,217 @@ describe('DashboardService', () => {
             }),
         );
     });
+    test('should update a private dashboard through direct Editor access', async () => {
+        const directEditor = createDirectUser(ProjectMemberRole.EDITOR);
+        dashboardModel.getByIdOrSlug
+            .mockResolvedValueOnce(directPrivateDashboard)
+            .mockResolvedValueOnce(directPrivateDashboard)
+            .mockResolvedValueOnce(directPrivateDashboard);
+        directAccessService.resolveUserAccessForUser
+            .mockResolvedValueOnce({
+                [directPrivateDashboard.uuid]: SpaceMemberRole.EDITOR,
+            })
+            .mockResolvedValueOnce({
+                [directPrivateDashboard.uuid]: SpaceMemberRole.EDITOR,
+            });
+
+        const update = {
+            ...updateDashboard,
+            spaceUuid: directPrivateDashboard.spaceUuid,
+        };
+        await service.update(
+            directEditor,
+            directPrivateDashboard.uuid,
+            update,
+            { projectUuid },
+        );
+
+        expect(dashboardModel.update).toHaveBeenCalledWith(
+            directPrivateDashboard.uuid,
+            update,
+        );
+    });
+
+    test('should preserve opaque denied dependency properties while updating layout', async () => {
+        const directEditor = createDirectUser(ProjectMemberRole.EDITOR);
+        dashboardModel.getByIdOrSlug
+            .mockResolvedValueOnce(directPrivateDashboard)
+            .mockResolvedValueOnce(directPrivateDashboard)
+            .mockResolvedValueOnce(directPrivateDashboard);
+        directAccessService.resolveUserAccessForUser
+            .mockResolvedValueOnce({
+                [directPrivateDashboard.uuid]: SpaceMemberRole.EDITOR,
+            })
+            .mockResolvedValueOnce({
+                [directPrivateDashboard.uuid]: SpaceMemberRole.EDITOR,
+            });
+        const deniedTileUpdate: UpdateDashboard = {
+            tiles: [
+                {
+                    ...directPrivateDashboard.tiles[0],
+                    x: 10,
+                    properties: {
+                        savedChartUuid: null,
+                        dependencyAccess: 'denied',
+                    },
+                } as DashboardChartTile,
+            ],
+            filters: directPrivateDashboard.filters,
+            tabs: directPrivateDashboard.tabs,
+        };
+
+        await service.update(
+            directEditor,
+            directPrivateDashboard.uuid,
+            deniedTileUpdate,
+            { projectUuid },
+        );
+
+        expect(dashboardModel.addVersion).toHaveBeenCalledWith(
+            directPrivateDashboard.uuid,
+            expect.objectContaining({
+                tiles: [
+                    expect.objectContaining({
+                        x: 10,
+                        properties: directPrivateDashboard.tiles[0].properties,
+                    }),
+                ],
+            }),
+            expect.objectContaining({ userUuid: directEditor.userUuid }),
+            projectUuid,
+        );
+    });
+
+    test.each([
+        ['missing', 'missing-tile'],
+        ['type-mismatched', directPrivateDashboard.tiles[0].uuid],
+    ])('should reject a %s opaque denied dependency tile', async (_, uuid) => {
+        dashboardModel.getByIdOrSlug.mockResolvedValueOnce(
+            directPrivateDashboard,
+        );
+        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce({
+            [directPrivateDashboard.uuid]: SpaceMemberRole.EDITOR,
+        });
+        const deniedTile = {
+            ...directPrivateDashboard.tiles[0],
+            uuid,
+            type:
+                uuid === 'missing-tile'
+                    ? directPrivateDashboard.tiles[0].type
+                    : DashboardTileTypes.MARKDOWN,
+            properties: { dependencyAccess: 'denied' },
+        } as unknown as DashboardChartTile;
+
+        await expect(
+            service.update(
+                createDirectUser(ProjectMemberRole.EDITOR),
+                directPrivateDashboard.uuid,
+                {
+                    tiles: [deniedTile],
+                    filters: directPrivateDashboard.filters,
+                    tabs: directPrivateDashboard.tabs,
+                },
+                { projectUuid },
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(dashboardModel.addVersion).not.toHaveBeenCalled();
+    });
+
+    test('should deny dashboard updates above the direct capability ceiling', async () => {
+        const directViewer = createDirectUser(ProjectMemberRole.VIEWER);
+        dashboardModel.getByIdOrSlug.mockResolvedValueOnce({
+            ...dashboard,
+            spaceUuid: privateSpace.uuid,
+        });
+        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce({
+            [dashboard.uuid]: SpaceMemberRole.VIEWER,
+        });
+
+        await expect(
+            service.update(directViewer, dashboard.uuid, updateDashboard, {
+                projectUuid,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    test('should delete a private dashboard through direct Admin access', async () => {
+        dashboardModel.getByIdOrSlug
+            .mockResolvedValueOnce(directPrivateDashboard)
+            .mockResolvedValueOnce(directPrivateDashboard)
+            .mockResolvedValueOnce(directPrivateDashboard);
+        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce({
+            [directPrivateDashboard.uuid]: SpaceMemberRole.ADMIN,
+        });
+
+        await service.delete(
+            createDirectUser(ProjectMemberRole.ADMIN),
+            directPrivateDashboard.uuid,
+            { projectUuid },
+        );
+
+        expect(dashboardModel.permanentDelete).toHaveBeenCalledWith(
+            directPrivateDashboard.uuid,
+        );
+    });
+
+    test('should rollback through direct Admin access', async () => {
+        dashboardModel.getByIdOrSlug.mockResolvedValueOnce(
+            directPrivateDashboard,
+        );
+        dashboardModel.getVersionByUuid.mockResolvedValueOnce({
+            ...directPrivateDashboard,
+            versionUuid: 'previous-version',
+            tiles: [],
+        });
+        directAccessService.resolveUserAccessForUser.mockResolvedValueOnce({
+            [directPrivateDashboard.uuid]: SpaceMemberRole.ADMIN,
+        });
+
+        await service.rollback(
+            createDirectUser(ProjectMemberRole.ADMIN),
+            directPrivateDashboard.uuid,
+            'previous-version',
+        );
+
+        expect(dashboardModel.addVersion).toHaveBeenCalledWith(
+            directPrivateDashboard.uuid,
+            expect.objectContaining({ tiles: [] }),
+            expect.objectContaining({ userUuid: user.userUuid }),
+            directPrivateDashboard.projectUuid,
+            expect.anything(),
+        );
+    });
+
+    test.each(['delete', 'rollback'])(
+        'should deny direct %s above the capability ceiling',
+        async (action) => {
+            dashboardModel.getByIdOrSlug.mockResolvedValueOnce(
+                directPrivateDashboard,
+            );
+            directAccessService.resolveUserAccessForUser.mockResolvedValueOnce({
+                [directPrivateDashboard.uuid]: SpaceMemberRole.ADMIN,
+            });
+            const directViewer = createDirectUser(ProjectMemberRole.VIEWER);
+
+            const operation =
+                action === 'delete'
+                    ? service.delete(
+                          directViewer,
+                          directPrivateDashboard.uuid,
+                          { projectUuid },
+                      )
+                    : service.rollback(
+                          directViewer,
+                          directPrivateDashboard.uuid,
+                          'previous-version',
+                      );
+
+            await expect(operation).rejects.toThrow(ForbiddenError);
+            expect(dashboardModel.permanentDelete).not.toHaveBeenCalled();
+            expect(dashboardModel.addVersion).not.toHaveBeenCalled();
+        },
+    );
+
     test('should update dashboard details', async () => {
         (dashboardModel.update as import('vitest').Mock).mockResolvedValueOnce({
             ...dashboard,

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -292,7 +292,9 @@ describe('DashboardService', () => {
             directAccessService as unknown as DirectAccessService,
     });
     afterEach(() => {
-        vi.clearAllMocks();
+        // Restores vi.fn(impl) defaults and drops unconsumed once-queues so
+        // a test's leftover mockResolvedValueOnce cannot leak into the next.
+        vi.resetAllMocks();
     });
 
     test('duplicates dashboard charts from the original slug base', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -136,6 +136,11 @@ export type DashboardTileDependency =
     | { type: 'savedChart'; uuid: string }
     | { type: 'savedSql'; uuid: string };
 
+type DashboardAccessContext = Pick<
+    Dashboard,
+    'organizationUuid' | 'projectUuid' | 'inheritsFromOrgOrProject' | 'access'
+>;
+
 export class DashboardService
     extends BaseService
     implements BulkActionable<Knex>, SoftDeletableService
@@ -981,6 +986,69 @@ export class DashboardService
         return dashboard;
     }
 
+    private async assertAction(
+        actor: DashboardAccessActor,
+        action: AbilityAction,
+        dashboardUuidOrSlug: UuidOrSlug,
+        options?: { projectUuid?: string },
+    ): Promise<Dashboard> {
+        const dashboard = await this.assertViewAccess(
+            actor,
+            dashboardUuidOrSlug,
+            { ...options, includeDependencies: false },
+        );
+        const auditedAbility = this.createAuditedAbility(actor);
+        if (
+            auditedAbility.cannot(
+                action,
+                subject('Dashboard', {
+                    ...dashboard,
+                    metadata: {
+                        dashboardUuid: dashboard.uuid,
+                        dashboardName: dashboard.name,
+                    },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                `You don't have access to ${action} this dashboard`,
+            );
+        }
+        return dashboard;
+    }
+
+    private static restoreDeniedDependencyProperties(
+        update: UpdateDashboard,
+        existingDashboard: DashboardDAO,
+    ): UpdateDashboard {
+        if (!isDashboardVersionedFields(update)) {
+            return update;
+        }
+        const existingTiles = new Map(
+            existingDashboard.tiles.map((tile) => [tile.uuid, tile]),
+        );
+        return {
+            ...update,
+            tiles: update.tiles.map((tile) => {
+                if (!('dependencyAccess' in tile.properties)) {
+                    return tile;
+                }
+                const existingTile = tile.uuid
+                    ? existingTiles.get(tile.uuid)
+                    : undefined;
+                if (!existingTile || existingTile.type !== tile.type) {
+                    throw new ForbiddenError(
+                        'Denied dashboard dependencies cannot be changed',
+                    );
+                }
+                return {
+                    ...tile,
+                    properties: existingTile.properties,
+                } as typeof tile;
+            }),
+        };
+    }
+
     private recordDashboardView(userUuid: UUID, dashboard: Dashboard): void {
         void this.analyticsModel
             .addDashboardViewEvent(dashboard.uuid, userUuid)
@@ -1771,19 +1839,35 @@ export class DashboardService
         dashboard: UpdateDashboard,
         options?: { projectUuid?: string },
     ): Promise<Dashboard> {
-        const existingDashboardDao = await this.dashboardModel.getByIdOrSlug(
+        const existingDashboard = await this.assertAction(
+            user,
+            'update',
             dashboardUuidOrSlug,
-            {
-                projectUuid: options?.projectUuid,
-            },
+            options,
         );
-        const { preserveVerification, ...dashboardFields } = dashboard;
+        return this.updateWithAccessContext({
+            user,
+            dashboard: DashboardService.restoreDeniedDependencyProperties(
+                dashboard,
+                existingDashboard,
+            ),
+            existingDashboard,
+            currentSpace: existingDashboard,
+        });
+    }
 
-        const currentSpace =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                existingDashboardDao.spaceUuid,
-            );
+    private async updateWithAccessContext({
+        user,
+        dashboard,
+        existingDashboard: existingDashboardDao,
+        currentSpace,
+    }: {
+        user: SessionUser;
+        dashboard: UpdateDashboard;
+        existingDashboard: DashboardDAO;
+        currentSpace: DashboardAccessContext;
+    }): Promise<Dashboard> {
+        const { preserveVerification, ...dashboardFields } = dashboard;
         const auditedAbility = this.createAuditedAbility(user);
         const canUpdateDashboardInCurrentSpace = auditedAbility.can(
             'update',
@@ -1809,7 +1893,10 @@ export class DashboardService
             });
 
         if (isDashboardUnversionedFields(dashboardFields)) {
-            if (dashboardFields.spaceUuid) {
+            if (
+                dashboardFields.spaceUuid &&
+                dashboardFields.spaceUuid !== existingDashboardDao.spaceUuid
+            ) {
                 const newSpace =
                     await this.spacePermissionService.getSpaceAccessContext(
                         user.userUuid,
@@ -2237,39 +2324,14 @@ export class DashboardService
         dashboardUuidOrSlug: UuidOrSlug,
         options?: SoftDeleteOptions & { projectUuid?: string },
     ): Promise<void> {
-        const dashboardToDelete = await this.dashboardModel.getByIdOrSlug(
-            dashboardUuidOrSlug,
-            {
-                projectUuid: options?.projectUuid,
-            },
-        );
-        const { organizationUuid, projectUuid, spaceUuid, tiles } =
-            dashboardToDelete;
-
-        if (!options?.bypassPermissions) {
-            const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getSpaceAccessContext(
-                    user.userUuid,
-                    spaceUuid,
-                );
-            const auditedAbility = this.createAuditedAbility(user);
-            if (
-                auditedAbility.cannot(
-                    'delete',
-                    subject('Dashboard', {
-                        organizationUuid,
-                        projectUuid,
-                        inheritsFromOrgOrProject,
-                        access,
-                        metadata: { dashboardUuid: dashboardToDelete.uuid },
-                    }),
-                )
-            ) {
-                throw new ForbiddenError(
-                    "You don't have access to the space this dashboard belongs to",
-                );
-            }
-        }
+        const dashboardToDelete = options?.bypassPermissions
+            ? await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug, {
+                  projectUuid: options?.projectUuid,
+              })
+            : await this.assertAction(user, 'delete', dashboardUuidOrSlug, {
+                  projectUuid: options?.projectUuid,
+              });
+        const { projectUuid, tiles } = dashboardToDelete;
 
         if (hasChartsInDashboard(dashboardToDelete)) {
             try {
@@ -2995,40 +3057,25 @@ export class DashboardService
         dashboardUuidOrSlug: UuidOrSlug,
         versionUuid: UUID,
     ): Promise<void> {
-        const dashboardDao =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
+        const dashboardDao = await this.assertAction(
+            user,
+            'manage',
+            dashboardUuidOrSlug,
+        );
 
-        // Check if trying to rollback to current version
+        await this.rollbackWithAccess(user, dashboardDao, versionUuid);
+    }
+
+    private async rollbackWithAccess(
+        user: SessionUser,
+        dashboardDao: DashboardDAO,
+        versionUuid: UUID,
+    ): Promise<void> {
         if (dashboardDao.versionUuid === versionUuid) {
             this.logger.info(
                 `Ignoring rollback request - version ${versionUuid} is already the current version for dashboard ${dashboardDao.uuid}`,
             );
             return;
-        }
-
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                dashboardDao.spaceUuid,
-            );
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('Dashboard', {
-                    ...dashboardDao,
-                    inheritsFromOrgOrProject,
-                    access,
-                    metadata: {
-                        dashboardUuid: dashboardDao.uuid,
-                        dashboardName: dashboardDao.name,
-                    },
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                "You don't have access to rollback this dashboard",
-            );
         }
 
         const targetVersion = await this.dashboardModel.getVersionByUuid(


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1250

## Summary

PR 3 of 5 applies direct dashboard access to existing update, delete, and rollback boundaries while preserving opaque dependencies the actor cannot inspect.

Stacks on [#28019](https://github.com/lightdash/lightdash/pull/28019), which secures dashboard query paths.

## Mutation path

```
dashboard mutation -> current dashboard role -> project capability ceiling
                                            -> validate visible + opaque tiles
                                            -> write or reject atomically
```

## Scope

- Authorizes existing dashboard update, delete, and rollback operations.
- Preserves inaccessible dependency properties during layout edits.
- Rejects missing or type-mismatched opaque tiles.
- Keeps same-space edits available to direct-only editors.
- Leaves duplicate, restore, move, and permanent-delete APIs out of scope.

## Test plan

- [x] Backend typecheck
- [x] Backend lint
- [x] 55 focused dashboard and content-verification tests

## Credit

Thanks @hrx-joseph-fahnestock for the initial direct-access exploration in [houserx/lightdash-hrx#25](https://github.com/houserx/lightdash-hrx/pull/25), which informed this stack.
