### PR TITLE
fix: align custom chart input sizes

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -214,7 +214,7 @@ export const ConfigTabs: FC = memo(() => {
                             setOption(dataAppVizUuid, name, value)
                         }
                         colorPalette={colorPalette}
-                        paletteControl={<ColorPaletteSection />}
+                        paletteControl={<ColorPaletteSection size="xs" />}
                     />
                 ) : (
                     <Text size="xs" c="dimmed">

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
@@ -63,6 +63,7 @@ const DataAppVizSettings: FC<Props> = ({
                         <Config.Section>
                             <Config.Heading>{field.label}</Config.Heading>
                             <FieldSelect
+                                size="xs"
                                 placeholder={`Select ${field.label.toLowerCase()}`}
                                 disabled={items.length === 0}
                                 item={selectedItem}

--- a/packages/frontend/src/components/VisualizationConfigs/common/ColorPaletteSection.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/ColorPaletteSection.tsx
@@ -1,5 +1,5 @@
 import { isDimension } from '@lightdash/common';
-import { useMemo, type FC } from 'react';
+import { useMemo, type ComponentProps, type FC } from 'react';
 import {
     selectSavedChart,
     selectUnsavedColorPaletteUuid,
@@ -14,7 +14,11 @@ import { PalettePicker } from '../../common/PalettePicker/PalettePicker';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from './Config';
 
-export const ColorPaletteSection: FC = () => {
+type Props = {
+    size?: ComponentProps<typeof PalettePicker>['size'];
+};
+
+export const ColorPaletteSection: FC<Props> = ({ size = 'sm' }) => {
     const dispatch = useExplorerDispatch();
     const savedChart = useExplorerSelector(selectSavedChart);
     const value = useExplorerSelector(selectUnsavedColorPaletteUuid);
@@ -70,7 +74,7 @@ export const ColorPaletteSection: FC = () => {
                     </Callout>
                 )}
                 <PalettePicker
-                    size="sm"
+                    size={size}
                     value={value}
                     onChange={(next) =>
                         dispatch(explorerActions.setColorPaletteUuid(next))


### PR DESCRIPTION
Closes: PROD-10514

### Description:
- Use compact sizing for custom chart field-mapping controls.
- Let the custom chart palette picker match configuration options without changing other chart panels.
- No test changes.

### Testing:
- Frontend typecheck passed.
- Existing focused suite: 14 tests passed.
- Focused formatter and linter checks passed.
- Browser verification: General, Display, and Appearance inputs render at 30px.

### Risk assessment:
- [ ] This is a high-risk change