### PR TITLE
fix(backend): treat migration-ledger supersets with nothing pending as database-ahead

### DIFF
--- a/packages/backend/src/scripts/migrate/migrationState.test.ts
+++ b/packages/backend/src/scripts/migrate/migrationState.test.ts
@@ -92,6 +92,35 @@ describe('getKnexMigrationState', () => {
         });
     });
 
+    test('classifies a back-dated database-only ledger as ahead when nothing is pending', async () => {
+        tracker.on.any(/information_schema\.tables/).response(true);
+        tracker.on
+            .select('knex_migrations')
+            .response([
+                { name: ossMigration },
+                { name: eeMigration },
+                { name: '20260810130000_backdated_database_only.ts' },
+            ]);
+
+        const state = await getKnexMigrationState(database, {
+            directory: [ossDirectory, eeDirectory],
+            loadExtensions: ['.ts'],
+            tableName: 'knex_migrations',
+        });
+
+        expect(state).toEqual({
+            completed: [
+                ossMigration,
+                eeMigration,
+                '20260810130000_backdated_database_only.ts',
+            ],
+            pending: [],
+            missing: ['20260810130000_backdated_database_only.ts'],
+            offending: [],
+            classification: 'database-ahead',
+        });
+    });
+
     test('classifies database-only migrations within the local range as diverged', async () => {
         tracker.on.any(/information_schema\.tables/).response(true);
         tracker.on
@@ -157,7 +186,6 @@ describe('getKnexMigrationState', () => {
             .select('knex_migrations')
             .response([
                 { name: ossMigration },
-                { name: eeMigration },
                 { name: '99999999999999_impossible.ts' },
                 { name: '20991301120000_invalid_month.ts' },
                 { name: '20990229120000_invalid_day.ts' },
@@ -189,7 +217,6 @@ describe('getKnexMigrationState', () => {
             .select('knex_migrations')
             .response([
                 { name: ossMigration },
-                { name: eeMigration },
                 { name: '20260810160000_zzz_database_only.ts' },
                 { name: '20260811120000_first_database_only.ts' },
                 { name: '20260811120000_same_timestamp.ts' },
@@ -214,7 +241,6 @@ describe('getKnexMigrationState', () => {
             .select('knex_migrations')
             .response([
                 { name: ossMigration },
-                { name: eeMigration },
                 { name: '20260812120000_first_database_only.ts' },
                 { name: '20260811120000_non_monotonic.ts' },
             ]);

--- a/packages/backend/src/scripts/migrate/migrationState.ts
+++ b/packages/backend/src/scripts/migrate/migrationState.ts
@@ -106,6 +106,12 @@ const classifyMigrationState = (
     if (newestLocalMigration === undefined) {
         return { classification: 'diverged', offending: missing };
     }
+    // Nothing pending means the ledger is a strict superset of local files (an
+    // older image on an already-upgraded database); safe regardless of
+    // timestamp ordering because no migration will run.
+    if (pending.length === 0) {
+        return { classification: 'database-ahead', offending: [] };
+    }
     const loadExtensions = new Set(
         getLoadExtensions(config).map((extension) =>
             extension.startsWith('.') ? extension : `.${extension}`,

--- a/packages/backend/src/scripts/migrate/preflight.test.ts
+++ b/packages/backend/src/scripts/migrate/preflight.test.ts
@@ -585,6 +585,24 @@ describe('preflight checks', () => {
         expect(result.decision).toBe('abort');
     });
 
+    test('passes a database-ahead ledger and surfaces the ledger-only migrations', async () => {
+        const result = await report({
+            migrationState: state({
+                pending: [],
+                missing: ['20260810120000_backdated.js'],
+                classification: 'database-ahead',
+            }),
+        });
+
+        expect(check(result, 'version-path')).toMatchObject({
+            outcome: 'pass',
+            message: expect.stringContaining(
+                'ledger-only migrations: 20260810120000_backdated.js',
+            ),
+        });
+        expect(result.decision).toBe('proceed');
+    });
+
     test('fails a diverged actual migration ledger', async () => {
         const result = await report({
             migrationState: state({

--- a/packages/backend/src/scripts/migrate/preflight.ts
+++ b/packages/backend/src/scripts/migrate/preflight.ts
@@ -554,7 +554,11 @@ const versionPathCheck = (
     }
     let message =
         'The artifact declares no unresolved historical version-path boundary';
-    if (
+    if (migrationState.classification === 'database-ahead') {
+        message = `The database ledger is ahead of this image's local migrations; ledger-only migrations: ${migrationState.missing.join(
+            ', ',
+        )}`;
+    } else if (
         artifact.upgrade.minPreviousVersion === null &&
         unresolvedHistoricalStops.length === 0
     ) {


### PR DESCRIPTION
## Problem

During a production rollout, backend pods for several tenants crash-looped (4 restarts each) and fired restart alerts. A node-pool upgrade evicted old-version pods mid-rollout; their ReplicaSets recreated them, and the recreated pods could not boot: the migration preflight's `version-path` check reported the ledger as **diverged** and aborted — even though there were **0 pending migrations** and nothing would run.

The root cause is back-dated migration timestamps: migrations merged later but named with earlier timestamps than migrations already shipped in a prior release. From the older image's viewpoint, those ledger entries sort before its newest local migration file, so `classifyMigrationState` failed the timestamp-monotonicity heuristic and classified the state as `diverged` instead of the benign `database-ahead`. This precondition already exists again on `main` (two migrations share the exact timestamp `20260824120000`), so the next rollout wave can hit the same crash-loop.

## Fix

A ledger that is a strict superset of the local migration files with **nothing pending** is now classified `database-ahead` regardless of timestamp ordering. With nothing to apply, `migrate up` is a no-op — the knex phase exits before touching the database, invalid-index cleanup early-returns on an empty list, and Graphile migrate already runs on every boot — so aborting only bricks the pod. The preflight `version-path` message now lists the ledger-only migration names so the situation stays visible.

The timestamp heuristic is unchanged for the `pending > 0` case, where out-of-order application is a genuine risk.

## Testing

- New classifier test: back-dated ledger-only entry with nothing pending → `database-ahead`.
- New preflight test: `database-ahead` state passes `version-path` and surfaces the ledger-only names.
- Three existing tests that pinned the old behavior now keep one local migration pending, preserving their original diverged/offending assertions on the branch where the heuristic still applies.
- End-to-end repro against a local database: inserted a back-dated ledger-only row, ran the real migrate CLI — old code aborts with "Migration ledger diverged from local files", fixed code proceeds and completes as a no-op.

Note: the fix ships in future images; older images already in the field still carry the old preflight, so the crash-loop can recur once more for upgrades whose old side predates this change (harmless, self-heals when the rollout completes).

Closes: PROD-10559