### PR TITLE
feat(coder): slug-only custom chart type bindings in chart YAML

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/contentWarnings.ts
+++ b/packages/backend/src/ee/services/ai/utils/contentWarnings.ts
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    ChartType,
     getUnusedDimensions,
     type ChartAsCode,
     type DashboardAsCode,
@@ -12,7 +13,12 @@ export type ContentWithWarnings =
 export const getChartContentWarnings = (content: ChartAsCode): string[] => {
     const { unusedDimensions } = getUnusedDimensions({
         chartType: content.chartConfig.type,
-        chartConfig: content.chartConfig.config,
+        // Viz bindings are as-code-shaped (slug identity) and irrelevant
+        // here anyway — getUnusedDimensions only reads cartesian configs.
+        chartConfig:
+            content.chartConfig.type === ChartType.DATA_APP_VIZ
+                ? undefined
+                : content.chartConfig.config,
         pivotDimensions: content.pivotConfig?.columns ?? [],
         queryDimensions: content.metricQuery.dimensions,
     });

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -1653,7 +1653,7 @@ describe('CoderService', () => {
             ) => AnyType[];
         };
 
-        it('stamps the viz slug into DATA_APP_VIZ chart configs', () => {
+        it('swaps the viz uuid for its slug in DATA_APP_VIZ chart configs', () => {
             const charts = [
                 {
                     slug: 'viz-chart',
@@ -1674,9 +1674,10 @@ describe('CoderService', () => {
                 charts,
                 new Map([['viz-uuid', 'my-chart-type']]),
             );
-            expect(result[0].chartConfig.config.dataAppVizSlug).toBe(
-                'my-chart-type',
-            );
+            expect(result[0].chartConfig.config).toEqual({
+                dataAppVizSlug: 'my-chart-type',
+                fieldMapping: {},
+            });
             expect(result[1]).toBe(charts[1]);
         });
 
@@ -1760,7 +1761,7 @@ describe('CoderService', () => {
             expect(warn).toHaveBeenCalled();
         });
 
-        it('passes non-viz and slug-less configs through untouched', async () => {
+        it('passes non-viz configs through and accepts legacy uuid-only files', async () => {
             const findAppsBySlugs = vi.fn();
             const { service } = buildResolver(findAppsBySlugs);
             const cartesian = {
@@ -1776,8 +1777,23 @@ describe('CoderService', () => {
             };
             expect(
                 await service.resolveDataAppVizBinding('proj', legacyViz),
-            ).toBe(legacyViz);
+            ).toEqual(legacyViz);
             expect(findAppsBySlugs).not.toHaveBeenCalled();
+        });
+
+        it('fails loudly when the slug is missing and there is no legacy uuid', async () => {
+            const { service } = buildResolver(vi.fn().mockResolvedValue([]));
+            await expect(
+                service.resolveDataAppVizBinding('proj', {
+                    type: ChartType.DATA_APP_VIZ,
+                    config: {
+                        dataAppVizSlug: 'gone-chart-type',
+                        fieldMapping: {},
+                    },
+                }),
+            ).rejects.toThrow(
+                'Custom chart type "gone-chart-type" was not found',
+            );
         });
     });
 });

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -17,7 +17,9 @@ import {
     ApiVirtualViewAsCodeUpsertResponse,
     assertUnreachable,
     ChartAsCode,
+    ChartAsCodeConfig,
     ChartAsCodeInternalization,
+    ChartConfig,
     ChartGoogleSheetsSyncAsCode,
     ChartScheduledDeliveryAsCode,
     ChartSummary,
@@ -2128,7 +2130,12 @@ export class CoderService extends BaseService {
         };
     }
 
-    /** Stamp each DATA_APP_VIZ chart's config with its viz's portable slug. */
+    /**
+     * Swap each DATA_APP_VIZ chart's binding to its viz's portable slug —
+     * the uuid is dropped from the file entirely. A viz whose slug can't be
+     * resolved (deleted since) keeps the uuid so the file still round-trips
+     * within its source project.
+     */
     private static withDataAppVizSlugs(
         charts: ChartAsCode[],
         dataAppVizSlugByUuid: ReadonlyMap<string, string>,
@@ -2140,9 +2147,12 @@ export class CoderService extends BaseService {
             ) {
                 return chart;
             }
-            const dataAppVizSlug = dataAppVizSlugByUuid.get(
-                chart.chartConfig.config.dataAppVizUuid,
-            );
+            const { dataAppVizUuid, ...configWithoutUuid } =
+                chart.chartConfig.config;
+            const dataAppVizSlug =
+                dataAppVizUuid !== undefined
+                    ? dataAppVizSlugByUuid.get(dataAppVizUuid)
+                    : undefined;
             if (dataAppVizSlug === undefined) {
                 return chart;
             }
@@ -2150,51 +2160,68 @@ export class CoderService extends BaseService {
                 ...chart,
                 chartConfig: {
                     ...chart.chartConfig,
-                    config: {
-                        ...chart.chartConfig.config,
-                        dataAppVizSlug,
-                    },
+                    config: { ...configWithoutUuid, dataAppVizSlug },
                 },
             };
         });
     }
 
     /**
-     * Charts on a custom chart type carry a portable dataAppVizSlug in YAML;
-     * resolve it against the target project's chart types and rewrite the
-     * config with the resolved uuid, stripping the slug (it is content-as-code
-     * identity only, never persisted). Unresolvable references upload as-is —
-     * the chart renders the viz-not-found state until the chart type arrives.
+     * Convert a chart YAML's viz binding to the runtime shape: resolve the
+     * portable dataAppVizSlug against the target project's chart types and
+     * rewrite the config with the resolved uuid. A slug missing in the target
+     * fails loudly (upload the chart type first) unless the file also carries
+     * a legacy uuid to fall back to; uuid-only legacy files are accepted
+     * verbatim.
      */
     private async resolveDataAppVizBinding(
         projectUuid: string,
-        chartConfig: ChartAsCode['chartConfig'],
-    ): Promise<ChartAsCode['chartConfig']> {
-        if (
-            chartConfig.type !== ChartType.DATA_APP_VIZ ||
-            chartConfig.config === undefined
-        ) {
+        chartConfig: ChartAsCodeConfig,
+    ): Promise<ChartConfig> {
+        if (chartConfig.type !== ChartType.DATA_APP_VIZ) {
             return chartConfig;
         }
-        const { dataAppVizSlug, ...configWithoutSlug } = chartConfig.config;
-        if (dataAppVizSlug === undefined) {
-            return chartConfig;
+        if (chartConfig.config === undefined) {
+            return { type: ChartType.DATA_APP_VIZ, config: undefined };
         }
-        const [vizRow] = await this.appModel.findAppsBySlugs(
-            projectUuid,
-            [dataAppVizSlug],
-            { dataAppVizsFilter: 'only' },
-        );
-        if (vizRow === undefined) {
-            this.logger.warn(
-                `Chart type "${dataAppVizSlug}" was not found in project ${projectUuid}; keeping the chart's existing dataAppVizUuid reference.`,
+        const { dataAppVizSlug, dataAppVizUuid, ...configRest } =
+            chartConfig.config;
+        if (dataAppVizSlug !== undefined) {
+            const [vizRow] = await this.appModel.findAppsBySlugs(
+                projectUuid,
+                [dataAppVizSlug],
+                { dataAppVizsFilter: 'only' },
             );
-            return { ...chartConfig, config: configWithoutSlug };
+            if (vizRow !== undefined) {
+                return {
+                    ...chartConfig,
+                    config: { ...configRest, dataAppVizUuid: vizRow.app_id },
+                };
+            }
+            // Interim files carry both identities — fall back to the uuid.
+            if (dataAppVizUuid !== undefined) {
+                this.logger.warn(
+                    `Chart type "${dataAppVizSlug}" was not found in project ${projectUuid}; keeping the chart's existing dataAppVizUuid reference.`,
+                );
+                return {
+                    ...chartConfig,
+                    config: { ...configRest, dataAppVizUuid },
+                };
+            }
+            throw new NotFoundError(
+                `Custom chart type "${dataAppVizSlug}" was not found in this project. Upload it first (lightdash upload --chart-types ${dataAppVizSlug}), then re-upload this chart.`,
+            );
         }
-        return {
-            ...chartConfig,
-            config: { ...configWithoutSlug, dataAppVizUuid: vizRow.app_id },
-        };
+        if (dataAppVizUuid !== undefined) {
+            // Legacy pre-slug file: accept the uuid verbatim.
+            return {
+                ...chartConfig,
+                config: { ...configRest, dataAppVizUuid },
+            };
+        }
+        throw new ParameterError(
+            'Chart uses a custom chart type but carries neither dataAppVizSlug nor dataAppVizUuid.',
+        );
     }
 
     async getCharts(

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -28,6 +28,7 @@ import {
     assertUnreachable,
     AuthorizationError,
     ChartAsCode,
+    ChartType,
     computeCustomDependencies,
     ContentAsCodeType as ContentAsCodeTypeEnum,
     DashboardAsCode,
@@ -357,7 +358,9 @@ const sanitizeChartForDownload = (
     chart: ChartAsCode,
     stripPivotSeries: boolean,
 ): ChartAsCode =>
-    stripPivotSeries
+    // Only cartesian configs carry pivoted series; the helper takes the
+    // runtime config union, so narrow before calling.
+    stripPivotSeries && chart.chartConfig.type === ChartType.CARTESIAN
         ? {
               ...chart,
               chartConfig: removePivotedSeriesValuesFromChartConfig(

--- a/packages/common/src/schemas/generateChartAsCodeSchema.ts
+++ b/packages/common/src/schemas/generateChartAsCodeSchema.ts
@@ -251,7 +251,10 @@ export const convertOpenApiToDraft07 = (value: JsonValue): JsonValue => {
 const tryBuildDiscriminatedChartConfig = (
     components: Record<string, JsonObject>,
 ): JsonObject | null => {
-    const chartConfigSchema = components.ChartConfig;
+    // Chart YAML carries the as-code config union (slug-based viz bindings);
+    // fall back to the runtime union for older swagger outputs.
+    const chartConfigSchema =
+        components.ChartAsCodeConfig ?? components.ChartConfig;
     if (!chartConfigSchema) {
         return null;
     }

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -414,7 +414,7 @@
             "enum": ["line", "bar", "scatter", "area"],
             "type": "string"
         },
-        "ChartConfig": {
+        "ChartAsCodeConfig": {
             "anyOf": [
                 {
                     "$ref": "#/$defs/BigNumberConfig"
@@ -441,15 +441,16 @@
                     "$ref": "#/$defs/GaugeChartConfig"
                 },
                 {
-                    "$ref": "#/$defs/DataAppVizChartConfig"
-                },
-                {
                     "$ref": "#/$defs/MapChartConfig"
                 },
                 {
                     "$ref": "#/$defs/SankeyChartConfig"
+                },
+                {
+                    "$ref": "#/$defs/DataAppVizChartConfigAsCode"
                 }
-            ]
+            ],
+            "description": "ChartConfig as serialized in chart YAML: viz bindings are slug-based.\nEnumerated rather than Exclude<ChartConfig, DataAppVizChartConfig> —\nTSOA cannot resolve Exclude over object unions, which corrupts the\ngenerated chart-as-code JSON schema. Keep in sync with ChartConfig."
         },
         "ChartType.BIG_NUMBER": {
             "enum": ["big_number"],
@@ -1176,32 +1177,32 @@
             "required": ["type"],
             "type": "object"
         },
-        "DataAppVizChart": {
-            "properties": {
-                "dataAppVizUuid": {
-                    "description": "The reusable data app viz this chart renders with (by reference).",
-                    "type": "string"
+        "DataAppVizChartAsCode": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/Omit_DataAppVizChart.dataAppVizUuid_"
                 },
-                "fieldMapping": {
-                    "$ref": "#/$defs/DataAppVizFieldMapping"
-                },
-                "optionValues": {
-                    "$ref": "#/$defs/DataAppVizOptionValues",
-                    "description": "Only options the user explicitly changed — declared defaults are never\nseeded here, they're resolved at render time. Absent on charts saved\nbefore config options shipped."
+                {
+                    "properties": {
+                        "dataAppVizSlug": {
+                            "type": "string"
+                        },
+                        "dataAppVizUuid": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 }
-            },
-            "required": ["fieldMapping", "dataAppVizUuid"],
-            "type": "object"
+            ],
+            "description": "The as-code shape of a custom chart type binding. Files carry the viz's\nproject-scoped slug — portable across projects/instances — and upload\nresolves it to the target project's viz uuid. Exactly one identity is\npresent: `dataAppVizSlug` in every file written today; `dataAppVizUuid`\nonly in legacy files that predate slugs (accepted on upload, never\nemitted)."
         },
-        "DataAppVizChartConfig": {
+        "DataAppVizChartConfigAsCode": {
             "properties": {
                 "config": {
-                    "$ref": "#/$defs/DataAppVizChart",
-                    "description": "Reference to a data app viz plus its field mapping."
+                    "$ref": "#/$defs/DataAppVizChartAsCode"
                 },
                 "type": {
-                    "$ref": "#/$defs/ChartType.DATA_APP_VIZ",
-                    "description": "Type of chart visualization"
+                    "$ref": "#/$defs/ChartType.DATA_APP_VIZ"
                 }
             },
             "required": ["type"],
@@ -2212,6 +2213,10 @@
             ],
             "type": "string"
         },
+        "Omit_DataAppVizChart.dataAppVizUuid_": {
+            "$ref": "#/$defs/Pick_DataAppVizChart.Exclude_keyofDataAppVizChart.dataAppVizUuid__",
+            "description": "Construct a type with the properties of T except for those in type K."
+        },
         "Omit_FilterRule.id_": {
             "$ref": "#/$defs/Pick_FilterRule.Exclude_keyofFilterRule.id__",
             "description": "Construct a type with the properties of T except for those in type K."
@@ -2406,6 +2411,20 @@
         "Pick_CompiledDimension.name-or-label-or-table_": {
             "description": "From T, pick a set of properties whose keys are in the union K",
             "properties": {},
+            "type": "object"
+        },
+        "Pick_DataAppVizChart.Exclude_keyofDataAppVizChart.dataAppVizUuid__": {
+            "description": "From T, pick a set of properties whose keys are in the union K",
+            "properties": {
+                "fieldMapping": {
+                    "$ref": "#/$defs/DataAppVizFieldMapping"
+                },
+                "optionValues": {
+                    "$ref": "#/$defs/DataAppVizOptionValues",
+                    "description": "Only options the user explicitly changed — declared defaults are never\nseeded here, they're resolved at render time. Absent on charts saved\nbefore config options shipped."
+                }
+            },
+            "required": ["fieldMapping"],
             "type": "object"
         },
         "Pick_Dimension.formatOptions_": {
@@ -3540,7 +3559,6 @@
     "description": "From T, pick a set of properties whose keys are in the union K",
     "properties": {
         "chartConfig": {
-            "description": "Visualization configuration for the chart",
             "discriminator": {
                 "propertyName": "type"
             },
@@ -3660,20 +3678,6 @@
                 {
                     "properties": {
                         "config": {
-                            "$ref": "#/$defs/DataAppVizChart",
-                            "description": "Reference to a data app viz plus its field mapping."
-                        },
-                        "type": {
-                            "const": "data_app_viz",
-                            "description": "Type of chart visualization"
-                        }
-                    },
-                    "required": ["type"],
-                    "type": "object"
-                },
-                {
-                    "properties": {
-                        "config": {
                             "$ref": "#/$defs/MapChart",
                             "description": "Chart-type-specific configuration"
                         },
@@ -3694,6 +3698,18 @@
                         "type": {
                             "const": "sankey",
                             "description": "Type of chart visualization"
+                        }
+                    },
+                    "required": ["type"],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "config": {
+                            "$ref": "#/$defs/DataAppVizChartAsCode"
+                        },
+                        "type": {
+                            "const": "data_app_viz"
                         }
                     },
                     "required": ["type"],
@@ -3832,10 +3848,10 @@
     "required": [
         "name",
         "tableName",
-        "chartConfig",
         "slug",
         "spaceSlug",
         "version",
+        "chartConfig",
         "metricQuery"
     ],
     "title": "Lightdash Chart as Code",

--- a/packages/common/src/types/contentAsCode/charts.ts
+++ b/packages/common/src/types/contentAsCode/charts.ts
@@ -3,10 +3,61 @@ import type { ChartAsCodeLanguageMap } from '../../utils/i18n/chartAsCode';
 import type { ContentVerificationInfo } from '../contentVerification';
 import type { MetricQuery } from '../metricQuery';
 import type { PromotionChanges } from '../promotion';
-import type { SavedChart } from '../savedCharts';
+import type {
+    BigNumberConfig,
+    CartesianChartConfig,
+    ChartType,
+    CustomVisConfig,
+    DataAppVizChart,
+    FunnelChartConfig,
+    GaugeChartConfig,
+    MapChartConfig,
+    PieChartConfig,
+    SankeyChartConfig,
+    SavedChart,
+    TableChartConfig,
+    TreemapChartConfig,
+} from '../savedCharts';
 import type { SqlChart } from '../sqlRunner';
 import type { ContentAsCodeType, FiltersInput } from './core';
 import type { SpaceAsCode } from './spaces';
+
+/**
+ * The as-code shape of a custom chart type binding. Files carry the viz's
+ * project-scoped slug — portable across projects/instances — and upload
+ * resolves it to the target project's viz uuid. Exactly one identity is
+ * present: `dataAppVizSlug` in every file written today; `dataAppVizUuid`
+ * only in legacy files that predate slugs (accepted on upload, never
+ * emitted).
+ */
+export type DataAppVizChartAsCode = Omit<DataAppVizChart, 'dataAppVizUuid'> & {
+    dataAppVizSlug?: string;
+    dataAppVizUuid?: string;
+};
+
+export type DataAppVizChartConfigAsCode = {
+    type: ChartType.DATA_APP_VIZ;
+    config?: DataAppVizChartAsCode;
+};
+
+/**
+ * ChartConfig as serialized in chart YAML: viz bindings are slug-based.
+ * Enumerated rather than Exclude<ChartConfig, DataAppVizChartConfig> —
+ * TSOA cannot resolve Exclude over object unions, which corrupts the
+ * generated chart-as-code JSON schema. Keep in sync with ChartConfig.
+ */
+export type ChartAsCodeConfig =
+    | BigNumberConfig
+    | CartesianChartConfig
+    | CustomVisConfig
+    | PieChartConfig
+    | FunnelChartConfig
+    | TableChartConfig
+    | TreemapChartConfig
+    | GaugeChartConfig
+    | MapChartConfig
+    | SankeyChartConfig
+    | DataAppVizChartConfigAsCode;
 
 // We want to only use properties that can be modified by the user
 // We'll be using slug to access these charts, so uuids are not included
@@ -23,9 +74,10 @@ export type ChartAsCode = Omit<
         | 'slug'
         | 'parameters'
     >,
-    'metricQuery'
+    'metricQuery' | 'chartConfig'
 > & {
     metricQuery: Omit<MetricQuery, 'filters'> & { filters: FiltersInput };
+    chartConfig: ChartAsCodeConfig;
     /** Not modifiable by user, but useful to know if it has been updated. Defaults to now if omitted. */
     updatedAt?: Date;
     /** Table configuration. Defaults to empty column order if omitted. */

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -793,15 +793,12 @@ export type DataAppVizFieldMapping = Record<string, string>;
 export type DataAppVizOptionValues = Record<string, DataAppVizOptionValue>;
 
 export type DataAppVizChart = {
-    /** The reusable data app viz this chart renders with (by reference). */
-    dataAppVizUuid: string;
     /**
-     * Content-as-code only: the viz's project-scoped slug, emitted on chart
-     * download and resolved back to dataAppVizUuid (then stripped) on upload
-     * so chart YAML stays portable across projects. Never persisted and
-     * never used at render time — dataAppVizUuid is the runtime identity.
+     * The reusable data app viz this chart renders with (by reference).
+     * Content-as-code files carry the viz's project-scoped slug instead —
+     * see DataAppVizChartAsCode.
      */
-    dataAppVizSlug?: string;
+    dataAppVizUuid: string;
     fieldMapping: DataAppVizFieldMapping;
     /**
      * Only options the user explicitly changed — declared defaults are never


### PR DESCRIPTION
Follow-up to #27865: chart YAML drops the viz UUID entirely — the project-scoped slug is the only identity a file carries.

- New \`DataAppVizChartAsCode\` / \`ChartAsCodeConfig\` types: \`ChartAsCode.chartConfig\` now has an as-code-specific shape for viz bindings (slug-based), while the runtime \`DataAppVizChart\` stays uuid-only and loses the as-code \`dataAppVizSlug\` field it briefly carried — the two layers no longer share one compromise type.
- Download swaps \`dataAppVizUuid\` → \`dataAppVizSlug\` (uuid removed from the file). A viz whose slug can't be resolved (deleted since) keeps the uuid so the file still round-trips in its source project.
- Upload resolves the slug in the target project. A missing slug now **fails loudly** with an actionable error (upload the chart type first) — there is no uuid to fall back to. Compatibility: interim files carrying both identities fall back to the uuid with a warning; legacy uuid-only files are accepted verbatim.
- The committed chart-as-code JSON schema is regenerated: \`dataAppVizUuid\` is no longer required, \`dataAppVizSlug\` is accepted — without this, \`lightdash lint\` rejects every slug-only file this PR writes.

Breaking change (accepted): previously downloaded viz-chart YAML carrying only a uuid keeps working via the legacy read path; files written after this PR are slug-only and require a server with slug resolution (#27865) to upload.

Test plan: CoderService suite (149 tests) incl. swap/strip/fail-loud coverage; chart-as-code schema regenerated and verified; common/backend/cli/frontend typechecks clean.

Relates: PROD-10449
Relates: #27856

🤖 Generated with [Claude Code](https://claude.com/claude-code)