### PR TITLE
fix(explorer): scroll the version history inside the embedded builder

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.module.css
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringView.module.css
@@ -1,7 +1,10 @@
 .root {
     container: authoring / inline-size;
-    flex: 1 1 auto;
-    min-height: 0;
+    /* Basis 0 sizes the builder to the viewport's share, not its content,
+       so history and canvas scroll internally; the floor keeps it usable
+       on short windows, where the page scrolls instead. */
+    flex: 1 1 0;
+    min-height: 380px;
     display: flex;
     flex-direction: column;
     border: 1px solid var(--mantine-color-ldGray-2);

--- a/packages/frontend/src/components/Explorer/Explorer.module.css
+++ b/packages/frontend/src/components/Explorer/Explorer.module.css
@@ -1,0 +1,9 @@
+.stack {
+    flex-grow: 1;
+}
+
+/* While authoring, the builder must be viewport-bounded so its history and
+   canvas scroll internally; the stack yields instead of growing to content. */
+.stackAuthoring {
+    min-height: 0;
+}

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -4,6 +4,7 @@ import {
     getReferencedParameterDefinitions,
 } from '@lightdash/common';
 import { Box, Stack } from '@mantine/core';
+import clsx from 'clsx';
 import {
     lazy,
     memo,
@@ -55,6 +56,7 @@ import UnderlyingDataModal from '../MetricQueryData/UnderlyingDataModal';
 import RefreshDbtButton from '../RefreshDbtButton';
 import { CustomDimensionModal } from './CustomDimensionModal';
 import { CustomMetricModal } from './CustomMetricModal';
+import classes from './Explorer.module.css';
 import ExplorerHeader from './ExplorerHeader';
 import FiltersCard from './FiltersCard/FiltersCard';
 import { FormatModal } from './FormatModal';
@@ -281,7 +283,12 @@ const Explorer: FC<{ hideHeader?: boolean; chartView?: boolean }> = memo(
                 parameters={parameters}
                 resolvedTimezone={query.data?.resolvedTimezone}
             >
-                <Stack style={{ flexGrow: 1 }}>
+                <Stack
+                    className={clsx(
+                        classes.stack,
+                        isAuthoring && classes.stackAuthoring,
+                    )}
+                >
                     <MergeAutoRun />
                     {/* The query controls keep their usual spot while a chart
                         type is authored; only the cards below make way. */}


### PR DESCRIPTION
## Summary

Opening version history while authoring a chart type in the explorer scrolled the whole page instead of the history list: the authoring surface sat inside the explorer's page scroll at its own content height, so the panel's internal `overflow-y: auto` never engaged and older versions were clipped below the fold.

The flex chain is now bounded while authoring: the explorer stack drops its content-height floor (`min-height: 0`, applied only in authoring mode) and the builder sizes to the viewport's share (`flex-basis: 0` with a 380px usability floor). The history list and canvas scroll internally, matching the standalone builder page; on windows shorter than the floor the page scrolls as a fallback.

Not authoring, nothing changes: the stack keeps its exact previous layout (the inline `flexGrow` style moved to a CSS module class with the same computed value), verified live by exiting authoring and watching the classic content-driven page scroll return.

## How to test

Enter authoring on a type with a few versions, open History, shrink the window: the version list scrolls inside the panel and the page stays put. Exit authoring: the Filters/Chart/Results/SQL cards scroll the page as before.

Relates: GLITCH-680
