### PR TITLE
feat: render data app content links

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -72,7 +72,7 @@ import {
     MessageSourcesToggle,
 } from './MessageMemorySources';
 import { MessageModelIndicator } from './MessageModelIndicator';
-import { rehypeAiAgentContentLinks } from './rehypeContentLinks';
+import { isContentType, rehypeAiAgentContentLinks } from './rehypeContentLinks';
 import { rehypeMemoryCitationIndices } from './rehypeMemoryCitations';
 import { StreamRecoveryAlert } from './StreamRecoveryAlert';
 import { AiEditDbtProjectToolCall } from './ToolCalls/AiEditDbtProjectToolCall';
@@ -672,8 +672,9 @@ const AssistantBubbleContent: FC<{
                                 a: ({ node, children, ...props }) => {
                                     const contentType =
                                         'data-content-type' in props &&
-                                        typeof props['data-content-type'] ===
-                                            'string'
+                                        isContentType(
+                                            props['data-content-type'],
+                                        )
                                             ? props['data-content-type']
                                             : undefined;
                                     return (
@@ -865,9 +866,9 @@ const AssistantBubbleContent: FC<{
                                     a: ({ node, children, ...props }) => {
                                         const contentType =
                                             'data-content-type' in props &&
-                                            typeof props[
-                                                'data-content-type'
-                                            ] === 'string'
+                                            isContentType(
+                                                props['data-content-type'],
+                                            )
                                                 ? props['data-content-type']
                                                 : undefined;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -1,4 +1,8 @@
-import { ChartKind, type AiAgentMessageAssistant } from '@lightdash/common';
+import {
+    assertUnreachable,
+    ChartKind,
+    type AiAgentMessageAssistant,
+} from '@lightdash/common';
 import { Anchor, Button, Text } from '@mantine/core';
 import {
     IconChartBar,
@@ -15,14 +19,21 @@ import {
 } from '../../store/hooks';
 import styles from './ContentLink.module.css';
 import { ContentReferenceLink } from './ContentReferenceLink';
+import { type ContentType } from './rehypeContentLinks';
 
 export type SqlRunnerLinkState = {
     sql: string;
     limit?: number;
 };
 
+const REFERENCE_LINK_KINDS = {
+    'dashboard-link': 'dashboard',
+    'data-app-link': 'data_app',
+    'scheduled-delivery-link': 'scheduled_delivery',
+} as const;
+
 type ContentLinkProps = {
-    contentType: string | undefined;
+    contentType: ContentType | undefined;
     props: Record<string, unknown>;
     children: ReactNode;
     message: AiAgentMessageAssistant;
@@ -86,12 +97,19 @@ export const ContentLink: FC<ContentLinkProps> = ({
         }
     };
 
+    if (contentType === undefined) {
+        return <a {...props}>{children}</a>;
+    }
+
     switch (contentType) {
         case 'dashboard-link':
+        // Resource view URL with ?scheduler_uuid — navigating opens that
+        // delivery's edit modal on the chart/dashboard page.
+        case 'scheduled-delivery-link':
             return (
                 <ContentReferenceLink
                     to={resourceHref || undefined}
-                    kind="dashboard"
+                    kind={REFERENCE_LINK_KINDS[contentType]}
                     onClick={handleResourceClick}
                     title={title}
                 >
@@ -100,25 +118,14 @@ export const ContentLink: FC<ContentLinkProps> = ({
             );
 
         case 'data-app-link':
+            // Apps are full-page experiences — open in a new tab so the chat
+            // thread stays put.
             return (
                 <ContentReferenceLink
                     to={resourceHref || undefined}
-                    kind="data_app"
-                    onClick={handleResourceClick}
-                    title={title}
-                >
-                    {children}
-                </ContentReferenceLink>
-            );
-
-        // Resource view URL with ?scheduler_uuid — navigating opens that
-        // delivery's edit modal on the chart/dashboard page.
-        case 'scheduled-delivery-link':
-            return (
-                <ContentReferenceLink
-                    to={resourceHref || undefined}
-                    kind="scheduled_delivery"
-                    onClick={handleResourceClick}
+                    kind={REFERENCE_LINK_KINDS[contentType]}
+                    target="_blank"
+                    rel="noreferrer"
                     title={title}
                 >
                     {children}
@@ -328,6 +335,9 @@ export const ContentLink: FC<ContentLinkProps> = ({
         }
 
         default:
-            return <a {...props}>{children}</a>;
+            return assertUnreachable(
+                contentType,
+                `Unknown content type: ${contentType}`,
+            );
     }
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -44,7 +44,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
 }) => {
     const navigate = useNavigate();
     const location = useLocation();
-    const dashboardHref = typeof props.href === 'string' ? props.href : '';
+    const resourceHref = typeof props.href === 'string' ? props.href : '';
     const title = typeof props.title === 'string' ? props.title : undefined;
     const dispatch = useAiAgentStoreDispatch();
     const currentArtifact = useAiAgentStoreSelector(
@@ -54,9 +54,9 @@ export const ContentLink: FC<ContentLinkProps> = ({
         (state) => state.aiArtifact.savedChart,
     );
 
-    const handleDashboardClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    const handleResourceClick = (e: MouseEvent<HTMLAnchorElement>) => {
         if (
-            !dashboardHref ||
+            !resourceHref ||
             e.defaultPrevented ||
             e.button !== 0 ||
             e.metaKey ||
@@ -73,7 +73,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
             pathname: location.pathname,
             search: location.search,
         });
-        const targetUrl = new URL(dashboardHref, window.location.origin);
+        const targetUrl = new URL(resourceHref, window.location.origin);
         const targetPath = createPath({
             pathname: targetUrl.pathname,
             search: targetUrl.search,
@@ -90,9 +90,21 @@ export const ContentLink: FC<ContentLinkProps> = ({
         case 'dashboard-link':
             return (
                 <ContentReferenceLink
-                    to={dashboardHref || undefined}
+                    to={resourceHref || undefined}
                     kind="dashboard"
-                    onClick={handleDashboardClick}
+                    onClick={handleResourceClick}
+                    title={title}
+                >
+                    {children}
+                </ContentReferenceLink>
+            );
+
+        case 'data-app-link':
+            return (
+                <ContentReferenceLink
+                    to={resourceHref || undefined}
+                    kind="data_app"
+                    onClick={handleResourceClick}
                     title={title}
                 >
                     {children}
@@ -104,9 +116,9 @@ export const ContentLink: FC<ContentLinkProps> = ({
         case 'scheduled-delivery-link':
             return (
                 <ContentReferenceLink
-                    to={dashboardHref || undefined}
+                    to={resourceHref || undefined}
                     kind="scheduled_delivery"
-                    onClick={handleDashboardClick}
+                    onClick={handleResourceClick}
                     title={title}
                 >
                     {children}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
@@ -2,6 +2,7 @@ import { ChartKind } from '@lightdash/common';
 import { Anchor, Box, Text, type AnchorProps } from '@mantine/core';
 import {
     IconArrowRight,
+    IconAppWindow,
     IconBrandGithub,
     IconChartBar,
     IconFile,
@@ -25,6 +26,7 @@ type ContentReferenceKind =
     | 'artifact'
     | 'chart'
     | 'dashboard'
+    | 'data_app'
     | 'thread'
     | 'file'
     | 'repository'
@@ -63,6 +65,12 @@ const getIconMeta = ({
                 color: 'green.7',
                 fill: 'green.6',
                 icon: IconLayoutDashboard,
+            };
+        case 'data_app':
+            return {
+                color: 'orange.7',
+                fill: 'orange.6',
+                icon: IconAppWindow,
             };
         case 'artifact':
             return {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.test.ts
@@ -103,15 +103,15 @@ describe('rehypeAiAgentContentLinks', () => {
         });
     });
 
-    it('marks data app scheduled delivery deep-links instead of data app links', () => {
+    it('keeps data app links classified as data app links despite a scheduler_uuid param', () => {
         expect(
             processHref(
                 '/projects/project-uuid/apps/app-uuid/view?scheduler_uuid=scheduler-uuid',
             ),
         ).toMatchObject({
             href: '/projects/project-uuid/apps/app-uuid/view?scheduler_uuid=scheduler-uuid',
-            'data-content-type': 'scheduled-delivery-link',
-            'data-scheduler-uuid': 'scheduler-uuid',
+            'data-content-type': 'data-app-link',
+            'data-app-uuid': 'app-uuid',
         });
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.test.ts
@@ -44,6 +44,16 @@ describe('rehypeAiAgentContentLinks', () => {
         });
     });
 
+    it('marks canonical data app links', () => {
+        expect(
+            processHref('/projects/project-uuid/apps/app-uuid/view'),
+        ).toMatchObject({
+            href: '/projects/project-uuid/apps/app-uuid/view',
+            'data-content-type': 'data-app-link',
+            'data-app-uuid': 'app-uuid',
+        });
+    });
+
     it('marks explicit saved chart reference links', () => {
         expect(
             processHref(
@@ -88,6 +98,18 @@ describe('rehypeAiAgentContentLinks', () => {
             ),
         ).toMatchObject({
             href: '/projects/project-uuid/dashboards/dashboard-uuid/view?scheduler_uuid=scheduler-uuid',
+            'data-content-type': 'scheduled-delivery-link',
+            'data-scheduler-uuid': 'scheduler-uuid',
+        });
+    });
+
+    it('marks data app scheduled delivery deep-links instead of data app links', () => {
+        expect(
+            processHref(
+                '/projects/project-uuid/apps/app-uuid/view?scheduler_uuid=scheduler-uuid',
+            ),
+        ).toMatchObject({
+            href: '/projects/project-uuid/apps/app-uuid/view?scheduler_uuid=scheduler-uuid',
             'data-content-type': 'scheduled-delivery-link',
             'data-scheduler-uuid': 'scheduler-uuid',
         });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.ts
@@ -1,14 +1,20 @@
 import { type Element, type Root } from 'hast';
 import { visit } from 'unist-util-visit';
 
-type ContentType =
-    | 'dashboard-link'
-    | 'chart-link'
-    | 'data-app-link'
-    | 'artifact-link'
-    | 'sql-runner-link'
-    | 'settings-link'
-    | 'scheduled-delivery-link';
+const CONTENT_TYPES = [
+    'dashboard-link',
+    'chart-link',
+    'data-app-link',
+    'artifact-link',
+    'sql-runner-link',
+    'settings-link',
+    'scheduled-delivery-link',
+] as const;
+
+export type ContentType = (typeof CONTENT_TYPES)[number];
+
+export const isContentType = (value: unknown): value is ContentType =>
+    typeof value === 'string' && CONTENT_TYPES.includes(value as ContentType);
 
 interface LinkProcessor {
     fragment: string;
@@ -71,75 +77,85 @@ const LINK_PROCESSORS: LinkProcessor[] = [
     },
 ];
 
+interface UrlMatcher {
+    pattern: RegExp;
+    contentType: ContentType;
+    // Whether the backend emits ?scheduler_uuid deep-links for this resource
+    // (only dashboard/chart view pages open the delivery's edit modal).
+    schedulable: boolean;
+    extractData: (match: RegExpMatchArray) => Record<string, string>;
+}
+
+const URL_MATCHERS: UrlMatcher[] = [
+    {
+        pattern: /\/projects\/[^/]+\/dashboards\/([^/]+)\/view/,
+        contentType: 'dashboard-link',
+        schedulable: true,
+        extractData: (match) => ({ 'data-dashboard-uuid': match[1] }),
+    },
+    {
+        pattern: /\/projects\/[^/]+\/saved\/([^/]+)\/view/,
+        contentType: 'chart-link',
+        schedulable: true,
+        extractData: (match) => ({
+            'data-chart-uuid': match[1],
+            'data-chart-source': 'saved-chart',
+        }),
+    },
+    {
+        pattern: /\/projects\/[^/]+\/apps\/([^/]+)\/view/,
+        contentType: 'data-app-link',
+        schedulable: false,
+        extractData: (match) => ({ 'data-app-uuid': match[1] }),
+    },
+    {
+        pattern: /\/projects\/[^/]+\/sql-runner\/([^/#?]+)/,
+        contentType: 'chart-link',
+        schedulable: false,
+        extractData: (match) => ({
+            'data-chart-uuid': match[1],
+            'data-chart-source': 'sql-runner',
+        }),
+    },
+    // Settings deep-links the agent emits (e.g. the "link your personal
+    // GitHub" nudge → /generalSettings/profile). Captured as a same-origin
+    // relative path so the click can route client-side instead of reloading.
+    {
+        pattern: /\/generalSettings\/[^\s)]*/,
+        contentType: 'settings-link',
+        schedulable: false,
+        extractData: (match) => ({ 'data-settings-path': match[0] }),
+    },
+];
+
 const processLink = (node: Element, href: string): void => {
     const processor = LINK_PROCESSORS.find((p) => href.includes(p.fragment));
     if (!processor) {
-        // Checked before the dashboard/chart matches: a scheduled delivery
-        // deep link is a resource view URL plus ?scheduler_uuid, so it would
-        // otherwise be misclassified as a chart/dashboard link and open the
-        // chart preview instead of the delivery's edit modal.
-        const schedulerMatch = href.match(/[?&]scheduler_uuid=([^&#]+)/);
-        const dashboardMatch = href.match(
-            /\/projects\/[^/]+\/dashboards\/([^/]+)\/view/,
-        );
-        const chartMatch = href.match(
-            /\/projects\/[^/]+\/saved\/([^/]+)\/view/,
-        );
-        const dataAppMatch = href.match(
-            /\/projects\/[^/]+\/apps\/([^/]+)\/view/,
-        );
-        const sqlRunnerMatch = href.match(
-            /\/projects\/[^/]+\/sql-runner\/([^/#?]+)/,
-        );
-        // Settings deep-links the agent emits (e.g. the "link your personal
-        // GitHub" nudge → /generalSettings/profile). Captured as a same-origin
-        // relative path so the click can route client-side instead of reloading.
-        const settingsMatch = href.match(/\/generalSettings\/[^\s)]*/);
+        for (const matcher of URL_MATCHERS) {
+            const match = href.match(matcher.pattern);
+            if (!match) continue;
 
-        if (schedulerMatch && (dashboardMatch || chartMatch || dataAppMatch)) {
-            node.properties = {
-                ...node.properties,
-                'data-content-type': 'scheduled-delivery-link',
-                'data-scheduler-uuid': schedulerMatch[1],
-                href,
-            };
-        } else if (dashboardMatch) {
-            node.properties = {
-                ...node.properties,
-                'data-content-type': 'dashboard-link',
-                'data-dashboard-uuid': dashboardMatch[1],
-                href,
-            };
-        } else if (chartMatch) {
-            node.properties = {
-                ...node.properties,
-                'data-content-type': 'chart-link',
-                'data-chart-uuid': chartMatch[1],
-                'data-chart-source': 'saved-chart',
-                href,
-            };
-        } else if (dataAppMatch) {
-            node.properties = {
-                ...node.properties,
-                'data-content-type': 'data-app-link',
-                'data-app-uuid': dataAppMatch[1],
-                href,
-            };
-        } else if (sqlRunnerMatch) {
-            node.properties = {
-                ...node.properties,
-                'data-content-type': 'chart-link',
-                'data-chart-uuid': sqlRunnerMatch[1],
-                'data-chart-source': 'sql-runner',
-                href,
-            };
-        } else if (settingsMatch) {
-            node.properties = {
-                ...node.properties,
-                'data-content-type': 'settings-link',
-                'data-settings-path': settingsMatch[0],
-                href,
-            };
+            // A schedulable resource view URL plus ?scheduler_uuid is a
+            // scheduled delivery deep link; classify it as such so the click
+            // opens the delivery's edit modal instead of the resource preview.
+            const schedulerMatch = matcher.schedulable
+                ? href.match(/[?&]scheduler_uuid=([^&#]+)/)
+                : null;
+
+            node.properties = schedulerMatch
+                ? {
+                      ...node.properties,
+                      'data-content-type': 'scheduled-delivery-link',
+                      'data-scheduler-uuid': schedulerMatch[1],
+                      href,
+                  }
+                : {
+                      ...node.properties,
+                      'data-content-type': matcher.contentType,
+                      ...matcher.extractData(match),
+                      href,
+                  };
+            return;
         }
 
         return;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.ts
@@ -4,6 +4,7 @@ import { visit } from 'unist-util-visit';
 type ContentType =
     | 'dashboard-link'
     | 'chart-link'
+    | 'data-app-link'
     | 'artifact-link'
     | 'sql-runner-link'
     | 'settings-link'
@@ -84,6 +85,9 @@ const processLink = (node: Element, href: string): void => {
         const chartMatch = href.match(
             /\/projects\/[^/]+\/saved\/([^/]+)\/view/,
         );
+        const dataAppMatch = href.match(
+            /\/projects\/[^/]+\/apps\/([^/]+)\/view/,
+        );
         const sqlRunnerMatch = href.match(
             /\/projects\/[^/]+\/sql-runner\/([^/#?]+)/,
         );
@@ -92,7 +96,7 @@ const processLink = (node: Element, href: string): void => {
         // relative path so the click can route client-side instead of reloading.
         const settingsMatch = href.match(/\/generalSettings\/[^\s)]*/);
 
-        if (schedulerMatch && (dashboardMatch || chartMatch)) {
+        if (schedulerMatch && (dashboardMatch || chartMatch || dataAppMatch)) {
             node.properties = {
                 ...node.properties,
                 'data-content-type': 'scheduled-delivery-link',
@@ -112,6 +116,13 @@ const processLink = (node: Element, href: string): void => {
                 'data-content-type': 'chart-link',
                 'data-chart-uuid': chartMatch[1],
                 'data-chart-source': 'saved-chart',
+                href,
+            };
+        } else if (dataAppMatch) {
+            node.properties = {
+                ...node.properties,
+                'data-content-type': 'data-app-link',
+                'data-app-uuid': dataAppMatch[1],
                 href,
             };
         } else if (sqlRunnerMatch) {


### PR DESCRIPTION
## Summary

- render canonical Data App URLs with the existing content-reference chip
- use the established orange Data App icon
- preserve scheduled-delivery link handling

## Testing

- frontend typecheck
- focused link processor tests
- frontend lint and format checks
- local visual verification

Closes: https://linear.app/lightdash/issue/ZAP-943/extend-findcontent-to-include-data-apps