### PR TITLE
feat(cli): add dry-run verdicts, --json, and --strict

### DIFF
--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -138,6 +138,8 @@ const makeDownloadHandlerOptions = (
     concurrency: 1,
     organization: false,
     dryRun: false,
+    json: false,
+    strict: false,
     ...overrides,
 });
 
@@ -1560,9 +1562,9 @@ describe('uploadHandler dry-run', () => {
 
         const printed = output.join('\n');
         expect(printed).toContain('Dry run — no changes will be made.');
-        expect(printed).toContain('would upload space finance');
-        expect(printed).toContain('would upload chart orders-over-time');
-        expect(printed).toContain('would upload dashboard weekly-kpis');
+        expect(printed).toContain('would update space finance');
+        expect(printed).toContain('would update chart orders-over-time');
+        expect(printed).toContain('would update dashboard weekly-kpis');
         expect(printed).toContain(
             'No files were written and no content was uploaded.',
         );
@@ -1573,6 +1575,42 @@ describe('uploadHandler dry-run', () => {
         expect(mutatingCalls).toEqual([]);
         expect(getContentAsCodeUploadPermissions).not.toHaveBeenCalled();
         await expect(fs.readFile(chartPath, 'utf-8')).resolves.toBe(before);
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    it('prints JSON and sets exit code 1 with --strict when content would change', async () => {
+        await writeProjectContent();
+        const previousExitCode = process.exitCode;
+
+        await expect(
+            uploadHandler(
+                makeDownloadHandlerOptions({
+                    dryRun: true,
+                    json: true,
+                    strict: true,
+                    path: tmpDir,
+                    project: 'project-uuid',
+                    skipSpaces: false,
+                    skipVirtualViews: true,
+                    skipAgents: true,
+                    skipAlerts: true,
+                    skipGoogleSheets: true,
+                    skipScheduledDeliveries: true,
+                    skipExternalConnections: true,
+                }),
+            ),
+        ).resolves.toBeUndefined();
+
+        const report = JSON.parse(
+            output.find((line) => line.startsWith('{')) ?? '',
+        ) as {
+            dryRun: true;
+            totals: { update: number };
+        };
+        expect(report.dryRun).toBe(true);
+        expect(report.totals.update).toBeGreaterThan(0);
+        expect(process.exitCode).toBe(1);
+        process.exitCode = previousExitCode;
     });
 
     it('previews organization uploads without calling upsert APIs', async () => {
@@ -1601,7 +1639,7 @@ describe('uploadHandler dry-run', () => {
         ).resolves.toBeUndefined();
 
         expect(output.join('\n')).toContain(
-            'would upload custom role Developer view only',
+            'would update custom role Developer view only',
         );
         expect(
             vi

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -161,6 +161,7 @@ import {
     collectOrganizationUploadPlan,
     createUploadDryRunGroup,
     printUploadDryRunPlan,
+    uploadDryRunWouldChange,
     type UploadDryRunGroup,
 } from './uploadDryRun';
 
@@ -215,6 +216,8 @@ export type DownloadHandlerOptions = {
     organization: boolean;
     sendInvites?: boolean;
     dryRun?: boolean;
+    json?: boolean;
+    strict?: boolean;
 };
 
 type FolderScheme = 'flat' | 'nested';
@@ -3476,9 +3479,16 @@ export const uploadHandler = async (
 
     if (isOrganizationUpload) {
         if (options.dryRun === true) {
-            printUploadDryRunPlan(
+            const report = printUploadDryRunPlan(
                 await collectOrganizationUploadPlan(options.path),
+                { json: options.json === true },
             );
+            if (
+                options.strict === true &&
+                uploadDryRunWouldChange(report.totals)
+            ) {
+                process.exitCode = 1;
+            }
             return;
         }
         await uploadOrganizationContent({
@@ -3509,14 +3519,18 @@ export const uploadHandler = async (
 
     if (options.dryRun === true) {
         // Skip upserts, file writes, and any last-applied snapshot PUT.
-        printUploadDryRunPlan(
+        const report = printUploadDryRunPlan(
             await collectProjectUploadPlan({
                 options,
                 hasFilters,
                 shouldReconcileSpaces,
                 spaceFiles: preflightSpaceFiles,
             }),
+            { json: options.json === true },
         );
+        if (options.strict === true && uploadDryRunWouldChange(report.totals)) {
+            process.exitCode = 1;
+        }
         return;
     }
 

--- a/packages/cli/src/handlers/uploadDryRun.test.ts
+++ b/packages/cli/src/handlers/uploadDryRun.test.ts
@@ -8,23 +8,29 @@ import {
     collectOrganizationUploadPlan,
     createUploadDryRunGroup,
     printUploadDryRunPlan,
+    summarizeUploadDryRun,
+    uploadDryRunWouldChange,
 } from './uploadDryRun';
 
 describe('addUploadDryRunOption', () => {
-    it('accepts --dry-run', () => {
+    it('accepts --dry-run, --json, and --strict', () => {
         const command = new Command();
         addUploadDryRunOption(command);
-        command.parse(['--dry-run'], { from: 'user' });
+        command.parse(['--dry-run', '--json', '--strict'], { from: 'user' });
 
         expect(command.opts().dryRun).toBe(true);
+        expect(command.opts().json).toBe(true);
+        expect(command.opts().strict).toBe(true);
     });
 
-    it('defaults --dry-run to false', () => {
+    it('defaults preview flags to false', () => {
         const command = new Command();
         addUploadDryRunOption(command);
         command.parse([], { from: 'user' });
 
         expect(command.opts().dryRun).toBe(false);
+        expect(command.opts().json).toBe(false);
+        expect(command.opts().strict).toBe(false);
     });
 });
 
@@ -44,16 +50,53 @@ describe('createUploadDryRunGroup', () => {
                 singular: 'chart',
                 slugs: ['zeta', 'alpha'],
                 unchangedSlugs: ['unchanged-chart'],
+                createSlugs: ['brand-new'],
+                skipAheadSlugs: ['edited-on-instance'],
             }),
         ).toEqual({
             label: 'Charts',
             singular: 'chart',
             items: [
-                { slug: 'alpha', action: 'UPLOAD' },
-                { slug: 'zeta', action: 'UPLOAD' },
-                { slug: 'unchanged-chart', action: 'NO_CHANGES' },
+                { slug: 'brand-new', action: 'create' },
+                { slug: 'alpha', action: 'update' },
+                { slug: 'zeta', action: 'update' },
+                { slug: 'unchanged-chart', action: 'no_change' },
+                { slug: 'edited-on-instance', action: 'skip_ahead' },
             ],
         });
+    });
+});
+
+describe('summarizeUploadDryRun', () => {
+    it('counts verdicts and treats skip-ahead as a change', () => {
+        const totals = summarizeUploadDryRun([
+            {
+                label: 'Charts',
+                singular: 'chart',
+                items: [
+                    { slug: 'new', action: 'create' },
+                    { slug: 'changed', action: 'update' },
+                    { slug: 'same', action: 'no_change' },
+                    { slug: 'ahead', action: 'skip_ahead' },
+                ],
+            },
+        ]);
+
+        expect(totals).toEqual({
+            create: 1,
+            update: 1,
+            no_change: 1,
+            skip_ahead: 1,
+        });
+        expect(uploadDryRunWouldChange(totals)).toBe(true);
+        expect(
+            uploadDryRunWouldChange({
+                create: 0,
+                update: 0,
+                no_change: 4,
+                skip_ahead: 0,
+            }),
+        ).toBe(false);
     });
 });
 
@@ -71,27 +114,62 @@ describe('printUploadDryRunPlan', () => {
         vi.restoreAllMocks();
     });
 
-    it('prints a grouped would-upload plan', () => {
+    it('prints a grouped would-update plan with totals', () => {
         printUploadDryRunPlan([
             {
                 label: 'Charts',
                 singular: 'chart',
                 items: [
-                    { slug: 'orders-over-time', action: 'UPLOAD' },
-                    { slug: 'stale-chart', action: 'NO_CHANGES' },
+                    { slug: 'orders-over-time', action: 'update' },
+                    { slug: 'stale-chart', action: 'no_change' },
+                    { slug: 'edited-on-instance', action: 'skip_ahead' },
                 ],
             },
         ]);
 
         const printed = output.join('\n');
         expect(printed).toContain('Dry run — no changes will be made.');
-        expect(printed).toContain('would upload chart orders-over-time');
+        expect(printed).toContain('would update chart orders-over-time');
+        expect(printed).toContain('no change chart stale-chart');
         expect(printed).toContain(
-            'would skip chart stale-chart (no local changes)',
+            'would skip chart edited-on-instance (instance ahead)',
+        );
+        expect(printed).toContain(
+            'Totals: 0 create, 1 update, 1 no change, 1 skip ahead.',
         );
         expect(printed).toContain(
             'No files were written and no content was uploaded.',
         );
+    });
+
+    it('prints JSON when requested', () => {
+        printUploadDryRunPlan(
+            [
+                {
+                    label: 'Charts',
+                    singular: 'chart',
+                    items: [{ slug: 'orders-over-time', action: 'update' }],
+                },
+            ],
+            { json: true },
+        );
+
+        expect(JSON.parse(output.join('\n'))).toEqual({
+            dryRun: true,
+            totals: {
+                create: 0,
+                update: 1,
+                no_change: 0,
+                skip_ahead: 0,
+            },
+            groups: [
+                {
+                    label: 'Charts',
+                    singular: 'chart',
+                    items: [{ slug: 'orders-over-time', action: 'update' }],
+                },
+            ],
+        });
     });
 
     it('prints an empty plan', () => {
@@ -135,7 +213,7 @@ describe('collectOrganizationUploadPlan', () => {
             {
                 label: 'Custom roles',
                 singular: 'custom role',
-                items: [{ slug: 'Developer view only', action: 'UPLOAD' }],
+                items: [{ slug: 'Developer view only', action: 'update' }],
             },
         ]);
     });

--- a/packages/cli/src/handlers/uploadDryRun.ts
+++ b/packages/cli/src/handlers/uploadDryRun.ts
@@ -1,3 +1,4 @@
+import { assertUnreachable } from '@lightdash/common'; // pragma: allowlist secret
 import { Command } from 'commander';
 import { promises as fs } from 'fs';
 import * as styles from '../styles';
@@ -11,7 +12,11 @@ import { GROUP_CODE_RESOURCE } from './organizationContent/groups';
 import { getThemesFolder } from './organizationContent/themePackage';
 import { USER_CODE_RESOURCE } from './organizationContent/users';
 
-export type UploadDryRunAction = 'UPLOAD' | 'NO_CHANGES';
+export type UploadDryRunAction =
+    | 'create'
+    | 'update'
+    | 'no_change'
+    | 'skip_ahead';
 
 export type UploadDryRunItem = {
     slug: string;
@@ -24,16 +29,40 @@ export type UploadDryRunGroup = {
     items: UploadDryRunItem[];
 };
 
+export type UploadDryRunTotals = {
+    create: number;
+    update: number;
+    no_change: number;
+    skip_ahead: number;
+};
+
+export type UploadDryRunReport = {
+    dryRun: true;
+    totals: UploadDryRunTotals;
+    groups: UploadDryRunGroup[];
+};
+
 export const addUploadDryRunOption = (command: Command): Command =>
-    command.option(
-        '--dry-run',
-        'Preview the upload without writing to the instance or recording a last-applied snapshot',
-        false,
-    );
+    command
+        .option(
+            '--dry-run',
+            'Preview the upload without writing to the instance or recording a last-applied snapshot',
+            false,
+        )
+        .option(
+            '--json',
+            'Print the dry-run plan as JSON. Only used with --dry-run',
+            false,
+        )
+        .option(
+            '--strict',
+            'Exit 1 when a dry-run would create, update, or skip ahead content. Preview still prints; without --strict the exit code is 0',
+            false,
+        );
 
 const toPlanItems = (
     slugs: string[],
-    action: UploadDryRunAction = 'UPLOAD',
+    action: UploadDryRunAction,
 ): UploadDryRunItem[] =>
     [...new Set(slugs)]
         .sort((left, right) => left.localeCompare(right))
@@ -44,19 +73,29 @@ export const createUploadDryRunGroup = ({
     singular,
     slugs,
     unchangedSlugs = [],
+    createSlugs = [],
+    skipAheadSlugs = [],
 }: {
     label: string;
     singular: string;
     slugs: string[];
     unchangedSlugs?: string[];
+    createSlugs?: string[];
+    skipAheadSlugs?: string[];
 }): UploadDryRunGroup | null => {
-    const unchanged = new Set(unchangedSlugs);
+    const reserved = new Set([
+        ...unchangedSlugs,
+        ...createSlugs,
+        ...skipAheadSlugs,
+    ]);
     const items = [
+        ...toPlanItems(createSlugs, 'create'),
         ...toPlanItems(
-            slugs.filter((slug) => !unchanged.has(slug)),
-            'UPLOAD',
+            slugs.filter((slug) => !reserved.has(slug)),
+            'update',
         ),
-        ...toPlanItems(unchangedSlugs, 'NO_CHANGES'),
+        ...toPlanItems(unchangedSlugs, 'no_change'),
+        ...toPlanItems(skipAheadSlugs, 'skip_ahead'),
     ];
     if (items.length === 0) {
         return null;
@@ -64,30 +103,82 @@ export const createUploadDryRunGroup = ({
     return { label, singular, items };
 };
 
-export const printUploadDryRunPlan = (groups: UploadDryRunGroup[]): void => {
+export const summarizeUploadDryRun = (
+    groups: UploadDryRunGroup[],
+): UploadDryRunTotals => {
+    const totals: UploadDryRunTotals = {
+        create: 0,
+        update: 0,
+        no_change: 0,
+        skip_ahead: 0,
+    };
+    groups.forEach((group) => {
+        group.items.forEach((item) => {
+            totals[item.action] += 1;
+        });
+    });
+    return totals;
+};
+
+export const uploadDryRunWouldChange = (totals: UploadDryRunTotals): boolean =>
+    totals.create + totals.update + totals.skip_ahead > 0;
+
+const actionLine = (singular: string, item: UploadDryRunItem): string => {
+    switch (item.action) {
+        case 'create':
+            return `  would create ${singular} ${item.slug}`;
+        case 'update':
+            return `  would update ${singular} ${item.slug}`;
+        case 'no_change':
+            return `  no change ${singular} ${item.slug}`;
+        case 'skip_ahead':
+            return `  would skip ${singular} ${item.slug} (instance ahead)`;
+        default:
+            return assertUnreachable(
+                item.action,
+                `Unknown dry-run action: ${item.action}`,
+            );
+    }
+};
+
+export const printUploadDryRunPlan = (
+    groups: UploadDryRunGroup[],
+    { json = false }: { json?: boolean } = {},
+): UploadDryRunReport => {
+    const report: UploadDryRunReport = {
+        dryRun: true,
+        totals: summarizeUploadDryRun(groups),
+        groups,
+    };
+
+    if (json) {
+        console.info(JSON.stringify(report));
+        return report;
+    }
+
     console.info(styles.success('Dry run — no changes will be made.'));
     if (groups.length === 0) {
         console.info(styles.secondary('Nothing would be uploaded.'));
-        return;
+        return report;
     }
 
     console.info('');
     groups.forEach((group) => {
         console.info(styles.bold(group.label));
         group.items.forEach((item) => {
-            if (item.action === 'NO_CHANGES') {
-                console.info(
-                    `  would skip ${group.singular} ${item.slug} (no local changes)`,
-                );
-                return;
-            }
-            console.info(`  would upload ${group.singular} ${item.slug}`);
+            console.info(actionLine(group.singular, item));
         });
         console.info('');
     });
     console.info(
+        styles.secondary(
+            `Totals: ${report.totals.create} create, ${report.totals.update} update, ${report.totals.no_change} no change, ${report.totals.skip_ahead} skip ahead.`,
+        ),
+    );
+    console.info(
         styles.secondary('No files were written and no content was uploaded.'),
     );
+    return report;
 };
 
 const readThemeSlugs = async (customPath?: string): Promise<string[]> => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -787,9 +787,11 @@ program
 
 const ORGANIZATION_MODE_OPTIONS = new Set([
     'dryRun',
+    'json',
     'organization',
     'path',
     'sendInvites',
+    'strict',
     'verbose',
 ]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: PROD-10510
Relates: PROD-2856

**PROD-2856 ship plan: wave 1 — protection.** Stacked on #28000. Verdicts and `--strict` are the rest of the 10510 contract; skip-ahead stays unused until 10508.

### Description

Aligns `lightdash upload --dry-run` with the remaining 10510 contract, stacked on the first dry-run PR.

- Per-slug verdicts: **create**, **update**, **no change**, **skip ahead**
- Human preview prints those lines plus totals
- `--json` prints `{ dryRun, totals, groups }`
- Preview still exits 0; `--strict` sets exit code 1 when the plan would create, update, or skip ahead
- Still writes nothing (no upserts, no snapshot restamp)

Skip-ahead is in the report schema but not evaluated yet. That needs João’s PROD-10508 skip gate. Until then every changing slug is `update` (local `needsUpdating`), same as the current no-POST preview.

### Risk assessment:
- [ ] This is a high-risk change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8ccfc64-3e19-47b0-ba73-d713ac376003?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8ccfc64-3e19-47b0-ba73-d713ac376003&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

