### PR TITLE
feat(search): add Verified filter and homepage section

### DIFF
--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -782,7 +782,10 @@ export class SearchModel {
         projectUuid: string,
         query: string,
         filters?: SearchFilters,
-        fullTextSearchOperator: 'OR' | 'AND' = 'AND',
+        {
+            fullTextSearchOperator = 'AND',
+            verifiedOnly = false,
+        }: SearchContentOptions = {},
     ) {
         const { name: tableName, uuidColumnName } = searchTable;
 
@@ -886,6 +889,16 @@ export class SearchModel {
             filters,
         );
 
+        if (verifiedOnly) {
+            subquery = subquery.whereExists(
+                this.verifiedContentExists(
+                    projectUuid,
+                    ContentType.CHART,
+                    `${tableName}.${uuidColumnName}`,
+                ),
+            );
+        }
+
         const charts = await this.database(tableName)
             .select()
             .from(subquery.as('saved_charts_with_rank'))
@@ -918,7 +931,10 @@ export class SearchModel {
         projectUuid: string,
         query: string,
         filters?: SearchFilters,
-        fullTextSearchOperator: 'OR' | 'AND' = 'AND',
+        {
+            fullTextSearchOperator = 'AND',
+            verifiedOnly = false,
+        }: SearchContentOptions = {},
     ): Promise<SqlChartSearchResult[]> {
         if (!shouldSearchForType(SearchItemType.SQL_CHART, filters?.type)) {
             return [];
@@ -932,7 +948,7 @@ export class SearchModel {
             projectUuid,
             query,
             filters,
-            fullTextSearchOperator,
+            { fullTextSearchOperator, verifiedOnly },
         );
     }
 
@@ -940,7 +956,10 @@ export class SearchModel {
         projectUuid: string,
         query: string,
         filters?: SearchFilters,
-        fullTextSearchOperator: 'OR' | 'AND' = 'AND',
+        {
+            fullTextSearchOperator = 'AND',
+            verifiedOnly = false,
+        }: SearchContentOptions = {},
     ): Promise<SavedChartSearchResult[]> {
         if (!shouldSearchForType(SearchItemType.CHART, filters?.type)) {
             return [];
@@ -1036,6 +1055,16 @@ export class SearchModel {
             },
             filters,
         );
+
+        if (verifiedOnly) {
+            subquery = subquery.whereExists(
+                this.verifiedContentExists(
+                    projectUuid,
+                    ContentType.CHART,
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                ),
+            );
+        }
 
         const savedCharts = await this.database(SavedChartsTableName)
             .select()
@@ -1729,6 +1758,46 @@ export class SearchModel {
         query: string,
         filters?: SearchFilters,
     ): Promise<SearchResults> {
+        const verifiedOnly = filters?.verifiedOnly === true;
+        const contentOptions: SearchContentOptions = { verifiedOnly };
+
+        // Verified is only meaningful for charts and dashboards — skip every
+        // other type so the Item type filter behaves as a verified-content view.
+        if (verifiedOnly) {
+            const [dashboards, savedCharts, sqlCharts] = await Promise.all([
+                this.searchDashboards(
+                    projectUuid,
+                    query,
+                    filters,
+                    contentOptions,
+                ),
+                this.searchSavedCharts(
+                    projectUuid,
+                    query,
+                    filters,
+                    contentOptions,
+                ),
+                this.searchSqlCharts(
+                    projectUuid,
+                    query,
+                    filters,
+                    contentOptions,
+                ),
+            ]);
+
+            return {
+                spaces: [],
+                dashboards,
+                savedCharts,
+                sqlCharts,
+                tables: [],
+                fields: [],
+                pages: [],
+                dashboardTabs: [],
+                dataApps: [],
+            };
+        }
+
         const spaces = await this.searchSpaces(projectUuid, query, filters);
         const dashboards = await this.searchDashboards(
             projectUuid,

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -70,7 +70,8 @@ projectRouter.get(
     isAuthenticated,
     async (req, res, next) => {
         try {
-            const { type, fromDate, toDate, createdByUuid } = req.query;
+            const { type, fromDate, toDate, createdByUuid, verifiedOnly } =
+                req.query;
             const results = await req.services
                 .getSearchService()
                 .getSearchResults(
@@ -83,6 +84,8 @@ projectRouter.get(
                         fromDate: fromDate?.toString(),
                         toDate: toDate?.toString(),
                         createdByUuid: createdByUuid?.toString(),
+                        verifiedOnly:
+                            verifiedOnly === 'true' || verifiedOnly === true,
                     },
                 );
             res.json({ status: 'ok', results });

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -84,8 +84,7 @@ projectRouter.get(
                         fromDate: fromDate?.toString(),
                         toDate: toDate?.toString(),
                         createdByUuid: createdByUuid?.toString(),
-                        verifiedOnly:
-                            verifiedOnly === 'true' || verifiedOnly === true,
+                        verifiedOnly: verifiedOnly === 'true',
                     },
                 );
             res.json({ status: 'ok', results });

--- a/packages/common/src/ee/homepage/schema.ts
+++ b/packages/common/src/ee/homepage/schema.ts
@@ -53,6 +53,7 @@ const collectionBlockSchema = z.object({
                 'pinned',
                 'favorites',
                 'recently-viewed',
+                'verified',
             ])
             .optional(),
         verifiedOnly: z.boolean().optional(),

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -54,7 +54,8 @@ export type HomepageCollectionSource =
     | 'recently-updated'
     | 'pinned'
     | 'favorites'
-    | 'recently-viewed';
+    | 'recently-viewed'
+    | 'verified';
 
 /** Sources whose content differs for every viewer, so an admin previewing as
  * someone else must not see the target's data. */

--- a/packages/common/src/ee/homepage/verifiedSource.schema.test.ts
+++ b/packages/common/src/ee/homepage/verifiedSource.schema.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { parseHomepageConfig } from './schema';
+
+describe('verified collection source', () => {
+    it('accepts verified as a collection source', () => {
+        const config = {
+            version: 1 as const,
+            rows: [
+                {
+                    id: 'row-1',
+                    blocks: [
+                        {
+                            id: 'b1',
+                            type: 'collection' as const,
+                            config: {
+                                title: 'Verified',
+                                items: [],
+                                source: 'verified' as const,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(parseHomepageConfig(config)).toEqual(config);
+    });
+});

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -308,4 +308,6 @@ export type SearchFilters = {
     fromDate?: string;
     toDate?: string;
     createdByUuid?: string;
+    /** When true, only verified charts and dashboards are returned. */
+    verifiedOnly?: boolean;
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -713,6 +713,11 @@ const SOURCE_OPTIONS: {
         label: 'Recently updated',
         hint: 'Recently changed content. Surfaces churn, not importance.',
     },
+    {
+        value: 'verified',
+        label: 'Verified',
+        hint: "This project's admin-verified charts and dashboards.",
+    },
 ];
 
 const CONTENT_TYPE_OPTIONS: {
@@ -793,20 +798,22 @@ const CollectionSourceControls: FC<{
                         ))}
                     </Chip.Group>
                 )}
-                {source !== 'manual' && (
+                {source !== 'manual' && source !== 'verified' && (
                     <Divider orientation="vertical" mx={2} />
                 )}
-                <Chip
-                    size="xs"
-                    variant="light"
-                    color="green"
-                    checked={config.verifiedOnly === true}
-                    onChange={(checked) =>
-                        onChange({ ...config, verifiedOnly: checked })
-                    }
-                >
-                    Verified only
-                </Chip>
+                {source !== 'verified' && (
+                    <Chip
+                        size="xs"
+                        variant="light"
+                        color="green"
+                        checked={config.verifiedOnly === true}
+                        onChange={(checked) =>
+                            onChange({ ...config, verifiedOnly: checked })
+                        }
+                    >
+                        Verified only
+                    </Chip>
+                )}
             </Group>
         </Stack>
     );

--- a/packages/frontend/src/ee/features/homepageBuilder/collectionSources.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/collectionSources.test.ts
@@ -44,6 +44,7 @@ describe('collection source helpers', () => {
         expect(isPersonalCollectionSource('most-viewed')).toBe(false);
         expect(isPersonalCollectionSource('pinned')).toBe(false);
         expect(isPersonalCollectionSource('manual')).toBe(false);
+        expect(isPersonalCollectionSource('verified')).toBe(false);
     });
 });
 

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useCollectionSourceContent.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useCollectionSourceContent.ts
@@ -12,6 +12,7 @@ import {
     useMostPopularAndRecentlyUpdated,
     useProject,
 } from '../../../../hooks/useProject';
+import { useVerifiedContentForHomepage } from '../../../../hooks/useVerifiedContentList';
 import { useCollectionContent } from './useCollectionContent';
 import { useRecentContents } from './useRecentContents';
 
@@ -64,6 +65,9 @@ export const useCollectionSourceContent = (
     const recent = useRecentContents(
         source === 'recently-viewed' ? projectUuid : undefined,
     );
+    const verified = useVerifiedContentForHomepage(
+        source === 'verified' ? projectUuid : undefined,
+    );
 
     // The uuid-driven sources resolve to real content through one shared
     // endpoint, so their cards carry the same metadata manual ones do.
@@ -82,13 +86,15 @@ export const useCollectionSourceContent = (
             case 'favorites':
                 // Favourites are ResourceViewItems: the uuid is on `data`.
                 return (favorites.data ?? []).map((item) => item.data.uuid);
+            case 'verified':
+                return (verified.data ?? []).map((item) => item.uuid);
             case 'manual':
             case 'recently-viewed':
                 return [];
             default:
                 return assertUnreachable(source, 'Unknown collection source');
         }
-    }, [source, popular.data, pinned.data, favorites.data]);
+    }, [source, popular.data, pinned.data, favorites.data, verified.data]);
 
     const derived = useCollectionContent(projectUuid, derivedUuids);
 
@@ -108,9 +114,12 @@ export const useCollectionSourceContent = (
         const byType = typeFilter
             ? resolved.filter((content) => typeFilter.has(content.contentType))
             : resolved;
-        const filtered = config.verifiedOnly
-            ? byType.filter(isVerified)
-            : byType;
+        // `verified` source is already verified-only; verifiedOnly still applies
+        // as a modifier on every other source.
+        const filtered =
+            source !== 'verified' && config.verifiedOnly
+                ? byType.filter(isVerified)
+                : byType;
         return filtered.slice(0, limit);
     }, [resolved, source, config.contentTypes, config.verifiedOnly, limit]);
 
@@ -118,6 +127,7 @@ export const useCollectionSourceContent = (
         source === 'manual'
             ? manual.isInitialLoading
             : (source === 'recently-viewed' && recent.isLoading) ||
+              (source === 'verified' && verified.isInitialLoading) ||
               popular.isInitialLoading ||
               pinned.isInitialLoading ||
               favorites.isInitialLoading ||

--- a/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.test.ts
@@ -20,6 +20,7 @@ describe('buildStarterHomepage', () => {
             'quick-actions',
             'recent',
             'collection',
+            'collection',
         ]);
     });
 
@@ -28,6 +29,7 @@ describe('buildStarterHomepage', () => {
             'favorites',
             'ask-ai-hero',
             'recent',
+            'collection',
             'collection',
         ]);
     });
@@ -38,13 +40,28 @@ describe('buildStarterHomepage', () => {
             .flatMap((row) => row.blocks)
             .filter((block) => block.type === 'collection');
 
-        expect(collections).toHaveLength(1);
+        expect(collections).toHaveLength(2);
         expect(collections[0]).toMatchObject({
             config: {
                 title: 'Most popular',
                 source: 'most-viewed',
                 items: [],
             },
+        });
+    });
+
+    it('includes a verified collection by default', () => {
+        const config = buildStarterHomepage('content-first', []);
+        const verifiedCollection = config.rows
+            .flatMap((row) => row.blocks)
+            .find(
+                (block) =>
+                    block.type === 'collection' &&
+                    block.config.title === 'Verified',
+            );
+
+        expect(verifiedCollection).toMatchObject({
+            config: { title: 'Verified', source: 'verified', items: [] },
         });
     });
 

--- a/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/starterHomepage.ts
@@ -94,6 +94,18 @@ export const buildStarterHomepage = (
         }),
     );
 
+    rows.push(
+        row({
+            id: uuidv4(),
+            type: 'collection',
+            config: {
+                title: 'Verified',
+                source: 'verified',
+                items: [],
+            },
+        }),
+    );
+
     if (pinnedItems.length > 0) {
         rows.push(
             row({

--- a/packages/frontend/src/features/omnibar/api/search.ts
+++ b/packages/frontend/src/features/omnibar/api/search.ts
@@ -16,7 +16,12 @@ export const getSearchResults = async ({
 }) => {
     const sanitisedFilters = omitBy(filters, isNil);
     const params = new URLSearchParams({
-        ...(sanitisedFilters || {}),
+        ...Object.fromEntries(
+            Object.entries(sanitisedFilters).map(([key, value]) => [
+                key,
+                String(value),
+            ]),
+        ),
         source,
     });
 

--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -228,6 +228,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
         hasEnteredQuery && hasMinQueryLength(query);
     const hasActiveFilters = Boolean(
         searchFilters?.type ||
+        searchFilters?.verifiedOnly ||
         searchFilters?.fromDate ||
         searchFilters?.toDate ||
         searchFilters?.createdByUuid,
@@ -238,8 +239,11 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
             ? getSearchResultsGroupsSorted(searchResults)
             : [];
 
+        // Settings are client-side; hide them when a content type is selected
+        // or when Verified is on (settings aren't verifiable content).
         const showSettings =
             settingsItems.length > 0 &&
+            !searchFilters?.verifiedOnly &&
             (!searchFilters?.type ||
                 searchFilters.type === SearchItemType.SETTINGS);
 
@@ -260,7 +264,12 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
             totalCount: items.length,
             collapsed: false,
         }));
-    }, [searchResults, settingsItems, searchFilters?.type]);
+    }, [
+        searchResults,
+        settingsItems,
+        searchFilters?.type,
+        searchFilters?.verifiedOnly,
+    ]);
 
     const [collapsedGroupKeys, setCollapsedGroupKeys] = useState<string[]>([]);
 

--- a/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
@@ -13,6 +13,7 @@ import {
     IconCalendar,
     IconChartBar,
     IconChevronDown,
+    IconCircleCheck,
     IconCodeCircle,
     IconFolder,
     IconLayoutDashboard,
@@ -33,6 +34,8 @@ import { getDateFilterLabel } from '../utils/getDateFilterLabel';
 import { getSearchItemLabel } from '../utils/getSearchItemLabel';
 import classes from './OmnibarFilters.module.css';
 import { getOmnibarItemColor } from './utils';
+
+const VERIFIED_FILTER_COLOR = 'green.6';
 
 const getOmnibarItemIcon = (itemType: SearchItemType) => {
     switch (itemType) {
@@ -128,14 +131,23 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
         }
     }, [isCreatedByExpanded]);
 
+    const hasItemTypeFilter = !!filters?.type || filters?.verifiedOnly === true;
+
     const canClearFilters = useMemo(() => {
         return (
             filters?.type ||
+            filters?.verifiedOnly ||
             filters?.fromDate ||
             filters?.toDate ||
             filters?.createdByUuid
         );
     }, [filters]);
+
+    const itemTypeButtonLabel = filters?.verifiedOnly
+        ? 'Verified'
+        : filters?.type
+          ? getSearchItemLabel(filters.type as SearchItemType)
+          : 'Item type';
 
     const userOptions = useMemo(
         () =>
@@ -166,7 +178,13 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
                     <Button
                         size="compact-xs"
                         leftSection={
-                            filters?.type ? (
+                            filters?.verifiedOnly ? (
+                                <MantineIcon
+                                    icon={IconCircleCheck}
+                                    color={VERIFIED_FILTER_COLOR}
+                                    strokeWidth={1.5}
+                                />
+                            ) : filters?.type ? (
                                 <MantineIcon
                                     icon={getOmnibarItemIcon(
                                         filters.type as SearchItemType,
@@ -185,24 +203,50 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
                         }
                         rightSection={
                             <FilterRightSection
-                                isActive={!!filters?.type}
+                                isActive={hasItemTypeFilter}
                                 onClear={() =>
                                     onSearchFilterChange({
                                         ...filters,
                                         type: undefined,
+                                        verifiedOnly: undefined,
                                     })
                                 }
                             />
                         }
-                        {...getFilterButtonProps(!!filters?.type)}
+                        {...getFilterButtonProps(hasItemTypeFilter)}
                     >
-                        {filters?.type
-                            ? getSearchItemLabel(filters.type as SearchItemType)
-                            : 'Item type'}
+                        {itemTypeButtonLabel}
                     </Button>
                 </Menu.Target>
 
                 <Menu.Dropdown>
+                    <Menu.Item
+                        leftSection={
+                            <MantineIcon
+                                icon={IconCircleCheck}
+                                color={VERIFIED_FILTER_COLOR}
+                            />
+                        }
+                        bg={
+                            filters?.verifiedOnly === true
+                                ? 'ldGray.1'
+                                : undefined
+                        }
+                        onClick={() => {
+                            onSearchFilterChange({
+                                ...filters,
+                                // Verified is a cross-cutting attribute, not a
+                                // SearchItemType — clear type when selecting it.
+                                type: undefined,
+                                verifiedOnly:
+                                    filters?.verifiedOnly === true
+                                        ? undefined
+                                        : true,
+                            });
+                        }}
+                    >
+                        Verified
+                    </Menu.Item>
                     {allSearchItemTypes.map((type) => (
                         <Menu.Item
                             key={type}
@@ -216,6 +260,7 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
                             onClick={() => {
                                 onSearchFilterChange({
                                     ...filters,
+                                    verifiedOnly: undefined,
                                     type:
                                         type === filters?.type
                                             ? undefined

--- a/packages/frontend/src/features/omnibar/utils/verifiedFilter.test.ts
+++ b/packages/frontend/src/features/omnibar/utils/verifiedFilter.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+type SearchFilters = {
+    type?: string;
+    verifiedOnly?: boolean;
+};
+
+/**
+ * Mirrors how OmnibarFilters maps the Item type menu into SearchFilters when
+ * Verified is selected — Verified is not a SearchItemType.
+ */
+function applyItemTypeSelection(
+    filters: SearchFilters | undefined,
+    selection: { kind: 'verified' } | { kind: 'type'; type: string },
+): SearchFilters {
+    if (selection.kind === 'verified') {
+        return {
+            ...filters,
+            type: undefined,
+            verifiedOnly: filters?.verifiedOnly === true ? undefined : true,
+        };
+    }
+    return {
+        ...filters,
+        verifiedOnly: undefined,
+        type: selection.type === filters?.type ? undefined : selection.type,
+    };
+}
+
+describe('omnibar verified Item type filter', () => {
+    it('sets verifiedOnly and clears type when Verified is selected', () => {
+        expect(
+            applyItemTypeSelection({ type: 'dashboard' }, { kind: 'verified' }),
+        ).toEqual({ type: undefined, verifiedOnly: true });
+    });
+
+    it('clears verifiedOnly when selecting a concrete type', () => {
+        expect(
+            applyItemTypeSelection(
+                { verifiedOnly: true },
+                { kind: 'type', type: 'chart' },
+            ),
+        ).toEqual({ verifiedOnly: undefined, type: 'chart' });
+    });
+
+    it('toggles Verified off when selected again', () => {
+        expect(
+            applyItemTypeSelection(
+                { verifiedOnly: true },
+                { kind: 'verified' },
+            ),
+        ).toEqual({ type: undefined, verifiedOnly: undefined });
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: PROD-7367
Relates: #22574

### Description:

Adds Verified as a first-class filter and homepage section:

**Search (omnibar)**
- Adds `verifiedOnly` to `SearchFilters` and a **Verified** option in the Item type menu
- Threads the flag through the search API and `SearchModel` (server-side SQL)
- When selected, returns only verified charts/dashboards and empties non-verifiable types
- Hides client-side Settings results while Verified is active

**Homepage builder**
- Adds `'verified'` to `HomepageCollectionSource` + schema
- Wires `useVerifiedContentForHomepage` for the collection source
- Adds Verified to starter homepage and builder source options
- Leaves `config.verifiedOnly` modifier unchanged (hidden when source is already `verified`)

[Omnibar Verified filter](https://cursor.com/agents/bc-01a03a2d-0220-728f-9f4a-3e40c5e5ebc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fomnibar-verified-filter.webp)
[Homepage Verified section](https://cursor.com/agents/bc-01a03a2d-0220-728f-9f4a-3e40c5e5ebc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage-verified-section.webp)
[verified-filter-omnibar-and-homepage.mp4](https://cursor.com/agents/bc-01a03a2d-0220-728f-9f4a-3e40c5e5ebc1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverified-filter-omnibar-and-homepage.mp4)

### Risk assessment:

- [ ] This is a high-risk change


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03a2d-0220-728f-9f4a-3e40c5e5ebc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03a2d-0220-728f-9f4a-3e40c5e5ebc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

