### PR TITLE
fix(frontend): show dashboard action for editors

### DIFF
--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -312,6 +312,15 @@ describe('Editor can create content', () => {
         cy.loginAsEditor();
     });
 
+    it('can create a dashboard from the global New menu', () => {
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/home`);
+
+        cy.get('[data-testid="ExploreMenu/NewButton"]').click();
+        cy.get('[data-testid="ExploreMenu/NewDashboardButton"]').should(
+            'be.visible',
+        );
+    });
+
     it('can create a new space', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/spaces`);
         // Parent Space 1/Child Space 1.1

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -13,6 +13,7 @@ import {
 import { memo, useState, type FC } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router';
 import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
+import useCreateInAnySpaceAccess from '../../hooks/user/useCreateInAnySpaceAccess';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../providers/Ability';
 import useApp from '../../providers/App/useApp';
@@ -44,6 +45,11 @@ const ExploreMenu: FC<Props> = memo((props) => {
     const [isOpen, setIsOpen] = useState(false);
     const [isCreateSpaceOpen, setIsCreateSpaceOpen] = useState(false);
     const [isCreateDashboardOpen, setIsCreateDashboardOpen] = useState(false);
+    const userCanCreateDashboards = useCreateInAnySpaceAccess(
+        projectUuid,
+        'Dashboard',
+        { enabled: isOpen },
+    );
 
     return (
         <>
@@ -60,6 +66,8 @@ const ExploreMenu: FC<Props> = memo((props) => {
                     position="bottom-start"
                     arrowOffset={16}
                     offset={-2}
+                    opened={isOpen}
+                    onChange={setIsOpen}
                     zIndex={getDefaultZIndex('max')}
                     portalProps={{ target: '#navbar-header' }}
                 >
@@ -74,7 +82,6 @@ const ExploreMenu: FC<Props> = memo((props) => {
                                     icon={IconSquareRoundedPlus}
                                 />
                             }
-                            onClick={() => setIsOpen(!isOpen)}
                             data-testid="ExploreMenu/NewButton"
                         >
                             New
@@ -120,13 +127,7 @@ const ExploreMenu: FC<Props> = memo((props) => {
                                 icon={IconTerminal2}
                             />
                         </Can>
-                        <Can
-                            I="create"
-                            this={subject('Dashboard', {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid,
-                            })}
-                        >
+                        {userCanCreateDashboards && (
                             <LargeMenuItem
                                 title="Dashboard"
                                 description="Arrange multiple charts into a single view."
@@ -134,7 +135,7 @@ const ExploreMenu: FC<Props> = memo((props) => {
                                 icon={IconLayoutDashboard}
                                 data-testid="ExploreMenu/NewDashboardButton"
                             />
-                        </Can>
+                        )}
 
                         {dataAppsFlag.data?.enabled && (
                             <Can


### PR DESCRIPTION
## Summary

- show the global Dashboard action when a user can create dashboards in at least one accessible space
- lazily load space access when the global New menu opens
- add focused editor regression coverage to the existing space E2E suite

## Reproduction

As the seeded Editor User, the project home global **New** menu omitted **Dashboard**, while the same user could create a dashboard from the editable **Shared** space.

## Validation

- `pnpm -F frontend exec oxfmt src/components/NavBar/ExploreMenu.tsx --check`
- `pnpm -F frontend linter ./src/components/NavBar/ExploreMenu.tsx`
- `pnpm -F frontend typecheck`
- `pnpm -F e2e exec oxfmt cypress/e2e/app/space.cy.ts --check`
- `pnpm -F e2e linter ./cypress/e2e/app/space.cy.ts`
- `git diff --check`
- live browser verification on localhost: Dashboard appears in the editor global New menu, opens the creation modal, and offers Shared as the destination; creation was canceled without writing data

Closes PROD-8883