### PR TITLE
feat(dashboards): run dashboard-owned charts through the dashboard grant

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -4996,3 +4996,127 @@ describe('AsyncQueryService', () => {
         });
     });
 });
+
+describe('checkDashboardChartQueryPermissions', () => {
+    const owningDashboardUuid = 'owned-dashboard-uuid';
+    const chartSpace = {
+        uuid: 'space-1',
+        organizationUuid: projectSummary.organizationUuid,
+    } as AnyType;
+
+    const buildGrantOnlyAccount = () => {
+        const account = buildAccount();
+        account.user.ability = new Ability<PossibleAbilities>([
+            {
+                subject: 'SavedChart',
+                action: ['view'],
+                conditions: {
+                    organizationUuid: projectSummary.organizationUuid,
+                    access: {
+                        $elemMatch: { userUuid: account.user.id },
+                    },
+                },
+            },
+            {
+                subject: 'Project',
+                action: ['view'],
+                conditions: {
+                    organizationUuid: projectSummary.organizationUuid,
+                },
+            },
+        ]);
+        return account;
+    };
+
+    const buildSpacePermissionService = (
+        dashboardAccess: { userUuid: string }[],
+    ) => ({
+        getDashboardAccessContext: vi.fn(async () => ({
+            organizationUuid: projectSummary.organizationUuid,
+            projectUuid: projectSummary.projectUuid,
+            inheritsFromOrgOrProject: false,
+            access: dashboardAccess.map(({ userUuid }) => ({
+                userUuid,
+                role: 'viewer',
+                hasDirectAccess: true,
+            })),
+            admins: [],
+            directOnly: true,
+        })),
+        getSpaceAccessContext: vi.fn(async () => ({
+            organizationUuid: projectSummary.organizationUuid,
+            projectUuid: projectSummary.projectUuid,
+            inheritsFromOrgOrProject: false,
+            access: [],
+            admins: [],
+        })),
+    });
+
+    it('authorizes a dashboard-owned chart through the dashboard grant', async () => {
+        const account = buildGrantOnlyAccount();
+        const service = getMockedAsyncQueryService(lightdashConfigMock);
+        const spacePermissionService = buildSpacePermissionService([
+            { userUuid: account.user.id },
+        ]);
+        (service as AnyType).spacePermissionService = spacePermissionService;
+
+        await expect(
+            (service as AnyType).checkDashboardChartQueryPermissions(
+                account,
+                projectSummary.projectUuid,
+                'chart-uuid',
+                chartSpace,
+                owningDashboardUuid,
+            ),
+        ).resolves.toBeUndefined();
+        expect(
+            spacePermissionService.getDashboardAccessContext,
+        ).toHaveBeenCalledWith(account.user.id, {
+            uuid: owningDashboardUuid,
+            spaceUuid: chartSpace.uuid,
+        });
+        expect(
+            spacePermissionService.getSpaceAccessContext,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('denies a dashboard-owned chart without a grant or space access', async () => {
+        const account = buildGrantOnlyAccount();
+        const service = getMockedAsyncQueryService(lightdashConfigMock);
+        (service as AnyType).spacePermissionService =
+            buildSpacePermissionService([]);
+
+        await expect(
+            (service as AnyType).checkDashboardChartQueryPermissions(
+                account,
+                projectSummary.projectUuid,
+                'chart-uuid',
+                chartSpace,
+                owningDashboardUuid,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('keeps the space check for reusable charts', async () => {
+        const account = buildGrantOnlyAccount();
+        const service = getMockedAsyncQueryService(lightdashConfigMock);
+        const spacePermissionService = buildSpacePermissionService([]);
+        (service as AnyType).spacePermissionService = spacePermissionService;
+
+        await expect(
+            (service as AnyType).checkDashboardChartQueryPermissions(
+                account,
+                projectSummary.projectUuid,
+                'chart-uuid',
+                chartSpace,
+                null,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(
+            spacePermissionService.getSpaceAccessContext,
+        ).toHaveBeenCalledWith(account.user.id, chartSpace.uuid);
+        expect(
+            spacePermissionService.getDashboardAccessContext,
+        ).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -742,12 +742,23 @@ export class AsyncQueryService extends ProjectService {
             project: Pick<Project, 'projectUuid'>;
             organization: Pick<Organization, 'organizationUuid'>;
             space: Pick<SpaceSummaryBase, 'uuid'>;
+            // Charts owned by a dashboard are covered by that dashboard's
+            // direct grants.
+            dashboard: { uuid: string } | null;
         },
     ) {
-        const ctx = await this.spacePermissionService.getSpaceAccessContext(
-            account.user.id,
-            savedChart.space.uuid,
-        );
+        const ctx = savedChart.dashboard?.uuid
+            ? await this.spacePermissionService.getDashboardAccessContext(
+                  account.user.id,
+                  {
+                      uuid: savedChart.dashboard.uuid,
+                      spaceUuid: savedChart.space.uuid,
+                  },
+              )
+            : await this.spacePermissionService.getSpaceAccessContext(
+                  account.user.id,
+                  savedChart.space.uuid,
+              );
 
         const auditedAbility = this.createAuditedAbility(account);
         if (
@@ -5994,6 +6005,9 @@ export class AsyncQueryService extends ProjectService {
         projectUuid: string,
         savedChartUuid: string,
         space: SpaceSummaryBase,
+        // Set when the chart is owned by a dashboard, whose direct grants
+        // then cover running it.
+        owningDashboardUuid: string | null,
     ) {
         if (isJwtUser(account)) {
             const embedWriteActions = account.authentication.data.writeActions;
@@ -6034,10 +6048,15 @@ export class AsyncQueryService extends ProjectService {
             );
         } else {
             const auditedAbility = this.createAuditedAbility(account);
-            const ctx = await this.spacePermissionService.getSpaceAccessContext(
-                account.user.id,
-                space.uuid,
-            );
+            const ctx = owningDashboardUuid
+                ? await this.spacePermissionService.getDashboardAccessContext(
+                      account.user.id,
+                      { uuid: owningDashboardUuid, spaceUuid: space.uuid },
+                  )
+                : await this.spacePermissionService.getSpaceAccessContext(
+                      account.user.id,
+                      space.uuid,
+                  );
 
             if (
                 auditedAbility.cannot(
@@ -6179,6 +6198,7 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             savedChart.uuid,
             space,
+            savedChart.dashboardUuid,
         );
 
         // Fire-and-forget: analytics tracking is non-critical and shouldn't block query execution

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -492,6 +492,24 @@ describe('DashboardService', () => {
         expect(dashboardModel.update).not.toHaveBeenCalled();
     });
 
+    test('blanks the space name in the update response for a grant-only editor', async () => {
+        spacePermissionService.getDashboardAccessContext
+            .mockResolvedValueOnce({
+                ...lookupSpaceContext(dashboard.spaceUuid),
+                directOnly: true,
+            })
+            .mockResolvedValueOnce({
+                ...lookupSpaceContext(dashboard.spaceUuid),
+                directOnly: true,
+            });
+
+        const result = await service.update(user, dashboard.uuid, {
+            name: 'renamed',
+        });
+
+        expect(result.spaceName).toBe('');
+    });
+
     test('should get dashboard charts after dashboard access check', async () => {
         const result = await service.getDashboardCharts(
             user,

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -492,9 +492,12 @@ export class DashboardService
         // Tile payloads can name any chart uuid; require view access on the
         // source chart before copying it into the target dashboard.
         const sourceContext =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                chartToDuplicate.spaceUuid,
+                {
+                    uuid: chartToDuplicate.dashboardUuid,
+                    spaceUuid: chartToDuplicate.spaceUuid,
+                },
             );
         const auditedAbility = this.createAuditedAbility(user);
         if (

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6577,10 +6577,18 @@ export class ProjectService extends BaseService {
         const { organizationUuid, projectUuid } = savedChart;
 
         const [spaceCtx, explore] = await Promise.all([
-            this.spacePermissionService.getSpaceAccessContext(
-                account.user.id,
-                savedChart.spaceUuid,
-            ),
+            savedChart.dashboardUuid
+                ? this.spacePermissionService.getDashboardAccessContext(
+                      account.user.id,
+                      {
+                          uuid: savedChart.dashboardUuid,
+                          spaceUuid: savedChart.spaceUuid,
+                      },
+                  )
+                : this.spacePermissionService.getSpaceAccessContext(
+                      account.user.id,
+                      savedChart.spaceUuid,
+                  ),
             this.getExplore(
                 account,
                 projectUuid,
@@ -6677,10 +6685,18 @@ export class ProjectService extends BaseService {
         const { organizationUuid, projectUuid } = savedChart;
 
         const [spaceCtx, explore] = await Promise.all([
-            this.spacePermissionService.getSpaceAccessContext(
-                account.user.id,
-                savedChart.spaceUuid,
-            ),
+            savedChart.dashboardUuid
+                ? this.spacePermissionService.getDashboardAccessContext(
+                      account.user.id,
+                      {
+                          uuid: savedChart.dashboardUuid,
+                          spaceUuid: savedChart.spaceUuid,
+                      },
+                  )
+                : this.spacePermissionService.getSpaceAccessContext(
+                      account.user.id,
+                      savedChart.spaceUuid,
+                  ),
             this.getExplore(
                 account,
                 projectUuid,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -1288,9 +1288,14 @@ export class SavedChartService
         account: Account,
         space: SpaceSummaryBase,
         savedChart: SavedChartDAO,
-    ): Promise<{ access: SpaceAccess[]; inheritsFromOrgOrProject: boolean }> {
+    ): Promise<{
+        access: SpaceAccess[];
+        inheritsFromOrgOrProject: boolean;
+        directOnly: boolean;
+    }> {
         let access;
         let inheritsFromOrgOrProject: boolean;
+        let directOnly = false;
         let permissionActor: Account | SessionUser = account;
         if (isJwtUser(account)) {
             const { embedWriteUser } = account;
@@ -1324,6 +1329,18 @@ export class SavedChartService
                     );
                 inheritsFromOrgOrProject = spaceCtx.inheritsFromOrgOrProject;
             }
+        } else if (savedChart.dashboardUuid) {
+            const ctx =
+                await this.spacePermissionService.getDashboardAccessContext(
+                    account.user.userUuid,
+                    {
+                        uuid: savedChart.dashboardUuid,
+                        spaceUuid: savedChart.spaceUuid,
+                    },
+                );
+            access = ctx.access;
+            inheritsFromOrgOrProject = ctx.inheritsFromOrgOrProject;
+            directOnly = ctx.directOnly;
         } else {
             const ctx = await this.spacePermissionService.getSpaceAccessContext(
                 account.user.userUuid,
@@ -1356,6 +1373,7 @@ export class SavedChartService
         return {
             access: isJwtUser(account) ? [] : (access as SpaceAccess[]),
             inheritsFromOrgOrProject,
+            directOnly,
         };
     }
 
@@ -1373,7 +1391,7 @@ export class SavedChartService
             savedChart.spaceUuid,
         );
 
-        const { access, inheritsFromOrgOrProject } =
+        const { access, inheritsFromOrgOrProject, directOnly } =
             await this.checkPermissions(account, space, savedChart);
 
         try {
@@ -1410,6 +1428,7 @@ export class SavedChartService
 
         return {
             ...savedChart,
+            spaceName: directOnly ? '' : savedChart.spaceName,
             inheritsFromOrgOrProject,
             access,
         };

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -26,6 +26,7 @@ const sqlChart = {
     organization: { organizationUuid },
     project: { projectUuid },
     space: { uuid: spaceUuid, name: 'Space' },
+    dashboard: null as { uuid: string; name: string } | null,
 };
 
 const baseUser = {
@@ -233,5 +234,112 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             );
             expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
         });
+    });
+});
+
+describe('SavedSqlService - dashboard-owned chart access', () => {
+    const owningDashboardUuid = 'owning-dashboard-uuid';
+    const accessContext = {
+        organizationUuid,
+        projectUuid,
+        inheritsFromOrgOrProject: true,
+        access: [],
+    };
+    const directAccessModel = {
+        getByUuid: vi.fn(async () => sqlChart),
+        resolveColorPalette: vi.fn(async () => null),
+    };
+    const directAccessPermissionService = {
+        getDashboardAccessContext: vi.fn(async () => ({
+            ...accessContext,
+            directOnly: true,
+        })),
+        getSpacesAccessContext: vi.fn(async () => ({
+            [spaceUuid]: accessContext,
+        })),
+    };
+    const service = new SavedSqlService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: {} as unknown as ProjectModel,
+        savedSqlModel: directAccessModel as unknown as SavedSqlModel,
+        schedulerClient: {} as unknown as SchedulerClient,
+        schedulerModel: {} as unknown as SchedulerModel,
+        analyticsModel: {} as unknown as AnalyticsModel,
+        spacePermissionService:
+            directAccessPermissionService as unknown as SpacePermissionService,
+    });
+    const chartViewer = {
+        ...baseUser,
+        role: OrganizationMemberRole.VIEWER,
+        ability: new Ability<PossibleAbilities>([
+            { subject: 'SavedChart', action: 'view' },
+        ]),
+    };
+
+    afterEach(() => vi.clearAllMocks());
+
+    it('authorizes a dashboard-owned sql chart through its dashboard access context', async () => {
+        directAccessModel.getByUuid.mockResolvedValueOnce({
+            ...sqlChart,
+            dashboard: { uuid: owningDashboardUuid, name: 'Dashboard' },
+        });
+
+        await expect(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).hasAccess(
+                'view',
+                { user: chartViewer, projectUuid },
+                { savedSqlUuid },
+            ),
+        ).resolves.toEqual({ ...accessContext, directOnly: true });
+        expect(
+            directAccessPermissionService.getDashboardAccessContext,
+        ).toHaveBeenCalledWith(chartViewer.userUuid, {
+            uuid: owningDashboardUuid,
+            spaceUuid,
+        });
+        expect(
+            directAccessPermissionService.getSpacesAccessContext,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('authorizes a space sql chart through its space access context', async () => {
+        directAccessModel.getByUuid.mockResolvedValueOnce({
+            ...sqlChart,
+            dashboard: null,
+        });
+
+        await expect(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).hasAccess(
+                'view',
+                { user: chartViewer, projectUuid },
+                { savedSqlUuid },
+            ),
+        ).resolves.toEqual({ ...accessContext, directOnly: false });
+        expect(
+            directAccessPermissionService.getDashboardAccessContext,
+        ).not.toHaveBeenCalled();
+        expect(
+            directAccessPermissionService.getSpacesAccessContext,
+        ).toHaveBeenCalledWith(chartViewer.userUuid, [spaceUuid]);
+    });
+
+    it('does not expose the private space name to a grant-only user', async () => {
+        const ownedChart = {
+            ...sqlChart,
+            dashboard: { uuid: owningDashboardUuid, name: 'Dashboard' },
+        };
+        directAccessModel.getByUuid.mockResolvedValue(ownedChart);
+
+        const result = await service.getSqlChart(
+            chartViewer,
+            projectUuid,
+            savedSqlUuid,
+        );
+
+        expect(result.space.name).toBe('');
+        expect(result.space.uuid).toBe(spaceUuid);
     });
 });

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -156,6 +156,7 @@ export class SavedSqlService
               },
     ) {
         let { spaceUuid } = resource;
+        let owningDashboardUuid: string | null = null;
 
         if (resource.savedSqlUuid !== null) {
             const savedSql = await this.savedSqlModel.getByUuid(
@@ -170,6 +171,7 @@ export class SavedSqlService
             }
 
             spaceUuid = savedSql.space.uuid;
+            owningDashboardUuid = savedSql.dashboard?.uuid ?? null;
         }
 
         if (!spaceUuid) {
@@ -179,15 +181,22 @@ export class SavedSqlService
         const needsNewSpaceCheck =
             resource.spaceUuid && spaceUuid !== resource.spaceUuid;
 
-        const ctx = needsNewSpaceCheck
-            ? await this.spacePermissionService.getSpacesAccessContext(
+        // Charts owned by a dashboard are covered by that dashboard's
+        // direct grants.
+        const currentCtx = owningDashboardUuid
+            ? await this.spacePermissionService.getDashboardAccessContext(
                   actor.user.userUuid,
-                  [spaceUuid, resource.spaceUuid!],
+                  { uuid: owningDashboardUuid, spaceUuid },
               )
-            : await this.spacePermissionService.getSpacesAccessContext(
-                  actor.user.userUuid,
-                  [spaceUuid],
-              );
+            : {
+                  ...(
+                      await this.spacePermissionService.getSpacesAccessContext(
+                          actor.user.userUuid,
+                          [spaceUuid],
+                      )
+                  )[spaceUuid],
+                  directOnly: false,
+              };
 
         const auditedAbility = this.createAuditedAbility(actor.user);
 
@@ -195,7 +204,7 @@ export class SavedSqlService
             auditedAbility.cannot(
                 action,
                 subject('SavedChart', {
-                    ...ctx[spaceUuid],
+                    ...currentCtx,
                     metadata: { savedSqlUuid: resource.savedSqlUuid ?? '' },
                 }),
             )
@@ -206,11 +215,17 @@ export class SavedSqlService
         }
 
         if (needsNewSpaceCheck) {
+            const newSpaceCtx = (
+                await this.spacePermissionService.getSpacesAccessContext(
+                    actor.user.userUuid,
+                    [resource.spaceUuid!],
+                )
+            )[resource.spaceUuid!];
             if (
                 auditedAbility.cannot(
                     action,
                     subject('SavedChart', {
-                        ...ctx[resource.spaceUuid!],
+                        ...newSpaceCtx,
                         metadata: { savedSqlUuid: resource.savedSqlUuid ?? '' },
                     }),
                 )
@@ -221,7 +236,7 @@ export class SavedSqlService
             }
         }
 
-        return ctx[spaceUuid];
+        return currentCtx;
     }
 
     async getSqlChart(
@@ -273,6 +288,7 @@ export class SavedSqlService
             ...savedChart,
             space: {
                 ...savedChart.space,
+                name: spaceCtx.directOnly ? '' : savedChart.space.name,
                 userAccess: spaceCtx.access[0],
             },
             resolvedColorPalette,
@@ -339,6 +355,7 @@ export class SavedSqlService
             ...savedChart,
             space: {
                 ...savedChart.space,
+                name: spaceCtx.directOnly ? '' : savedChart.space.name,
                 userAccess: embedWriteActions ? undefined : spaceCtx.access[0],
             },
             resolvedColorPalette,


### PR DESCRIPTION
## Summary

PR 3 of 3 for [SPK-1417](https://linear.app/lightdash/issue/SPK-1417). Makes granted dashboards actually render: charts **owned by** a dashboard (saved-chart tiles with `dashboardUuid` set, and dashboard-owned SQL charts) are authorized through that dashboard's access context, so a grant-only user can load and run them. Reusable charts that merely appear as tiles keep today's per-chart space check — inaccessible ones still show the error tile.

Stacks on top of PR 2 (#28051), which merged dashboard grants into the CASL access array.

Closes: https://linear.app/lightdash/issue/SPK-1417

## How it works

An owned chart lives in its dashboard's space (`COALESCE(saved_queries.space_id, dashboards.space_id)`), so each converted site swaps the space context for the dashboard context only when the chart has an owning dashboard:

```
chart.dashboardUuid set?
  yes ─▶ getDashboardAccessContext(user, { uuid: dashboardUuid, spaceUuid })
  no  ─▶ getSpaceAccessContext(user, spaceUuid)        (unchanged)
```

**Converted sites**
- `AsyncQueryService.checkDashboardChartQueryPermissions` — the funnel for all non-JWT dashboard tile queries; callers now pass the chart's owning dashboard.
- `AsyncQueryService.assertSavedChartAccess` — `dashboard: { uuid } | null` is now a required part of the contract.
- `ProjectService.runViewChartQuery` + `getChartAndResults` — chart view/results outside the dashboard context.
- `SavedChartService.checkPermissions` — chart definition fetch; also returns `directOnly` so `get()` blanks `spaceName` for grant-only readers.
- `SavedSqlService.hasAccess` — the single choke point for SQL-chart reads/updates/result jobs; dashboard-owned SQL charts resolve through the owning dashboard, so SQL tiles render too. The move-target space check stays space-based.
- `DashboardService.duplicateChartForDashboard` — the PR 2 source-chart guard now uses the source chart's own dashboard context, so a grant-only editor can duplicate tabs within their granted dashboard.

Role semantics are unchanged: a `viewer` grant runs tiles, an `editor` grant edits owned tiles, and org-role ceilings still cap both.

## Test plan

- [x] `pnpm -F backend|common|frontend typecheck`, `pnpm -F backend lint` + format — clean
- [x] `AsyncQueryService.test.ts` — 3 new `checkDashboardChartQueryPermissions` cases (owned grant allow, reusable deny, no-grant deny)
- [x] `SavedSqlService.test.ts` — 2 new cases pinning dashboard-context vs space-context selection
- [x] `DashboardService.test.ts` — duplicate-guard allow/deny
- [x] All affected service suites (358 tests, 13 files) + 10 model integration tests — green
- [x] Runtime matrix on a seeded dev instance: grant-only user loads a private dashboard and its owned tiles return data; reusable tile still 403s into an error tile; revocation immediately restores 403

## Notes

- EE `ManagedAgentService` keeps its private space-context helper; converting it is a noted follow-up, not part of this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
