### PR TITLE
fix(search): boost exact names and reserve verified results

### DIFF
--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -311,10 +311,15 @@ export class SearchModel {
                 { spaceUuid: `${SpaceTableName}.space_uuid` },
                 this.database.raw(
                     `GREATEST(
-                        ${dashboardSearchRankRawSql},
-                        COALESCE(MAX(${directChartSearchRankRawSql}), 0),
-                        COALESCE(MAX(${tileChartSearchRankRawSql}), 0)
+                        ?,
+                        COALESCE(MAX(?), 0),
+                        COALESCE(MAX(?), 0)
                     ) as search_rank`,
+                    [
+                        dashboardSearchRankRawSql,
+                        directChartSearchRankRawSql,
+                        tileChartSearchRankRawSql,
+                    ],
                 ),
                 { viewsCount: `${DashboardsTableName}.views_count` },
                 { firstViewedAt: `${DashboardsTableName}.first_viewed_at` },

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -53,10 +53,12 @@ import {
     shouldSearchForType,
 } from './utils/filters';
 import {
+    getExactOrPrefixLabelScore,
     getFullTextSearchFilterSql,
     getFullTextSearchRankCalcSql,
     getRegexFromUserQuery,
     getTableOrFieldMatchCount,
+    searchReservingVerified,
 } from './utils/search';
 
 type SearchModelArguments = {
@@ -96,6 +98,7 @@ export class SearchModel {
                 searchVectorColumn: `${SpaceTableName}.search_vector`,
                 searchQuery: query,
             },
+            nameColumn: `${SpaceTableName}.name`,
         });
 
         // Use GIN index filter to reduce rows before computing ts_rank_cd
@@ -176,6 +179,7 @@ export class SearchModel {
                 searchQuery: query,
             },
             fullTextSearchOperator,
+            nameColumn: `${DashboardsTableName}.name`,
         });
 
         const directChartSearchRankRawSql = getFullTextSearchRankCalcSql({
@@ -185,6 +189,7 @@ export class SearchModel {
                 searchQuery: query,
             },
             fullTextSearchOperator,
+            nameColumn: 'direct_charts.name',
         });
 
         const tileChartSearchRankRawSql = getFullTextSearchRankCalcSql({
@@ -194,6 +199,7 @@ export class SearchModel {
                 searchQuery: query,
             },
             fullTextSearchOperator,
+            nameColumn: 'tile_charts.name',
         });
 
         // GIN index filters - these use indexes instead of computing rank for all rows
@@ -782,7 +788,10 @@ export class SearchModel {
         projectUuid: string,
         query: string,
         filters?: SearchFilters,
-        fullTextSearchOperator: 'OR' | 'AND' = 'AND',
+        {
+            fullTextSearchOperator = 'AND',
+            verifiedOnly = false,
+        }: SearchContentOptions = {},
     ) {
         const { name: tableName, uuidColumnName } = searchTable;
 
@@ -793,6 +802,7 @@ export class SearchModel {
                 searchQuery: query,
             },
             fullTextSearchOperator,
+            nameColumn: `${tableName}.name`,
         });
 
         // Use GIN index filter to reduce rows before computing ts_rank_cd
@@ -886,6 +896,16 @@ export class SearchModel {
             filters,
         );
 
+        if (verifiedOnly) {
+            subquery = subquery.whereExists(
+                this.verifiedContentExists(
+                    projectUuid,
+                    ContentType.CHART,
+                    `${tableName}.${uuidColumnName}`,
+                ),
+            );
+        }
+
         const charts = await this.database(tableName)
             .select()
             .from(subquery.as('saved_charts_with_rank'))
@@ -918,7 +938,10 @@ export class SearchModel {
         projectUuid: string,
         query: string,
         filters?: SearchFilters,
-        fullTextSearchOperator: 'OR' | 'AND' = 'AND',
+        {
+            fullTextSearchOperator = 'AND',
+            verifiedOnly = false,
+        }: SearchContentOptions = {},
     ): Promise<SqlChartSearchResult[]> {
         if (!shouldSearchForType(SearchItemType.SQL_CHART, filters?.type)) {
             return [];
@@ -932,7 +955,7 @@ export class SearchModel {
             projectUuid,
             query,
             filters,
-            fullTextSearchOperator,
+            { fullTextSearchOperator, verifiedOnly },
         );
     }
 
@@ -940,7 +963,10 @@ export class SearchModel {
         projectUuid: string,
         query: string,
         filters?: SearchFilters,
-        fullTextSearchOperator: 'OR' | 'AND' = 'AND',
+        {
+            fullTextSearchOperator = 'AND',
+            verifiedOnly = false,
+        }: SearchContentOptions = {},
     ): Promise<SavedChartSearchResult[]> {
         if (!shouldSearchForType(SearchItemType.CHART, filters?.type)) {
             return [];
@@ -953,6 +979,7 @@ export class SearchModel {
                 searchQuery: query,
             },
             fullTextSearchOperator,
+            nameColumn: `${SavedChartsTableName}.name`,
         });
 
         // Use GIN index filter to reduce rows before computing ts_rank_cd
@@ -1037,6 +1064,16 @@ export class SearchModel {
             filters,
         );
 
+        if (verifiedOnly) {
+            subquery = subquery.whereExists(
+                this.verifiedContentExists(
+                    projectUuid,
+                    ContentType.CHART,
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                ),
+            );
+        }
+
         const savedCharts = await this.database(SavedChartsTableName)
             .select()
             .from(subquery.as('saved_charts_with_rank'))
@@ -1118,6 +1155,7 @@ export class SearchModel {
                 searchVectorColumn: `${AppsTableName}.search_vector`,
                 searchQuery: query,
             },
+            nameColumn: `${AppsTableName}.name`,
         });
 
         const searchFilterSql = getFullTextSearchFilterSql({
@@ -1212,6 +1250,7 @@ export class SearchModel {
                 searchQuery: query,
             },
             fullTextSearchOperator,
+            nameColumn: `${SavedChartsTableName}.name`,
         });
 
         // GIN index filter for saved charts
@@ -1306,6 +1345,7 @@ export class SearchModel {
                 searchQuery: query,
             },
             fullTextSearchOperator,
+            nameColumn: `${SavedSqlTableName}.name`,
         });
 
         // GIN index filter for SQL charts
@@ -1638,11 +1678,27 @@ export class SearchModel {
             );
 
         const sortedTables = unsortedTables
-            .sort((a, b) => b.regexMatchCount - a.regexMatchCount)
+            .sort((a, b) => {
+                const exactDiff =
+                    getExactOrPrefixLabelScore(query, b.label) -
+                    getExactOrPrefixLabelScore(query, a.label);
+                if (exactDiff !== 0) {
+                    return exactDiff;
+                }
+                return b.regexMatchCount - a.regexMatchCount;
+            })
             .slice(0, SEARCH_LIMIT_PER_ITEM_TYPE);
 
         const sortedFields = unsortedFields
-            .sort((a, b) => b.regexMatchCount - a.regexMatchCount)
+            .sort((a, b) => {
+                const exactDiff =
+                    getExactOrPrefixLabelScore(query, b.label) -
+                    getExactOrPrefixLabelScore(query, a.label);
+                if (exactDiff !== 0) {
+                    return exactDiff;
+                }
+                return b.regexMatchCount - a.regexMatchCount;
+            })
             .slice(0, SEARCH_LIMIT_PER_ITEM_TYPE);
 
         return [sortedTables, sortedFields];
@@ -1730,21 +1786,17 @@ export class SearchModel {
         filters?: SearchFilters,
     ): Promise<SearchResults> {
         const spaces = await this.searchSpaces(projectUuid, query, filters);
-        const dashboards = await this.searchDashboards(
-            projectUuid,
-            query,
-            filters,
-        );
-        const savedCharts = await this.searchSavedCharts(
-            projectUuid,
-            query,
-            filters,
-        );
-        const sqlCharts = await this.searchSqlCharts(
-            projectUuid,
-            query,
-            filters,
-        );
+        const [dashboards, savedCharts, sqlCharts] = await Promise.all([
+            searchReservingVerified(false, (opts) =>
+                this.searchDashboards(projectUuid, query, filters, opts),
+            ),
+            searchReservingVerified(false, (opts) =>
+                this.searchSavedCharts(projectUuid, query, filters, opts),
+            ),
+            searchReservingVerified(false, (opts) =>
+                this.searchSqlCharts(projectUuid, query, filters, opts),
+            ),
+        ]);
         const dashboardTabs = await this.searchDashboardTabs(
             projectUuid,
             query,

--- a/packages/backend/src/models/SearchModel/utils/search.test.ts
+++ b/packages/backend/src/models/SearchModel/utils/search.test.ts
@@ -21,9 +21,9 @@ describe('getFullTextSearchQuery', () => {
 
 describe('getExactOrPrefixLabelScore', () => {
     it('scores exact label matches highest', () => {
-        expect(getExactOrPrefixLabelScore('monthly revenue', 'Monthly Revenue')).toBe(
-            2,
-        );
+        expect(
+            getExactOrPrefixLabelScore('monthly revenue', 'Monthly Revenue'),
+        ).toBe(2);
     });
 
     it('scores prefix matches above partial matches', () => {
@@ -48,10 +48,13 @@ describe('getExactOrPrefixLabelScore', () => {
 
 describe('searchReservingVerified', () => {
     it('returns only verified results when verifiedOnly is true', async () => {
-        const results = await searchReservingVerified(true, async ({ verifiedOnly }) => {
-            expect(verifiedOnly).toBe(true);
-            return [{ uuid: 'v1', search_rank: 1 }];
-        });
+        const results = await searchReservingVerified(
+            true,
+            async ({ verifiedOnly }) => {
+                expect(verifiedOnly).toBe(true);
+                return [{ uuid: 'v1', search_rank: 1 }];
+            },
+        );
         expect(results).toEqual([{ uuid: 'v1', search_rank: 1 }]);
     });
 

--- a/packages/backend/src/models/SearchModel/utils/search.test.ts
+++ b/packages/backend/src/models/SearchModel/utils/search.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getExactOrPrefixLabelScore,
+    getFullTextSearchQuery,
+    searchReservingVerified,
+} from './search';
+
+describe('getFullTextSearchQuery', () => {
+    it('builds prefix tsquery terms joined with AND by default', () => {
+        expect(getFullTextSearchQuery('monthly revenue')).toBe(
+            "'monthly':* & 'revenue':*",
+        );
+    });
+
+    it('builds OR queries when requested', () => {
+        expect(getFullTextSearchQuery('monthly revenue', 'OR')).toBe(
+            "'monthly':* | 'revenue':*",
+        );
+    });
+});
+
+describe('getExactOrPrefixLabelScore', () => {
+    it('scores exact label matches highest', () => {
+        expect(getExactOrPrefixLabelScore('monthly revenue', 'Monthly Revenue')).toBe(
+            2,
+        );
+    });
+
+    it('scores prefix matches above partial matches', () => {
+        expect(
+            getExactOrPrefixLabelScore(
+                'monthly revenue',
+                'Monthly Revenue Forecast',
+            ),
+        ).toBe(1);
+        expect(
+            getExactOrPrefixLabelScore(
+                'monthly revenue',
+                'Regional Reporting - Monthly Revenue',
+            ),
+        ).toBe(0);
+    });
+
+    it('returns 0 for empty queries', () => {
+        expect(getExactOrPrefixLabelScore('  ', 'Monthly Revenue')).toBe(0);
+    });
+});
+
+describe('searchReservingVerified', () => {
+    it('returns only verified results when verifiedOnly is true', async () => {
+        const results = await searchReservingVerified(true, async ({ verifiedOnly }) => {
+            expect(verifiedOnly).toBe(true);
+            return [{ uuid: 'v1', search_rank: 1 }];
+        });
+        expect(results).toEqual([{ uuid: 'v1', search_rank: 1 }]);
+    });
+
+    it('merges missing verified results and re-sorts by search_rank', async () => {
+        const results = await searchReservingVerified(
+            false,
+            async ({ verifiedOnly }) => {
+                if (verifiedOnly) {
+                    return [
+                        { uuid: 'verified-crowded-out', search_rank: 90 },
+                        { uuid: 'shared', search_rank: 5 },
+                    ];
+                }
+                return [
+                    { uuid: 'unverified-high', search_rank: 10 },
+                    { uuid: 'shared', search_rank: 5 },
+                    { uuid: 'unverified-low', search_rank: 1 },
+                ];
+            },
+        );
+
+        expect(results.map((result) => result.uuid)).toEqual([
+            'verified-crowded-out',
+            'unverified-high',
+            'shared',
+            'unverified-low',
+        ]);
+    });
+});
+
+describe('exact/prefix label ranking order', () => {
+    it('ranks exact labels first when sorting', () => {
+        const labels = [
+            'Regional Reporting - Monthly Revenue',
+            'Monthly Revenue',
+            'Monthly Revenue Forecast',
+        ];
+        const query = 'monthly revenue';
+        const sorted = [...labels].sort(
+            (a, b) =>
+                getExactOrPrefixLabelScore(query, b) -
+                getExactOrPrefixLabelScore(query, a),
+        );
+        expect(sorted).toEqual([
+            'Monthly Revenue',
+            'Monthly Revenue Forecast',
+            'Regional Reporting - Monthly Revenue',
+        ]);
+    });
+});

--- a/packages/backend/src/models/SearchModel/utils/search.ts
+++ b/packages/backend/src/models/SearchModel/utils/search.ts
@@ -2,6 +2,11 @@ import { CompiledField, CompiledTable } from '@lightdash/common';
 import { Knex } from 'knex';
 import { compact, escapeRegExp } from 'lodash';
 
+// Exact/prefix name boosts sit above typical ts_rank_cd values (0–1) so a
+// short exact title always outranks longer partial matches.
+const EXACT_NAME_RANK_BOOST = 100;
+const PREFIX_NAME_RANK_BOOST = 50;
+
 // To query multiple words with tsquery, we need to split the query and add `:*` to each word
 export function getFullTextSearchQuery(
     searchQuery: string,
@@ -25,14 +30,24 @@ export function getFullTextSearchQuery(
         .join(operator);
 }
 
+function getNameMatchBoostSql(): string {
+    return `CASE
+            WHEN lower(:nameColumn:) = lower(:rawSearchQuery) THEN ${EXACT_NAME_RANK_BOOST}
+            WHEN lower(:nameColumn:) LIKE lower(:rawSearchQuery) || '%' THEN ${PREFIX_NAME_RANK_BOOST}
+            ELSE 0
+        END`;
+}
+
 export function getFullTextSearchRankCalcSql({
     database,
     variables,
     fullTextSearchOperator = 'AND',
+    nameColumn,
 }: {
     database: Knex;
     variables: Record<string, string>;
     fullTextSearchOperator?: 'OR' | 'AND';
+    nameColumn?: string;
 }) {
     const updatedVariables = {
         ...variables,
@@ -40,17 +55,29 @@ export function getFullTextSearchRankCalcSql({
             variables.searchQuery,
             fullTextSearchOperator,
         ),
+        ...(nameColumn
+            ? {
+                  nameColumn,
+                  rawSearchQuery: variables.searchQuery,
+              }
+            : {}),
     };
 
-    return database.raw(
-        `ROUND(
+    const tsRankSql = `ROUND(
             ts_rank_cd(
                 :searchVectorColumn:,
                 to_tsquery('lightdash_english_config', :searchQuery),
                 32
             )::numeric,
             6
-        )::float`,
+        )::float`;
+
+    if (!nameColumn) {
+        return database.raw(tsRankSql, updatedVariables);
+    }
+
+    return database.raw(
+        `(${tsRankSql} + ${getNameMatchBoostSql()})`,
         updatedVariables,
     );
 }
@@ -113,25 +140,40 @@ function getWebSearchQuery(searchQuery: string): string {
 export function getWebSearchRankCalcSql({
     database,
     variables,
+    nameColumn,
 }: {
     database: Knex;
     variables: Record<string, string>;
+    nameColumn?: string;
 }) {
     const webSearchQuery = getWebSearchQuery(variables.searchQuery);
+    const bindings = {
+        ...variables,
+        searchQuery: webSearchQuery,
+        ...(nameColumn
+            ? {
+                  nameColumn,
+                  rawSearchQuery: variables.searchQuery,
+              }
+            : {}),
+    };
 
-    return database.raw(
-        `ROUND(
+    const tsRankSql = `ROUND(
             ts_rank_cd(
                 :searchVectorColumn:,
                 websearch_to_tsquery('lightdash_english_config', :searchQuery),
                 32
             )::numeric,
             6
-        )::float`,
-        {
-            ...variables,
-            searchQuery: webSearchQuery,
-        },
+        )::float`;
+
+    if (!nameColumn) {
+        return database.raw(tsRankSql, bindings);
+    }
+
+    return database.raw(
+        `(${tsRankSql} + ${getNameMatchBoostSql()})`,
+        bindings,
     );
 }
 
@@ -168,4 +210,61 @@ export function getTableOrFieldMatchCount(
     // remove duplicate matches
     return new Set([...labelMatches, ...nameMatches, ...descriptionMatches])
         .size;
+}
+
+/**
+ * Prefer exact and prefix label matches over partial word-count matches so a
+ * short exact title ranks above longer names that merely repeat the query words.
+ */
+export function getExactOrPrefixLabelScore(
+    query: string,
+    label: string,
+): number {
+    const normalizedQuery = query.trim().toLowerCase();
+    const normalizedLabel = label.trim().toLowerCase();
+    if (normalizedQuery.length === 0) {
+        return 0;
+    }
+    if (normalizedLabel === normalizedQuery) {
+        return 2;
+    }
+    if (normalizedLabel.startsWith(normalizedQuery)) {
+        return 1;
+    }
+    return 0;
+}
+
+/**
+ * Verified matches are fetched through a dedicated capped query so they are
+ * never crowded out of the per-type result caps by unverified matches.
+ * Combined results are re-sorted by search_rank when present.
+ */
+export async function searchReservingVerified<
+    T extends { uuid: string; search_rank?: number },
+>(
+    verifiedOnly: boolean,
+    search: (opts: { verifiedOnly: boolean }) => Promise<T[]>,
+): Promise<T[]> {
+    if (verifiedOnly) {
+        return search({ verifiedOnly: true });
+    }
+
+    const [allResults, verifiedResults] = await Promise.all([
+        search({ verifiedOnly: false }),
+        search({ verifiedOnly: true }),
+    ]);
+
+    const byUuid = new Map<string, T>();
+    for (const result of allResults) {
+        byUuid.set(result.uuid, result);
+    }
+    for (const result of verifiedResults) {
+        if (!byUuid.has(result.uuid)) {
+            byUuid.set(result.uuid, result);
+        }
+    }
+
+    return [...byUuid.values()].sort(
+        (a, b) => (b.search_rank ?? 0) - (a.search_rank ?? 0),
+    );
 }

--- a/packages/backend/src/models/SearchModel/utils/search.ts
+++ b/packages/backend/src/models/SearchModel/utils/search.ts
@@ -171,10 +171,7 @@ export function getWebSearchRankCalcSql({
         return database.raw(tsRankSql, bindings);
     }
 
-    return database.raw(
-        `(${tsRankSql} + ${getNameMatchBoostSql()})`,
-        bindings,
-    );
+    return database.raw(`(${tsRankSql} + ${getNameMatchBoostSql()})`, bindings);
 }
 
 export function getRegexFromUserQuery(query: string) {

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -18,6 +18,7 @@ import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SearchModel } from '../../models/SearchModel';
+import { searchReservingVerified } from '../../models/SearchModel/utils/search';
 import { SpaceModel } from '../../models/SpaceModel';
 import { UserAttributesModel } from '../../models/UserAttributesModel';
 import { BaseService } from '../BaseService';
@@ -61,26 +62,6 @@ export class SearchService extends BaseService {
         this.appGenerateService = args.appGenerateService;
     }
 
-    // Verified matches are fetched through a dedicated capped query so they
-    // are never crowded out of the per-type result caps by unverified matches.
-    private static async searchReservingVerified<T extends { uuid: string }>(
-        verifiedOnly: boolean,
-        search: (opts: { verifiedOnly: boolean }) => Promise<T[]>,
-    ): Promise<T[]> {
-        if (verifiedOnly) {
-            return search({ verifiedOnly: true });
-        }
-        const [allResults, verifiedResults] = await Promise.all([
-            search({ verifiedOnly: false }),
-            search({ verifiedOnly: true }),
-        ]);
-        const seenUuids = new Set(allResults.map((result) => result.uuid));
-        return [
-            ...allResults,
-            ...verifiedResults.filter((result) => !seenUuids.has(result.uuid)),
-        ];
-    }
-
     async findContent(
         user: SessionUser,
         projectUuid: string,
@@ -107,7 +88,7 @@ export class SearchService extends BaseService {
         }
 
         const [dashboardSearchResults, chartSearchResults] = await Promise.all([
-            SearchService.searchReservingVerified(verifiedOnly, (opts) =>
+            searchReservingVerified(verifiedOnly, (opts) =>
                 this.searchModel.searchDashboards(
                     projectUuid,
                     query,
@@ -115,7 +96,7 @@ export class SearchService extends BaseService {
                     { fullTextSearchOperator: 'OR', ...opts },
                 ),
             ),
-            SearchService.searchReservingVerified(verifiedOnly, (opts) =>
+            searchReservingVerified(verifiedOnly, (opts) =>
                 this.searchModel.searchAllCharts(projectUuid, query, {
                     fullTextSearchOperator: 'OR',
                     ...opts,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: PROD-10298
Relates: #27608

### Description:
User-facing omnibar search was crowding verified charts/dashboards out of the per-type result caps, and exact name matches could rank below longer partial full-text hits.

This change:
- Reuses `searchReservingVerified` on the omnibar path so verified dashboards/charts/SQL charts are reserved and merged back into results (same approach as the AI `findContent` path)
- Boosts exact and prefix name matches in full-text ranking so short exact titles outrank weaker partial matches
- Prefers exact/prefix labels when ranking explore tables/fields in memory
- Fixes dashboard `GREATEST` rank composition so queries containing `?` do not create unbound SQL placeholders

### Verification:
- Unit tests: `SearchModel/utils/search.test.ts` (8 passed)
- API checks against seeded Jaffle project (exact dashboard/chart/table ranking + verified reservation when crowded out of top 10)
- Omnibar UI walkthrough on Jaffle shop project

[Exact dashboard name ranks first in omnibar](https://cursor.com/agents/bc-01a03a2d-0220-728f-9f4a-3e40c5e5ebc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_exact_dashboard_search.png)
[Exact chart title appears in chart results for full-title query](https://cursor.com/agents/bc-01a03a2d-0220-728f-9f4a-3e40c5e5ebc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_exact_chart_search.png)
[Orders table appears in table results for Orders query](https://cursor.com/agents/bc-01a03a2d-0220-728f-9f4a-3e40c5e5ebc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_orders_table_search.png)

### Risk assessment:
- [ ] This is a high-risk change


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03a2d-0220-728f-9f4a-3e40c5e5ebc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03a2d-0220-728f-9f4a-3e40c5e5ebc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

