### PR TITLE
fix(scim): accept group schema extensions

### DIFF
--- a/packages/backend/src/ee/controllers/scimGroupController.ts
+++ b/packages/backend/src/ee/controllers/scimGroupController.ts
@@ -1,5 +1,5 @@
 import {
-    ScimCreateGroup,
+    ScimCreateGroupRequest,
     ScimErrorPayload,
     ScimGroup,
     ScimListResponse,
@@ -146,7 +146,8 @@ export class ScimGroupController extends BaseController {
     @Post('/')
     async createScimGroup(
         @Request() req: express.Request,
-        @Body() body: ScimCreateGroup,
+        // Keep the existing shape as a union member so TSOA generates an additive anyOf.
+        @Body() body: ScimUpsertGroup | ScimCreateGroupRequest,
     ): Promise<ScimGroup> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
         return this.getScimService().createGroup(

--- a/packages/backend/src/ee/controllers/scimGroupController.ts
+++ b/packages/backend/src/ee/controllers/scimGroupController.ts
@@ -1,4 +1,5 @@
 import {
+    ScimCreateGroup,
     ScimErrorPayload,
     ScimGroup,
     ScimListResponse,
@@ -145,7 +146,7 @@ export class ScimGroupController extends BaseController {
     @Post('/')
     async createScimGroup(
         @Request() req: express.Request,
-        @Body() body: ScimUpsertGroup,
+        @Body() body: ScimCreateGroup,
     ): Promise<ScimGroup> {
         const organizationUuid = req.serviceAccount?.organizationUuid as string;
         return this.getScimService().createGroup(

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -1450,6 +1450,90 @@ describe('ScimService', () => {
         });
     });
 
+    describe('createGroup', () => {
+        const createdGroup: GroupWithMembers = {
+            uuid: 'group-uuid',
+            name: 'Data Platform',
+            createdAt: new Date('2024-01-01'),
+            createdByUserUuid: null,
+            updatedAt: new Date('2024-01-01'),
+            updatedByUserUuid: null,
+            organizationUuid: mockUser.organizationUuid,
+            members: [],
+            memberUuids: [],
+        };
+
+        test('should accept schema extensions alongside the core group schema', async () => {
+            const createGroup = vi.fn().mockResolvedValue(createdGroup);
+            const groupService = new ScimService({
+                ...ScimServiceArgumentsMock,
+                groupsModel: {
+                    find: vi.fn().mockResolvedValue({ data: [] }),
+                    createGroup,
+                } as never,
+            });
+
+            await expect(
+                groupService.createGroup(
+                    mockScimAccount,
+                    mockUser.organizationUuid,
+                    {
+                        schemas: [
+                            ScimSchemaType.GROUP,
+                            'urn:example:params:scim:schemas:extension:2.0:Group',
+                        ],
+                        displayName: createdGroup.name,
+                        members: [],
+                    },
+                ),
+            ).resolves.toMatchObject({
+                schemas: [ScimSchemaType.GROUP],
+                displayName: createdGroup.name,
+            });
+
+            expect(createGroup).toHaveBeenCalledOnce();
+        });
+
+        test.each([
+            { name: 'an empty array', schemas: [] },
+            {
+                name: 'an extension without the core group schema',
+                schemas: [
+                    'urn:example:params:scim:schemas:extension:2.0:Group',
+                ],
+            },
+        ])('should reject $name', async ({ schemas }) => {
+            const find = vi.fn();
+            const createGroup = vi.fn();
+            const groupService = new ScimService({
+                ...ScimServiceArgumentsMock,
+                groupsModel: {
+                    find,
+                    createGroup,
+                } as never,
+            });
+
+            await expect(
+                groupService.createGroup(
+                    mockScimAccount,
+                    mockUser.organizationUuid,
+                    {
+                        schemas,
+                        displayName: createdGroup.name,
+                        members: [],
+                    },
+                ),
+            ).rejects.toMatchObject({
+                detail: `schemas must include ${ScimSchemaType.GROUP}`,
+                status: '400',
+                scimType: 'invalidValue',
+            });
+
+            expect(find).not.toHaveBeenCalled();
+            expect(createGroup).not.toHaveBeenCalled();
+        });
+    });
+
     describe('group default user spaces', () => {
         const existingMember = {
             userUuid: 'existing-user-uuid',

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -18,6 +18,7 @@ import {
     ParameterError,
     ProjectType,
     Role,
+    ScimCreateGroup,
     ScimError,
     ScimGroup,
     ScimListResponse,
@@ -1471,7 +1472,7 @@ export class ScimService extends BaseService {
     async createGroup(
         account: Account,
         organizationUuid: string,
-        groupToCreate: ScimUpsertGroup,
+        groupToCreate: ScimCreateGroup,
     ): Promise<ScimGroup> {
         this.logger.info('SCIM: Creating group', {
             organizationUuid,
@@ -1497,6 +1498,13 @@ export class ScimService extends BaseService {
             if (!groupToCreate.displayName) {
                 throw new ScimError({
                     detail: 'displayName is required',
+                    status: 400,
+                    scimType: 'invalidValue',
+                });
+            }
+            if (!groupToCreate.schemas.includes(ScimSchemaType.GROUP)) {
+                throw new ScimError({
+                    detail: `schemas must include ${ScimSchemaType.GROUP}`,
                     status: 400,
                     scimType: 'invalidValue',
                 });

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -18,7 +18,7 @@ import {
     ParameterError,
     ProjectType,
     Role,
-    ScimCreateGroup,
+    ScimCreateGroupRequest,
     ScimError,
     ScimGroup,
     ScimListResponse,
@@ -1472,7 +1472,7 @@ export class ScimService extends BaseService {
     async createGroup(
         account: Account,
         organizationUuid: string,
-        groupToCreate: ScimCreateGroup,
+        groupToCreate: ScimCreateGroupRequest,
     ): Promise<ScimGroup> {
         this.logger.info('SCIM: Creating group', {
             organizationUuid,

--- a/packages/common/src/ee/scim/types.ts
+++ b/packages/common/src/ee/scim/types.ts
@@ -147,7 +147,7 @@ export interface ScimUpsertGroup {
     members?: ScimGroupMember[];
 }
 
-export interface ScimCreateGroup {
+export interface ScimCreateGroupRequest {
     schemas: string[];
     displayName: string;
     members?: ScimGroupMember[];

--- a/packages/common/src/ee/scim/types.ts
+++ b/packages/common/src/ee/scim/types.ts
@@ -147,6 +147,12 @@ export interface ScimUpsertGroup {
     members?: ScimGroupMember[];
 }
 
+export interface ScimCreateGroup {
+    schemas: string[];
+    displayName: string;
+    members?: ScimGroupMember[];
+}
+
 export type ScimUpsertUser = Omit<ScimUser, 'id'> & {
     password?: string; // optional for create
     title?: string; // okta sends this on create


### PR DESCRIPTION
Closes: [PROD-10586](https://linear.app/lightdash/issue/PROD-10586/scim-accept-schema-extensions-when-creating-groups)

### Description:

- Accept SCIM schema extension URNs when creating groups while still requiring the core Group schema.
- Preserve the existing create request schema as the first branch of an additive OpenAPI `anyOf`.
- Keep PUT group validation strict and preserve existing persistence and response behavior.
- Add service regression coverage for extension schemas, empty schemas, and extension-only schemas.

### Validation:

- Focused SCIM service suite: 82 tests passed.
- Common and backend typechecks passed.
- Backend API generation passed; generated artifacts are intentionally excluded.
- Pinned oasdiff v1.21.0 with `--fail-on ERR`: 0 errors and 3 non-blocking advisories.
- Focused Oxlint/Oxfmt checks and `git diff --check` passed.
- Authenticated localhost validation passed for core plus extension, core-only, missing core, missing required fields, and malformed members.
- Both temporary groups were deleted and the disposable SCIM token was revoked and verified with a 401 response.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: the POST input schema is broadened additively, valid existing payloads remain accepted, PUT behavior is unchanged, and invalid payloads without the required core schema are rejected before persistence.