### PR TITLE
fix(data-apps): show latest scheduled delivery run

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -985,6 +985,7 @@ export class AppGenerateController extends BaseController {
     /**
      * List schedulers for a data app
      * @summary List app schedulers
+     * @param includeLatestRun include the most recent run for each scheduler
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
@@ -994,6 +995,7 @@ export class AppGenerateController extends BaseController {
         @Request() req: express.Request,
         @Path() projectUuid: string,
         @Path() appUuid: string,
+        @Query() includeLatestRun?: boolean,
     ): Promise<ApiAppSchedulersResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -1001,7 +1003,11 @@ export class AppGenerateController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getSchedulerService()
-                .getAppSchedulers(toSessionUser(req.account), appUuid),
+                .getAppSchedulers(
+                    toSessionUser(req.account),
+                    appUuid,
+                    includeLatestRun,
+                ),
         };
     }
 

--- a/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
+++ b/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
@@ -278,6 +278,42 @@ describe('Scheduler model test', () => {
         });
     });
 
+    describe('attachLatestRunToSchedulerList', () => {
+        it('attaches each scheduler latest run and marks missing runs as null', async () => {
+            const model = new SchedulerModel({ database: {} as AnyType });
+            const schedulers = [
+                { schedulerUuid: 'scheduler-1' },
+                { schedulerUuid: 'scheduler-2' },
+            ] as SchedulerAndTargets[];
+            const latestRun = {
+                schedulerUuid: 'scheduler-1',
+                runId: 'run-1',
+            } as AnyType;
+            const getRunsSpy = vi
+                .spyOn(model, 'getRunsForSchedulers')
+                .mockResolvedValue({
+                    pagination: {
+                        page: 1,
+                        pageSize: 1,
+                        totalPageCount: 1,
+                        totalResults: 1,
+                    },
+                    data: [latestRun],
+                });
+
+            await expect(
+                model.attachLatestRunToSchedulerList(schedulers),
+            ).resolves.toEqual([
+                { ...schedulers[0], latestRun },
+                { ...schedulers[1], latestRun: null },
+            ]);
+            expect(getRunsSpy).toHaveBeenCalledWith({
+                schedulers,
+                latestOnly: true,
+            });
+        });
+    });
+
     describe('getSchedulerRuns scheduler filtering', () => {
         const createModel = () =>
             new SchedulerModel({ database: {} as AnyType });

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -2520,15 +2520,15 @@ export class SchedulerModel {
         };
     }
 
-    async attachLatestRunToSchedulers(
-        schedulers: KnexPaginatedData<SchedulerAndTargets[]>,
-    ): Promise<KnexPaginatedData<SchedulerAndTargets[]>> {
-        if (schedulers.data.length === 0) {
+    async attachLatestRunToSchedulerList(
+        schedulers: SchedulerAndTargets[],
+    ): Promise<SchedulerAndTargets[]> {
+        if (schedulers.length === 0) {
             return schedulers;
         }
 
         const runs = await this.getRunsForSchedulers({
-            schedulers: schedulers.data,
+            schedulers,
             latestOnly: true,
         });
 
@@ -2537,13 +2537,19 @@ export class SchedulerModel {
             latestRunByScheduler.set(run.schedulerUuid, run);
         });
 
+        return schedulers.map((scheduler) => ({
+            ...scheduler,
+            latestRun:
+                latestRunByScheduler.get(scheduler.schedulerUuid) ?? null,
+        }));
+    }
+
+    async attachLatestRunToSchedulers(
+        schedulers: KnexPaginatedData<SchedulerAndTargets[]>,
+    ): Promise<KnexPaginatedData<SchedulerAndTargets[]>> {
         return {
             ...schedulers,
-            data: schedulers.data.map((scheduler) => ({
-                ...scheduler,
-                latestRun:
-                    latestRunByScheduler.get(scheduler.schedulerUuid) ?? null,
-            })),
+            data: await this.attachLatestRunToSchedulerList(schedulers.data),
         };
     }
 

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -542,7 +542,12 @@ describe('SchedulerService', () => {
 
         const buildAppListService = () => {
             const appListSchedulerModel = {
-                getAppSchedulers: vi.fn(async () => []),
+                getAppSchedulers: vi.fn(
+                    async (): Promise<SchedulerAndTargets[]> => [],
+                ),
+                attachLatestRunToSchedulerList: vi.fn(
+                    async (schedulers: SchedulerAndTargets[]) => schedulers,
+                ),
             };
             const appListService = new SchedulerService({
                 lightdashConfig: lightdashConfigMock,
@@ -601,6 +606,31 @@ describe('SchedulerService', () => {
                 listAppUuid,
                 undefined,
             );
+        });
+
+        test('includes the latest run when requested', async () => {
+            const { appListService, appListSchedulerModel } =
+                buildAppListService();
+            const user = buildUser([viewDataApp, createDeliveries]);
+            const appScheduler = {
+                schedulerUuid: 'appSchedulerUuid',
+                appUuid: listAppUuid,
+                targets: [],
+            } as unknown as SchedulerAndTargets;
+            appListSchedulerModel.getAppSchedulers.mockResolvedValueOnce([
+                appScheduler,
+            ]);
+
+            const result = await appListService.getAppSchedulers(
+                user,
+                listAppUuid,
+                true,
+            );
+
+            expect(
+                appListSchedulerModel.attachLatestRunToSchedulerList,
+            ).toHaveBeenCalledWith([appScheduler]);
+            expect(result).toEqual([appScheduler]);
         });
 
         test('throws ForbiddenError before listing when the user cannot create deliveries', async () => {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -670,6 +670,7 @@ export class SchedulerService extends BaseService {
     async getAppSchedulers(
         user: SessionUser,
         appUuid: string,
+        includeLatestRun?: boolean,
     ): Promise<SchedulerAndTargets[]> {
         const app = await this.checkAppScheduledDeliveryAccess(user, appUuid);
         // Same narrowing as the chart/SQL chart lists — without `manage` you
@@ -681,10 +682,16 @@ export class SchedulerService extends BaseService {
                 projectUuid: app.project_uuid,
             }),
         );
-        return this.schedulerModel.getAppSchedulers(
+        const schedulers = await this.schedulerModel.getAppSchedulers(
             appUuid,
             canManageAll ? undefined : user.userUuid,
         );
+
+        if (!includeLatestRun) {
+            return schedulers;
+        }
+
+        return this.schedulerModel.attachLatestRunToSchedulerList(schedulers);
     }
 
     async createAppScheduler(

--- a/packages/frontend/src/features/scheduler/components/SchedulerModals.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModals.tsx
@@ -103,7 +103,11 @@ export const AppSchedulersModal: FC<AppSchedulersProps> = ({
     name,
     ...modalProps
 }) => {
-    const schedulersQuery = useAppSchedulers({ projectUuid, appUuid });
+    const schedulersQuery = useAppSchedulers({
+        projectUuid,
+        appUuid,
+        includeLatestRun: true,
+    });
     const createMutation = useAppSchedulerCreateMutation(projectUuid);
 
     // The modal only mounts while open, and its hosts (builder/viewer) sync

--- a/packages/frontend/src/features/scheduler/hooks/useAppSchedulers.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useAppSchedulers.ts
@@ -23,9 +23,19 @@ type AppSchedulersPage = KnexPaginatedData<SchedulerAndTargets[]>;
 const getAppSchedulers = async (
     projectUuid: string,
     appUuid: string,
+    includeLatestRun?: boolean,
 ): Promise<AppSchedulersPage> => {
+    const params = new URLSearchParams();
+
+    if (includeLatestRun) {
+        params.set('includeLatestRun', 'true');
+    }
+
+    const queryString = params.toString();
     const results = await lightdashApi<ApiAppSchedulersResponse['results']>({
-        url: `/ee/projects/${projectUuid}/apps/${appUuid}/schedulers`,
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}/schedulers${
+            queryString ? `?${queryString}` : ''
+        }`,
         method: 'GET',
         body: undefined,
     });
@@ -43,15 +53,17 @@ const getAppSchedulers = async (
 export type UseAppSchedulersParams = {
     projectUuid: string;
     appUuid: string;
+    includeLatestRun?: boolean;
 };
 
 export const useAppSchedulers = ({
     projectUuid,
     appUuid,
+    includeLatestRun,
 }: UseAppSchedulersParams) =>
     useInfiniteQuery<AppSchedulersPage, ApiError>({
-        queryKey: ['app_schedulers', appUuid],
-        queryFn: () => getAppSchedulers(projectUuid, appUuid),
+        queryKey: ['app_schedulers', appUuid, includeLatestRun],
+        queryFn: () => getAppSchedulers(projectUuid, appUuid, includeLatestRun),
         getNextPageParam: () => undefined, // single-page wrapper
         keepPreviousData: true,
         refetchOnWindowFocus: false,


### PR DESCRIPTION
## Summary

- request latest-run metadata when opening Data App scheduled deliveries
- enrich the flat app scheduler response using the shared latest-run query
- cover the app service branch and latest-run list mapping

## Testing

- `pnpm exec vitest run --config vitest.config.ts src/services/SchedulerService/SchedulerService.test.ts src/models/SchedulerModel/SchedulerModel.test.ts` (64 tests)
- `pnpm -F backend typecheck`
- `pnpm -F frontend typecheck`
- focused Oxlint and Oxfmt checks
- `pnpm generate-api`
- local browser verification: the Data App scheduler endpoint returned `latestRun` with `runStatus: completed`, and the modal rendered the completed run instead of `Not run yet`