### PR TITLE
feat(dashboards): enforce direct grants through the CASL access array

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -38,6 +38,10 @@ export const user: SessionUser = {
             action: ['view', 'update', 'delete', 'create'],
         },
         {
+            subject: 'SavedChart',
+            action: ['view'],
+        },
+        {
             subject: 'Project',
             action: ['manage'],
         },

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -12,6 +12,7 @@ import {
     SCHEDULER_TASKS,
     SchedulerFormat,
     SessionUser,
+    SpaceMemberRole,
     type Account,
     type ContentVerificationInfo,
     type Dashboard,
@@ -161,17 +162,25 @@ const spaceContexts = {
     },
 };
 
+const lookupSpaceContext = (spaceUuid: string) => {
+    if (spaceUuid === space.space_uuid) {
+        return spaceContexts[space.space_uuid];
+    }
+    if (spaceUuid === privateSpace.uuid) {
+        return spaceContexts[privateSpace.uuid];
+    }
+    return spaceContexts[publicSpace.uuid];
+};
+
 const spacePermissionService = {
-    getSpaceAccessContext: vi.fn(
-        async (_userUuid: string, spaceUuid: string) => {
-            if (spaceUuid === space.space_uuid) {
-                return spaceContexts[space.space_uuid];
-            }
-            if (spaceUuid === privateSpace.uuid) {
-                return spaceContexts[privateSpace.uuid];
-            }
-            return spaceContexts[publicSpace.uuid];
-        },
+    getSpaceAccessContext: vi.fn(async (_userUuid: string, spaceUuid: string) =>
+        lookupSpaceContext(spaceUuid),
+    ),
+    getDashboardAccessContext: vi.fn(
+        async (_userUuid: string, dashboardRef: { spaceUuid: string }) => ({
+            ...lookupSpaceContext(dashboardRef.spaceUuid),
+            directOnly: false,
+        }),
     ),
     getSpacesAccessContext: vi.fn(
         async (_userUuid: string, spaceUuids: string[]) => spaceContexts,
@@ -221,6 +230,11 @@ describe('DashboardService', () => {
             user,
         });
 
+        expect(savedChartModel.get).toHaveBeenCalledWith(
+            chart.uuid,
+            undefined,
+            { projectUuid },
+        );
         expect(savedChartModel.create).toHaveBeenCalledWith(
             projectUuid,
             user.userUuid,
@@ -229,6 +243,26 @@ describe('DashboardService', () => {
                 dashboardUuid,
             }),
         );
+    });
+
+    test('refuses to duplicate a source chart the user cannot view', async () => {
+        const userWithoutChartAccess = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'Dashboard', action: ['view', 'update'] },
+            ]),
+        };
+
+        await expect(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).duplicateChartForDashboard({
+                chartUuid: chart.uuid,
+                projectUuid,
+                dashboardUuid,
+                user: userWithoutChartAccess,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(savedChartModel.create).not.toHaveBeenCalled();
     });
 
     test('should get dashboard by uuid', async () => {
@@ -243,6 +277,96 @@ describe('DashboardService', () => {
             dashboard.uuid,
             { projectUuid: undefined },
         );
+    });
+
+    test('loads a private dashboard through a direct grant without exposing its space name', async () => {
+        const directViewer = {
+            ...user,
+            ability: defineUserAbility(
+                { ...user, organizationUuid: 'another-org-uuid' },
+                [
+                    {
+                        projectUuid: dashboard.projectUuid,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: user.userUuid,
+                        roleUuid: undefined,
+                    },
+                ],
+            ),
+        };
+        const privateDashboard = {
+            ...dashboard,
+            spaceUuid: privateSpace.uuid,
+            spaceName: 'Private finance',
+        };
+        dashboardModel.getByIdOrSlug.mockResolvedValueOnce(privateDashboard);
+        spacePermissionService.getDashboardAccessContext.mockResolvedValueOnce({
+            ...spaceContexts[privateSpace.uuid],
+            access: [
+                {
+                    userUuid: user.userUuid,
+                    role: SpaceMemberRole.VIEWER,
+                    hasDirectAccess: true,
+                    projectRole: undefined,
+                    inheritedRole: undefined,
+                    inheritedFrom: undefined,
+                },
+            ],
+            directOnly: true,
+        } as never);
+
+        const result = await service.getByIdOrSlug(
+            directViewer,
+            privateDashboard.uuid,
+        );
+
+        expect(result).toMatchObject({
+            uuid: privateDashboard.uuid,
+            spaceUuid: privateSpace.uuid,
+            spaceName: '',
+            access: [
+                expect.objectContaining({
+                    userUuid: user.userUuid,
+                    role: SpaceMemberRole.VIEWER,
+                    hasDirectAccess: true,
+                }),
+            ],
+        });
+        expect(
+            spacePermissionService.getDashboardAccessContext,
+        ).toHaveBeenCalledWith(user.userUuid, {
+            uuid: privateDashboard.uuid,
+            spaceUuid: privateSpace.uuid,
+        });
+    });
+
+    test('denies the same private dashboard without a direct grant', async () => {
+        const outsider = {
+            ...user,
+            ability: defineUserAbility(
+                { ...user, organizationUuid: 'another-org-uuid' },
+                [
+                    {
+                        projectUuid: dashboard.projectUuid,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: user.userUuid,
+                        roleUuid: undefined,
+                    },
+                ],
+            ),
+        };
+        dashboardModel.getByIdOrSlug.mockResolvedValueOnce({
+            ...dashboard,
+            spaceUuid: privateSpace.uuid,
+        });
+        spacePermissionService.getDashboardAccessContext.mockResolvedValueOnce({
+            ...spaceContexts[privateSpace.uuid],
+            directOnly: false,
+        });
+
+        await expect(
+            service.getByIdOrSlug(outsider, dashboard.uuid),
+        ).rejects.toThrow(ForbiddenError);
     });
 
     test('should forward the applied parameter values when exporting content', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -187,9 +187,9 @@ export class DashboardService
             // real session, so it is not available to embed/JWT callers.
             assertRegisteredAccount(account);
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getSpaceAccessContext(
+                await this.spacePermissionService.getDashboardAccessContext(
                     account.user.userUuid,
-                    dashboard.spaceUuid,
+                    { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
                 );
 
             if (
@@ -479,10 +479,41 @@ export class DashboardService
         dashboardUuid: UUID;
         user: SessionUser;
     }): Promise<string> {
-        const chartToDuplicate = await this.savedChartModel.get(chartUuid);
+        const chartToDuplicate = await this.savedChartModel.get(
+            chartUuid,
+            undefined,
+            { projectUuid },
+        );
         if (!chartToDuplicate.dashboardUuid) {
             throw new ParameterError(
                 'We cannot duplicate a chart that is not part of a dashboard',
+            );
+        }
+        // Tile payloads can name any chart uuid; require view access on the
+        // source chart before copying it into the target dashboard.
+        const sourceContext =
+            await this.spacePermissionService.getSpaceAccessContext(
+                user.userUuid,
+                chartToDuplicate.spaceUuid,
+            );
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('SavedChart', {
+                    organizationUuid: chartToDuplicate.organizationUuid,
+                    projectUuid: chartToDuplicate.projectUuid,
+                    inheritsFromOrgOrProject:
+                        sourceContext.inheritsFromOrgOrProject,
+                    access: sourceContext.access,
+                    metadata: {
+                        spaceUuid: chartToDuplicate.spaceUuid,
+                    },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                "You don't have access to the chart being duplicated",
             );
         }
         const duplicatedChart = await this.savedChartModel.create(
@@ -603,15 +634,18 @@ export class DashboardService
             },
         );
 
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+        const { inheritsFromOrgOrProject, access, directOnly } =
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                dashboardDao.spaceUuid,
+                { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
             );
         const dashboard = {
             ...dashboardDao,
             inheritsFromOrgOrProject,
             access,
+            // Grant-only readers can open the dashboard but must not learn
+            // the private space's name.
+            spaceName: directOnly ? '' : dashboardDao.spaceName,
         };
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -677,9 +711,9 @@ export class DashboardService
             { projectUuid },
         );
         const spaceContext =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                dashboard.spaceUuid,
+                { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
             );
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -1433,9 +1467,12 @@ export class DashboardService
         const { preserveVerification, ...dashboardFields } = dashboard;
 
         const currentSpace =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                existingDashboardDao.spaceUuid,
+                {
+                    uuid: existingDashboardDao.uuid,
+                    spaceUuid: existingDashboardDao.spaceUuid,
+                },
             );
         const auditedAbility = this.createAuditedAbility(user);
         const canUpdateDashboardInCurrentSpace = auditedAbility.can(
@@ -1663,13 +1700,19 @@ export class DashboardService
             existingDashboardDao.uuid,
         );
         const updatedSpace =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                updatedNewDashboard.spaceUuid,
+                {
+                    uuid: updatedNewDashboard.uuid,
+                    spaceUuid: updatedNewDashboard.spaceUuid,
+                },
             );
 
         return {
             ...updatedNewDashboard,
+            spaceName: updatedSpace.directOnly
+                ? ''
+                : updatedNewDashboard.spaceName,
             inheritsFromOrgOrProject: updatedSpace.inheritsFromOrgOrProject,
             access: updatedSpace.access,
         };
@@ -1723,9 +1766,12 @@ export class DashboardService
         const existingDashboardDao =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                existingDashboardDao.spaceUuid,
+                {
+                    uuid: existingDashboardDao.uuid,
+                    spaceUuid: existingDashboardDao.spaceUuid,
+                },
             );
         const existingDashboard = {
             ...existingDashboardDao,
@@ -1816,9 +1862,12 @@ export class DashboardService
                     dashboardToUpdate.uuid,
                 );
                 const currentSpaceContext =
-                    await this.spacePermissionService.getSpaceAccessContext(
+                    await this.spacePermissionService.getDashboardAccessContext(
                         user.userUuid,
-                        dashboard.spaceUuid,
+                        {
+                            uuid: dashboard.uuid,
+                            spaceUuid: dashboard.spaceUuid,
+                        },
                     );
                 const canUpdateDashboardInCurrentSpace = auditedAbility.can(
                     'update',
@@ -1869,12 +1918,18 @@ export class DashboardService
         const updatedDashboardsWithSpacesAccess = updatedDashboards.map(
             async (dashboard) => {
                 const dashboardSpaceContext =
-                    await this.spacePermissionService.getSpaceAccessContext(
+                    await this.spacePermissionService.getDashboardAccessContext(
                         user.userUuid,
-                        dashboard.spaceUuid,
+                        {
+                            uuid: dashboard.uuid,
+                            spaceUuid: dashboard.spaceUuid,
+                        },
                     );
                 return {
                     ...dashboard,
+                    spaceName: dashboardSpaceContext.directOnly
+                        ? ''
+                        : dashboard.spaceName,
                     inheritsFromOrgOrProject:
                         dashboardSpaceContext.inheritsFromOrgOrProject,
                     access: dashboardSpaceContext.access,
@@ -1901,9 +1956,9 @@ export class DashboardService
 
         if (!options?.bypassPermissions) {
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getSpaceAccessContext(
+                await this.spacePermissionService.getDashboardAccessContext(
                     user.userUuid,
-                    spaceUuid,
+                    { uuid: dashboardToDelete.uuid, spaceUuid },
                 );
             const auditedAbility = this.createAuditedAbility(user);
             if (
@@ -2010,9 +2065,9 @@ export class DashboardService
             });
         } else {
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getSpaceAccessContext(
+                await this.spacePermissionService.getDashboardAccessContext(
                     user.userUuid,
-                    dashboard.spaceUuid,
+                    { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
                 );
             const auditedAbility = this.createAuditedAbility(user);
             if (
@@ -2341,9 +2396,9 @@ export class DashboardService
         const dashboardDao =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                dashboardDao.spaceUuid,
+                { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
             );
         const dashboard = {
             ...dashboardDao,
@@ -2406,9 +2461,9 @@ export class DashboardService
             throw new NotFoundError('Dashboard not found');
         }
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 actor.user.userUuid,
-                dashboard.spaceUuid,
+                { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
             );
 
         const auditedAbility = this.createAuditedAbility(actor.user);
@@ -2462,9 +2517,9 @@ export class DashboardService
         const dashboardDao =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                dashboardDao.spaceUuid,
+                { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
             );
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -2510,10 +2565,10 @@ export class DashboardService
     ): Promise<DashboardVersion> {
         const dashboardDao =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+        const { inheritsFromOrgOrProject, access, directOnly } =
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                dashboardDao.spaceUuid,
+                { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
             );
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -2562,6 +2617,7 @@ export class DashboardService
             updatedByUser: dashboard.updatedByUser,
             inheritsFromOrgOrProject,
             access,
+            spaceName: directOnly ? '' : dashboardDao.spaceName,
         };
 
         // Check if this is the current version
@@ -2660,9 +2716,9 @@ export class DashboardService
         }
 
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                dashboardDao.spaceUuid,
+                { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
             );
         const auditedAbility = this.createAuditedAbility(user);
         if (

--- a/packages/backend/src/services/DirectAccess/DirectAccessFeatureGate.test.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessFeatureGate.test.ts
@@ -70,7 +70,7 @@ describe('DirectAccessFeatureGate', () => {
     });
 
     it('fails closed when flag resolution is unknown', async () => {
-        const { gate } = buildGate({
+        const { gate, get } = buildGate({
             licensed: true,
             flagResult: new Error('flag unavailable'),
         });
@@ -78,5 +78,38 @@ describe('DirectAccessFeatureGate', () => {
         await expect(gate.assertEnabled(account)).rejects.toMatchObject({
             name: 'ForbiddenError',
         });
+        // Failures are never cached — each call retries flag resolution.
+        expect(get).toHaveBeenCalledTimes(2);
+    });
+
+    it('resolves the flag once per user within the cache TTL', async () => {
+        const { gate, get } = buildGate({ licensed: true, flagResult: true });
+        await expect(
+            Promise.all([gate.isEnabled(account), gate.isEnabled(account)]),
+        ).resolves.toEqual([true, true]);
+        await expect(gate.isEnabled(account)).resolves.toBe(true);
+        expect(get).toHaveBeenCalledTimes(1);
+
+        await gate.isEnabledForUser({
+            userUuid: 'other-user-uuid',
+            organizationUuid: 'organization-uuid',
+        });
+        expect(get).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-resolves the flag after the cache TTL expires', async () => {
+        vi.useFakeTimers();
+        try {
+            const { gate, get } = buildGate({
+                licensed: true,
+                flagResult: true,
+            });
+            await expect(gate.isEnabled(account)).resolves.toBe(true);
+            vi.advanceTimersByTime(31_000);
+            await expect(gate.isEnabled(account)).resolves.toBe(true);
+            expect(get).toHaveBeenCalledTimes(2);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/packages/backend/src/services/DirectAccess/DirectAccessFeatureGate.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessFeatureGate.ts
@@ -8,7 +8,19 @@ import Logger from '../../logging/logger';
 import { type FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { type LicenseService } from '../LicenseService/LicenseService';
 
+const FLAG_CACHE_TTL_MS = 30_000;
+const FLAG_CACHE_MAX_ENTRIES = 10_000;
+
 export class DirectAccessFeatureGate {
+    // Authorization resolves the flag once per subject, so a dashboard load
+    // with N owned tiles would otherwise query the flag tables N times.
+    // Caching the promise also collapses concurrent lookups into one query.
+    // Flag/license changes take up to FLAG_CACHE_TTL_MS to reach this path.
+    private readonly flagCache = new Map<
+        string,
+        { promise: Promise<boolean>; expiresAt: number }
+    >();
+
     constructor(
         private readonly featureFlagModel: Pick<FeatureFlagModel, 'get'>,
         private readonly licenseService: Pick<
@@ -18,21 +30,56 @@ export class DirectAccessFeatureGate {
     ) {}
 
     async isEnabled(account: RegisteredAccount): Promise<boolean> {
-        if (!this.licenseService.getLicenseStatus().valid) {
+        return this.isEnabledForUser({
+            userUuid: account.user.userUuid,
+            organizationUuid: account.organization.organizationUuid,
+        });
+    }
+
+    async isEnabledForUser(user: {
+        userUuid: string;
+        organizationUuid: string | undefined;
+    }): Promise<boolean> {
+        if (
+            user.organizationUuid === undefined ||
+            !this.licenseService.getLicenseStatus().valid
+        ) {
             return false;
         }
+        const cacheKey = `${user.userUuid}:${user.organizationUuid}`;
+        const cached = this.flagCache.get(cacheKey);
+        if (cached && cached.expiresAt > Date.now()) {
+            return cached.promise;
+        }
+        if (this.flagCache.size >= FLAG_CACHE_MAX_ENTRIES) {
+            this.flagCache.clear();
+        }
+        const promise = this.resolveFlag(cacheKey, {
+            userUuid: user.userUuid,
+            organizationUuid: user.organizationUuid,
+        });
+        this.flagCache.set(cacheKey, {
+            promise,
+            expiresAt: Date.now() + FLAG_CACHE_TTL_MS,
+        });
+        return promise;
+    }
+
+    private async resolveFlag(
+        cacheKey: string,
+        user: { userUuid: string; organizationUuid: string },
+    ): Promise<boolean> {
         try {
             const featureFlag = await this.featureFlagModel.get({
                 featureFlagId: CommercialFeatureFlags.DirectAccess,
-                user: {
-                    userUuid: account.user.userUuid,
-                    organizationUuid: account.organization.organizationUuid,
-                },
+                user,
             });
             return featureFlag.enabled;
         } catch (error) {
             // Fail closed, but keep fault-denials distinguishable from
-            // policy denials in the logs.
+            // policy denials in the logs. Don't cache the failure — a
+            // transient error must not pin denials for the TTL.
+            this.flagCache.delete(cacheKey);
             Logger.warn(
                 `Direct access flag resolution failed; failing closed: ${getErrorMessage(
                     error,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -133,6 +133,11 @@ const spacePermissionService = {
         inheritsFromOrgOrProject: false,
         access: [],
     })),
+    getDashboardAccessContext: vi.fn(async () => ({
+        inheritsFromOrgOrProject: false,
+        access: [],
+        directOnly: false,
+    })),
 };
 
 const schedulerClient = {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -412,14 +412,18 @@ export class SchedulerService extends BaseService {
             )
                 throw new ForbiddenError();
         } else if (scheduler.dashboardUuid) {
-            const { organizationUuid, spaceUuid, projectUuid } =
-                await this.dashboardModel.getByIdOrSlug(
-                    scheduler.dashboardUuid,
-                );
+            const {
+                uuid: dashboardUuid,
+                organizationUuid,
+                spaceUuid,
+                projectUuid,
+            } = await this.dashboardModel.getByIdOrSlug(
+                scheduler.dashboardUuid,
+            );
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getSpaceAccessContext(
+                await this.spacePermissionService.getDashboardAccessContext(
                     user.userUuid,
-                    spaceUuid,
+                    { uuid: dashboardUuid, spaceUuid },
                 );
 
             if (

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -30,6 +30,7 @@ import { ContentVerificationService } from './ContentVerificationService';
 import { CsvService } from './CsvService/CsvService';
 import { DashboardService } from './DashboardService/DashboardService';
 import { DeployService } from './DeployService';
+import { DirectAccessFeatureGate } from './DirectAccess/DirectAccessFeatureGate';
 import { DownloadFileService } from './DownloadFileService/DownloadFileService';
 import { EmailWhitelabelService } from './EmailWhitelabelService/EmailWhitelabelService';
 import { FavoritesService } from './FavoritesService/FavoritesService';
@@ -1109,10 +1110,15 @@ export class ServiceRepository
         return this.getService(
             'spacePermissionService',
             () =>
-                new SpacePermissionService(
-                    this.models.getSpaceModel(),
-                    this.models.getSpacePermissionModel(),
-                ),
+                new SpacePermissionService({
+                    spaceModel: this.models.getSpaceModel(),
+                    spacePermissionModel: this.models.getSpacePermissionModel(),
+                    dashboardAccessModel: this.models.getDashboardAccessModel(),
+                    directAccessFeatureGate: new DirectAccessFeatureGate(
+                        this.models.getFeatureFlagModel(),
+                        this.getLicenseService(),
+                    ),
+                }),
         );
     }
 

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -12,13 +12,18 @@ import {
     type SpaceInheritanceChain,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
+import { type DashboardAccessModel } from '../../models/DashboardAccessModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import {
     SpacePermissionModel,
     type OrganizationSpaceAccessWithCustomRole,
     type ProjectSpaceAccessWithCustomRole,
 } from '../../models/SpacePermissionModel';
-import { SpacePermissionService } from './SpacePermissionService';
+import { type DirectAccessFeatureGate } from '../DirectAccess/DirectAccessFeatureGate';
+import {
+    SpacePermissionService,
+    type SpaceAccessContextForCasl,
+} from './SpacePermissionService';
 
 const createMockSpacePermissionModel = () => ({
     getInheritanceChains:
@@ -83,10 +88,21 @@ const createMockSpacePermissionModel = () => ({
 
 describe('SpacePermissionService', () => {
     const mockPermissionModel = createMockSpacePermissionModel();
-    const service = new SpacePermissionService(
-        {} as SpaceModel,
-        mockPermissionModel as unknown as SpacePermissionModel,
-    );
+    const dashboardAccessModel = {
+        getUserAccess: vi.fn(async () => ({})),
+    };
+    const directAccessFeatureGate = {
+        isEnabledForUser: vi.fn(async () => false),
+    };
+    const service = new SpacePermissionService({
+        spaceModel: {} as SpaceModel,
+        spacePermissionModel:
+            mockPermissionModel as unknown as SpacePermissionModel,
+        dashboardAccessModel:
+            dashboardAccessModel as unknown as DashboardAccessModel,
+        directAccessFeatureGate:
+            directAccessFeatureGate as unknown as DirectAccessFeatureGate,
+    });
 
     afterEach(() => {
         vi.resetAllMocks();
@@ -1741,5 +1757,160 @@ describe('SpacePermissionService', () => {
             );
             expect(userAccess).toBeUndefined();
         });
+    });
+});
+
+describe('getDashboardAccessContext', () => {
+    const spaceContext: SpaceAccessContextForCasl = {
+        organizationUuid: 'organization-uuid',
+        projectUuid: 'project-uuid',
+        inheritsFromOrgOrProject: false,
+        access: [],
+        admins: [],
+    };
+    const dashboardRef = { uuid: 'dashboard-uuid', spaceUuid: 'space-uuid' };
+
+    const createService = ({
+        enabled,
+        grants = {},
+        context = spaceContext,
+    }: {
+        enabled: boolean;
+        grants?: Record<string, unknown>;
+        context?: typeof spaceContext;
+    }) => {
+        const dashboardAccessModel = {
+            getUserAccess: vi.fn(async () => grants),
+        };
+        const directAccessFeatureGate = {
+            isEnabledForUser: vi.fn(async () => enabled),
+        };
+        const service = new SpacePermissionService({
+            spaceModel: {} as SpaceModel,
+            spacePermissionModel: {} as unknown as SpacePermissionModel,
+            dashboardAccessModel:
+                dashboardAccessModel as unknown as DashboardAccessModel,
+            directAccessFeatureGate:
+                directAccessFeatureGate as unknown as DirectAccessFeatureGate,
+        });
+        vi.spyOn(service, 'getSpaceAccessContext').mockResolvedValue(context);
+        return { service, dashboardAccessModel, directAccessFeatureGate };
+    };
+
+    test('returns the plain space context while the feature is off', async () => {
+        const { service, dashboardAccessModel } = createService({
+            enabled: false,
+        });
+
+        await expect(
+            service.getDashboardAccessContext('user-uuid', dashboardRef),
+        ).resolves.toEqual({ ...spaceContext, directOnly: false });
+        expect(dashboardAccessModel.getUserAccess).not.toHaveBeenCalled();
+    });
+
+    test('returns the plain space context without a grant', async () => {
+        const { service } = createService({ enabled: true });
+
+        await expect(
+            service.getDashboardAccessContext('user-uuid', dashboardRef),
+        ).resolves.toEqual({ ...spaceContext, directOnly: false });
+    });
+
+    test('appends grant rows and marks grant-only readers', async () => {
+        const { service, dashboardAccessModel } = createService({
+            enabled: true,
+            grants: {
+                'dashboard-uuid': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    userRole: SpaceMemberRole.VIEWER,
+                    groupRoles: [SpaceMemberRole.EDITOR],
+                },
+            },
+        });
+
+        await expect(
+            service.getDashboardAccessContext('user-uuid', dashboardRef),
+        ).resolves.toEqual({
+            ...spaceContext,
+            access: [
+                {
+                    userUuid: 'user-uuid',
+                    role: SpaceMemberRole.VIEWER,
+                    hasDirectAccess: true,
+                    projectRole: undefined,
+                    inheritedRole: undefined,
+                    inheritedFrom: undefined,
+                },
+                {
+                    userUuid: 'user-uuid',
+                    role: SpaceMemberRole.EDITOR,
+                    hasDirectAccess: true,
+                    projectRole: undefined,
+                    inheritedRole: undefined,
+                    inheritedFrom: undefined,
+                },
+            ],
+            directOnly: true,
+        });
+        expect(dashboardAccessModel.getUserAccess).toHaveBeenCalledWith(
+            ['dashboard-uuid'],
+            'user-uuid',
+            { organizationUuid: 'organization-uuid' },
+        );
+    });
+
+    test('does not mark space members or admins as grant-only', async () => {
+        const memberContext = {
+            ...spaceContext,
+            access: [
+                {
+                    userUuid: 'user-uuid',
+                    role: SpaceMemberRole.VIEWER,
+                    hasDirectAccess: true,
+                    projectRole: undefined,
+                    inheritedRole: undefined,
+                    inheritedFrom: undefined,
+                },
+            ],
+        };
+        const { service } = createService({
+            enabled: true,
+            context: memberContext,
+            grants: {
+                'dashboard-uuid': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    userRole: SpaceMemberRole.EDITOR,
+                    groupRoles: [],
+                },
+            },
+        });
+
+        await expect(
+            service.getDashboardAccessContext('user-uuid', dashboardRef),
+        ).resolves.toMatchObject({ directOnly: false });
+
+        const adminContext: SpaceAccessContextForCasl = {
+            ...spaceContext,
+            admins: [
+                { userUuid: 'user-uuid', source: 'organization' as const },
+            ],
+        };
+        const { service: adminService } = createService({
+            enabled: true,
+            context: adminContext,
+            grants: {
+                'dashboard-uuid': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    userRole: SpaceMemberRole.EDITOR,
+                    groupRoles: [],
+                },
+            },
+        });
+        await expect(
+            adminService.getDashboardAccessContext('user-uuid', dashboardRef),
+        ).resolves.toMatchObject({ directOnly: false });
     });
 });

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -21,6 +21,7 @@ import {
     type SpaceShare,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { type DashboardAccessModel } from '../../models/DashboardAccessModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import {
     SpacePermissionModel,
@@ -28,6 +29,7 @@ import {
     type ProjectSpaceAccessWithCustomRole,
 } from '../../models/SpacePermissionModel';
 import { BaseService } from '../BaseService';
+import { type DirectAccessFeatureGate } from '../DirectAccess/DirectAccessFeatureGate';
 
 export type SpaceAdmin = {
     userUuid: string;
@@ -44,12 +46,40 @@ export type SpaceAccessContextForCasl = {
     admins: SpaceAdmin[];
 };
 
+export type DashboardAccessContextForCasl = SpaceAccessContextForCasl & {
+    /**
+     * True when the requester reaches the dashboard only through direct
+     * grants: no space access path and no org/project admin standing.
+     * Callers use it to suppress private space names in responses.
+     */
+    directOnly: boolean;
+};
+
 export class SpacePermissionService extends BaseService {
-    constructor(
-        private readonly spaceModel: SpaceModel,
-        private readonly spacePermissionModel: SpacePermissionModel,
-    ) {
+    private readonly spaceModel: SpaceModel;
+
+    private readonly spacePermissionModel: SpacePermissionModel;
+
+    private readonly dashboardAccessModel: DashboardAccessModel;
+
+    private readonly directAccessFeatureGate: DirectAccessFeatureGate;
+
+    constructor({
+        spaceModel,
+        spacePermissionModel,
+        dashboardAccessModel,
+        directAccessFeatureGate,
+    }: {
+        spaceModel: SpaceModel;
+        spacePermissionModel: SpacePermissionModel;
+        dashboardAccessModel: DashboardAccessModel;
+        directAccessFeatureGate: DirectAccessFeatureGate;
+    }) {
         super();
+        this.spaceModel = spaceModel;
+        this.spacePermissionModel = spacePermissionModel;
+        this.dashboardAccessModel = dashboardAccessModel;
+        this.directAccessFeatureGate = directAccessFeatureGate;
     }
 
     /**
@@ -157,6 +187,67 @@ export class SpacePermissionService extends BaseService {
             );
         }
         return ctx;
+    }
+
+    /**
+     * Returns the CASL context for a dashboard: the space context plus the
+     * requester's direct dashboard grants appended as ordinary access rows,
+     * so the existing `access` elemMatch ability rules interpret them with
+     * no dashboard-specific rules. Behind the direct-access feature gate;
+     * with the flag off the result equals the plain space context.
+     */
+    async getDashboardAccessContext(
+        userUuid: string,
+        dashboard: { uuid: string; spaceUuid: string },
+    ): Promise<DashboardAccessContextForCasl> {
+        const spaceContext = await this.getSpaceAccessContext(
+            userUuid,
+            dashboard.spaceUuid,
+        );
+        const spaceOnlyContext = { ...spaceContext, directOnly: false };
+        if (
+            !(await this.directAccessFeatureGate.isEnabledForUser({
+                userUuid,
+                organizationUuid: spaceContext.organizationUuid,
+            }))
+        ) {
+            return spaceOnlyContext;
+        }
+
+        const grants = await this.dashboardAccessModel.getUserAccess(
+            [dashboard.uuid],
+            userUuid,
+            { organizationUuid: spaceContext.organizationUuid },
+        );
+        const grant = grants[dashboard.uuid];
+        const grantRoles = [
+            ...(grant?.userRole ? [grant.userRole] : []),
+            ...(grant?.groupRoles ?? []),
+        ];
+        if (grantRoles.length === 0) {
+            return spaceOnlyContext;
+        }
+
+        const hasSpacePath =
+            spaceContext.access.some(
+                (access) => access.userUuid === userUuid,
+            ) ||
+            spaceContext.admins.some((admin) => admin.userUuid === userUuid);
+        return {
+            ...spaceContext,
+            access: [
+                ...spaceContext.access,
+                ...grantRoles.map((role) => ({
+                    userUuid,
+                    role,
+                    hasDirectAccess: true,
+                    projectRole: undefined,
+                    inheritedRole: undefined,
+                    inheritedFrom: undefined,
+                })),
+            ],
+            directOnly: !hasSpacePath,
+        };
     }
 
     /**

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -936,9 +936,9 @@ export class UnfurlService extends BaseService {
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                dashboard.spaceUuid,
+                { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
             );
 
         validateSelectedTabs(selectedTabs, dashboard.tiles);

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -107,6 +107,11 @@ const spacePermissionService = {
         inheritsFromOrgOrProject: false,
         access: [],
     })),
+    getDashboardAccessContext: vi.fn(async () => ({
+        inheritsFromOrgOrProject: false,
+        access: [],
+        directOnly: false,
+    })),
     getSpacesAccessContext: vi.fn(async () => ({})),
     getAccessibleSpaceUuids: vi.fn(async () => []),
 };

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -2096,9 +2096,9 @@ export class ValidationService extends BaseService {
 
         // Check user permissions
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                dashboard.spaceUuid,
+                { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
             );
 
         if (


### PR DESCRIPTION
## Summary

PR 2 of 3 for [SPK-1417](https://linear.app/lightdash/issue/SPK-1417). Makes dashboard direct grants take effect: a user or group granted `viewer`/`editor` on a dashboard can now access that dashboard through the normal CASL checks, without space membership. The grant rows are merged into the existing `access` array at one seam — no new CASL rules, no new subject fields the ability files must learn.

Stacks on top of PR 1 (#28050), which reduced direct access to the dashboard grant kernel.

Contributes to: https://linear.app/lightdash/issue/SPK-1417

## How it works

`SpacePermissionService.getDashboardAccessContext(userUuid, { uuid, spaceUuid })` wraps `getSpaceAccessContext` and, when the feature gate passes, appends the user's dashboard grant roles to the context's `access` array:

```
getSpaceAccessContext(spaceUuid)          gate off / no grant
        │                                        │
        ▼                                        ▼
DirectAccessFeatureGate ──false──▶ { ...spaceContext, directOnly: false }
        │ true
        ▼
DashboardAccessModel.getUserAccess (org-scoped, user + group grants)
        │
        ▼
{ ...spaceContext,
  access: [...spaceContext.access, ...grantRoles (hasDirectAccess: true)],
  directOnly: !hasSpacePath }        ◀─ true only when the grant is the ONLY path
```

Existing `subject('Dashboard', …)` construction is untouched — the elemMatch rules already match on `access`, so a `viewer` grant satisfies `view` and an `editor` grant satisfies `update`/`delete`. Org-role capability ceilings still apply (an org viewer with an editor grant cannot update — same as space roles today, verified against a `space_user_access` control).

`directOnly` lets read paths blank `spaceName` so a grant-only user never learns the private space's name (`getByIdOrSlug`, `getVersion`, `update`, `updateMultiple` responses).

**Converted call sites (one-line swaps to the new seam):** 15 in `DashboardService` (get, charts, update, updateMultiple, delete, softDelete, pinning, history, version, rollback, scheduled-delivery checks, export) plus `SchedulerService`, `UnfurlService`, `ValidationService`. Target-space checks for create/move/duplicate deliberately stay space-based — a grant does not let you write into someone else's space.

**Hardening found during review:** `duplicateChartForDashboard` previously fetched the source chart unscoped and unchecked; tile payloads can name any chart uuid. It now fetches scoped to the project and requires `view` on the source chart before copying.

**Gating:** EE license + `direct-access` commercial flag (default **off**, standard override precedence, fail-closed on resolution errors). Flag resolution is memoized for 30s per user+org so a dashboard load with N tiles resolves it once; flag/license changes take up to 30s to reach this path. With the flag off the merged context is byte-identical to the space context.

## Test plan

- [x] `pnpm -F backend|common|frontend typecheck`, `pnpm -F backend lint` + format — clean
- [x] `SpacePermissionService.test.ts` — 4 `getDashboardAccessContext` cases (gate off, no grant, grant append, directOnly)
- [x] `DirectAccessFeatureGate.test.ts` — 6 tests incl. memoization, TTL expiry, errors-never-cached
- [x] `DashboardService.test.ts` — grant-view with blanked `spaceName`, deny without grant, duplicate-source-chart deny
- [x] Full backend service suites for every converted service — green
- [x] Runtime matrix on a seeded dev instance: 403→grant→200 flip, `spaceName` suppression, viewer-grant PATCH 403, editor-grant PATCH 200, revocation immediate, org/project admins unaffected, flag-off identical

## Notes

- Product-design point per SPK-1247: a direct **editor** grant allows moving the dashboard out of its private space (same power a space editor has today).
- Known cosmetic gap: grant-only users may see a promote-button 403; UI/discovery is Stack 5's scope.
- EE `ManagedAgentService` has a private space-context helper that is intentionally not converted here; follow-up noted on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
