### PR TITLE
refactor(explorer): absent config for a chart type not yet built

### DIFF
--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -45,7 +45,7 @@ const mocks = vi.hoisted(() => ({
         current: undefined as ReturnType<typeof apiError> | undefined,
     },
     embedToken: { current: undefined as string | undefined },
-    dataAppVizUuid: { current: 'viz-uuid' as string | undefined },
+    dataAppVizUuid: { current: 'viz-uuid' as string | null },
     iframePreview: vi.fn(() => null),
     renderMetadataHook: vi.fn(),
     previewTokenHook: vi.fn(),
@@ -119,11 +119,14 @@ vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
     useVisualizationContext: () => ({
         visualizationConfig: {
             chartConfig: {
-                validConfig: {
-                    dataAppVizUuid: mocks.dataAppVizUuid.current,
-                    fieldMapping: { category: 'orders.category' },
-                    optionValues: { title: 12 },
-                },
+                validConfig:
+                    mocks.dataAppVizUuid.current === null
+                        ? null
+                        : {
+                              dataAppVizUuid: mocks.dataAppVizUuid.current,
+                              fieldMapping: { category: 'orders.category' },
+                              optionValues: { title: 12 },
+                          },
             },
         },
         savedChartUuid: 'saved-chart-uuid',
@@ -196,7 +199,7 @@ describe('DataAppVizRenderer', () => {
     });
 
     it('prompts for a visualization when none is selected', () => {
-        mocks.dataAppVizUuid.current = undefined;
+        mocks.dataAppVizUuid.current = null;
 
         renderRenderer();
 

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -98,8 +98,8 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
 
     const config = isDataAppVizVisualizationConfig(visualizationConfig)
         ? visualizationConfig.chartConfig.validConfig
-        : undefined;
-    const dataAppVizUuid = config?.dataAppVizUuid ?? '';
+        : null;
+    const dataAppVizUuid = config?.dataAppVizUuid;
     const fieldMapping = config?.fieldMapping;
     const optionValues = config?.optionValues;
     const rows = resultsData?.rows;
@@ -111,16 +111,12 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         [embedToken, savedChartUuid, chartVersionUuid],
     );
     const { data: renderMetadata, error: renderMetadataError } =
-        useDataAppVizRenderMetadata(
-            projectUuid,
-            dataAppVizUuid || undefined,
-            renderTarget,
-        );
+        useDataAppVizRenderMetadata(projectUuid, dataAppVizUuid, renderTarget);
     const readyMetadata =
         renderMetadata?.state === 'ready' ? renderMetadata : undefined;
     const { data: token, error: previewTokenError } = useDataAppVizPreviewToken(
         projectUuid,
-        dataAppVizUuid || undefined,
+        dataAppVizUuid,
         readyMetadata?.version,
         renderTarget,
     );
@@ -296,7 +292,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         drillDownEnabled,
     ]);
 
-    if (!projectUuid || !dataAppVizUuid) {
+    if (!projectUuid || dataAppVizUuid === undefined) {
         return (
             <DataAppVizPlaceholder message="Pick a custom chart type to render." />
         );

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -56,10 +56,10 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
     const { getSelectedChartTypeItem } = useChartTypeOptions();
     const dataAppVizUuid = isDataAppVizVisualizationConfig(visualizationConfig)
         ? visualizationConfig.chartConfig.dataAppVizUuid
-        : undefined;
+        : null;
     const { data: selectedProjectType } = useDataAppVisualization(
         projectUuid,
-        dataAppVizUuid,
+        dataAppVizUuid ?? undefined,
         null,
     );
     const canEditChartType = useCanEditDataAppChecker(projectUuid);
@@ -165,7 +165,7 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
                                             size="sm"
                                             aria-label="Edit chart type"
                                             onClick={() =>
-                                                dataAppVizUuid &&
+                                                dataAppVizUuid !== null &&
                                                 dispatch(
                                                     explorerActions.startChartTypeAuthoring(
                                                         { dataAppVizUuid },

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -496,7 +496,7 @@ describe('ExplorerChartTypeAuthoring', () => {
         });
     });
 
-    it('leaves a new type on the empty custom config until it has a version', () => {
+    it('leaves a new type without a viz until it has a version', () => {
         vi.mocked(useChartTypeBuilderWorkspace).mockReturnValue(
             newTypeWorkspace(),
         );
@@ -504,14 +504,7 @@ describe('ExplorerChartTypeAuthoring', () => {
 
         expect(
             store.getState().explorer.unsavedChartVersion.chartConfig,
-        ).toEqual({
-            type: ChartType.DATA_APP_VIZ,
-            config: {
-                dataAppVizUuid: '',
-                fieldMapping: {},
-                optionValues: {},
-            },
-        });
+        ).toStrictEqual({ type: ChartType.DATA_APP_VIZ });
         expect(previewContexts.at(-1)).toBeNull();
     });
 

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationDataAppVizConfig.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationDataAppVizConfig.tsx
@@ -9,8 +9,11 @@ const VisualizationDataAppVizConfig: FC<VisualizationDataAppVizConfigProps> = ({
     children,
 }) => {
     const handleConfigChange = useCallback(
-        (config: DataAppVizChart) => {
-            onChartConfigChange?.({ type: ChartType.DATA_APP_VIZ, config });
+        (config: DataAppVizChart | null) => {
+            onChartConfigChange?.({
+                type: ChartType.DATA_APP_VIZ,
+                config: config ?? undefined,
+            });
         },
         [onChartConfigChange],
     );

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -2,6 +2,8 @@ import {
     ChartType,
     type CustomDimension,
     type DashboardFilters,
+    type DataAppVizChart,
+    type DataAppVizChartConfig,
     type DateZoom,
     type Dimension,
     type ItemsMap,
@@ -215,10 +217,16 @@ export const isDataAppVizVisualizationConfig = (
     return visualizationConfig?.chartType === ChartType.DATA_APP_VIZ;
 };
 
-export type VisualizationDataAppVizConfigProps =
-    VisualizationConfigCommon<VisualizationConfigDataAppViz> & {
-        itemsMap?: ItemsMap | undefined;
-    };
+// Local state is null while the chart points at no viz; the saved chart
+// carries that as an absent config, so the two sides are typed apart.
+export type VisualizationDataAppVizConfigProps = Omit<
+    VisualizationConfigCommon<VisualizationConfigDataAppViz>,
+    'initialChartConfig' | 'onChartConfigChange'
+> & {
+    initialChartConfig: DataAppVizChart | undefined;
+    onChartConfigChange?: (chartConfig: DataAppVizChartConfig) => void;
+    itemsMap?: ItemsMap | undefined;
+};
 
 // Gauge
 

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/customChartTypeOption.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/customChartTypeOption.ts
@@ -21,7 +21,8 @@ export const fromOptionValue = (
     if (value === BUILT_IN_VEGA_VALUE) return { kind: 'builtInVega' };
     if (value.startsWith(PROJECT_TYPE_PREFIX)) {
         const dataAppVizUuid = value.slice(PROJECT_TYPE_PREFIX.length);
-        return dataAppVizUuid ? { kind: 'projectType', dataAppVizUuid } : null;
+        if (dataAppVizUuid === '') return null;
+        return { kind: 'projectType', dataAppVizUuid };
     }
     return null;
 };

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.test.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.test.ts
@@ -8,7 +8,10 @@ import {
 } from '@lightdash/common';
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useSelectProjectChartType } from './useSelectProjectChartType';
+import {
+    useCreateProjectChartType,
+    useSelectProjectChartType,
+} from './useSelectProjectChartType';
 
 const { dispatch } = vi.hoisted(() => ({ dispatch: vi.fn() }));
 
@@ -123,5 +126,27 @@ describe('useSelectProjectChartType', () => {
                 },
             },
         });
+    });
+});
+
+describe('useCreateProjectChartType', () => {
+    beforeEach(() => dispatch.mockClear());
+
+    it('points the chart at no viz and drops the pivot', () => {
+        const { result } = renderHook(() => useCreateProjectChartType());
+
+        act(() => result.current());
+
+        expect(dispatch.mock.calls.map(([action]) => action)).toStrictEqual([
+            {
+                type: 'setChartType',
+                payload: { chartType: ChartType.DATA_APP_VIZ },
+            },
+            {
+                type: 'setChartConfig',
+                payload: { chartConfig: { type: ChartType.DATA_APP_VIZ } },
+            },
+            { type: 'setPivotConfig', payload: undefined },
+        ]);
     });
 });

--- a/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/CustomChartType/useSelectProjectChartType.ts
@@ -55,8 +55,9 @@ export const useSelectProjectChartType = () => {
 };
 
 /**
- * Start a new custom chart type: move to an empty data-app-viz config, which is
- * the state the build dock treats as "describe a new visualization".
+ * Start a new custom chart type: move to a data-app-viz chart that points at
+ * no viz yet, which is the state the build dock treats as "describe a new
+ * visualization".
  */
 export const useCreateProjectChartType = () => {
     const dispatch = useExplorerDispatch();
@@ -69,14 +70,7 @@ export const useCreateProjectChartType = () => {
         );
         dispatch(
             explorerActions.setChartConfig({
-                chartConfig: {
-                    type: ChartType.DATA_APP_VIZ,
-                    config: {
-                        dataAppVizUuid: '',
-                        fieldMapping: {},
-                        optionValues: {},
-                    },
-                },
+                chartConfig: { type: ChartType.DATA_APP_VIZ },
             }),
         );
         dispatch(explorerActions.setPivotConfig(undefined));

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -248,12 +248,13 @@ const queryColumns: ItemsMap = {
 describe('DataAppVizConfigTabs', () => {
     const setOption = vi.fn();
     const setDataAppVizUuid = vi.fn();
+    const clearDataAppViz = vi.fn();
     const setField = vi.fn();
     const setPivotDimensions = vi.fn();
 
     const mockContext = (
         itemsMap: ItemsMap,
-        dataAppVizUuid: string = 'data-app-viz-uuid',
+        dataAppVizUuid: string | null = 'data-app-viz-uuid',
         optionValues: Record<string, boolean | number | string> = {},
         fieldMapping: Record<string, string> = {},
     ) =>
@@ -263,10 +264,13 @@ describe('DataAppVizConfigTabs', () => {
             visualizationConfig: {
                 chartType: ChartType.DATA_APP_VIZ,
                 chartConfig: {
+                    validConfig:
+                        dataAppVizUuid === null
+                            ? null
+                            : { dataAppVizUuid, fieldMapping, optionValues },
                     dataAppVizUuid,
-                    fieldMapping,
-                    optionValues,
                     setDataAppVizUuid,
+                    clearDataAppViz,
                     setField,
                     setOption,
                 },
@@ -282,6 +286,7 @@ describe('DataAppVizConfigTabs', () => {
         navigate.mockClear();
         setOption.mockClear();
         setDataAppVizUuid.mockClear();
+        clearDataAppViz.mockClear();
         setField.mockClear();
         setPivotDimensions.mockClear();
         defaultAbility.update([]);
@@ -467,7 +472,7 @@ describe('DataAppVizConfigTabs', () => {
 
     it('points builders at the dedicated builder when nothing is selected', async () => {
         signInAs(OrganizationMemberRole.EDITOR);
-        mockContext(queryColumns, '');
+        mockContext(queryColumns, null);
         vi.mocked(useDataAppVisualization).mockReturnValue({
             data: undefined,
         } as unknown as ReturnType<typeof useDataAppVisualization>);
@@ -482,7 +487,7 @@ describe('DataAppVizConfigTabs', () => {
 
     it('keeps the Explorer query in builder links', async () => {
         signInAs(OrganizationMemberRole.EDITOR);
-        mockContext(queryColumns, '');
+        mockContext(queryColumns, null);
         locationSearch.current =
             '?create_saved_chart_version=serialized-query&fromSpace=space-1';
         vi.mocked(useDataAppVisualization).mockReturnValue({
@@ -506,7 +511,7 @@ describe('DataAppVizConfigTabs', () => {
 
     it('starts authoring in place from inside the chart gallery', async () => {
         signInAs(OrganizationMemberRole.EDITOR);
-        mockContext(queryColumns, '');
+        mockContext(queryColumns, null);
         vi.mocked(useDataAppVisualization).mockReturnValue({
             data: undefined,
         } as unknown as ReturnType<typeof useDataAppVisualization>);
@@ -530,7 +535,7 @@ describe('DataAppVizConfigTabs', () => {
 
     it('explains the empty configuration while a new type is being authored', async () => {
         signInAs(OrganizationMemberRole.EDITOR);
-        mockContext(queryColumns, '');
+        mockContext(queryColumns, null);
         authoringState.current = { dataAppVizUuid: null };
         vi.mocked(useDataAppVisualization).mockReturnValue({
             data: undefined,
@@ -554,7 +559,7 @@ describe('DataAppVizConfigTabs', () => {
 
     it('offers no builder link to who cannot create chart types', async () => {
         signInAs(OrganizationMemberRole.INTERACTIVE_VIEWER);
-        mockContext(queryColumns, '');
+        mockContext(queryColumns, null);
         vi.mocked(useDataAppVisualization).mockReturnValue({
             data: undefined,
         } as unknown as ReturnType<typeof useDataAppVisualization>);

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -21,6 +21,7 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { type SelectedDataAppViz } from '../../../hooks/useDataAppVizVisualizationConfig';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { useIsInsideChartGallery } from '../../common/ChartGallery/ChartGalleryContext';
@@ -51,18 +52,20 @@ export const ConfigTabs: FC = memo(() => {
     const isDataAppViz = isDataAppVizVisualizationConfig(visualizationConfig);
     const dataAppVizUuid = isDataAppViz
         ? visualizationConfig.chartConfig.dataAppVizUuid
-        : '';
+        : null;
 
     // A chart renders the viz's latest ready version, so its options come from
     // that version's declaration — unless the builder is previewing an older
     // version of this same viz, whose own declaration the panel then follows.
     const authoringVersion =
-        authoring !== null && authoring.dataAppVizUuid === dataAppVizUuid
+        authoring !== null &&
+        dataAppVizUuid !== null &&
+        authoring.dataAppVizUuid === dataAppVizUuid
             ? authoring.viewedVersion
             : null;
     const { data: dataAppViz } = useDataAppVisualization(
         projectUuid,
-        dataAppVizUuid || undefined,
+        dataAppVizUuid ?? undefined,
         authoringVersion,
     );
 
@@ -101,89 +104,103 @@ export const ConfigTabs: FC = memo(() => {
     if (!isDataAppViz) return null;
 
     const {
-        setDataAppVizUuid,
+        validConfig: selected,
+        clearDataAppViz,
         setField,
         setOption,
-        fieldMapping,
-        optionValues,
     } = visualizationConfig.chartConfig;
     const fields = dataAppViz?.schema?.fields ?? [];
-    const effectiveValues = getEffectiveOptionValues(
-        configOptions,
-        optionValues,
-    );
-    // The contract can change under a stable uuid when the viz is rebuilt, so
-    // what the selects show is the saved mapping reconciled against the
-    // contract and columns in force now — the same value the renderer uses.
-    const effectiveMapping = reconcileDataAppVizFieldMapping(
-        fields,
-        itemsMap ?? NO_COLUMNS,
-        fieldMapping,
-    );
 
-    const setMappingPivotDimensions = (
-        nextFields: typeof fields,
-        nextMapping: typeof effectiveMapping,
-    ) =>
-        setPivotDimensions(
-            deriveDataAppVizPivotConfig(nextFields, nextMapping)?.columns,
+    const selectedOption: CustomChartTypeOption | null =
+        selected !== null
+            ? { kind: 'projectType', dataAppVizUuid: selected.dataAppVizUuid }
+            : null;
+
+    const selectedTypeTabs = (selectedViz: SelectedDataAppViz) => {
+        const effectiveValues = getEffectiveOptionValues(
+            configOptions,
+            selectedViz.optionValues,
+        );
+        // A rebuild can change the contract under a stable uuid, so the selects
+        // show the saved mapping reconciled the way the renderer does.
+        const effectiveMapping = reconcileDataAppVizFieldMapping(
+            fields,
+            itemsMap ?? NO_COLUMNS,
+            selectedViz.fieldMapping,
         );
 
-    const handleFieldChange = (fieldName: string, fieldId: string | null) => {
-        const nextMapping = { ...effectiveMapping };
-        if (fieldId) nextMapping[fieldName] = fieldId;
-        else delete nextMapping[fieldName];
+        const handleFieldChange = (
+            fieldName: string,
+            fieldId: string | null,
+        ) => {
+            const nextMapping = { ...effectiveMapping };
+            if (fieldId) nextMapping[fieldName] = fieldId;
+            else delete nextMapping[fieldName];
 
-        setField(fieldName, fieldId);
-        setMappingPivotDimensions(fields, nextMapping);
-    };
+            setField(fieldName, fieldId);
+            setPivotDimensions(
+                deriveDataAppVizPivotConfig(fields, nextMapping)?.columns,
+            );
+        };
 
-    const selectedOption: CustomChartTypeOption | null = dataAppVizUuid
-        ? { kind: 'projectType', dataAppVizUuid }
-        : null;
-
-    const settings = (
-        <Stack>
-            <DataAppVizSettings
-                dataAppVizUuid={dataAppVizUuid}
-                itemsMap={itemsMap ?? NO_COLUMNS}
-                fields={fields}
-                fieldMapping={effectiveMapping}
-                onFieldChange={handleFieldChange}
-            />
-            {dataAppViz && !isInsideChartGallery && (
-                <Box className={classes.typeCard}>
-                    <Text fz="xs" fw={500}>
-                        {getAppDisplayName(
-                            dataAppViz.name,
-                            dataAppViz.dataAppVizUuid,
+        const settings = (
+            <Stack>
+                <DataAppVizSettings
+                    itemsMap={itemsMap ?? NO_COLUMNS}
+                    fields={fields}
+                    fieldMapping={effectiveMapping}
+                    onFieldChange={handleFieldChange}
+                />
+                {dataAppViz && !isInsideChartGallery && (
+                    <Box className={classes.typeCard}>
+                        <Text fz="xs" fw={500}>
+                            {getAppDisplayName(
+                                dataAppViz.name,
+                                dataAppViz.dataAppVizUuid,
+                            )}
+                        </Text>
+                        <Text fz="xs" c="dimmed" lh={1.5}>
+                            {dataAppViz.description || 'No description'}
+                        </Text>
+                        {canEditSelectedType && !isInsideChartGallery && (
+                            <Anchor
+                                component={Link}
+                                to={{
+                                    pathname: chartTypeBuilderPath(
+                                        projectUuid ?? '',
+                                        dataAppViz.dataAppVizUuid,
+                                    ),
+                                    search: location.search,
+                                }}
+                                fz="xs"
+                                fw={500}
+                                mt={4}
+                                display="inline-block"
+                            >
+                                Edit ↗
+                            </Anchor>
                         )}
-                    </Text>
-                    <Text fz="xs" c="dimmed" lh={1.5}>
-                        {dataAppViz.description || 'No description'}
-                    </Text>
-                    {canEditSelectedType && !isInsideChartGallery && (
-                        <Anchor
-                            component={Link}
-                            to={{
-                                pathname: chartTypeBuilderPath(
-                                    projectUuid ?? '',
-                                    dataAppViz.dataAppVizUuid,
-                                ),
-                                search: location.search,
-                            }}
-                            fz="xs"
-                            fw={500}
-                            mt={4}
-                            display="inline-block"
-                        >
-                            Edit ↗
-                        </Anchor>
-                    )}
-                </Box>
-            )}
-        </Stack>
-    );
+                    </Box>
+                )}
+            </Stack>
+        );
+
+        return (
+            <DataAppVizOptionTabs
+                // Remount on a viz switch so no control keeps the previous
+                // viz's draft edit.
+                key={`${selectedViz.dataAppVizUuid}:${optionContractKey}`}
+                generalContent={settings}
+                configOptions={configOptions}
+                values={effectiveValues}
+                onChange={(name, value) =>
+                    setOption(selectedViz.dataAppVizUuid, name, value)
+                }
+                colorPalette={colorPalette}
+                paletteControl={<ColorPaletteSection size="xs" />}
+            />
+        );
+    };
 
     return (
         <Box className={classes.panel}>
@@ -202,7 +219,7 @@ export const ConfigTabs: FC = memo(() => {
                             )
                         }
                         onClear={() => {
-                            setDataAppVizUuid('', {});
+                            clearDataAppViz();
                             setPivotDimensions(undefined);
                         }}
                         onCreateNew={
@@ -223,20 +240,8 @@ export const ConfigTabs: FC = memo(() => {
                 )}
 
                 {/* With nothing selected the tabs would only be an empty row. */}
-                {dataAppVizUuid ? (
-                    <DataAppVizOptionTabs
-                        // Remount on a viz switch so no control keeps the
-                        // previous viz's draft edit.
-                        key={`${dataAppVizUuid}:${optionContractKey}`}
-                        generalContent={settings}
-                        configOptions={configOptions}
-                        values={effectiveValues}
-                        onChange={(name, value) =>
-                            setOption(dataAppVizUuid, name, value)
-                        }
-                        colorPalette={colorPalette}
-                        paletteControl={<ColorPaletteSection size="xs" />}
-                    />
+                {selected !== null ? (
+                    selectedTypeTabs(selected)
                 ) : isAuthoring ? (
                     <Text size="xs" c="dimmed">
                         Describe the chart type you need. Its bindings and

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
@@ -13,8 +13,6 @@ import FieldSelect from '../../common/FieldSelect';
 import { Config } from '../common/Config';
 
 type Props = {
-    /** The visualization the chart points at; empty when it points at none. */
-    dataAppVizUuid: string;
     itemsMap: ItemsMap;
     /** The contract's declared slots. */
     fields: DataAppVizField[];
@@ -30,7 +28,6 @@ type Props = {
  * separates them from the build session docked below.
  */
 const DataAppVizSettings: FC<Props> = ({
-    dataAppVizUuid,
     itemsMap,
     fields,
     fieldMapping,
@@ -46,7 +43,7 @@ const DataAppVizSettings: FC<Props> = ({
 
     return (
         <Stack>
-            {dataAppVizUuid && fields.length === 0 && (
+            {fields.length === 0 && (
                 <Text c="dimmed" size="sm">
                     This chart type has no fields to map.
                 </Text>

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVisualization.test.tsx
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVisualization.test.tsx
@@ -1,0 +1,69 @@
+import { type DataAppViz } from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../api';
+import { useDataAppVisualization } from './useDataAppVisualization';
+
+vi.mock('../../../api', () => ({ lightdashApi: vi.fn() }));
+
+const viz = (version: number) =>
+    ({ dataAppVizUuid: 'viz-1', name: `Viz v${version}` }) as DataAppViz;
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+};
+
+type Props = { dataAppVizUuid: string | undefined; version: number | null };
+
+const renderViz = (initialProps: Props) =>
+    renderHook(
+        ({ dataAppVizUuid, version }: Props) =>
+            useDataAppVisualization('project-1', dataAppVizUuid, version),
+        { wrapper: createWrapper(), initialProps },
+    );
+
+describe('useDataAppVisualization', () => {
+    beforeEach(() => {
+        // The pinned version never resolves, so what the hook shows meanwhile
+        // is observable.
+        vi.mocked(lightdashApi).mockImplementation(({ url }) =>
+            url.includes('version=')
+                ? new Promise(() => {})
+                : Promise.resolve(viz(1)),
+        );
+    });
+
+    it('keeps the current version on screen while a pinned one loads', async () => {
+        const { result, rerender } = renderViz({
+            dataAppVizUuid: 'viz-1',
+            version: null,
+        });
+        await waitFor(() => expect(result.current.data).toEqual(viz(1)));
+
+        rerender({ dataAppVizUuid: 'viz-1', version: 2 });
+
+        expect(result.current.data).toEqual(viz(1));
+        expect(result.current.isPreviousData).toBe(true);
+    });
+
+    it('drops the viz once the chart points at none', async () => {
+        const { result, rerender } = renderViz({
+            dataAppVizUuid: 'viz-1',
+            version: null,
+        });
+        await waitFor(() => expect(result.current.data).toEqual(viz(1)));
+
+        rerender({ dataAppVizUuid: undefined, version: null });
+
+        expect(result.current.data).toBeUndefined();
+    });
+});

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVisualization.ts
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVisualization.ts
@@ -30,7 +30,7 @@ export const useDataAppVisualization = (
         queryFn: () =>
             getDataAppVisualization(projectUuid!, dataAppVizUuid!, version),
         enabled: !!projectUuid && !!dataAppVizUuid,
-        // Switching version keeps the panel on the previous schema until the new
-        // one lands, so the configuration column doesn't collapse mid-swap.
-        keepPreviousData: true,
+        // A version switch keeps the previous schema so the panel doesn't
+        // collapse; deselecting must not, or callers would name a stale type.
+        keepPreviousData: !!dataAppVizUuid,
     });

--- a/packages/frontend/src/features/chartTypes/utils/chartTypeBuilderPath.ts
+++ b/packages/frontend/src/features/chartTypes/utils/chartTypeBuilderPath.ts
@@ -1,7 +1,4 @@
 export const chartTypeBuilderPath = (
     projectUuid: string,
     dataAppVizUuid: string | null = null,
-) =>
-    `/projects/${projectUuid}/chart-types/${
-        dataAppVizUuid ? dataAppVizUuid : 'new'
-    }`;
+) => `/projects/${projectUuid}/chart-types/${dataAppVizUuid ?? 'new'}`;

--- a/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
@@ -100,7 +100,7 @@ describe('explorerSlice chart type authoring', () => {
         explorerActions.startChartTypeAuthoring({ dataAppVizUuid: null }),
     );
 
-    it('moves a new type onto the empty custom config and shows Configure', () => {
+    it('moves a new type onto a chart with no viz yet and shows Configure', () => {
         expect(authoringNew.chartTypeAuthoring).toEqual({
             dataAppVizUuid: null,
             viewedVersion: null,
@@ -111,15 +111,69 @@ describe('explorerSlice chart type authoring', () => {
                 pivotConfig: undefined,
             },
         });
-        expect(authoringNew.unsavedChartVersion.chartConfig).toEqual({
+        expect(authoringNew.unsavedChartVersion.chartConfig).toStrictEqual({
             type: ChartType.DATA_APP_VIZ,
-            config: { dataAppVizUuid: '', fieldMapping: {}, optionValues: {} },
         });
         expect(authoringNew.chartSidebarStep).toBe('configure');
         expect(authoringNew.isVisualizationConfigOpen).toBe(true);
         expect(
             authoringNew.cachedChartConfigs[ChartType.CARTESIAN]?.chartConfig,
         ).toEqual(fromChoose.unsavedChartVersion.chartConfig.config);
+    });
+
+    it('switches away from a chart with no viz without a config to cache', () => {
+        const switched = explorerReducer(
+            authoringNew,
+            explorerActions.setChartType({ chartType: ChartType.TABLE }),
+        );
+
+        expect(switched.unsavedChartVersion.chartConfig.type).toBe(
+            ChartType.TABLE,
+        );
+        expect(
+            switched.cachedChartConfigs[ChartType.DATA_APP_VIZ]?.chartConfig,
+        ).toBeUndefined();
+    });
+
+    it('starts a new type again from a chart with no viz', () => {
+        const again = explorerReducer(
+            authoringNew,
+            explorerActions.startChartTypeAuthoring({ dataAppVizUuid: null }),
+        );
+
+        expect(again.unsavedChartVersion.chartConfig).toStrictEqual({
+            type: ChartType.DATA_APP_VIZ,
+        });
+    });
+
+    it('points at no viz through setChartConfig even with a viz cached', () => {
+        const vizConfig = {
+            dataAppVizUuid: 'viz-1',
+            fieldMapping: {},
+            optionValues: {},
+        };
+        const onViz = explorerReducer(
+            fromChoose,
+            explorerActions.setChartConfig({
+                chartConfig: {
+                    type: ChartType.DATA_APP_VIZ,
+                    config: vizConfig,
+                },
+            }),
+        );
+        const created = [
+            explorerActions.setChartType({ chartType: ChartType.DATA_APP_VIZ }),
+            explorerActions.setChartConfig({
+                chartConfig: { type: ChartType.DATA_APP_VIZ },
+            }),
+        ].reduce(explorerReducer, onViz);
+
+        expect(
+            created.cachedChartConfigs[ChartType.DATA_APP_VIZ]?.chartConfig,
+        ).toEqual(vizConfig);
+        expect(created.unsavedChartVersion.chartConfig).toStrictEqual({
+            type: ChartType.DATA_APP_VIZ,
+        });
     });
 
     it('keeps the chart as it is when revising an existing type', () => {

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -62,6 +62,10 @@ function saveConfigToCache<T extends ChartType>(
     } as ConfigCacheMap[T];
 }
 
+// `current` rejects undefined, and a data app viz chart may carry no config.
+const snapshotChartConfig = (config: ChartConfig['config']) =>
+    config === undefined ? undefined : current(config);
+
 const initialState: ExplorerSliceState = defaultState;
 
 const removePivotValuesFromSorts = (sorts: SortField[]): SortField[] => {
@@ -351,8 +355,8 @@ const explorerSlice = createSlice({
             state.chartSidebarStep = action.payload;
         },
 
-        // A new type starts as the empty custom config until its first version
-        // lands; what was there before is kept so cancelling restores it.
+        // A new type has no viz to point at until its first version lands;
+        // what was there before is kept so cancelling restores it.
         startChartTypeAuthoring: (
             state,
             action: PayloadAction<{ dataAppVizUuid: string | null }>,
@@ -379,7 +383,7 @@ const explorerSlice = createSlice({
                 saveConfigToCache(
                     state.cachedChartConfigs,
                     before.type,
-                    current(before.config),
+                    snapshotChartConfig(before.config),
                     beforePivotConfig
                         ? (current(
                               beforePivotConfig,
@@ -388,11 +392,6 @@ const explorerSlice = createSlice({
                 );
                 state.unsavedChartVersion.chartConfig = {
                     type: ChartType.DATA_APP_VIZ,
-                    config: {
-                        dataAppVizUuid: '',
-                        fieldMapping: {},
-                        optionValues: {},
-                    },
                 };
                 state.unsavedChartVersion.pivotConfig = undefined;
             }
@@ -606,7 +605,7 @@ const explorerSlice = createSlice({
             saveConfigToCache(
                 state.cachedChartConfigs,
                 before.type,
-                current(before.config),
+                snapshotChartConfig(before.config),
                 beforePivotConfig
                     ? (current(beforePivotConfig) as SavedChart['pivotConfig'])
                     : undefined,

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
@@ -16,8 +16,10 @@ describe('useDataAppVizVisualizationConfig', () => {
             useDataAppVizVisualizationConfig(initialConfig),
         );
 
-        expect(result.current.optionValues).toEqual({ showLegend: false });
-        expect(result.current.validConfig.optionValues).toEqual({
+        expect(result.current.validConfig?.optionValues).toEqual({
+            showLegend: false,
+        });
+        expect(result.current.validConfig?.optionValues).toEqual({
             showLegend: false,
         });
     });
@@ -30,7 +32,7 @@ describe('useDataAppVizVisualizationConfig', () => {
             }),
         );
 
-        expect(result.current.optionValues).toEqual({});
+        expect(result.current.validConfig?.optionValues).toEqual({});
     });
 
     it('stores only explicitly set options and pushes them up', () => {
@@ -41,7 +43,7 @@ describe('useDataAppVizVisualizationConfig', () => {
 
         act(() => result.current.setOption('viz-1', 'barColor', '#ff0000'));
 
-        expect(result.current.optionValues).toEqual({
+        expect(result.current.validConfig?.optionValues).toEqual({
             showLegend: false,
             barColor: '#ff0000',
         });
@@ -65,7 +67,7 @@ describe('useDataAppVizVisualizationConfig', () => {
             result.current.setOption('viz-1', 'title', 'Revenue');
         });
 
-        expect(result.current.optionValues).toEqual({
+        expect(result.current.validConfig?.optionValues).toEqual({
             showLegend: false,
             barColor: '#ff0000',
             title: 'Revenue',
@@ -92,7 +94,7 @@ describe('useDataAppVizVisualizationConfig', () => {
             result.current.setField('series', 'orders_channel');
         });
 
-        expect(result.current.fieldMapping).toEqual({
+        expect(result.current.validConfig?.fieldMapping).toEqual({
             category: 'orders_status',
             value: 'orders_count',
             series: 'orders_channel',
@@ -134,7 +136,7 @@ describe('useDataAppVizVisualizationConfig', () => {
 
         act(() => result.current.setDataAppVizUuid('viz-2', {}));
 
-        expect(result.current.optionValues).toEqual({});
+        expect(result.current.validConfig?.optionValues).toEqual({});
         expect(onConfigChange).toHaveBeenCalledWith({
             dataAppVizUuid: 'viz-2',
             fieldMapping: {},
@@ -155,7 +157,7 @@ describe('useDataAppVizVisualizationConfig', () => {
         onConfigChange.mockClear();
         act(() => result.current.setOption('viz-1', 'title', 'Revenue'));
 
-        expect(result.current.optionValues).toEqual({});
+        expect(result.current.validConfig?.optionValues).toEqual({});
         expect(onConfigChange).not.toHaveBeenCalled();
     });
 
@@ -186,7 +188,7 @@ describe('useDataAppVizVisualizationConfig', () => {
 
         act(() => result.current.setOption('viz-1', 'barColor', '#ff0000'));
 
-        expect(result.current.optionValues).toEqual({
+        expect(result.current.validConfig?.optionValues).toEqual({
             showLegend: false,
             barColor: '#ff0000',
         });
@@ -217,8 +219,10 @@ describe('useDataAppVizVisualizationConfig', () => {
         });
 
         expect(result.current.dataAppVizUuid).toBe('viz-2');
-        expect(result.current.fieldMapping).toEqual({ value: 'orders_total' });
-        expect(result.current.optionValues).toEqual({});
+        expect(result.current.validConfig?.fieldMapping).toEqual({
+            value: 'orders_total',
+        });
+        expect(result.current.validConfig?.optionValues).toEqual({});
         expect(onConfigChange).not.toHaveBeenCalled();
 
         act(() => result.current.setOption('viz-2', 'barColor', '#00ff00'));
@@ -241,10 +245,77 @@ describe('useDataAppVizVisualizationConfig', () => {
         act(() => result.current.setOption('viz-1', 'barColor', '#ff0000'));
         rerender({ config: { ...initialConfig } });
 
-        expect(result.current.optionValues).toEqual({
+        expect(result.current.validConfig?.optionValues).toEqual({
             showLegend: false,
             barColor: '#ff0000',
         });
+    });
+
+    it('points at no viz when the chart has no config', () => {
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(undefined),
+        );
+
+        expect(result.current.validConfig).toBeNull();
+        expect(result.current.dataAppVizUuid).toBeNull();
+    });
+
+    it('reads the legacy empty uuid as no viz', () => {
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig({
+                dataAppVizUuid: '',
+                fieldMapping: {},
+                optionValues: {},
+            }),
+        );
+
+        expect(result.current.validConfig).toBeNull();
+        expect(result.current.dataAppVizUuid).toBeNull();
+    });
+
+    it('clears the selection and pushes the absence up', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
+        );
+
+        act(() => result.current.clearDataAppViz());
+
+        expect(result.current.validConfig).toBeNull();
+        expect(onConfigChange).toHaveBeenCalledWith(null);
+    });
+
+    it('ignores field and option edits while no viz is selected', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(undefined, onConfigChange),
+        );
+
+        act(() => {
+            result.current.setField('value', 'orders_count');
+            result.current.setOption('viz-1', 'title', 'Revenue');
+        });
+
+        expect(result.current.validConfig).toBeNull();
+        expect(onConfigChange).not.toHaveBeenCalled();
+    });
+
+    it('adopts an absent config from outside without echoing it back', () => {
+        const onConfigChange = vi.fn();
+        const { result, rerender } = renderHook(
+            ({ config }) =>
+                useDataAppVizVisualizationConfig(config, onConfigChange),
+            {
+                initialProps: {
+                    config: initialConfig as DataAppVizChart | undefined,
+                },
+            },
+        );
+
+        rerender({ config: undefined });
+
+        expect(result.current.validConfig).toBeNull();
+        expect(onConfigChange).not.toHaveBeenCalled();
     });
 
     it('round-trips the emitted config back into a fresh hook', () => {

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
@@ -2,15 +2,15 @@ import {
     type DataAppVizChart,
     type DataAppVizFieldMapping,
     type DataAppVizOptionValue,
-    type DataAppVizOptionValues,
 } from '@lightdash/common';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
+/** The chart's binding to a picked viz; null while it points at none. */
+export type SelectedDataAppViz = Required<DataAppVizChart>;
+
 export interface DataAppVizVisualizationConfigAndData {
-    validConfig: DataAppVizChart;
-    dataAppVizUuid: string;
-    fieldMapping: DataAppVizFieldMapping;
-    optionValues: DataAppVizOptionValues;
+    validConfig: SelectedDataAppViz | null;
+    dataAppVizUuid: string | null;
     /**
      * `fieldMapping` is the caller's binding for the newly selected viz —
      * computed from its contract and the query's result columns. Passed in
@@ -20,6 +20,8 @@ export interface DataAppVizVisualizationConfigAndData {
         dataAppVizUuid: string,
         fieldMapping: DataAppVizFieldMapping,
     ) => void;
+    /** Back to pointing at no viz; bindings and options go with it. */
+    clearDataAppViz: () => void;
     setField: (fieldName: string, fieldId: string | null) => void;
     /** `dataAppVizUuid` is the viz the edited control belonged to. */
     setOption: (
@@ -29,20 +31,37 @@ export interface DataAppVizVisualizationConfigAndData {
     ) => void;
 }
 
+// Charts saved while '' stood in for "no viz yet" still carry that value.
+const readDataAppVizUuid = (
+    chartConfig: DataAppVizChart | undefined,
+): string | null =>
+    chartConfig === undefined || chartConfig.dataAppVizUuid === ''
+        ? null
+        : chartConfig.dataAppVizUuid;
+
+const toSelected = (
+    chartConfig: DataAppVizChart | undefined,
+): SelectedDataAppViz | null => {
+    const dataAppVizUuid = readDataAppVizUuid(chartConfig);
+    return chartConfig !== undefined && dataAppVizUuid !== null
+        ? {
+              dataAppVizUuid,
+              fieldMapping: chartConfig.fieldMapping,
+              optionValues: chartConfig.optionValues ?? {},
+          }
+        : null;
+};
+
 // Local state for a data-app-viz chart (selected viz + field mapping + config
 // option values); setters push each change up via `onConfigChange`. Mirrors
 // useCustomVisualizationConfig. Only options the user explicitly changed are
 // stored — declared defaults are resolved at render time.
 const useDataAppVizVisualizationConfig = (
     initialChartConfig: DataAppVizChart | undefined,
-    onConfigChange?: (config: DataAppVizChart) => void,
+    onConfigChange?: (config: SelectedDataAppViz | null) => void,
 ): DataAppVizVisualizationConfigAndData => {
-    const [config, setConfigState] = useState<Required<DataAppVizChart>>(
-        () => ({
-            dataAppVizUuid: initialChartConfig?.dataAppVizUuid ?? '',
-            fieldMapping: initialChartConfig?.fieldMapping ?? {},
-            optionValues: initialChartConfig?.optionValues ?? {},
-        }),
+    const [config, setConfigState] = useState<SelectedDataAppViz | null>(() =>
+        toSelected(initialChartConfig),
     );
 
     // Track the committed config in a ref so setters called within a single
@@ -64,19 +83,16 @@ const useDataAppVizVisualizationConfig = (
 
     // A viz switched from outside this hook (the chart gallery goes through
     // the store) arrives as a new initial config while the hook stays mounted.
-    const externalDataAppVizUuid = initialChartConfig?.dataAppVizUuid ?? '';
+    const externalDataAppVizUuid = readDataAppVizUuid(initialChartConfig);
     useLayoutEffect(() => {
-        if (externalDataAppVizUuid === configRef.current.dataAppVizUuid) return;
-        const next = {
-            dataAppVizUuid: externalDataAppVizUuid,
-            fieldMapping: initialChartConfig?.fieldMapping ?? {},
-            optionValues: initialChartConfig?.optionValues ?? {},
-        };
+        const currentUuid = configRef.current?.dataAppVizUuid ?? null;
+        if (externalDataAppVizUuid === currentUuid) return;
+        const next = toSelected(initialChartConfig);
         configRef.current = next;
         setConfigState(next);
     }, [externalDataAppVizUuid, initialChartConfig]);
 
-    const commit = useCallback((next: Required<DataAppVizChart>) => {
+    const commit = useCallback((next: SelectedDataAppViz | null) => {
         configRef.current = next;
         setConfigState(next);
         onConfigChangeRef.current?.(next);
@@ -96,15 +112,19 @@ const useDataAppVizVisualizationConfig = (
         [commit],
     );
 
+    const clearDataAppViz = useCallback(() => commit(null), [commit]);
+
     const setField = useCallback(
         (fieldName: string, fieldId: string | null) => {
-            const nextMapping = { ...configRef.current.fieldMapping };
+            const selected = configRef.current;
+            if (selected === null) return;
+            const nextMapping = { ...selected.fieldMapping };
             if (fieldId === null) {
                 delete nextMapping[fieldName];
             } else {
                 nextMapping[fieldName] = fieldId;
             }
-            commit({ ...configRef.current, fieldMapping: nextMapping });
+            commit({ ...selected, fieldMapping: nextMapping });
         },
         [commit],
     );
@@ -119,13 +139,12 @@ const useDataAppVizVisualizationConfig = (
             // point the edit can belong to a config that no longer owns the
             // chart, or to a viz the user has switched away from.
             if (!isOwningChartConfigRef.current) return;
-            if (dataAppVizUuid !== configRef.current.dataAppVizUuid) return;
+            const selected = configRef.current;
+            if (selected === null || dataAppVizUuid !== selected.dataAppVizUuid)
+                return;
             commit({
-                ...configRef.current,
-                optionValues: {
-                    ...configRef.current.optionValues,
-                    [optionName]: value,
-                },
+                ...selected,
+                optionValues: { ...selected.optionValues, [optionName]: value },
             });
         },
         [commit],
@@ -133,10 +152,9 @@ const useDataAppVizVisualizationConfig = (
 
     return {
         validConfig: config,
-        dataAppVizUuid: config.dataAppVizUuid,
-        fieldMapping: config.fieldMapping,
-        optionValues: config.optionValues,
+        dataAppVizUuid: config?.dataAppVizUuid ?? null,
         setDataAppVizUuid,
+        clearDataAppViz,
         setField,
         setOption,
     };

--- a/packages/frontend/src/providers/Explorer/utils.test.ts
+++ b/packages/frontend/src/providers/Explorer/utils.test.ts
@@ -5,7 +5,38 @@ import {
     type Series,
 } from '@lightdash/common';
 import { describe, expect, test } from 'vitest';
-import { cleanConfig } from './utils';
+import { cleanConfig, getValidChartConfig } from './utils';
+
+describe('getValidChartConfig', () => {
+    const cached = {
+        [ChartType.DATA_APP_VIZ]: {
+            chartConfig: {
+                dataAppVizUuid: 'viz-1',
+                fieldMapping: {},
+                optionValues: {},
+            },
+            pivotConfig: undefined,
+        },
+    };
+
+    test('keeps a config given for the requested type, absent included', () => {
+        expect(
+            getValidChartConfig(ChartType.DATA_APP_VIZ, cached, {
+                type: ChartType.DATA_APP_VIZ,
+            }),
+        ).toStrictEqual({ type: ChartType.DATA_APP_VIZ });
+    });
+
+    test('falls back to the cache, then the default, without a config', () => {
+        expect(
+            getValidChartConfig(ChartType.DATA_APP_VIZ, cached).config,
+        ).toEqual(cached[ChartType.DATA_APP_VIZ].chartConfig);
+        expect(getValidChartConfig(ChartType.DATA_APP_VIZ, {})).toEqual({
+            type: ChartType.DATA_APP_VIZ,
+            config: {},
+        });
+    });
+});
 
 describe('cleanConfig', () => {
     test('should strip isFilteredOut from cartesian series', () => {

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -27,21 +27,23 @@ const DEFAULTS = {
 // simple clone; reducer guarantees we’re not handing in drafts
 const clone = <T>(v: T): T => structuredClone(v as unknown as object) as T;
 
+// A config given for the requested type is taken as it is, absent included:
+// that is how a data app viz chart says it points at no viz yet.
 export const getValidChartConfig = (
     chartType: ChartType,
     cachedConfigs?: Partial<ConfigCacheMap>,
     chartConfig?: ChartConfig,
 ): ChartConfig => {
-    const fromAction =
-        chartConfig?.type === chartType ? chartConfig.config : undefined;
-
-    const fromCache = cachedConfigs?.[chartType]?.chartConfig;
-    const fromDefault = DEFAULTS[chartType]();
-
-    const source = fromAction ?? fromCache ?? fromDefault;
-    const config = clone(source);
-
-    return { type: chartType, config } as ChartConfig;
+    const source =
+        chartConfig?.type === chartType
+            ? chartConfig.config
+            : (cachedConfigs?.[chartType]?.chartConfig ??
+              DEFAULTS[chartType]());
+    return (
+        source === undefined
+            ? { type: chartType }
+            : { type: chartType, config: clone(source) }
+    ) as ChartConfig;
 };
 
 export const getCachedPivotConfig = (


### PR DESCRIPTION
## Summary

While a new chart type is authored in Explorer, the chart carried a data-app-viz config whose `dataAppVizUuid` was `''` until the first build claimed a real uuid. That sentinel flowed through code that treats the uuid as real, so every consumer guarded on truthiness (`uuid || undefined`, `uuid ? ... : ...`).

`DataAppVizChartConfig.config` is already optional in common, so "no viz yet" is now an absent config. Frontend only; no shared-type or API change.

- Store: `startChartTypeAuthoring` (new type) and `useCreateProjectChartType` write `{ type: DATA_APP_VIZ }` with no config.
- Reducer: `getValidChartConfig` takes a config given for the requested type as it is, absent included, instead of swapping it for the cached or default one; snapshotting the previous config no longer assumes one exists (Immer's `current` rejects `undefined`). Both are pinned by slice tests, including the legacy picker sequence and switching type after a reload.
- `useDataAppVizVisualizationConfig`: `validConfig` is `Required<DataAppVizChart> | null`, `dataAppVizUuid` is `string | null`, and `clearDataAppViz()` replaces `setDataAppVizUuid('', {})`. `setField` / `setOption` are no-ops with nothing selected. A legacy `''` uuid from an old URL or save reads as no viz. The provider maps null back to an absent config on the saved chart; `VisualizationDataAppVizConfigProps` types the saved and local sides explicitly instead of deriving both from `validConfig`.
- Consumers branch on presence: `DataAppVizRenderer`, `DataAppVizConfigTabs` (tabs, settings and type card live inside the selected branch; `DataAppVizSettings` drops its now-dead uuid prop), `ExplorerChartSidebar`, `fromOptionValue`, `chartTypeBuilderPath`.
- Tests pinning the sentinel move to the absent-config shape, plus null-state coverage for the hook.

Also fixes a sidebar bug surfaced while testing: `useDataAppVisualization` kept its previous data (there so a version switch does not collapse the configuration column) even once the chart pointed at no viz, so starting a new type from a chart on an existing one kept showing that type's name instead of "New chart type". Previous data is now kept only while a viz is selected, with a regression test.

## Test plan

- `pnpm -F frontend typecheck`, oxlint on the changed files
- vitest on the touched areas (explorer slice, explorer utils, authoring, renderer, config tabs, gallery sidebar, hooks)
- Manually: preselect a project chart type, Configure → Change → New chart type shows "New chart type" and the URL serializes `chartConfig: {"type":"data_app_viz"}` only; Back to chart restores the previous type
- Manually: reload while on the new type (URL restores the absent config), Configure → Change → Bar chart switches cleanly; Change → project type → Change → New chart type again

Closes: GLITCH-692
