### PR TITLE
feat(dashboards): add direct access handler

### DIFF
--- a/packages/backend/src/models/AppAccessModel.ts
+++ b/packages/backend/src/models/AppAccessModel.ts
@@ -222,7 +222,15 @@ export class AppAccessModel implements DirectAccessModel {
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
             if (existing === undefined) {
-                throw new NotFoundError('Direct access target not found');
+                assertCanRevokeDirectAccess({
+                    actorRole,
+                    isSelfRevoke,
+                });
+                return {
+                    ...context,
+                    beforeRole: null,
+                    afterRole: null,
+                };
             }
             assertCanRevokeDirectAccess({
                 actorRole,
@@ -272,7 +280,15 @@ export class AppAccessModel implements DirectAccessModel {
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
             if (existing === undefined) {
-                throw new NotFoundError('Direct access target not found');
+                assertCanRevokeDirectAccess({
+                    actorRole,
+                    isSelfRevoke: false,
+                });
+                return {
+                    ...context,
+                    beforeRole: null,
+                    afterRole: null,
+                };
             }
             assertCanRevokeDirectAccess({
                 actorRole,

--- a/packages/backend/src/models/DashboardAccessModel.ts
+++ b/packages/backend/src/models/DashboardAccessModel.ts
@@ -1,16 +1,25 @@
-import { NotFoundError, type SpaceMemberRole } from '@lightdash/common';
+import {
+    DirectAccessOrigin,
+    NotFoundError,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
+    type SpaceMemberRole,
+} from '@lightdash/common';
 import { type Knex } from 'knex';
 import {
     DashboardGroupAccessTableName,
     DashboardUserAccessTableName,
 } from '../database/entities/dashboardAccess';
 import { DashboardsTableName } from '../database/entities/dashboards';
+import { EmailTableName } from '../database/entities/emails';
 import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { GroupTableName } from '../database/entities/groups';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectTableName } from '../database/entities/projects';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
+import KnexPaginate from '../database/pagination';
 import {
     assertCanGrantDirectAccess,
     assertCanResetDirectAccess,
@@ -28,8 +37,31 @@ import {
     type DirectAccessResetResult,
     type DirectAccessRow,
 } from './directAccessModelUtils';
+import { getColumnMatchRegexQuery } from './SearchModel/utils/search';
 
 export type DashboardDirectAccess = DirectAccess;
+
+export type DashboardDirectAccessListRow =
+    | {
+          origin: DirectAccessOrigin.USER;
+          principalUuid: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+          isInternal: boolean;
+          name: null;
+          directRole: SpaceMemberRole;
+      }
+    | {
+          origin: DirectAccessOrigin.GROUP;
+          principalUuid: string;
+          firstName: null;
+          lastName: null;
+          email: null;
+          isInternal: null;
+          name: string;
+          directRole: SpaceMemberRole;
+      };
 
 export class DashboardAccessModel implements DirectAccessModel {
     constructor(private readonly database: Knex) {}
@@ -235,7 +267,15 @@ export class DashboardAccessModel implements DirectAccessModel {
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
             if (existing === undefined) {
-                throw new NotFoundError('Direct access target not found');
+                assertCanRevokeDirectAccess({
+                    actorRole,
+                    isSelfRevoke,
+                });
+                return {
+                    ...context,
+                    beforeRole: null,
+                    afterRole: null,
+                };
             }
             assertCanRevokeDirectAccess({
                 actorRole,
@@ -285,7 +325,15 @@ export class DashboardAccessModel implements DirectAccessModel {
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
             if (existing === undefined) {
-                throw new NotFoundError('Direct access target not found');
+                assertCanRevokeDirectAccess({
+                    actorRole,
+                    isSelfRevoke: false,
+                });
+                return {
+                    ...context,
+                    beforeRole: null,
+                    afterRole: null,
+                };
             }
             assertCanRevokeDirectAccess({
                 actorRole,
@@ -336,6 +384,259 @@ export class DashboardAccessModel implements DirectAccessModel {
             ]);
             return { ...context, revokedUsers, revokedGroups };
         });
+    }
+
+    async getDirectAccessList(
+        dashboardUuid: string,
+        organizationUuid: string,
+        {
+            paginateArgs,
+            searchQuery,
+            principal,
+        }: {
+            paginateArgs?: KnexPaginateArgs;
+            searchQuery?: string;
+            principal?: {
+                origin: DirectAccessOrigin;
+                uuid: string;
+            };
+        } = {},
+    ): Promise<KnexPaginatedData<DashboardDirectAccessListRow[]>> {
+        const users = this.database(DashboardUserAccessTableName)
+            .innerJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${DashboardUserAccessTableName}.dashboard_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${DashboardsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${DashboardUserAccessTableName}.user_uuid`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                function joinCurrentOrganizationMembership() {
+                    this.on(
+                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOn(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    );
+                },
+            )
+            .leftJoin(EmailTableName, function joinPrimaryEmail() {
+                this.on(
+                    `${EmailTableName}.user_id`,
+                    `${UserTableName}.user_id`,
+                ).andOnVal(`${EmailTableName}.is_primary`, true);
+            })
+            .where(
+                `${DashboardUserAccessTableName}.dashboard_uuid`,
+                dashboardUuid,
+            )
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .whereNull(`${DashboardsTableName}.deleted_at`)
+            .where(getActiveProjectMemberPredicate(this.database))
+            .select({
+                origin: this.database.raw('?', [DirectAccessOrigin.USER]),
+                principalUuid: `${DashboardUserAccessTableName}.user_uuid`,
+                firstName: `${UserTableName}.first_name`,
+                lastName: `${UserTableName}.last_name`,
+                email: this.database.raw('COALESCE(??, ?)', [
+                    `${EmailTableName}.email`,
+                    '',
+                ]),
+                isInternal: `${UserTableName}.is_internal`,
+                name: this.database.raw('NULL::text'),
+                directRole: `${DashboardUserAccessTableName}.space_role`,
+            });
+
+        const groups = this.database(DashboardGroupAccessTableName)
+            .innerJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${DashboardGroupAccessTableName}.dashboard_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${DashboardsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .innerJoin(GroupTableName, function joinSourceOrganizationGroup() {
+                this.on(
+                    `${GroupTableName}.group_uuid`,
+                    `${DashboardGroupAccessTableName}.group_uuid`,
+                ).andOn(
+                    `${GroupTableName}.organization_id`,
+                    `${ProjectTableName}.organization_id`,
+                );
+            })
+            .where(
+                `${DashboardGroupAccessTableName}.dashboard_uuid`,
+                dashboardUuid,
+            )
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .whereNull(`${DashboardsTableName}.deleted_at`)
+            .where(
+                getActiveGrantedGroupPredicate(
+                    this.database,
+                    DashboardGroupAccessTableName,
+                ),
+            )
+            .select({
+                origin: this.database.raw('?', [DirectAccessOrigin.GROUP]),
+                principalUuid: `${DashboardGroupAccessTableName}.group_uuid`,
+                firstName: this.database.raw('NULL::text'),
+                lastName: this.database.raw('NULL::text'),
+                email: this.database.raw('NULL::text'),
+                isInternal: this.database.raw('NULL::boolean'),
+                name: `${GroupTableName}.name`,
+                directRole: `${DashboardGroupAccessTableName}.space_role`,
+            });
+
+        let query = this.database
+            .select<DashboardDirectAccessListRow[]>('*')
+            .from(users.unionAll(groups).as('dashboard_direct_access'));
+
+        if (searchQuery) {
+            query = getColumnMatchRegexQuery(query, searchQuery, [
+                'firstName',
+                'lastName',
+                'email',
+                'name',
+            ]);
+        }
+        if (principal) {
+            void query
+                .where('origin', principal.origin)
+                .where('principalUuid', principal.uuid);
+        }
+        void query
+            .orderByRaw('LOWER(COALESCE(??, ??, ?))', ['name', 'firstName', ''])
+            .orderBy('origin')
+            .orderBy('principalUuid');
+
+        return KnexPaginate.paginate(query, paginateArgs);
+    }
+
+    async getGroupRolesForUsers(
+        dashboardUuid: string,
+        userUuids: string[],
+        organizationUuid: string,
+    ): Promise<Record<string, SpaceMemberRole[]>> {
+        if (userUuids.length === 0) {
+            return {};
+        }
+
+        const rows = await this.database(DashboardGroupAccessTableName)
+            .innerJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${DashboardGroupAccessTableName}.dashboard_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${DashboardsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .innerJoin(
+                GroupMembershipTableName,
+                `${GroupMembershipTableName}.group_uuid`,
+                `${DashboardGroupAccessTableName}.group_uuid`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_id`,
+                `${GroupMembershipTableName}.user_id`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                function joinCurrentOrganizationMembership() {
+                    this.on(
+                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOn(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    );
+                },
+            )
+            .where(
+                `${DashboardGroupAccessTableName}.dashboard_uuid`,
+                dashboardUuid,
+            )
+            .whereIn(`${UserTableName}.user_uuid`, userUuids)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(
+                `${GroupMembershipTableName}.organization_id`,
+                this.database.ref(`${ProjectTableName}.organization_id`),
+            )
+            .where(getActiveProjectMemberPredicate(this.database))
+            .where(
+                getActiveGrantedGroupPredicate(
+                    this.database,
+                    DashboardGroupAccessTableName,
+                ),
+            )
+            .whereNull(`${DashboardsTableName}.deleted_at`)
+            .select<{ userUuid: string; role: SpaceMemberRole }[]>(
+                `${UserTableName}.user_uuid as userUuid`,
+                `${DashboardGroupAccessTableName}.space_role as role`,
+            );
+
+        const rolesByUserUuid: Record<string, SpaceMemberRole[]> = {};
+        for (const { userUuid, role } of rows) {
+            rolesByUserUuid[userUuid] = [
+                ...(rolesByUserUuid[userUuid] ?? []),
+                role,
+            ];
+        }
+        return rolesByUserUuid;
     }
 
     async getUserAccess(

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -194,17 +194,25 @@ describe('DashboardModel', () => {
     });
 
     test('strict UUID lookup does not fall back to a matching slug', async () => {
+        const validUuid = '2a93d63d-ca81-421c-b88b-1124a2f02407';
         tracker.on.select(DashboardsTableName).response([]);
 
         await expect(
-            model.getByIdOrSlug(expectedDashboard.uuid, { strictUuid: true }),
+            model.getByIdOrSlug(validUuid, { strictUuid: true }),
         ).rejects.toThrowError(NotFoundError);
 
         const [query] = tracker.history.select;
         const whereClause = query.sql.slice(query.sql.indexOf(' where '));
         expect(whereClause).toContain('"dashboards"."dashboard_uuid" = $1');
         expect(whereClause).not.toContain('"dashboards"."slug"');
-        expect(query.bindings[0]).toBe(expectedDashboard.uuid);
+        expect(query.bindings[0]).toBe(validUuid);
+    });
+
+    test('strict UUID lookup rejects a non-uuid value without querying', async () => {
+        await expect(
+            model.getByIdOrSlug('my_dashboard_slug', { strictUuid: true }),
+        ).rejects.toThrowError(NotFoundError);
+        expect(tracker.history.select).toHaveLength(0);
     });
 
     test('should get all by project uuid', async () => {

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -193,6 +193,20 @@ describe('DashboardModel', () => {
         ).rejects.toThrowError(NotFoundError);
     });
 
+    test('strict UUID lookup does not fall back to a matching slug', async () => {
+        tracker.on.select(DashboardsTableName).response([]);
+
+        await expect(
+            model.getByIdOrSlug(expectedDashboard.uuid, { strictUuid: true }),
+        ).rejects.toThrowError(NotFoundError);
+
+        const [query] = tracker.history.select;
+        const whereClause = query.sql.slice(query.sql.indexOf(' where '));
+        expect(whereClause).toContain('"dashboards"."dashboard_uuid" = $1');
+        expect(whereClause).not.toContain('"dashboards"."slug"');
+        expect(query.bindings[0]).toBe(expectedDashboard.uuid);
+    });
+
     test('should get all by project uuid', async () => {
         tracker.on
             .select(queryMatcher(DashboardsTableName, [projectUuid]))

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -805,7 +805,11 @@ export class DashboardModel {
 
     async getByIdOrSlug(
         dashboardUuidOrSlug: string,
-        options?: { deleted?: boolean | 'any'; projectUuid?: string },
+        options?: {
+            deleted?: boolean | 'any';
+            projectUuid?: string;
+            strictUuid?: boolean;
+        },
     ): Promise<DashboardDAO> {
         const query = this.database(DashboardsTableName)
             .leftJoin(
@@ -898,7 +902,12 @@ export class DashboardModel {
             void query.whereNull(`${DashboardsTableName}.deleted_at`);
         }
 
-        if (isValidUuid(dashboardUuidOrSlug)) {
+        if (options?.strictUuid) {
+            void query.where(
+                `${DashboardsTableName}.dashboard_uuid`,
+                dashboardUuidOrSlug,
+            );
+        } else if (isValidUuid(dashboardUuidOrSlug)) {
             void query.where((builder) => {
                 void builder
                     .where(

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -903,6 +903,11 @@ export class DashboardModel {
         }
 
         if (options?.strictUuid) {
+            // A non-uuid value would make Postgres raise a cast error (500);
+            // under strictUuid it simply isn't a match.
+            if (!isValidUuid(dashboardUuidOrSlug)) {
+                throw new NotFoundError('Dashboard not found');
+            }
             void query.where(
                 `${DashboardsTableName}.dashboard_uuid`,
                 dashboardUuidOrSlug,

--- a/packages/backend/src/models/DirectAccessModels.integration.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.integration.test.ts
@@ -1,5 +1,6 @@
 import {
     ChartKind,
+    DirectAccessOrigin,
     OrganizationMemberRole,
     ProjectMemberRole,
     SEED_ORG_1_ADMIN,
@@ -333,6 +334,94 @@ describe('direct access read models PostgreSQL integration', () => {
                 expect(accessQueryCount).toBe(1);
             }),
         );
+    });
+
+    it('lists dashboard user and group grants without expanding group members', async () => {
+        const result = await model.getDirectAccessList(
+            dashboardUuid,
+            organizationUuid,
+            { paginateArgs: { page: 1, pageSize: 20 } },
+        );
+
+        expect(result.data).toEqual([
+            expect.objectContaining({
+                origin: DirectAccessOrigin.USER,
+                principalUuid: SEED_ORG_1_ADMIN.user_uuid,
+                directRole: SpaceMemberRole.VIEWER,
+            }),
+            expect.objectContaining({
+                origin: DirectAccessOrigin.GROUP,
+                principalUuid: groupUuid,
+                directRole: SpaceMemberRole.ADMIN,
+            }),
+        ]);
+        expect(result.pagination).toMatchObject({
+            page: 1,
+            pageSize: 20,
+            totalPageCount: 1,
+            totalResults: 2,
+        });
+        await expect(
+            model.getGroupRolesForUsers(
+                dashboardUuid,
+                [SEED_ORG_1_ADMIN.user_uuid],
+                organizationUuid,
+            ),
+        ).resolves.toEqual({
+            [SEED_ORG_1_ADMIN.user_uuid]: [SpaceMemberRole.ADMIN],
+        });
+    });
+
+    it('searches and scopes dashboard grant lists before pagination', async () => {
+        const groupOnly = await model.getDirectAccessList(
+            dashboardUuid,
+            organizationUuid,
+            {
+                searchQuery: 'Direct access group',
+                paginateArgs: { page: 1, pageSize: 1 },
+            },
+        );
+        expect(groupOnly.data).toEqual([
+            expect.objectContaining({
+                origin: DirectAccessOrigin.GROUP,
+                principalUuid: groupUuid,
+            }),
+        ]);
+        expect(groupOnly.pagination).toMatchObject({ totalResults: 1 });
+
+        await expect(
+            model.getDirectAccessList(dashboardUuid, randomUUID()),
+        ).resolves.toEqual({ data: [] });
+
+        await transaction(ProjectGroupAccessTableName)
+            .where({ project_uuid: projectUuid, group_uuid: groupUuid })
+            .delete();
+        await expect(
+            model.getDirectAccessList(dashboardUuid, organizationUuid),
+        ).resolves.toMatchObject({
+            data: [
+                expect.objectContaining({
+                    origin: DirectAccessOrigin.USER,
+                    principalUuid: SEED_ORG_1_ADMIN.user_uuid,
+                }),
+            ],
+        });
+        await expect(
+            model.getGroupRolesForUsers(
+                dashboardUuid,
+                [SEED_ORG_1_ADMIN.user_uuid],
+                organizationUuid,
+            ),
+        ).resolves.toEqual({});
+
+        await transaction(UserTableName)
+            .where('user_uuid', SEED_ORG_1_ADMIN.user_uuid)
+            .update({ is_active: false });
+        await expect(
+            model.getDirectAccessList(dashboardUuid, organizationUuid),
+        ).resolves.toMatchObject({
+            data: [],
+        });
     });
 
     it('scopes every concrete read and write to the expected organization', async () => {
@@ -997,13 +1086,20 @@ describe('direct access read models PostgreSQL integration', () => {
         ).rejects.toMatchObject({ name: 'ForbiddenError' });
     });
 
-    it('hides resource existence when a self-revoke has no direct grant', async () => {
+    it('makes dashboard self-revoke idempotent without changing other resources', async () => {
         const principalUuid = randomUUID();
-        const cases = [
-            {
-                model: new DashboardAccessModel(transaction),
+        await expect(
+            new DashboardAccessModel(transaction).revokeUserAccess({
+                organizationUuid,
                 resourceUuid: dashboardUuid,
-            },
+                userUuid: principalUuid,
+                actorRole: SpaceMemberRole.VIEWER,
+                actorRoleResolver: async () => SpaceMemberRole.VIEWER,
+                actorUserUuid: principalUuid,
+            }),
+        ).resolves.toMatchObject({ beforeRole: null, afterRole: null });
+
+        const cases = [
             {
                 model: new SavedChartAccessModel(transaction),
                 resourceUuid: savedChartUuid,
@@ -1050,13 +1146,19 @@ describe('direct access read models PostgreSQL integration', () => {
         });
     });
 
-    it('throws NotFoundError when revoking a missing group grant', async () => {
+    it('makes dashboard group revoke idempotent without changing other resources', async () => {
         const missingGroupUuid = randomUUID();
-        const cases = [
-            {
-                model: new DashboardAccessModel(transaction),
+        await expect(
+            new DashboardAccessModel(transaction).revokeGroupAccess({
                 resourceUuid: dashboardUuid,
-            },
+                groupUuid: missingGroupUuid,
+                actorRole: SpaceMemberRole.ADMIN,
+                actorRoleResolver: async () => SpaceMemberRole.ADMIN,
+                organizationUuid,
+            }),
+        ).resolves.toMatchObject({ beforeRole: null, afterRole: null });
+
+        const cases = [
             {
                 model: new SavedChartAccessModel(transaction),
                 resourceUuid: savedChartUuid,

--- a/packages/backend/src/models/DirectAccessModels.integration.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.integration.test.ts
@@ -372,6 +372,51 @@ describe('direct access read models PostgreSQL integration', () => {
         });
     });
 
+    it('filters dashboard grant lists to a single principal', async () => {
+        const userOnly = await model.getDirectAccessList(
+            dashboardUuid,
+            organizationUuid,
+            {
+                principal: {
+                    origin: DirectAccessOrigin.USER,
+                    uuid: SEED_ORG_1_ADMIN.user_uuid,
+                },
+            },
+        );
+        expect(userOnly.data).toEqual([
+            expect.objectContaining({
+                origin: DirectAccessOrigin.USER,
+                principalUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ]);
+
+        const groupOnly = await model.getDirectAccessList(
+            dashboardUuid,
+            organizationUuid,
+            {
+                principal: {
+                    origin: DirectAccessOrigin.GROUP,
+                    uuid: groupUuid,
+                },
+            },
+        );
+        expect(groupOnly.data).toEqual([
+            expect.objectContaining({
+                origin: DirectAccessOrigin.GROUP,
+                principalUuid: groupUuid,
+            }),
+        ]);
+
+        await expect(
+            model.getDirectAccessList(dashboardUuid, organizationUuid, {
+                principal: {
+                    origin: DirectAccessOrigin.USER,
+                    uuid: randomUUID(),
+                },
+            }),
+        ).resolves.toEqual({ data: [] });
+    });
+
     it('searches and scopes dashboard grant lists before pagination', async () => {
         const groupOnly = await model.getDirectAccessList(
             dashboardUuid,
@@ -1086,7 +1131,7 @@ describe('direct access read models PostgreSQL integration', () => {
         ).rejects.toMatchObject({ name: 'ForbiddenError' });
     });
 
-    it('makes dashboard self-revoke idempotent without changing other resources', async () => {
+    it('makes self-revoke of a missing grant idempotent for every model', async () => {
         const principalUuid = randomUUID();
         await expect(
             new DashboardAccessModel(transaction).revokeUserAccess({
@@ -1125,9 +1170,9 @@ describe('direct access read models PostgreSQL integration', () => {
                         actorRoleResolver: async () => SpaceMemberRole.VIEWER,
                         actorUserUuid: principalUuid,
                     }),
-                ).rejects.toMatchObject({
-                    name: 'NotFoundError',
-                    message: 'Direct access target not found',
+                ).resolves.toMatchObject({
+                    beforeRole: null,
+                    afterRole: null,
                 }),
             ),
         );
@@ -1146,7 +1191,7 @@ describe('direct access read models PostgreSQL integration', () => {
         });
     });
 
-    it('makes dashboard group revoke idempotent without changing other resources', async () => {
+    it('makes group revoke of a missing grant idempotent for every model', async () => {
         const missingGroupUuid = randomUUID();
         await expect(
             new DashboardAccessModel(transaction).revokeGroupAccess({
@@ -1183,9 +1228,9 @@ describe('direct access read models PostgreSQL integration', () => {
                         actorRoleResolver: async () => SpaceMemberRole.ADMIN,
                         organizationUuid,
                     }),
-                ).rejects.toMatchObject({
-                    name: 'NotFoundError',
-                    message: 'Direct access target not found',
+                ).resolves.toMatchObject({
+                    beforeRole: null,
+                    afterRole: null,
                 }),
             ),
         );

--- a/packages/backend/src/models/SavedChartAccessModel.ts
+++ b/packages/backend/src/models/SavedChartAccessModel.ts
@@ -223,7 +223,15 @@ export class SavedChartAccessModel implements DirectAccessModel {
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
             if (existing === undefined) {
-                throw new NotFoundError('Direct access target not found');
+                assertCanRevokeDirectAccess({
+                    actorRole,
+                    isSelfRevoke,
+                });
+                return {
+                    ...context,
+                    beforeRole: null,
+                    afterRole: null,
+                };
             }
             assertCanRevokeDirectAccess({
                 actorRole,
@@ -273,7 +281,15 @@ export class SavedChartAccessModel implements DirectAccessModel {
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
             if (existing === undefined) {
-                throw new NotFoundError('Direct access target not found');
+                assertCanRevokeDirectAccess({
+                    actorRole,
+                    isSelfRevoke: false,
+                });
+                return {
+                    ...context,
+                    beforeRole: null,
+                    afterRole: null,
+                };
             }
             assertCanRevokeDirectAccess({
                 actorRole,

--- a/packages/backend/src/models/SavedSqlAccessModel.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.ts
@@ -223,7 +223,15 @@ export class SavedSqlAccessModel implements DirectAccessModel {
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
             if (existing === undefined) {
-                throw new NotFoundError('Direct access target not found');
+                assertCanRevokeDirectAccess({
+                    actorRole,
+                    isSelfRevoke,
+                });
+                return {
+                    ...context,
+                    beforeRole: null,
+                    afterRole: null,
+                };
             }
             assertCanRevokeDirectAccess({
                 actorRole,
@@ -273,7 +281,15 @@ export class SavedSqlAccessModel implements DirectAccessModel {
                 .first<{ space_role: SpaceMemberRole }>('space_role')
                 .forUpdate();
             if (existing === undefined) {
-                throw new NotFoundError('Direct access target not found');
+                assertCanRevokeDirectAccess({
+                    actorRole,
+                    isSelfRevoke: false,
+                });
+                return {
+                    ...context,
+                    beforeRole: null,
+                    afterRole: null,
+                };
             }
             assertCanRevokeDirectAccess({
                 actorRole,

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -759,7 +759,11 @@ export class DashboardService
     async getByIdOrSlug(
         user: SessionUser,
         dashboardUuidOrSlug: UuidOrSlug,
-        options?: { projectUuid?: string; includeDependencies?: boolean },
+        options?: {
+            projectUuid?: string;
+            includeDependencies?: boolean;
+            strictUuid?: boolean;
+        },
     ): Promise<Dashboard> {
         const dashboard = await this.assertViewAccess(
             user,
@@ -773,12 +777,17 @@ export class DashboardService
     async assertViewAccess(
         actor: DashboardAccessActor,
         dashboardUuidOrSlug: UuidOrSlug,
-        options?: { projectUuid?: string; includeDependencies?: boolean },
+        options?: {
+            projectUuid?: string;
+            includeDependencies?: boolean;
+            strictUuid?: boolean;
+        },
     ): Promise<Dashboard> {
         const dashboardDao = await this.dashboardModel.getByIdOrSlug(
             dashboardUuidOrSlug,
             {
                 projectUuid: options?.projectUuid,
+                strictUuid: options?.strictUuid,
             },
         );
         const { isDirectOnly, ...accessContext } =

--- a/packages/backend/src/services/DirectAccess/DashboardAccessHandler.test.ts
+++ b/packages/backend/src/services/DirectAccess/DashboardAccessHandler.test.ts
@@ -93,6 +93,7 @@ const createMocks = () => {
                     role: SpaceMemberRole.VIEWER,
                 },
             ],
+            admins: [],
         }),
     } as unknown as SpacePermissionService;
 
@@ -101,12 +102,12 @@ const createMocks = () => {
         dashboardService,
         directAccessService,
         spacePermissionService,
-        handler: new DashboardAccessHandler(
+        handler: new DashboardAccessHandler({
             dashboardAccessModel,
             dashboardService,
             directAccessService,
             spacePermissionService,
-        ),
+        }),
     };
 };
 
@@ -208,7 +209,6 @@ describe('DashboardAccessHandler', () => {
                     },
                     directRole: SpaceMemberRole.VIEWER,
                     effectiveRole: SpaceMemberRole.EDITOR,
-                    origin: DirectAccessOrigin.USER,
                 },
                 {
                     principal: {
@@ -217,8 +217,6 @@ describe('DashboardAccessHandler', () => {
                         name: 'Analysts',
                     },
                     directRole: SpaceMemberRole.EDITOR,
-                    effectiveRole: SpaceMemberRole.EDITOR,
-                    origin: DirectAccessOrigin.GROUP,
                 },
             ],
             pagination: {
@@ -272,6 +270,7 @@ describe('DashboardAccessHandler', () => {
                     role: SpaceMemberRole.ADMIN,
                 },
             ],
+            admins: [],
         } as never);
 
         await expect(
@@ -297,7 +296,7 @@ describe('DashboardAccessHandler', () => {
                 resourceUuid: dashboardUuid,
             }),
         ).resolves.toMatchObject({
-            data: [{ origin: DirectAccessOrigin.GROUP }],
+            data: [{ principal: { type: DirectAccessOrigin.GROUP } }],
         });
         expect(
             mocks.dashboardAccessModel.getGroupRolesForUsers,
@@ -480,5 +479,56 @@ describe('DashboardAccessHandler', () => {
             mocks.directAccessService.revokeGroupAccess,
         ).not.toHaveBeenCalled();
         expect(mocks.directAccessService.resetAccess).not.toHaveBeenCalled();
+    });
+
+    it('grants administration to org and project admins without space access', async () => {
+        vi.mocked(mocks.dashboardService.assertViewAccess).mockResolvedValue({
+            ...dashboard,
+            access: [],
+        } as never);
+        vi.mocked(
+            mocks.spacePermissionService.getSpaceAccessContextForUsers,
+        ).mockResolvedValue({
+            access: [],
+            admins: [{ userUuid: actorUuid, source: 'organization' }],
+        } as never);
+
+        await expect(
+            mocks.handler.listAccess({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+            }),
+        ).resolves.toMatchObject({ data: expect.any(Array) });
+        expect(
+            mocks.spacePermissionService.getSpaceAccessContextForUsers,
+        ).toHaveBeenCalledWith([actorUuid], spaceUuid);
+        expect(
+            mocks.dashboardAccessModel.getDirectAccessList,
+        ).toHaveBeenCalledWith(dashboardUuid, organizationUuid, {
+            paginateArgs: { page: 1, pageSize: 100 },
+            searchQuery: undefined,
+        });
+    });
+
+    it('throws when the replaced grant cannot be read back', async () => {
+        vi.mocked(
+            mocks.dashboardAccessModel.getDirectAccessList,
+        ).mockResolvedValueOnce({ data: [] });
+
+        await expect(
+            mocks.handler.replaceUserRole({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+                userUuid: 'user-uuid',
+                role: SpaceMemberRole.EDITOR,
+            }),
+        ).rejects.toEqual(new NotFoundError('Direct access grant not found'));
+        expect(
+            mocks.dashboardAccessModel.getDirectAccessList,
+        ).toHaveBeenCalledWith(dashboardUuid, organizationUuid, {
+            principal: { origin: DirectAccessOrigin.USER, uuid: 'user-uuid' },
+        });
     });
 });

--- a/packages/backend/src/services/DirectAccess/DashboardAccessHandler.test.ts
+++ b/packages/backend/src/services/DirectAccess/DashboardAccessHandler.test.ts
@@ -1,0 +1,484 @@
+import {
+    DirectAccessOrigin,
+    ForbiddenError,
+    NotFoundError,
+    SpaceMemberRole,
+    type SessionUser,
+} from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    type DashboardAccessModel,
+    type DashboardDirectAccessListRow,
+} from '../../models/DashboardAccessModel';
+import { type DashboardService } from '../DashboardService/DashboardService';
+import { type SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { DashboardAccessHandler } from './DashboardAccessHandler';
+import { type DirectAccessService } from './DirectAccessService';
+
+const dashboardUuid = '11111111-1111-4111-8111-111111111111';
+const projectUuid = '22222222-2222-4222-8222-222222222222';
+const organizationUuid = '33333333-3333-4333-8333-333333333333';
+const spaceUuid = '44444444-4444-4444-8444-444444444444';
+const actorUuid = '55555555-5555-4555-8555-555555555555';
+
+const user = {
+    organizationUuid,
+    userUuid: actorUuid,
+} as unknown as SessionUser;
+
+const dashboard = {
+    uuid: dashboardUuid,
+    organizationUuid,
+    projectUuid,
+    spaceUuid,
+    access: [{ userUuid: actorUuid, role: SpaceMemberRole.ADMIN }],
+};
+
+const userRow: DashboardDirectAccessListRow = {
+    origin: DirectAccessOrigin.USER,
+    principalUuid: 'user-uuid',
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    email: 'ada@example.com',
+    isInternal: false,
+    name: null,
+    directRole: SpaceMemberRole.VIEWER,
+};
+
+const groupRow: DashboardDirectAccessListRow = {
+    origin: DirectAccessOrigin.GROUP,
+    principalUuid: 'group-uuid',
+    firstName: null,
+    lastName: null,
+    email: null,
+    isInternal: null,
+    name: 'Analysts',
+    directRole: SpaceMemberRole.EDITOR,
+};
+
+const createMocks = () => {
+    const dashboardAccessModel = {
+        getDirectAccessList: vi.fn().mockResolvedValue({
+            data: [userRow, groupRow],
+            pagination: {
+                page: 1,
+                pageSize: 20,
+                totalPageCount: 1,
+                totalResults: 2,
+            },
+        }),
+        getGroupRolesForUsers: vi.fn().mockResolvedValue({
+            'user-uuid': [SpaceMemberRole.EDITOR],
+        }),
+    } as unknown as DashboardAccessModel;
+    const dashboardService = {
+        assertViewAccess: vi.fn().mockResolvedValue(dashboard),
+    } as unknown as DashboardService;
+    const directAccessService = {
+        assertEnabled: vi.fn().mockResolvedValue(undefined),
+        upsertUserAccess: vi.fn().mockResolvedValue(undefined),
+        upsertGroupAccess: vi.fn().mockResolvedValue(undefined),
+        revokeUserAccess: vi.fn().mockResolvedValue(undefined),
+        revokeGroupAccess: vi.fn().mockResolvedValue(undefined),
+        resetAccess: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DirectAccessService;
+    const spacePermissionService = {
+        mergeAdminAccess: vi.fn(
+            (context: { access: unknown[] }) => context.access,
+        ),
+        getSpaceAccessContextForUsers: vi.fn().mockResolvedValue({
+            access: [
+                {
+                    userUuid: 'user-uuid',
+                    role: SpaceMemberRole.VIEWER,
+                },
+            ],
+        }),
+    } as unknown as SpacePermissionService;
+
+    return {
+        dashboardAccessModel,
+        dashboardService,
+        directAccessService,
+        spacePermissionService,
+        handler: new DashboardAccessHandler(
+            dashboardAccessModel,
+            dashboardService,
+            directAccessService,
+            spacePermissionService,
+        ),
+    };
+};
+
+describe('DashboardAccessHandler', () => {
+    let mocks: ReturnType<typeof createMocks>;
+
+    beforeEach(() => {
+        mocks = createMocks();
+    });
+
+    it('normalizes invalid, unknown, mismatched, and inaccessible resources', async () => {
+        await expect(
+            mocks.handler.listAccess({
+                user,
+                projectUuid,
+                resourceUuid: 'dashboard-slug',
+            }),
+        ).rejects.toEqual(new NotFoundError('Access target not found'));
+        expect(mocks.dashboardService.assertViewAccess).not.toHaveBeenCalled();
+
+        vi.mocked(
+            mocks.dashboardService.assertViewAccess,
+        ).mockRejectedValueOnce(new NotFoundError('Dashboard not found'));
+        await expect(
+            mocks.handler.listAccess({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+            }),
+        ).rejects.toEqual(new NotFoundError('Access target not found'));
+
+        vi.mocked(
+            mocks.dashboardService.assertViewAccess,
+        ).mockRejectedValueOnce(new ForbiddenError());
+        await expect(
+            mocks.handler.listAccess({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+            }),
+        ).rejects.toEqual(new NotFoundError('Access target not found'));
+    });
+
+    it('requires effective dashboard admin access', async () => {
+        vi.mocked(
+            mocks.dashboardService.assertViewAccess,
+        ).mockResolvedValueOnce({
+            ...dashboard,
+            access: [{ userUuid: actorUuid, role: SpaceMemberRole.EDITOR }],
+        } as never);
+
+        await expect(
+            mocks.handler.listAccess({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+            }),
+        ).rejects.toEqual(new ForbiddenError('Admin access is required'));
+    });
+
+    it('fails closed before resolving a dashboard when direct access is unavailable', async () => {
+        const unavailable = new ForbiddenError('Direct access unavailable');
+        vi.mocked(
+            mocks.directAccessService.assertEnabled,
+        ).mockRejectedValueOnce(unavailable);
+
+        await expect(
+            mocks.handler.listAccess({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+            }),
+        ).rejects.toBe(unavailable);
+        expect(mocks.dashboardService.assertViewAccess).not.toHaveBeenCalled();
+        expect(
+            mocks.dashboardAccessModel.getDirectAccessList,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('returns paginated direct principals with additive effective roles', async () => {
+        const result = await mocks.handler.listAccess({
+            user,
+            projectUuid,
+            resourceUuid: dashboardUuid,
+            paginateArgs: { page: 1, pageSize: 20 },
+            filters: { searchQuery: 'ada' },
+        });
+
+        expect(result).toEqual({
+            data: [
+                {
+                    principal: {
+                        type: DirectAccessOrigin.USER,
+                        uuid: 'user-uuid',
+                        firstName: 'Ada',
+                        lastName: 'Lovelace',
+                        email: 'ada@example.com',
+                        isInternal: false,
+                    },
+                    directRole: SpaceMemberRole.VIEWER,
+                    effectiveRole: SpaceMemberRole.EDITOR,
+                    origin: DirectAccessOrigin.USER,
+                },
+                {
+                    principal: {
+                        type: DirectAccessOrigin.GROUP,
+                        uuid: 'group-uuid',
+                        name: 'Analysts',
+                    },
+                    directRole: SpaceMemberRole.EDITOR,
+                    effectiveRole: SpaceMemberRole.EDITOR,
+                    origin: DirectAccessOrigin.GROUP,
+                },
+            ],
+            pagination: {
+                page: 1,
+                pageSize: 20,
+                totalPageCount: 1,
+                totalResults: 2,
+            },
+        });
+        expect(
+            mocks.dashboardAccessModel.getDirectAccessList,
+        ).toHaveBeenCalledWith(dashboardUuid, organizationUuid, {
+            paginateArgs: { page: 1, pageSize: 20 },
+            searchQuery: 'ada',
+        });
+        expect(mocks.dashboardService.assertViewAccess).toHaveBeenCalledWith(
+            user,
+            dashboardUuid,
+            {
+                projectUuid,
+                includeDependencies: false,
+                strictUuid: true,
+            },
+        );
+        expect(
+            mocks.dashboardAccessModel.getGroupRolesForUsers,
+        ).toHaveBeenCalledWith(dashboardUuid, ['user-uuid'], organizationUuid);
+        expect(
+            mocks.spacePermissionService.getSpaceAccessContextForUsers,
+        ).toHaveBeenCalledWith(['user-uuid'], spaceUuid);
+        expect(mocks.directAccessService.assertEnabled).toHaveBeenCalledWith(
+            user,
+        );
+    });
+
+    it('uses logical access when it is the highest user role', async () => {
+        vi.mocked(
+            mocks.dashboardAccessModel.getDirectAccessList,
+        ).mockResolvedValueOnce({ data: [userRow] });
+        vi.mocked(
+            mocks.dashboardAccessModel.getGroupRolesForUsers,
+        ).mockResolvedValueOnce({
+            'user-uuid': [SpaceMemberRole.VIEWER],
+        });
+        vi.mocked(
+            mocks.spacePermissionService.getSpaceAccessContextForUsers,
+        ).mockResolvedValueOnce({
+            access: [
+                {
+                    userUuid: 'user-uuid',
+                    role: SpaceMemberRole.ADMIN,
+                },
+            ],
+        } as never);
+
+        await expect(
+            mocks.handler.listAccess({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+            }),
+        ).resolves.toMatchObject({
+            data: [{ effectiveRole: SpaceMemberRole.ADMIN }],
+        });
+    });
+
+    it('does not resolve user access for group-only pages', async () => {
+        vi.mocked(
+            mocks.dashboardAccessModel.getDirectAccessList,
+        ).mockResolvedValueOnce({ data: [groupRow] });
+
+        await expect(
+            mocks.handler.listAccess({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+            }),
+        ).resolves.toMatchObject({
+            data: [{ origin: DirectAccessOrigin.GROUP }],
+        });
+        expect(
+            mocks.dashboardAccessModel.getGroupRolesForUsers,
+        ).not.toHaveBeenCalled();
+        expect(
+            mocks.spacePermissionService.getSpaceAccessContextForUsers,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('replaces user and group roles through the direct-access service', async () => {
+        vi.mocked(
+            mocks.dashboardAccessModel.getDirectAccessList,
+        ).mockResolvedValueOnce({
+            data: [{ ...userRow, directRole: SpaceMemberRole.EDITOR }],
+        });
+        await expect(
+            mocks.handler.replaceUserRole({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+                userUuid: 'user-uuid',
+                role: SpaceMemberRole.EDITOR,
+            }),
+        ).resolves.toMatchObject({
+            principal: { uuid: 'user-uuid' },
+            directRole: SpaceMemberRole.EDITOR,
+        });
+        expect(mocks.directAccessService.upsertUserAccess).toHaveBeenCalledWith(
+            {
+                user,
+                resource: { type: 'dashboard', uuid: dashboardUuid },
+                userUuid: 'user-uuid',
+                role: SpaceMemberRole.EDITOR,
+            },
+        );
+
+        vi.mocked(
+            mocks.dashboardAccessModel.getDirectAccessList,
+        ).mockResolvedValueOnce({
+            data: [{ ...groupRow, directRole: SpaceMemberRole.ADMIN }],
+        });
+        await mocks.handler.replaceGroupRole({
+            user,
+            projectUuid,
+            resourceUuid: dashboardUuid,
+            groupUuid: 'group-uuid',
+            role: SpaceMemberRole.ADMIN,
+        });
+        expect(
+            mocks.directAccessService.upsertGroupAccess,
+        ).toHaveBeenCalledWith({
+            user,
+            resource: { type: 'dashboard', uuid: dashboardUuid },
+            groupUuid: 'group-uuid',
+            role: SpaceMemberRole.ADMIN,
+        });
+    });
+
+    it('delegates idempotent revoke and reset operations', async () => {
+        await mocks.handler.revokeUser({
+            user,
+            projectUuid,
+            resourceUuid: dashboardUuid,
+            userUuid: 'user-uuid',
+        });
+        await mocks.handler.revokeGroup({
+            user,
+            projectUuid,
+            resourceUuid: dashboardUuid,
+            groupUuid: 'group-uuid',
+        });
+        await mocks.handler.reset({
+            user,
+            projectUuid,
+            resourceUuid: dashboardUuid,
+        });
+
+        expect(mocks.directAccessService.revokeUserAccess).toHaveBeenCalledWith(
+            {
+                user,
+                resource: { type: 'dashboard', uuid: dashboardUuid },
+                userUuid: 'user-uuid',
+            },
+        );
+        expect(
+            mocks.directAccessService.revokeGroupAccess,
+        ).toHaveBeenCalledWith({
+            user,
+            resource: { type: 'dashboard', uuid: dashboardUuid },
+            groupUuid: 'group-uuid',
+        });
+        expect(mocks.directAccessService.resetAccess).toHaveBeenCalledWith({
+            user,
+            resource: { type: 'dashboard', uuid: dashboardUuid },
+        });
+    });
+
+    it('allows a non-admin to revoke their own direct grant', async () => {
+        vi.mocked(
+            mocks.dashboardService.assertViewAccess,
+        ).mockResolvedValueOnce({
+            ...dashboard,
+            access: [{ userUuid: actorUuid, role: SpaceMemberRole.VIEWER }],
+        } as never);
+
+        await mocks.handler.revokeUser({
+            user,
+            projectUuid,
+            resourceUuid: dashboardUuid,
+            userUuid: actorUuid,
+        });
+
+        expect(mocks.directAccessService.revokeUserAccess).toHaveBeenCalledWith(
+            {
+                user,
+                resource: { type: 'dashboard', uuid: dashboardUuid },
+                userUuid: actorUuid,
+            },
+        );
+    });
+
+    it('denies every administrative mutation to non-admins', async () => {
+        vi.mocked(mocks.dashboardService.assertViewAccess).mockResolvedValue({
+            ...dashboard,
+            access: [{ userUuid: actorUuid, role: SpaceMemberRole.EDITOR }],
+        } as never);
+
+        const results = await Promise.allSettled([
+            mocks.handler.replaceUserRole({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+                userUuid: 'user-uuid',
+                role: SpaceMemberRole.VIEWER,
+            }),
+            mocks.handler.replaceGroupRole({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+                groupUuid: 'group-uuid',
+                role: SpaceMemberRole.VIEWER,
+            }),
+            mocks.handler.revokeUser({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+                userUuid: 'other-user-uuid',
+            }),
+            mocks.handler.revokeGroup({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+                groupUuid: 'group-uuid',
+            }),
+            mocks.handler.reset({
+                user,
+                projectUuid,
+                resourceUuid: dashboardUuid,
+            }),
+        ]);
+
+        expect(results).toHaveLength(5);
+        expect(
+            results.every(
+                (result) =>
+                    result.status === 'rejected' &&
+                    result.reason instanceof ForbiddenError,
+            ),
+        ).toBe(true);
+        expect(
+            mocks.directAccessService.upsertUserAccess,
+        ).not.toHaveBeenCalled();
+        expect(
+            mocks.directAccessService.upsertGroupAccess,
+        ).not.toHaveBeenCalled();
+        expect(
+            mocks.directAccessService.revokeUserAccess,
+        ).not.toHaveBeenCalled();
+        expect(
+            mocks.directAccessService.revokeGroupAccess,
+        ).not.toHaveBeenCalled();
+        expect(mocks.directAccessService.resetAccess).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/DirectAccess/DashboardAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/DashboardAccessHandler.ts
@@ -1,0 +1,329 @@
+import {
+    DirectAccessOrigin,
+    ForbiddenError,
+    getHighestSpaceRole,
+    NotFoundError,
+    SpaceMemberRole,
+    type DirectAccessGrant,
+    type DirectAccessList,
+    type DirectAccessListFilters,
+    type KnexPaginateArgs,
+    type SessionUser,
+} from '@lightdash/common';
+import { validate as isValidUuid } from 'uuid';
+import type {
+    DashboardAccessModel,
+    DashboardDirectAccessListRow,
+} from '../../models/DashboardAccessModel';
+import { BaseService } from '../BaseService';
+import type { DashboardService } from '../DashboardService/DashboardService';
+import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import type { DirectAccessService } from './DirectAccessService';
+import { type ResourceAccessHandler } from './ResourceAccessHandler';
+
+type DashboardAccessInput = {
+    user: SessionUser;
+    projectUuid: string;
+    resourceUuid: string;
+};
+
+export class DashboardAccessHandler
+    extends BaseService
+    implements ResourceAccessHandler
+{
+    constructor(
+        private readonly dashboardAccessModel: DashboardAccessModel,
+        private readonly dashboardService: DashboardService,
+        private readonly directAccessService: DirectAccessService,
+        private readonly spacePermissionService: SpacePermissionService,
+    ) {
+        super();
+    }
+
+    private async resolveDashboard({
+        user,
+        projectUuid,
+        resourceUuid,
+    }: DashboardAccessInput) {
+        await this.directAccessService.assertEnabled(user);
+        if (!isValidUuid(resourceUuid)) {
+            throw new NotFoundError('Access target not found');
+        }
+
+        let dashboard: Awaited<
+            ReturnType<DashboardService['assertViewAccess']>
+        >;
+        try {
+            dashboard = await this.dashboardService.assertViewAccess(
+                user,
+                resourceUuid,
+                {
+                    projectUuid,
+                    includeDependencies: false,
+                    strictUuid: true,
+                },
+            );
+        } catch (error) {
+            if (
+                error instanceof NotFoundError ||
+                error instanceof ForbiddenError
+            ) {
+                throw new NotFoundError('Access target not found');
+            }
+            throw error;
+        }
+
+        return dashboard;
+    }
+
+    private async assertAdmin(input: DashboardAccessInput) {
+        const dashboard = await this.resolveDashboard(input);
+        const role = getHighestSpaceRole(
+            (dashboard.access ?? [])
+                .filter(({ userUuid }) => userUuid === input.user.userUuid)
+                .map(({ role: accessRole }) => accessRole),
+        );
+        if (role !== SpaceMemberRole.ADMIN) {
+            throw new ForbiddenError('Admin access is required');
+        }
+        return dashboard;
+    }
+
+    private async getGrant(
+        dashboard: Awaited<ReturnType<DashboardService['assertViewAccess']>>,
+        principal: { origin: DirectAccessOrigin; uuid: string },
+    ): Promise<DirectAccessGrant> {
+        const { data } = await this.dashboardAccessModel.getDirectAccessList(
+            dashboard.uuid,
+            dashboard.organizationUuid,
+            { principal },
+        );
+        const row = data[0];
+        if (!row) {
+            throw new NotFoundError('Direct access grant not found');
+        }
+
+        const [grant] = await this.resolveGrants(dashboard, [row]);
+        if (!grant) {
+            throw new NotFoundError('Direct access grant not found');
+        }
+        return grant;
+    }
+
+    private async resolveGrants(
+        dashboard: Awaited<ReturnType<DashboardService['assertViewAccess']>>,
+        rows: DashboardDirectAccessListRow[],
+    ): Promise<DirectAccessGrant[]> {
+        const userUuids = rows
+            .filter(
+                (
+                    row,
+                ): row is Extract<
+                    DashboardDirectAccessListRow,
+                    { origin: DirectAccessOrigin.USER }
+                > => row.origin === DirectAccessOrigin.USER,
+            )
+            .map(({ principalUuid }) => principalUuid);
+
+        if (userUuids.length === 0) {
+            const groupRows = rows.filter(
+                (
+                    row,
+                ): row is Extract<
+                    DashboardDirectAccessListRow,
+                    { origin: DirectAccessOrigin.GROUP }
+                > => row.origin === DirectAccessOrigin.GROUP,
+            );
+            return groupRows.map((row) => ({
+                principal: {
+                    type: DirectAccessOrigin.GROUP,
+                    uuid: row.principalUuid,
+                    name: row.name,
+                },
+                directRole: row.directRole,
+                effectiveRole: row.directRole,
+                origin: DirectAccessOrigin.GROUP,
+            }));
+        }
+
+        const [groupRolesByUserUuid, spaceContext] = await Promise.all([
+            this.dashboardAccessModel.getGroupRolesForUsers(
+                dashboard.uuid,
+                userUuids,
+                dashboard.organizationUuid,
+            ),
+            this.spacePermissionService.getSpaceAccessContextForUsers(
+                userUuids,
+                dashboard.spaceUuid,
+            ),
+        ]);
+        const logicalRolesByUserUuid = new Map<string, SpaceMemberRole[]>();
+        for (const access of this.spacePermissionService.mergeAdminAccess(
+            spaceContext,
+        )) {
+            const roles = logicalRolesByUserUuid.get(access.userUuid) ?? [];
+            roles.push(access.role);
+            logicalRolesByUserUuid.set(access.userUuid, roles);
+        }
+
+        return rows.map((row) => {
+            if (row.origin === DirectAccessOrigin.GROUP) {
+                return {
+                    principal: {
+                        type: DirectAccessOrigin.GROUP,
+                        uuid: row.principalUuid,
+                        name: row.name,
+                    },
+                    directRole: row.directRole,
+                    effectiveRole: row.directRole,
+                    origin: row.origin,
+                };
+            }
+
+            return {
+                principal: {
+                    type: DirectAccessOrigin.USER,
+                    uuid: row.principalUuid,
+                    firstName: row.firstName,
+                    lastName: row.lastName,
+                    email: row.email,
+                    isInternal: row.isInternal,
+                },
+                directRole: row.directRole,
+                effectiveRole:
+                    getHighestSpaceRole([
+                        row.directRole,
+                        ...(groupRolesByUserUuid[row.principalUuid] ?? []),
+                        ...(logicalRolesByUserUuid.get(row.principalUuid) ??
+                            []),
+                    ]) ?? row.directRole,
+                origin: row.origin,
+            };
+        });
+    }
+
+    async listAccess({
+        user,
+        projectUuid,
+        resourceUuid,
+        paginateArgs,
+        filters,
+    }: DashboardAccessInput & {
+        paginateArgs?: KnexPaginateArgs;
+        filters?: DirectAccessListFilters;
+    }): Promise<DirectAccessList> {
+        const dashboard = await this.assertAdmin({
+            user,
+            projectUuid,
+            resourceUuid,
+        });
+        const { data, pagination } =
+            await this.dashboardAccessModel.getDirectAccessList(
+                dashboard.uuid,
+                dashboard.organizationUuid,
+                { paginateArgs, searchQuery: filters?.searchQuery },
+            );
+        return {
+            data: await this.resolveGrants(dashboard, data),
+            ...(pagination ? { pagination } : {}),
+        };
+    }
+
+    async replaceUserRole({
+        user,
+        projectUuid,
+        resourceUuid,
+        userUuid,
+        role,
+    }: DashboardAccessInput & {
+        userUuid: string;
+        role: SpaceMemberRole;
+    }): Promise<DirectAccessGrant> {
+        const dashboard = await this.assertAdmin({
+            user,
+            projectUuid,
+            resourceUuid,
+        });
+        await this.directAccessService.upsertUserAccess({
+            user,
+            resource: { type: 'dashboard', uuid: dashboard.uuid },
+            userUuid,
+            role,
+        });
+        return this.getGrant(dashboard, {
+            origin: DirectAccessOrigin.USER,
+            uuid: userUuid,
+        });
+    }
+
+    async replaceGroupRole({
+        user,
+        projectUuid,
+        resourceUuid,
+        groupUuid,
+        role,
+    }: DashboardAccessInput & {
+        groupUuid: string;
+        role: SpaceMemberRole;
+    }): Promise<DirectAccessGrant> {
+        const dashboard = await this.assertAdmin({
+            user,
+            projectUuid,
+            resourceUuid,
+        });
+        await this.directAccessService.upsertGroupAccess({
+            user,
+            resource: { type: 'dashboard', uuid: dashboard.uuid },
+            groupUuid,
+            role,
+        });
+        return this.getGrant(dashboard, {
+            origin: DirectAccessOrigin.GROUP,
+            uuid: groupUuid,
+        });
+    }
+
+    async revokeUser({
+        user,
+        projectUuid,
+        resourceUuid,
+        userUuid,
+    }: DashboardAccessInput & { userUuid: string }): Promise<void> {
+        const input = { user, projectUuid, resourceUuid };
+        const dashboard =
+            userUuid === user.userUuid
+                ? await this.resolveDashboard(input)
+                : await this.assertAdmin(input);
+        await this.directAccessService.revokeUserAccess({
+            user,
+            resource: { type: 'dashboard', uuid: dashboard.uuid },
+            userUuid,
+        });
+    }
+
+    async revokeGroup({
+        user,
+        projectUuid,
+        resourceUuid,
+        groupUuid,
+    }: DashboardAccessInput & { groupUuid: string }): Promise<void> {
+        const dashboard = await this.assertAdmin({
+            user,
+            projectUuid,
+            resourceUuid,
+        });
+        await this.directAccessService.revokeGroupAccess({
+            user,
+            resource: { type: 'dashboard', uuid: dashboard.uuid },
+            groupUuid,
+        });
+    }
+
+    async reset(input: DashboardAccessInput): Promise<void> {
+        const dashboard = await this.assertAdmin(input);
+        await this.directAccessService.resetAccess({
+            user: input.user,
+            resource: { type: 'dashboard', uuid: dashboard.uuid },
+        });
+    }
+}

--- a/packages/backend/src/services/DirectAccess/DashboardAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/DashboardAccessHandler.ts
@@ -4,6 +4,7 @@ import {
     getHighestSpaceRole,
     NotFoundError,
     SpaceMemberRole,
+    type Dashboard,
     type DirectAccessGrant,
     type DirectAccessList,
     type DirectAccessListFilters,
@@ -27,32 +28,50 @@ type DashboardAccessInput = {
     resourceUuid: string;
 };
 
+// A list call without explicit pagination must not read every grant row.
+const DEFAULT_ACCESS_LIST_PAGE: KnexPaginateArgs = { page: 1, pageSize: 100 };
+
 export class DashboardAccessHandler
     extends BaseService
     implements ResourceAccessHandler
 {
-    constructor(
-        private readonly dashboardAccessModel: DashboardAccessModel,
-        private readonly dashboardService: DashboardService,
-        private readonly directAccessService: DirectAccessService,
-        private readonly spacePermissionService: SpacePermissionService,
-    ) {
+    private readonly dashboardAccessModel: DashboardAccessModel;
+
+    private readonly dashboardService: DashboardService;
+
+    private readonly directAccessService: DirectAccessService;
+
+    private readonly spacePermissionService: SpacePermissionService;
+
+    constructor({
+        dashboardAccessModel,
+        dashboardService,
+        directAccessService,
+        spacePermissionService,
+    }: {
+        dashboardAccessModel: DashboardAccessModel;
+        dashboardService: DashboardService;
+        directAccessService: DirectAccessService;
+        spacePermissionService: SpacePermissionService;
+    }) {
         super();
+        this.dashboardAccessModel = dashboardAccessModel;
+        this.dashboardService = dashboardService;
+        this.directAccessService = directAccessService;
+        this.spacePermissionService = spacePermissionService;
     }
 
     private async resolveDashboard({
         user,
         projectUuid,
         resourceUuid,
-    }: DashboardAccessInput) {
+    }: DashboardAccessInput): Promise<Dashboard> {
         await this.directAccessService.assertEnabled(user);
         if (!isValidUuid(resourceUuid)) {
             throw new NotFoundError('Access target not found');
         }
 
-        let dashboard: Awaited<
-            ReturnType<DashboardService['assertViewAccess']>
-        >;
+        let dashboard: Dashboard;
         try {
             dashboard = await this.dashboardService.assertViewAccess(
                 user,
@@ -76,21 +95,35 @@ export class DashboardAccessHandler
         return dashboard;
     }
 
-    private async assertAdmin(input: DashboardAccessInput) {
+    private async assertAdmin(input: DashboardAccessInput): Promise<Dashboard> {
         const dashboard = await this.resolveDashboard(input);
         const role = getHighestSpaceRole(
             (dashboard.access ?? [])
                 .filter(({ userUuid }) => userUuid === input.user.userUuid)
                 .map(({ role: accessRole }) => accessRole),
         );
-        if (role !== SpaceMemberRole.ADMIN) {
+        if (role === SpaceMemberRole.ADMIN) {
+            return dashboard;
+        }
+        // Org and project admins reach every space through CASL rather than
+        // space access rows, so merge their standing before denying — the
+        // same source resolveGrants merges for listed principals.
+        const spaceContext =
+            await this.spacePermissionService.getSpaceAccessContextForUsers(
+                [input.user.userUuid],
+                dashboard.spaceUuid,
+            );
+        const isOrgOrProjectAdmin = spaceContext.admins.some(
+            ({ userUuid }) => userUuid === input.user.userUuid,
+        );
+        if (!isOrgOrProjectAdmin) {
             throw new ForbiddenError('Admin access is required');
         }
         return dashboard;
     }
 
     private async getGrant(
-        dashboard: Awaited<ReturnType<DashboardService['assertViewAccess']>>,
+        dashboard: Dashboard,
         principal: { origin: DirectAccessOrigin; uuid: string },
     ): Promise<DirectAccessGrant> {
         const { data } = await this.dashboardAccessModel.getDirectAccessList(
@@ -111,7 +144,7 @@ export class DashboardAccessHandler
     }
 
     private async resolveGrants(
-        dashboard: Awaited<ReturnType<DashboardService['assertViewAccess']>>,
+        dashboard: Dashboard,
         rows: DashboardDirectAccessListRow[],
     ): Promise<DirectAccessGrant[]> {
         const userUuids = rows
@@ -141,8 +174,6 @@ export class DashboardAccessHandler
                     name: row.name,
                 },
                 directRole: row.directRole,
-                effectiveRole: row.directRole,
-                origin: DirectAccessOrigin.GROUP,
             }));
         }
 
@@ -175,8 +206,6 @@ export class DashboardAccessHandler
                         name: row.name,
                     },
                     directRole: row.directRole,
-                    effectiveRole: row.directRole,
-                    origin: row.origin,
                 };
             }
 
@@ -197,7 +226,6 @@ export class DashboardAccessHandler
                         ...(logicalRolesByUserUuid.get(row.principalUuid) ??
                             []),
                     ]) ?? row.directRole,
-                origin: row.origin,
             };
         });
     }
@@ -221,7 +249,10 @@ export class DashboardAccessHandler
             await this.dashboardAccessModel.getDirectAccessList(
                 dashboard.uuid,
                 dashboard.organizationUuid,
-                { paginateArgs, searchQuery: filters?.searchQuery },
+                {
+                    paginateArgs: paginateArgs ?? DEFAULT_ACCESS_LIST_PAGE,
+                    searchQuery: filters?.searchQuery,
+                },
             );
         return {
             data: await this.resolveGrants(dashboard, data),

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
@@ -25,6 +25,17 @@ const account = {
     isServiceAccount: () => true,
 } as unknown as RegisteredAccount;
 
+const user = {
+    userUuid: 'persisted-user-uuid',
+    organizationUuid: 'organization-uuid',
+    role: 'admin',
+    serviceAccount: {
+        uuid: 'audit-service-account-uuid',
+        description: 'Test service account',
+    },
+    requestContext: { requestId: 'request-id' },
+} as unknown as Parameters<DirectAccessService['assertEnabled']>[0];
+
 const mutationResult = {
     organizationId: 1,
     organizationUuid: 'organization-uuid',
@@ -73,12 +84,48 @@ const createActorRoleResolver = () =>
 const createFeatureGate = (isEnabled: boolean): DirectAccessFeatureGate =>
     ({
         isEnabled: vi.fn().mockResolvedValue(isEnabled),
+        isEnabledForUser: vi.fn().mockResolvedValue(isEnabled),
         assertEnabled: isEnabled
             ? vi.fn().mockResolvedValue(undefined)
             : vi.fn().mockRejectedValue(new Error('Direct access unavailable')),
     }) as unknown as DirectAccessFeatureGate;
 
 describe('DirectAccessService', () => {
+    it('uses the existing session user for mutations', async () => {
+        const models = createModels();
+        const actorRoleResolver = createActorRoleResolver();
+        const featureGate = createFeatureGate(true);
+        const service = new DirectAccessService({
+            models,
+            actorRoleResolver,
+            featureGate,
+        });
+
+        await service.upsertUserAccess({
+            user,
+            resource: { type: 'dashboard', uuid: 'dashboard-uuid' },
+            userUuid: 'principal-uuid',
+            role: SpaceMemberRole.VIEWER,
+        });
+
+        expect(featureGate.isEnabledForUser).toHaveBeenCalledWith({
+            userUuid: 'persisted-user-uuid',
+            organizationUuid: 'organization-uuid',
+        });
+        expect(actorRoleResolver).toHaveBeenCalledWith({
+            actorUserUuid: 'persisted-user-uuid',
+            organizationUuid: 'organization-uuid',
+            phase: 'preflight',
+            resource: { type: 'dashboard', uuid: 'dashboard-uuid' },
+        });
+        expect(models.dashboard.upsertUserAccess).toHaveBeenCalledWith(
+            expect.objectContaining({
+                grantedByUserUuid: 'persisted-user-uuid',
+                organizationUuid: 'organization-uuid',
+            }),
+        );
+    });
+
     it('issues zero direct-model reads while the feature is unavailable', async () => {
         const models = createModels();
         const service = new DirectAccessService({
@@ -251,7 +298,7 @@ describe('DirectAccessService', () => {
         });
         const operations = resourceTypes.flatMap((type) => {
             const mutation = {
-                account,
+                user,
                 resource: { type, uuid: `${type}-uuid` },
             };
             return [
@@ -305,7 +352,7 @@ describe('DirectAccessService', () => {
         await Promise.all(
             resourceTypes.map((type) =>
                 service.upsertUserAccess({
-                    account,
+                    user,
                     resource: { type, uuid: `${type}-uuid` },
                     userUuid: 'principal-uuid',
                     role: SpaceMemberRole.VIEWER,
@@ -333,13 +380,13 @@ describe('DirectAccessService', () => {
         });
         expect(actorRoleResolver).toHaveBeenCalledTimes(5);
         expect(actorRoleResolver).toHaveBeenCalledWith({
-            account,
+            actorUserUuid: 'persisted-user-uuid',
             organizationUuid: 'organization-uuid',
             phase: 'preflight',
             resource: { type: 'dashboard', uuid: 'dashboard-uuid' },
         });
         expect(actorRoleResolver).toHaveBeenCalledWith({
-            account,
+            actorUserUuid: 'persisted-user-uuid',
             organizationUuid: 'organization-uuid',
             phase: 'transaction',
             transaction: {},
@@ -390,7 +437,7 @@ describe('DirectAccessService', () => {
             featureGate: createFeatureGate(true),
         });
         const mutation = {
-            account,
+            user,
             resource: {
                 type: 'dashboard' as const,
                 uuid: 'dashboard-uuid',
@@ -469,7 +516,7 @@ describe('DirectAccessService', () => {
 
         await expect(
             service.upsertUserAccess({
-                account,
+                user,
                 resource: {
                     type: 'dashboard',
                     uuid: 'dashboard-uuid',
@@ -494,6 +541,10 @@ describe('DirectAccessService', () => {
             ...account,
             organization: {},
         } as RegisteredAccount;
+        const userWithoutOrganization = {
+            ...user,
+            organizationUuid: undefined,
+        } as unknown as Parameters<DirectAccessService['assertEnabled']>[0];
 
         await expect(
             service.getUserAccess({
@@ -504,7 +555,7 @@ describe('DirectAccessService', () => {
         ).rejects.toMatchObject({ name: 'ForbiddenError' });
         await expect(
             service.resetAccess({
-                account: accountWithoutOrganization,
+                user: userWithoutOrganization,
                 resource: { type: 'dashboard', uuid: 'dashboard-uuid' },
             }),
         ).rejects.toMatchObject({ name: 'ForbiddenError' });

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.ts
@@ -1,10 +1,11 @@
 import {
     ForbiddenError,
     type RegisteredAccount,
+    type SessionUser,
     type SpaceMemberRole,
     type UUID,
 } from '@lightdash/common';
-import { createActorFromAccount } from '../../logging/caslAuditWrapper';
+import { createActorFromUser } from '../../logging/caslAuditWrapper';
 import {
     type DirectAccess,
     type DirectAccessModel,
@@ -50,7 +51,7 @@ const auditResourceTypes: Record<DirectAccessResourceType, string> = {
 };
 
 type DirectAccessActorRoleResolverInput = {
-    account: RegisteredAccount;
+    actorUserUuid: UUID;
     organizationUuid: UUID;
     resource: DirectAccessResource;
 } & (
@@ -74,7 +75,7 @@ export type DirectAccessActorRoleResolver = (
 ) => Promise<SpaceMemberRole | undefined>;
 
 type DirectAccessMutationInput = {
-    account: RegisteredAccount;
+    user: SessionUser;
     resource: DirectAccessResource;
 };
 
@@ -113,18 +114,27 @@ export class DirectAccessService extends BaseService {
         return organizationUuid;
     }
 
+    private static getMutationOrganizationUuid(
+        input: DirectAccessMutationInput,
+    ): UUID {
+        const { organizationUuid } = input.user;
+        if (organizationUuid === undefined) {
+            throw new ForbiddenError('Direct access is not available');
+        }
+        return organizationUuid;
+    }
+
     private createActorRoleResolver(
         input: DirectAccessMutationInput,
     ): DirectAccessModelActorRoleResolver {
-        const organizationUuid = DirectAccessService.getOrganizationUuid(
-            input.account,
-        );
+        const organizationUuid =
+            DirectAccessService.getMutationOrganizationUuid(input);
         return ({ transaction, context }) => {
             if (context.organizationUuid !== organizationUuid) {
                 throw new ForbiddenError('Direct access is not available');
             }
             return this.actorRoleResolver({
-                account: input.account,
+                actorUserUuid: input.user.userUuid,
                 organizationUuid,
                 phase: 'transaction',
                 transaction,
@@ -137,11 +147,10 @@ export class DirectAccessService extends BaseService {
     private resolveActorRole(
         input: DirectAccessMutationInput,
     ): Promise<SpaceMemberRole | undefined> {
-        const organizationUuid = DirectAccessService.getOrganizationUuid(
-            input.account,
-        );
+        const organizationUuid =
+            DirectAccessService.getMutationOrganizationUuid(input);
         return this.actorRoleResolver({
-            account: input.account,
+            actorUserUuid: input.user.userUuid,
             organizationUuid,
             phase: 'preflight',
             resource: input.resource,
@@ -153,10 +162,9 @@ export class DirectAccessService extends BaseService {
         actorRole?: SpaceMemberRole;
         actorRoleResolver: DirectAccessModelActorRoleResolver;
     }> {
-        const organizationUuid = DirectAccessService.getOrganizationUuid(
-            input.account,
-        );
-        await this.featureGate.assertEnabled(input.account);
+        const organizationUuid =
+            DirectAccessService.getMutationOrganizationUuid(input);
+        await this.assertEnabled(input.user);
         const actorRole = await this.resolveActorRole(input);
         return {
             organizationUuid,
@@ -171,14 +179,25 @@ export class DirectAccessService extends BaseService {
         return this.models[resourceType];
     }
 
+    async assertEnabled(user: SessionUser): Promise<void> {
+        if (
+            !(await this.featureGate.isEnabledForUser({
+                userUuid: user.userUuid,
+                organizationUuid: user.organizationUuid,
+            }))
+        ) {
+            throw new ForbiddenError('Direct access is not available');
+        }
+    }
+
     private auditMutation(
         input: DirectAccessMutationInput,
         principal: { type: 'user' | 'group'; uuid: UUID },
         result: DirectAccessMutationResult,
     ): void {
         auditDirectAccessMutation({
-            actor: createActorFromAccount(input.account),
-            context: input.account.requestContext ?? {},
+            actor: createActorFromUser(input.user),
+            context: input.user.requestContext ?? {},
             resourceType: auditResourceTypes[input.resource.type],
             resourceUuid: input.resource.uuid,
             principal,
@@ -192,8 +211,8 @@ export class DirectAccessService extends BaseService {
         result: DirectAccessResetResult,
     ): void {
         auditDirectAccessReset({
-            actor: createActorFromAccount(input.account),
-            context: input.account.requestContext ?? {},
+            actor: createActorFromUser(input.user),
+            context: input.user.requestContext ?? {},
             resourceType: auditResourceTypes[input.resource.type],
             resourceUuid: input.resource.uuid,
             result,
@@ -299,7 +318,7 @@ export class DirectAccessService extends BaseService {
             role: input.role,
             actorRole,
             actorRoleResolver,
-            grantedByUserUuid: input.account.user.userUuid,
+            grantedByUserUuid: input.user.userUuid,
             organizationUuid,
         });
         this.auditMutation(
@@ -325,7 +344,7 @@ export class DirectAccessService extends BaseService {
             role: input.role,
             actorRole,
             actorRoleResolver,
-            grantedByUserUuid: input.account.user.userUuid,
+            grantedByUserUuid: input.user.userUuid,
             organizationUuid,
         });
         this.auditMutation(
@@ -347,7 +366,7 @@ export class DirectAccessService extends BaseService {
             userUuid: input.userUuid,
             actorRole,
             actorRoleResolver,
-            actorUserUuid: input.account.user.userUuid,
+            actorUserUuid: input.user.userUuid,
             organizationUuid,
         });
         this.auditMutation(

--- a/packages/backend/src/services/DirectAccess/ResourceAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/ResourceAccessHandler.ts
@@ -13,6 +13,11 @@ type ResourceAccessInput = {
     resourceUuid: string;
 };
 
+/**
+ * Revokes are idempotent for every implementation: revoking a grant that does
+ * not exist succeeds as a no-op (and emits no audit event). A missing or
+ * inaccessible resource still fails with a not-found error.
+ */
 export type ResourceAccessHandler = {
     listAccess(
         input: ResourceAccessInput & {

--- a/packages/backend/src/services/DirectAccess/ResourceAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/ResourceAccessHandler.ts
@@ -1,0 +1,42 @@
+import {
+    type DirectAccessGrant,
+    type DirectAccessList,
+    type DirectAccessListFilters,
+    type KnexPaginateArgs,
+    type SessionUser,
+    type SpaceMemberRole,
+} from '@lightdash/common';
+
+type ResourceAccessInput = {
+    user: SessionUser;
+    projectUuid: string;
+    resourceUuid: string;
+};
+
+export type ResourceAccessHandler = {
+    listAccess(
+        input: ResourceAccessInput & {
+            paginateArgs?: KnexPaginateArgs;
+            filters?: DirectAccessListFilters;
+        },
+    ): Promise<DirectAccessList>;
+    replaceUserRole(
+        input: ResourceAccessInput & {
+            userUuid: string;
+            role: SpaceMemberRole;
+        },
+    ): Promise<DirectAccessGrant>;
+    replaceGroupRole(
+        input: ResourceAccessInput & {
+            groupUuid: string;
+            role: SpaceMemberRole;
+        },
+    ): Promise<DirectAccessGrant>;
+    revokeUser(
+        input: ResourceAccessInput & { userUuid: string },
+    ): Promise<void>;
+    revokeGroup(
+        input: ResourceAccessInput & { groupUuid: string },
+    ): Promise<void>;
+    reset(input: ResourceAccessInput): Promise<void>;
+};

--- a/packages/backend/src/services/DirectAccess/directAccessAudit.ts
+++ b/packages/backend/src/services/DirectAccess/directAccessAudit.ts
@@ -34,6 +34,11 @@ export const auditDirectAccessMutation = ({
     result: DirectAccessMutationResult;
     auditLogger?: DirectAccessAuditLogger;
 }): void => {
+    // An idempotent revoke of a grant that never existed mutated nothing;
+    // auditing it would pollute the stream with phantom revokes.
+    if (result.beforeRole === null && result.afterRole === null) {
+        return;
+    }
     let action = 'direct_access.role_change';
     if (result.afterRole === null) {
         action = 'direct_access.revoke';

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -457,12 +457,12 @@ export class ServiceRepository
         return this.getService(
             'dashboardAccessHandler',
             () =>
-                new DashboardAccessHandler(
-                    this.models.getDashboardAccessModel(),
-                    this.getDashboardService(),
-                    this.getDirectAccessService(),
-                    this.getSpacePermissionService(),
-                ),
+                new DashboardAccessHandler({
+                    dashboardAccessModel: this.models.getDashboardAccessModel(),
+                    dashboardService: this.getDashboardService(),
+                    directAccessService: this.getDirectAccessService(),
+                    spacePermissionService: this.getSpacePermissionService(),
+                }),
         );
     }
 
@@ -481,9 +481,10 @@ export class ServiceRepository
                         this.models.getFeatureFlagModel(),
                         this.getLicenseService(),
                     ),
-                    // Read paths are available before Stack 5 wires the
-                    // authoritative transactional mutation resolver. Returning
-                    // no actor role keeps every write fail-closed meanwhile.
+                    // Read paths ship in this stack; the routes stack that
+                    // mounts the handlers wires the authoritative transactional
+                    // mutation resolver. Returning no actor role keeps every
+                    // write except self-revoke fail-closed until then.
                     actorRoleResolver: async () => undefined,
                 }),
         );

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -30,6 +30,7 @@ import { ContentVerificationService } from './ContentVerificationService';
 import { CsvService } from './CsvService/CsvService';
 import { DashboardService } from './DashboardService/DashboardService';
 import { DeployService } from './DeployService';
+import { DashboardAccessHandler } from './DirectAccess/DashboardAccessHandler';
 import { DirectAccessFeatureGate } from './DirectAccess/DirectAccessFeatureGate';
 import { DirectAccessService } from './DirectAccess/DirectAccessService';
 import { DownloadFileService } from './DownloadFileService/DownloadFileService';
@@ -98,6 +99,7 @@ interface ServiceManifest {
     analyticsService: AnalyticsService;
     commentService: CommentService;
     csvService: CsvService;
+    dashboardAccessHandler: DashboardAccessHandler;
     dashboardService: DashboardService;
     directAccessService: DirectAccessService;
     deployService: DeployService;
@@ -448,6 +450,19 @@ export class ServiceRepository
                         this.models.getContentVerificationModel(),
                     directAccessService: this.getDirectAccessService(),
                 }),
+        );
+    }
+
+    public getDashboardAccessHandler(): DashboardAccessHandler {
+        return this.getService(
+            'dashboardAccessHandler',
+            () =>
+                new DashboardAccessHandler(
+                    this.models.getDashboardAccessModel(),
+                    this.getDashboardService(),
+                    this.getDirectAccessService(),
+                    this.getSpacePermissionService(),
+                ),
         );
     }
 

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -191,6 +191,22 @@ export class SpacePermissionService extends BaseService {
         return ctx;
     }
 
+    async getSpaceAccessContextForUsers(
+        userUuids: string[],
+        spaceUuid: string,
+    ): Promise<SpaceAccessContextForCasl> {
+        const accessContext = await this.getSpacesCaslContext([spaceUuid], {
+            userUuids,
+        });
+        const ctx = accessContext[spaceUuid];
+        if (!ctx) {
+            throw new NotFoundError(
+                `Couldn't find access context for space ${spaceUuid}`,
+            );
+        }
+        return ctx;
+    }
+
     mergeAdminAccess(ctx: SpaceAccessContextForCasl): SpaceAccess[] {
         const existingAccessUuids = new Set(
             ctx.access.map((access) => access.userUuid),

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -122,6 +122,7 @@ export * from './types/content';
 export * from './types/contentSlug';
 export * from './types/contentVerification';
 export * from './types/dashboard';
+export * from './types/directAccess';
 export * from './types/emailWhitelabel';
 export * from './types/dataTimezonePreview';
 export * from './types/fieldImpact';

--- a/packages/common/src/types/directAccess.ts
+++ b/packages/common/src/types/directAccess.ts
@@ -27,18 +27,21 @@ export type DirectAccessPrincipal =
 
 export type DirectAccessGrant =
     | {
-          origin: DirectAccessOrigin.USER;
           principal: DirectAccessUserPrincipal;
           directRole: SpaceMemberRole;
-          /** Highest additive access role. Capability scopes are enforced separately. */
+          /**
+           * Highest additive access role before capability scopes, which are
+           * enforced separately at query time.
+           */
           effectiveRole: SpaceMemberRole;
       }
     | {
-          origin: DirectAccessOrigin.GROUP;
+          /**
+           * Group grants carry only their direct contribution: each member's
+           * effective role varies with their other access paths.
+           */
           principal: DirectAccessGroupPrincipal;
           directRole: SpaceMemberRole;
-          /** A group's member-effective roles vary; this is the group's direct contribution. */
-          effectiveRole: SpaceMemberRole;
       };
 
 export type DirectAccessListFilters = {

--- a/packages/common/src/types/directAccess.ts
+++ b/packages/common/src/types/directAccess.ts
@@ -1,0 +1,48 @@
+import type { KnexPaginatedData } from './knex-paginate';
+import type { SpaceMemberRole } from './space';
+
+export enum DirectAccessOrigin {
+    USER = 'user',
+    GROUP = 'group',
+}
+
+export type DirectAccessUserPrincipal = {
+    type: DirectAccessOrigin.USER;
+    uuid: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    isInternal: boolean;
+};
+
+export type DirectAccessGroupPrincipal = {
+    type: DirectAccessOrigin.GROUP;
+    uuid: string;
+    name: string;
+};
+
+export type DirectAccessPrincipal =
+    | DirectAccessUserPrincipal
+    | DirectAccessGroupPrincipal;
+
+export type DirectAccessGrant =
+    | {
+          origin: DirectAccessOrigin.USER;
+          principal: DirectAccessUserPrincipal;
+          directRole: SpaceMemberRole;
+          /** Highest additive access role. Capability scopes are enforced separately. */
+          effectiveRole: SpaceMemberRole;
+      }
+    | {
+          origin: DirectAccessOrigin.GROUP;
+          principal: DirectAccessGroupPrincipal;
+          directRole: SpaceMemberRole;
+          /** A group's member-effective roles vary; this is the group's direct contribution. */
+          effectiveRole: SpaceMemberRole;
+      };
+
+export type DirectAccessListFilters = {
+    searchQuery?: string;
+};
+
+export type DirectAccessList = KnexPaginatedData<DirectAccessGrant[]>;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1250

## Summary

PR 5 of 5 adds the shared six-operation resource-access contract and its dashboard handler. It accepts the existing `SessionUser` directly and does not expose routes; the shared public route family remains in the API stack.

Stacks on [#28021](https://github.com/lightdash/lightdash/pull/28021), which secures dashboard export and delivery paths.

## Access-management path

```
SessionUser + resource UUID -> feature gate -> strict dashboard lookup -> admin guard
                                                                  ├─> paginated user/group list
                                                                  └─> replace / revoke / reset
```

## Scope

- Lists searchable, paginated user and group grants without expanding groups into users.
- Reports direct and highest additive policy roles; capability scopes remain independently enforced.
- Bounds inherited and group-role resolution to users on the requested page.
- Delegates replace, revoke, reset, and role-delegation checks to the shared direct-access service.
- Normalizes invalid UUIDs, inaccessible dashboards, and project mismatches.
- Adds no controller conversion, RegisteredAccount handler, `*FromAccount` method, route, or OpenAPI change.

## Test plan

- [x] Common and backend typecheck
- [x] Common and backend lint
- [x] 111 focused unit tests
- [x] 20 PostgreSQL direct-access integration tests for the unchanged persistence diff
- [x] Five-lens correctness, scope, tenant-safety, architecture, and test review

## Credit

Thanks @hrx-joseph-fahnestock for the initial direct-access exploration in [houserx/lightdash-hrx#25](https://github.com/houserx/lightdash-hrx/pull/25), which informed this stack.