### PR TITLE
feat: add server-directed mobile login

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -8,6 +8,9 @@ import { LightdashConfig } from './parseConfig';
 export const lightdashConfigMock: LightdashConfig = {
     allowMultiOrgs: false,
     auth: {
+        mobileLogin: {
+            enabled: true,
+        },
         pat: {
             enabled: false,
             allowedOrgRoles: Object.values(OrganizationMemberRole),

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -39,6 +39,18 @@ beforeEach(() => {
     };
 });
 
+describe('mobile login config', () => {
+    it('is available by default', () => {
+        expect(parseConfig().auth.mobileLogin).toEqual({ enabled: true });
+    });
+
+    it('supports the rollback switch', () => {
+        process.env.AUTH_MOBILE_LOGIN_ENABLED = 'false';
+
+        expect(parseConfig().auth.mobileLogin).toEqual({ enabled: false });
+    });
+});
+
 describe('Query phase metrics config', () => {
     it('defaults to an empty project allowlist', () => {
         expect(parseConfig().queryPhaseMetrics).toEqual({ projectUuids: [] });

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2199,6 +2199,9 @@ type AuthDatabricksConfig = {
 
 export type AuthConfig = {
     disablePasswordAuthentication: boolean;
+    mobileLogin: {
+        enabled: boolean;
+    };
     /**
      * @deprecated Group Sync is deprecated. https://github.com/lightdash/lightdash/issues/12430
      */
@@ -2826,6 +2829,9 @@ export const parseConfig = (): LightdashConfig => {
                 process.env.ALLOW_MISSING_MIGRATIONS === 'true',
         },
         auth: {
+            mobileLogin: {
+                enabled: process.env.AUTH_MOBILE_LOGIN_ENABLED !== 'false',
+            },
             pat: {
                 enabled: process.env.DISABLE_PAT !== 'true',
                 allowedOrgRoles:

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -19,6 +19,7 @@ import {
     getRequestMethod,
     hasInviteCode,
     isEmailOnlyUser,
+    isMobileLoginIntent,
     LightdashRequestMethodHeader,
     NotFoundError,
     ParameterError,
@@ -33,6 +34,7 @@ import {
     UserWarehouseCredentials,
     validatePassword,
     WarehouseTypes,
+    type MobileLoginOptions,
 } from '@lightdash/common';
 import {
     Body,
@@ -614,14 +616,24 @@ export class UserController extends BaseController {
     async getLoginOptions(
         @Request() req: express.Request,
         @Query() email?: string,
+        @Query() mobile_login_intent?: string,
     ): Promise<ApiGetLoginOptionsResponse> {
-        const loginOptions = await this.services
-            .getUserService()
-            .getLoginOptions(email);
+        const userService = this.services.getUserService();
+        const mobileLoginIntent = isMobileLoginIntent(mobile_login_intent)
+            ? mobile_login_intent
+            : undefined;
+        const [loginOptions, mobileLoginPresentation] = await Promise.all([
+            userService.getLoginOptions(email, mobileLoginIntent),
+            userService.getMobileLoginPresentation(),
+        ]);
+        const results: MobileLoginOptions = {
+            ...loginOptions,
+            ...mobileLoginPresentation,
+        };
         this.setStatus(200);
         return {
             status: 'ok',
-            results: loginOptions,
+            results,
         };
     }
 

--- a/packages/backend/src/models/OrganizationSsoModel.test.ts
+++ b/packages/backend/src/models/OrganizationSsoModel.test.ts
@@ -159,6 +159,7 @@ describe('OrganizationSsoModel', () => {
             const { sql } = tracker.history.select[0];
             const lowered = sql.toLowerCase();
             const selectList = lowered.slice(0, lowered.indexOf(' from '));
+            expect(selectList).toContain('distinct');
             expect(selectList).toContain('"provider"');
             expect(selectList).toContain('"enabled"');
             expect(selectList).not.toContain('"config"');

--- a/packages/backend/src/models/OrganizationSsoModel.test.ts
+++ b/packages/backend/src/models/OrganizationSsoModel.test.ts
@@ -133,6 +133,39 @@ describe('OrganizationSsoModel', () => {
         });
     });
 
+    describe('findAllPolicySummaries', () => {
+        it('returns only provider and enabled authority fields', async () => {
+            tracker.on
+                .select(OrganizationSsoConfigurationsTableName)
+                .responseOnce([
+                    dbRow(),
+                    dbRow({
+                        provider: OrganizationSsoProvider.GOOGLE,
+                        enabled: false,
+                    }),
+                ]);
+
+            await expect(model.findAllPolicySummaries()).resolves.toEqual([
+                {
+                    provider: OrganizationSsoProvider.AZUREAD,
+                    enabled: true,
+                },
+                {
+                    provider: OrganizationSsoProvider.GOOGLE,
+                    enabled: false,
+                },
+            ]);
+
+            const { sql } = tracker.history.select[0];
+            const lowered = sql.toLowerCase();
+            const selectList = lowered.slice(0, lowered.indexOf(' from '));
+            expect(selectList).toContain('"provider"');
+            expect(selectList).toContain('"enabled"');
+            expect(selectList).not.toContain('"config"');
+            expect(encryptionUtil.decrypt).not.toHaveBeenCalled();
+        });
+    });
+
     describe('findGoogleMethodsForEmailDomain', () => {
         it('matches the verified domain but does NOT filter on enabled, so a disabled policy row is returned', async () => {
             tracker.on

--- a/packages/backend/src/models/OrganizationSsoModel.ts
+++ b/packages/backend/src/models/OrganizationSsoModel.ts
@@ -185,7 +185,7 @@ export class OrganizationSsoModel {
     async findAllPolicySummaries(): Promise<OrganizationSsoPolicySummary[]> {
         const rows = await this.database(
             OrganizationSsoConfigurationsTableName,
-        ).select('provider', 'enabled');
+        ).distinct('provider', 'enabled');
 
         return rows.map((row) => ({
             provider: row.provider as OrganizationSsoProvider,

--- a/packages/backend/src/models/OrganizationSsoModel.ts
+++ b/packages/backend/src/models/OrganizationSsoModel.ts
@@ -48,6 +48,11 @@ export type OrganizationGoogleMethod = {
     allowPassword: boolean;
 };
 
+export type OrganizationSsoPolicySummary = {
+    provider: OrganizationSsoProvider;
+    enabled: boolean;
+};
+
 /**
  * Restricts an SSO-config query to rows whose organization has verified the
  * given (already-normalized) domain. Uses an EXISTS against
@@ -174,6 +179,17 @@ export class OrganizationSsoModel {
             overrideEmailDomains: row.override_email_domains,
             emailDomains: row.email_domains ?? [],
             allowPassword: row.allow_password,
+        }));
+    }
+
+    async findAllPolicySummaries(): Promise<OrganizationSsoPolicySummary[]> {
+        const rows = await this.database(
+            OrganizationSsoConfigurationsTableName,
+        ).select('provider', 'enabled');
+
+        return rows.map((row) => ({
+            provider: row.provider as OrganizationSsoProvider,
+            enabled: row.enabled,
         }));
     }
 

--- a/packages/backend/src/routers/oauthRouter.test.ts
+++ b/packages/backend/src/routers/oauthRouter.test.ts
@@ -99,7 +99,65 @@ const requestAuthorize = async ({
     }
 };
 
+const requestAuthorizationLoginRedirect = async (path: string) => {
+    const app = express();
+    app.use((request, _response, next) => {
+        request.user = undefined;
+        next();
+    });
+    app.use('/api/v1/oauth', oauthRouter);
+
+    const server = app.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+
+    try {
+        return await new Promise<{
+            headers: IncomingHttpHeaders;
+            status: number;
+        }>((resolve, reject) => {
+            const request = httpRequest(
+                {
+                    hostname: '127.0.0.1',
+                    method: 'GET',
+                    path,
+                    port: (server.address() as AddressInfo).port,
+                },
+                (response) => {
+                    response.resume();
+                    response.on('end', () =>
+                        resolve({
+                            headers: response.headers,
+                            status: response.statusCode ?? 0,
+                        }),
+                    );
+                },
+            );
+            request.on('error', reject);
+            request.end();
+        });
+    } finally {
+        await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+        });
+    }
+};
+
 describe('OAuth authorize redirects', () => {
+    it.each(['sso', 'local'])(
+        'preserves the %s mobile login intent in the outer authorization request',
+        async (intent) => {
+            const authorizePath = `/api/v1/oauth/authorize?client_id=mobile-client&redirect_uri=lightdash%3A%2F%2Foauth%2Fcallback&state=request-state&mobile_login_intent=${intent}`;
+
+            const response =
+                await requestAuthorizationLoginRedirect(authorizePath);
+
+            expect(response.status).toBe(302);
+            expect(response.headers.location).toBe(
+                `/login?redirect=${encodeURIComponent(authorizePath)}`,
+            );
+        },
+    );
+
     it.each([
         'https://unregistered.example/callback',
         'urn:example:unregistered-callback',

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -64,6 +64,10 @@ export const BaseResponse: HealthState = {
         databricks: {
             enabled: false,
         },
+        mobileLogin: {
+            loginExperienceVersion: 1,
+            available: true,
+        },
     },
     intercom: {
         apiBase: '',

--- a/packages/backend/src/services/HealthService/HealthService.test.ts
+++ b/packages/backend/src/services/HealthService/HealthService.test.ts
@@ -88,6 +88,31 @@ describe('health', () => {
         });
     });
 
+    it('can disable the mobile login capability without changing its version', async () => {
+        const service = new HealthService({
+            organizationModel:
+                organizationModel as unknown as OrganizationModel,
+            lightdashConfig: {
+                ...lightdashConfigMock,
+                auth: {
+                    ...lightdashConfigMock.auth,
+                    mobileLogin: { enabled: false },
+                },
+            },
+            licenseService,
+            migrationModel: migrationModel as unknown as MigrationModel,
+            organizationSettingsModel:
+                organizationSettingsModel as unknown as OrganizationSettingsModel,
+        });
+
+        expect(
+            (await service.getHealthState(undefined)).auth.mobileLogin,
+        ).toEqual({
+            loginExperienceVersion: 1,
+            available: false,
+        });
+    });
+
     it('advertises playground projects only when a license key is configured', async () => {
         expect(
             (await healthService.getHealthState(undefined))

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -228,6 +228,10 @@ export class HealthService extends BaseService {
                         !!this.lightdashConfig.auth.databricks.clientId &&
                         this.isEnterpriseEnabled(),
                 },
+                mobileLogin: {
+                    loginExperienceVersion: 1,
+                    available: this.lightdashConfig.auth.mobileLogin.enabled,
+                },
             },
             hasEmailClient: !!this.lightdashConfig.smtp,
             // Deliberately not isEnterpriseEnabled(): that check is `!==

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -181,6 +181,9 @@ const projectModel = {
 };
 
 const organizationSsoModel = {
+    findAllPolicySummaries: vi.fn<
+        OrganizationSsoModel['findAllPolicySummaries']
+    >(async () => []),
     findEnabledMethodsForEmailDomain: vi.fn<
         OrganizationSsoModel['findEnabledMethodsForEmailDomain']
     >(async () => []),
@@ -1876,6 +1879,329 @@ describe('UserService', () => {
                 redirectUri:
                     'https://test.lightdash.cloud/api/v1/login/okta?login_hint=email',
                 showOptions: ['okta'],
+            });
+        });
+    });
+
+    describe('getMobileLoginPresentation', () => {
+        const configForProvider = (provider: OpenIdIdentityIssuerType) => ({
+            ...lightdashConfigMock,
+            auth: {
+                ...lightdashConfigMock.auth,
+                google: {
+                    ...lightdashConfigMock.auth.google,
+                    loginPath: '/login/google',
+                    enabled: provider === OpenIdIdentityIssuerType.GOOGLE,
+                },
+                okta: {
+                    ...lightdashConfigMock.auth.okta,
+                    loginPath: '/login/okta',
+                    oauth2ClientId:
+                        provider === OpenIdIdentityIssuerType.OKTA
+                            ? 'client-id'
+                            : undefined,
+                },
+                oneLogin: {
+                    ...lightdashConfigMock.auth.oneLogin,
+                    loginPath: '/login/oneLogin',
+                    oauth2ClientId:
+                        provider === OpenIdIdentityIssuerType.ONELOGIN
+                            ? 'client-id'
+                            : undefined,
+                },
+                azuread: {
+                    ...lightdashConfigMock.auth.azuread,
+                    loginPath: '/login/azuread',
+                    oauth2ClientId:
+                        provider === OpenIdIdentityIssuerType.AZUREAD
+                            ? 'client-id'
+                            : undefined,
+                },
+                oidc: {
+                    ...lightdashConfigMock.auth.oidc,
+                    loginPath: '/login/oidc',
+                    clientId:
+                        provider === OpenIdIdentityIssuerType.GENERIC_OIDC
+                            ? 'client-id'
+                            : undefined,
+                },
+            },
+        });
+
+        it.each([
+            OpenIdIdentityIssuerType.GOOGLE,
+            OpenIdIdentityIssuerType.OKTA,
+            OpenIdIdentityIssuerType.ONELOGIN,
+            OpenIdIdentityIssuerType.AZUREAD,
+            OpenIdIdentityIssuerType.GENERIC_OIDC,
+        ])('brands the sole invariant %s provider', async (provider) => {
+            const service = createUserService(configForProvider(provider));
+
+            await expect(service.getMobileLoginPresentation()).resolves.toEqual(
+                {
+                    ssoPresentation: { kind: 'branded', provider },
+                    localEmailAvailable: true,
+                },
+            );
+        });
+
+        it('returns neutral for several instance providers', async () => {
+            const service = createUserService({
+                ...configForProvider(OpenIdIdentityIssuerType.GOOGLE),
+                auth: {
+                    ...configForProvider(OpenIdIdentityIssuerType.GOOGLE).auth,
+                    okta: {
+                        ...lightdashConfigMock.auth.okta,
+                        oauth2ClientId: 'client-id',
+                    },
+                },
+            });
+
+            await expect(service.getMobileLoginPresentation()).resolves.toEqual(
+                {
+                    ssoPresentation: { kind: 'neutral' },
+                    localEmailAvailable: true,
+                },
+            );
+        });
+
+        it('returns neutral when per-organization routing can replace the provider', async () => {
+            organizationSsoModel.findAllPolicySummaries.mockResolvedValueOnce([
+                {
+                    provider: OrganizationSsoProvider.AZUREAD,
+                    enabled: true,
+                },
+            ]);
+            const service = createUserService(
+                configForProvider(OpenIdIdentityIssuerType.GOOGLE),
+            );
+
+            await expect(service.getMobileLoginPresentation()).resolves.toEqual(
+                {
+                    ssoPresentation: { kind: 'neutral' },
+                    localEmailAvailable: true,
+                },
+            );
+        });
+
+        it('returns neutral when a disabled per-organization Google policy can suppress Google', async () => {
+            organizationSsoModel.findAllPolicySummaries.mockResolvedValueOnce([
+                {
+                    provider: OrganizationSsoProvider.GOOGLE,
+                    enabled: false,
+                },
+            ]);
+            const service = createUserService(
+                configForProvider(OpenIdIdentityIssuerType.GOOGLE),
+            );
+
+            await expect(service.getMobileLoginPresentation()).resolves.toEqual(
+                {
+                    ssoPresentation: { kind: 'neutral' },
+                    localEmailAvailable: true,
+                },
+            );
+        });
+
+        it('returns neutral for an unknown enabled provider', async () => {
+            organizationSsoModel.findAllPolicySummaries.mockResolvedValueOnce([
+                {
+                    provider: 'future-provider' as OrganizationSsoProvider,
+                    enabled: true,
+                },
+            ]);
+            const service = createUserService(lightdashConfigMock);
+
+            await expect(service.getMobileLoginPresentation()).resolves.toEqual(
+                {
+                    ssoPresentation: { kind: 'neutral' },
+                    localEmailAvailable: true,
+                },
+            );
+        });
+
+        it('reports local email without SSO for a local-only instance', async () => {
+            const service = createUserService(lightdashConfigMock);
+
+            await expect(service.getMobileLoginPresentation()).resolves.toEqual(
+                {
+                    ssoPresentation: { kind: 'none' },
+                    localEmailAvailable: true,
+                },
+            );
+        });
+
+        it('reports no methods when local and SSO methods are disabled', async () => {
+            const service = createUserService({
+                ...lightdashConfigMock,
+                auth: {
+                    ...lightdashConfigMock.auth,
+                    disablePasswordAuthentication: true,
+                },
+            });
+
+            await expect(service.getMobileLoginPresentation()).resolves.toEqual(
+                {
+                    ssoPresentation: { kind: 'none' },
+                    localEmailAvailable: false,
+                },
+            );
+        });
+
+        it('fails closed to neutral when the authority query fails', async () => {
+            organizationSsoModel.findAllPolicySummaries.mockRejectedValueOnce(
+                new Error('query failed'),
+            );
+            const service = createUserService(
+                configForProvider(OpenIdIdentityIssuerType.OKTA),
+            );
+
+            await expect(service.getMobileLoginPresentation()).resolves.toEqual(
+                {
+                    ssoPresentation: { kind: 'neutral' },
+                    localEmailAvailable: true,
+                },
+            );
+        });
+    });
+
+    it('suppresses an SSO-only auto-redirect for the local browser intent', async () => {
+        const service = createUserService(
+            {
+                ...lightdashConfigMock,
+                auth: {
+                    ...lightdashConfigMock.auth,
+                    disablePasswordAuthentication: true,
+                    okta: {
+                        ...lightdashConfigMock.auth.okta,
+                        oauth2ClientId: 'client-id',
+                    },
+                },
+            },
+            {},
+        );
+        userModel.getOpenIdIssuers.mockResolvedValueOnce([
+            OpenIdIdentityIssuerType.OKTA,
+        ]);
+
+        await expect(
+            service.getLoginOptions('user@example.com', 'local'),
+        ).resolves.toEqual({
+            forceRedirect: false,
+            redirectUri: undefined,
+            showOptions: [],
+        });
+    });
+
+    describe('mobile login intent filtering', () => {
+        const mixedConfig = {
+            ...lightdashConfigMock,
+            auth: {
+                ...lightdashConfigMock.auth,
+                google: {
+                    ...lightdashConfigMock.auth.google,
+                    loginPath: '/login/google',
+                    enabled: true,
+                },
+            },
+        };
+
+        it('filters no-email instance defaults for both intents', async () => {
+            const service = createUserService(mixedConfig);
+
+            await expect(
+                service.getLoginOptions(undefined, 'sso'),
+            ).resolves.toEqual({
+                showOptions: [OpenIdIdentityIssuerType.GOOGLE],
+                forceRedirect: false,
+                redirectUri: undefined,
+            });
+            await expect(
+                service.getLoginOptions(undefined, 'local'),
+            ).resolves.toEqual({
+                showOptions: [LocalIssuerTypes.EMAIL],
+                forceRedirect: false,
+                redirectUri: undefined,
+            });
+        });
+
+        it('filters normal email options and redirects only the SSO intent', async () => {
+            userModel.getOpenIdIssuers
+                .mockResolvedValueOnce([OpenIdIdentityIssuerType.GOOGLE])
+                .mockResolvedValueOnce([OpenIdIdentityIssuerType.GOOGLE]);
+            userModel.hasPasswordByEmail
+                .mockResolvedValueOnce(true)
+                .mockResolvedValueOnce(true);
+            const service = createUserService(mixedConfig);
+
+            await expect(
+                service.getLoginOptions('user@example.com', 'sso'),
+            ).resolves.toEqual({
+                showOptions: [OpenIdIdentityIssuerType.GOOGLE],
+                forceRedirect: true,
+                redirectUri:
+                    'https://test.lightdash.cloud/api/v1/login/google?login_hint=user%40example.com',
+            });
+            await expect(
+                service.getLoginOptions('user@example.com', 'local'),
+            ).resolves.toEqual({
+                showOptions: [LocalIssuerTypes.EMAIL],
+                forceRedirect: false,
+                redirectUri: undefined,
+            });
+        });
+
+        it('filters the empty-result instance fallback for both intents', async () => {
+            const service = createUserService(mixedConfig);
+
+            await expect(
+                service.getLoginOptions('new@example.com', 'sso'),
+            ).resolves.toEqual({
+                showOptions: [OpenIdIdentityIssuerType.GOOGLE],
+                forceRedirect: true,
+                redirectUri:
+                    'https://test.lightdash.cloud/api/v1/login/google?login_hint=new%40example.com',
+            });
+            await expect(
+                service.getLoginOptions('new@example.com', 'local'),
+            ).resolves.toEqual({
+                showOptions: [LocalIssuerTypes.EMAIL],
+                forceRedirect: false,
+                redirectUri: undefined,
+            });
+        });
+
+        it('preserves and suppresses a sole-provider force redirect by intent', async () => {
+            const service = createUserService({
+                ...lightdashConfigMock,
+                auth: {
+                    ...lightdashConfigMock.auth,
+                    disablePasswordAuthentication: true,
+                    okta: {
+                        ...lightdashConfigMock.auth.okta,
+                        oauth2ClientId: 'client-id',
+                        loginPath: '/login/okta',
+                    },
+                },
+            });
+            userModel.getOpenIdIssuers
+                .mockResolvedValueOnce([OpenIdIdentityIssuerType.OKTA])
+                .mockResolvedValueOnce([OpenIdIdentityIssuerType.OKTA]);
+
+            await expect(
+                service.getLoginOptions('user@example.com', 'sso'),
+            ).resolves.toEqual({
+                showOptions: [OpenIdIdentityIssuerType.OKTA],
+                forceRedirect: true,
+                redirectUri:
+                    'https://test.lightdash.cloud/api/v1/login/okta?login_hint=user%40example.com',
+            });
+            await expect(
+                service.getLoginOptions('user@example.com', 'local'),
+            ).resolves.toEqual({
+                showOptions: [],
+                forceRedirect: false,
+                redirectUri: undefined,
             });
         });
     });

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -32,6 +32,7 @@ import {
     InviteLink,
     InviteLinkPurpose,
     isEmailOnlyUser,
+    isMobileLoginSsoProvider,
     isOpenIdIdentityIssuerType,
     isOpenIdUser,
     isUserAvatarColorValue,
@@ -40,15 +41,17 @@ import {
     LightdashMode,
     LightdashUser,
     LocalIssuerTypes,
-    LoginOptions,
     LoginOptionTypes,
     MissingConfigError,
+    MobileLoginIntent,
+    MobileLoginSsoPresentation,
     NotFoundError,
     NotImplementedError,
     OpenIdIdentityIssuerType,
     OpenIdIdentitySummary,
     OpenIdUser,
     OrganizationMemberRole,
+    OrganizationSsoProvider,
     ParameterError,
     PasswordReset,
     ProjectMemberRole,
@@ -67,6 +70,7 @@ import {
     UpsertUserWarehouseCredentials,
     USER_ONBOARDING_TOURS,
     UserAllowedOrganization,
+    UserLoginOptions,
     UserOnboarding,
     UserOnboardingTour,
     validateEmail,
@@ -3772,7 +3776,115 @@ export class UserService extends BaseService {
         return options;
     }
 
-    async getLoginOptions(email?: string): Promise<LoginOptions> {
+    async getMobileLoginPresentation(): Promise<{
+        ssoPresentation: MobileLoginSsoPresentation;
+        localEmailAvailable: boolean;
+    }> {
+        const instanceOptions = this.getInstanceLoginOptions();
+        const localEmailAvailable = instanceOptions.has(LocalIssuerTypes.EMAIL);
+        const instanceSsoProviders = Array.from(instanceOptions).filter(
+            isOpenIdIdentityIssuerType,
+        );
+
+        try {
+            const policySummaries =
+                await this.organizationSsoModel.findAllPolicySummaries();
+            const routingPolicies = policySummaries.filter(
+                ({ provider, enabled }) =>
+                    enabled || provider === OrganizationSsoProvider.GOOGLE,
+            );
+            const possibleProviders = new Set<string>(instanceSsoProviders);
+
+            for (const policy of routingPolicies) {
+                if (policy.enabled) {
+                    possibleProviders.add(policy.provider);
+                }
+            }
+
+            if (possibleProviders.size === 0) {
+                return {
+                    ssoPresentation: { kind: 'none' },
+                    localEmailAvailable,
+                };
+            }
+
+            if (routingPolicies.length > 0 || possibleProviders.size !== 1) {
+                return {
+                    ssoPresentation: { kind: 'neutral' },
+                    localEmailAvailable,
+                };
+            }
+
+            const [provider] = possibleProviders;
+            if (!isMobileLoginSsoProvider(provider)) {
+                return {
+                    ssoPresentation: { kind: 'neutral' },
+                    localEmailAvailable,
+                };
+            }
+
+            return {
+                ssoPresentation: { kind: 'branded', provider },
+                localEmailAvailable,
+            };
+        } catch (error) {
+            Logger.warn('Failed to resolve mobile login presentation', {
+                error: error instanceof Error ? error.message : String(error),
+            });
+            return {
+                ssoPresentation: { kind: 'neutral' },
+                localEmailAvailable,
+            };
+        }
+    }
+
+    private applyMobileLoginIntent(
+        loginOptions: UserLoginOptions,
+        email: string | undefined,
+        mobileLoginIntent: MobileLoginIntent | undefined,
+    ): UserLoginOptions {
+        if (mobileLoginIntent === 'local') {
+            return {
+                showOptions: loginOptions.showOptions.filter(
+                    (option) =>
+                        option === LocalIssuerTypes.EMAIL ||
+                        option === LocalIssuerTypes.EMAIL_OTP,
+                ),
+                forceRedirect: false,
+                redirectUri: undefined,
+            };
+        }
+
+        if (mobileLoginIntent === 'sso') {
+            const showOptions = loginOptions.showOptions.filter(
+                isOpenIdIdentityIssuerType,
+            );
+            if (email && showOptions.length === 1) {
+                return {
+                    showOptions,
+                    forceRedirect: true,
+                    redirectUri: new URL(
+                        `/api/v1${this.getRedirectUri(
+                            showOptions[0],
+                        )}?login_hint=${encodeURIComponent(email)}`,
+                        this.lightdashConfig.siteUrl,
+                    ).href,
+                };
+            }
+
+            return {
+                showOptions,
+                forceRedirect: false,
+                redirectUri: undefined,
+            };
+        }
+
+        return loginOptions;
+    }
+
+    private async getUnfilteredLoginOptions(
+        email?: string,
+    ): Promise<UserLoginOptions> {
         const instancesOptions = this.getInstanceLoginOptions();
         if (!email) {
             return {
@@ -3936,6 +4048,18 @@ export class UserService extends BaseService {
             forceRedirect: false,
             redirectUri: undefined,
         };
+    }
+
+    async getLoginOptions(
+        email?: string,
+        mobileLoginIntent?: MobileLoginIntent,
+    ): Promise<UserLoginOptions> {
+        const loginOptions = await this.getUnfilteredLoginOptions(email);
+        return this.applyMobileLoginIntent(
+            loginOptions,
+            email,
+            mobileLoginIntent,
+        );
     }
 
     /**

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -623,6 +623,10 @@ export type HealthState = {
         databricks: {
             enabled: boolean;
         };
+        mobileLogin?: {
+            loginExperienceVersion: 1;
+            available: boolean;
+        };
     };
     siteUrl: string;
     intercom: {

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -1,7 +1,7 @@
 import { type AbilityBuilder } from '@casl/ability';
 import { type MemberAbility } from '../authorization/types';
 import { type AnyType } from './any';
-import { type OpenIdIdentityIssuerType } from './openIdIdentity';
+import { OpenIdIdentityIssuerType } from './openIdIdentity';
 import { type OrganizationMemberRole } from './organizationMemberProfile';
 import { type PromotionAction } from './promotion';
 import { type UserAvatarColorValue } from './userAvatars';
@@ -262,11 +262,51 @@ export enum LocalIssuerTypes {
 
 export type LoginOptionTypes = OpenIdIdentityIssuerType | LocalIssuerTypes;
 
+export type MobileLoginIntent = 'sso' | 'local';
+
+export const isMobileLoginIntent = (
+    value: unknown,
+): value is MobileLoginIntent => value === 'sso' || value === 'local';
+
+export type MobileLoginSsoProvider =
+    | OpenIdIdentityIssuerType.GOOGLE
+    | OpenIdIdentityIssuerType.OKTA
+    | OpenIdIdentityIssuerType.ONELOGIN
+    | OpenIdIdentityIssuerType.AZUREAD
+    | OpenIdIdentityIssuerType.GENERIC_OIDC;
+
+export const isMobileLoginSsoProvider = (
+    value: unknown,
+): value is MobileLoginSsoProvider =>
+    value === OpenIdIdentityIssuerType.GOOGLE ||
+    value === OpenIdIdentityIssuerType.OKTA ||
+    value === OpenIdIdentityIssuerType.ONELOGIN ||
+    value === OpenIdIdentityIssuerType.AZUREAD ||
+    value === OpenIdIdentityIssuerType.GENERIC_OIDC;
+
+export type MobileLoginSsoPresentation =
+    | { kind: 'none' }
+    | { kind: 'neutral' }
+    | {
+          kind: 'branded';
+          provider: MobileLoginSsoProvider;
+      };
+
 export type LoginOptions = {
     showOptions: LoginOptionTypes[];
     forceRedirect?: boolean;
     redirectUri?: string;
+    ssoPresentation?: MobileLoginSsoPresentation;
+    localEmailAvailable?: boolean;
 };
+
+export type UserLoginOptions = Pick<
+    LoginOptions,
+    'showOptions' | 'forceRedirect' | 'redirectUri'
+>;
+
+export type MobileLoginOptions = UserLoginOptions &
+    Required<Pick<LoginOptions, 'ssoPresentation' | 'localEmailAvailable'>>;
 
 export type ApiGetLoginOptionsResponse = {
     status: 'ok';

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -6,6 +6,8 @@ import {
     SEED_ORG_1_ADMIN_EMAIL,
     SEED_ORG_1_ADMIN_PASSWORD,
     type LightdashUser,
+    type LoginOptions,
+    type MobileLoginIntent,
     type OpenIdIdentityIssuerType,
 } from '@lightdash/common';
 import {
@@ -18,7 +20,7 @@ import {
     Anchor,
     PasswordInput,
 } from '@mantine/core';
-import { useForm, zodResolver } from '@mantine/form';
+import { useForm, zodResolver, type UseFormReturnType } from '@mantine/form';
 import { useTimeout } from '@mantine/hooks';
 import { IconX } from '@tabler/icons-react';
 import {
@@ -53,7 +55,279 @@ import {
     writeLastLoginMethod,
     writePendingSsoLoginMethod,
 } from '../utils/lastLoginMethod';
+import {
+    getMobileLoginIntentFromRedirect,
+    setMobileLoginIntentOnRedirect,
+} from '../utils/mobileLoginIntent';
 import LoginWithEmailOtp from './LoginWithEmailOtp';
+
+const getVisibleSsoOptions = ({
+    loginOptions,
+    mobileLoginIntent,
+    preCheckEmail,
+    lastUsedSsoProvider,
+}: {
+    loginOptions: LoginOptions | undefined;
+    mobileLoginIntent: MobileLoginIntent | undefined;
+    preCheckEmail: string | undefined;
+    lastUsedSsoProvider: OpenIdIdentityIssuerType | undefined;
+}): OpenIdIdentityIssuerType[] => {
+    const shouldResolveSsoByEmail =
+        mobileLoginIntent === 'sso' &&
+        loginOptions?.ssoPresentation?.kind !== 'branded' &&
+        !preCheckEmail;
+    const ssoOptions =
+        loginOptions &&
+        mobileLoginIntent !== 'local' &&
+        !shouldResolveSsoByEmail
+            ? (loginOptions.showOptions.filter(
+                  isOpenIdIdentityIssuerType,
+              ) as OpenIdIdentityIssuerType[])
+            : [];
+
+    return mobileLoginIntent
+        ? ssoOptions
+        : lastUsedSsoProvider
+          ? [
+                lastUsedSsoProvider,
+                ...ssoOptions.filter(
+                    (provider) => provider !== lastUsedSsoProvider,
+                ),
+            ]
+          : ssoOptions;
+};
+
+const getAlternativeLoginIntent = ({
+    formStage,
+    mobileLoginIntent,
+    isEmailLoginAvailable,
+    isEmailOtpLoginAvailable,
+    ssoOptions,
+    loginOptions,
+}: {
+    formStage: 'precheck' | 'login';
+    mobileLoginIntent: MobileLoginIntent | undefined;
+    isEmailLoginAvailable: boolean;
+    isEmailOtpLoginAvailable: boolean;
+    ssoOptions: OpenIdIdentityIssuerType[];
+    loginOptions: LoginOptions | undefined;
+}): MobileLoginIntent | undefined => {
+    if (
+        formStage === 'login' &&
+        mobileLoginIntent === 'local' &&
+        !isEmailLoginAvailable &&
+        !isEmailOtpLoginAvailable &&
+        loginOptions?.ssoPresentation?.kind !== 'none'
+    ) {
+        return 'sso';
+    }
+    if (
+        formStage === 'login' &&
+        mobileLoginIntent === 'sso' &&
+        ssoOptions.length === 0 &&
+        loginOptions?.localEmailAvailable
+    ) {
+        return 'local';
+    }
+    return undefined;
+};
+
+const LoginForm: FC<{
+    alternativeLoginIntent: MobileLoginIntent | undefined;
+    availability: { email: boolean; emailOtp: boolean };
+    form: UseFormReturnType<LoginParams>;
+    formStatus: 'idle' | 'loading';
+    formStage: 'precheck' | 'login';
+    lastUsedSsoProvider: OpenIdIdentityIssuerType | undefined;
+    layout: 'new' | 'legacy';
+    loginHint: string | undefined;
+    mobileLoginIntent: MobileLoginIntent | undefined;
+    onClearEmail: () => void;
+    onEmailOtpSuccess: (data: LightdashUser) => void;
+    onSubmit: () => void;
+    preCheckEmail: string | undefined;
+    redirectUrl: string;
+    signupPath: string | null;
+    signupUrl: string;
+    ssoOptions: OpenIdIdentityIssuerType[];
+}> = ({
+    alternativeLoginIntent,
+    availability,
+    form,
+    formStatus,
+    formStage,
+    lastUsedSsoProvider,
+    layout,
+    loginHint,
+    mobileLoginIntent,
+    onClearEmail,
+    onEmailOtpSuccess,
+    onSubmit,
+    preCheckEmail,
+    redirectUrl,
+    signupPath,
+    signupUrl,
+    ssoOptions,
+}) => {
+    const isNewLayout = layout === 'new';
+    const isFormLoading = formStatus === 'loading';
+    const ssoButtons = ssoOptions.length > 0 && (
+        <Stack>
+            {ssoOptions.map((providerName) => (
+                <ThirdPartySignInButton
+                    key={providerName}
+                    providerName={providerName}
+                    intent={isNewLayout ? 'continue' : 'signin'}
+                    redirect={redirectUrl}
+                    loginHint={loginHint}
+                    disabled={isFormLoading}
+                    forceShow
+                    lastUsed={providerName === lastUsedSsoProvider}
+                    onClick={() => writePendingSsoLoginMethod(providerName)}
+                />
+            ))}
+        </Stack>
+    );
+    const ssoDivider = (
+        <Divider
+            my="sm"
+            labelPosition="center"
+            label={
+                <Text c="ldGray.5" size="sm" fw={500}>
+                    {isNewLayout ? 'or' : 'OR'}
+                </Text>
+            }
+        />
+    );
+
+    return (
+        <form name="login" onSubmit={form.onSubmit(onSubmit)}>
+            <Stack gap="lg">
+                {isNewLayout && ssoButtons ? (
+                    <>
+                        {ssoButtons}
+                        {ssoDivider}
+                    </>
+                ) : null}
+                <TextInput
+                    label={isNewLayout ? 'Work email' : 'Email address'}
+                    name="email"
+                    placeholder={
+                        isNewLayout ? 'maya@acme.com' : 'Your email address'
+                    }
+                    required
+                    {...form.getInputProps('email')}
+                    disabled={isFormLoading}
+                    rightSectionPointerEvents="all"
+                    rightSection={
+                        preCheckEmail ? (
+                            <ActionIcon
+                                aria-label="Clear email address"
+                                onMouseDown={(event) => event.preventDefault()}
+                                variant="subtle"
+                                color="gray"
+                                onClick={onClearEmail}
+                            >
+                                <MantineIcon icon={IconX} />
+                            </ActionIcon>
+                        ) : null
+                    }
+                />
+                {availability.email && formStage === 'login' ? (
+                    <>
+                        <PasswordInput
+                            label="Password"
+                            name="password"
+                            placeholder="Your password"
+                            autoComplete="current-password"
+                            required
+                            autoFocus
+                            {...form.getInputProps('password')}
+                            disabled={isFormLoading}
+                        />
+                        <Anchor
+                            inherit
+                            component={Link}
+                            to="/recover-password"
+                            mx="auto"
+                        >
+                            Forgot your password?
+                        </Anchor>
+                        <Button
+                            type="submit"
+                            loading={isFormLoading}
+                            disabled={isFormLoading}
+                            fullWidth={isNewLayout}
+                            data-cy="signin-button"
+                        >
+                            Sign in
+                        </Button>
+                    </>
+                ) : null}
+                {availability.emailOtp && formStage === 'login' ? (
+                    <LoginWithEmailOtp
+                        email={preCheckEmail ?? form.values.email}
+                        disabled={isFormLoading}
+                        onSuccess={onEmailOtpSuccess}
+                    />
+                ) : null}
+                {formStage === 'precheck' ? (
+                    <Button
+                        type="submit"
+                        loading={isFormLoading}
+                        disabled={isFormLoading}
+                        fullWidth={isNewLayout}
+                        data-cy="signin-button"
+                    >
+                        Continue
+                    </Button>
+                ) : null}
+                {alternativeLoginIntent ? (
+                    <Button
+                        component="a"
+                        variant="default"
+                        href={setMobileLoginIntentOnRedirect(
+                            redirectUrl,
+                            window.location.origin,
+                            alternativeLoginIntent,
+                        )}
+                    >
+                        Continue with{' '}
+                        {alternativeLoginIntent === 'sso'
+                            ? 'SSO'
+                            : 'work email'}
+                    </Button>
+                ) : null}
+                {!isNewLayout && ssoButtons ? (
+                    <>
+                        {availability.email ||
+                        availability.emailOtp ||
+                        formStage === 'precheck'
+                            ? ssoDivider
+                            : null}
+                        {ssoButtons}
+                    </>
+                ) : null}
+                {!mobileLoginIntent ? (
+                    <Text mx="auto" mt="md" fz="sm">
+                        {isNewLayout
+                            ? 'New to Lightdash?'
+                            : "Don't have an account?"}{' '}
+                        {signupPath ? (
+                            <Anchor component={Link} to={signupPath} fz="sm">
+                                {isNewLayout ? 'Create an account' : 'Sign up'}
+                            </Anchor>
+                        ) : (
+                            <Anchor href={signupUrl} fz="sm">
+                                {isNewLayout ? 'Create an account' : 'Sign up'}
+                            </Anchor>
+                        )}
+                    </Text>
+                ) : null}
+            </Stack>
+        </form>
+    );
+};
 
 const Login: FC<{}> = () => {
     const { health } = useApp();
@@ -101,6 +375,10 @@ const Login: FC<{}> = () => {
             ? `${location.state.from.pathname}${location.state.from.search}`
             : redirectParam,
     );
+    const mobileLoginIntent = getMobileLoginIntentFromRedirect(
+        redirectUrl,
+        window.location.origin,
+    );
 
     const form = useForm<LoginParams>({
         initialValues: {
@@ -121,6 +399,7 @@ const Login: FC<{}> = () => {
         isSuccess: loginOptionsSuccess,
     } = useFetchLoginOptions({
         email: preCheckEmail,
+        mobileLoginIntent,
         useQueryOptions: {
             keepPreviousData: true,
         },
@@ -180,24 +459,12 @@ const Login: FC<{}> = () => {
         track,
     ]);
 
-    const ssoOptions = loginOptions
-        ? (loginOptions.showOptions.filter(
-              isOpenIdIdentityIssuerType,
-          ) as OpenIdIdentityIssuerType[])
-        : [];
-
-    // Pin the last-used SSO provider to the top of the list, and include it even
-    // when it's a private per-org method not in the default options — it reuses
-    // the same public login path/button we'd show after the email precheck step,
-    // so it can surface on the first page.
-    const ssoOptionsLastUsedFirst = lastUsedSsoProvider
-        ? [
-              lastUsedSsoProvider,
-              ...ssoOptions.filter(
-                  (provider) => provider !== lastUsedSsoProvider,
-              ),
-          ]
-        : ssoOptions;
+    const ssoOptions = getVisibleSsoOptions({
+        loginOptions,
+        mobileLoginIntent,
+        preCheckEmail,
+        lastUsedSsoProvider,
+    });
 
     // Delayed loading state - only show loading if request takes longer than 400ms
     const { start: startDelayedState, clear: clearDelayedState } = useTimeout(
@@ -253,13 +520,15 @@ const Login: FC<{}> = () => {
         }
     }, [isDemo, mutate, isIdle]);
 
-    const isEmailLoginAvailable =
-        loginOptions?.showOptions &&
-        loginOptions?.showOptions.includes(LocalIssuerTypes.EMAIL);
+    const isEmailLoginAvailable = Boolean(
+        mobileLoginIntent !== 'sso' &&
+        loginOptions?.showOptions.includes(LocalIssuerTypes.EMAIL),
+    );
 
-    const isEmailOtpLoginAvailable =
-        loginOptions?.showOptions &&
-        loginOptions?.showOptions.includes(LocalIssuerTypes.EMAIL_OTP);
+    const isEmailOtpLoginAvailable = Boolean(
+        mobileLoginIntent !== 'sso' &&
+        loginOptions?.showOptions.includes(LocalIssuerTypes.EMAIL_OTP),
+    );
 
     const formStage =
         preCheckEmail &&
@@ -288,6 +557,15 @@ const Login: FC<{}> = () => {
         isLoading ||
         isSuccess;
 
+    const alternativeLoginIntent = getAlternativeLoginIntent({
+        formStage,
+        mobileLoginIntent,
+        isEmailLoginAvailable,
+        isEmailOtpLoginAvailable,
+        ssoOptions,
+        loginOptions,
+    });
+
     if (health.isInitialLoading || isDemo || isInitialLoadingLoginOptions) {
         return <PageSpinner />;
     }
@@ -305,154 +583,37 @@ const Login: FC<{}> = () => {
         return <Navigate to={redirectUrl} />;
     }
 
-    const ssoButtons = ssoOptionsLastUsedFirst.length > 0 && (
-        <Stack>
-            {ssoOptionsLastUsedFirst.map((providerName) => (
-                <ThirdPartySignInButton
-                    key={providerName}
-                    providerName={providerName}
-                    intent={isNewLayout ? 'continue' : 'signin'}
-                    redirect={redirectUrl}
-                    loginHint={preCheckEmail ?? lastLoginMethod?.email}
-                    disabled={isFormLoading}
-                    forceShow
-                    lastUsed={providerName === lastUsedSsoProvider}
-                    onClick={() => writePendingSsoLoginMethod(providerName)}
-                />
-            ))}
-        </Stack>
-    );
-
     const signupUrl = health.data?.signupUrl || '/register';
     const signupPath = resolveInternalPath(signupUrl);
 
-    const ssoDivider = (
-        <Divider
-            my="sm"
-            labelPosition="center"
-            label={
-                <Text c="ldGray.5" size="sm" fw={500}>
-                    {isNewLayout ? 'or' : 'OR'}
-                </Text>
-            }
-        />
-    );
-
     return (
-        <form name="login" onSubmit={form.onSubmit(() => handleFormSubmit())}>
-            <Stack gap="lg">
-                {isNewLayout && ssoButtons && (
-                    <>
-                        {ssoButtons}
-                        {ssoDivider}
-                    </>
-                )}
-                <TextInput
-                    label={isNewLayout ? 'Work email' : 'Email address'}
-                    name="email"
-                    placeholder={
-                        isNewLayout ? 'maya@acme.com' : 'Your email address'
-                    }
-                    required
-                    {...form.getInputProps('email')}
-                    disabled={isFormLoading}
-                    rightSectionPointerEvents="all"
-                    rightSection={
-                        preCheckEmail ? (
-                            <ActionIcon
-                                aria-label="Clear email address"
-                                onMouseDown={(event) => event.preventDefault()}
-                                variant="subtle"
-                                color="gray"
-                                onClick={() => {
-                                    setPreCheckEmail(undefined);
-                                    form.setValues({
-                                        email: '',
-                                        password: '',
-                                    });
-                                }}
-                            >
-                                <MantineIcon icon={IconX} />
-                            </ActionIcon>
-                        ) : null
-                    }
-                />
-                {isEmailLoginAvailable && formStage === 'login' && (
-                    <>
-                        <PasswordInput
-                            label="Password"
-                            name="password"
-                            placeholder="Your password"
-                            autoComplete="current-password"
-                            required
-                            autoFocus
-                            {...form.getInputProps('password')}
-                            disabled={isFormLoading}
-                        />
-                        <Anchor
-                            inherit
-                            component={Link}
-                            to="/recover-password"
-                            mx="auto"
-                        >
-                            Forgot your password?
-                        </Anchor>
-                        <Button
-                            type="submit"
-                            loading={isFormLoading}
-                            disabled={isFormLoading}
-                            fullWidth={isNewLayout}
-                            data-cy="signin-button"
-                        >
-                            Sign in
-                        </Button>
-                    </>
-                )}
-                {isEmailOtpLoginAvailable && formStage === 'login' && (
-                    <LoginWithEmailOtp
-                        email={preCheckEmail ?? form.values.email}
-                        disabled={isFormLoading}
-                        onSuccess={(data) =>
-                            handleLoginSuccess(data, LocalIssuerTypes.EMAIL_OTP)
-                        }
-                    />
-                )}
-                {formStage === 'precheck' && (
-                    <Button
-                        type="submit"
-                        loading={isFormLoading}
-                        disabled={isFormLoading}
-                        fullWidth={isNewLayout}
-                        data-cy="signin-button"
-                    >
-                        Continue
-                    </Button>
-                )}
-                {!isNewLayout && ssoButtons && (
-                    <>
-                        {(isEmailLoginAvailable ||
-                            isEmailOtpLoginAvailable ||
-                            formStage === 'precheck') &&
-                            ssoDivider}
-                        {ssoButtons}
-                    </>
-                )}
-                <Text mx="auto" mt="md" fz="sm">
-                    {isNewLayout
-                        ? 'New to Lightdash?'
-                        : "Don't have an account?"}{' '}
-                    {signupPath ? (
-                        <Anchor component={Link} to={signupPath} fz="sm">
-                            {isNewLayout ? 'Create an account' : 'Sign up'}
-                        </Anchor>
-                    ) : (
-                        <Anchor href={signupUrl} fz="sm">
-                            {isNewLayout ? 'Create an account' : 'Sign up'}
-                        </Anchor>
-                    )}
-                </Text>
-            </Stack>
-        </form>
+        <LoginForm
+            alternativeLoginIntent={alternativeLoginIntent}
+            availability={{
+                email: isEmailLoginAvailable,
+                emailOtp: isEmailOtpLoginAvailable,
+            }}
+            form={form}
+            formStatus={isFormLoading ? 'loading' : 'idle'}
+            formStage={formStage}
+            lastUsedSsoProvider={lastUsedSsoProvider}
+            layout={isNewLayout ? 'new' : 'legacy'}
+            loginHint={preCheckEmail ?? lastLoginMethod?.email}
+            mobileLoginIntent={mobileLoginIntent}
+            onClearEmail={() => {
+                setPreCheckEmail(undefined);
+                form.setValues({ email: '', password: '' });
+            }}
+            onEmailOtpSuccess={(data) =>
+                handleLoginSuccess(data, LocalIssuerTypes.EMAIL_OTP)
+            }
+            onSubmit={handleFormSubmit}
+            preCheckEmail={preCheckEmail}
+            redirectUrl={redirectUrl}
+            signupPath={signupPath}
+            signupUrl={signupUrl}
+            ssoOptions={ssoOptions}
+        />
     );
 };
 

--- a/packages/frontend/src/features/users/hooks/useLogin.ts
+++ b/packages/frontend/src/features/users/hooks/useLogin.ts
@@ -3,6 +3,7 @@ import {
     type ApiError,
     type LightdashUser,
     type LoginOptions,
+    type MobileLoginIntent,
 } from '@lightdash/common';
 import {
     useMutation,
@@ -15,28 +16,41 @@ import useQueryError from '../../../hooks/useQueryError';
 
 export type LoginParams = { email: string; password: string };
 
-const fetchLoginOptions = async (email?: string) =>
-    lightdashApi<LoginOptions>({
-        url: `/user/login-options${
-            email ? `?email=${encodeURIComponent(email)}` : ''
-        }`,
+const fetchLoginOptions = async (
+    email?: string,
+    mobileLoginIntent?: MobileLoginIntent,
+) => {
+    const queryParams = new URLSearchParams();
+    if (email) {
+        queryParams.set('email', email);
+    }
+    if (mobileLoginIntent) {
+        queryParams.set('mobile_login_intent', mobileLoginIntent);
+    }
+    const query = queryParams.toString();
+
+    return lightdashApi<LoginOptions>({
+        url: `/user/login-options${query ? `?${query}` : ''}`,
         method: 'GET',
         body: undefined,
     });
+};
 
 export const useFetchLoginOptions = ({
     email,
+    mobileLoginIntent,
     useQueryOptions,
 }: {
     email?: string;
+    mobileLoginIntent?: MobileLoginIntent;
     useQueryOptions?: UseQueryOptions<LoginOptions, ApiError>;
 }) => {
     const setErrorResponse = useQueryError();
     const { showToastError } = useToaster();
 
     return useQuery<LoginOptions, ApiError>({
-        queryKey: ['loginOptions', email],
-        queryFn: () => fetchLoginOptions(email),
+        queryKey: ['loginOptions', email, mobileLoginIntent],
+        queryFn: () => fetchLoginOptions(email, mobileLoginIntent),
         retry: false,
         onError: (result) => {
             setErrorResponse(result);

--- a/packages/frontend/src/features/users/utils/mobileLoginIntent.test.ts
+++ b/packages/frontend/src/features/users/utils/mobileLoginIntent.test.ts
@@ -1,0 +1,51 @@
+import {
+    getMobileLoginIntentFromRedirect,
+    setMobileLoginIntentOnRedirect,
+} from './mobileLoginIntent';
+
+describe('mobileLoginIntent', () => {
+    const origin = 'https://lightdash.example';
+    const authorizeUrl =
+        '/api/v1/oauth/authorize?client_id=mobile&redirect_uri=lightdash%3A%2F%2Fcallback&state=request-state';
+
+    it.each(['sso', 'local'] as const)(
+        'reads the %s intent from the outer authorization request',
+        (intent) => {
+            expect(
+                getMobileLoginIntentFromRedirect(
+                    `${authorizeUrl}&mobile_login_intent=${intent}`,
+                    origin,
+                ),
+            ).toBe(intent);
+        },
+    );
+
+    it.each([undefined, 'other'])(
+        'ignores an unsupported %s intent',
+        (intent) => {
+            expect(
+                getMobileLoginIntentFromRedirect(
+                    `${authorizeUrl}${
+                        intent ? `&mobile_login_intent=${intent}` : ''
+                    }`,
+                    origin,
+                ),
+            ).toBeUndefined();
+        },
+    );
+
+    it('ignores an intent outside the outer authorization route', () => {
+        expect(
+            getMobileLoginIntentFromRedirect(
+                '/projects/project-uuid?mobile_login_intent=sso',
+                origin,
+            ),
+        ).toBeUndefined();
+    });
+
+    it('changes only the browser intent on the outer authorization request', () => {
+        expect(
+            setMobileLoginIntentOnRedirect(authorizeUrl, origin, 'sso'),
+        ).toBe(`${authorizeUrl}&mobile_login_intent=sso`);
+    });
+});

--- a/packages/frontend/src/features/users/utils/mobileLoginIntent.ts
+++ b/packages/frontend/src/features/users/utils/mobileLoginIntent.ts
@@ -1,0 +1,27 @@
+import { isMobileLoginIntent, type MobileLoginIntent } from '@lightdash/common';
+
+export const getMobileLoginIntentFromRedirect = (
+    redirect: string,
+    origin: string,
+): MobileLoginIntent | undefined => {
+    try {
+        const redirectUrl = new URL(redirect, origin);
+        if (redirectUrl.pathname !== '/api/v1/oauth/authorize') {
+            return undefined;
+        }
+        const intent = redirectUrl.searchParams.get('mobile_login_intent');
+        return isMobileLoginIntent(intent) ? intent : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+export const setMobileLoginIntentOnRedirect = (
+    redirect: string,
+    origin: string,
+    intent: MobileLoginIntent,
+): string => {
+    const url = new URL(redirect, origin);
+    url.searchParams.set('mobile_login_intent', intent);
+    return `${url.pathname}${url.search}${url.hash}`;
+};


### PR DESCRIPTION
## What changed

- Expose a versioned mobile login capability and server-directed presentation.
- Enforce SSO-only and local-only browser login intents.
- Preserve the outer mobile OAuth return path through each login method.
- Fall back to neutral SSO when the provider is ambiguous.

## Test plan

- Run common, backend, and frontend typechecks.
- Run focused health, login-option, OAuth router, and browser-intent tests.
- Run touched-path format and lint checks.
- Run React Doctor on the touched frontend files.

Linear: SPK-1433