### PR TITLE
feat(ai-agents): Slack merged custom answers link into the merge editor

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -4,6 +4,7 @@ import {
     FilterOperator,
     FilterType,
     MergeJoinType,
+    parseMergeState,
 } from '@lightdash/common';
 import type { AgentSelectOption } from './getSlackBlocks';
 import {
@@ -586,9 +587,106 @@ describe('Slack AI agent blocks', () => {
         expect(saved.pivotConfig).toBeUndefined();
     });
 
-    it('keeps the merge fallback for merged custom chart type answers', async () => {
+    type CardArtifact = NonNullable<
+        Parameters<typeof getModernArtifactCardBlocks>[7]
+    >[number];
+    type GetDataAppVizSchemaFields = NonNullable<
+        Parameters<typeof getModernArtifactCardBlocks>[9]
+    >;
+
+    const mergedCustomChartTypeArtifact: CardArtifact = {
+        artifactUuid: 'artifact-1',
+        threadUuid: 'thread-1',
+        promptUuid: 'prompt-1',
+        artifactType: 'chart',
+        savedQueryUuid: null,
+        savedDashboardUuid: null,
+        createdAt: new Date(),
+        versionNumber: 1,
+        versionUuid: 'version-1',
+        title: 'Orders vs Targets',
+        description: null,
+        dashboardConfig: null,
+        versionCreatedAt: new Date(),
+        verifiedByUserUuid: null,
+        verifiedAt: null,
+        chartConfig: {
+            source: 'customChartType',
+            schemaVersion: 1,
+            dataAppVizUuid: 'data-app-viz-1',
+            config: {
+                title: 'Orders vs Targets',
+                description: 'Orders vs targets by month',
+                queryConfig: {
+                    exploreName: 'orders',
+                    dimensions: ['orders_order_date_month'],
+                    metrics: ['orders_unique_order_count'],
+                    sorts: [],
+                    limit: 500,
+                    parameters: null,
+                    customMetrics: [],
+                    tableCalculations: [],
+                    filters: null,
+                },
+                chartConfig: {
+                    customChartTypeSlug: 'fuzzy-bar',
+                    fieldMapping: {
+                        x: 'merge_month',
+                        y: 'primary_orders_unique_order_count',
+                        series: 'merge_month',
+                    },
+                    options: null,
+                },
+                mergeConfig: {
+                    primarySourceId: 'primary',
+                    additionalSources: [
+                        {
+                            id: 'targets',
+                            queryConfig: {
+                                exploreName: 'targets',
+                                dimensions: ['targets_month'],
+                                metrics: ['targets_target'],
+                                sorts: [],
+                                customMetrics: [],
+                                filters: null,
+                            },
+                        },
+                    ],
+                    joinKey: [
+                        {
+                            name: 'month',
+                            fields: [
+                                {
+                                    sourceId: 'primary',
+                                    fieldId: 'orders_order_date_month',
+                                },
+                                {
+                                    sourceId: 'targets',
+                                    fieldId: 'targets_month',
+                                },
+                            ],
+                        },
+                    ],
+                    joinType: MergeJoinType.FULL,
+                },
+            },
+        },
+    };
+
+    it('links merged custom chart type answers into the merge editor with the custom chart', async () => {
         let sharedParams: string | undefined;
-        const getDataAppVizSchemaFields = vi.fn();
+        const getDataAppVizSchemaFields = vi.fn<GetDataAppVizSchemaFields>(
+            async () => [
+                { name: 'x', label: 'X', type: 'dimension', required: true },
+                { name: 'y', label: 'Y', type: 'metric', required: true },
+                {
+                    name: 'series',
+                    label: 'Series',
+                    type: 'series',
+                    required: false,
+                },
+            ],
+        );
         await getModernArtifactCardBlocks(
             {
                 promptUuid: 'prompt-1',
@@ -604,101 +702,148 @@ describe('Slack AI agent blocks', () => {
             async () => ({}) as never,
             async () => true,
             'agent-1',
-            [
-                {
-                    artifactUuid: 'artifact-1',
-                    threadUuid: 'thread-1',
-                    promptUuid: 'prompt-1',
-                    artifactType: 'chart',
-                    savedQueryUuid: null,
-                    savedDashboardUuid: null,
-                    createdAt: new Date(),
-                    versionNumber: 1,
-                    versionUuid: 'version-1',
-                    title: 'Orders vs Targets',
-                    description: null,
-                    dashboardConfig: null,
-                    versionCreatedAt: new Date(),
-                    verifiedByUserUuid: null,
-                    verifiedAt: null,
-                    chartConfig: {
-                        source: 'customChartType',
-                        schemaVersion: 1,
-                        dataAppVizUuid: 'data-app-viz-1',
-                        config: {
-                            title: 'Orders vs Targets',
-                            description: 'Orders vs targets by month',
-                            queryConfig: {
-                                exploreName: 'orders',
-                                dimensions: ['orders_order_date_month'],
-                                metrics: ['orders_unique_order_count'],
-                                sorts: [],
-                                limit: 500,
-                                parameters: null,
-                                customMetrics: [],
-                                tableCalculations: [],
-                                filters: null,
-                            },
-                            chartConfig: {
-                                customChartTypeSlug: 'fuzzy-bar',
-                                fieldMapping: {
-                                    x: 'merge_month',
-                                    y: 'primary_orders_unique_order_count',
-                                },
-                                options: null,
-                            },
-                            mergeConfig: {
-                                primarySourceId: 'primary',
-                                additionalSources: [
-                                    {
-                                        id: 'targets',
-                                        queryConfig: {
-                                            exploreName: 'targets',
-                                            dimensions: ['targets_month'],
-                                            metrics: ['targets_target'],
-                                            sorts: [],
-                                            customMetrics: [],
-                                            filters: null,
-                                        },
-                                    },
-                                ],
-                                joinKey: [
-                                    {
-                                        name: 'month',
-                                        fields: [
-                                            {
-                                                sourceId: 'primary',
-                                                fieldId:
-                                                    'orders_order_date_month',
-                                            },
-                                            {
-                                                sourceId: 'targets',
-                                                fieldId: 'targets_month',
-                                            },
-                                        ],
-                                    },
-                                ],
-                                joinType: MergeJoinType.FULL,
-                            },
-                        },
-                    },
-                },
-            ],
+            [mergedCustomChartTypeArtifact],
             [],
             getDataAppVizSchemaFields,
         );
 
-        // The custom-chart branch is skipped for merged answers: the link
-        // stays the table-configured primary-source explore.
-        expect(getDataAppVizSchemaFields).not.toHaveBeenCalled();
-        const saved = JSON.parse(
-            new URLSearchParams(sharedParams).get(
-                'create_saved_chart_version',
-            )!,
+        expect(getDataAppVizSchemaFields).toHaveBeenCalledWith(
+            'data-app-viz-1',
         );
+        const search = new URLSearchParams(sharedParams);
+        const saved = JSON.parse(search.get('create_saved_chart_version')!);
+        // Canonical primary source carries the query; ids are renamed to the
+        // merge editor's conventions.
+        expect(saved.tableName).toBe('orders');
+        expect(saved.metricQuery.exploreName).toBe('orders');
+        expect(saved.chartConfig).toEqual({
+            type: ChartType.DATA_APP_VIZ,
+            config: {
+                dataAppVizUuid: 'data-app-viz-1',
+                fieldMapping: {
+                    x: 'merge_join_key_0',
+                    y: 'a_orders_unique_order_count',
+                    series: 'merge_join_key_0',
+                },
+            },
+        });
+        expect(saved.pivotConfig).toEqual({ columns: ['merge_join_key_0'] });
+        expect(saved.tableConfig.columnOrder).toEqual([
+            'merge_join_key_0',
+            'a_orders_unique_order_count',
+            'b_targets_target',
+        ]);
+        // The whole merge rides in the merge search param, so the link lands
+        // in the merge editor fully set up.
+        const mergeState = parseMergeState(search.get('merge'));
+        expect(mergeState).toEqual({
+            focus: { kind: 'source', sourceId: 'a' },
+            additionalSources: [
+                {
+                    id: 'b',
+                    exploreName: 'targets',
+                    dimensions: ['targets_month'],
+                    metrics: ['targets_target'],
+                    // The persisted parse normalizes null filters to empty
+                    // groups; empty groups carry no rules.
+                    filters: {
+                        dimensions: expect.objectContaining({ and: [] }),
+                        metrics: expect.objectContaining({ and: [] }),
+                        tableCalculations: expect.objectContaining({
+                            and: [],
+                        }),
+                    },
+                    additionalMetrics: [],
+                    customDimensions: undefined,
+                },
+            ],
+            joinParts: [
+                {
+                    fieldIdBySourceId: {
+                        a: 'orders_order_date_month',
+                        b: 'targets_month',
+                    },
+                },
+            ],
+            joinType: MergeJoinType.FULL,
+        });
+        // Explore-from-here links auto-run; web sets the same flag.
+        expect(search.get('isExploreFromHere')).toBe('true');
+    });
+
+    it('keeps the table fallback when a merge source explore cannot be loaded', async () => {
+        let sharedParams: string | undefined;
+        const getDataAppVizSchemaFields = vi.fn<GetDataAppVizSchemaFields>(
+            async () => [
+                { name: 'x', label: 'X', type: 'dimension', required: true },
+                { name: 'y', label: 'Y', type: 'metric', required: true },
+            ],
+        );
+        await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async (_path, params) => {
+                sharedParams = params;
+                return 'https://lightdash.example.com/share/custom';
+            },
+            async (exploreName) => {
+                if (exploreName === 'targets') {
+                    throw new Error('Explore not found');
+                }
+                return {} as never;
+            },
+            async () => true,
+            'agent-1',
+            [mergedCustomChartTypeArtifact],
+            [],
+            getDataAppVizSchemaFields,
+        );
+
+        const search = new URLSearchParams(sharedParams);
+        const saved = JSON.parse(search.get('create_saved_chart_version')!);
+        expect(saved.tableName).toBe('orders');
+        expect(saved.chartConfig.type).toBe(ChartType.TABLE);
+        expect(search.get('merge')).toBeNull();
+    });
+
+    it('keeps the table fallback for merged custom chart type answers when the schema is unavailable', async () => {
+        let sharedParams: string | undefined;
+        const getDataAppVizSchemaFields = vi.fn<GetDataAppVizSchemaFields>(
+            async () => null,
+        );
+        await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async (_path, params) => {
+                sharedParams = params;
+                return 'https://lightdash.example.com/share/custom';
+            },
+            async () => ({}) as never,
+            async () => true,
+            'agent-1',
+            [mergedCustomChartTypeArtifact],
+            [],
+            getDataAppVizSchemaFields,
+        );
+
+        // Without the type's schema the link stays the table-configured
+        // primary-source explore, so it still works.
+        const search = new URLSearchParams(sharedParams);
+        const saved = JSON.parse(search.get('create_saved_chart_version')!);
         expect(saved.tableName).toBe('orders');
         expect(saved.chartConfig.type).toBe(ChartType.TABLE);
         expect(saved.pivotConfig).toBeUndefined();
+        expect(search.get('merge')).toBeNull();
     });
 
     it('omits the hero but keeps the Open image button when the image URL is unreachable', async () => {

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -3,28 +3,41 @@ import {
     AiAgentMessageAssistantArtifact,
     AiAgentToolResult,
     AiArtifact,
+    canonicalizeAiMerge,
     ChartType,
     deriveDataAppVizPivotConfig,
     getDataAppVizChartFromArtifact,
     getGroupByDimensions,
+    getItemId,
     getItemMap,
     getWebAiChartConfig,
     isAiComposerChartArtifactConfig,
     isAiSqlChartArtifactConfig,
     isToolEditDbtProjectResult,
     isToolSetupPreviewDeployResult,
+    MERGE_TABLE_NAME,
+    MERGE_URL_PARAM,
+    mergeUrlStateFromCanonicalAiMerge,
     parseAiArtifactChartConfig,
     parseVizConfig,
+    remapFieldIdsDeep,
+    serializeMergeState,
     SlackPrompt,
     type AiLegacySemanticChartArtifactConfig,
     type ChartConfig,
+    type DataAppVizChart,
     type DataAppVizField,
     type Explore,
+    type ToolRunQueryArgsTransformed,
 } from '@lightdash/common';
 import { Block, KnownBlock } from '@slack/bolt';
 import { partition } from 'lodash';
 import { z } from 'zod';
 import type { SlackStreamChunk } from '../../../../clients/Slack/SlackClient';
+import {
+    buildAiMergeQuery,
+    buildAiMergeSourceConfigs,
+} from './buildAiMergeQuery';
 import { stripMemoryCitations } from './memoryCitation';
 import { populateCustomMetricsSQL } from './populateCustomMetricsSQL';
 
@@ -526,6 +539,98 @@ const buildSlackCardBlock = ({
         ...(actions?.length ? { actions: actions.slice(0, 3) } : {}),
     }) as unknown as Block;
 
+// Mirrors the web explore-from-here for merged custom answers: opens the merge
+// editor on the canonical primary source carrying the custom chart and pivot.
+const buildMergedCustomChartTypeExploreLink = async ({
+    vizTool,
+    dataAppVizChart,
+    schemaFields,
+    getExplore,
+    maxQueryLimit,
+    projectUuid,
+}: {
+    vizTool: ToolRunQueryArgsTransformed;
+    dataAppVizChart: DataAppVizChart;
+    schemaFields: DataAppVizField[];
+    getExplore: (exploreName: string) => Promise<Explore>;
+    maxQueryLimit: number;
+    projectUuid: string;
+}): Promise<{ path: string; params: string } | null> => {
+    const exploreNames = [
+        ...new Set(
+            buildAiMergeSourceConfigs(vizTool).map(
+                (source) => source.queryConfig.exploreName,
+            ),
+        ),
+    ];
+    const explores = new Map(
+        await Promise.all(
+            exploreNames.map(
+                async (name) => [name, await getExplore(name)] as const,
+            ),
+        ),
+    );
+    const mergeQuery = buildAiMergeQuery({
+        toolArgs: vizTool,
+        getExplore: (name) => {
+            const explore = explores.get(name);
+            if (!explore) throw new Error(`Explore not found: ${name}`);
+            return explore;
+        },
+        maxQueryLimit,
+    });
+    const canonical = canonicalizeAiMerge(mergeQuery);
+    if (!canonical) return null;
+
+    const { fieldIdByAiFieldId } = canonical;
+    const [primary, additional] = canonical.mergeQuery.sources;
+    const chartConfig: ChartConfig = remapFieldIdsDeep(
+        { type: ChartType.DATA_APP_VIZ, config: dataAppVizChart },
+        fieldIdByAiFieldId,
+    );
+    const pivotConfig = remapFieldIdsDeep(
+        deriveDataAppVizPivotConfig(schemaFields, dataAppVizChart.fieldMapping),
+        fieldIdByAiFieldId,
+    );
+    // Merged output columns: join keys, then each source's metrics and calcs.
+    const columnOrder = [
+        ...canonical.mergeQuery.joinKey.map((part) =>
+            getItemId({ table: MERGE_TABLE_NAME, name: part.name }),
+        ),
+        ...[primary, additional].flatMap((source) =>
+            [
+                ...source.metricQuery.metrics,
+                ...source.metricQuery.tableCalculations.map(
+                    (calculation) => calculation.name,
+                ),
+            ].map((column) => getItemId({ table: source.id, name: column })),
+        ),
+    ];
+
+    const search = new URLSearchParams();
+    search.set(
+        'create_saved_chart_version',
+        JSON.stringify({
+            tableName: primary.metricQuery.exploreName,
+            metricQuery: primary.metricQuery,
+            tableConfig: { columnOrder },
+            chartConfig,
+            ...(pivotConfig ? { pivotConfig } : {}),
+        }),
+    );
+    search.set(
+        MERGE_URL_PARAM,
+        serializeMergeState(mergeUrlStateFromCanonicalAiMerge(canonical)),
+    );
+    // Web explore-from-here links always carry this; it gates the auto-fetch.
+    search.set('isExploreFromHere', 'true');
+
+    return {
+        path: `/projects/${projectUuid}/tables/${primary.metricQuery.exploreName}`,
+        params: `?${search.toString()}`,
+    };
+};
+
 const getArtifactTitle = (artifact: AiArtifact) =>
     artifact.title ||
     (artifact.artifactType === 'dashboard'
@@ -732,12 +837,13 @@ export async function getModernArtifactCardBlocks(
                     },
                 };
                 let pivotConfig: { columns: string[] } | undefined;
-                if (
-                    artifact.chartConfig.source === 'customChartType' &&
-                    // Merged custom answers keep the merge fallback while
-                    // Slack rendering of custom chart types stays deferred.
-                    !vizConfig.vizTool.mergeConfig
-                ) {
+                // Whole URL for merged custom answers: the merge rides in its
+                // own search param beside the chart state.
+                let mergedCustomLink: {
+                    path: string;
+                    params: string;
+                } | null = null;
+                if (artifact.chartConfig.source === 'customChartType') {
                     // Mirror the web save flow: DATA_APP_VIZ config plus the
                     // type's schema-derived pivot. Without the schema (app
                     // deleted / invalid) keep the table fallback so the link
@@ -751,14 +857,33 @@ export async function getModernArtifactCardBlocks(
                           )
                         : null;
                     if (dataAppVizChart && schemaFields) {
-                        chartConfig = {
-                            type: ChartType.DATA_APP_VIZ,
-                            config: dataAppVizChart,
-                        };
-                        pivotConfig = deriveDataAppVizPivotConfig(
-                            schemaFields,
-                            dataAppVizChart.fieldMapping,
-                        );
+                        if (vizConfig.vizTool.mergeConfig) {
+                            try {
+                                mergedCustomLink =
+                                    await buildMergedCustomChartTypeExploreLink(
+                                        {
+                                            vizTool: vizConfig.vizTool,
+                                            dataAppVizChart,
+                                            schemaFields,
+                                            getExplore,
+                                            maxQueryLimit,
+                                            projectUuid:
+                                                slackPrompt.projectUuid,
+                                        },
+                                    );
+                            } catch {
+                                // keep the table fallback
+                            }
+                        } else {
+                            chartConfig = {
+                                type: ChartType.DATA_APP_VIZ,
+                                config: dataAppVizChart,
+                            };
+                            pivotConfig = deriveDataAppVizPivotConfig(
+                                schemaFields,
+                                dataAppVizChart.fieldMapping,
+                            );
+                        }
                     }
                 } else {
                     try {
@@ -785,18 +910,22 @@ export async function getModernArtifactCardBlocks(
                     }
                 }
 
-                const path = `/projects/${slackPrompt.projectUuid}/tables/${vizConfig.metricQuery.exploreName}`;
-                const params = `?create_saved_chart_version=${encodeURIComponent(
-                    JSON.stringify({
-                        tableName: vizConfig.metricQuery.exploreName,
-                        metricQuery: metricQueryWithSql,
-                        tableConfig: {
-                            columnOrder,
-                        },
-                        chartConfig,
-                        ...(pivotConfig ? { pivotConfig } : {}),
-                    }),
-                )}`;
+                const path =
+                    mergedCustomLink?.path ??
+                    `/projects/${slackPrompt.projectUuid}/tables/${vizConfig.metricQuery.exploreName}`;
+                const params =
+                    mergedCustomLink?.params ??
+                    `?create_saved_chart_version=${encodeURIComponent(
+                        JSON.stringify({
+                            tableName: vizConfig.metricQuery.exploreName,
+                            metricQuery: metricQueryWithSql,
+                            tableConfig: {
+                                columnOrder,
+                            },
+                            chartConfig,
+                            ...(pivotConfig ? { pivotConfig } : {}),
+                        }),
+                    )}`;
 
                 // Always link via a short /share URL — inlining the full chart
                 // state in the button URL exceeds Slack's URL length limits.

--- a/packages/common/src/ee/AiAgent/canonicalizeAiMerge.test.ts
+++ b/packages/common/src/ee/AiAgent/canonicalizeAiMerge.test.ts
@@ -1,9 +1,9 @@
-import { MergeJoinType, type MergeQuery } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import {
     parseMergeState,
     serializeMergeState,
-} from '../../../../features/mergeQuery/context/mergeUrlState';
+} from '../../types/mergeEditorState';
+import { MergeJoinType, type MergeQuery } from '../../types/mergeQuery';
 import { canonicalizeAiMerge, remapFieldIdsDeep } from './canonicalizeAiMerge';
 
 const aiMergeQuery: MergeQuery = {

--- a/packages/common/src/ee/AiAgent/canonicalizeAiMerge.ts
+++ b/packages/common/src/ee/AiAgent/canonicalizeAiMerge.ts
@@ -1,18 +1,22 @@
 import {
-    getItemId,
+    DEFAULT_ADDITIONAL_SOURCE_ID,
+    JOIN_KEY,
+    PRIMARY_SOURCE_ID,
+    type MergeUrlState,
+} from '../../types/mergeEditorState';
+import {
     isMergeMetricSource,
     MERGE_TABLE_NAME,
     type MergeQuery,
     type MergeQueryMetricSource,
-} from '@lightdash/common';
-import {
-    DEFAULT_ADDITIONAL_SOURCE_ID,
-    JOIN_KEY,
-    PRIMARY_SOURCE_ID,
-} from '../../../../features/mergeQuery/constants';
+} from '../../types/mergeQuery';
+import { getItemId } from '../../utils/item';
 
 export type CanonicalAiMerge = {
-    mergeQuery: MergeQuery & { sources: MergeQueryMetricSource[] };
+    mergeQuery: MergeQuery & {
+        /** Primary first; canonicalization refuses anything but two. */
+        sources: [MergeQueryMetricSource, MergeQueryMetricSource];
+    };
     /** Merged output column ids under the AI's names to their canonical ids. */
     fieldIdByAiFieldId: Record<string, string>;
 };
@@ -72,16 +76,47 @@ export const canonicalizeAiMerge = (
 
     return {
         mergeQuery: {
-            sources: metricSources.map((source) => ({
-                id: idBySourceId[source.id],
-                metricQuery: source.metricQuery,
-            })),
+            sources: [
+                { id: PRIMARY_SOURCE_ID, metricQuery: primary.metricQuery },
+                {
+                    id: DEFAULT_ADDITIONAL_SOURCE_ID,
+                    metricQuery: additional.metricQuery,
+                },
+            ],
             joinKey,
             joinType: mergeQuery.joinType,
             tableCalculations: mergeQuery.tableCalculations,
             limit: mergeQuery.limit,
         },
         fieldIdByAiFieldId,
+    };
+};
+
+/**
+ * The merge editor state a canonical AI merge restores from — one authority
+ * for the merge URL payload the web and Slack links carry.
+ */
+export const mergeUrlStateFromCanonicalAiMerge = (
+    canonical: CanonicalAiMerge,
+): MergeUrlState => {
+    const [primary, additional] = canonical.mergeQuery.sources;
+    return {
+        focus: { kind: 'source', sourceId: primary.id },
+        additionalSources: [
+            {
+                id: additional.id,
+                exploreName: additional.metricQuery.exploreName,
+                dimensions: additional.metricQuery.dimensions,
+                metrics: additional.metricQuery.metrics,
+                filters: additional.metricQuery.filters,
+                additionalMetrics: additional.metricQuery.additionalMetrics,
+                customDimensions: additional.metricQuery.customDimensions,
+            },
+        ],
+        joinParts: canonical.mergeQuery.joinKey.map((part) => ({
+            fieldIdBySourceId: part.fieldIdBySourceId,
+        })),
+        joinType: canonical.mergeQuery.joinType,
     };
 };
 

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -36,6 +36,7 @@ import { type AiMetricQuery, type AiResultType } from './types';
 
 export * from './adminTypes';
 export * from './aiEvalAssessment';
+export * from './canonicalizeAiMerge';
 export * from './chartConfig/slack';
 export * from './chartConfig/web';
 export * from './constants';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -152,6 +152,7 @@ export * from './types/job';
 export * from './types/knex-paginate';
 export * from './types/lightdashModel';
 export * from './types/lightdashProjectConfig';
+export * from './types/mergeEditorState';
 export * from './types/mergeQuery';
 export * from './types/metricQuery';
 export * from './types/metricsExplorer';

--- a/packages/common/src/types/mergeEditorState.test.ts
+++ b/packages/common/src/types/mergeEditorState.test.ts
@@ -1,10 +1,10 @@
-import { MergeJoinType } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import {
     parseMergeState,
     serializeMergeState,
     type MergeUrlState,
-} from './mergeUrlState';
+} from './mergeEditorState';
+import { MergeJoinType } from './mergeQuery';
 
 const state: MergeUrlState = {
     focus: { kind: 'source', sourceId: 'subscriptions' },

--- a/packages/common/src/types/mergeEditorState.ts
+++ b/packages/common/src/types/mergeEditorState.ts
@@ -1,14 +1,33 @@
-import { MergeJoinType, type Filters } from '@lightdash/common';
-import {
-    DEFAULT_ADDITIONAL_SOURCE_ID,
-    MAX_MERGE_SOURCES,
-    PRIMARY_SOURCE_ID,
-} from '../constants';
-import {
-    type MergeEditorSource,
-    type MergeFocus,
-    type MergeJoinPart,
-} from './context';
+import { type Filters } from './filter';
+import { MergeJoinType } from './mergeQuery';
+import { type MetricQuery } from './metricQuery';
+
+// The merge editor's canonical naming: sources take these fixed ids and join
+// keys `join_key_<i>`, so a merge built anywhere reads identically downstream.
+export const PRIMARY_SOURCE_ID = 'a';
+export const DEFAULT_ADDITIONAL_SOURCE_ID = 'b';
+export const MAX_MERGE_SOURCES = 2;
+export const JOIN_KEY = 'join_key';
+
+export type MergeEditorSource = {
+    id: string;
+    exploreName: string | null;
+    dimensions: string[];
+    metrics: string[];
+    filters: Filters;
+    /** Keep saved-query-only fields intact while the merge is edited. */
+    additionalMetrics?: MetricQuery['additionalMetrics'];
+    customDimensions?: MetricQuery['customDimensions'];
+};
+
+export type MergeFocus =
+    | { kind: 'source'; sourceId: string }
+    | { kind: 'join' };
+
+/** One part of the join key: the field each source contributes. */
+export type MergeJoinPart = {
+    fieldIdBySourceId: Record<string, string | null>;
+};
 
 /** Search param the merge relationship is kept in. */
 export const MERGE_URL_PARAM = 'merge';

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -1,5 +1,10 @@
 import { subject } from '@casl/ability';
 import {
+    canonicalizeAiMerge,
+    MERGE_URL_PARAM,
+    mergeUrlStateFromCanonicalAiMerge,
+    remapFieldIdsDeep,
+    serializeMergeState,
     type AiAgentMessageAssistant,
     type AiArtifact,
     type ApiError,
@@ -34,10 +39,6 @@ import { useVisualizationContext } from '../../../../../components/LightdashVisu
 import useEmbed from '../../../../../ee/providers/Embed/useEmbed';
 import { useChartVersionPreview } from '../../../../../features/apps/ChartVersionPreview/useChartVersionPreview';
 import { useDataAppVizRenderMetadata } from '../../../../../features/chartTypes/hooks/useDataAppVizRender';
-import {
-    MERGE_URL_PARAM,
-    serializeMergeState,
-} from '../../../../../features/mergeQuery/context/mergeUrlState';
 import useToaster from '../../../../../hooks/toaster/useToaster';
 import useCreateInAnySpaceAccess from '../../../../../hooks/user/useCreateInAnySpaceAccess';
 import { useCreateShareMutation } from '../../../../../hooks/useShare';
@@ -62,10 +63,6 @@ import {
     buildAiSavedChartData,
     getCustomChartTypeConfig,
 } from '../../utils/aiSavedChartData';
-import {
-    canonicalizeAiMerge,
-    remapFieldIdsDeep,
-} from '../../utils/canonicalizeAiMerge';
 import { AiChartDownloadModal } from './AiChartDownloadModal';
 import {
     AiChartImageExportMenuItem,
@@ -340,7 +337,7 @@ export const AiChartQuickOptions = ({
             // (already canonical); until the schema loads there is no URL.
             if (customChartTypeConfig && !savedData) return undefined;
             const { fieldIdByAiFieldId } = canonicalMerge;
-            const [primary, additional] = canonicalMerge.mergeQuery.sources;
+            const [primary] = canonicalMerge.mergeQuery.sources;
             const url = getOpenInExploreUrl({
                 metricQuery: primary.metricQuery,
                 projectUuid,
@@ -355,28 +352,9 @@ export const AiChartQuickOptions = ({
             const search = new URLSearchParams(url.search);
             search.set(
                 MERGE_URL_PARAM,
-                serializeMergeState({
-                    focus: { kind: 'source', sourceId: primary.id },
-                    additionalSources: [
-                        {
-                            id: additional.id,
-                            exploreName: additional.metricQuery.exploreName,
-                            dimensions: additional.metricQuery.dimensions,
-                            metrics: additional.metricQuery.metrics,
-                            filters: additional.metricQuery.filters,
-                            additionalMetrics:
-                                additional.metricQuery.additionalMetrics,
-                            customDimensions:
-                                additional.metricQuery.customDimensions,
-                        },
-                    ],
-                    joinParts: canonicalMerge.mergeQuery.joinKey.map(
-                        (part) => ({
-                            fieldIdBySourceId: part.fieldIdBySourceId,
-                        }),
-                    ),
-                    joinType: canonicalMerge.mergeQuery.joinType,
-                }),
+                serializeMergeState(
+                    mergeUrlStateFromCanonicalAiMerge(canonicalMerge),
+                ),
             );
             return { pathname: url.pathname, search: search.toString() };
         }

--- a/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.test.ts
@@ -1,17 +1,15 @@
 import {
     ChartType,
+    DEFAULT_ADDITIONAL_SOURCE_ID,
     MergeJoinType,
+    PRIMARY_SOURCE_ID,
+    type CanonicalAiMerge,
     type ChartConfig,
     type DataAppVizRenderMetadata,
     type MetricQuery,
 } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
-import {
-    DEFAULT_ADDITIONAL_SOURCE_ID,
-    PRIMARY_SOURCE_ID,
-} from '../../../../features/mergeQuery/constants';
 import { buildAiSavedChartData } from './aiSavedChartData';
-import { type CanonicalAiMerge } from './canonicalizeAiMerge';
 
 const metricQuery: MetricQuery = {
     exploreName: 'orders',

--- a/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/aiSavedChartData.ts
@@ -1,6 +1,8 @@
 import {
     ChartType,
     deriveDataAppVizPivotConfig,
+    remapFieldIdsDeep,
+    type CanonicalAiMerge,
     type ChartConfig,
     type CreateSavedChartVersion,
     type DataAppVizChart,
@@ -9,10 +11,6 @@ import {
     type ParametersValuesMap,
 } from '@lightdash/common';
 import { toSavedMerge } from '../../../../features/mergeQuery/hooks/useSavedMerge';
-import {
-    remapFieldIdsDeep,
-    type CanonicalAiMerge,
-} from './canonicalizeAiMerge';
 
 type BuildAiSavedChartDataArgs = {
     metricQuery: MetricQuery | undefined;

--- a/packages/frontend/src/features/mergeQuery/constants.ts
+++ b/packages/frontend/src/features/mergeQuery/constants.ts
@@ -1,10 +1,18 @@
-import { MergeJoinType } from '@lightdash/common';
+import {
+    DEFAULT_ADDITIONAL_SOURCE_ID,
+    MergeJoinType,
+    PRIMARY_SOURCE_ID,
+} from '@lightdash/common';
 import { type MergeEditorSource, type MergeJoinPart } from './context/context';
 
-export const PRIMARY_SOURCE_ID = 'a';
-export const DEFAULT_ADDITIONAL_SOURCE_ID = 'b';
-export const MAX_MERGE_SOURCES = 2;
-export const JOIN_KEY = 'join_key';
+// Canonical merge editor naming lives in common so the backend can mint
+// merge links with the exact same conventions.
+export {
+    DEFAULT_ADDITIONAL_SOURCE_ID,
+    JOIN_KEY,
+    MAX_MERGE_SOURCES,
+    PRIMARY_SOURCE_ID,
+} from '@lightdash/common';
 
 export const emptyMergeSource = (id: string): MergeEditorSource => ({
     id,

--- a/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
+++ b/packages/frontend/src/features/mergeQuery/context/MergeContext.tsx
@@ -1,11 +1,14 @@
 import {
     derivePivotConfigurationFromChart,
+    MERGE_URL_PARAM,
     MergeJoinType,
+    parseMergeState,
+    serializeMergeState,
     type ApiCompiledMergeQueryResults,
     type ApiError,
     type ApiExecuteAsyncMetricQueryResults,
-    type MergeQuery,
     type Filters,
+    type MergeQuery,
     type MergeQueryError,
     type ParametersValuesMap,
     type SavedChartDAO,
@@ -31,11 +34,6 @@ import {
 } from '../constants';
 import { executeMergeQuery } from '../hooks/useMergeQuery';
 import { MergeContext, type MergeFocus, type MergeJoinPart } from './context';
-import {
-    MERGE_URL_PARAM,
-    parseMergeState,
-    serializeMergeState,
-} from './mergeUrlState';
 import { restoreSavedMerge } from './restoreSavedMerge';
 
 /**

--- a/packages/frontend/src/features/mergeQuery/context/context.ts
+++ b/packages/frontend/src/features/mergeQuery/context/context.ts
@@ -2,6 +2,9 @@ import {
     type ApiError,
     type Filters,
     type ItemsMap,
+    type MergeEditorSource,
+    type MergeFocus,
+    type MergeJoinPart,
     type MergeJoinType,
     type MergeFieldOrigins,
     type MergeQuery,
@@ -13,25 +16,13 @@ import {
 import { createContext } from 'react';
 import { type InfiniteQueryResults } from '../../../hooks/useQueryResults';
 
-export type MergeEditorSource = {
-    id: string;
-    exploreName: string | null;
-    dimensions: string[];
-    metrics: string[];
-    filters: Filters;
-    /** Keep saved-query-only fields intact while the merge is edited. */
-    additionalMetrics?: MetricQuery['additionalMetrics'];
-    customDimensions?: MetricQuery['customDimensions'];
-};
-
-export type MergeFocus =
-    | { kind: 'source'; sourceId: string }
-    | { kind: 'join' };
-
-/** One part of the join key: the field each source contributes. */
-export type MergeJoinPart = {
-    fieldIdBySourceId: Record<string, string | null>;
-};
+// Editor state shapes live in common (beside the merge URL contract) so the
+// backend can mint merge links; re-exported here for the editor's modules.
+export type {
+    MergeEditorSource,
+    MergeFocus,
+    MergeJoinPart,
+} from '@lightdash/common';
 
 /**
  * A merged run, in the shape the explorer's results machinery expects.


### PR DESCRIPTION
Stacked on #27994.

## What changed

- Slack cards for merged custom chart type answers no longer degrade to the primary-explore table fallback. The "Explore in Lightdash" link now mirrors the web's explore-from-here for merged custom answers: it opens the merge editor on the canonical primary source, carrying the `DATA_APP_VIZ` chart config and the type's schema-derived pivot, with all AI merged-column ids renamed to the merge editor's canonical ids, and the whole merge serialized into the `merge` search param (plus `isExploreFromHere` so it auto-runs like web links).
- The shared link contract moves from the frontend into `@lightdash/common` so backend and web mint identical URLs from one authority:
  - `canonicalizeAiMerge` / `remapFieldIdsDeep` (plus a new shared `mergeUrlStateFromCanonicalAiMerge` builder used by both web explore-from-here and the Slack card)
  - the canonical merge editor constants (`a`/`b` source ids, `join_key_<i>`)
  - the merge URL state serde (`serializeMergeState`/`parseMergeState`, `MERGE_URL_PARAM`) and editor state types; frontend modules re-export from common so existing imports keep working
- `CanonicalAiMerge.mergeQuery.sources` is now a two-tuple, matching what canonicalization guarantees.

## Fallbacks

When the custom chart type's schema is unavailable (app deleted/invalid), or a merge source explore can't be loaded, the link keeps the previous table-configured primary-explore fallback so it still works. Plain (non-custom) merged answers in Slack are untouched.

## Validation

- New/updated unit tests: merged custom Slack link (canonical ids, pivot, column order, merge param round-trip via `parseMergeState`, `isExploreFromHere`), schema-unavailable fallback, source-explore-failure fallback.
- `common`/`backend`/`frontend` typecheck + lint green; `common` full suite, backend Slack/runQuery suites, and frontend mergeQuery/aiCopilot suites pass.

Closes: ZAP-934
