### PR TITLE
feat: add embedded dashboard drill-down and filtering

### DIFF
--- a/packages/frontend/sdk/index.test.tsx
+++ b/packages/frontend/sdk/index.test.tsx
@@ -1,8 +1,39 @@
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let mockEmbedWriteContext: { canUpdateSavedChart: boolean } | undefined;
+
+vi.mock('../src/ee/pages/EmbedDashboard', async () => {
+    const { default: useEmbed } =
+        await import('../src/ee/providers/Embed/useEmbed');
+
+    return {
+        default: function MockEmbedDashboard() {
+            const { onExplore } = useEmbed();
+            return (
+                <div data-testid="embed-dashboard">
+                    <button
+                        data-testid="saved-chart-explore"
+                        onClick={() =>
+                            onExplore({
+                                chart: { uuid: 'saved-chart-uuid' } as never,
+                            })
+                        }
+                    />
+                    <button
+                        data-testid="drill-down-explore"
+                        onClick={() =>
+                            onExplore({
+                                chart: { tableName: 'orders' } as never,
+                            })
+                        }
+                    />
+                </div>
+            );
+        },
+    };
+});
 
 vi.mock('../src/components/MonacoEditor', () => ({
     default: () => null,
@@ -25,7 +56,9 @@ vi.mock('../src/ee/pages/EmbedExplore', () => ({
         chartView?: boolean;
     }) => (
         <div
-            data-testid="embed-chart-edit"
+            data-testid={
+                chartView === undefined ? 'embed-explore' : 'embed-chart-edit'
+            }
             data-allow-chart-update={allowChartUpdate}
             data-edit-mode={isEditMode}
             data-chart-view={chartView}
@@ -354,7 +387,7 @@ describe('SDK Dashboard - URL Sync Behavior', () => {
     it('should handle explore navigation without syncing URL', async () => {
         const mockOnExplore = vi.fn();
 
-        render(
+        const { getByTestId } = render(
             <Dashboard
                 token={mockToken}
                 instanceUrl={mockInstanceUrl}
@@ -363,11 +396,37 @@ describe('SDK Dashboard - URL Sync Behavior', () => {
             />,
         );
 
-        // Simulate explore navigation
-        // In SDK mode, this should call onExplore callback but not update browser URL
+        await waitFor(() => {
+            expect(getByTestId('embed-dashboard')).toBeTruthy();
+        });
+
+        fireEvent.click(getByTestId('saved-chart-explore'));
 
         await waitFor(() => {
-            // Browser URL should not change
+            expect(mockOnExplore).toHaveBeenCalledWith({
+                chart: { uuid: 'saved-chart-uuid' },
+            });
+            expect(window.location.pathname).toBe('/test');
+        });
+    });
+
+    it('should render drill-down explores inside the SDK dashboard', async () => {
+        const { getByTestId } = render(
+            <Dashboard
+                token={mockToken}
+                instanceUrl={mockInstanceUrl}
+                filters={[]}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(getByTestId('embed-dashboard')).toBeTruthy();
+        });
+
+        fireEvent.click(getByTestId('drill-down-explore'));
+
+        await waitFor(() => {
+            expect(getByTestId('embed-explore')).toBeTruthy();
             expect(window.location.pathname).toBe('/test');
         });
     });

--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@lightdash/common';
 import { ModalsProvider } from '@mantine/modals';
 import {
+    useCallback,
     useEffect,
     useRef,
     useState,
@@ -207,6 +208,28 @@ const getSavedChartExploreHandler = (onExplore: BaseProps['onExplore']) =>
           }
         : undefined;
 
+const useDashboardExploreNavigation = (onExplore: BaseProps['onExplore']) => {
+    const [exploreChart, setExploreChart] = useState<EmbedExploreChart>();
+
+    const handleExplore = useCallback(
+        ({ chart }: { chart: EmbedExploreChart }) => {
+            if ('uuid' in chart) {
+                onExplore?.({ chart });
+            } else {
+                setExploreChart(chart);
+            }
+        },
+        [onExplore],
+    );
+
+    const handleBackToDashboard = useCallback(
+        () => setExploreChart(undefined),
+        [],
+    );
+
+    return { exploreChart, handleExplore, handleBackToDashboard };
+};
+
 const getAiAgentEmbedUrl = ({
     agentUuid,
     instanceUrl,
@@ -344,6 +367,8 @@ const Dashboard: FC<DashboardProps> = ({
     onEditModeChange,
 }) => {
     const tokenContext = useEmbedTokenContext(instanceUrl, tokenOrTokenPromise);
+    const { exploreChart, handleExplore, handleBackToDashboard } =
+        useDashboardExploreNavigation(onExplore);
 
     if (!tokenContext) {
         return null;
@@ -361,13 +386,28 @@ const Dashboard: FC<DashboardProps> = ({
                 filters={filters}
                 paletteUuid={paletteUuid}
                 contentOverrides={contentOverrides}
-                onExplore={getSavedChartExploreHandler(onExplore)}
+                onExplore={handleExplore}
+                onBackToDashboard={handleBackToDashboard}
             >
-                <EmbedDashboard
-                    containerStyles={getDashboardContainerStyles(styles, theme)}
-                    isEditMode={isEditMode}
-                    onEditModeChange={onEditModeChange}
-                />
+                {exploreChart ? (
+                    <EmbedExplore
+                        exploreId={exploreChart.tableName}
+                        savedChart={exploreChart}
+                        containerStyles={getDashboardContainerStyles(
+                            styles,
+                            theme,
+                        )}
+                    />
+                ) : (
+                    <EmbedDashboard
+                        containerStyles={getDashboardContainerStyles(
+                            styles,
+                            theme,
+                        )}
+                        isEditMode={isEditMode}
+                        onEditModeChange={onEditModeChange}
+                    />
+                )}
             </EmbedProvider>
         </SdkProviders>
     );
@@ -490,6 +530,8 @@ const DashboardBuilder: FC<DashboardBuilderProps> = ({
     onDashboardReady,
 }) => {
     const tokenContext = useEmbedTokenContext(instanceUrl, tokenOrTokenPromise);
+    const { exploreChart, handleExplore, handleBackToDashboard } =
+        useDashboardExploreNavigation(onExplore);
 
     if (!tokenContext) {
         return null;
@@ -507,14 +549,29 @@ const DashboardBuilder: FC<DashboardBuilderProps> = ({
                 filters={filters}
                 paletteUuid={paletteUuid}
                 contentOverrides={contentOverrides}
-                onExplore={getSavedChartExploreHandler(onExplore)}
+                onExplore={handleExplore}
+                onBackToDashboard={handleBackToDashboard}
             >
-                <DashboardBuilderContent
-                    containerStyles={getDashboardContainerStyles(styles, theme)}
-                    isEditMode={isEditMode}
-                    onEditModeChange={onEditModeChange}
-                    onDashboardReady={onDashboardReady}
-                />
+                {exploreChart ? (
+                    <EmbedExplore
+                        exploreId={exploreChart.tableName}
+                        savedChart={exploreChart}
+                        containerStyles={getDashboardContainerStyles(
+                            styles,
+                            theme,
+                        )}
+                    />
+                ) : (
+                    <DashboardBuilderContent
+                        containerStyles={getDashboardContainerStyles(
+                            styles,
+                            theme,
+                        )}
+                        isEditMode={isEditMode}
+                        onEditModeChange={onEditModeChange}
+                        onDashboardReady={onDashboardReady}
+                    />
+                )}
             </EmbedProvider>
         </SdkProviders>
     );

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -161,6 +161,7 @@ import MantineIcon from '../common/MantineIcon';
 import MoveChartThatBelongsToDashboardModal from '../common/modal/MoveChartThatBelongsToDashboardModal';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import LightdashVisualization from '../LightdashVisualization';
+import { type EmbeddedDashboardInteractivity } from '../LightdashVisualization/context';
 import VisualizationProvider from '../LightdashVisualization/VisualizationProvider';
 import DrillDownMenuItem from '../MetricQueryData/DrillDownMenuItem';
 import { DrillDownModal } from '../MetricQueryData/DrillDownModal';
@@ -171,6 +172,9 @@ import { getDataFromChartClick } from '../MetricQueryData/utils';
 import { type EchartsSeriesClickEvent } from '../SimpleChart';
 import { DashboardExportImage } from './DashboardExportImage';
 import EditChartMenuItem from './EditChartMenuItem';
+import EmbeddedDashboardChartInteractions, {
+    type EmbeddedDashboardInteractions,
+} from './EmbeddedDashboardChartInteractions';
 import ExportDataModal from './ExportDataModal';
 import ExportImageModal from './ExportImageModal';
 import TileBase from './TileBase';
@@ -445,6 +449,7 @@ const ValidDashboardChartTileMinimal: FC<{
     ) => void;
     resultsData: InfiniteQueryResults;
     setEchartsRef?: (ref: RefObject<EChartsReact | null> | undefined) => void;
+    embeddedDashboardInteractivity?: EmbeddedDashboardInteractivity;
 }> = ({
     tileUuid,
     chart,
@@ -455,6 +460,7 @@ const ValidDashboardChartTileMinimal: FC<{
     isTitleHidden = false,
     onSeriesContextMenu,
     setEchartsRef,
+    embeddedDashboardInteractivity,
 }) => {
     const { health } = useApp();
     const { data: org } = useOrganization();
@@ -567,6 +573,7 @@ const ValidDashboardChartTileMinimal: FC<{
             containerWidth={containerWidth}
             containerHeight={containerHeight}
             isDashboard
+            embeddedDashboardInteractivity={embeddedDashboardInteractivity}
             dateZoom={chartDateZoom}
         >
             <LightdashVisualization
@@ -1864,7 +1871,13 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
     },
 );
 
-const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
+type DashboardChartTileMinimalProps = DashboardChartTileMainProps & {
+    embeddedDashboardInteractions?: EmbeddedDashboardInteractions;
+};
+
+const DashboardChartTileMinimal: FC<DashboardChartTileMinimalProps> = (
+    props,
+) => {
     const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
     const [contextMenuTargetOffset, setContextMenuTargetOffset] = useState<{
         left: number;
@@ -1885,12 +1898,14 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         canViewExplore: canViewExploreOverride,
         onExplore,
         onEditChart,
+        embeddedDashboardInteractions,
         colorPaletteOverride,
         darkColorPaletteOverride,
     } = props;
     const {
         colorPaletteOverride: _colorPaletteOverride,
         darkColorPaletteOverride: _darkColorPaletteOverride,
+        embeddedDashboardInteractions: _embeddedDashboardInteractions,
         ...tileBaseProps
     } = props;
 
@@ -2012,6 +2027,30 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         [chart.chartConfig.type, chart.chartConfig.config],
     );
 
+    const renderVisualization = (
+        contextMenuHandler:
+            | ((
+                  event: EchartsSeriesClickEvent,
+                  series: EChartsSeries[],
+              ) => void)
+            | undefined,
+        embeddedInteractivity?: EmbeddedDashboardInteractivity,
+    ) => (
+        <ValidDashboardChartTileMinimal
+            tileUuid={tileUuid}
+            isTitleHidden={hideTitle}
+            chart={chart}
+            dashboardChartReadyQuery={dashboardChartReadyQuery}
+            colorPaletteOverride={colorPaletteOverride}
+            darkColorPaletteOverride={darkColorPaletteOverride}
+            onSeriesContextMenu={contextMenuHandler}
+            resultsData={resultsData}
+            title={title || chart.name}
+            setEchartsRef={setEchartRef}
+            embeddedDashboardInteractivity={embeddedInteractivity}
+        />
+    );
+
     return (
         <>
             <TileBase
@@ -2123,18 +2162,33 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                             </Menu.Dropdown>
                         </Can>
                     </Menu>
-                    <ValidDashboardChartTileMinimal
-                        tileUuid={tileUuid}
-                        isTitleHidden={hideTitle}
-                        chart={chart}
-                        dashboardChartReadyQuery={dashboardChartReadyQuery}
-                        colorPaletteOverride={colorPaletteOverride}
-                        darkColorPaletteOverride={darkColorPaletteOverride}
-                        onSeriesContextMenu={onSeriesContextMenu}
-                        resultsData={resultsData}
-                        title={title || chart.name}
-                        setEchartsRef={setEchartRef}
-                    />
+                    {embeddedDashboardInteractions ? (
+                        <EmbeddedDashboardChartInteractions
+                            tileUuid={tileUuid}
+                            isEditMode={props.isEditMode}
+                            chart={chart}
+                            explore={explore}
+                            dateZoom={dashboardChartReadyQuery.dateZoom}
+                            dateDimension={
+                                metricQuery?.metadata?.hasADateDimension
+                            }
+                            interactions={embeddedDashboardInteractions}
+                        >
+                            {(embeddedOnSeriesContextMenu) =>
+                                renderVisualization(
+                                    embeddedOnSeriesContextMenu,
+                                    {
+                                        canDrillDown:
+                                            embeddedDashboardInteractions.canDrillDown,
+                                        canCrossFilter:
+                                            embeddedDashboardInteractions.canCrossFilter,
+                                    },
+                                )
+                            }
+                        </EmbeddedDashboardChartInteractions>
+                    ) : (
+                        renderVisualization(onSeriesContextMenu)
+                    )}
                 </>
             </TileBase>
             {canExportCsv && (
@@ -2184,6 +2238,7 @@ type DashboardChartTileProps = Omit<
     dashboardChartReadyQuery?: DashboardChartReadyQuery;
     resultsData?: InfiniteQueryResults;
     onExplore?: (options: { chart: SavedChart }) => void;
+    embeddedDashboardInteractions?: EmbeddedDashboardInteractions;
     queryContextOverride?: QueryExecutionContext;
 };
 
@@ -2206,6 +2261,7 @@ export const GenericDashboardChartTile: FC<
     canExportImages = false,
     canViewExplore,
     onExplore,
+    embeddedDashboardInteractions,
     colorPaletteOverride,
     darkColorPaletteOverride,
     ...rest
@@ -2347,6 +2403,9 @@ export const GenericDashboardChartTile: FC<
                     canExportImages={canExportImages}
                     canViewExplore={canViewExplore}
                     onExplore={onExplore}
+                    embeddedDashboardInteractions={
+                        embeddedDashboardInteractions
+                    }
                     colorPaletteOverride={effectiveColorPaletteOverride}
                     darkColorPaletteOverride={effectiveDarkColorPaletteOverride}
                 />
@@ -2363,7 +2422,9 @@ export const GenericDashboardChartTile: FC<
                 />
             )}
             <UnderlyingDataModal />
-            <DrillDownModal />
+            <DrillDownModal
+                onExplore={embeddedDashboardInteractions?.onDrillDownExplore}
+            />
         </MetricQueryDataProvider>
     );
 };

--- a/packages/frontend/src/components/DashboardTiles/EmbeddedDashboardChartInteractions.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmbeddedDashboardChartInteractions.tsx
@@ -1,0 +1,203 @@
+import {
+    type CreateSavedChartVersion,
+    type DashboardFilterRule,
+    type EChartsSeries,
+    type SavedChart,
+} from '@lightdash/common';
+import { Menu, Portal } from '@mantine/core';
+import React, { useCallback, useState, type FC, type ReactNode } from 'react';
+import { FilterDashboardTo } from '../../features/dashboardFilters/FilterDashboardTo';
+import { type DashboardChartReadyQuery } from '../../hooks/dashboard/useDashboardChartReadyQuery';
+import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
+import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
+import { type EmbeddedDashboardInteractivity } from '../LightdashVisualization/context';
+import DrillDownMenuItem from '../MetricQueryData/DrillDownMenuItem';
+import { useMetricQueryDataContext } from '../MetricQueryData/useMetricQueryDataContext';
+import { type EchartsSeriesClickEvent } from '../SimpleChart';
+import {
+    getAppliedTileDateZoom,
+    type AppliedTileDateZoomArgs,
+} from './getAppliedTileDateZoom';
+import {
+    getDashboardTileContextMenuOptions,
+    shouldOpenEmbeddedChartContextMenu,
+} from './getDashboardTileContextMenuOptions';
+import { UnderlyingDataMenuItem } from './UnderlyingDataMenuItem';
+
+export type EmbeddedDashboardInteractions = EmbeddedDashboardInteractivity & {
+    onDrillDownExplore?: (options: { chart: CreateSavedChartVersion }) => void;
+};
+
+type Props = {
+    tileUuid: string;
+    isEditMode: boolean;
+    chart: SavedChart;
+    explore: DashboardChartReadyQuery['explore'];
+    dateZoom: DashboardChartReadyQuery['dateZoom'];
+    dateDimension: AppliedTileDateZoomArgs['dateDimension'];
+    interactions: EmbeddedDashboardInteractions;
+    children: (
+        onSeriesContextMenu: (
+            event: EchartsSeriesClickEvent,
+            series: EChartsSeries[],
+        ) => void,
+    ) => ReactNode;
+};
+
+const EmbeddedDashboardChartInteractions: FC<Props> = ({
+    tileUuid,
+    isEditMode,
+    chart,
+    explore,
+    dateZoom,
+    dateDimension,
+    interactions,
+    children,
+}) => {
+    const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
+    const [contextMenuTargetOffset, setContextMenuTargetOffset] = useState<{
+        left: number;
+        top: number;
+    }>();
+    const [contextMenuOptions, setContextMenuOptions] =
+        useState<ReturnType<typeof getDashboardTileContextMenuOptions>>();
+    const projectUuid = useProjectUuid();
+    const { canViewUnderlyingData } = useContextMenuPermissions({
+        organizationUuid: chart.organizationUuid,
+        projectUuid: chart.projectUuid,
+    });
+    const tilesWithDateZoomApplied = useDashboardContext(
+        (context) => context.tilesWithDateZoomApplied,
+    );
+    const addDimensionDashboardFilter = useDashboardContext(
+        (context) => context.addDimensionDashboardFilter,
+    );
+    const { openUnderlyingDataModal } = useMetricQueryDataContext();
+
+    const handleAddFilter = useCallback(
+        (filter: DashboardFilterRule) => {
+            addDimensionDashboardFilter(filter, !isEditMode);
+        },
+        [addDimensionDashboardFilter, isEditMode],
+    );
+
+    const handleViewUnderlyingData = useCallback(() => {
+        if (!contextMenuOptions) return;
+
+        const appliedDateZoom = getAppliedTileDateZoom({
+            tileUuid,
+            tilesWithDateZoomApplied,
+            dateZoom,
+            dateDimension,
+        });
+
+        openUnderlyingDataModal({
+            ...contextMenuOptions.viewUnderlyingDataOptions,
+            ...(appliedDateZoom?.xAxisFieldId && {
+                dateZoom: appliedDateZoom,
+            }),
+        });
+    }, [
+        contextMenuOptions,
+        dateDimension,
+        dateZoom,
+        openUnderlyingDataModal,
+        tileUuid,
+        tilesWithDateZoomApplied,
+    ]);
+
+    const onSeriesContextMenu = useCallback(
+        (event: EchartsSeriesClickEvent, series: EChartsSeries[]) => {
+            if (!explore) return;
+
+            const options = getDashboardTileContextMenuOptions({
+                clickEvent: event,
+                series,
+                explore,
+                chart,
+            });
+
+            if (
+                !shouldOpenEmbeddedChartContextMenu({
+                    canViewUnderlyingData,
+                    canExplore: interactions.canDrillDown,
+                    canCrossFilter: interactions.canCrossFilter,
+                    dashboardTileFilterOptionsCount:
+                        options.dashboardTileFilterOptions.length,
+                })
+            ) {
+                setContextMenuIsOpen(false);
+                return;
+            }
+
+            setContextMenuOptions(options);
+            setContextMenuIsOpen(true);
+            setContextMenuTargetOffset({
+                left: event.event.event.pageX,
+                top: event.event.event.pageY,
+            });
+        },
+        [canViewUnderlyingData, chart, explore, interactions],
+    );
+
+    return (
+        <>
+            <Menu
+                opened={contextMenuIsOpen}
+                onClose={() => setContextMenuIsOpen(false)}
+                withinPortal
+                closeOnItemClick
+                closeOnEscape
+                shadow="md"
+                radius={0}
+                position="bottom-start"
+                offset={{ crossAxis: 0, mainAxis: 0 }}
+            >
+                <Portal>
+                    <Menu.Target>
+                        <div
+                            onContextMenu={(event) => event.preventDefault()}
+                            style={{
+                                position: 'absolute',
+                                ...contextMenuTargetOffset,
+                            }}
+                        />
+                    </Menu.Target>
+                </Portal>
+                <Menu.Dropdown>
+                    {canViewUnderlyingData && (
+                        <UnderlyingDataMenuItem
+                            metricQuery={chart.metricQuery}
+                            onViewUnderlyingData={handleViewUnderlyingData}
+                        />
+                    )}
+                    {interactions.canDrillDown && (
+                        <DrillDownMenuItem
+                            {...contextMenuOptions?.viewUnderlyingDataOptions}
+                            trackingData={{
+                                organizationId: chart.organizationUuid,
+                                userId: undefined,
+                                projectId: projectUuid,
+                            }}
+                        />
+                    )}
+                    {interactions.canCrossFilter &&
+                        contextMenuOptions &&
+                        contextMenuOptions.dashboardTileFilterOptions.length >
+                            0 && (
+                            <FilterDashboardTo
+                                filters={
+                                    contextMenuOptions.dashboardTileFilterOptions
+                                }
+                                onAddFilter={handleAddFilter}
+                            />
+                        )}
+                </Menu.Dropdown>
+            </Menu>
+            {children(onSeriesContextMenu)}
+        </>
+    );
+};
+
+export default EmbeddedDashboardChartInteractions;

--- a/packages/frontend/src/components/DashboardTiles/getDashboardTileContextMenuOptions.test.ts
+++ b/packages/frontend/src/components/DashboardTiles/getDashboardTileContextMenuOptions.test.ts
@@ -1,0 +1,215 @@
+/// <reference types="vitest/globals" />
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    type ApiExploreResults,
+    type CompiledDimension,
+    type CompiledMetric,
+    type EChartsSeries,
+    type SavedChart,
+} from '@lightdash/common';
+import { type EchartsSeriesClickEvent } from '../SimpleChart';
+import {
+    getDashboardTileContextMenuOptions,
+    shouldOpenEmbeddedChartContextMenu,
+} from './getDashboardTileContextMenuOptions';
+
+const statusDimension: CompiledDimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name: 'status',
+    label: 'Status',
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    compiledSql: '',
+    tablesReferences: ['orders'],
+    hidden: false,
+};
+
+const priorityDimension: CompiledDimension = {
+    ...statusDimension,
+    name: 'priority',
+    label: 'Priority',
+};
+
+const countMetric: CompiledMetric = {
+    fieldType: FieldType.METRIC,
+    type: MetricType.COUNT,
+    name: 'count',
+    label: 'Count',
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '',
+    compiledSql: '',
+    tablesReferences: ['orders'],
+    hidden: false,
+};
+
+const explore = {
+    name: 'orders',
+    label: 'Orders',
+    baseTable: 'orders',
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            dimensions: {
+                status: statusDimension,
+                priority: priorityDimension,
+            },
+            metrics: { count: countMetric },
+        },
+    },
+} as unknown as ApiExploreResults;
+
+const chart = {
+    metricQuery: {
+        dimensions: ['orders_status', 'orders_priority'],
+        metrics: ['orders_count'],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+        additionalMetrics: [],
+        customDimensions: [],
+    },
+    pivotConfig: undefined,
+} as unknown as Pick<SavedChart, 'metricQuery' | 'pivotConfig'>;
+
+const series = [
+    {
+        type: 'bar',
+        encode: {
+            x: 'orders_status',
+            y: 'orders_count',
+            tooltip: [],
+            seriesName: 'orders_count',
+        },
+    } as unknown as EChartsSeries,
+];
+
+const baseClickEvent = {
+    componentType: 'series' as const,
+    seriesIndex: 0,
+    dataIndex: 0,
+    dimensionNames: ['orders_status', 'orders_count'],
+    event: { event: {} as MouseEvent },
+} as EchartsSeriesClickEvent;
+
+describe('getDashboardTileContextMenuOptions', () => {
+    it('creates a temporary dashboard filter from a clicked dimension', () => {
+        const options = getDashboardTileContextMenuOptions({
+            clickEvent: {
+                ...baseClickEvent,
+                value: 12,
+                data: {
+                    orders_status: 'completed',
+                    orders_count: 12,
+                },
+            },
+            series,
+            explore,
+            chart,
+        });
+
+        expect(options.dashboardTileFilterOptions).toHaveLength(1);
+        expect(options.dashboardTileFilterOptions[0]).toMatchObject({
+            target: {
+                fieldId: 'orders_status',
+                fieldName: 'status',
+                tableName: 'orders',
+            },
+            values: ['completed'],
+        });
+        expect(options.viewUnderlyingDataOptions.item).toBe(countMetric);
+        expect(options.viewUnderlyingDataOptions.dimensions).toEqual([
+            'orders_status',
+            'orders_priority',
+        ]);
+    });
+
+    it('creates filters for dimensions restored from a tuple dataset row', () => {
+        const options = getDashboardTileContextMenuOptions({
+            clickEvent: {
+                ...baseClickEvent,
+                value: ['completed', 12],
+                data: { value: ['completed', 12] },
+                datasetRow: {
+                    orders_status: 'completed',
+                    orders_priority: 'urgent',
+                    orders_count: 12,
+                },
+            },
+            series,
+            explore,
+            chart,
+        });
+
+        expect(options.dashboardTileFilterOptions).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    target: expect.objectContaining({
+                        fieldId: 'orders_status',
+                    }),
+                    values: ['completed'],
+                }),
+                expect.objectContaining({
+                    target: expect.objectContaining({
+                        fieldId: 'orders_priority',
+                    }),
+                    values: ['urgent'],
+                }),
+            ]),
+        );
+    });
+});
+
+describe('shouldOpenEmbeddedChartContextMenu', () => {
+    it('does not open an empty menu for view-only embeds', () => {
+        expect(
+            shouldOpenEmbeddedChartContextMenu({
+                canViewUnderlyingData: false,
+                canExplore: false,
+                canCrossFilter: false,
+                dashboardTileFilterOptionsCount: 0,
+            }),
+        ).toBe(false);
+    });
+
+    it('does not open an empty menu when a click has no filterable fields', () => {
+        expect(
+            shouldOpenEmbeddedChartContextMenu({
+                canViewUnderlyingData: false,
+                canExplore: false,
+                canCrossFilter: true,
+                dashboardTileFilterOptionsCount: 0,
+            }),
+        ).toBe(false);
+    });
+
+    it.each([
+        {
+            canViewUnderlyingData: true,
+            canExplore: false,
+            canCrossFilter: false,
+            dashboardTileFilterOptionsCount: 0,
+        },
+        {
+            canViewUnderlyingData: false,
+            canExplore: true,
+            canCrossFilter: false,
+            dashboardTileFilterOptionsCount: 0,
+        },
+        {
+            canViewUnderlyingData: false,
+            canExplore: false,
+            canCrossFilter: true,
+            dashboardTileFilterOptionsCount: 1,
+        },
+    ])('opens when an embedded action is available', (permissions) => {
+        expect(shouldOpenEmbeddedChartContextMenu(permissions)).toBe(true);
+    });
+});

--- a/packages/frontend/src/components/DashboardTiles/getDashboardTileContextMenuOptions.ts
+++ b/packages/frontend/src/components/DashboardTiles/getDashboardTileContextMenuOptions.ts
@@ -1,0 +1,118 @@
+import {
+    createDashboardFilterRuleFromField,
+    getDimensions,
+    getFields,
+    getItemId,
+    getItemMap,
+    type ApiExploreResults,
+    type EChartsSeries,
+    type SavedChart,
+} from '@lightdash/common';
+import { getDataFromChartClick } from '../MetricQueryData/utils';
+import { type EchartsSeriesClickEvent } from '../SimpleChart';
+
+type DashboardChartContext = Pick<SavedChart, 'metricQuery' | 'pivotConfig'>;
+
+export const shouldOpenEmbeddedChartContextMenu = ({
+    canViewUnderlyingData,
+    canExplore,
+    canCrossFilter,
+    dashboardTileFilterOptionsCount,
+}: {
+    canViewUnderlyingData: boolean;
+    canExplore: boolean;
+    canCrossFilter: boolean;
+    dashboardTileFilterOptionsCount: number;
+}) =>
+    canViewUnderlyingData ||
+    canExplore ||
+    (canCrossFilter && dashboardTileFilterOptionsCount > 0);
+
+export const getDashboardTileContextMenuOptions = ({
+    clickEvent,
+    series,
+    explore,
+    chart,
+}: {
+    clickEvent: EchartsSeriesClickEvent;
+    series: EChartsSeries[];
+    explore: ApiExploreResults;
+    chart: DashboardChartContext;
+}) => {
+    const allDimensions = getDimensions(explore);
+    const allItemsMap = getItemMap(
+        explore,
+        chart.metricQuery.additionalMetrics,
+        chart.metricQuery.tableCalculations,
+        chart.metricQuery.customDimensions,
+    );
+
+    const clickedColumnNames = new Set([
+        ...clickEvent.dimensionNames,
+        ...Object.keys(clickEvent.datasetRow ?? {}),
+    ]);
+    const exploreDimensions = allDimensions.filter((dimension) =>
+        clickedColumnNames.has(getItemId(dimension)),
+    );
+
+    const getValueFromClickData = (fieldId: string) => {
+        if (Array.isArray(clickEvent.value)) {
+            const index = clickEvent.dimensionNames.indexOf(fieldId);
+            if (index >= 0) return clickEvent.value[index];
+            return clickEvent.datasetRow?.[fieldId];
+        }
+        return (clickEvent.data as Record<string, unknown>)[fieldId];
+    };
+
+    const dimensionOptions = exploreDimensions.map((field) =>
+        createDashboardFilterRuleFromField({
+            field,
+            availableTileFilters: {},
+            isTemporary: true,
+            value: getValueFromClickData(getItemId(field)),
+        }),
+    );
+
+    const clickedSeries = series[clickEvent.seriesIndex];
+    const fields = getFields(explore);
+    const pivot = chart.pivotConfig?.columns?.[0];
+    const pivotField = fields.find(
+        (field) => `${field.table}_${field.name}` === pivot,
+    );
+    const seriesName = clickedSeries.encode?.seriesName;
+
+    let pivotValue =
+        pivot && seriesName?.includes(`.${pivot}.`)
+            ? seriesName.split(`.${pivot}.`)[1]
+            : undefined;
+
+    if (!pivotValue && clickedSeries.pivotReference?.pivotValues) {
+        const pivotReferenceValue =
+            clickedSeries.pivotReference.pivotValues.find(
+                (value) => value.field === pivot,
+            );
+        if (pivotReferenceValue) {
+            pivotValue = pivotReferenceValue.value as string;
+        }
+    }
+
+    const pivotOptions =
+        pivot && pivotField && pivotValue
+            ? [
+                  createDashboardFilterRuleFromField({
+                      field: pivotField,
+                      availableTileFilters: {},
+                      isTemporary: true,
+                      value: pivotValue,
+                  }),
+              ]
+            : [];
+
+    return {
+        dashboardTileFilterOptions: [...dimensionOptions, ...pivotOptions],
+        viewUnderlyingDataOptions: {
+            ...getDataFromChartClick(clickEvent, allItemsMap, series),
+            dimensions: chart.metricQuery.dimensions ?? [],
+        },
+    };
+};

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -39,7 +39,7 @@ import { type InfiniteQueryResults } from '../../hooks/useQueryResults';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { type EChartsReact } from '../EChartsReactWrapper';
 import { type EchartsSeriesClickEvent } from '../SimpleChart';
-import Context from './context';
+import Context, { type EmbeddedDashboardInteractivity } from './context';
 import { type useVisualizationContext } from './useVisualizationContext';
 import VisualizationBigNumberConfig from './VisualizationBigNumberConfig';
 import VisualizationCartesianConfig from './VisualizationConfigCartesian';
@@ -87,6 +87,7 @@ export type VisualizationProviderProps = {
     containerHeight?: number;
     isDashboard?: boolean;
     isEditMode?: boolean;
+    embeddedDashboardInteractivity?: EmbeddedDashboardInteractivity;
     hasExplorerStore?: boolean;
     dateZoom?: DateZoom;
 };
@@ -121,6 +122,7 @@ const VisualizationProvider: FC<
     containerHeight,
     isDashboard,
     isEditMode,
+    embeddedDashboardInteractivity,
     hasExplorerStore = true,
     dateZoom,
 }) => {
@@ -367,6 +369,7 @@ const VisualizationProvider: FC<
         containerHeight,
         isDashboard,
         isEditMode,
+        embeddedDashboardInteractivity,
         hasExplorerStore,
         isTouchDevice,
         resolvedTimezone: lastValidResultsData?.resolvedTimezone,

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -18,6 +18,11 @@ import { type EChartsReact } from '../EChartsReactWrapper';
 import { type EchartsSeriesClickEvent } from '../SimpleChart';
 import { type VisualizationConfig } from './types';
 
+export type EmbeddedDashboardInteractivity = {
+    canDrillDown: boolean;
+    canCrossFilter: boolean;
+};
+
 type VisualizationContext = {
     minimal: boolean;
     chartRef: RefObject<EChartsReact | null>;
@@ -57,6 +62,7 @@ type VisualizationContext = {
     containerHeight?: number;
     isDashboard?: boolean;
     isEditMode?: boolean;
+    embeddedDashboardInteractivity?: EmbeddedDashboardInteractivity;
     hasExplorerStore: boolean;
     // Touch device detection for tooltip positioning
     isTouchDevice: boolean;

--- a/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownModal.tsx
@@ -135,7 +135,7 @@ export const combineFilters = ({
     };
 };
 
-type DrillDownExploreUrlArgs = {
+type DrillDownExploreArgs = {
     fieldValues: Record<string, ResultValue>;
     projectUuid: string;
     tableName: string;
@@ -148,7 +148,7 @@ type DrillDownExploreUrlArgs = {
     timezone?: string;
 };
 
-const drillDownExploreUrl = ({
+const getDrillDownExplore = ({
     fieldValues,
     projectUuid,
     tableName,
@@ -159,7 +159,7 @@ const drillDownExploreUrl = ({
     pivotReference,
     explore,
     timezone,
-}: DrillDownExploreUrlArgs) => {
+}: DrillDownExploreArgs) => {
     const createSavedChartVersion: CreateSavedChartVersion = {
         tableName,
         metricQuery: {
@@ -198,10 +198,17 @@ const drillDownExploreUrl = ({
         projectUuid,
         createSavedChartVersion,
     );
-    return `${pathname}?${search}`;
+    return {
+        chart: createSavedChartVersion,
+        url: `${pathname}?${search}`,
+    };
 };
 
-export const DrillDownModal: FC = () => {
+type DrillDownModalProps = {
+    onExplore?: (options: { chart: CreateSavedChartVersion }) => void;
+};
+
+export const DrillDownModal: FC<DrillDownModalProps> = ({ onExplore }) => {
     const projectUuid = useProjectUuid();
 
     const [selectedDimension, setSelectedDimension] =
@@ -239,7 +246,7 @@ export const DrillDownModal: FC = () => {
         }
     }, [drillDownConfig]);
 
-    const url = useMemo(() => {
+    const drillDownExplore = useMemo(() => {
         if (
             selectedDimension &&
             metricQuery &&
@@ -247,7 +254,7 @@ export const DrillDownModal: FC = () => {
             drillDownConfig &&
             projectUuid
         ) {
-            return drillDownExploreUrl({
+            return getDrillDownExplore({
                 projectUuid,
                 tableName: explore.name,
                 metricQuery,
@@ -281,16 +288,31 @@ export const DrillDownModal: FC = () => {
             size="md"
             icon={IconArrowBarToDown}
             actions={
-                <Button
-                    component="a"
-                    target="_blank"
-                    href={url}
-                    leftSection={<MantineIcon icon={IconExternalLink} />}
-                    disabled={!selectedDimension}
-                    onClick={() => setTimeout(onClose, 500)}
-                >
-                    Open in new tab
-                </Button>
+                onExplore ? (
+                    <Button
+                        leftSection={<MantineIcon icon={IconArrowBarToDown} />}
+                        disabled={!drillDownExplore}
+                        onClick={() => {
+                            if (drillDownExplore) {
+                                onExplore({ chart: drillDownExplore.chart });
+                                onClose();
+                            }
+                        }}
+                    >
+                        Drill down
+                    </Button>
+                ) : (
+                    <Button
+                        component="a"
+                        target="_blank"
+                        href={drillDownExplore?.url}
+                        leftSection={<MantineIcon icon={IconExternalLink} />}
+                        disabled={!drillDownExplore}
+                        onClick={() => setTimeout(onClose, 500)}
+                    >
+                        Open in new tab
+                    </Button>
+                )
             }
         >
             <FieldSelect

--- a/packages/frontend/src/components/SimpleTable/MinimalCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/MinimalCellContextMenu.tsx
@@ -1,15 +1,112 @@
-import { isDimension, isField, type ResultValue } from '@lightdash/common';
+import {
+    createDashboardFilterRuleFromField,
+    isDimension,
+    isDimensionValueInvalidDate,
+    isField,
+    isFilterableField,
+    type FilterDashboardToRule,
+    type ResultValue,
+} from '@lightdash/common';
 import { Menu } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';
+import { FilterDashboardTo } from '../../features/dashboardFilters/FilterDashboardTo';
 import useToaster from '../../hooks/toaster/useToaster';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
+import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import MantineIcon from '../common/MantineIcon';
 import { type CellContextMenuProps } from '../common/Table/types';
 import { UnderlyingDataMenuItem } from '../DashboardTiles/UnderlyingDataMenuItem';
 import UrlMenuItems from '../Explorer/ResultsCard/UrlMenuItems';
+import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
+import DrillDownMenuItem from '../MetricQueryData/DrillDownMenuItem';
 import { useMetricQueryDataContext } from '../MetricQueryData/useMetricQueryDataContext';
+
+const MinimalDashboardCellInteractions: FC<
+    Pick<CellContextMenuProps, 'cell'>
+> = ({ cell }) => {
+    const { embeddedDashboardInteractivity, itemsMap } =
+        useVisualizationContext();
+    const addDimensionDashboardFilter = useDashboardContext(
+        (c) => c.addDimensionDashboardFilter,
+    );
+    const projectUuid = useProjectUuid();
+
+    const meta = cell.column.columnDef.meta;
+    const item = meta?.item;
+    const value: ResultValue = cell.getValue()?.value || {};
+    const fieldValues = mapValues(cell.row.original, (v) => v?.value) || {};
+
+    const filterValue =
+        value.raw === undefined ||
+        (isDimension(item) && isDimensionValueInvalidDate(item, value))
+            ? null
+            : value.raw;
+
+    const fieldFilters =
+        isDimension(item) && !item.hidden
+            ? [
+                  createDashboardFilterRuleFromField({
+                      field: item,
+                      availableTileFilters: {},
+                      isTemporary: true,
+                      value: filterValue,
+                  }),
+              ]
+            : [];
+
+    const pivotFilters = (meta?.pivotReference?.pivotValues || []).reduce<
+        FilterDashboardToRule[]
+    >((acc, pivot) => {
+        const pivotField = itemsMap?.[pivot.field];
+        if (
+            !pivotField ||
+            !isField(pivotField) ||
+            !isFilterableField(pivotField)
+        ) {
+            return acc;
+        }
+
+        return [
+            ...acc,
+            createDashboardFilterRuleFromField({
+                field: pivotField,
+                availableTileFilters: {},
+                isTemporary: true,
+                value: pivot.value,
+            }),
+        ];
+    }, []);
+
+    const filters = [...fieldFilters, ...pivotFilters];
+
+    return (
+        <>
+            {embeddedDashboardInteractivity?.canDrillDown && (
+                <DrillDownMenuItem
+                    item={item}
+                    fieldValues={fieldValues}
+                    pivotReference={meta?.pivotReference}
+                    trackingData={{
+                        organizationId: undefined,
+                        userId: undefined,
+                        projectId: projectUuid,
+                    }}
+                />
+            )}
+
+            {embeddedDashboardInteractivity?.canCrossFilter &&
+                filters.length > 0 && (
+                    <FilterDashboardTo
+                        filters={filters}
+                        onAddFilter={addDimensionDashboardFilter}
+                    />
+                )}
+        </>
+    );
+};
 
 const MinimalCellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({
     cell,
@@ -17,6 +114,7 @@ const MinimalCellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({
     const { showToastSuccess } = useToaster();
     const { openUnderlyingDataModal, metricQuery } =
         useMetricQueryDataContext();
+    const { embeddedDashboardInteractivity } = useVisualizationContext();
 
     const meta = cell.column.columnDef.meta;
     const item = meta?.item;
@@ -74,6 +172,10 @@ const MinimalCellContextMenu: FC<Pick<CellContextMenuProps, 'cell'>> = ({
                     metricQuery={metricQuery}
                     onViewUnderlyingData={handleViewUnderlyingData}
                 />
+            )}
+
+            {embeddedDashboardInteractivity && (
+                <MinimalDashboardCellInteractions cell={cell} />
             )}
         </>
     );

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -3,6 +3,7 @@ import {
     DashboardTileTypes,
     QueryExecutionContext,
     assertUnreachable,
+    canAddDashboardFiltersInEmbed,
     getDefaultChartTileSize,
     isDashboardContent,
     type DashboardTile,
@@ -149,6 +150,16 @@ const EmbedDashboardGrid: FC<{
                                         onEdit={onEditTile}
                                         onEditChart={onEditChart}
                                         onExplore={onExplore}
+                                        embeddedDashboardInteractions={{
+                                            canDrillDown:
+                                                dashboard.canExplore &&
+                                                onExplore !== undefined,
+                                            canCrossFilter:
+                                                canAddDashboardFiltersInEmbed(
+                                                    dashboard.dashboardFiltersInteractivity,
+                                                ),
+                                            onDrillDownExplore: onExplore,
+                                        }}
                                         canExportCsv={dashboard.canExportCsv}
                                         canExportImages={
                                             dashboard.canExportImages
@@ -179,6 +190,16 @@ const EmbedDashboardGrid: FC<{
                                             dashboard.canExportImages
                                         }
                                         canViewExplore={dashboard.canExplore}
+                                        embeddedDashboardInteractions={{
+                                            canDrillDown:
+                                                dashboard.canExplore &&
+                                                onExplore !== undefined,
+                                            canCrossFilter:
+                                                canAddDashboardFiltersInEmbed(
+                                                    dashboard.dashboardFiltersInteractivity,
+                                                ),
+                                            onDrillDownExplore: onExplore,
+                                        }}
                                         locked={hasUnmetFilterRequirements}
                                         tileIndex={index}
                                     />


### PR DESCRIPTION
## Summary
- add drill-down and dashboard filtering to embedded chart context menus
- support the same permission-gated interactions for embedded table cells
- reuse the existing `canExplore` and `dashboardFiltersInteractivity.canAddFilters` token controls
- keep SDK drill-down inside the embed with Back to Dashboard
- suppress empty action menus when an embedded viewer has no permitted interaction
- isolate embedded chart menu state and handlers in `EmbeddedDashboardChartInteractions`
- preserve the regular non-minimal dashboard component unchanged and keep embedding props out of its type boundary
- preserve optional host navigation for saved-chart Explore actions and the existing non-embed new-tab flow

## Testing
- `pnpm -F frontend typecheck`
- 28 focused SDK, drill-down modal, and chart interaction tests passing
- targeted type-aware frontend lint: zero warnings
- formatting and diff checks
- tested embed-showcase with Analyst and Viewer role tokens
- verified Analyst table drill-down renders Explore in place, keeps the host on `/interactivity`, and returns via Back to Dashboard
- verified Analyst table filtering applies in place
- verified Viewer chart/table clicks do not open an empty interaction menu or modal
- audited the final shared tile diff: regular non-minimal behavior has no change; embedded behavior is activated only by the explicit `embeddedDashboardInteractions` prop on the minimal path

## Examples
- lightdash/embed-showcase#5 demonstrates both interactions, drill-only, filter-only, and view-only policies
- the showcase documents the optional saved-chart `onExplore` callback; drill-down needs no host routing code

Closes: SPK-1358