### PR TITLE
feat: headless export of AI artifacts to hosted images

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -174,6 +174,180 @@ describe('UnfurlService', () => {
         });
     });
 
+    describe('exportAiAgentArtifact', () => {
+        const ACTING_USER = {
+            userUuid: 'user-uuid-1',
+            organizationUuid: 'org-uuid-1',
+        } as never;
+        const ARTIFACT_REFS = {
+            projectUuid: '11111111-1111-4111-8111-111111111111',
+            agentUuid: '22222222-2222-4222-8222-222222222222',
+            artifactUuid: '33333333-3333-4333-8333-333333333333',
+            versionUuid: '44444444-4444-4444-8444-444444444444',
+        };
+        // Callers resolve this via AiAgentService.getArtifact (access-checked)
+        // and pass the result in.
+        const customChartArtifact = {
+            artifactUuid: ARTIFACT_REFS.artifactUuid,
+            versionUuid: ARTIFACT_REFS.versionUuid,
+            title: 'Revenue treemap',
+            chartConfig: {
+                source: 'customChartType',
+                schemaVersion: 1,
+                dataAppVizUuid: 'viz-1',
+                config: {},
+            },
+        };
+        const EXPORT_ARGS = {
+            projectUuid: ARTIFACT_REFS.projectUuid,
+            agentUuid: ARTIFACT_REFS.agentUuid,
+            artifact: customChartArtifact as never,
+        };
+
+        const createScreenshotMockPage = () => {
+            const cdpSession = { send: vi.fn().mockResolvedValue(undefined) };
+            const pageContext = {
+                addCookies: vi.fn().mockResolvedValue(undefined),
+                newCDPSession: vi.fn().mockResolvedValue(cdpSession),
+                route: vi.fn().mockResolvedValue(undefined),
+                routeWebSocket: vi.fn().mockResolvedValue(undefined),
+            };
+            return {
+                cdpSession,
+                pageContext,
+                addInitScript: vi.fn().mockResolvedValue(undefined),
+                context: vi.fn().mockReturnValue(pageContext),
+                on: vi.fn(),
+                goto: vi.fn().mockResolvedValue(undefined),
+                waitForSelector: vi.fn().mockResolvedValue(undefined),
+                evaluate: vi.fn().mockResolvedValue(undefined),
+                locator: vi.fn().mockReturnValue({
+                    first: vi.fn().mockReturnValue({
+                        elementHandle: vi
+                            .fn()
+                            .mockRejectedValue(new Error('no element')),
+                    }),
+                }),
+                setViewportSize: vi.fn().mockResolvedValue(undefined),
+                waitForTimeout: vi.fn().mockResolvedValue(undefined),
+                screenshot: vi.fn().mockResolvedValue(Buffer.from('png-bytes')),
+                close: vi.fn().mockResolvedValue(undefined),
+            };
+        };
+
+        const setup = () => {
+            const page = createScreenshotMockPage();
+            const browser = {
+                newPage: vi.fn().mockResolvedValue(page),
+                close: vi.fn().mockResolvedValue(undefined),
+            };
+            playwrightMocks.connectOverCDP.mockResolvedValue(browser);
+            const service = createService({
+                headlessBrowser: {
+                    host: 'headless-browser',
+                    browserEndpoint: 'ws://headless-browser:3000',
+                    screenshotTimeoutMs: 180_000,
+                    maxScreenshotRetries: 1,
+                },
+            });
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            vi.spyOn(service as any, 'getUserCookie').mockResolvedValue(
+                'connect.sid=session-value; Path=/; HttpOnly',
+            );
+            return { service, browser, page };
+        };
+
+        it('rejects artifacts that are not custom chart type answers', async () => {
+            const { service } = setup();
+
+            await expect(
+                service.exportAiAgentArtifact(ACTING_USER, {
+                    ...EXPORT_ARGS,
+                    artifact: {
+                        ...customChartArtifact,
+                        chartConfig: { source: 'semantic', config: {} },
+                    } as never,
+                }),
+            ).rejects.toThrow(/custom chart type/);
+            expect(playwrightMocks.connectOverCDP).not.toHaveBeenCalled();
+        });
+
+        it('renders the minimal artifact page with app-style launch args and a fixed 800x600@2x viewport', async () => {
+            const { service, browser, page } = setup();
+            mockFileStorageClient.isEnabled.mockReturnValue(true);
+            mockFileStorageClient.uploadImage.mockResolvedValue(
+                'https://s3.example.com/raw-signed-url',
+            );
+            mockSlackUnfurlImageModel.create.mockResolvedValue(undefined);
+
+            const imageUrl = await service.exportAiAgentArtifact(
+                ACTING_USER,
+                EXPORT_ARGS,
+            );
+
+            // App-style launch: window sizing + secure-context for the
+            // sandboxed viz iframe SDK.
+            const [endpoint] = playwrightMocks.connectOverCDP.mock.calls[0];
+            expect(endpoint).toContain('--window-size%3D800%2C600');
+            expect(endpoint).toContain(
+                'unsafely-treat-insecure-origin-as-secure',
+            );
+
+            expect(browser.newPage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    viewport: { width: 800, height: 600 },
+                    deviceScaleFactor: 2,
+                    serviceWorkers: 'block',
+                }),
+            );
+            expect(page.cdpSession.send).toHaveBeenCalledWith(
+                'Emulation.setDeviceMetricsOverride',
+                expect.objectContaining({
+                    width: 800,
+                    height: 600,
+                    deviceScaleFactor: 2,
+                }),
+            );
+
+            expect(page.goto).toHaveBeenCalledWith(
+                `http://headless-browser:8080/minimal/projects/${ARTIFACT_REFS.projectUuid}/ai-agents/${ARTIFACT_REFS.agentUuid}/artifacts/${ARTIFACT_REFS.artifactUuid}/versions/${ARTIFACT_REFS.versionUuid}`,
+                expect.objectContaining({ timeout: expect.any(Number) }),
+            );
+            expect(page.waitForSelector).toHaveBeenCalledWith(
+                SCREENSHOT_SELECTORS.READY_INDICATOR,
+                { state: 'attached', timeout: 180_000 },
+            );
+
+            // Fixed-frame capture: viewport-sized, never content-measured.
+            expect(page.setViewportSize).not.toHaveBeenCalled();
+            expect(page.screenshot).toHaveBeenCalledTimes(1);
+            expect(page.screenshot.mock.calls[0][0]).not.toMatchObject({
+                fullPage: true,
+            });
+
+            expect(mockSlackUnfurlImageModel.create).toHaveBeenCalledWith(
+                expect.objectContaining({ organizationUuid: 'org-uuid-1' }),
+            );
+            expect(imageUrl).toMatch(
+                /^https:\/\/app\.lightdash\.cloud\/api\/v1\/slack\/preview\//,
+            );
+        });
+
+        it('fails closed when the ready indicator never mounts', async () => {
+            const { service, page } = setup();
+            const { errors } = await import('playwright');
+            page.waitForSelector.mockRejectedValue(
+                new errors.TimeoutError('Timeout 180000ms exceeded'),
+            );
+
+            await expect(
+                service.exportAiAgentArtifact(ACTING_USER, EXPORT_ARGS),
+            ).rejects.toThrow(/Screenshot timeout/);
+            expect(page.screenshot).not.toHaveBeenCalled();
+            expect(page.close).toHaveBeenCalled();
+        });
+    });
+
     describe('getPreviewSignedUrl', () => {
         const service = createService();
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -35,10 +35,12 @@ import {
     snakeCaseName,
     UnexpectedServerError,
     validateSelectedTabs,
+    type AiArtifact,
     type DashboardFilterRule,
     type DashboardFilters,
     type DeliveryCaptureManifest,
     type ParametersValuesMap,
+    type UUID,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
@@ -229,11 +231,19 @@ const bigNumberViewport = {
     height: 500,
 };
 
+// Fixed-frame AI artifact card, captured @2x for crisp Slack rendering.
+const aiArtifactViewport = {
+    width: 800,
+    height: 600,
+    deviceScaleFactor: 2,
+} as const;
+
 export enum ScreenshotContext {
     SCHEDULED_DELIVERY = 'scheduled_delivery',
     SLACK = 'slack',
     EXPORT_DASHBOARD = 'export_dashboard',
     EXPORT_CHART = 'export_chart',
+    EXPORT_AI_ARTIFACT = 'export_ai_artifact',
 }
 
 // Default values
@@ -574,6 +584,12 @@ export class UnfurlService extends BaseService {
                     organizationUuid: app.organization_uuid,
                     resourceUuid: app.app_id,
                 };
+            case LightdashPage.AI_ARTIFACT:
+                // Never produced by parseUrl; artifact exports go through
+                // exportAiAgentArtifact, not unfurls.
+                throw new ParameterError(
+                    `AI artifact pages cannot be unfurled: ${parsedUrl.url}`,
+                );
             case undefined:
                 throw new Error(`Unrecognized page for URL ${parsedUrl.url}`);
             default:
@@ -723,38 +739,11 @@ export class UnfurlService extends BaseService {
 
         let imageUrl;
         if (imageBuffer) {
-            if (this.fileStorageClient.isEnabled()) {
-                imageUrl = await this.fileStorageClient.uploadImage(
-                    imageBuffer,
-                    imageId,
-                );
-
-                if (details?.organizationUuid) {
-                    const previewId = useNanoid();
-                    await this.slackUnfurlImageModel.create({
-                        nanoid: previewId,
-                        s3Key: `${imageId}.png`,
-                        organizationUuid: details.organizationUuid,
-                    });
-                    imageUrl = new URL(
-                        `/api/v1/slack/preview/${previewId}`,
-                        this.lightdashConfig.siteUrl,
-                    ).href;
-                }
-            } else {
-                const filePath = `/tmp/${imageId}.png`;
-                const downloadFileId = useNanoid();
-                await this.downloadFileModel.createDownloadFile(
-                    downloadFileId,
-                    filePath,
-                    DownloadFileType.IMAGE,
-                );
-
-                imageUrl = new URL(
-                    `/api/v1/slack/image/${downloadFileId}`,
-                    this.lightdashConfig.siteUrl,
-                ).href;
-            }
+            imageUrl = await this.hostImage(
+                imageBuffer,
+                imageId,
+                details?.organizationUuid,
+            );
         }
 
         let pdfFile;
@@ -766,6 +755,51 @@ export class UnfurlService extends BaseService {
             imageUrl,
             pdfFile,
         };
+    }
+
+    /**
+     * Hosts a screenshot buffer and returns a fetchable URL. With storage +
+     * an org, the stable Lightdash preview URL; with storage only, the raw
+     * storage URL; otherwise a local /tmp-backed download URL.
+     */
+    private async hostImage(
+        imageBuffer: Buffer,
+        imageId: string,
+        organizationUuid: string | undefined,
+    ): Promise<string> {
+        if (this.fileStorageClient.isEnabled()) {
+            let imageUrl = await this.fileStorageClient.uploadImage(
+                imageBuffer,
+                imageId,
+            );
+
+            if (organizationUuid) {
+                const previewId = useNanoid();
+                await this.slackUnfurlImageModel.create({
+                    nanoid: previewId,
+                    s3Key: `${imageId}.png`,
+                    organizationUuid,
+                });
+                imageUrl = new URL(
+                    `/api/v1/slack/preview/${previewId}`,
+                    this.lightdashConfig.siteUrl,
+                ).href;
+            }
+            return imageUrl;
+        }
+
+        const filePath = `/tmp/${imageId}.png`;
+        const downloadFileId = useNanoid();
+        await this.downloadFileModel.createDownloadFile(
+            downloadFileId,
+            filePath,
+            DownloadFileType.IMAGE,
+        );
+
+        return new URL(
+            `/api/v1/slack/image/${downloadFileId}`,
+            this.lightdashConfig.siteUrl,
+        ).href;
     }
 
     /**
@@ -1084,6 +1118,83 @@ export class UnfurlService extends BaseService {
     }
 
     /**
+     * Renders a custom chart type AI artifact version to a hosted PNG under
+     * the acting user's identity (one-time login grant). The caller must
+     * resolve `artifact` — and the project/agent refs it passes — via
+     * AiAgentService.getArtifact for the same user, which enforces the
+     * agent + thread access chain.
+     */
+    async exportAiAgentArtifact(
+        user: SessionUser,
+        {
+            projectUuid,
+            agentUuid,
+            artifact,
+        }: {
+            projectUuid: UUID;
+            agentUuid: UUID;
+            artifact: AiArtifact;
+        },
+    ): Promise<string> {
+        const { artifactUuid, versionUuid } = artifact;
+        if (artifact.chartConfig?.source !== 'customChartType') {
+            throw new ParameterError(
+                `Artifact version ${artifactUuid}/${versionUuid} is not a custom chart type answer`,
+            );
+        }
+
+        const minimalUrl = new URL(
+            `/minimal/projects/${projectUuid}/ai-agents/${agentUuid}/artifacts/${artifactUuid}/versions/${versionUuid}`,
+            this.lightdashConfig.headlessBrowser.internalLightdashHost,
+        ).href;
+
+        this.logger.info(`Exporting AI artifact to hosted image`, {
+            userUuid: user.userUuid,
+            organizationUuid: user.organizationUuid,
+            projectUuid,
+            agentUuid,
+            artifactUuid,
+            versionUuid,
+            minimalUrl,
+        });
+
+        const cookie = await this.getUserCookie(user.userUuid);
+        const imageId = `ai-artifact-image_${snakeCaseName(
+            artifact.title ?? 'chart',
+        )}_${useNanoid()}`;
+
+        const result = await this.saveScreenshot({
+            authUserUuid: user.userUuid,
+            imageId,
+            cookie,
+            url: minimalUrl,
+            lightdashPage: LightdashPage.AI_ARTIFACT,
+            organizationUuid: user.organizationUuid,
+            resourceUuid: versionUuid,
+            resourceName: artifact.title ?? undefined,
+            context: ScreenshotContext.EXPORT_AI_ARTIFACT,
+            selectedTabs: null,
+        });
+        if (!result?.imageBuffer) {
+            throw new UnexpectedServerError(
+                'Unable to export AI artifact image',
+            );
+        }
+
+        const imageUrl = await this.hostImage(
+            result.imageBuffer,
+            imageId,
+            user.organizationUuid,
+        );
+        this.logger.info(`AI artifact exported successfully`, {
+            userUuid: user.userUuid,
+            artifactUuid,
+            versionUuid,
+        });
+        return imageUrl;
+    }
+
+    /**
      * Reads the always-mounted #lightdash-screenshot-progress element and
      * logs which tile UUIDs are still unaccounted for, so that on
      * #lightdash-ready-indicator timeouts we can identify the specific
@@ -1360,6 +1471,12 @@ export class UnfurlService extends BaseService {
                             ...appViewport,
                             width: gridWidth ?? appViewport.width,
                         };
+                    } else if (lightdashPage === LightdashPage.AI_ARTIFACT) {
+                        // Fixed frame: never widened by gridWidth or content.
+                        initialViewport = {
+                            width: aiArtifactViewport.width,
+                            height: aiArtifactViewport.height,
+                        };
                     } else {
                         initialViewport = {
                             ...viewport,
@@ -1367,17 +1484,23 @@ export class UnfurlService extends BaseService {
                         };
                     }
 
-                    const browserConnectionEndpoint =
-                        lightdashPage === LightdashPage.APP
-                            ? getAppBrowserEndpoint(
-                                  browserEndpoint,
-                                  initialViewport,
-                                  this.screenshotTimeoutMs +
-                                      BROWSERLESS_SESSION_BUFFER_MS,
-                                  this.lightdashConfig.headlessBrowser
-                                      .internalLightdashHost,
-                              )
-                            : browserEndpoint;
+                    // Both page types host the sandboxed iframe SDK, which
+                    // needs the app-style launch args (window sizing + secure
+                    // context).
+                    const usesAppLaunchArgs =
+                        lightdashPage === LightdashPage.APP ||
+                        lightdashPage === LightdashPage.AI_ARTIFACT;
+
+                    const browserConnectionEndpoint = usesAppLaunchArgs
+                        ? getAppBrowserEndpoint(
+                              browserEndpoint,
+                              initialViewport,
+                              this.screenshotTimeoutMs +
+                                  BROWSERLESS_SESSION_BUFFER_MS,
+                              this.lightdashConfig.headlessBrowser
+                                  .internalLightdashHost,
+                          )
+                        : browserEndpoint;
 
                     browser = await playwright.chromium.connectOverCDP(
                         browserConnectionEndpoint,
@@ -1409,6 +1532,12 @@ export class UnfurlService extends BaseService {
 
                     page = await browser.newPage({
                         viewport: initialViewport,
+                        ...(lightdashPage === LightdashPage.AI_ARTIFACT
+                            ? {
+                                  deviceScaleFactor:
+                                      aiArtifactViewport.deviceScaleFactor,
+                              }
+                            : {}),
                         serviceWorkers: 'block',
                         // Allow self-signed / untrusted certs when the
                         // internal Lightdash host is reached through an
@@ -1425,6 +1554,13 @@ export class UnfurlService extends BaseService {
                             page,
                             initialViewport,
                             `unfurlId: ${imageId}`,
+                        );
+                    } else if (lightdashPage === LightdashPage.AI_ARTIFACT) {
+                        await this.overrideCdpViewport(
+                            page,
+                            initialViewport,
+                            `unfurlId: ${imageId}`,
+                            aiArtifactViewport.deviceScaleFactor,
                         );
                     }
 
@@ -2062,23 +2198,27 @@ export class UnfurlService extends BaseService {
                         }
                     }
 
-                    const fullPage = await page.locator(finalSelector);
-                    const fullPageSize = await fullPage?.boundingBox({
-                        timeout: this.screenshotTimeoutMs,
-                    });
-
-                    if (
-                        chartType !== ChartType.BIG_NUMBER &&
-                        lightdashPage !== LightdashPage.APP &&
-                        fullPageSize?.height
-                    ) {
-                        await page.setViewportSize({
-                            width: gridWidth ?? viewport.width,
-                            height: Math.round(fullPageSize.height),
+                    // AI artifacts keep their fixed frame: no content
+                    // measurement, no viewport resize.
+                    if (lightdashPage !== LightdashPage.AI_ARTIFACT) {
+                        const fullPage = await page.locator(finalSelector);
+                        const fullPageSize = await fullPage?.boundingBox({
+                            timeout: this.screenshotTimeoutMs,
                         });
-                        // Viewport changes can trigger layout shifts - wait for things to settle
-                        // before taking the shot 📸
-                        await page.waitForTimeout(100);
+
+                        if (
+                            chartType !== ChartType.BIG_NUMBER &&
+                            lightdashPage !== LightdashPage.APP &&
+                            fullPageSize?.height
+                        ) {
+                            await page.setViewportSize({
+                                width: gridWidth ?? viewport.width,
+                                height: Math.round(fullPageSize.height),
+                            });
+                            // Viewport changes can trigger layout shifts - wait for things to settle
+                            // before taking the shot 📸
+                            await page.waitForTimeout(100);
+                        }
                     }
 
                     // Helper: generate PDF from the current page state
@@ -2262,6 +2402,13 @@ export class UnfurlService extends BaseService {
                                     timeout: this.screenshotTimeoutMs,
                                 });
                         }
+                    } else if (lightdashPage === LightdashPage.AI_ARTIFACT) {
+                        // Fixed-frame capture at the declared viewport.
+                        imageBuffer = await page.screenshot({
+                            path,
+                            animations: 'disabled',
+                            timeout: this.screenshotTimeoutMs,
+                        });
                     } else {
                         // Full page screenshot for charts
                         imageBuffer = await page.screenshot({
@@ -2406,13 +2553,14 @@ export class UnfurlService extends BaseService {
         page: playwright.Page,
         size: { width: number; height: number },
         logContext: string,
+        deviceScaleFactor = 1,
     ): Promise<void> {
         try {
             const cdp = await page.context().newCDPSession(page);
             await cdp.send('Emulation.setDeviceMetricsOverride', {
                 width: size.width,
                 height: size.height,
-                deviceScaleFactor: 1,
+                deviceScaleFactor,
                 mobile: false,
             });
         } catch (cdpErr) {

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -680,6 +680,7 @@ export enum LightdashPage {
     EXPLORE = 'explore',
     SQL_CHART = 'sql_chart',
     APP = 'app',
+    AI_ARTIFACT = 'ai_artifact',
 }
 
 // Info-only delivery notice — never a failure, must not affect run status.


### PR DESCRIPTION
Adds the headless primitive that turns a custom chart type AI artifact version into a hosted PNG (for Slack attachment in ZAP-939).

**New `ai_artifact` screenshot page type** in `UnfurlService.saveScreenshot`:
- App-style browser launch args: `--window-size` + secure-context flag, required by the sandboxed viz iframe SDK
- Fixed viewport **800×600 @2x** declared as a constant (`aiArtifactViewport`), applied via Playwright + CDP device-metrics override
- **Fail-closed** ready-indicator wait — timeout throws, no half-loaded capture
- Fixed-frame screenshot: no content measurement, no viewport resize, no `fullPage`; whole-app (`APP`) behavior untouched

**`UnfurlService.exportAiAgentArtifact(user, { projectUuid, agentUuid, artifact })`**:
- Caller resolves `artifact` via `AiAgentService.getArtifact` for the acting user (agent + thread access chain enforced upstream); UnfurlService keeps no EE dependency
- Rejects non-custom-chart-type artifacts
- Builds the ZAP-937 minimal artifact URL, authenticates the headless browser as the acting user via the existing one-time login grant, screenshots, uploads, returns the stable hosted preview URL (extracted shared `hostImage` helper)
- Internal primitive — no public endpoint

Unit tests cover: launch args + fixed viewport + @2x, fail-closed timeout (no image produced), non-custom rejection.

Closes: ZAP-938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MDtcEEDhT6tcXPTSk4t6a
