### PR TITLE
feat(frontend): propose drifted content to git from the sync panel

### DIFF
--- a/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeWriteBackStatus.test.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeWriteBackStatus.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+vi.mock('../../../api', () => ({
+    lightdashApi: vi.fn(), // pragma: allowlist secret
+}));
+
+import { lightdashApi as api } from '../../../api'; // pragma: allowlist secret
+import { getContentAsCodeWriteBackStatus } from './getContentAsCodeWriteBackStatus';
+
+const mockApi = api as unknown as Mock;
+
+const writeBackStatus = {
+    contentType: 'chart',
+    slug: 'orders',
+    syncEnabled: true,
+    writeBackEnabled: true,
+    state: 'ahead',
+    writeBack: {
+        prState: 'none',
+        prUrl: null,
+        prTitle: null,
+    },
+};
+
+describe('getContentAsCodeWriteBackStatus', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns write-back status when the endpoint succeeds', async () => {
+        mockApi.mockResolvedValueOnce(writeBackStatus);
+
+        await expect(
+            getContentAsCodeWriteBackStatus('project-uuid', 'chart', 'orders'),
+        ).resolves.toEqual({ kind: 'ok', status: writeBackStatus });
+        expect(mockApi).toHaveBeenCalledWith({
+            url: '/projects/project-uuid/code/write-back-status?contentType=chart&slug=orders',
+            method: 'GET',
+            body: undefined,
+        });
+    });
+
+    it('returns unavailable when the endpoint is not deployed yet', async () => {
+        mockApi.mockRejectedValueOnce({
+            status: 'error',
+            error: {
+                name: 'NotFoundError',
+                statusCode: 404,
+                message: 'Not found',
+                data: {},
+            },
+        });
+
+        await expect(
+            getContentAsCodeWriteBackStatus('project-uuid', 'chart', 'orders'),
+        ).resolves.toEqual({ kind: 'unavailable' });
+    });
+});

--- a/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeWriteBackStatus.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/api/getContentAsCodeWriteBackStatus.ts
@@ -1,0 +1,32 @@
+import { type AnyType } from '@lightdash/common'; // pragma: allowlist secret
+import { lightdashApi as api } from '../../../api'; // pragma: allowlist secret
+import {
+    type ContentAsCodeSyncContentType,
+    type ContentAsCodeWriteBackStatus,
+    type ContentAsCodeWriteBackStatusResult,
+} from '../types';
+import { isMissingSyncStatus } from './isMissingSyncStatus';
+
+export const getContentAsCodeWriteBackStatus = async (
+    projectUuid: string,
+    contentType: ContentAsCodeSyncContentType,
+    slug: string,
+): Promise<ContentAsCodeWriteBackStatusResult> => {
+    try {
+        const status = (await api<AnyType>({
+            url: `/projects/${projectUuid}/code/write-back-status?${new URLSearchParams(
+                { contentType, slug },
+            ).toString()}`,
+            method: 'GET',
+            body: undefined,
+        })) as ContentAsCodeWriteBackStatus;
+
+        return { kind: 'ok', status };
+    } catch (error) {
+        if (isMissingSyncStatus(error)) {
+            return { kind: 'unavailable' };
+        }
+
+        throw error;
+    }
+};

--- a/packages/frontend/src/features/contentAsCodeSync/api/proposeContentAsCode.test.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/api/proposeContentAsCode.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+vi.mock('../../../api', () => ({
+    lightdashApi: vi.fn(), // pragma: allowlist secret
+}));
+
+import { lightdashApi as api } from '../../../api'; // pragma: allowlist secret
+import { proposeContentAsCode } from './proposeContentAsCode';
+
+const mockApi = api as unknown as Mock;
+
+describe('proposeContentAsCode', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('posts the slug to the propose endpoint', async () => {
+        mockApi.mockResolvedValueOnce({
+            prUrl: 'https://example.com/pull/2',
+            prTitle: 'Add chart `orders`',
+            filesWritten: ['charts/orders.yml'],
+            notedChartSlugs: [],
+        });
+
+        await expect(
+            proposeContentAsCode('project-uuid', 'chart', 'orders'),
+        ).resolves.toEqual({
+            prUrl: 'https://example.com/pull/2',
+            prTitle: 'Add chart `orders`',
+            filesWritten: ['charts/orders.yml'],
+            notedChartSlugs: [],
+        });
+        expect(mockApi).toHaveBeenCalledWith({
+            url: '/projects/project-uuid/code/propose',
+            method: 'POST',
+            body: JSON.stringify({ contentType: 'chart', slug: 'orders' }),
+        });
+    });
+});

--- a/packages/frontend/src/features/contentAsCodeSync/api/proposeContentAsCode.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/api/proposeContentAsCode.ts
@@ -1,0 +1,17 @@
+import { type AnyType } from '@lightdash/common'; // pragma: allowlist secret
+import { lightdashApi as api } from '../../../api'; // pragma: allowlist secret
+import {
+    type ContentAsCodeProposeResult,
+    type ContentAsCodeSyncContentType,
+} from '../types';
+
+export const proposeContentAsCode = async (
+    projectUuid: string,
+    contentType: ContentAsCodeSyncContentType,
+    slug: string,
+): Promise<ContentAsCodeProposeResult> =>
+    (await api<AnyType>({
+        url: `/projects/${projectUuid}/code/propose`,
+        method: 'POST',
+        body: JSON.stringify({ contentType, slug }),
+    })) as ContentAsCodeProposeResult;

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncItemRow.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncItemRow.tsx
@@ -19,15 +19,21 @@ import {
 } from '../utils/contentAsCodeSyncState';
 import { getContentAsCodeTypeLabel } from '../utils/contentAsCodeTypeLabel';
 import { toDate } from '../utils/toDate';
+import ContentAsCodeSyncProposeActions from './ContentAsCodeSyncProposeActions';
 import classes from './ContentAsCodeSyncStatusPanel.module.css';
 
 type ContentAsCodeSyncItemRowProps = {
+    projectUuid: string;
     item: ContentAsCodeSyncItem;
     canRestamp: boolean;
+    canPropose: boolean;
     isRestamping: boolean;
+    isProposing: boolean;
     isRestampAvailable: boolean;
+    isProposeAvailable: boolean;
     onViewDiff: () => void;
     onRestamp: () => void;
+    onPropose: () => void;
 };
 
 const AppliedTime: FC<{ value: Date | string }> = ({ value }) => {
@@ -64,12 +70,17 @@ const restampDisabledReason = ({
 };
 
 const ContentAsCodeSyncItemRow: FC<ContentAsCodeSyncItemRowProps> = ({
+    projectUuid,
     item,
     canRestamp,
+    canPropose,
     isRestamping,
+    isProposing,
     isRestampAvailable,
+    isProposeAvailable,
     onViewDiff,
     onRestamp,
+    onPropose,
 }) => {
     const stateBadge = CONTENT_AS_CODE_SYNC_STATE_BADGE[item.state];
     const canShowRestamp = canRestamp;
@@ -120,7 +131,15 @@ const ContentAsCodeSyncItemRow: FC<ContentAsCodeSyncItemRowProps> = ({
                             View diff
                         </Button>
                     ) : null}
-                    {/* Write-back later adds "Propose to git" here. */}
+                    {canPropose ? (
+                        <ContentAsCodeSyncProposeActions
+                            projectUuid={projectUuid}
+                            item={item}
+                            isProposeAvailable={isProposeAvailable}
+                            isProposing={isProposing}
+                            onPropose={onPropose}
+                        />
+                    ) : null}
                     {canShowRestamp ? (
                         <Tooltip
                             label={disabledReason}

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncProposeActions.test.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncProposeActions.test.tsx
@@ -1,0 +1,135 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import ContentAsCodeSyncProposeActions from './ContentAsCodeSyncProposeActions';
+
+const useContentAsCodeWriteBackStatus = vi.hoisted(() => vi.fn());
+
+vi.mock('../hooks/useContentAsCodeWriteBackStatus', () => ({
+    useContentAsCodeWriteBackStatus,
+}));
+
+const aheadItem = {
+    contentType: 'dashboard' as const,
+    slug: 'revenue',
+    state: 'ahead' as const,
+    appliedAt: new Date('2026-08-24T15:30:00.000Z'),
+    contentHash: 'fff0001112223334',
+    snapshot: { name: 'old revenue' },
+    current: { name: 'new revenue' },
+};
+
+describe('ContentAsCodeSyncProposeActions', () => {
+    it('shows propose when there is no open write-back PR', () => {
+        useContentAsCodeWriteBackStatus.mockReturnValue({
+            data: {
+                kind: 'ok',
+                status: {
+                    contentType: 'dashboard',
+                    slug: 'revenue',
+                    syncEnabled: true,
+                    writeBackEnabled: true,
+                    state: 'ahead',
+                    writeBack: {
+                        prState: 'none',
+                        prUrl: null,
+                        prTitle: null,
+                    },
+                },
+            },
+            isInitialLoading: false,
+        });
+
+        renderWithProviders(
+            <ContentAsCodeSyncProposeActions
+                projectUuid="project-uuid"
+                item={aheadItem}
+                isProposeAvailable
+                isProposing={false}
+                onPropose={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getByRole('button', { name: 'Propose to git' }),
+        ).toBeVisible();
+    });
+
+    it('shows a merged write-back PR instead of propose', () => {
+        useContentAsCodeWriteBackStatus.mockReturnValue({
+            data: {
+                kind: 'ok',
+                status: {
+                    contentType: 'dashboard',
+                    slug: 'revenue',
+                    syncEnabled: true,
+                    writeBackEnabled: true,
+                    state: 'ahead',
+                    writeBack: {
+                        prState: 'merged',
+                        prUrl: 'https://example.com/pull/9',
+                        prTitle: 'Update dashboard `revenue`',
+                    },
+                },
+            },
+            isInitialLoading: false,
+        });
+
+        renderWithProviders(
+            <ContentAsCodeSyncProposeActions
+                projectUuid="project-uuid"
+                item={aheadItem}
+                isProposeAvailable
+                isProposing={false}
+                onPropose={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getByRole('button', {
+                name: 'Merged, applies on the next deploy',
+            }),
+        ).toBeDisabled();
+        expect(
+            screen.queryByRole('button', { name: 'Propose to git' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('links to an open write-back PR', () => {
+        useContentAsCodeWriteBackStatus.mockReturnValue({
+            data: {
+                kind: 'ok',
+                status: {
+                    contentType: 'dashboard',
+                    slug: 'revenue',
+                    syncEnabled: true,
+                    writeBackEnabled: true,
+                    state: 'ahead',
+                    writeBack: {
+                        prState: 'open',
+                        prUrl: 'https://example.com/pull/4',
+                        prTitle: 'Update dashboard `revenue`',
+                    },
+                },
+            },
+            isInitialLoading: false,
+        });
+
+        renderWithProviders(
+            <ContentAsCodeSyncProposeActions
+                projectUuid="project-uuid"
+                item={aheadItem}
+                isProposeAvailable
+                isProposing={false}
+                onPropose={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getByRole('link', { name: 'Open pull request' }),
+        ).toHaveAttribute('href', 'https://example.com/pull/4');
+        expect(
+            screen.getByRole('button', { name: 'Propose to git' }),
+        ).toBeVisible();
+    });
+});

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncProposeActions.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncProposeActions.tsx
@@ -1,0 +1,91 @@
+import { Box, Button, Tooltip } from '@mantine/core';
+import { type FC } from 'react';
+import { useContentAsCodeWriteBackStatus } from '../hooks/useContentAsCodeWriteBackStatus';
+import { type ContentAsCodeSyncItem } from '../types';
+import { canProposeContentAsCodeSyncItem } from '../utils/contentAsCodeSyncState';
+
+type ContentAsCodeSyncProposeActionsProps = {
+    projectUuid: string;
+    item: ContentAsCodeSyncItem;
+    isProposeAvailable: boolean;
+    isProposing: boolean;
+    onPropose: () => void;
+};
+
+const proposeLabel = (state: ContentAsCodeSyncItem['state']): string =>
+    state === 'ui_only' ? 'Add to git' : 'Propose to git';
+
+const ContentAsCodeSyncProposeActions: FC<
+    ContentAsCodeSyncProposeActionsProps
+> = ({ projectUuid, item, isProposeAvailable, isProposing, onPropose }) => {
+    const canProposeNow = canProposeContentAsCodeSyncItem(item.state);
+    const statusQuery = useContentAsCodeWriteBackStatus(
+        projectUuid,
+        item.contentType,
+        item.slug,
+        canProposeNow,
+    );
+
+    if (!canProposeNow) {
+        return null;
+    }
+
+    if (statusQuery.isInitialLoading) {
+        return null;
+    }
+
+    const result = statusQuery.data;
+    if (!result || result.kind === 'unavailable') {
+        return null;
+    }
+
+    const { status } = result;
+    if (status.state === 'unavailable' || !status.writeBackEnabled) {
+        return null;
+    }
+
+    if (status.writeBack.prState === 'merged') {
+        return (
+            <Button variant="default" size="xs" disabled>
+                Merged, applies on the next deploy
+            </Button>
+        );
+    }
+
+    const proposeDisabled = !isProposeAvailable;
+    const disabledReason = isProposeAvailable
+        ? null
+        : 'The API is not available yet.';
+
+    return (
+        <>
+            {status.writeBack.prState === 'open' && status.writeBack.prUrl ? (
+                <Button
+                    variant="default"
+                    size="xs"
+                    component="a"
+                    href={status.writeBack.prUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Open pull request
+                </Button>
+            ) : null}
+            <Tooltip label={disabledReason} disabled={!disabledReason}>
+                <Box>
+                    <Button
+                        variant="default"
+                        size="xs"
+                        disabled={proposeDisabled}
+                        loading={isProposing}
+                        onClick={onPropose}
+                    >
+                        {proposeLabel(item.state)}
+                    </Button>
+                </Box>
+            </Tooltip>
+        </>
+    );
+};
+
+export default ContentAsCodeSyncProposeActions;

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.test.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.test.tsx
@@ -1,10 +1,12 @@
 import { screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import ContentAsCodeSyncStatusPanel from './ContentAsCodeSyncStatusPanel';
 
 const useContentAsCodeSyncStatus = vi.hoisted(() => vi.fn());
 const useRestampContentAsCodeRevision = vi.hoisted(() => vi.fn());
+const useProposeContentAsCode = vi.hoisted(() => vi.fn());
+const useContentAsCodeWriteBackStatus = vi.hoisted(() => vi.fn());
 
 vi.mock('../hooks/useContentAsCodeSyncStatus', () => ({
     useContentAsCodeSyncStatus,
@@ -14,12 +16,47 @@ vi.mock('../hooks/useRestampContentAsCodeRevision', () => ({
     useRestampContentAsCodeRevision,
 }));
 
+vi.mock('../hooks/useProposeContentAsCode', () => ({
+    useProposeContentAsCode,
+}));
+
+vi.mock('../hooks/useContentAsCodeWriteBackStatus', () => ({
+    useContentAsCodeWriteBackStatus,
+}));
+
 const restampMock = {
     mutate: vi.fn(),
     isLoading: false,
     isError: false,
     error: null,
     variables: undefined,
+};
+
+const proposeMock = {
+    mutate: vi.fn(),
+    isLoading: false,
+    isError: false,
+    error: null,
+    variables: undefined,
+};
+
+const noneWriteBackStatus = {
+    data: {
+        kind: 'ok' as const,
+        status: {
+            contentType: 'chart' as const,
+            slug: 'orders',
+            syncEnabled: true,
+            writeBackEnabled: true,
+            state: 'ahead' as const,
+            writeBack: {
+                prState: 'none' as const,
+                prUrl: null,
+                prTitle: null,
+            },
+        },
+    },
+    isInitialLoading: false,
 };
 
 const populatedItems = {
@@ -68,6 +105,11 @@ const createAbility = {
 };
 
 describe('ContentAsCodeSyncStatusPanel', () => {
+    beforeEach(() => {
+        useProposeContentAsCode.mockReturnValue(proposeMock);
+        useContentAsCodeWriteBackStatus.mockReturnValue(noneWriteBackStatus);
+    });
+
     it('shows a not-available state when the API is missing', () => {
         useContentAsCodeSyncStatus.mockReturnValue({
             data: { kind: 'unavailable' },
@@ -143,6 +185,12 @@ describe('ContentAsCodeSyncStatusPanel', () => {
         expect(restampButtons[0]).toBeDisabled();
         expect(restampButtons[1]).toBeEnabled();
         expect(restampButtons[2]).toBeEnabled();
+        expect(
+            screen.getByRole('button', { name: 'Propose to git' }),
+        ).toBeVisible();
+        expect(
+            screen.getByRole('button', { name: 'Add to git' }),
+        ).toBeVisible();
     });
 
     it('hides restamp when the user cannot create content as code', async () => {
@@ -165,6 +213,12 @@ describe('ContentAsCodeSyncStatusPanel', () => {
             screen.queryByRole('button', {
                 name: 'Use git version on next deploy',
             }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Propose to git' }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Add to git' }),
         ).not.toBeInTheDocument();
     });
 
@@ -227,5 +281,31 @@ describe('ContentAsCodeSyncStatusPanel', () => {
         expect(restampButtons[0]).toBeDisabled();
         expect(restampButtons[1]).toBeDisabled();
         expect(restampButtons[2]).toBeDisabled();
+    });
+
+    it('hides propose when the write-back API is not deployed yet', () => {
+        useContentAsCodeSyncStatus.mockReturnValue({
+            data: populatedItems,
+            isInitialLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        });
+        useRestampContentAsCodeRevision.mockReturnValue(restampMock);
+        useContentAsCodeWriteBackStatus.mockReturnValue({
+            data: { kind: 'unavailable' },
+            isInitialLoading: false,
+        });
+
+        renderWithProviders(
+            <ContentAsCodeSyncStatusPanel projectUuid="project-uuid" />,
+            createAbility,
+        );
+
+        expect(
+            screen.queryByRole('button', { name: 'Propose to git' }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Add to git' }),
+        ).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.tsx
+++ b/packages/frontend/src/features/contentAsCodeSync/components/ContentAsCodeSyncStatusPanel.tsx
@@ -9,6 +9,7 @@ import { SettingsEmptyState } from '../../../components/common/Settings/Settings
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import useApp from '../../../providers/App/useApp';
 import { useContentAsCodeSyncStatus } from '../hooks/useContentAsCodeSyncStatus';
+import { useProposeContentAsCode } from '../hooks/useProposeContentAsCode';
 import { useRestampContentAsCodeRevision } from '../hooks/useRestampContentAsCodeRevision';
 import { type ContentAsCodeSyncItem } from '../types';
 import { toDate } from '../utils/toDate';
@@ -37,11 +38,12 @@ const ContentAsCodeSyncStatusPanel: FC<ContentAsCodeSyncStatusPanelProps> = ({
     const { data, isInitialLoading, isError, refetch } =
         useContentAsCodeSyncStatus(projectUuid);
     const restampMutation = useRestampContentAsCodeRevision(projectUuid);
+    const proposeMutation = useProposeContentAsCode(projectUuid);
     const [diffItem, setDiffItem] = useState<ContentAsCodeSyncItem | null>(
         null,
     );
 
-    const canRestamp =
+    const canManageGit =
         user.data?.ability.can(
             'create',
             subject('ContentAsCode', {
@@ -49,6 +51,8 @@ const ContentAsCodeSyncStatusPanel: FC<ContentAsCodeSyncStatusPanelProps> = ({
                 projectUuid,
             }),
         ) ?? false;
+    const canRestamp = canManageGit;
+    const canPropose = canManageGit;
 
     const isRestampAvailable =
         data?.kind === 'ok' &&
@@ -56,6 +60,10 @@ const ContentAsCodeSyncStatusPanel: FC<ContentAsCodeSyncStatusPanelProps> = ({
             restampMutation.isError &&
             restampMutation.error.error.statusCode === 404
         );
+    const isProposeAvailable = !(
+        proposeMutation.isError &&
+        proposeMutation.error.error.statusCode === 404
+    );
 
     if (isInitialLoading) {
         return <EmptyStateLoader title="Loading sync status" />;
@@ -97,6 +105,9 @@ const ContentAsCodeSyncStatusPanel: FC<ContentAsCodeSyncStatusPanelProps> = ({
     const restampingKey = restampMutation.isLoading
         ? `${restampMutation.variables?.contentType}:${restampMutation.variables?.slug}`
         : null;
+    const proposingKey = proposeMutation.isLoading
+        ? `${proposeMutation.variables?.contentType}:${proposeMutation.variables?.slug}`
+        : null;
 
     return (
         <Stack gap="md">
@@ -111,17 +122,29 @@ const ContentAsCodeSyncStatusPanel: FC<ContentAsCodeSyncStatusPanelProps> = ({
                 {status.items.map((item) => (
                     <ContentAsCodeSyncItemRow
                         key={`${item.contentType}:${item.slug}`}
+                        projectUuid={projectUuid}
                         item={item}
                         canRestamp={canRestamp}
+                        canPropose={canPropose}
                         isRestampAvailable={isRestampAvailable}
+                        isProposeAvailable={isProposeAvailable}
                         isRestamping={
                             restampingKey === `${item.contentType}:${item.slug}`
+                        }
+                        isProposing={
+                            proposingKey === `${item.contentType}:${item.slug}`
                         }
                         onViewDiff={() => {
                             setDiffItem(item);
                         }}
                         onRestamp={() => {
                             restampMutation.mutate({
+                                contentType: item.contentType,
+                                slug: item.slug,
+                            });
+                        }}
+                        onPropose={() => {
+                            proposeMutation.mutate({
                                 contentType: item.contentType,
                                 slug: item.slug,
                             });

--- a/packages/frontend/src/features/contentAsCodeSync/hooks/useContentAsCodeWriteBackStatus.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/hooks/useContentAsCodeWriteBackStatus.ts
@@ -1,0 +1,26 @@
+import { type ApiError } from '@lightdash/common'; // pragma: allowlist secret
+import { useQuery } from '@tanstack/react-query';
+import { getContentAsCodeWriteBackStatus } from '../api/getContentAsCodeWriteBackStatus';
+import {
+    CONTENT_AS_CODE_WRITE_BACK_STATUS_QUERY_KEY,
+    type ContentAsCodeSyncContentType,
+    type ContentAsCodeWriteBackStatusResult,
+} from '../types';
+
+export const useContentAsCodeWriteBackStatus = (
+    projectUuid: string,
+    contentType: ContentAsCodeSyncContentType,
+    slug: string,
+    enabled: boolean,
+) =>
+    useQuery<ContentAsCodeWriteBackStatusResult, ApiError>({
+        queryKey: [
+            CONTENT_AS_CODE_WRITE_BACK_STATUS_QUERY_KEY,
+            projectUuid,
+            contentType,
+            slug,
+        ],
+        queryFn: () =>
+            getContentAsCodeWriteBackStatus(projectUuid, contentType, slug),
+        enabled,
+    });

--- a/packages/frontend/src/features/contentAsCodeSync/hooks/useProposeContentAsCode.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/hooks/useProposeContentAsCode.ts
@@ -1,0 +1,57 @@
+import { isApiError, type ApiError } from '@lightdash/common'; // pragma: allowlist secret
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { proposeContentAsCode } from '../api/proposeContentAsCode';
+import {
+    CONTENT_AS_CODE_WRITE_BACK_STATUS_QUERY_KEY,
+    type ContentAsCodeProposeResult,
+    type ContentAsCodeSyncContentType,
+} from '../types';
+
+type ProposeVariables = {
+    contentType: ContentAsCodeSyncContentType;
+    slug: string;
+};
+
+export const useProposeContentAsCode = (projectUuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<ContentAsCodeProposeResult, ApiError, ProposeVariables>({
+        mutationFn: ({ contentType, slug }) =>
+            proposeContentAsCode(projectUuid, contentType, slug),
+        onSuccess: (result, { contentType, slug }) => {
+            void queryClient.invalidateQueries({
+                queryKey: [
+                    CONTENT_AS_CODE_WRITE_BACK_STATUS_QUERY_KEY,
+                    projectUuid,
+                    contentType,
+                    slug,
+                ],
+            });
+            showToastSuccess({
+                title:
+                    result.notedChartSlugs.length > 0
+                        ? 'Opened a pull request'
+                        : 'Proposed changes to git',
+                action: {
+                    children: 'View pull request',
+                    onClick: () =>
+                        window.open(
+                            result.prUrl,
+                            '_blank',
+                            'noopener,noreferrer',
+                        ),
+                },
+            });
+        },
+        onError: (error) => {
+            if (isApiError(error)) {
+                showToastApiError({
+                    title: 'Failed to propose to git',
+                    apiError: error.error,
+                });
+            }
+        },
+    });
+};

--- a/packages/frontend/src/features/contentAsCodeSync/types.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/types.ts
@@ -35,6 +35,35 @@ export type ContentAsCodeSyncStatusResult =
 export const CONTENT_AS_CODE_SYNC_STATUS_QUERY_KEY =
     'content-as-code-sync-status';
 
+export const CONTENT_AS_CODE_WRITE_BACK_STATUS_QUERY_KEY =
+    'content-as-code-write-back-status';
+
+export type ContentAsCodeWriteBackPrState = 'open' | 'merged' | 'none';
+
+export type ContentAsCodeWriteBackStatus = {
+    contentType: ContentAsCodeSyncContentType;
+    slug: string;
+    syncEnabled: boolean;
+    writeBackEnabled: boolean;
+    state: ContentAsCodeSyncItemState | 'unavailable';
+    writeBack: {
+        prState: ContentAsCodeWriteBackPrState;
+        prUrl: string | null;
+        prTitle: string | null;
+    };
+};
+
+export type ContentAsCodeWriteBackStatusResult =
+    | { kind: 'unavailable' }
+    | { kind: 'ok'; status: ContentAsCodeWriteBackStatus };
+
+export type ContentAsCodeProposeResult = {
+    prUrl: string;
+    prTitle: string;
+    filesWritten: string[];
+    notedChartSlugs: string[];
+};
+
 export const shouldShowContentAsCodeSync = (
     result: ContentAsCodeSyncStatusResult | undefined,
 ): boolean => {

--- a/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeSyncState.test.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeSyncState.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+    canProposeContentAsCodeSyncItem,
     canRestampContentAsCodeSyncItem,
     CONTENT_AS_CODE_SYNC_STATE_BADGE,
 } from './contentAsCodeSyncState';
@@ -15,5 +16,11 @@ describe('contentAsCodeSyncState', () => {
         expect(canRestampContentAsCodeSyncItem('ahead')).toBe(true);
         expect(canRestampContentAsCodeSyncItem('ui_only')).toBe(true);
         expect(canRestampContentAsCodeSyncItem('in_sync')).toBe(false);
+    });
+
+    it('allows propose for ahead and UI-only, not in sync', () => {
+        expect(canProposeContentAsCodeSyncItem('ahead')).toBe(true);
+        expect(canProposeContentAsCodeSyncItem('ui_only')).toBe(true);
+        expect(canProposeContentAsCodeSyncItem('in_sync')).toBe(false);
     });
 });

--- a/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeSyncState.ts
+++ b/packages/frontend/src/features/contentAsCodeSync/utils/contentAsCodeSyncState.ts
@@ -12,3 +12,7 @@ export const CONTENT_AS_CODE_SYNC_STATE_BADGE: Record<
 export const canRestampContentAsCodeSyncItem = (
     state: ContentAsCodeSyncItemState,
 ): boolean => state === 'ahead' || state === 'ui_only';
+
+export const canProposeContentAsCodeSyncItem = (
+    state: ContentAsCodeSyncItemState,
+): boolean => state === 'ahead' || state === 'ui_only';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: PROD-10512
Relates: PROD-10509
Relates: PROD-2856

**PROD-2856 ship plan: wave 2** with the 10509 panel. The propose API currently lives in #28014 (held with auto write-back). This UI is 404-safe and can merge with the panel; buttons stay hidden until an extracted propose API ships.

### Description

Completes the remaining PROD-10512 surface: **Propose to git** / **Add to git** on the project-settings Content as code sync panel (page actions already live on the write-back PR).

- Ahead rows: **Propose to git**
- UI-only rows: **Add to git**
- Open write-back PR: **Open pull request** plus propose (updates the same PR)
- Merged but not deployed: **Merged, applies on the next deploy**
- `create:ContentAsCode` required, same as restamp
- `GET /code/write-back-status` and `POST /code/propose` are 404-safe so the panel still works before the write-back stack is deployed

Stacked on the sync-status panel PR.

### Risk assessment:
- [ ] This is a high-risk change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8ccfc64-3e19-47b0-ba73-d713ac376003?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8ccfc64-3e19-47b0-ba73-d713ac376003&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

