### PR TITLE
fix: compile joined custom dimensions from pre-aggregates

### DIFF
--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationExternalResolver.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationExternalResolver.test.ts
@@ -175,6 +175,64 @@ describe('PreAggregationExternalResolver', () => {
         expect(result.query).toContain(`FROM ${EXTERNAL_TABLE} AS "orders"`);
     });
 
+    test('recompiles SQL custom dimensions from joined tables against materialized columns', async () => {
+        const { resolver } = getResolver({
+            explore: {
+                ...externalPreAggExplore,
+                tables: {
+                    ...externalPreAggExplore.tables,
+                    value_stream: {
+                        ...externalPreAggExplore.tables.orders,
+                        name: 'value_stream',
+                        label: 'Value Stream',
+                        dimensions: {
+                            pillar_name: {
+                                fieldType: FieldType.DIMENSION,
+                                type: DimensionType.STRING,
+                                name: 'pillar_name',
+                                label: 'Pillar name',
+                                table: 'value_stream',
+                                tableLabel: 'Value Stream',
+                                sql: 'orders.value_stream_pillar_name',
+                                compiledSql: 'orders.value_stream_pillar_name',
+                                tablesReferences: ['orders'],
+                                hidden: false,
+                            },
+                        },
+                        metrics: {},
+                    },
+                },
+            },
+        });
+
+        const result = await resolver.resolve({
+            ...baseResolveArgs,
+            metricQuery: {
+                ...metricQuery,
+                dimensions: ['is_labeled'],
+                metrics: [],
+                customDimensions: [
+                    {
+                        id: 'is_labeled',
+                        type: CustomDimensionType.SQL,
+                        name: 'Is labeled',
+                        table: 'value_stream',
+                        sql: 'NOT ${value_stream.pillar_name} IS NULL',
+                        dimensionType: DimensionType.BOOLEAN,
+                    },
+                ],
+            },
+        });
+
+        expect(result.resolved).toBe(true);
+        if (!result.resolved) throw new Error('unreachable');
+        expect(result.query).toContain(
+            '(NOT (orders.value_stream_pillar_name) IS NULL) AS "is_labeled"',
+        );
+        expect(result.query).toContain(`FROM ${EXTERNAL_TABLE} AS "orders"`);
+        expect(result.query).not.toContain('JOIN');
+    });
+
     test('recompiles SQL custom dimension filters against materialized columns', async () => {
         const { resolver } = getResolver();
 

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -6,6 +6,7 @@ import {
     FieldType,
     friendlyName,
     MetricType,
+    type CompiledDimension,
 } from '../types/field';
 import { FilterOperator, UnitOfTime } from '../types/filter';
 import { TimeFrames } from '../types/timeFrames';
@@ -850,6 +851,33 @@ describe('Compiled custom dimensions', () => {
                 [],
             ),
         ).toStrictEqual(expectedCompiledCustomSqlDimensionWithReferences);
+    });
+
+    test('should preserve precompiled joined dimension table references', () => {
+        expect(
+            compiler.compileCustomDimension(
+                customSqlDimensionWithReferences,
+                {
+                    ...simpleJoinedExplore.tables,
+                    b: {
+                        ...simpleJoinedExplore.tables.b,
+                        dimensions: {
+                            dim1: {
+                                ...simpleJoinedExplore.tables.b.dimensions.dim1,
+                                sql: '"a".b_dim1',
+                                compiledSql: '"a".b_dim1',
+                                tablesReferences: ['a'],
+                            } as CompiledDimension,
+                        },
+                    },
+                },
+                [],
+            ),
+        ).toStrictEqual({
+            ...expectedCompiledCustomSqlDimensionWithReferences,
+            compiledSql: '("a".dim1) + ("a".b_dim1)',
+            tablesReferences: ['a'],
+        });
     });
 });
 

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -12,6 +12,7 @@ import {
 import {
     DimensionType,
     friendlyName,
+    isCompiledDimension,
     isCustomBinDimension,
     isNonAggregateMetric,
     isPostCalculationMetric,
@@ -1647,6 +1648,18 @@ export class ExploreCompiler {
                 {},
             );
         }
+        // Already-compiled dimensions (e.g. pre-aggregate explores rewritten to
+        // materialized columns) are authoritative: reuse instead of recompiling.
+        if (
+            isCompiledDimension(referencedDimension) &&
+            referencedDimension.tablesReferences
+        ) {
+            return {
+                sql: `(${referencedDimension.compiledSql})`,
+                tablesReferences: new Set(referencedDimension.tablesReferences),
+            };
+        }
+
         const compiledDimension = this.compileDimensionSql(
             referencedDimension,
             tables,

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -890,6 +890,10 @@ export const isDimension = (
 ): field is Dimension =>
     isField(field) && field.fieldType === FieldType.DIMENSION;
 
+export const isCompiledDimension = (
+    field: ItemsMap[string] | AdditionalMetric | undefined,
+): field is CompiledDimension => isDimension(field) && 'compiledSql' in field;
+
 export const isTimeBasedDimension = (
     item: ItemsMap[string] | AdditionalMetric | undefined,
 ): item is Dimension =>


### PR DESCRIPTION
## Summary

- preserve compiled table dependencies for SQL custom dimensions
- avoid restoring removed source joins when a joined field is materialized by a pre-aggregate
- cover normal compilation and joined external pre-aggregate routing

## Verification

- common compiler tests: 192 passed
- pre-aggregate matcher, resolver, builder, and query compiler tests: 197 passed
- common and backend typechecks passed
- live external pre-aggregate and source-warehouse control returned identical normalized results

Closes: ZAP-940
Closes: #28039
