### PR TITLE
fix(frontend): prevent dashboard scroll button overlap

### DIFF
--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -72,6 +72,10 @@ const EMPTY_LAYOUTS: { lg: Layout[]; md: Layout[]; sm: Layout[] } = {
     sm: [],
 };
 
+const DASHBOARD_GRID_BOTTOM_PADDING = 60;
+const SCROLL_TO_TOP_BOTTOM = 24;
+const SCROLL_TO_TOP_BOTTOM_WITH_LAUNCHER = 52;
+
 type TabGridPanelProps = {
     tabUuid: string;
     tiles: DashboardTile[];
@@ -356,6 +360,13 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     const [isHeaderStuck, setIsHeaderStuck] = useState<boolean>(false);
 
     const isLauncherMounted = useIsLauncherMounted(projectUuid);
+    const scrollToTopBottom = isLauncherMounted
+        ? SCROLL_TO_TOP_BOTTOM_WITH_LAUNCHER
+        : SCROLL_TO_TOP_BOTTOM;
+    const dashboardGridBottomPadding =
+        DASHBOARD_GRID_BOTTOM_PADDING +
+        scrollToTopBottom -
+        SCROLL_TO_TOP_BOTTOM;
 
     // tabs state
     const [isEditingTab, setEditingTab] = useState<boolean>(false);
@@ -1132,7 +1143,11 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                     />
                                 )}
 
-                                <Group grow pb={60} px="xs">
+                                <Group
+                                    grow
+                                    pb={dashboardGridBottomPadding}
+                                    px="xs"
+                                >
                                     <div
                                         ref={gridWrapperRef}
                                         className={[
@@ -1378,10 +1393,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                 )}
             </Droppable>
 
-            <ScrollToTop
-                show={isHeaderStuck}
-                bottom={isLauncherMounted ? 52 : 24}
-            />
+            <ScrollToTop show={isHeaderStuck} bottom={scrollToTopBottom} />
         </DragDropContext>
     );
 };


### PR DESCRIPTION
## What changed

Adjusted the dashboard’s bottom clearance by the same amount that the AI launcher raises the scroll-to-top button, keeping bottom table footers visible while preserving the non-launcher layout.

### Validation
- `pnpm -F 'frontend' exec oxfmt 'src/features/dashboardTabs/index.tsx'` — passed
- `pnpm -F 'frontend' run --if-present lint` — passed
- `pnpm -F 'frontend' run --if-present typecheck` — passed
- `pnpm -F 'frontend' run --if-present test` — passed

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10461-9d36f2493da6.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10461

