### PR TITLE
refactor(explorer): pass the data app viz uuid as string or null

### DIFF
--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -99,7 +99,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const config = isDataAppVizVisualizationConfig(visualizationConfig)
         ? visualizationConfig.chartConfig.validConfig
         : null;
-    const dataAppVizUuid = config?.dataAppVizUuid;
+    const dataAppVizUuid = config?.dataAppVizUuid ?? null;
     const fieldMapping = config?.fieldMapping;
     const optionValues = config?.optionValues;
     const rows = resultsData?.rows;
@@ -292,7 +292,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         drillDownEnabled,
     ]);
 
-    if (!projectUuid || dataAppVizUuid === undefined) {
+    if (!projectUuid || dataAppVizUuid === null) {
         return (
             <DataAppVizPlaceholder message="Pick a custom chart type to render." />
         );

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -59,7 +59,7 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
         : null;
     const { data: selectedProjectType } = useDataAppVisualization(
         projectUuid,
-        dataAppVizUuid ?? undefined,
+        dataAppVizUuid,
         null,
     );
     const canEditChartType = useCanEditDataAppChecker(projectUuid);

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -65,7 +65,7 @@ export const ConfigTabs: FC = memo(() => {
             : null;
     const { data: dataAppViz } = useDataAppVisualization(
         projectUuid,
-        dataAppVizUuid ?? undefined,
+        dataAppVizUuid,
         authoringVersion,
     );
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -39,6 +39,7 @@ import {
     serializeMergeState,
 } from '../../../../../features/mergeQuery/context/mergeUrlState';
 import useToaster from '../../../../../hooks/toaster/useToaster';
+import { readDataAppVizUuid } from '../../../../../hooks/useDataAppVizVisualizationConfig';
 import useCreateInAnySpaceAccess from '../../../../../hooks/user/useCreateInAnySpaceAccess';
 import { useCreateShareMutation } from '../../../../../hooks/useShare';
 import useApp from '../../../../../providers/App/useApp';
@@ -213,7 +214,7 @@ export const AiChartQuickOptions = ({
     );
     const { data: customChartTypeMetadata } = useDataAppVizRenderMetadata(
         projectUuid,
-        customChartTypeConfig?.dataAppVizUuid,
+        readDataAppVizUuid(customChartTypeConfig),
         customChartTypeRenderTarget,
     );
 

--- a/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.ts
+++ b/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.ts
@@ -247,11 +247,7 @@ export const useChartTypeBuilderWorkspace = ({
     // The schema follows the preview: the options beside a version are the
     // ones that version declares.
     const { data: dataAppViz, isFetching: isFetchingSchema } =
-        useDataAppVisualization(
-            projectUuid,
-            dataAppVizUuid ?? undefined,
-            previewVersion,
-        );
+        useDataAppVisualization(projectUuid, dataAppVizUuid, previewVersion);
 
     const onViewVersion = useCallback(
         (version: number | null) => {

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVisualization.test.tsx
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVisualization.test.tsx
@@ -22,7 +22,7 @@ const createWrapper = () => {
     );
 };
 
-type Props = { dataAppVizUuid: string | undefined; version: number | null };
+type Props = { dataAppVizUuid: string | null; version: number | null };
 
 const renderViz = (initialProps: Props) =>
     renderHook(
@@ -62,7 +62,7 @@ describe('useDataAppVisualization', () => {
         });
         await waitFor(() => expect(result.current.data).toEqual(viz(1)));
 
-        rerender({ dataAppVizUuid: undefined, version: null });
+        rerender({ dataAppVizUuid: null, version: null });
 
         expect(result.current.data).toBeUndefined();
     });

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVisualization.ts
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVisualization.ts
@@ -22,15 +22,15 @@ const getDataAppVisualization = async (
 // is pinned to an older one.
 export const useDataAppVisualization = (
     projectUuid: string | undefined,
-    dataAppVizUuid: string | undefined,
+    dataAppVizUuid: string | null,
     version: number | null,
 ) =>
     useQuery<DataAppViz, ApiError>({
         queryKey: ['data-app-viz', projectUuid, dataAppVizUuid, version],
         queryFn: () =>
             getDataAppVisualization(projectUuid!, dataAppVizUuid!, version),
-        enabled: !!projectUuid && !!dataAppVizUuid,
+        enabled: !!projectUuid && dataAppVizUuid !== null,
         // A version switch keeps the previous schema so the panel doesn't
         // collapse; deselecting must not, or callers would name a stale type.
-        keepPreviousData: !!dataAppVizUuid,
+        keepPreviousData: dataAppVizUuid !== null,
     });

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVizRender.ts
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVizRender.ts
@@ -48,11 +48,11 @@ const getChartVersionQuery = ({
 
 const isTargetReady = (
     projectUuid: string | undefined,
-    dataAppVizUuid: string | undefined,
+    dataAppVizUuid: string | null,
     target: DataAppVizRenderTarget,
 ): boolean =>
     !!projectUuid &&
-    !!dataAppVizUuid &&
+    dataAppVizUuid !== null &&
     (!target.isEmbedded || !!target.savedChartUuid);
 
 const shouldRetryDataAppVizRenderQuery = (
@@ -68,7 +68,7 @@ const shouldRetryDataAppVizRenderQuery = (
 
 export const useDataAppVizRenderMetadata = (
     projectUuid: string | undefined,
-    dataAppVizUuid: string | undefined,
+    dataAppVizUuid: string | null,
     target: DataAppVizRenderTarget,
 ) =>
     useQuery<DataAppVizRenderMetadata, ApiError>({
@@ -99,7 +99,7 @@ export const useDataAppVizRenderMetadata = (
 
 export const useDataAppVizPreviewToken = (
     projectUuid: string | undefined,
-    dataAppVizUuid: string | undefined,
+    dataAppVizUuid: string | null,
     version: number | undefined,
     target: DataAppVizRenderTarget,
 ) =>

--- a/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
@@ -135,6 +135,20 @@ describe('explorerSlice chart type authoring', () => {
         ).toBeUndefined();
     });
 
+    it('comes back to no viz after visiting another type', () => {
+        const back = explorerReducer(
+            explorerReducer(
+                authoringNew,
+                explorerActions.setChartType({ chartType: ChartType.TABLE }),
+            ),
+            explorerActions.setChartType({ chartType: ChartType.DATA_APP_VIZ }),
+        );
+
+        expect(back.unsavedChartVersion.chartConfig).toStrictEqual({
+            type: ChartType.DATA_APP_VIZ,
+        });
+    });
+
     it('starts a new type again from a chart with no viz', () => {
         const again = explorerReducer(
             authoringNew,

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
@@ -273,6 +273,15 @@ describe('useDataAppVizVisualizationConfig', () => {
         expect(result.current.dataAppVizUuid).toBeNull();
     });
 
+    it('reads a config with no uuid as no viz', () => {
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig({} as DataAppVizChart),
+        );
+
+        expect(result.current.validConfig).toBeNull();
+        expect(result.current.dataAppVizUuid).toBeNull();
+    });
+
     it('clears the selection and pushes the absence up', () => {
         const onConfigChange = vi.fn();
         const { result } = renderHook(() =>

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
@@ -31,13 +31,14 @@ export interface DataAppVizVisualizationConfigAndData {
     ) => void;
 }
 
-// Charts saved while '' stood in for "no viz yet" still carry that value.
-const readDataAppVizUuid = (
+// Charts saved while '' stood in for "no viz yet" still carry that value,
+// and a config from a URL may carry no uuid at all.
+export const readDataAppVizUuid = (
     chartConfig: DataAppVizChart | undefined,
-): string | null =>
-    chartConfig === undefined || chartConfig.dataAppVizUuid === ''
-        ? null
-        : chartConfig.dataAppVizUuid;
+): string | null => {
+    const uuid = chartConfig?.dataAppVizUuid;
+    return typeof uuid === 'string' && uuid !== '' ? uuid : null;
+};
 
 const toSelected = (
     chartConfig: DataAppVizChart | undefined,

--- a/packages/frontend/src/providers/Explorer/utils.test.ts
+++ b/packages/frontend/src/providers/Explorer/utils.test.ts
@@ -31,9 +31,8 @@ describe('getValidChartConfig', () => {
         expect(
             getValidChartConfig(ChartType.DATA_APP_VIZ, cached).config,
         ).toEqual(cached[ChartType.DATA_APP_VIZ].chartConfig);
-        expect(getValidChartConfig(ChartType.DATA_APP_VIZ, {})).toEqual({
+        expect(getValidChartConfig(ChartType.DATA_APP_VIZ, {})).toStrictEqual({
             type: ChartType.DATA_APP_VIZ,
-            config: {},
         });
     });
 });

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -21,7 +21,7 @@ const DEFAULTS = {
     [ChartType.MAP]: () => ({}),
     [ChartType.CUSTOM]: () => ({}),
     [ChartType.SANKEY]: () => ({}),
-    [ChartType.DATA_APP_VIZ]: () => ({}),
+    [ChartType.DATA_APP_VIZ]: () => undefined, // no viz until one is picked
 };
 
 // simple clone; reducer guarantees we’re not handing in drafts


### PR DESCRIPTION
## Summary

Follow-up to #28043. The visualization config there carries the selected viz as `string | null`, but `useDataAppVizRenderMetadata`, `useDataAppVizPreviewToken` and `useDataAppVisualization` took `string | undefined`, so every caller bridged the two with `?? undefined` and `DataAppVizRenderer` guarded the same absence two ways (`config === null` next to `dataAppVizUuid === undefined`).

- The three hooks take `string | null` for the viz uuid; `null` disables the query.
- `ExplorerChartSidebar`, `DataAppVizConfigTabs` and `useChartTypeBuilderWorkspace` pass their `string | null` straight through.
- `DataAppVizRenderer` derives `dataAppVizUuid` as `string | null` and guards on `null`.

Also closes the last gap in "no viz is an absent config": the explorer default for a data app viz chart was `{}`, which is not a valid `DataAppVizChart`, so a chart with no viz came back with `config: {}` after visiting another type, and a URL carrying `config: {}` made the sidebar treat it as a selected type.

- `DEFAULTS[DATA_APP_VIZ]` is the absent config.
- `readDataAppVizUuid` reads a missing uuid as no viz (not just the legacy `''`) and is shared with `AiChartQuickOptions`, so the AI copilot boundary normalises the same way.

Frontend only.

## Test plan

- `pnpm -F frontend typecheck`, oxlint and oxfmt on the changed files
- vitest on chartTypes hooks and builder, the renderer, the gallery sidebar, config tabs, the AI chart options, the explorer slice, explorer utils and the viz config hook (new: absent default, absent -> other type -> back stays absent, hook fed `{}` reports no viz)
- Manually on the frontend stack: reload on an absent config then pick Bar chart; project type -> Create new chart type -> Back to chart; legacy `''` URL and `config: {}` URL both show the empty-state sidebar, matching main

Relates: GLITCH-692