### PR TITLE
feat: minimal AI-artifact page renders custom chart type answers

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -230,6 +230,22 @@ const MINIMAL_ROUTES: RouteObject[] = [
                 },
             },
             {
+                path: '/minimal/projects/:projectUuid/ai-agents/:agentUuid/artifacts/:artifactUuid/versions/:versionUuid',
+                lazy: async () => {
+                    const MinimalAiAgentArtifact = await loadLazyRouteDefault(
+                        './ee/pages/MinimalAiAgentArtifact',
+                        () => import('./ee/pages/MinimalAiAgentArtifact'),
+                    );
+                    return {
+                        Component: () => (
+                            <Stack p="lg" h="100vh">
+                                <MinimalAiAgentArtifact />
+                            </Stack>
+                        ),
+                    };
+                },
+            },
+            {
                 path: '/minimal/projects/:projectUuid/apps/:appUuid',
                 lazy: async () => {
                     const MinimalApp = await loadLazyRouteDefault(

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -76,6 +76,11 @@ type Props = {
     displayFilters?: boolean;
     loadExplore?: boolean;
     interactionMode?: 'full' | 'read-only';
+    // Screenshot/export surfaces: flips VisualizationProvider into minimal
+    // mode so renderers disable drill-down/underlying-data structurally.
+    minimal?: boolean;
+    onScreenshotReady?: () => void;
+    onScreenshotError?: () => void;
 };
 
 export const AiVisualizationRenderer: FC<Props> = ({
@@ -92,6 +97,9 @@ export const AiVisualizationRenderer: FC<Props> = ({
     displayFilters: displayFiltersProp = true,
     loadExplore = true,
     interactionMode = 'full',
+    minimal = false,
+    onScreenshotReady,
+    onScreenshotError,
 }) => {
     const { data: health } = useHealth();
     const projectUuid = useProjectUuid();
@@ -253,6 +261,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
         >
             <VisualizationProvider
                 hasExplorerStore={false}
+                minimal={minimal}
                 key={selectedChartType ?? 'default'}
                 resultsData={resultsData}
                 chartConfig={providerChartConfig}
@@ -321,6 +330,8 @@ export const AiVisualizationRenderer: FC<Props> = ({
                             className="sentry-block ph-no-capture"
                             data-testid="ai-visualization"
                             enableContextMenu={allowsAnalyticalInteraction}
+                            onScreenshotReady={onScreenshotReady}
+                            onScreenshotError={onScreenshotError}
                         />
 
                         {allowsAnalyticalInteraction &&

--- a/packages/frontend/src/ee/pages/MinimalAiAgentArtifact.test.tsx
+++ b/packages/frontend/src/ee/pages/MinimalAiAgentArtifact.test.tsx
@@ -1,0 +1,356 @@
+import {
+    AiResultType,
+    ChartType,
+    getDataAppVizChartFromArtifact,
+    type AiCustomChartTypeChartArtifactConfig,
+    type ApiAiAgentThreadMessageVizQuery,
+    type ToolRunQueryArgs,
+} from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+import MinimalAiAgentArtifact from './MinimalAiAgentArtifact';
+
+const PROJECT_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const AGENT_UUID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const ARTIFACT_UUID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const VERSION_UUID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+
+const mocks = vi.hoisted(() => ({
+    useAiAgentArtifact: vi.fn(),
+    useAiAgentArtifactVizQuery: vi.fn(),
+    useInfiniteQueryResults: vi.fn(),
+    useExplore: vi.fn(),
+}));
+
+vi.mock('react-router', async (importOriginal) => ({
+    ...(await importOriginal<object>()),
+    useParams: () => ({
+        projectUuid: PROJECT_UUID,
+        agentUuid: AGENT_UUID,
+        artifactUuid: ARTIFACT_UUID,
+        versionUuid: VERSION_UUID,
+    }),
+}));
+
+vi.mock('../features/aiCopilot/hooks/useAiAgentArtifacts', () => ({
+    useAiAgentArtifact: mocks.useAiAgentArtifact,
+}));
+
+vi.mock('../features/aiCopilot/hooks/useProjectAiAgents', () => ({
+    useAiAgentArtifactVizQuery: mocks.useAiAgentArtifactVizQuery,
+}));
+
+vi.mock('../../hooks/useQueryResults', () => ({
+    useInfiniteQueryResults: mocks.useInfiniteQueryResults,
+}));
+
+vi.mock('../../hooks/health/useHealth', () => ({
+    default: () => ({ data: { query: { maxLimit: 5_000 } } }),
+}));
+
+vi.mock('../../hooks/appearance/useProjectColorPalette', () => ({
+    useProjectColorPalette: () => ({ data: undefined }),
+}));
+
+vi.mock('../../hooks/useExplore', () => ({
+    useExplore: mocks.useExplore,
+}));
+
+vi.mock('../features/aiCopilot/hooks/aiAgentRouting', () => ({
+    isEmbedAiAgentRoute: () => false,
+}));
+
+vi.mock('../../components/MetricQueryData/MetricQueryDataProvider', () => ({
+    default: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock(
+    '../../components/LightdashVisualization/VisualizationProvider',
+    () => ({
+        default: ({
+            children,
+            onSeriesContextMenu,
+            chartConfig,
+            minimal,
+        }: {
+            children: ReactNode;
+            onSeriesContextMenu?: unknown;
+            chartConfig?: { type?: string; config?: unknown };
+            minimal?: boolean;
+        }) => (
+            <div
+                data-testid="visualization-provider"
+                data-context-menu-enabled={String(
+                    onSeriesContextMenu !== undefined,
+                )}
+                data-chart-config-type={chartConfig?.type}
+                data-chart-config={JSON.stringify(chartConfig?.config)}
+                data-minimal={String(minimal === true)}
+            >
+                {children}
+            </div>
+        ),
+    }),
+);
+
+vi.mock('../../components/LightdashVisualization', () => ({
+    default: ({
+        enableContextMenu,
+        onScreenshotReady,
+        onScreenshotError,
+    }: {
+        enableContextMenu?: boolean;
+        onScreenshotReady?: () => void;
+        onScreenshotError?: () => void;
+    }) => (
+        <div
+            data-testid="lightdash-visualization"
+            data-context-menu-enabled={String(enableContextMenu)}
+        >
+            <button
+                data-testid="signal-screenshot-ready"
+                onClick={() => onScreenshotReady?.()}
+            />
+            <button
+                data-testid="signal-screenshot-error"
+                onClick={() => onScreenshotError?.()}
+            />
+        </div>
+    ),
+}));
+
+vi.mock(
+    '../../components/Explorer/VisualizationCard/SeriesContextMenu',
+    () => ({
+        SeriesContextMenu: () => <div data-testid="series-context-menu" />,
+    }),
+);
+
+vi.mock('../../components/MetricQueryData/UnderlyingDataModal', () => ({
+    default: () => <div data-testid="underlying-data-modal" />,
+}));
+
+vi.mock('../../components/MetricQueryData/DrillDownModal', () => ({
+    DrillDownModal: () => <div data-testid="drill-down-modal" />,
+}));
+
+vi.mock(
+    '../features/aiCopilot/components/ChatElements/AgentVisualizationChartTypeSwitcher',
+    () => ({
+        AgentVisualizationChartTypeSwitcher: () => (
+            <div data-testid="chart-type-switcher" />
+        ),
+    }),
+);
+
+const metricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_order_month'],
+    metrics: ['orders_total_revenue'],
+    sorts: [],
+    limit: 500,
+    filters: {},
+    tableCalculations: [],
+    additionalMetrics: [],
+};
+
+const vizQueryData = {
+    source: 'semantic' as const,
+    type: AiResultType.QUERY_RESULT,
+    query: {
+        queryUuid: '11111111-1111-4111-8111-111111111111',
+        metricQuery,
+        fields: {},
+        cacheMetadata: { cacheHit: false },
+        parameterReferences: [],
+        resolvedTimezone: 'UTC',
+        usedParametersValues: {},
+        warnings: [],
+    },
+    mergeQuery: null,
+    metadata: { title: 'Revenue trend', description: null },
+} as ApiAiAgentThreadMessageVizQuery;
+
+// Verbatim tool args from the envelope — slug config intact.
+const customToolArgs: ToolRunQueryArgs = {
+    title: 'Revenue trend',
+    description: 'Revenue by month.',
+    queryConfig: {
+        exploreName: 'orders',
+        dimensions: ['orders_order_month'],
+        metrics: ['orders_total_revenue'],
+        sorts: [],
+        limit: 500,
+        parameters: null,
+        filters: null,
+        customMetrics: null,
+        tableCalculations: null,
+    },
+    chartConfig: {
+        customChartTypeSlug: 'cohort-waterfall',
+        fieldMapping: {
+            x: 'orders_order_month',
+            y: 'orders_total_revenue',
+        },
+        options: { showLegend: true },
+    },
+};
+
+const customArtifactChartConfig: AiCustomChartTypeChartArtifactConfig = {
+    source: 'customChartType',
+    schemaVersion: 1,
+    dataAppVizUuid: '22222222-2222-4222-8222-222222222222',
+    config: customToolArgs,
+};
+
+const buildArtifact = (chartConfig: unknown = customArtifactChartConfig) => ({
+    artifactUuid: ARTIFACT_UUID,
+    versionUuid: VERSION_UUID,
+    artifactType: 'chart',
+    chartConfig,
+});
+
+const queryResults = {
+    rows: [{ orders_order_month: { value: { raw: '2026-01' } } }],
+    isFetchingRows: false,
+    error: null,
+    setFetchAll: vi.fn(),
+};
+
+const getReadyIndicator = () =>
+    document.getElementById('lightdash-ready-indicator');
+
+describe('MinimalAiAgentArtifact', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.useExplore.mockReturnValue({ data: undefined });
+        mocks.useAiAgentArtifact.mockReturnValue({
+            data: buildArtifact(),
+            isLoading: false,
+            error: null,
+        });
+        mocks.useAiAgentArtifactVizQuery.mockReturnValue({
+            data: vizQueryData,
+            isLoading: false,
+            error: null,
+        });
+        mocks.useInfiniteQueryResults.mockReturnValue(queryResults);
+    });
+
+    it('derives the renderer chart config from the artifact exactly as the web thread does', () => {
+        renderWithProviders(<MinimalAiAgentArtifact />);
+
+        const provider = screen.getByTestId('visualization-provider');
+        expect(provider).toHaveAttribute(
+            'data-chart-config-type',
+            ChartType.DATA_APP_VIZ,
+        );
+        expect(JSON.parse(provider.getAttribute('data-chart-config')!)).toEqual(
+            getDataAppVizChartFromArtifact(customArtifactChartConfig),
+        );
+    });
+
+    it('keeps analytical interactions structurally off', () => {
+        renderWithProviders(<MinimalAiAgentArtifact />);
+
+        const provider = screen.getByTestId('visualization-provider');
+        expect(provider).toHaveAttribute('data-minimal', 'true');
+        expect(provider).toHaveAttribute('data-context-menu-enabled', 'false');
+        expect(screen.getByTestId('lightdash-visualization')).toHaveAttribute(
+            'data-context-menu-enabled',
+            'false',
+        );
+        expect(mocks.useExplore).toHaveBeenCalledWith(undefined);
+        expect(screen.queryByTestId('underlying-data-modal')).toBeNull();
+        expect(screen.queryByTestId('drill-down-modal')).toBeNull();
+        expect(screen.queryByTestId('series-context-menu')).toBeNull();
+        expect(screen.queryByTestId('chart-type-switcher')).toBeNull();
+    });
+
+    it('mounts the ready indicator only after the renderer signals ready', () => {
+        renderWithProviders(<MinimalAiAgentArtifact />);
+
+        expect(getReadyIndicator()).toBeNull();
+
+        fireEvent.click(screen.getByTestId('signal-screenshot-ready'));
+
+        expect(getReadyIndicator()).not.toBeNull();
+        expect(getReadyIndicator()).toHaveAttribute('data-status', 'ready');
+    });
+
+    it('marks the tile errored when the renderer signals a screenshot error', () => {
+        renderWithProviders(<MinimalAiAgentArtifact />);
+
+        fireEvent.click(screen.getByTestId('signal-screenshot-error'));
+
+        expect(getReadyIndicator()).toHaveAttribute(
+            'data-status',
+            'completed-with-errors',
+        );
+        // Renderer stays mounted — its terminal frame is what gets captured.
+        expect(screen.getByTestId('visualization-provider')).toBeVisible();
+    });
+
+    it('does not mount the renderer or the ready indicator while rows are fetching', () => {
+        mocks.useInfiniteQueryResults.mockReturnValue({
+            ...queryResults,
+            isFetchingRows: true,
+        });
+
+        renderWithProviders(<MinimalAiAgentArtifact />);
+
+        expect(screen.queryByTestId('visualization-provider')).toBeNull();
+        expect(getReadyIndicator()).toBeNull();
+    });
+
+    it('reports an errored ready indicator for non custom chart type artifacts', () => {
+        mocks.useAiAgentArtifact.mockReturnValue({
+            data: buildArtifact({
+                source: 'semantic',
+                config: customToolArgs,
+            }),
+            isLoading: false,
+            error: null,
+        });
+        mocks.useAiAgentArtifactVizQuery.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            error: null,
+        });
+
+        renderWithProviders(<MinimalAiAgentArtifact />);
+
+        expect(screen.queryByTestId('visualization-provider')).toBeNull();
+        expect(
+            screen.getByText(
+                'This artifact is not a custom chart type answer.',
+            ),
+        ).toBeInTheDocument();
+        expect(getReadyIndicator()).toHaveAttribute(
+            'data-status',
+            'completed-with-errors',
+        );
+        expect(mocks.useAiAgentArtifactVizQuery).toHaveBeenCalledWith(
+            expect.anything(),
+            { enabled: false },
+        );
+    });
+
+    it('reports an errored ready indicator when the viz query fails', () => {
+        mocks.useAiAgentArtifactVizQuery.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            error: { error: { statusCode: 500 } },
+        });
+
+        renderWithProviders(<MinimalAiAgentArtifact />);
+
+        expect(screen.queryByTestId('visualization-provider')).toBeNull();
+        expect(getReadyIndicator()).toHaveAttribute(
+            'data-status',
+            'completed-with-errors',
+        );
+    });
+});

--- a/packages/frontend/src/ee/pages/MinimalAiAgentArtifact.tsx
+++ b/packages/frontend/src/ee/pages/MinimalAiAgentArtifact.tsx
@@ -1,0 +1,142 @@
+import { isAiAgentSqlArtifactVizQuery } from '@lightdash/common';
+import { Center, Text } from '@mantine/core';
+import { useCallback, useEffect, useState, type FC } from 'react';
+import { useParams } from 'react-router';
+import ScreenshotProgressIndicator from '../../components/common/ScreenshotProgressIndicator';
+import ScreenshotReadyIndicator from '../../components/common/ScreenshotReadyIndicator';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
+import { useInfiniteQueryResults } from '../../hooks/useQueryResults';
+import { AiVisualizationRenderer } from '../features/aiCopilot/components/ChatElements/AiVisualizationRenderer';
+import { useAiAgentArtifact } from '../features/aiCopilot/hooks/useAiAgentArtifacts';
+import { getAiArtifactChartSource } from '../features/aiCopilot/hooks/useAiArtifactChart';
+import { useAiAgentArtifactVizQuery } from '../features/aiCopilot/hooks/useProjectAiAgents';
+
+// Minimal render of a custom chart type artifact version for headless
+// capture: web-thread derivation/renderer, interactions structurally off.
+const MinimalAiAgentArtifact: FC = () => {
+    const { agentUuid, artifactUuid, versionUuid } = useParams<{
+        agentUuid: string;
+        artifactUuid: string;
+        versionUuid: string;
+    }>();
+    const projectUuid = useProjectUuid();
+    const artifactRef = {
+        projectUuid: projectUuid!,
+        agentUuid: agentUuid!,
+        artifactUuid: artifactUuid!,
+        versionUuid: versionUuid!,
+    };
+
+    // White page background for screenshot exports, regardless of theme
+    useEffect(() => {
+        document.documentElement.style.backgroundColor = 'white';
+        document.body.style.backgroundColor = 'white';
+    }, []);
+
+    const {
+        data: artifactData,
+        isLoading: isArtifactLoading,
+        error: artifactError,
+    } = useAiAgentArtifact(artifactRef);
+
+    const { semanticChartConfig, customChartType } = getAiArtifactChartSource(
+        artifactData?.chartConfig,
+    );
+
+    const vizQueryHandle = useAiAgentArtifactVizQuery(artifactRef, {
+        enabled: customChartType !== null,
+    });
+    const vizQueryData =
+        vizQueryHandle.data &&
+        !isAiAgentSqlArtifactVizQuery(vizQueryHandle.data)
+            ? vizQueryHandle.data
+            : undefined;
+
+    const queryResults = useInfiniteQueryResults(
+        projectUuid,
+        vizQueryData?.query.queryUuid,
+    );
+
+    const [isScreenshotReady, setIsScreenshotReady] = useState(false);
+    const [hasRendererError, setHasRendererError] = useState(false);
+    const handleScreenshotReady = useCallback(
+        () => setIsScreenshotReady(true),
+        [],
+    );
+    const handleScreenshotError = useCallback(() => {
+        setHasRendererError(true);
+        setIsScreenshotReady(true);
+    }, []);
+
+    if (!projectUuid || !agentUuid || !artifactUuid || !versionUuid) {
+        return null;
+    }
+
+    const isUnsupportedArtifact =
+        !isArtifactLoading && !artifactError && artifactData
+            ? customChartType === null
+            : false;
+    const hasLoadError =
+        !!artifactError ||
+        isUnsupportedArtifact ||
+        !!vizQueryHandle.error ||
+        !!queryResults.error;
+    // Renderer errors keep the (terminal) frame mounted but mark it errored.
+    const hasError = hasLoadError || hasRendererError;
+    const readyTileUuids = isScreenshotReady && !hasError ? [versionUuid] : [];
+    const erroredTileUuids = hasError ? [versionUuid] : [];
+
+    // Same gate as the web thread's artifact panel: mount the renderer only
+    // once the viz query and all result rows are in.
+    const isReadyToRender =
+        !hasLoadError &&
+        !!vizQueryData &&
+        !!semanticChartConfig &&
+        !!customChartType &&
+        !queryResults.isFetchingRows;
+
+    return (
+        <>
+            <ScreenshotProgressIndicator
+                expectedTileUuids={[versionUuid]}
+                readyTileUuids={readyTileUuids}
+                erroredTileUuids={erroredTileUuids}
+            />
+
+            {isReadyToRender ? (
+                <AiVisualizationRenderer
+                    vizQueryData={vizQueryData}
+                    results={queryResults}
+                    chartConfig={semanticChartConfig}
+                    customChartType={customChartType}
+                    selectedChartType={null}
+                    displayFields={false}
+                    displayFilters={false}
+                    loadExplore={false}
+                    interactionMode="read-only"
+                    minimal
+                    onScreenshotReady={handleScreenshotReady}
+                    onScreenshotError={handleScreenshotError}
+                />
+            ) : hasLoadError ? (
+                <Center h="100%">
+                    <Text size="sm" c="dimmed" ta="center">
+                        {isUnsupportedArtifact
+                            ? 'This artifact is not a custom chart type answer.'
+                            : 'Failed to load artifact visualization.'}
+                    </Text>
+                </Center>
+            ) : null}
+
+            {(isScreenshotReady || hasError) && (
+                <ScreenshotReadyIndicator
+                    tilesTotal={1}
+                    tilesReady={readyTileUuids.length}
+                    tilesErrored={erroredTileUuids.length}
+                />
+            )}
+        </>
+    );
+};
+
+export default MinimalAiAgentArtifact;


### PR DESCRIPTION
## Summary

New minimal route for rendering an AI agent artifact version's custom chart type answer standalone, for headless capture (groundwork for exporting agent answers as images).

- `/minimal/projects/:projectUuid/ai-agents/:agentUuid/artifacts/:artifactUuid/versions/:versionUuid` → new `ee/pages/MinimalAiAgentArtifact.tsx`, registered alongside the other `/minimal` capture routes (logged-in only).
- Reuses the exact web-thread pipeline — `useAiAgentArtifact` → `getAiArtifactChartSource` → `useAiAgentArtifactVizQuery` → `AiVisualizationRenderer` — so derivation, field-mapping reconciliation, options, palette, and pivot are shared by construction, not duplicated.
- `AiVisualizationRenderer` gains `minimal` (forwarded to `VisualizationProvider`; structurally disables drill-down/underlying-data in `DataAppVizRenderer`) and `onScreenshotReady`/`onScreenshotError` passthrough.
- The shared screenshot-ready indicator mounts only on the renderer's truthful ready signal (the gating added in the parent PR), never on mount; load/renderer errors mark the tile `completed-with-errors`. `ScreenshotProgressIndicator` mounts from first paint for timeout diagnostics.
- 403s surface the artifact endpoints' existing not-authorized handling.

## Testing

- 7 unit tests for the page, incl. asserting the page derives the identical `DATA_APP_VIZ` provider config as the web-thread derivation, ready-indicator gating, structural interaction lockout, and error paths.
- Verified live in the browser: custom viz paints in the sandbox iframe, ready indicator reports `ready` with the version uuid tracked.

Closes: ZAP-937