### PR TITLE
feat(dashboards): apply direct access to exports

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -989,6 +989,31 @@ describe('uploadGsheets — pivot routing', () => {
         const appendToSheet = vi.fn().mockResolvedValue(undefined);
         const appendCsvToSheet = vi.fn().mockResolvedValue(undefined);
         const logSchedulerJob = vi.fn().mockResolvedValue(undefined);
+        const getSessionByUserUuidAndOrg = vi.fn().mockResolvedValue({});
+        const getAccountByUserUuid = vi.fn().mockResolvedValue({
+            user: { email: 'demo@lightdash.com' },
+            organization: { organizationUuid: 'org-1' },
+        });
+        const getDashboard = vi.fn().mockResolvedValue({
+            uuid: source === 'dashboard' ? 'dashboard-1' : null,
+            projectUuid: 'project-1',
+            filters: {
+                dimensions: [],
+                metrics: [],
+                tableCalculations: [],
+            },
+            tiles: [
+                {
+                    uuid: 'tile-1',
+                    type: DashboardTileTypes.SAVED_CHART,
+                    properties: {
+                        title: 'Chart',
+                        savedChartUuid: 'chart-1',
+                    },
+                },
+            ],
+            displayTimezone: null,
+        });
         const chart = makeChart(hasPivotConfig);
         const dashboardUuid = source === 'dashboard' ? 'dashboard-1' : null;
         const scheduler = {
@@ -1026,11 +1051,8 @@ describe('uploadGsheets — pivot routing', () => {
                 logSchedulerJob,
             }),
             userService: asDep<'userService'>({
-                getSessionByUserUuid: vi.fn().mockResolvedValue({}),
-                getAccountByUserUuid: vi.fn().mockResolvedValue({
-                    user: { email: 'demo@lightdash.com' },
-                    organization: { organizationUuid: 'org-1' },
-                }),
+                getSessionByUserUuidAndOrg,
+                getAccountByUserUuid,
                 getRefreshToken: vi.fn().mockResolvedValue('refresh-token'),
             }),
             asyncQueryService: asDep<'asyncQueryService'>({
@@ -1050,26 +1072,7 @@ describe('uploadGsheets — pivot routing', () => {
                     }),
             }),
             dashboardService: asDep<'dashboardService'>({
-                getByIdOrSlug: vi.fn().mockResolvedValue({
-                    uuid: dashboardUuid,
-                    projectUuid: 'project-1',
-                    filters: {
-                        dimensions: [],
-                        metrics: [],
-                        tableCalculations: [],
-                    },
-                    tiles: [
-                        {
-                            uuid: 'tile-1',
-                            type: DashboardTileTypes.SAVED_CHART,
-                            properties: {
-                                title: 'Chart',
-                                savedChartUuid: chart.uuid,
-                            },
-                        },
-                    ],
-                    displayTimezone: null,
-                }),
+                getByIdOrSlug: getDashboard,
             }),
             analytics: asDep<'analytics'>({ track: vi.fn() }),
             lightdashConfig: asDep<'lightdashConfig'>({
@@ -1101,7 +1104,15 @@ describe('uploadGsheets — pivot routing', () => {
                 projectUuid: 'project-1',
             });
 
-        return { appendToSheet, appendCsvToSheet, logSchedulerJob, run };
+        return {
+            appendToSheet,
+            appendCsvToSheet,
+            getAccountByUserUuid,
+            getDashboard,
+            getSessionByUserUuidAndOrg,
+            logSchedulerJob,
+            run,
+        };
     };
 
     it.each(['saved-chart', 'dashboard'] as const)(
@@ -1115,6 +1126,19 @@ describe('uploadGsheets — pivot routing', () => {
 
             await result.run();
 
+            if (source === 'dashboard') {
+                expect(result.getSessionByUserUuidAndOrg).toHaveBeenCalledWith(
+                    'user-1',
+                    'org-1',
+                );
+                expect(result.getAccountByUserUuid).toHaveBeenCalledWith(
+                    'user-1',
+                );
+                expect(result.getDashboard).toHaveBeenCalledWith(
+                    expect.anything(),
+                    'dashboard-1',
+                );
+            }
             expect(result.appendToSheet).toHaveBeenCalledOnce();
             expect(result.appendCsvToSheet).not.toHaveBeenCalled();
         },
@@ -1135,6 +1159,22 @@ describe('uploadGsheets — pivot routing', () => {
             expect(result.appendToSheet).not.toHaveBeenCalled();
         },
     );
+
+    it('does not write a queued dashboard sync after access is revoked', async () => {
+        const result = setup({
+            source: 'dashboard',
+            hasPivotConfig: false,
+            pivotDetails: null,
+        });
+        result.getDashboard.mockRejectedValueOnce(
+            new ForbiddenError('Dashboard access revoked'),
+        );
+
+        await expect(result.run()).rejects.toThrow('Dashboard access revoked');
+
+        expect(result.appendToSheet).not.toHaveBeenCalled();
+        expect(result.appendCsvToSheet).not.toHaveBeenCalled();
+    });
 
     it('keeps non-pivoted saved-chart results on the flat writer', async () => {
         const result = setup({
@@ -2167,7 +2207,7 @@ describe('uploadGsheets — app branch', () => {
                 logSchedulerJob,
             }),
             userService: asDep<'userService'>({
-                getSessionByUserUuid: vi.fn().mockResolvedValue({}),
+                getSessionByUserUuidAndOrg: vi.fn().mockResolvedValue({}),
                 getAccountByUserUuid: vi.fn().mockResolvedValue({
                     user: { email: 'demo@lightdash.com' },
                     organization: { organizationUuid: 'org-1' },

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -4061,8 +4061,9 @@ export default class SchedulerTask {
                     createdByUserUuid: notification.userUuid,
                 },
             });
-            sessionUser = await this.userService.getSessionByUserUuid(
+            sessionUser = await this.userService.getSessionByUserUuidAndOrg(
                 scheduler.createdBy,
+                notification.organizationUuid,
             );
             account = await this.userService.getAccountByUserUuid(
                 scheduler.createdBy,

--- a/packages/backend/src/services/CommentService/CommentService.test.ts
+++ b/packages/backend/src/services/CommentService/CommentService.test.ts
@@ -13,6 +13,7 @@ import type { CommentModel } from '../../models/CommentModel/CommentModel';
 import type { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import type { NotificationsModel } from '../../models/NotificationsModel/NotificationsModel';
 import type { UserModel } from '../../models/UserModel';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { CommentService } from './CommentService';
 
@@ -136,6 +137,7 @@ const userModel = {
 const spacePermissionService = {
     can: vi.fn(async () => true),
 };
+const assertDashboardViewAccess = vi.fn(async () => dashboard);
 
 describe('CommentService', () => {
     let service: CommentService;
@@ -154,6 +156,10 @@ describe('CommentService', () => {
             userModel: userModel as unknown as UserModel,
             spacePermissionService:
                 spacePermissionService as unknown as SpacePermissionService,
+            getDashboardService: () =>
+                ({
+                    assertViewAccess: assertDashboardViewAccess,
+                }) as unknown as DashboardService,
         });
         logBypassEventSpy = vi.spyOn(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -162,6 +168,72 @@ describe('CommentService', () => {
         );
         analyticsTrackSpy = vi.spyOn(analyticsMock, 'track');
     });
+
+    it('checks direct dashboard access before listing comments', async () => {
+        await service.findCommentsForDashboard(adminUser, 'dashboard-slug');
+
+        expect(assertDashboardViewAccess).toHaveBeenCalledWith(
+            adminUser,
+            'dashboard-slug',
+            { projectUuid: undefined, includeDependencies: false },
+        );
+        expect(dashboardModel.getByIdOrSlug).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        [
+            'create',
+            (user: SessionUser) =>
+                service.createComment(
+                    user,
+                    'dashboard-uuid',
+                    'tile-uuid',
+                    'text',
+                    '<p>text</p>',
+                    null,
+                    [],
+                ),
+        ],
+        [
+            'list',
+            (user: SessionUser) =>
+                service.findCommentsForDashboard(user, 'dashboard-uuid'),
+        ],
+        [
+            'resolve',
+            (user: SessionUser) =>
+                service.resolveComment(
+                    user,
+                    'dashboard-uuid',
+                    'comment-uuid',
+                    true,
+                ),
+        ],
+        [
+            'delete',
+            (user: SessionUser) =>
+                service.deleteComment(user, 'dashboard-uuid', 'comment-uuid'),
+        ],
+    ])(
+        'does not %s comments after dashboard access is revoked',
+        async (_, run) => {
+            assertDashboardViewAccess.mockRejectedValueOnce(
+                new ForbiddenError('Dashboard access revoked'),
+            );
+
+            await expect(run(adminUser)).rejects.toThrow(ForbiddenError);
+
+            expect(commentModel.createComment).not.toHaveBeenCalled();
+            expect(
+                commentModel.findCommentsForDashboard,
+            ).not.toHaveBeenCalled();
+            expect(commentModel.resolveComment).not.toHaveBeenCalled();
+            expect(commentModel.deleteComment).not.toHaveBeenCalled();
+            expect(
+                notificationsModel.createDashboardCommentNotification,
+            ).not.toHaveBeenCalled();
+        },
+    );
 
     describe('resolveComment', () => {
         it.each([
@@ -279,8 +351,10 @@ describe('CommentService', () => {
             );
         });
 
-        it('throws ForbiddenError when user lacks space access', async () => {
-            spacePermissionService.can.mockResolvedValueOnce(false);
+        it('throws ForbiddenError when user lacks dashboard access', async () => {
+            assertDashboardViewAccess.mockRejectedValueOnce(
+                new ForbiddenError(),
+            );
 
             await expect(
                 service.deleteComment(

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -13,6 +13,7 @@ import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { NotificationsModel } from '../../models/NotificationsModel/NotificationsModel';
 import { UserModel } from '../../models/UserModel';
 import { BaseService } from '../BaseService';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 
 type CommentServiceArguments = {
@@ -23,6 +24,7 @@ type CommentServiceArguments = {
     notificationsModel: NotificationsModel;
     userModel: UserModel;
     spacePermissionService: SpacePermissionService;
+    getDashboardService: () => DashboardService;
 };
 
 export class CommentService extends BaseService {
@@ -40,6 +42,8 @@ export class CommentService extends BaseService {
 
     spacePermissionService: SpacePermissionService;
 
+    getDashboardService: () => DashboardService;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -48,6 +52,7 @@ export class CommentService extends BaseService {
         notificationsModel,
         userModel,
         spacePermissionService,
+        getDashboardService,
     }: CommentServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -57,6 +62,7 @@ export class CommentService extends BaseService {
         this.notificationsModel = notificationsModel;
         this.userModel = userModel;
         this.spacePermissionService = spacePermissionService;
+        this.getDashboardService = getDashboardService;
     }
 
     async hasDashboardSpaceAccess(
@@ -144,8 +150,11 @@ export class CommentService extends BaseService {
     ): Promise<string> {
         this.throwIfDisabled();
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.getDashboardService().assertViewAccess(
+            user,
+            dashboardUuid,
+            { includeDependencies: false },
+        );
 
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -161,17 +170,31 @@ export class CommentService extends BaseService {
             throw new ForbiddenError();
         }
 
-        if (!(await this.hasDashboardSpaceAccess(user, dashboard.spaceUuid))) {
-            throw new ForbiddenError(
-                "You don't have access to the space this dashboard belongs to",
-            );
-        }
+        return this.createCommentWithAccess(
+            user,
+            dashboard,
+            dashboardTileUuid,
+            text,
+            unsafeTextHtml,
+            replyTo,
+            mentions,
+        );
+    }
 
+    private async createCommentWithAccess(
+        user: SessionUser,
+        dashboard: DashboardDAO,
+        dashboardTileUuid: string,
+        text: string,
+        unsafeTextHtml: string,
+        replyTo: string | null,
+        mentions: string[],
+    ): Promise<string> {
         this.analytics.track({
             event: 'comment.created',
             userId: user.userUuid,
             properties: {
-                dashboardUuid,
+                dashboardUuid: dashboard.uuid,
                 dashboardTileUuid,
                 isReply: !!replyTo,
                 hasMention: mentions.length > 0,
@@ -179,7 +202,7 @@ export class CommentService extends BaseService {
         });
 
         const comment = await this.commentModel.createComment(
-            dashboardUuid,
+            dashboard.uuid,
             dashboardTileUuid,
             text,
             unsafeTextHtml,
@@ -209,10 +232,12 @@ export class CommentService extends BaseService {
     ): Promise<Record<string, Comment[]>> {
         this.throwIfDisabled();
 
-        const dashboard = await this.dashboardModel.getByIdOrSlug(
+        const dashboard = await this.getDashboardService().assertViewAccess(
+            user,
             dashboardUuidOrSlug,
             {
                 projectUuid: options?.projectUuid,
+                includeDependencies: false,
             },
         );
 
@@ -230,26 +255,32 @@ export class CommentService extends BaseService {
             throw new ForbiddenError();
         }
 
-        if (!(await this.hasDashboardSpaceAccess(user, dashboard.spaceUuid))) {
-            throw new ForbiddenError(
-                "You don't have access to the space this dashboard belongs to",
-            );
-        }
-
-        const canUserRemoveAnyComment = auditedAbility.can(
-            'manage',
-            subject('DashboardComments', {
-                organizationUuid: dashboard.organizationUuid,
-                projectUuid: dashboard.projectUuid,
-                metadata: { dashboardName: dashboard.name },
-            }),
+        return this.findCommentsWithAccess(
+            user,
+            dashboard,
+            auditedAbility.can(
+                'manage',
+                subject('DashboardComments', {
+                    organizationUuid: dashboard.organizationUuid,
+                    projectUuid: dashboard.projectUuid,
+                    metadata: { dashboardName: dashboard.name },
+                }),
+            ),
+            options?.resolved,
         );
+    }
 
+    private findCommentsWithAccess(
+        user: SessionUser,
+        dashboard: DashboardDAO,
+        canUserRemoveAnyComment: boolean,
+        resolved?: boolean,
+    ): Promise<Record<string, Comment[]>> {
         return this.commentModel.findCommentsForDashboard(
             dashboard.uuid,
             user.userUuid,
             canUserRemoveAnyComment,
-            options?.resolved ?? false,
+            resolved ?? false,
         );
     }
 
@@ -261,8 +292,11 @@ export class CommentService extends BaseService {
     ): Promise<void> {
         this.throwIfDisabled();
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.getDashboardService().assertViewAccess(
+            user,
+            dashboardUuid,
+            { includeDependencies: false },
+        );
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
@@ -277,12 +311,20 @@ export class CommentService extends BaseService {
             throw new ForbiddenError();
         }
 
-        if (!(await this.hasDashboardSpaceAccess(user, dashboard.spaceUuid))) {
-            throw new ForbiddenError(
-                "You don't have access to the space this dashboard belongs to",
-            );
-        }
+        await this.resolveCommentWithAccess(
+            user,
+            dashboard,
+            commentId,
+            resolved,
+        );
+    }
 
+    private async resolveCommentWithAccess(
+        user: SessionUser,
+        dashboard: DashboardDAO,
+        commentId: string,
+        resolved: boolean,
+    ): Promise<void> {
         const comment = await this.commentModel.getComment(
             dashboard.uuid,
             commentId,
@@ -294,7 +336,7 @@ export class CommentService extends BaseService {
             properties: {
                 isReply: !!comment.replyTo,
                 dashboardTileUuid: comment.dashboardTileUuid,
-                dashboardUuid,
+                dashboardUuid: dashboard.uuid,
                 isOwner: comment.userUuid === user.userUuid,
                 hasMention: comment.mentions.length > 0,
             },
@@ -312,15 +354,20 @@ export class CommentService extends BaseService {
     ): Promise<void> {
         this.throwIfDisabled();
 
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.getDashboardService().assertViewAccess(
+            user,
+            dashboardUuid,
+            { includeDependencies: false },
+        );
 
-        if (!(await this.hasDashboardSpaceAccess(user, dashboard.spaceUuid))) {
-            throw new ForbiddenError(
-                "You don't have access to the space this dashboard belongs to",
-            );
-        }
+        await this.deleteCommentWithAccess(user, dashboard, commentId);
+    }
 
+    private async deleteCommentWithAccess(
+        user: SessionUser,
+        dashboard: DashboardDAO,
+        commentId: string,
+    ): Promise<void> {
         const auditedAbility = this.createAuditedAbility(user);
         const canRemoveAnyComment = auditedAbility.can(
             'manage',
@@ -358,7 +405,7 @@ export class CommentService extends BaseService {
             properties: {
                 isReply: !!comment.replyTo,
                 dashboardTileUuid: comment.dashboardTileUuid,
-                dashboardUuid,
+                dashboardUuid: dashboard.uuid,
                 isOwner,
                 hasMention: comment.mentions.length > 0,
             },

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -2,6 +2,7 @@ import {
     DimensionType,
     FieldType,
     ItemsMap,
+    type Account,
     type Dimension,
 } from '@lightdash/common';
 import * as fs from 'fs/promises';
@@ -43,6 +44,7 @@ import { WarehouseAvailableTablesModel } from '../../models/WarehouseAvailableTa
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
 import { ProjectService } from '../ProjectService/ProjectService';
@@ -52,6 +54,7 @@ import { itemMap, metricQuery } from './CsvService.mock';
 
 describe('Csv service', () => {
     const createDownloadFile = vi.fn();
+    const assertDashboardViewAccess = vi.fn();
     const csvService = new CsvService({
         lightdashConfig,
         analytics: analyticsMock,
@@ -126,6 +129,37 @@ describe('Csv service', () => {
             organizationSettingsModel: {} as OrganizationSettingsModel,
         }),
         persistentDownloadFileService: {} as PersistentDownloadFileService,
+        getDashboardService: () =>
+            ({
+                assertViewAccess: assertDashboardViewAccess,
+            }) as unknown as DashboardService,
+    });
+
+    it('checks current dashboard access before scheduling an export', async () => {
+        const accessError = new Error('dashboard access revoked');
+        assertDashboardViewAccess.mockRejectedValueOnce(accessError);
+        const account = {
+            user: { type: 'registered' },
+        } as unknown as Account;
+
+        await expect(
+            csvService.scheduleExportCsvDashboard(
+                account,
+                'dashboard-uuid',
+                {
+                    dimensions: [],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+                null,
+            ),
+        ).rejects.toBe(accessError);
+
+        expect(assertDashboardViewAccess).toHaveBeenCalledWith(
+            account,
+            'dashboard-uuid',
+            { includeDependencies: false },
+        );
     });
 
     it('persists the owning project for a local CSV download', async () => {

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -66,6 +66,7 @@ import {
     streamJsonlData,
 } from '../../utils/FileDownloadUtils/FileDownloadUtils';
 import { BaseService } from '../BaseService';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
 import { ProjectService } from '../ProjectService/ProjectService';
@@ -84,6 +85,7 @@ type CsvServiceArguments = {
     projectModel: ProjectModel;
     pivotTableService: PivotTableService;
     persistentDownloadFileService: PersistentDownloadFileService;
+    getDashboardService: () => DashboardService;
 };
 
 export const getSchedulerCsvLimit = (
@@ -161,6 +163,8 @@ export class CsvService extends BaseService {
 
     persistentDownloadFileService: PersistentDownloadFileService;
 
+    getDashboardService: () => DashboardService;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -175,6 +179,7 @@ export class CsvService extends BaseService {
         projectModel,
         pivotTableService,
         persistentDownloadFileService,
+        getDashboardService,
     }: CsvServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -190,6 +195,7 @@ export class CsvService extends BaseService {
         this.projectModel = projectModel;
         this.pivotTableService = pivotTableService;
         this.persistentDownloadFileService = persistentDownloadFileService;
+        this.getDashboardService = getDashboardService;
     }
 
     static convertRowToCsv(
@@ -583,8 +589,11 @@ export class CsvService extends BaseService {
         // JWT-scheduled job would fail at the worker. Embeds use the v2
         // dashboard exports endpoint instead.
         assertRegisteredAccount(account);
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.getDashboardService().assertViewAccess(
+            account,
+            dashboardUuid,
+            { includeDependencies: false },
+        );
         const auditedAbility = this.createAuditedAbility(account);
         if (
             auditedAbility.cannot(

--- a/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
@@ -4,6 +4,7 @@ import {
     ForbiddenError,
     OrganizationMemberRole,
     PossibleAbilities,
+    SpaceMemberRole,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { SlackClient } from '../../clients/Slack/SlackClient';
@@ -32,6 +33,25 @@ const dashboardData = {
     organizationUuid: 'org-uuid',
     projectUuid: 'project-uuid',
     uuid: 'dashboard-uuid',
+    spaceUuid: 'space-uuid',
+    name: 'Dashboard',
+    tiles: [],
+};
+
+const spacePermissionService = {
+    getSpaceAccessContext: vi.fn(async () => ({
+        organizationUuid: 'org-uuid',
+        projectUuid: 'project-uuid',
+        inheritsFromOrgOrProject: true,
+        access: [],
+        admins: [],
+    })),
+};
+
+const directAccessService = {
+    resolveUserAccessForUser: vi.fn(async () => ({
+        'dashboard-uuid': SpaceMemberRole.VIEWER,
+    })),
 };
 
 const verificationInfo = {
@@ -115,10 +135,12 @@ describe('DashboardService - Content Verification', () => {
         schedulerClient: {} as unknown as SchedulerClient,
         catalogModel: {} as unknown as CatalogModel,
         organizationModel: {} as unknown as OrganizationModel,
-        spacePermissionService: {} as unknown as SpacePermissionService,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
-        directAccessService: {} as unknown as DirectAccessService,
+        directAccessService:
+            directAccessService as unknown as DirectAccessService,
     });
 
     afterEach(() => {

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -165,6 +165,7 @@ const contentVerificationModel = {
     getByContent: vi.fn(
         async (): Promise<ContentVerificationInfo | null> => null,
     ),
+    verify: vi.fn(async () => undefined),
     unverify: vi.fn(async () => undefined),
 };
 
@@ -663,6 +664,43 @@ describe('DashboardService', () => {
         );
     });
 
+    test('should not schedule an export after dashboard access is revoked', async () => {
+        const account = fromSession(user);
+        vi.spyOn(service, 'assertViewAccess').mockRejectedValueOnce(
+            new ForbiddenError('Dashboard access revoked'),
+        );
+
+        await expect(
+            service.scheduleExportContent(account, dashboard.uuid, {
+                format: SchedulerFormat.IMAGE,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+
+        expect(schedulerClient.scheduleTask).not.toHaveBeenCalled();
+    });
+
+    test.each([
+        [
+            'verify',
+            (actor: SessionUser) =>
+                service.verifyDashboard(actor, dashboard.uuid),
+        ],
+        [
+            'unverify',
+            (actor: SessionUser) =>
+                service.unverifyDashboard(actor, dashboard.uuid),
+        ],
+    ])('should not %s after dashboard access is revoked', async (_, run) => {
+        vi.spyOn(service, 'assertViewAccess').mockRejectedValueOnce(
+            new ForbiddenError('Dashboard access revoked'),
+        );
+
+        await expect(run(user)).rejects.toThrow(ForbiddenError);
+
+        expect(contentVerificationModel.verify).not.toHaveBeenCalled();
+        expect(contentVerificationModel.unverify).not.toHaveBeenCalled();
+    });
+
     const embedExportAccount = () => {
         const sessionAccount = fromSession(user);
         return {
@@ -1106,16 +1144,21 @@ describe('DashboardService', () => {
     );
 
     test('should update dashboard details', async () => {
-        (dashboardModel.update as import('vitest').Mock).mockResolvedValueOnce({
-            ...dashboard,
-            filters: {
-                dimensions: [
-                    { lockedTabUuids: ['tab-uuid'] } as DashboardFilterRule,
-                ],
-                metrics: [{} as DashboardFilterRule],
-                tableCalculations: [],
-            },
-        });
+        dashboardModel.getByIdOrSlug.mockReset().mockResolvedValue(dashboard);
+        (dashboardModel.update as import('vitest').Mock)
+            .mockReset()
+            .mockResolvedValueOnce({
+                ...dashboard,
+                filters: {
+                    dimensions: [
+                        {
+                            lockedTabUuids: ['tab-uuid'],
+                        } as DashboardFilterRule,
+                    ],
+                    metrics: [{} as DashboardFilterRule],
+                    tableCalculations: [],
+                },
+            });
 
         const result = await service.update(
             user,
@@ -1671,6 +1714,35 @@ describe('DashboardService', () => {
             );
         });
 
+        test('returns runs through direct dashboard access', async () => {
+            const result = await service.getSchedulerRuns(
+                editorOwnUser,
+                dashboard.uuid,
+                schedulerUuid,
+            );
+
+            expect(result).toBe(runsPayload);
+        });
+
+        test('does not query runs after direct dashboard access is revoked', async () => {
+            vi.spyOn(service, 'assertViewAccess').mockRejectedValueOnce(
+                new ForbiddenError('Dashboard access revoked'),
+            );
+
+            await expect(
+                service.getSchedulerRuns(
+                    editorOwnUser,
+                    dashboard.uuid,
+                    schedulerUuid,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(schedulerModel.getScheduler).not.toHaveBeenCalled();
+            expect(
+                schedulerModel.getProjectSchedulerRuns,
+            ).not.toHaveBeenCalled();
+        });
+
         test('throws 403 when the user cannot manage scheduled deliveries', async () => {
             await expect(
                 service.getSchedulerRuns(
@@ -1808,6 +1880,24 @@ describe('DashboardService', () => {
             );
         });
 
+        test('lists schedulers through direct dashboard access', async () => {
+            await service.getSchedulers(editorUser, dashboard.uuid);
+
+            expect(schedulerModel.getSchedulers).toHaveBeenCalled();
+        });
+
+        test('does not list schedulers after direct dashboard access is revoked', async () => {
+            vi.spyOn(service, 'assertViewAccess').mockRejectedValueOnce(
+                new ForbiddenError('Dashboard access revoked'),
+            );
+
+            await expect(
+                service.getSchedulers(editorUser, dashboard.uuid),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(schedulerModel.getSchedulers).not.toHaveBeenCalled();
+        });
+
         test('resolves slug to uuid when filtering schedulers', async () => {
             await service.getSchedulers(adminUser, dashboard.slug);
 
@@ -1869,6 +1959,34 @@ describe('DashboardService', () => {
             expect(schedulerModel.createScheduler).toHaveBeenCalledWith(
                 expect.objectContaining({ dashboardUuid: dashboard.uuid }),
             );
+        });
+
+        test('creates a scheduler through direct dashboard access', async () => {
+            await service.createScheduler(
+                editorUser,
+                dashboard.uuid,
+                newScheduler,
+            );
+
+            expect(schedulerModel.createScheduler).toHaveBeenCalledWith(
+                expect.objectContaining({ dashboardUuid: dashboard.uuid }),
+            );
+        });
+
+        test('does not create a scheduler after direct dashboard access is revoked', async () => {
+            vi.spyOn(service, 'assertViewAccess').mockRejectedValueOnce(
+                new ForbiddenError('Dashboard access revoked'),
+            );
+
+            await expect(
+                service.createScheduler(
+                    editorUser,
+                    dashboard.uuid,
+                    newScheduler,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -525,7 +525,7 @@ describe('DashboardService', () => {
             tiles: [
                 {
                     uuid: 'markdown-tile-uuid',
-                    type: DashboardTileTypes.MARKDOWN,
+                    type: DashboardTileTypes.MARKDOWN as const,
                     properties: { title: 'Notes', content: 'Hello' },
                     x: 0,
                     y: 0,

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -61,6 +61,7 @@ import {
     type DuplicateDashboardParams,
     type Explore,
     type ExploreError,
+    type Scheduler,
     type SpaceAccess,
     type UUID,
     type UuidOrSlug,
@@ -192,8 +193,11 @@ export class DashboardService
         dashboardUuidOrSlug: UuidOrSlug,
         data: ExportContentRequest,
     ) {
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
+        const dashboard = isJwtUser(account)
+            ? await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug)
+            : await this.assertViewAccess(account, dashboardUuidOrSlug, {
+                  includeDependencies: false,
+              });
 
         if (
             ![
@@ -210,20 +214,11 @@ export class DashboardService
             // Image export renders the dashboard in a headless browser using a
             // real session, so it is not available to embed/JWT callers.
             assertRegisteredAccount(account);
-            const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getSpaceAccessContext(
-                    account.user.userUuid,
-                    dashboard.spaceUuid,
-                );
-
             if (
                 auditedAbility.cannot(
                     'view',
                     subject('Dashboard', {
-                        organizationUuid: dashboard.organizationUuid,
-                        projectUuid: dashboard.projectUuid,
-                        inheritsFromOrgOrProject,
-                        access,
+                        ...dashboard,
                         metadata: {
                             dashboardUuid: dashboard.uuid,
                             dashboardName: dashboard.name,
@@ -454,8 +449,18 @@ export class DashboardService
         user: SessionUser,
         dashboardUuidOrSlug: UuidOrSlug,
     ): Promise<ContentVerificationInfo> {
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
+        const dashboard = await this.assertViewAccess(
+            user,
+            dashboardUuidOrSlug,
+            { includeDependencies: false },
+        );
+        return this.verifyDashboardWithAccess(user, dashboard);
+    }
+
+    private async verifyDashboardWithAccess(
+        user: SessionUser,
+        dashboard: DashboardDAO,
+    ): Promise<ContentVerificationInfo> {
         const { organizationUuid, projectUuid } = dashboard;
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -507,8 +512,18 @@ export class DashboardService
         user: SessionUser,
         dashboardUuidOrSlug: UuidOrSlug,
     ): Promise<void> {
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
+        const dashboard = await this.assertViewAccess(
+            user,
+            dashboardUuidOrSlug,
+            { includeDependencies: false },
+        );
+        await this.unverifyDashboardWithAccess(user, dashboard);
+    }
+
+    private async unverifyDashboardWithAccess(
+        user: SessionUser,
+        dashboard: DashboardDAO,
+    ): Promise<void> {
         const { organizationUuid, projectUuid } = dashboard;
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -2561,6 +2576,22 @@ export class DashboardService
             user,
             dashboardUuidOrSlug,
         );
+        return this.getSchedulersWithAccess(
+            user,
+            dashboard,
+            searchQuery,
+            paginateArgs,
+            includeLatestRun,
+        );
+    }
+
+    private async getSchedulersWithAccess(
+        user: SessionUser,
+        dashboard: DashboardDAO,
+        searchQuery?: string,
+        paginateArgs?: KnexPaginateArgs,
+        includeLatestRun?: boolean,
+    ): Promise<KnexPaginatedData<SchedulerAndTargets[]>> {
         const auditedAbility = this.createAuditedAbility(user);
         const canManageAll = auditedAbility.can(
             'manage',
@@ -2602,9 +2633,37 @@ export class DashboardService
             destinations?: string[];
         },
     ): Promise<KnexPaginatedData<SchedulerRun[]>> {
+        const dashboard = await this.assertViewAccess(
+            user,
+            dashboardUuidOrSlug,
+            { includeDependencies: false },
+        );
         const scheduler = await this.schedulerModel.getScheduler(schedulerUuid);
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
+        return this.getSchedulerRunsWithAccess(
+            user,
+            dashboard,
+            scheduler,
+            schedulerUuid,
+            paginateArgs,
+            searchQuery,
+            sort,
+            filters,
+        );
+    }
+
+    private async getSchedulerRunsWithAccess(
+        user: SessionUser,
+        dashboard: DashboardDAO,
+        scheduler: Scheduler,
+        schedulerUuid: UUID,
+        paginateArgs?: KnexPaginateArgs,
+        searchQuery?: string,
+        sort?: { column: string; direction: 'asc' | 'desc' },
+        filters?: {
+            statuses?: SchedulerRunStatus[];
+            destinations?: string[];
+        },
+    ): Promise<KnexPaginatedData<SchedulerRun[]>> {
         const auditedAbility = this.createAuditedAbility(user);
         // Authorize before revealing whether the scheduler belongs to this
         // dashboard, so unauthorized callers can't distinguish 404 (wrong
@@ -2646,6 +2705,18 @@ export class DashboardService
         dashboardUuidOrSlug: UuidOrSlug,
         newScheduler: CreateSchedulerAndTargetsWithoutIds,
     ): Promise<SchedulerAndTargets> {
+        DashboardService.validateCreateScheduler(user, newScheduler);
+        const dashboard = await this.checkCreateScheduledDeliveryAccess(
+            user,
+            dashboardUuidOrSlug,
+        );
+        return this.createSchedulerWithAccess(user, dashboard, newScheduler);
+    }
+
+    private static validateCreateScheduler(
+        user: SessionUser,
+        newScheduler: CreateSchedulerAndTargetsWithoutIds,
+    ): void {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
@@ -2665,11 +2736,13 @@ export class DashboardService
                 'Targets is required and must be an array',
             );
         }
+    }
 
-        const dashboard = await this.checkCreateScheduledDeliveryAccess(
-            user,
-            dashboardUuidOrSlug,
-        );
+    private async createSchedulerWithAccess(
+        user: SessionUser,
+        dashboard: DashboardDAO,
+        newScheduler: CreateSchedulerAndTargetsWithoutIds,
+    ): Promise<SchedulerAndTargets> {
         const { projectUuid, organizationUuid } = dashboard;
 
         if (newScheduler.format === SchedulerFormat.GSHEETS) {
@@ -2724,7 +2797,7 @@ export class DashboardService
         this.analytics.track(createSchedulerData);
 
         await this.slackClient.joinChannels(
-            user.organizationUuid,
+            organizationUuid,
             SchedulerModel.getSlackChannels(scheduler.targets),
         );
 
@@ -2747,18 +2820,18 @@ export class DashboardService
         user: SessionUser,
         dashboardUuidOrSlug: UuidOrSlug,
     ): Promise<Dashboard> {
-        const dashboardDao =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                dashboardDao.spaceUuid,
-            );
-        const dashboard = {
-            ...dashboardDao,
-            inheritsFromOrgOrProject,
-            access,
-        };
+        const dashboard = await this.assertViewAccess(
+            user,
+            dashboardUuidOrSlug,
+            { includeDependencies: false },
+        );
+        return this.assertCreateScheduledDeliveryAccess(user, dashboard);
+    }
+
+    private assertCreateScheduledDeliveryAccess(
+        user: SessionUser,
+        dashboard: Dashboard,
+    ): Dashboard {
         const { organizationUuid, projectUuid } = dashboard;
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -2792,9 +2865,7 @@ export class DashboardService
             );
         }
 
-        return {
-            ...dashboard,
-        };
+        return dashboard;
     }
 
     async hasAccess(

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -26,6 +26,7 @@ import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { UserModel } from '../../models/UserModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { UserService } from '../UserService';
 import { SchedulerService } from './SchedulerService';
@@ -98,6 +99,8 @@ const chartSchedulerInPrivateSpace: ChartScheduler = {
 const dashboardScheduler = {
     schedulerUuid: 'schedulerUuid',
     name: 'scheduler name',
+    createdBy: 'userUuid',
+    format: SchedulerFormat.CSV,
     dashboardUuid: 'dashboardUuid',
     savedChartUuid: null,
     savedSqlUuid: null,
@@ -114,6 +117,10 @@ const dashboardSummary = {
 const schedulerModel = {
     getScheduler: vi.fn(async () => chartSchedulerInPrivateSpace),
     getSchedulerAndTargets: vi.fn(async () => dashboardScheduler),
+    updateScheduler: vi.fn(),
+    setSchedulerEnabled: vi.fn(),
+    deleteScheduler: vi.fn(),
+    deleteScheduledLogs: vi.fn(),
 };
 
 const savedChartModel = {
@@ -137,6 +144,8 @@ const spacePermissionService = {
 
 const schedulerClient = {
     addScheduledDeliveryJob: vi.fn(async () => ({})),
+    deleteScheduledJobs: vi.fn(),
+    generateDailyJobsForScheduler: vi.fn(),
 };
 
 const slackClient = {
@@ -153,9 +162,17 @@ const buildUser = (
         organizationCreatedAt: new Date(),
         role: OrganizationMemberRole.VIEWER,
         ability: new Ability<PossibleAbilities>(abilities),
+        abilityRules: abilities,
     }) as unknown as SessionUser;
 
-const buildService = () =>
+const dashboardService = {
+    assertViewAccess: vi.fn(async () => dashboardSummary),
+};
+
+const buildService = (
+    getDashboardService: () => DashboardService = () =>
+        dashboardService as unknown as DashboardService,
+) =>
     new SchedulerService({
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
@@ -174,6 +191,7 @@ const buildService = () =>
         jobModel: {} as JobModel,
         spacePermissionService:
             spacePermissionService as unknown as SpacePermissionService,
+        getDashboardService,
     });
 
 describe('SchedulerService', () => {
@@ -183,6 +201,93 @@ describe('SchedulerService', () => {
         vi.clearAllMocks();
     });
 
+    test('checks direct dashboard access when reading a dashboard scheduler', async () => {
+        const assertViewAccess = vi.fn().mockResolvedValue({});
+        const directAccessService = buildService(
+            () =>
+                ({
+                    assertViewAccess,
+                }) as unknown as DashboardService,
+        );
+        const user = buildUser([]);
+
+        await directAccessService.getScheduler(user, 'schedulerUuid');
+
+        expect(assertViewAccess).toHaveBeenCalledWith(user, 'dashboardUuid', {
+            includeDependencies: false,
+        });
+    });
+
+    test.each([
+        [
+            'read',
+            (schedulerService: SchedulerService, user: SessionUser) =>
+                schedulerService.getScheduler(user, 'schedulerUuid'),
+        ],
+        [
+            'update',
+            (schedulerService: SchedulerService, user: SessionUser) =>
+                schedulerService.updateScheduler(user, 'schedulerUuid', {
+                    name: 'scheduler',
+                    cron: '0 0 * * *',
+                    timezone: 'UTC',
+                    format: SchedulerFormat.CSV,
+                    options: { formatted: true, limit: 'table' },
+                    targets: [],
+                    includeLinks: true,
+                } as UpdateSchedulerAndTargetsWithoutId),
+        ],
+        [
+            'toggle',
+            (schedulerService: SchedulerService, user: SessionUser) =>
+                schedulerService.setSchedulerEnabled(
+                    user,
+                    'schedulerUuid',
+                    true,
+                ),
+        ],
+        [
+            'delete',
+            (schedulerService: SchedulerService, user: SessionUser) =>
+                schedulerService.deleteScheduler(user, 'schedulerUuid'),
+        ],
+    ])(
+        'does not %s a scheduler after dashboard access is revoked',
+        async (action, run) => {
+            const accessError = new ForbiddenError('Dashboard access revoked');
+            const assertViewAccess = vi.fn().mockRejectedValue(accessError);
+            const directAccessService = buildService(
+                () =>
+                    ({
+                        assertViewAccess,
+                    }) as unknown as DashboardService,
+            );
+            const user = buildUser([
+                { subject: 'ScheduledDeliveries', action: ['manage'] },
+            ]);
+            if (action === 'read') {
+                schedulerModel.getSchedulerAndTargets.mockResolvedValueOnce(
+                    dashboardScheduler as never,
+                );
+            } else {
+                schedulerModel.getScheduler.mockResolvedValueOnce(
+                    dashboardScheduler as never,
+                );
+            }
+
+            await expect(run(directAccessService, user)).rejects.toBe(
+                accessError,
+            );
+            expect(
+                schedulerClient.addScheduledDeliveryJob,
+            ).not.toHaveBeenCalled();
+            expect(schedulerModel.updateScheduler).not.toHaveBeenCalled();
+            expect(schedulerModel.setSchedulerEnabled).not.toHaveBeenCalled();
+            expect(schedulerModel.deleteScheduler).not.toHaveBeenCalled();
+            expect(schedulerClient.deleteScheduledJobs).not.toHaveBeenCalled();
+        },
+    );
+
     describe('sendSchedulerByUuid', () => {
         const userWhoCanSendPersistedScheduler = buildUser([
             { subject: 'ScheduledDeliveries', action: ['create'] },
@@ -190,6 +295,11 @@ describe('SchedulerService', () => {
         ]);
 
         test('should throw ForbiddenError when user cannot view the underlying resource', async () => {
+            spacePermissionService.getSpaceAccessContext.mockResolvedValueOnce({
+                inheritsFromOrgOrProject: false,
+                access: [],
+            });
+
             await expect(
                 service.sendSchedulerByUuid(
                     interactiveViewer,
@@ -219,6 +329,57 @@ describe('SchedulerService', () => {
                 }),
                 chartSchedulerInPrivateSpace.schedulerUuid,
             );
+        });
+
+        test('sends a dashboard scheduler through direct access', async () => {
+            const assertViewAccess = vi.fn().mockResolvedValue({});
+            const directAccessService = buildService(
+                () =>
+                    ({
+                        assertViewAccess,
+                    }) as unknown as DashboardService,
+            );
+            schedulerModel.getScheduler.mockResolvedValueOnce(
+                dashboardScheduler as never,
+            );
+
+            await directAccessService.sendSchedulerByUuid(
+                userWhoCanSendPersistedScheduler,
+                'schedulerUuid',
+            );
+
+            expect(assertViewAccess).toHaveBeenCalledWith(
+                userWhoCanSendPersistedScheduler,
+                'dashboardUuid',
+                { includeDependencies: false },
+            );
+            expect(schedulerClient.addScheduledDeliveryJob).toHaveBeenCalled();
+        });
+
+        test('does not send a dashboard scheduler after access is revoked', async () => {
+            const accessError = new ForbiddenError('Dashboard access revoked');
+            const directAccessService = buildService(
+                () =>
+                    ({
+                        assertViewAccess: vi
+                            .fn()
+                            .mockRejectedValue(accessError),
+                    }) as unknown as DashboardService,
+            );
+            schedulerModel.getScheduler.mockResolvedValueOnce(
+                dashboardScheduler as never,
+            );
+
+            await expect(
+                directAccessService.sendSchedulerByUuid(
+                    userWhoCanSendPersistedScheduler,
+                    'schedulerUuid',
+                ),
+            ).rejects.toBe(accessError);
+
+            expect(
+                schedulerClient.addScheduledDeliveryJob,
+            ).not.toHaveBeenCalled();
         });
     });
 
@@ -297,6 +458,52 @@ describe('SchedulerService', () => {
             );
         });
 
+        test('sends an unsaved dashboard delivery through direct access', async () => {
+            const assertViewAccess = vi.fn().mockResolvedValue({});
+            const directAccessService = buildService(
+                () =>
+                    ({
+                        assertViewAccess,
+                    }) as unknown as DashboardService,
+            );
+            await directAccessService.sendScheduler(userWhoCanSend, {
+                ...sendNowPayload,
+                savedChartUuid: null,
+                dashboardUuid: 'dashboardUuid',
+            });
+
+            expect(assertViewAccess).toHaveBeenCalledWith(
+                userWhoCanSend,
+                'dashboardUuid',
+                { includeDependencies: false },
+            );
+            expect(schedulerClient.addScheduledDeliveryJob).toHaveBeenCalled();
+        });
+
+        test('does not send an unsaved dashboard delivery after access is revoked', async () => {
+            const accessError = new ForbiddenError('Dashboard access revoked');
+            const directAccessService = buildService(
+                () =>
+                    ({
+                        assertViewAccess: vi
+                            .fn()
+                            .mockRejectedValue(accessError),
+                    }) as unknown as DashboardService,
+            );
+
+            await expect(
+                directAccessService.sendScheduler(userWhoCanSend, {
+                    ...sendNowPayload,
+                    savedChartUuid: null,
+                    dashboardUuid: 'dashboardUuid',
+                }),
+            ).rejects.toBe(accessError);
+
+            expect(
+                schedulerClient.addScheduledDeliveryJob,
+            ).not.toHaveBeenCalled();
+        });
+
         test.each([
             { webhook: 'https://169.254.169.254/latest/meta-data' },
             { googleChatWebhook: 'https://127.0.0.1/hook' },
@@ -355,6 +562,7 @@ describe('SchedulerService', () => {
                     jobModel: {} as JobModel,
                     spacePermissionService:
                         spacePermissionService as unknown as SpacePermissionService,
+                    getDashboardService: () => ({}) as DashboardService,
                 });
                 return { appSendService, appSendSchedulerClient };
             };
@@ -497,9 +705,17 @@ describe('SchedulerService', () => {
 
         test('throws ForbiddenError when the user cannot view the underlying resource', async () => {
             const user = buildUser([]);
+            const deniedService = buildService(
+                () =>
+                    ({
+                        assertViewAccess: vi
+                            .fn()
+                            .mockRejectedValue(new ForbiddenError()),
+                    }) as unknown as DashboardService,
+            );
 
             await expect(
-                service.getScheduler(user, 'schedulerUuid'),
+                deniedService.getScheduler(user, 'schedulerUuid'),
             ).rejects.toThrowError(ForbiddenError);
         });
 
@@ -565,6 +781,7 @@ describe('SchedulerService', () => {
                 jobModel: {} as JobModel,
                 spacePermissionService:
                     spacePermissionService as unknown as SpacePermissionService,
+                getDashboardService: () => ({}) as DashboardService,
             });
             return { appListService, appListSchedulerModel };
         };
@@ -706,6 +923,7 @@ describe('SchedulerService', () => {
                 jobModel: {} as JobModel,
                 spacePermissionService:
                     spacePermissionService as unknown as SpacePermissionService,
+                getDashboardService: () => ({}) as DashboardService,
             });
 
             return { reassignService, reassignSchedulerModel };
@@ -834,6 +1052,7 @@ describe('SchedulerService', () => {
                 jobModel: {} as JobModel,
                 spacePermissionService:
                     spacePermissionService as unknown as SpacePermissionService,
+                getDashboardService: () => ({}) as DashboardService,
             });
 
             return { updateService, updateSchedulerModel };
@@ -963,6 +1182,7 @@ describe('SchedulerService', () => {
                 jobModel: {} as JobModel,
                 spacePermissionService:
                     spacePermissionService as unknown as SpacePermissionService,
+                getDashboardService: () => ({}) as DashboardService,
             });
             return {
                 appService,
@@ -1375,6 +1595,7 @@ describe('SchedulerService', () => {
                 jobModel: {} as JobModel,
                 spacePermissionService:
                     spacePermissionService as unknown as SpacePermissionService,
+                getDashboardService: () => ({}) as DashboardService,
             });
             return { appUpdateService, appUpdateSchedulerModel };
         };

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -78,6 +78,7 @@ import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { getAdjustedCronByOffset } from '../../utils/cronUtils';
 import { validateSchedulerWebhookTargets } from '../../utils/schedulerWebhookValidation';
 import { BaseService } from '../BaseService';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import type { SoftDeleteOptions } from '../SoftDeletableService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { UserService } from '../UserService';
@@ -99,6 +100,7 @@ type SchedulerServiceArguments = {
     userService: UserService;
     jobModel: JobModel;
     spacePermissionService: SpacePermissionService;
+    getDashboardService: () => DashboardService;
 };
 
 const getLightdashJobUuid = (
@@ -147,6 +149,8 @@ export class SchedulerService extends BaseService {
 
     spacePermissionService: SpacePermissionService;
 
+    getDashboardService: () => DashboardService;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -164,6 +168,7 @@ export class SchedulerService extends BaseService {
         userService,
         jobModel,
         spacePermissionService,
+        getDashboardService,
     }: SchedulerServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -182,6 +187,7 @@ export class SchedulerService extends BaseService {
         this.userService = userService;
         this.jobModel = jobModel;
         this.spacePermissionService = spacePermissionService;
+        this.getDashboardService = getDashboardService;
     }
 
     public async getSchedulerProjectContext(
@@ -412,31 +418,11 @@ export class SchedulerService extends BaseService {
             )
                 throw new ForbiddenError();
         } else if (scheduler.dashboardUuid) {
-            const { organizationUuid, spaceUuid, projectUuid } =
-                await this.dashboardModel.getByIdOrSlug(
-                    scheduler.dashboardUuid,
-                );
-            const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getSpaceAccessContext(
-                    user.userUuid,
-                    spaceUuid,
-                );
-
-            if (
-                auditedAbility.cannot(
-                    'view',
-                    subject('Dashboard', {
-                        organizationUuid,
-                        projectUuid,
-                        inheritsFromOrgOrProject,
-                        access,
-                        metadata: {
-                            dashboardUuid: scheduler.dashboardUuid,
-                        },
-                    }),
-                )
-            )
-                throw new ForbiddenError();
+            await this.getDashboardService().assertViewAccess(
+                user,
+                scheduler.dashboardUuid,
+                { includeDependencies: false },
+            );
         } else if (scheduler.savedSqlUuid) {
             const sqlChart = await this.savedSqlModel.getByUuid(
                 scheduler.savedSqlUuid,
@@ -965,6 +951,13 @@ export class SchedulerService extends BaseService {
             scheduler: existingScheduler,
             resource: { organizationUuid, projectUuid },
         } = await this.checkUserCanUpdateSchedulerResource(user, schedulerUuid);
+        if (existingScheduler.dashboardUuid) {
+            await this.getDashboardService().assertViewAccess(
+                user,
+                existingScheduler.dashboardUuid,
+                { includeDependencies: false },
+            );
+        }
 
         if (isAppScheduler(existingScheduler)) {
             SchedulerService.validateAppSchedulerDelivery(updatedScheduler);
@@ -1071,8 +1064,16 @@ export class SchedulerService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
         const {
+            scheduler: existingScheduler,
             resource: { organizationUuid, projectUuid },
         } = await this.checkUserCanUpdateSchedulerResource(user, schedulerUuid);
+        if (existingScheduler.dashboardUuid) {
+            await this.getDashboardService().assertViewAccess(
+                user,
+                existingScheduler.dashboardUuid,
+                { includeDependencies: false },
+            );
+        }
 
         // Remove scheduled jobs, even if the scheduler is not enabled
         await this.schedulerClient.deleteScheduledJobs(schedulerUuid, {
@@ -1293,6 +1294,13 @@ export class SchedulerService extends BaseService {
             scheduler,
             resource: { organizationUuid, projectUuid },
         } = await this.checkUserCanUpdateSchedulerResource(user, schedulerUuid);
+        if (scheduler.dashboardUuid) {
+            await this.getDashboardService().assertViewAccess(
+                user,
+                scheduler.dashboardUuid,
+                { includeDependencies: false },
+            );
+        }
         await this.schedulerClient.deleteScheduledJobs(schedulerUuid, {
             organizationUuid,
             projectUuid,
@@ -1816,6 +1824,22 @@ export class SchedulerService extends BaseService {
 
         await this.checkViewResource(user, scheduler);
 
+        return this.enqueueSchedulerByUuid(
+            user,
+            scheduler,
+            schedulerUuid,
+            organizationUuid,
+            projectUuid,
+        );
+    }
+
+    private enqueueSchedulerByUuid(
+        user: SessionUser,
+        scheduler: Scheduler,
+        schedulerUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
+    ) {
         return this.schedulerClient.addScheduledDeliveryJob(
             new Date(),
             {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -391,6 +391,7 @@ export class ServiceRepository
                     notificationsModel: this.models.getNotificationsModel(),
                     userModel: this.models.getUserModel(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    getDashboardService: () => this.getDashboardService(),
                 }),
         );
     }
@@ -414,6 +415,7 @@ export class ServiceRepository
                     pivotTableService: this.getPivotTableService(),
                     persistentDownloadFileService:
                         this.getPersistentDownloadFileService(),
+                    getDashboardService: () => this.getDashboardService(),
                 }),
         );
     }
@@ -1076,6 +1078,7 @@ export class ServiceRepository
                     userService: this.getUserService(),
                     jobModel: this.models.getJobModel(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    getDashboardService: () => this.getDashboardService(),
                 }),
         );
     }
@@ -1194,6 +1197,8 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     headlessBrowserLoginGrantModel:
                         this.models.getHeadlessBrowserLoginGrantModel(),
+                    getDashboardService: () => this.getDashboardService(),
+                    userService: this.getUserService(),
                 }),
         );
     }
@@ -1265,6 +1270,7 @@ export class ServiceRepository
                     schedulerClient: this.clients.getSchedulerClient(),
                     spacePermissionService: this.getSpacePermissionService(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
+                    getDashboardService: () => this.getDashboardService(),
                 }),
         );
     }

--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -1,6 +1,7 @@
 import {
     DELIVERY_CAPTURE_GLOBAL,
     DownloadFileType,
+    ForbiddenError,
     LightdashPage,
     LightdashRequestMethodHeader,
     NotFoundError,
@@ -8,6 +9,7 @@ import {
     SCREENSHOT_SELECTORS,
     UnexpectedServerError,
     type DeliveryCaptureManifest,
+    type SessionUser,
 } from '@lightdash/common';
 import type { Route, WebSocketRoute } from 'playwright';
 import { type LightdashAnalytics } from '../../analytics/LightdashAnalytics';
@@ -24,7 +26,9 @@ import { type SavedSqlModel } from '../../models/SavedSqlModel';
 import { type ShareModel } from '../../models/ShareModel';
 import { type SlackAuthenticationModel } from '../../models/SlackAuthenticationModel';
 import { type SlackUnfurlImageModel } from '../../models/SlackUnfurlImageModel';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import type { UserService } from '../UserService';
 import { UnfurlService } from './UnfurlService';
 
 const playwrightMocks = vi.hoisted(() => ({
@@ -83,6 +87,8 @@ function createService(
         dashboardModel: Partial<DashboardModel>;
         projectModel: Partial<ProjectModel>;
         slackAuthenticationModel: Partial<SlackAuthenticationModel>;
+        dashboardService: Partial<DashboardService>;
+        userService: Partial<UserService>;
         headlessBrowser: Record<string, unknown>;
     }> = {},
 ) {
@@ -117,10 +123,60 @@ function createService(
         spacePermissionService: {} as unknown as SpacePermissionService,
         headlessBrowserLoginGrantModel:
             {} as unknown as HeadlessBrowserLoginGrantModel,
+        getDashboardService: () =>
+            (overrides.dashboardService ?? {}) as DashboardService,
+        userService: (overrides.userService ?? {}) as Pick<
+            UserService,
+            'getSessionByUserUuidAndOrg'
+        >,
     });
 }
 
 describe('UnfurlService', () => {
+    it('passes the organization-scoped user to Slack unfurls and suppresses revoked links', async () => {
+        const user = {} as SessionUser;
+        const getSessionByUserUuidAndOrg = vi.fn().mockResolvedValue(user);
+        const service = createService({
+            slackAuthenticationModel: {
+                getUnfurlsEnabled: vi.fn().mockResolvedValue(true),
+                getOrganizationUuidFromTeamId: vi
+                    .fn()
+                    .mockResolvedValue('organization-uuid'),
+                getUserUuid: vi.fn().mockResolvedValue('user-uuid'),
+            },
+            userService: { getSessionByUserUuidAndOrg },
+        });
+        const accessError = new ForbiddenError('Dashboard access revoked');
+        const unfurlDetails = vi
+            .spyOn(service, 'unfurlDetails')
+            .mockRejectedValue(accessError);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const sendUnfurl = vi.spyOn(service as any, 'sendUnfurl');
+
+        await service.unfurlSlackUrls({
+            event: {
+                channel: 'channel',
+                message_ts: 'timestamp',
+                links: [{ url: 'https://app.lightdash.cloud/dashboard' }],
+            },
+            context: { teamId: 'team-uuid' },
+        } as never);
+
+        expect(getSessionByUserUuidAndOrg).toHaveBeenCalledWith(
+            'user-uuid',
+            'organization-uuid',
+        );
+        await vi.waitFor(() => {
+            expect(unfurlDetails).toHaveBeenCalledWith(
+                'https://app.lightdash.cloud/dashboard',
+                null,
+                'organization-uuid',
+                user,
+            );
+        });
+        expect(sendUnfurl).not.toHaveBeenCalled();
+    });
+
     afterEach(() => {
         vi.clearAllMocks();
     });
@@ -1102,6 +1158,97 @@ describe('UnfurlService', () => {
             expect(page.screenshot).not.toHaveBeenCalled();
             expect(page.close).toHaveBeenCalled();
             expect(browser.close).toHaveBeenCalled();
+        });
+    });
+
+    describe('getTitleAndDescription - DASHBOARD', () => {
+        it('uses current user access before returning dashboard metadata', async () => {
+            const user = {} as SessionUser;
+            const assertViewAccess = vi.fn().mockResolvedValue({
+                uuid: 'dashboard-uuid',
+                name: 'Direct dashboard',
+                description: 'Private metadata',
+                organizationUuid: 'organization-uuid',
+                tiles: [],
+            });
+            const getByIdOrSlug = vi.fn();
+            const service = createService({
+                dashboardModel: { getByIdOrSlug },
+                dashboardService: { assertViewAccess },
+            });
+
+            const result = await service.getTitleAndDescription(
+                {
+                    isValid: true,
+                    lightdashPage: LightdashPage.DASHBOARD,
+                    url: 'irrelevant',
+                    minimalUrl: 'irrelevant',
+                    projectUuid: 'project-uuid',
+                    dashboardUuid: 'dashboard-uuid',
+                },
+                null,
+                user,
+            );
+
+            expect(assertViewAccess).toHaveBeenCalledWith(
+                user,
+                'dashboard-uuid',
+                {
+                    projectUuid: 'project-uuid',
+                    includeDependencies: false,
+                },
+            );
+            expect(getByIdOrSlug).not.toHaveBeenCalled();
+            expect(result).toMatchObject({
+                title: 'Direct dashboard',
+                description: 'Private metadata',
+            });
+        });
+
+        it('does not return dashboard metadata after access is revoked', async () => {
+            const accessError = new ForbiddenError('Dashboard access revoked');
+            const service = createService({
+                dashboardService: {
+                    assertViewAccess: vi.fn().mockRejectedValue(accessError),
+                },
+            });
+
+            await expect(
+                service.getTitleAndDescription(
+                    {
+                        isValid: true,
+                        lightdashPage: LightdashPage.DASHBOARD,
+                        url: 'irrelevant',
+                        minimalUrl: 'irrelevant',
+                        projectUuid: 'project-uuid',
+                        dashboardUuid: 'dashboard-uuid',
+                    },
+                    null,
+                    {} as SessionUser,
+                ),
+            ).rejects.toBe(accessError);
+        });
+
+        it('does not render an export after access is revoked', async () => {
+            const accessError = new ForbiddenError('Dashboard access revoked');
+            const service = createService({
+                dashboardService: {
+                    assertViewAccess: vi.fn().mockRejectedValue(accessError),
+                },
+            });
+            const unfurlImage = vi.spyOn(service, 'unfurlImage');
+
+            await expect(
+                service.exportDashboard(
+                    'dashboard-uuid',
+                    '',
+                    undefined,
+                    {} as SessionUser,
+                    null,
+                ),
+            ).rejects.toBe(accessError);
+
+            expect(unfurlImage).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -177,6 +177,33 @@ describe('UnfurlService', () => {
         expect(sendUnfurl).not.toHaveBeenCalled();
     });
 
+    it('skips unfurling when the installing user can no longer be resolved', async () => {
+        const service = createService({
+            slackAuthenticationModel: {
+                getUnfurlsEnabled: vi.fn().mockResolvedValue(true),
+                getOrganizationUuidFromTeamId: vi
+                    .fn()
+                    .mockResolvedValue('organization-uuid'),
+                getUserUuid: vi
+                    .fn()
+                    .mockRejectedValue(new NotFoundError('installer deleted')),
+            },
+        });
+        const unfurlDetails = vi.spyOn(service, 'unfurlDetails');
+
+        await expect(
+            service.unfurlSlackUrls({
+                event: {
+                    channel: 'channel',
+                    message_ts: 'timestamp',
+                    links: [{ url: 'https://app.lightdash.cloud/dashboard' }],
+                },
+                context: { teamId: 'team-uuid' },
+            } as never),
+        ).resolves.toBeUndefined();
+        expect(unfurlDetails).not.toHaveBeenCalled();
+    });
+
     afterEach(() => {
         vi.clearAllMocks();
     });

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -35,6 +35,7 @@ import {
     snakeCaseName,
     UnexpectedServerError,
     validateSelectedTabs,
+    type DashboardDAO,
     type DashboardFilterRule,
     type DashboardFilters,
     type DeliveryCaptureManifest,
@@ -76,7 +77,9 @@ import { SlackUnfurlImageModel } from '../../models/SlackUnfurlImageModel';
 import { traceSpan } from '../../tracing/tracing';
 import { validatePublicHttpUrl } from '../../utils/ssrfProtection';
 import { BaseService } from '../BaseService';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import type { UserService } from '../UserService';
 import { countPdfPages } from './countPdfPages';
 
 const uuid = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
@@ -342,6 +345,8 @@ type UnfurlServiceArguments = {
     slackAuthenticationModel: SlackAuthenticationModel;
     spacePermissionService: SpacePermissionService;
     headlessBrowserLoginGrantModel: HeadlessBrowserLoginGrantModel;
+    getDashboardService: () => DashboardService;
+    userService: Pick<UserService, 'getSessionByUserUuidAndOrg'>;
 };
 
 export class UnfurlService extends BaseService {
@@ -375,6 +380,10 @@ export class UnfurlService extends BaseService {
 
     headlessBrowserLoginGrantModel: HeadlessBrowserLoginGrantModel;
 
+    getDashboardService: () => DashboardService;
+
+    userService: Pick<UserService, 'getSessionByUserUuidAndOrg'>;
+
     private readonly screenshotTimeoutMs: number;
 
     constructor({
@@ -393,6 +402,8 @@ export class UnfurlService extends BaseService {
         slackAuthenticationModel,
         spacePermissionService,
         headlessBrowserLoginGrantModel,
+        getDashboardService,
+        userService,
     }: UnfurlServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -410,6 +421,8 @@ export class UnfurlService extends BaseService {
         this.slackAuthenticationModel = slackAuthenticationModel;
         this.spacePermissionService = spacePermissionService;
         this.headlessBrowserLoginGrantModel = headlessBrowserLoginGrantModel;
+        this.getDashboardService = getDashboardService;
+        this.userService = userService;
         this.screenshotTimeoutMs =
             lightdashConfig.headlessBrowser.screenshotTimeoutMs;
     }
@@ -466,6 +479,19 @@ export class UnfurlService extends BaseService {
     async getTitleAndDescription(
         parsedUrl: ParsedUrl,
         selectedTabs: string[] | null,
+        user?: SessionUser,
+    ) {
+        return this.getTitleAndDescriptionWithAccess(parsedUrl, selectedTabs, {
+            ...(user
+                ? { type: 'user' as const, user }
+                : { type: 'legacy' as const }),
+        });
+    }
+
+    private async getTitleAndDescriptionWithAccess(
+        parsedUrl: ParsedUrl,
+        selectedTabs: string[] | null,
+        authorization: { type: 'legacy' } | { type: 'user'; user: SessionUser },
     ): Promise<
         Pick<
             Unfurl,
@@ -483,9 +509,19 @@ export class UnfurlService extends BaseService {
                     throw new ParameterError(
                         `Missing dashboardUuid when unfurling Dashboard URL ${parsedUrl.url}`,
                     );
-                const dashboard = await this.dashboardModel.getByIdOrSlug(
-                    parsedUrl.dashboardUuid,
-                );
+                const dashboard =
+                    authorization.type === 'user'
+                        ? await this.getDashboardService().assertViewAccess(
+                              authorization.user,
+                              parsedUrl.dashboardUuid,
+                              {
+                                  projectUuid: parsedUrl.projectUuid,
+                                  includeDependencies: false,
+                              },
+                          )
+                        : await this.dashboardModel.getByIdOrSlug(
+                              parsedUrl.dashboardUuid,
+                          );
 
                 validateSelectedTabs(selectedTabs, dashboard.tiles);
 
@@ -588,6 +624,21 @@ export class UnfurlService extends BaseService {
         originUrl: string,
         selectedTabs: string[] | null,
         organizationUuidContext?: string,
+        user?: SessionUser,
+    ): Promise<Unfurl | undefined> {
+        return this.unfurlDetailsWithAccess(
+            originUrl,
+            selectedTabs,
+            organizationUuidContext,
+            user ? { type: 'user', user } : { type: 'legacy' },
+        );
+    }
+
+    private async unfurlDetailsWithAccess(
+        originUrl: string,
+        selectedTabs: string[] | null,
+        organizationUuidContext: string | undefined,
+        authorization: { type: 'legacy' } | { type: 'user'; user: SessionUser },
     ): Promise<Unfurl | undefined> {
         const parsedUrl = await this.parseUrl(
             originUrl,
@@ -609,7 +660,14 @@ export class UnfurlService extends BaseService {
             chartType,
             resourceUuid,
             ...rest
-        } = await this.getTitleAndDescription(parsedUrl, selectedTabs);
+        } =
+            authorization.type === 'user'
+                ? await this.getTitleAndDescription(
+                      parsedUrl,
+                      selectedTabs,
+                      authorization.user,
+                  )
+                : await this.getTitleAndDescription(parsedUrl, selectedTabs);
 
         return {
             title,
@@ -933,72 +991,57 @@ export class UnfurlService extends BaseService {
         user: SessionUser,
         selectedTabs: string[] | null,
     ): Promise<string> {
-        const dashboard =
-            await this.dashboardModel.getByIdOrSlug(dashboardUuid);
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                dashboard.spaceUuid,
-            );
+        const dashboard = await this.getDashboardService().assertViewAccess(
+            user,
+            dashboardUuid,
+            { includeDependencies: false },
+        );
 
+        return this.exportDashboardWithAccess(
+            dashboard,
+            queryFilters,
+            gridWidth,
+            user.userUuid,
+            selectedTabs,
+        );
+    }
+
+    private async exportDashboardWithAccess(
+        dashboard: DashboardDAO,
+        queryFilters: string,
+        gridWidth: number | undefined,
+        authUserUuid: string,
+        selectedTabs: string[] | null,
+    ): Promise<string> {
+        const dashboardUuid = dashboard.uuid;
         validateSelectedTabs(selectedTabs, dashboard.tiles);
-
         const selectedTabsParams = new URLSearchParams();
         const selectedTabsList = expandSelectedTabs(
             selectedTabs,
             dashboard.tiles,
         );
 
-        if (selectedTabsList.length > 0)
+        if (selectedTabsList.length > 0) {
             selectedTabsParams.set(
                 'selectedTabs',
                 JSON.stringify(selectedTabsList),
             );
+        }
 
-        const urlBase = `/minimal/projects/${dashboard.projectUuid}/dashboards/${dashboardUuid}`;
-
-        // Normalize the query filters
         const suffix =
             queryFilters &&
             !(queryFilters.startsWith('?') || queryFilters.startsWith('&'))
                 ? `?${queryFilters}`
                 : (queryFilters ?? '');
-
         const url = new URL(
-            urlBase + suffix,
+            `/minimal/projects/${dashboard.projectUuid}/dashboards/${dashboardUuid}${suffix}`,
             this.lightdashConfig.headlessBrowser.internalLightdashHost,
         );
-
-        for (const [k, v] of selectedTabsParams.entries()) {
-            url.searchParams.set(k, v);
-        }
-
-        const { organizationUuid, projectUuid, name, minimalUrl, pageType } = {
-            organizationUuid: dashboard.organizationUuid,
-            projectUuid: dashboard.projectUuid,
-            name: dashboard.name,
-            minimalUrl: url.href,
-            pageType: LightdashPage.DASHBOARD,
-        };
-
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('Dashboard', {
-                    organizationUuid,
-                    projectUuid,
-                    inheritsFromOrgOrProject,
-                    access,
-                    metadata: {
-                        dashboardUuid: dashboard.uuid,
-                        dashboardName: name,
-                    },
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
+        selectedTabsParams.forEach((value, key) => {
+            url.searchParams.set(key, value);
+        });
+        const { name } = dashboard;
+        const minimalUrl = url.href;
 
         this.logger.info(
             `Exporting dashboard ${name} with minimalUrl ${minimalUrl}${
@@ -1010,9 +1053,9 @@ export class UnfurlService extends BaseService {
 
         const unfurlImage = await this.unfurlImage({
             url: minimalUrl,
-            lightdashPage: pageType,
+            lightdashPage: LightdashPage.DASHBOARD,
             imageId: `slack-image_${snakeCaseName(name)}_${useNanoid()}`,
-            authUserUuid: user.userUuid,
+            authUserUuid,
             gridWidth,
             context: ScreenshotContext.EXPORT_DASHBOARD,
             selectedTabs,
@@ -2855,6 +2898,12 @@ export class UnfurlService extends BaseService {
             await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(
                 teamId,
             );
+        const authUserUuid =
+            await this.slackAuthenticationModel.getUserUuid(teamId);
+        const user = await this.userService.getSessionByUserUuidAndOrg(
+            authUserUuid,
+            organizationUuid,
+        );
 
         void event.links.map(async (l) => {
             const eventUserId = context.botUserId;
@@ -2864,6 +2913,7 @@ export class UnfurlService extends BaseService {
                     l.url,
                     null,
                     organizationUuid,
+                    user,
                 );
 
                 if (details) {
@@ -2890,9 +2940,6 @@ export class UnfurlService extends BaseService {
                     }
 
                     const imageId = `slack-image-${useNanoid()}`;
-                    const authUserUuid =
-                        await this.slackAuthenticationModel.getUserUuid(teamId);
-
                     const installation =
                         await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
                             details?.organizationUuid,

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -2894,16 +2894,30 @@ export class UnfurlService extends BaseService {
             return;
         }
 
-        const organizationUuid =
-            await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(
-                teamId,
+        // A missing installer mapping (user deleted or out of the org) must
+        // degrade to "no unfurl", not reject the whole link_shared handler.
+        let organizationUuid: string;
+        let authUserUuid: string;
+        let user: SessionUser;
+        try {
+            organizationUuid =
+                await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(
+                    teamId,
+                );
+            authUserUuid =
+                await this.slackAuthenticationModel.getUserUuid(teamId);
+            user = await this.userService.getSessionByUserUuidAndOrg(
+                authUserUuid,
+                organizationUuid,
             );
-        const authUserUuid =
-            await this.slackAuthenticationModel.getUserUuid(teamId);
-        const user = await this.userService.getSessionByUserUuidAndOrg(
-            authUserUuid,
-            organizationUuid,
-        );
+        } catch (error) {
+            Logger.warn(
+                `Slack unfurl skipped for team ${teamId}: could not resolve the installing user (${getErrorMessage(
+                    error,
+                )})`,
+            );
+            return;
+        }
 
         void event.links.map(async (l) => {
             const eventUserId = context.botUserId;

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -22,6 +22,7 @@ import { SavedChartModel } from '../../models/SavedChartModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { ValidationModel } from '../../models/ValidationModel/ValidationModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { ValidationService } from './ValidationService';
 import {
@@ -110,6 +111,14 @@ const spacePermissionService = {
     getSpacesAccessContext: vi.fn(async () => ({})),
     getAccessibleSpaceUuids: vi.fn(async () => []),
 };
+const dashboardForDirectAccess = {
+    ...dashboardForValidation,
+    uuid: dashboardForValidation.dashboardUuid,
+    spaceUuid: 'spaceUuid',
+    organizationUuid: 'orgUuid',
+    projectUuid: 'projectUuid',
+};
+const assertDashboardViewAccess = vi.fn(async () => dashboardForDirectAccess);
 describe('validation', () => {
     const validationService = new ValidationService({
         analytics: analyticsMock,
@@ -124,6 +133,10 @@ describe('validation', () => {
         spacePermissionService:
             spacePermissionService as unknown as SpacePermissionService,
         featureFlagModel: {} as FeatureFlagModel,
+        getDashboardService: () =>
+            ({
+                assertViewAccess: assertDashboardViewAccess,
+            }) as unknown as DashboardService,
     });
     const allAccessUser = {
         ...user,
@@ -163,14 +176,49 @@ describe('validation', () => {
             'dashboardUuid',
         );
 
-        expect(dashboardModel.getByIdOrSlug).toHaveBeenCalledWith(
+        expect(assertDashboardViewAccess).toHaveBeenCalledWith(
+            allAccessUser,
             'dashboardUuid',
-            { projectUuid: 'projectUuid' },
+            { projectUuid: 'projectUuid', includeDependencies: false },
         );
         expect(validationModel.deleteDashboardValidations).toHaveBeenCalledWith(
             'dashboardUuid',
             'projectUuid',
         );
+    });
+
+    it('checks direct dashboard access before dashboard validation', async () => {
+        await validationService.validateAndUpdateDashboard(
+            allAccessUser,
+            'projectUuid',
+            'dashboardUuid',
+        );
+
+        expect(assertDashboardViewAccess).toHaveBeenCalledWith(
+            allAccessUser,
+            'dashboardUuid',
+            { projectUuid: 'projectUuid', includeDependencies: false },
+        );
+        expect(dashboardModel.getByIdOrSlug).not.toHaveBeenCalled();
+    });
+
+    it('does not validate after direct dashboard access is revoked', async () => {
+        assertDashboardViewAccess.mockRejectedValueOnce(
+            new ForbiddenError('Dashboard access revoked'),
+        );
+
+        await expect(
+            validationService.validateAndUpdateDashboard(
+                allAccessUser,
+                'projectUuid',
+                'dashboardUuid',
+            ),
+        ).rejects.toThrow(ForbiddenError);
+
+        expect(
+            validationModel.deleteDashboardValidations,
+        ).not.toHaveBeenCalled();
+        expect(validationModel.create).not.toHaveBeenCalled();
     });
 
     it('Should validate project without errors', async () => {
@@ -1440,6 +1488,7 @@ describe('ValidationService.getValidationSummary', () => {
         spacePermissionService:
             spacePermissionService as unknown as SpacePermissionService,
         featureFlagModel: {} as FeatureFlagModel,
+        getDashboardService: () => ({}) as DashboardService,
     });
 
     afterEach(() => {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -49,6 +49,7 @@ import {
     ValidationResponse,
     ValidationSourceType,
     ValidationTarget,
+    type DashboardDAO,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
@@ -62,6 +63,7 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { ValidationModel } from '../../models/ValidationModel/ValidationModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { BaseService } from '../BaseService';
+import type { DashboardService } from '../DashboardService/DashboardService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 
 const VALIDATION_SUMMARY_AFFECTED_CONTENT_LIMIT = 20;
@@ -78,6 +80,7 @@ type ValidationServiceArguments = {
     schedulerClient: SchedulerClient;
     spacePermissionService: SpacePermissionService;
     featureFlagModel: FeatureFlagModel;
+    getDashboardService: () => DashboardService;
 };
 
 export class ValidationService extends BaseService {
@@ -214,6 +217,8 @@ export class ValidationService extends BaseService {
 
     featureFlagModel: FeatureFlagModel;
 
+    getDashboardService: () => DashboardService;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -226,6 +231,7 @@ export class ValidationService extends BaseService {
         schedulerClient,
         spacePermissionService,
         featureFlagModel,
+        getDashboardService,
     }: ValidationServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -239,6 +245,7 @@ export class ValidationService extends BaseService {
         this.schedulerClient = schedulerClient;
         this.spacePermissionService = spacePermissionService;
         this.featureFlagModel = featureFlagModel;
+        this.getDashboardService = getDashboardService;
     }
 
     static getTableCalculationFieldIds(
@@ -2086,40 +2093,26 @@ export class ValidationService extends BaseService {
             throw new ForbiddenError();
         }
 
-        // Get the dashboard to check permissions
-        const dashboard = await this.dashboardModel.getByIdOrSlug(
+        const dashboard = await this.getDashboardService().assertViewAccess(
+            user,
             dashboardUuid,
             {
                 projectUuid,
+                includeDependencies: false,
             },
         );
 
-        // Check user permissions
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                dashboard.spaceUuid,
-            );
+        return this.validateAndUpdateDashboardWithAccess(
+            projectUuid,
+            dashboard,
+        );
+    }
 
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('Dashboard', {
-                    organizationUuid: dashboard.organizationUuid,
-                    projectUuid: dashboard.projectUuid,
-                    inheritsFromOrgOrProject,
-                    access,
-                    metadata: {
-                        dashboardUuid,
-                        dashboardName: dashboard.name,
-                    },
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                "You don't have access to validate this dashboard",
-            );
-        }
+    private async validateAndUpdateDashboardWithAccess(
+        projectUuid: string,
+        dashboard: DashboardDAO,
+    ): Promise<CreateDashboardValidation[]> {
+        const dashboardUuid = dashboard.uuid;
 
         // Get all explores for dashboard validation
         const compiledExploresMap =


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1250

## Summary

PR 4 of 5 applies current dashboard access to manual exports, scheduled deliveries, Google Sheets jobs, Slack unfurls, comments, notifications, validation, and verification.

Stacks on [#28020](https://github.com/lightdash/lightdash/pull/28020), which secures dashboard lifecycle mutations.

## Delivery path

```
export / scheduled job / unfurl / notification
                  -> use the existing SessionUser boundary
                  -> authorize current dashboard access
                  -> render, query, enqueue, or send
```

## Scope

- Checks dashboard access before manual CSV and image exports.
- Reauthorizes schedule configuration, send-now, worker, and Sheets execution.
- Authorizes Slack metadata before unfurling.
- Prevents revoked users from querying, mutating, enqueueing, notifying, rendering, or writing sheets.
- Preserves existing controller conversions, session, embed, and public behavior.
- Adds no RegisteredAccount or `*FromAccount` service variants.

## Test plan

- [x] Backend typecheck
- [x] Backend lint and format
- [x] 358 focused tests

## Credit

Thanks @hrx-joseph-fahnestock for the initial direct-access exploration in [houserx/lightdash-hrx#25](https://github.com/houserx/lightdash-hrx/pull/25), which informed this stack.