### PR TITLE
fix(explorer): review follow-ups for the embedded builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ scripts/playground-bundle/.venv/
 scripts/k8s-dev/terraform/.terraform/
 examples/metricflow-demo/.fusion/
 .claude/worktrees/
+
+# Impeccable design-skill artifacts
+.impeccable/

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
@@ -28,19 +28,21 @@
     min-width: 0;
 }
 
-/* Always visible: hover-only editing hides the affordance from discovery
-   and from touch entirely. Rest is quiet; hover/focus lifts it to full ink. */
+/* Edit fades in on hover/focus so resting cards stay clean; the configure
+   step's persistent "Edit chart type" action covers discovery and touch. */
 .cardEdit {
     position: absolute;
     top: 4px;
     right: 4px;
-    opacity: 0.7;
+    opacity: 0;
+    pointer-events: none;
     transition: opacity 100ms ease-out;
 }
 
 .cardWrapper:hover .cardEdit,
 .cardWrapper:focus-within .cardEdit {
     opacity: 1;
+    pointer-events: auto;
 }
 
 .card {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -154,14 +154,18 @@ const SectionBody: FC<{ section: ChartTypeGallerySection }> = ({ section }) => {
     const itemCount = section.items.length;
 
     // The "+N more" tile can unmount on reveal; move focus to the first new
-    // card so keyboard users are not dropped back to the body.
+    // card so keyboard users are not dropped back to the body. The pending
+    // index is consumed by whatever count change answers the click, so a
+    // failed or shorter load cannot leave it armed for a later, unrelated
+    // change.
     useEffect(() => {
         const index = pendingFocusIndex.current;
-        if (index === null || itemCount <= index) return;
+        if (index === null) return;
         pendingFocusIndex.current = null;
+        if (itemCount === 0) return;
         gridRef.current
             ?.querySelectorAll<HTMLButtonElement>(`.${classes.card}`)
-            [index]?.focus();
+            [Math.min(index, itemCount - 1)]?.focus();
     }, [itemCount]);
 
     if (section.loading) {
@@ -174,7 +178,8 @@ const SectionBody: FC<{ section: ChartTypeGallerySection }> = ({ section }) => {
             </Group>
         );
     }
-    if (section.errorMessage !== null) {
+    // A transient refetch failure must not hide types already on screen.
+    if (section.errorMessage !== null && section.items.length === 0) {
         return (
             <Group justify="space-between" wrap="nowrap">
                 <Text fz="xs" c="red">
@@ -375,7 +380,11 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
                 selected: selectedProjectUuid === dataAppViz.dataAppVizUuid,
                 disabled,
                 select: () => {
-                    selectProjectChartType(dataAppViz, itemsMap ?? {});
+                    // Re-selecting the active type must not overwrite the
+                    // chart's local bindings with a fresh automap.
+                    if (selectedProjectUuid !== dataAppViz.dataAppVizUuid) {
+                        selectProjectChartType(dataAppViz, itemsMap ?? {});
+                    }
                     onSelected();
                 },
                 onEdit: canEditChartType(dataAppViz)

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -294,6 +294,13 @@ describe('ExplorerChartTypeAuthoring', () => {
     it('binds the chart to the type once its schema is known', () => {
         const store = renderAuthoring();
 
+        // Builds from this host carry the explorer's analytics source.
+        expect(useChartTypeBuilderWorkspace).toHaveBeenCalledWith(
+            expect.objectContaining({
+                creationExperience: 'explorer_chart_config',
+            }),
+        );
+
         expect(
             store.getState().explorer.unsavedChartVersion.chartConfig,
         ).toEqual({

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
@@ -119,8 +119,7 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
         selectProjectChartType,
     ]);
 
-    // Latest-abandonment cleanup, callable from the forbidden ejection
-    // effect above render order without stale captures.
+    // Ref so the forbidden-exit effect can call cleanup without stale closures.
     const cleanupAbandonedTypeRef = useRef<() => void>(() => {});
 
     // The entry points gate already; this closes a door opened by hand.
@@ -137,8 +136,7 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
     useEffect(() => {
         if (!isForbidden) return;
         showToastError({ title: 'You cannot author this chart type' });
-        // The same abandonment cleanup a manual cancel runs; without it a
-        // forbidden ejection strands a running draft or a never-built type.
+        // Run the same cleanup as a manual cancel to avoid orphaned drafts.
         cleanupAbandonedTypeRef.current();
         dispatch(explorerActions.cancelChartTypeAuthoring());
     }, [isForbidden, showToastError, dispatch]);

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
@@ -116,6 +116,10 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
         selectProjectChartType,
     ]);
 
+    // Latest-abandonment cleanup, callable from the forbidden ejection
+    // effect above render order without stale captures.
+    const cleanupAbandonedTypeRef = useRef<() => void>(() => {});
+
     // The entry points gate already; this closes a door opened by hand.
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const canCreate = useCanCreateDataApp(projectUuid);
@@ -130,6 +134,9 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
     useEffect(() => {
         if (!isForbidden) return;
         showToastError({ title: 'You cannot author this chart type' });
+        // The same abandonment cleanup a manual cancel runs; without it a
+        // forbidden ejection strands a running draft or a never-built type.
+        cleanupAbandonedTypeRef.current();
         dispatch(explorerActions.cancelChartTypeAuthoring());
     }, [isForbidden, showToastError, dispatch]);
 
@@ -172,6 +179,25 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
     const [isExitConfirmOpen, setIsExitConfirmOpen] = useState(false);
     // A running first build dies with the exit; a revision build survives it.
     const exitDiscardsBuild = build.isBuilding && build.draft !== null;
+    const cleanupAbandonedType = () => {
+        if (exitDiscardsBuild && build.discard) {
+            // A first build still running would leave an orphan behind.
+            build.discard();
+        } else if (
+            projectUuid &&
+            authoring.createdInSession &&
+            dataAppVizUuid !== null &&
+            history.latestReadyVersion === null
+        ) {
+            // Created here and never got a usable version: nothing to keep.
+            deleteApp({
+                projectUuid,
+                appUuid: dataAppVizUuid,
+                successTitle: 'Chart type discarded',
+            });
+        }
+    };
+    cleanupAbandonedTypeRef.current = cleanupAbandonedType;
     const performExit = () => {
         if (chartUsesThisType && dataAppVizUuid !== null) {
             // The chart renders through metadata that may still hold the
@@ -197,22 +223,7 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
             });
             dispatch(explorerActions.finishChartTypeAuthoring());
         } else {
-            if (exitDiscardsBuild && build.discard) {
-                // A first build still running would leave an orphan behind.
-                build.discard();
-            } else if (
-                projectUuid &&
-                authoring.createdInSession &&
-                dataAppVizUuid !== null &&
-                history.latestReadyVersion === null
-            ) {
-                // Created here and never got a usable version: nothing to keep.
-                deleteApp({
-                    projectUuid,
-                    appUuid: dataAppVizUuid,
-                    successTitle: 'Chart type discarded',
-                });
-            }
+            cleanupAbandonedType();
             dispatch(explorerActions.cancelChartTypeAuthoring());
         }
         focusSidebar();

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
@@ -67,6 +67,9 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
     const workspace = useChartTypeBuilderWorkspace({
         projectUuid,
         dataAppVizUuid: authoring.dataAppVizUuid,
+        // The pre-builder explorer surface reported this source; the
+        // embedded builder is its successor.
+        creationExperience: 'explorer_chart_config',
         itemsMap,
     });
     const { build, dataAppViz, dataAppVizUuid, history } = workspace;

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.tsx
@@ -20,6 +20,7 @@ import { useEffect, useRef, useState, type FC, type ReactNode } from 'react';
 import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
 import AppUpgradeModal from '../../../features/apps/components/AppUpgradeModal';
 import { type SdkUpgradeOffer } from '../../../features/apps/hooks/useSdkUpgradeStatus';
+import { type ChartTypeAppMeta } from '../../../features/chartTypes/builder/appMeta';
 import MantineIcon from '../../common/MantineIcon';
 import { authoringStatusLabel, type AuthoringStatus } from './authoringStatus';
 import classes from './ExplorerChartTypeAuthoringHeader.module.css';
@@ -28,7 +29,7 @@ type Props = {
     projectUuid: string;
     titleId: string;
     /** Null while no app exists yet (a new type before its first build). */
-    app: { appUuid: string; name: string; description: string } | null;
+    app: ChartTypeAppMeta | null;
     status: AuthoringStatus | null;
     upgrade: (SdkUpgradeOffer & { disabled: boolean }) | null;
     hasHistory: boolean;

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.tsx
@@ -2,6 +2,7 @@ import { type DataAppVizContext } from '@lightdash/common';
 import { Box } from '@mantine/core';
 import { useId, type FC, type ReactNode } from 'react';
 import { type SdkUpgradeOffer } from '../../../features/apps/hooks/useSdkUpgradeStatus';
+import { type ChartTypeAppMeta } from '../../../features/chartTypes/builder/appMeta';
 import ChartTypeBuilderWorkspace from '../../../features/chartTypes/builder/ChartTypeBuilderWorkspace';
 import { type ChartTypeBuilderWorkspaceState } from '../../../features/chartTypes/builder/useChartTypeBuilderWorkspace';
 import { deriveAuthoringStatus } from './authoringStatus';
@@ -10,7 +11,7 @@ import classes from './ExplorerChartTypeAuthoringView.module.css';
 
 type Props = {
     projectUuid: string;
-    app: { appUuid: string; name: string; description: string } | null;
+    app: ChartTypeAppMeta | null;
     upgrade: (SdkUpgradeOffer & { disabled: boolean }) | null;
     workspace: ChartTypeBuilderWorkspaceState;
     previewContext: DataAppVizContext | null;

--- a/packages/frontend/src/components/Explorer/Explorer.authoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/Explorer.authoring.test.tsx
@@ -121,10 +121,13 @@ describe('Explorer while a chart type is authored', () => {
         expect(cardProps.at(-1)?.renderVisualization).toBe(true);
     });
 
-    it('puts the builder in the chart’s place and keeps the card alive without drawing it', () => {
+    it('puts the builder in the chart’s place and keeps the card alive without drawing it', async () => {
         renderExplorer({ authoring: true });
 
-        expect(screen.getByTestId('chart-type-authoring')).toBeInTheDocument();
+        // The builder chunk is lazy-loaded, so its mount is a tick away.
+        expect(
+            await screen.findByTestId('chart-type-authoring'),
+        ).toBeInTheDocument();
         // The query controls stay where they always are.
         expect(screen.getByTestId('explorer-header')).toBeInTheDocument();
         expect(screen.queryByTestId('results-card')).not.toBeInTheDocument();

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -5,7 +5,9 @@ import {
 } from '@lightdash/common';
 import { Box, Stack } from '@mantine/core';
 import {
+    lazy,
     memo,
+    Suspense,
     useCallback,
     useEffect,
     useMemo,
@@ -51,7 +53,6 @@ import { DrillDownModal } from '../MetricQueryData/DrillDownModal';
 import MetricQueryDataProvider from '../MetricQueryData/MetricQueryDataProvider';
 import UnderlyingDataModal from '../MetricQueryData/UnderlyingDataModal';
 import RefreshDbtButton from '../RefreshDbtButton';
-import ExplorerChartTypeAuthoring from './ChartTypeAuthoring/ExplorerChartTypeAuthoring';
 import { CustomDimensionModal } from './CustomDimensionModal';
 import { CustomMetricModal } from './CustomMetricModal';
 import ExplorerHeader from './ExplorerHeader';
@@ -65,6 +66,11 @@ import VisualizationCard from './VisualizationCard/VisualizationCard';
 import { WriteBackModal } from './WriteBackModal';
 
 const EMPTY_PARAMETER_REFERENCES: string[] = [];
+
+// Flag-gated surface; keep it out of the flag-off Explorer chunk.
+const ExplorerChartTypeAuthoring = lazy(
+    () => import('./ChartTypeAuthoring/ExplorerChartTypeAuthoring'),
+);
 
 const Explorer: FC<{ hideHeader?: boolean; chartView?: boolean }> = memo(
     ({ hideHeader = false, chartView = false }) => {
@@ -286,9 +292,11 @@ const Explorer: FC<{ hideHeader?: boolean; chartView?: boolean }> = memo(
                             !savedChart && <RefreshDbtButton />
                         ))}
                     {isAuthoring && chartTypeAuthoring && (
-                        <ExplorerChartTypeAuthoring
-                            authoring={chartTypeAuthoring}
-                        />
+                        <Suspense fallback={null}>
+                            <ExplorerChartTypeAuthoring
+                                authoring={chartTypeAuthoring}
+                            />
+                        </Suspense>
                     )}
 
                     {!isAuthoring && !isFullscreen && showQueryBuilder && (

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -67,7 +67,7 @@ import { WriteBackModal } from './WriteBackModal';
 
 const EMPTY_PARAMETER_REFERENCES: string[] = [];
 
-// Flag-gated surface; keep it out of the flag-off Explorer chunk.
+// Lazy-load to keep the flag-off Explorer bundle small.
 const ExplorerChartTypeAuthoring = lazy(
     () => import('./ChartTypeAuthoring/ExplorerChartTypeAuthoring'),
 );

--- a/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderHeader.tsx
@@ -21,6 +21,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
 import AppUpgradeModal from '../../apps/components/AppUpgradeModal';
 import { type SdkUpgradeOffer } from '../../apps/hooks/useSdkUpgradeStatus';
+import { type ChartTypeAppMeta } from './appMeta';
 import classes from './ChartTypeBuilderHeader.module.css';
 
 type Props = {
@@ -30,7 +31,7 @@ type Props = {
         to: To;
     };
     /** Null while no app exists yet (create flow before the first build). */
-    app: { appUuid: string; name: string; description: string } | null;
+    app: ChartTypeAppMeta | null;
     latestReadyVersion: number | null;
     /** False while the visualization has no versions to look back through. */
     hasHistory: boolean;

--- a/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderWorkspace.module.css
+++ b/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderWorkspace.module.css
@@ -14,11 +14,18 @@
     flex-direction: column;
 }
 
+.historyPanel {
+    min-width: 240px;
+}
+
 .historyResizeHandle {
     width: 1px;
     flex: 0 0 1px;
     cursor: col-resize;
-    background-color: var(--mantine-color-ldGray-2);
+    background-color: light-dark(
+        var(--mantine-color-ldGray-2),
+        var(--mantine-color-ldDark-4)
+    );
     transition:
         background-color 120ms ease,
         box-shadow 120ms ease;
@@ -27,6 +34,10 @@
 .historyResizeHandle[data-resize-handle-state='hover'],
 .historyResizeHandle[data-resize-handle-state='drag'],
 .historyResizeHandle:focus-visible {
-    background-color: var(--mantine-color-ldGray-4);
-    box-shadow: 0 0 0 1px var(--mantine-color-ldGray-4);
+    background-color: light-dark(
+        var(--mantine-color-ldGray-4),
+        var(--mantine-color-ldDark-3)
+    );
+    box-shadow: 0 0 0 1px
+        light-dark(var(--mantine-color-ldGray-4), var(--mantine-color-ldDark-3));
 }

--- a/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderWorkspace.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/ChartTypeBuilderWorkspace.tsx
@@ -105,6 +105,7 @@ const ChartTypeBuilderWorkspace: FC<Props> = ({
                     />
                     <Panel
                         id="chart-type-builder-history"
+                        className={classes.historyPanel}
                         order={2}
                         defaultSize={20}
                         minSize={15}

--- a/packages/frontend/src/features/chartTypes/builder/appMeta.ts
+++ b/packages/frontend/src/features/chartTypes/builder/appMeta.ts
@@ -1,0 +1,6 @@
+/** The identity slice of a chart type the builder headers work with. */
+export type ChartTypeAppMeta = {
+    appUuid: string;
+    name: string;
+    description: string;
+};

--- a/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.test.ts
+++ b/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.test.ts
@@ -75,6 +75,7 @@ const renderWorkspace = (args: Partial<ChartTypeBuilderWorkspaceArgs> = {}) =>
             initialProps: {
                 projectUuid: 'project-1',
                 dataAppVizUuid: 'viz-1',
+                creationExperience: 'chart_type_builder' as const,
                 itemsMap: {},
                 ...args,
             },
@@ -114,6 +115,7 @@ describe('useChartTypeBuilderWorkspace', () => {
         rerender({
             projectUuid: 'project-1',
             dataAppVizUuid: 'viz-1',
+            creationExperience: 'chart_type_builder',
             itemsMap: {},
         });
         expect(mockedClarificationRound).toHaveBeenLastCalledWith(
@@ -134,6 +136,7 @@ describe('useChartTypeBuilderWorkspace', () => {
         rerender({
             projectUuid: 'project-1',
             dataAppVizUuid: 'viz-2',
+            creationExperience: 'chart_type_builder',
             itemsMap: {},
         });
 
@@ -154,6 +157,7 @@ describe('useChartTypeBuilderWorkspace', () => {
         rerender({
             projectUuid: 'project-1',
             dataAppVizUuid: 'viz-1',
+            creationExperience: 'chart_type_builder',
             itemsMap: {},
         });
 
@@ -187,6 +191,7 @@ describe('useChartTypeBuilderWorkspace', () => {
         rerender({
             projectUuid: 'project-1',
             dataAppVizUuid: 'viz-1',
+            creationExperience: 'chart_type_builder',
             itemsMap: {},
         });
 
@@ -252,6 +257,7 @@ describe('useChartTypeBuilderWorkspace', () => {
         rerender({
             projectUuid: 'project-1',
             dataAppVizUuid: 'viz-1',
+            creationExperience: 'chart_type_builder',
             itemsMap: {},
         });
         expect(result.current.failureMessage).toBeNull();
@@ -282,6 +288,7 @@ describe('useChartTypeBuilderWorkspace', () => {
         rerender({
             projectUuid: 'project-1',
             dataAppVizUuid: 'viz-1',
+            creationExperience: 'chart_type_builder',
             itemsMap: {},
         });
         expect(result.current.onCancelBuild).toBe(cancel);
@@ -297,6 +304,7 @@ describe('useChartTypeBuilderWorkspace', () => {
         rerender({
             projectUuid: 'project-1',
             dataAppVizUuid: null,
+            creationExperience: 'chart_type_builder',
             itemsMap: {},
         });
         expect(result.current.composerAppUuid).toBe('viz-claimed');
@@ -308,6 +316,7 @@ describe('useChartTypeBuilderWorkspace', () => {
         rerender({
             projectUuid: 'project-1',
             dataAppVizUuid: 'viz-1',
+            creationExperience: 'chart_type_builder',
             itemsMap: {},
         });
         expect(result.current.composerAppUuid).toBe('viz-1');

--- a/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.ts
+++ b/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.ts
@@ -2,6 +2,7 @@ import {
     DATA_APP_VIZ_TEMPLATE,
     isAppVersionInProgress,
     type AppClarification,
+    type DataAppCreationExperience,
     type DataAppViz,
     type ItemsMap,
 } from '@lightdash/common';
@@ -60,6 +61,8 @@ export type ChartTypeBuilderWorkspaceArgs = {
      *  adopts the uuid a first build claims passes it back here without
      *  resetting the session. */
     dataAppVizUuid: string | null;
+    /** The surface builds are reported from in analytics. */
+    creationExperience: DataAppCreationExperience;
     /** Result columns the build binds fields against; {} when no query
      *  backs the session. */
     itemsMap: ItemsMap;
@@ -105,10 +108,12 @@ export type ChartTypeBuilderWorkspaceState = {
 export const useChartTypeBuilderWorkspace = ({
     projectUuid,
     dataAppVizUuid,
+    creationExperience,
     itemsMap,
 }: ChartTypeBuilderWorkspaceArgs): ChartTypeBuilderWorkspaceState => {
     const build = useDataAppVizBuild({
         projectUuid,
+        creationExperience,
         itemsMap,
         dataAppVizUuid,
         // Selection is the host's explicit act; nothing binds on landing.

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVizBuild.test.ts
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVizBuild.test.ts
@@ -106,6 +106,7 @@ describe('useDataAppVizBuild', () => {
         const rendered = renderHookWithProviders(
             ({ dataAppVizUuid }: { dataAppVizUuid: string | null }) =>
                 useDataAppVizBuild({
+                    creationExperience: 'chart_type_builder',
                     projectUuid: 'project-1',
                     itemsMap,
                     dataAppVizUuid,

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVizBuild.ts
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVizBuild.ts
@@ -1,5 +1,6 @@
 import {
     DATA_APP_VIZ_TEMPLATE,
+    type DataAppCreationExperience,
     getErrorMessage,
     type ApiAppVersionSummary,
     type AppClarification,
@@ -22,6 +23,8 @@ type Args = {
     itemsMap: ItemsMap;
     /** The visualization being revised; null while authoring a new one. */
     dataAppVizUuid: string | null;
+    /** The surface the build is reported from in analytics. */
+    creationExperience: DataAppCreationExperience;
     /** Called once a new visualization lands ready with the chart still
      *  pointing at nothing, with its contract bound. */
     onCreated: (
@@ -103,6 +106,7 @@ export const useDataAppVizBuild = ({
     projectUuid,
     itemsMap,
     dataAppVizUuid,
+    creationExperience,
     onCreated,
 }: Args): DataAppVizBuildState => {
     // The request in flight, and the app it is building — both null when idle.
@@ -178,7 +182,7 @@ export const useDataAppVizBuild = ({
                         projectUuid,
                         prompt,
                         template: DATA_APP_VIZ_TEMPLATE,
-                        creationExperience: 'chart_type_builder',
+                        creationExperience,
                         appUuid: draftAppUuid,
                         fileIds: files,
                         ...(request.codexModel
@@ -209,7 +213,7 @@ export const useDataAppVizBuild = ({
                     projectUuid,
                     appUuid: dataAppVizUuid,
                     prompt,
-                    creationExperience: 'chart_type_builder',
+                    creationExperience,
                     fileIds: files,
                     ...(request.codexModel
                         ? { codexModel: request.codexModel }
@@ -230,6 +234,7 @@ export const useDataAppVizBuild = ({
         [
             projectUuid,
             dataAppVizUuid,
+            creationExperience,
             building,
             draftAppUuid,
             generateApp,

--- a/packages/frontend/src/pages/ChartTypeBuilder.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.tsx
@@ -71,6 +71,7 @@ const ChartTypeBuilder: FC = () => {
     const workspace = useChartTypeBuilderWorkspace({
         projectUuid,
         dataAppVizUuid: activeVizUuid ?? null,
+        creationExperience: 'chart_type_builder',
         itemsMap: NO_ITEMS,
     });
     const { build, history, isBuilding, isHistoryOpen } = workspace;


### PR DESCRIPTION
## Summary

Closes out the non-blocking findings from the stack's code review and pre-merge pass:

- **Forbidden-exit cleanup**: a mid-session flag or permission flip ejects authoring via a toast; that path now runs the same abandonment cleanup as a manual cancel (discard a running first build, delete a never-built type created in the session) instead of stranding orphans.
- **Flag-off bundle**: the embedded builder is `lazy()`-loaded, so the Explorer chunk without `explorer-chart-gallery` stays at base size.
- **Gallery resilience**: a transient refetch failure no longer hides project types already on screen; re-selecting the active type no longer overwrites the chart's local bindings with a fresh automap; the "+N more" tile's keyboard-focus handoff can't go stale after a shorter-than-expected load.
- **Standalone port parity**: the extracted builder workspace regains the history panel's 240px floor and the resize handle's dark-mode `light-dark()` colors, both lost in the extraction.
- **Type hygiene**: the `{ appUuid, name, description }` shape the two builder headers and the authoring view each redeclared is now one `ChartTypeAppMeta` type.
- `.impeccable/` design-skill artifacts are gitignored.
- **Analytics source**: builds from the embedded flow now report `creationExperience: explorer_chart_config` (the source the pre-builder explorer surface used until #27201), while the standalone page keeps `chart_type_builder` — the two hosts are distinguishable in `data_app.created` / `data_app.iterated` again.

Deliberately deferred (larger or needing a product decision): the shared-type blast-radius signal, gallery tile thumbnails, deduplicating the two builder headers into one component, and the bind-on-entry derive-refactor.

## How to test

Covered by the existing suites (328 tests across the explorer, chart-types, and gallery areas; the lazy mount is pinned in `Explorer.authoring.test.tsx`). Live: kill the data-apps flag mid-authoring and check the draft is discarded; toggle history open in dark mode on the standalone builder.

Relates: GLITCH-680

