### PR TITLE
feat: add mobile minimum versions to health response

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -230,6 +230,12 @@ export const lightdashConfigMock: LightdashConfig = {
     helpMenuUrl: undefined,
     trustProxy: false,
     mode: LightdashMode.DEFAULT,
+    mobile: {
+        minimumSupportedVersion: {
+            android: null,
+            ios: null,
+        },
+    },
     license: {
         licenseKey: null,
     },

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -97,6 +97,68 @@ describe('HTTP server config', () => {
     });
 });
 
+describe('mobile minimum supported versions', () => {
+    it('defaults both platforms to null', () => {
+        expect(parseConfig().mobile).toEqual({
+            minimumSupportedVersion: {
+                android: null,
+                ios: null,
+            },
+        });
+    });
+
+    it.each([
+        {
+            environmentVariable: 'LIGHTDASH_MOBILE_MINIMUM_ANDROID_VERSION',
+            platform: 'android' as const,
+            otherPlatform: 'ios' as const,
+        },
+        {
+            environmentVariable: 'LIGHTDASH_MOBILE_MINIMUM_IOS_VERSION',
+            platform: 'ios' as const,
+            otherPlatform: 'android' as const,
+        },
+    ])(
+        'configures $platform independently',
+        ({ environmentVariable, platform, otherPlatform }) => {
+            process.env[environmentVariable] = '2.3.4';
+
+            expect(parseConfig().mobile.minimumSupportedVersion).toMatchObject({
+                [platform]: '2.3.4',
+                [otherPlatform]: null,
+            });
+        },
+    );
+
+    it('keeps 1.10 as a string', () => {
+        process.env.LIGHTDASH_MOBILE_MINIMUM_ANDROID_VERSION = '1.10';
+
+        expect(parseConfig().mobile.minimumSupportedVersion.android).toBe(
+            '1.10',
+        );
+    });
+
+    it.each([
+        '',
+        ' ',
+        '-1',
+        '+1',
+        '.1',
+        '1.',
+        '1..2',
+        '1. 2',
+        '1e2',
+        '1.2-beta',
+    ])('rejects invalid version %j', (value) => {
+        process.env.LIGHTDASH_MOBILE_MINIMUM_ANDROID_VERSION = value;
+
+        expect(() => parseConfig()).toThrowError(ParseError);
+        expect(() => parseConfig()).toThrow(
+            'LIGHTDASH_MOBILE_MINIMUM_ANDROID_VERSION',
+        );
+    });
+});
+
 describe('MotherDuck instance cache config', () => {
     afterEach(() => {
         vi.restoreAllMocks();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -29,6 +29,7 @@ import {
     WarehouseTypes,
     WeekDay,
     type GroupProjectAccessSetupEntry,
+    type HealthState,
     type SchedulerTaskName,
     type UserAttributeSetupEntry,
 } from '@lightdash/common';
@@ -414,6 +415,21 @@ const parseEnum = <T>(
         );
     }
     return value as T;
+};
+
+const getMobileMinimumVersionFromEnvironmentVariable = (
+    name: string,
+): string | null => {
+    const value = process.env[name];
+    if (value === undefined) return null;
+
+    if (!/^\d+(?:\.\d+)*$/.test(value)) {
+        throw new ParseError(
+            `Cannot parse environment variable "${name}". Value must contain dot-separated non-negative integer components but ${name}=${value}`,
+        );
+    }
+
+    return value;
 };
 
 // WeekDay is a numeric enum, so a generic Object.values check would accept the
@@ -1432,6 +1448,7 @@ export type LightdashConfig = {
     postmark: PostmarkConfig;
     rudder: RudderConfig;
     mode: LightdashMode;
+    mobile: HealthState['mobile'];
     license: {
         licenseKey: string | null;
     };
@@ -2717,6 +2734,16 @@ export const parseConfig = (): LightdashConfig => {
 
     return {
         mode,
+        mobile: {
+            minimumSupportedVersion: {
+                android: getMobileMinimumVersionFromEnvironmentVariable(
+                    'LIGHTDASH_MOBILE_MINIMUM_ANDROID_VERSION',
+                ),
+                ios: getMobileMinimumVersionFromEnvironmentVariable(
+                    'LIGHTDASH_MOBILE_MINIMUM_IOS_VERSION',
+                ),
+            },
+        },
         cookieSameSite: iframeEmbeddingEnabled ? 'none' : 'lax',
         license: {
             licenseKey,

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -14,6 +14,12 @@ export const BaseResponse: HealthState = {
     },
     version: '0.1.0',
     mode: LightdashMode.DEFAULT,
+    mobile: {
+        minimumSupportedVersion: {
+            android: null,
+            ios: null,
+        },
+    },
     isAuthenticated: false,
     requiresOrgRegistration: false,
     localDbtEnabled: true,

--- a/packages/backend/src/services/HealthService/HealthService.test.ts
+++ b/packages/backend/src/services/HealthService/HealthService.test.ts
@@ -113,6 +113,36 @@ describe('health', () => {
         });
     });
 
+    it('returns independently configured mobile minimum versions', async () => {
+        const service = new HealthService({
+            organizationModel:
+                organizationModel as unknown as OrganizationModel,
+            lightdashConfig: {
+                ...lightdashConfigMock,
+                mobile: {
+                    minimumSupportedVersion: {
+                        android: '1.10',
+                        ios: '2.3.4',
+                    },
+                },
+            },
+            licenseService,
+            migrationModel: migrationModel as unknown as MigrationModel,
+            organizationSettingsModel:
+                organizationSettingsModel as unknown as OrganizationSettingsModel,
+        });
+
+        await expect(service.getHealthState(undefined)).resolves.toEqual({
+            ...BaseResponse,
+            mobile: {
+                minimumSupportedVersion: {
+                    android: '1.10',
+                    ios: '2.3.4',
+                },
+            },
+        });
+    });
+
     it('advertises playground projects only when a license key is configured', async () => {
         expect(
             (await healthService.getHealthState(undefined))

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -130,6 +130,7 @@ export class HealthService extends BaseService {
             license: this.licenseService.getLicenseStatus(),
             mode: this.lightdashConfig.mode,
             version: VERSION,
+            mobile: this.lightdashConfig.mobile,
             localDbtEnabled,
             defaultProject: undefined,
             isAuthenticated,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -554,6 +554,12 @@ export type HealthState = {
     };
     mode: LightdashMode;
     version: string;
+    mobile: {
+        minimumSupportedVersion: {
+            android: string | null;
+            ios: string | null;
+        };
+    };
     localDbtEnabled: boolean;
     defaultProject?: DbtProjectConfig;
     isAuthenticated: boolean;

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -12,6 +12,12 @@ export default function mockHealthResponse(
         },
         mode: LightdashMode.CLOUD_BETA,
         version: '0.0.0',
+        mobile: {
+            minimumSupportedVersion: {
+                android: null,
+                ios: null,
+            },
+        },
         localDbtEnabled: true,
         isAuthenticated: true,
         requiresOrgRegistration: false,


### PR DESCRIPTION
## What changes

- Add the required mobile minimum version object to successful health results.
- Read Android and iOS values from separate environment variables.
- Reject values that are not dot-separated non-negative integer components.
- Keep configured versions as strings.

## Tests

- pnpm common-build
- pnpm warehouses-build
- pnpm formula:build
- pnpm -F common typecheck
- pnpm -F common run linter ./src/types/api.ts
- pnpm -F backend typecheck
- pnpm -F backend exec vitest run --config vitest.config.ts src/config/parseConfig.test.ts src/services/HealthService/HealthService.test.ts
- pnpm -F backend run linter on the touched backend files

Linear: SPK-1430