### PR TITLE
fix: gate custom chart type screenshot-ready on iframe announce + viz context

### DIFF
--- a/packages/frontend/src/components/DataAppVizRenderer/constants.ts
+++ b/packages/frontend/src/components/DataAppVizRenderer/constants.ts
@@ -1,0 +1,3 @@
+// Mirrors MinimalApp's SDK-alive fallback: a stale app bundle that never
+// announces must not hang an entire dashboard delivery.
+export const SCREENSHOT_READY_FALLBACK_MS = 8_000;

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -1,5 +1,5 @@
 import { MantineProvider } from '@mantine/core';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mirrors the real hook's failSilently contract: TrackingContextType | undefined.
@@ -139,6 +139,7 @@ vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
     }),
 }));
 
+import { SCREENSHOT_READY_FALLBACK_MS } from './constants';
 import DataAppVizRenderer from './index';
 
 function apiError(statusCode: number) {
@@ -153,10 +154,10 @@ function apiError(statusCode: number) {
     };
 }
 
-const renderRenderer = () =>
+const renderRenderer = (props?: Parameters<typeof DataAppVizRenderer>[0]) =>
     render(
         <MantineProvider env="test">
-            <DataAppVizRenderer />
+            <DataAppVizRenderer {...props} />
         </MantineProvider>,
     );
 
@@ -384,6 +385,155 @@ describe('DataAppVizRenderer', () => {
                 savedChartUuid: 'saved-chart-uuid',
             },
         );
+    });
+});
+
+describe('DataAppVizRenderer screenshot-ready contract', () => {
+    const lastIframeProps = () =>
+        (
+            mocks.iframePreview.mock.calls.at(-1) as unknown[] | undefined
+        )?.[0] as {
+            onScreenshotAvailabilityChange?: (available: boolean) => void;
+        };
+
+    const announceScreenshotAvailable = () => {
+        act(() => {
+            lastIframeProps().onScreenshotAvailabilityChange?.(true);
+        });
+    };
+
+    beforeEach(() => {
+        mocks.metadata.current = readyMetadata();
+        mocks.metadataError.current = undefined;
+        mocks.token.current = 'preview-token';
+        mocks.tokenError.current = undefined;
+        mocks.embedToken.current = undefined;
+        mocks.dataAppVizUuid.current = 'viz-uuid';
+        mocks.iframePreview.mockClear();
+        mocks.canViewUnderlyingData.current = true;
+        mocks.explore.current = undefined;
+        mocks.vizContextOverrides.current = {};
+        mocks.trackingContext.current = { track: mocks.track };
+    });
+
+    it('does not signal ready on mount, and signals once the iframe announces with context delivered', () => {
+        const onScreenshotReady = vi.fn();
+
+        renderRenderer({ onScreenshotReady });
+
+        expect(onScreenshotReady).not.toHaveBeenCalled();
+
+        announceScreenshotAvailable();
+
+        expect(onScreenshotReady).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not signal on announce while the viz context is missing, then signals once it arrives', () => {
+        const onScreenshotReady = vi.fn();
+        mocks.vizContextOverrides.current = {
+            resultsData: { rows: undefined, setFetchAll: mocks.setFetchAll },
+        };
+
+        const view = renderRenderer({ onScreenshotReady });
+        announceScreenshotAvailable();
+
+        expect(onScreenshotReady).not.toHaveBeenCalled();
+
+        mocks.vizContextOverrides.current = {};
+        view.rerender(
+            <MantineProvider env="test">
+                <DataAppVizRenderer onScreenshotReady={onScreenshotReady} />
+            </MantineProvider>,
+        );
+
+        expect(onScreenshotReady).toHaveBeenCalledTimes(1);
+    });
+
+    it('signals after the fallback timeout when the sandbox never announces', () => {
+        vi.useFakeTimers();
+        try {
+            const onScreenshotReady = vi.fn();
+
+            renderRenderer({ onScreenshotReady });
+
+            act(() => {
+                vi.advanceTimersByTime(SCREENSHOT_READY_FALLBACK_MS - 1);
+            });
+            expect(onScreenshotReady).not.toHaveBeenCalled();
+
+            act(() => {
+                vi.advanceTimersByTime(1);
+            });
+            expect(onScreenshotReady).toHaveBeenCalledTimes(1);
+
+            // A late announce must not fire the callback a second time.
+            announceScreenshotAvailable();
+            expect(onScreenshotReady).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    // Terminal placeholders render synchronously and never mount the iframe —
+    // waiting on the announce (or the 8s fallback) would stall the delivery
+    // for tiles whose final frame is already painted.
+    it.each([
+        [
+            'no viz selected',
+            () => {
+                mocks.dataAppVizUuid.current = undefined;
+            },
+        ],
+        [
+            'metadata failed state',
+            () => {
+                mocks.metadata.current = {
+                    state: 'failed',
+                    latestBuildInProgress: false,
+                };
+            },
+        ],
+        [
+            'metadata building state',
+            () => {
+                mocks.metadata.current = {
+                    state: 'building',
+                    latestBuildInProgress: true,
+                };
+            },
+        ],
+        [
+            'metadata unavailable state',
+            () => {
+                mocks.metadata.current = {
+                    state: 'unavailable',
+                    latestBuildInProgress: false,
+                };
+            },
+        ],
+        [
+            'terminal 403 on metadata',
+            () => {
+                mocks.metadata.current = undefined;
+                mocks.metadataError.current = apiError(403);
+            },
+        ],
+    ])('%s: signals ready for the placeholder frame', (_label, arrange) => {
+        const onScreenshotReady = vi.fn();
+        arrange();
+
+        renderRenderer({ onScreenshotReady });
+
+        expect(onScreenshotReady).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not treat a pending metadata fetch as a terminal placeholder', () => {
+        const onScreenshotReady = vi.fn();
+        mocks.metadata.current = undefined;
+
+        renderRenderer({ onScreenshotReady });
+
+        expect(onScreenshotReady).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -474,14 +474,39 @@ describe('DataAppVizRenderer screenshot-ready contract', () => {
         }
     });
 
-    // Terminal placeholders render synchronously and never mount the iframe —
-    // waiting on the announce (or the 8s fallback) would stall the delivery
-    // for tiles whose final frame is already painted.
+    it('re-renders with a new callback identity do not reset the fallback timeout', () => {
+        vi.useFakeTimers();
+        try {
+            const first = vi.fn();
+            const view = renderRenderer({ onScreenshotReady: first });
+
+            act(() => {
+                vi.advanceTimersByTime(SCREENSHOT_READY_FALLBACK_MS - 1000);
+            });
+            const second = vi.fn();
+            view.rerender(
+                <MantineProvider env="test">
+                    <DataAppVizRenderer onScreenshotReady={second} />
+                </MantineProvider>,
+            );
+            act(() => {
+                vi.advanceTimersByTime(1000);
+            });
+
+            expect(second).toHaveBeenCalledTimes(1);
+            expect(first).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    // Terminal placeholders never mount the iframe — waiting on the announce
+    // or the fallback would stall delivery for an already-final frame.
     it.each([
         [
             'no viz selected',
             () => {
-                mocks.dataAppVizUuid.current = undefined;
+                mocks.dataAppVizUuid.current = null;
             },
         ],
         [

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -89,11 +89,15 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     // screenshot/export/unfurl renders simply skip the drill-by event.
     const trackingContext = useTracking({ failSilently: true });
     const hasSignaledScreenshotReady = useRef(false);
+    // Latest callback in a ref so the signal helper stays identity-stable —
+    // the fallback timer must arm once, not reset on parent re-renders.
+    const onScreenshotReadyRef = useRef(onScreenshotReady);
+    onScreenshotReadyRef.current = onScreenshotReady;
     const signalScreenshotReady = useCallback(() => {
         if (hasSignaledScreenshotReady.current) return;
         hasSignaledScreenshotReady.current = true;
-        onScreenshotReady?.();
-    }, [onScreenshotReady]);
+        onScreenshotReadyRef.current?.();
+    }, []);
 
     // The iframe SDK posts `lightdash:sdk:screenshot-available` at bundle
     // boot — proof the sandbox is alive, not that the viz painted.
@@ -308,16 +312,13 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     ]);
 
     // Ready only once the sandbox has booted AND the viz context has been
-    // handed to the bridge — the closest renderer-side proxy for "the viz has
-    // what it needs to paint". The context push itself runs in the child's
-    // effect, which commits before this one.
+    // handed to the bridge (whose push effect commits before this one).
     useEffect(() => {
         if (screenshotAnnounced && dataAppVizContext) signalScreenshotReady();
     }, [screenshotAnnounced, dataAppVizContext, signalScreenshotReady]);
 
-    // Terminal placeholders render synchronously and never mount the iframe —
-    // their placeholder frame IS the final frame, so report it ready now
-    // instead of stalling the delivery until the fallback timeout.
+    // Terminal placeholders never mount the iframe — their frame is final,
+    // so report ready now instead of stalling until the fallback timeout.
     const terminalRequestErrorMessage = getTerminalRequestErrorMessage([
         renderMetadataError,
         getVisiblePreviewTokenError(previewTokenError, !!token),
@@ -333,14 +334,15 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         if (isTerminalPlaceholder) signalScreenshotReady();
     }, [isTerminalPlaceholder, signalScreenshotReady]);
 
+    // Armed once on mount — capture surfaces pass the callback from mount.
     useEffect(() => {
-        if (!onScreenshotReady) return;
+        if (!onScreenshotReadyRef.current) return;
         const timer = setTimeout(
             signalScreenshotReady,
             SCREENSHOT_READY_FALLBACK_MS,
         );
         return () => clearTimeout(timer);
-    }, [onScreenshotReady, signalScreenshotReady]);
+    }, [signalScreenshotReady]);
 
     if (!projectUuid || dataAppVizUuid === null) {
         return (

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -6,7 +6,14 @@ import {
 } from '@lightdash/common';
 import { Stack, Text } from '@mantine/core';
 import { IconPuzzle } from '@tabler/icons-react';
-import { useEffect, useMemo, useRef, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import useEmbed from '../../ee/providers/Embed/useEmbed';
 import AppIframePreview from '../../features/apps/AppIframePreview';
 import { useChartVersionPreview } from '../../features/apps/ChartVersionPreview/useChartVersionPreview';
@@ -28,6 +35,7 @@ import MantineIcon from '../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 import { useMetricQueryDataContext } from '../MetricQueryData/useMetricQueryDataContext';
+import { SCREENSHOT_READY_FALLBACK_MS } from './constants';
 import { resolveVizDrillDownConfig } from './vizDrillDownConfig';
 import { buildVizUnderlyingDataRequest } from './vizUnderlyingDataRequest';
 
@@ -81,14 +89,21 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     // screenshot/export/unfurl renders simply skip the drill-by event.
     const trackingContext = useTracking({ failSilently: true });
     const hasSignaledScreenshotReady = useRef(false);
-
-    // Signal screenshot readiness on mount so dashboard capture isn't blocked
-    // waiting on the sandboxed iframe (which runs its own async query).
-    useEffect(() => {
+    const signalScreenshotReady = useCallback(() => {
         if (hasSignaledScreenshotReady.current) return;
-        onScreenshotReady?.();
         hasSignaledScreenshotReady.current = true;
+        onScreenshotReady?.();
     }, [onScreenshotReady]);
+
+    // The iframe SDK posts `lightdash:sdk:screenshot-available` at bundle
+    // boot — proof the sandbox is alive, not that the viz painted.
+    const [screenshotAnnounced, setScreenshotAnnounced] = useState(false);
+    const handleScreenshotAvailabilityChange = useCallback(
+        (available: boolean) => {
+            if (available) setScreenshotAnnounced(true);
+        },
+        [],
+    );
 
     // Fetch every page so the renderer gets all rows — surfaces that don't
     // auto-fetch (dashboard tiles) would otherwise push a partial result.
@@ -292,16 +307,47 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         drillDownEnabled,
     ]);
 
+    // Ready only once the sandbox has booted AND the viz context has been
+    // handed to the bridge — the closest renderer-side proxy for "the viz has
+    // what it needs to paint". The context push itself runs in the child's
+    // effect, which commits before this one.
+    useEffect(() => {
+        if (screenshotAnnounced && dataAppVizContext) signalScreenshotReady();
+    }, [screenshotAnnounced, dataAppVizContext, signalScreenshotReady]);
+
+    // Terminal placeholders render synchronously and never mount the iframe —
+    // their placeholder frame IS the final frame, so report it ready now
+    // instead of stalling the delivery until the fallback timeout.
+    const terminalRequestErrorMessage = getTerminalRequestErrorMessage([
+        renderMetadataError,
+        getVisiblePreviewTokenError(previewTokenError, !!token),
+    ]);
+    const isTerminalPlaceholder =
+        !projectUuid ||
+        dataAppVizUuid === null ||
+        !!terminalRequestErrorMessage ||
+        renderMetadata?.state === 'building' ||
+        renderMetadata?.state === 'unavailable' ||
+        renderMetadata?.state === 'failed';
+    useEffect(() => {
+        if (isTerminalPlaceholder) signalScreenshotReady();
+    }, [isTerminalPlaceholder, signalScreenshotReady]);
+
+    useEffect(() => {
+        if (!onScreenshotReady) return;
+        const timer = setTimeout(
+            signalScreenshotReady,
+            SCREENSHOT_READY_FALLBACK_MS,
+        );
+        return () => clearTimeout(timer);
+    }, [onScreenshotReady, signalScreenshotReady]);
+
     if (!projectUuid || dataAppVizUuid === null) {
         return (
             <DataAppVizPlaceholder message="Pick a custom chart type to render." />
         );
     }
 
-    const terminalRequestErrorMessage = getTerminalRequestErrorMessage([
-        renderMetadataError,
-        getVisiblePreviewTokenError(previewTokenError, !!token),
-    ]);
     if (terminalRequestErrorMessage) {
         return <DataAppVizPlaceholder message={terminalRequestErrorMessage} />;
     }
@@ -359,6 +405,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
             appUuid={dataAppVizUuid}
             identityKey={dataAppVizUuid}
             dataAppVizContext={dataAppVizContext}
+            onScreenshotAvailabilityChange={handleScreenshotAvailabilityChange}
             rewriteVizUnderlyingDataRequest={rewriteVizUnderlyingDataRequest}
             onVizDrillDownIntent={onVizDrillDownIntent}
         />


### PR DESCRIPTION
## Problem

The custom chart type renderer signalled screenshot-readiness on mount, unconditionally — before the sandboxed app iframe loaded or painted anything. Any headless capture of content with a `DATA_APP_VIZ` tile (scheduled deliveries of dashboards today) screenshotted before the viz painted, shipping blank or half-loaded tiles. Also a prerequisite for rendering agent custom-chart answers as images in Slack, which needs a truthful fail-closed ready signal.

## Fix

`DataAppVizRenderer` now fires `onScreenshotReady` (once, latched) only when:

- the iframe has announced screenshot availability over the app SDK bridge (`lightdash:sdk:screenshot-available`), **and** the viz context (field mapping, rows, options, pivot details) has been handed to the bridge; or
- a terminal placeholder renders (no viz selected, 403/404, building/unavailable/failed) — that frame is final, no point waiting; or
- an 8s fallback elapses (mirrors MinimalApp's SDK-alive fallback) so a stale bundle that never announces can't hang a whole dashboard delivery. The timer arms once on mount; the callback is held in a ref so unstable parent callbacks can't reset it.

No change to whole-app delivery readiness (MinimalApp keeps its own logic).

## Testing

- Behavioral unit tests at the renderer's ready-signal contract: not-ready on mount, announce without context, context without announce, ready after both, ready after timeout, once-only, timer not reset by re-renders, terminal placeholders, pending metadata ≠ terminal.
- Verified end-to-end locally: a real dashboard image export waited for the ready indicator and captured a fully painted custom chart tile.

Closes ZAP-935
