### PR TITLE
fix: resolve project slugs in minimal saved charts

### DIFF
--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
@@ -135,6 +135,7 @@ const spacePermissionService = {
 
 const projectModel = {
     getExploreFromCache: vi.fn(async () => null),
+    getUuidBySlug: vi.fn(async () => 'resolved-project-uuid'),
     getSummary: vi.fn(async () => ({
         organizationUuid: 'org-uuid',
         projectUuid: 'project-uuid',
@@ -176,6 +177,33 @@ describe('SavedChartService - Content Verification', () => {
 
     afterEach(() => {
         vi.clearAllMocks();
+    });
+
+    it('resolves a project slug before loading a saved chart', async () => {
+        await service.get('orders', fromSession(adminUser, 'session-cookie'), {
+            projectUuid: 'my-project',
+        });
+
+        expect(projectModel.getUuidBySlug).toHaveBeenCalledWith(
+            'org-uuid',
+            'my-project',
+        );
+        expect(savedChartModel.get).toHaveBeenCalledWith('orders', undefined, {
+            projectUuid: 'resolved-project-uuid',
+        });
+    });
+
+    it('keeps a project uuid unchanged when loading a saved chart', async () => {
+        const projectUuid = '5b3c6f00-7d53-4f87-b43a-75d774b1651e';
+
+        await service.get('orders', fromSession(adminUser, 'session-cookie'), {
+            projectUuid,
+        });
+
+        expect(projectModel.getUuidBySlug).not.toHaveBeenCalled();
+        expect(savedChartModel.get).toHaveBeenCalledWith('orders', undefined, {
+            projectUuid,
+        });
     });
 
     it('returns split candidates when a saved chart uses an original explore name', async () => {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -62,6 +62,7 @@ import {
 } from '@lightdash/common';
 import cronstrue from 'cronstrue';
 import { Knex } from 'knex';
+import { validate as isValidUuid } from 'uuid';
 import {
     ConditionalFormattingRuleSavedEvent,
     CreateSavedChartVersionEvent,
@@ -1364,10 +1365,17 @@ export class SavedChartService
         account: Account,
         options?: { projectUuid?: string },
     ): Promise<SavedChart> {
+        const projectUuid =
+            options?.projectUuid && !isValidUuid(options.projectUuid)
+                ? await this.projectModel.getUuidBySlug(
+                      account.organization.organizationUuid ?? '',
+                      options.projectUuid,
+                  )
+                : options?.projectUuid;
         const savedChart = await this.savedChartModel.get(
             savedChartUuidOrSlug,
             undefined,
-            { projectUuid: options?.projectUuid },
+            { projectUuid },
         );
         const space = await this.spaceModel.getSpaceSummary(
             savedChart.spaceUuid,

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import { Provider } from 'react-redux';
 import { useParams } from 'react-router';
+import { validate as isUuidString } from 'uuid';
 import ScreenshotProgressIndicator from '../components/common/ScreenshotProgressIndicator';
 import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndicator';
 import LightdashVisualization from '../components/LightdashVisualization';
@@ -26,11 +27,15 @@ import {
 } from '../features/explorer/store';
 import { useExplorerQuery } from '../hooks/useExplorerQuery';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
+import { useProject } from '../hooks/useProject';
+import { ProjectRouteContext } from '../hooks/useProjectRoute';
+import { useProjects } from '../hooks/useProjects';
 import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useResizeObserver } from '../hooks/useResizeObserver';
 import { useSavedQuery } from '../hooks/useSavedQuery';
 import useApp from '../providers/App/useApp';
 import { ExplorerSection } from '../providers/Explorer/types';
+import { getProjectUrlIdentifier } from '../utils/projectUrl';
 
 type Props = {
     savedQueryUuid?: string;
@@ -189,7 +194,30 @@ const MinimalSavedExplorer: FC<Props> = ({
         projectUuid: string;
     }>();
     const savedQueryUuid = queryUuidProps || params.savedQueryUuid!;
-    const projectUuid = useProjectUuid();
+    const projectIdentifier = useProjectUuid();
+    const isProjectUuid = isUuidString(projectIdentifier ?? '');
+    const projectsQuery = useProjects({
+        enabled: !!projectIdentifier && !isProjectUuid,
+    });
+    const projectUuid = isProjectUuid
+        ? projectIdentifier
+        : projectsQuery.data?.find(
+              (project) => project.slug === projectIdentifier,
+          )?.projectUuid;
+    const projectQuery = useProject(projectUuid);
+    const projectRouteContext = useMemo(
+        () =>
+            projectUuid && projectQuery.data
+                ? {
+                      project: projectQuery.data,
+                      projectUuid,
+                      projectUrlIdentifier: getProjectUrlIdentifier(
+                          projectQuery.data,
+                      ),
+                  }
+                : null,
+        [projectQuery.data, projectUuid],
+    );
 
     const { data, isInitialLoading, isError, error } = useSavedQuery({
         uuidOrSlug: savedQueryUuid,
@@ -218,15 +246,20 @@ const MinimalSavedExplorer: FC<Props> = ({
         store.dispatch(explorerActions.reset(initialState));
     }, [data, store]);
 
-    // Early return if no data yet
-    if (isInitialLoading || !data) {
-        return null;
-    }
-
-    if (isError) {
+    if (
+        projectsQuery.isError ||
+        projectQuery.isError ||
+        isError ||
+        (!projectUuid && !projectsQuery.isInitialLoading)
+    ) {
         return (
             <>
-                <span>{error.error.message}</span>
+                <span>
+                    {projectsQuery.error?.error.message ??
+                        projectQuery.error?.error.message ??
+                        error?.error.message ??
+                        `Cannot find project: ${projectIdentifier}`}
+                </span>
                 <ScreenshotReadyIndicator
                     tilesTotal={1}
                     tilesReady={0}
@@ -236,10 +269,23 @@ const MinimalSavedExplorer: FC<Props> = ({
         );
     }
 
+    // Early return if no data yet
+    if (
+        projectsQuery.isInitialLoading ||
+        projectQuery.isInitialLoading ||
+        isInitialLoading ||
+        !projectRouteContext ||
+        !data
+    ) {
+        return null;
+    }
+
     return (
-        <Provider store={store} key={`minimal-${savedQueryUuid}`}>
-            <MinimalExplorerContent />
-        </Provider>
+        <ProjectRouteContext.Provider value={projectRouteContext}>
+            <Provider store={store} key={`minimal-${savedQueryUuid}`}>
+                <MinimalExplorerContent />
+            </Provider>
+        </ProjectRouteContext.Provider>
     );
 };
 


### PR DESCRIPTION
Closes: [SPK-1411](https://linear.app/lightdash/issue/SPK-1411/minimal-saved-chart-route-returns-500-when-given-a-project-slug)

### Description:

- resolve project slugs to organization-scoped UUIDs before the saved-chart model query
- resolve the minimal chart route project identifier once and provide the canonical project context to all downstream project, explore, and query requests
- preserve existing UUID-based minimal routes
- add regression coverage for project slug resolution and the UUID passthrough path

### Testing:

- `pnpm -F backend test --run src/services/SavedChartsService/SavedChartService.contentVerification.test.ts`
- `pnpm -F backend typecheck`
- `pnpm -F frontend typecheck`
- targeted backend/frontend oxlint checks
- live: slug-based and UUID-based minimal chart URLs both rendered the seeded revenue chart (`2,397`)

### Risk assessment:

- [ ] This is a high-risk change

Low risk: the change is limited to identifier canonicalization and preserves UUID behavior.