### PR TITLE
feat: restore unsaved chart edits after app-initiated reloads

### DIFF
--- a/packages/frontend/src/components/VersionAutoUpdater/VersionAutoUpdater.tsx
+++ b/packages/frontend/src/components/VersionAutoUpdater/VersionAutoUpdater.tsx
@@ -1,5 +1,6 @@
 import { IconReload } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
+import { markAppInitiatedReload } from '../../features/appReload/appInitiatedReload';
 import useHealth from '../../hooks/health/useHealth';
 import useToaster from '../../hooks/toaster/useToaster';
 
@@ -22,7 +23,10 @@ const VersionAutoUpdater: FC = () => {
                     action: {
                         children: 'Use new version',
                         icon: IconReload,
-                        onClick: () => window.location.reload(),
+                        onClick: () => {
+                            markAppInitiatedReload();
+                            window.location.reload();
+                        },
                     },
                 });
             }

--- a/packages/frontend/src/features/appReload/appInitiatedReload.test.ts
+++ b/packages/frontend/src/features/appReload/appInitiatedReload.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const APP_INITIATED_RELOAD_KEY = 'lightdash-app-initiated-reload';
+
+const importModule = async () => import('./appInitiatedReload');
+
+describe('appInitiatedReload', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        sessionStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns false when no marker was set', async () => {
+        const { wasAppInitiatedReload } = await importModule();
+        expect(wasAppInitiatedReload()).toBe(false);
+    });
+
+    it('returns true after marking, consumes the marker, and caches the result', async () => {
+        const { markAppInitiatedReload, wasAppInitiatedReload } =
+            await importModule();
+
+        markAppInitiatedReload();
+        expect(sessionStorage.getItem(APP_INITIATED_RELOAD_KEY)).not.toBeNull();
+
+        expect(wasAppInitiatedReload()).toBe(true);
+        expect(sessionStorage.getItem(APP_INITIATED_RELOAD_KEY)).toBeNull();
+
+        // Cached for repeat callers within the same page load
+        expect(wasAppInitiatedReload()).toBe(true);
+    });
+
+    it('returns false when the marker is stale', async () => {
+        vi.useFakeTimers();
+        const { markAppInitiatedReload, wasAppInitiatedReload } =
+            await importModule();
+
+        markAppInitiatedReload();
+        vi.advanceTimersByTime(61_000);
+
+        expect(wasAppInitiatedReload()).toBe(false);
+    });
+
+    it('returns false for a garbage marker value', async () => {
+        sessionStorage.setItem(APP_INITIATED_RELOAD_KEY, 'not-a-timestamp');
+        const { wasAppInitiatedReload } = await importModule();
+        expect(wasAppInitiatedReload()).toBe(false);
+    });
+});

--- a/packages/frontend/src/features/appReload/appInitiatedReload.ts
+++ b/packages/frontend/src/features/appReload/appInitiatedReload.ts
@@ -1,0 +1,40 @@
+const APP_INITIATED_RELOAD_KEY = 'lightdash-app-initiated-reload';
+const MAX_AGE_MS = 60_000;
+
+// Cached so every caller in a page lifetime sees the same consumed value.
+let consumedResult: boolean | null = null;
+
+/**
+ * Record that the app itself is about to force a page reload (new deploy,
+ * chunk load error, build skew) so post-reload code can tell it apart from
+ * a user-initiated refresh.
+ */
+export const markAppInitiatedReload = (): void => {
+    try {
+        sessionStorage.setItem(APP_INITIATED_RELOAD_KEY, Date.now().toString());
+    } catch {
+        // Storage unavailable; post-reload restore just won't trigger.
+    }
+};
+
+/**
+ * Whether this page load was caused by an app-initiated reload. Consumes the
+ * marker on first call and caches the result for the rest of the page load.
+ */
+export const wasAppInitiatedReload = (): boolean => {
+    if (consumedResult !== null) {
+        return consumedResult;
+    }
+
+    try {
+        const raw = sessionStorage.getItem(APP_INITIATED_RELOAD_KEY);
+        sessionStorage.removeItem(APP_INITIATED_RELOAD_KEY);
+        const markedAt = raw === null ? NaN : parseInt(raw, 10);
+        consumedResult =
+            Number.isFinite(markedAt) && Date.now() - markedAt <= MAX_AGE_MS;
+    } catch {
+        consumedResult = false;
+    }
+
+    return consumedResult;
+};

--- a/packages/frontend/src/features/buildHashHandshake/buildHashHandshake.ts
+++ b/packages/frontend/src/features/buildHashHandshake/buildHashHandshake.ts
@@ -1,4 +1,5 @@
 import { LightdashBuildHashHeader } from '@lightdash/common';
+import { markAppInitiatedReload } from '../appReload/appInitiatedReload';
 
 const BUILD_HASH_META_NAME = 'lightdash-build-hash';
 const SKEW_RELOAD_KEY = 'lightdash-build-skew-reload';
@@ -120,6 +121,7 @@ export const refreshForBuildSkew = (): boolean => {
         return false;
     }
 
+    markAppInitiatedReload();
     window.location.reload();
     return true;
 };

--- a/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.ts
@@ -1,3 +1,5 @@
+import { markAppInitiatedReload } from '../appReload/appInitiatedReload';
+
 const CHUNK_ERROR_RELOAD_KEY = 'lightdash-chunk-error-reload';
 const RELOAD_COOLDOWN_MS = 60_000; // 60 seconds before allowing another auto-reload
 
@@ -77,6 +79,7 @@ export const triggerChunkErrorReload = (): void => {
         // sessionStorage may throw in private browsing or when storage is disabled.
         // Proceed with reload anyway - worst case user sees manual refresh UI.
     }
+    markAppInitiatedReload();
     window.location.reload();
 };
 

--- a/packages/frontend/src/features/explorer/draftPersistence.test.ts
+++ b/packages/frontend/src/features/explorer/draftPersistence.test.ts
@@ -1,0 +1,108 @@
+import { ChartType, type CreateSavedChartVersion } from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { wasAppInitiatedReload } from '../appReload/appInitiatedReload';
+import {
+    chartVersionStamp,
+    clearExplorerDraft,
+    persistExplorerDraft,
+    readRestorableExplorerDraft,
+} from './draftPersistence';
+
+vi.mock('../appReload/appInitiatedReload', () => ({
+    wasAppInitiatedReload: vi.fn(),
+}));
+
+const wasAppInitiatedReloadMock = vi.mocked(wasAppInitiatedReload);
+
+const CHART_UUID = 'chart-uuid-1';
+const UPDATED_AT = new Date('2026-08-01T10:00:00.000Z');
+
+const draft: CreateSavedChartVersion = {
+    tableName: 'orders',
+    metricQuery: {
+        exploreName: 'orders',
+        dimensions: ['orders_status'],
+        metrics: ['orders_total'],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+    },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: { layout: {}, eChartsConfig: {} },
+    },
+    tableConfig: { columnOrder: [] },
+};
+
+const savedChart = {
+    uuid: CHART_UUID,
+    updatedAt: UPDATED_AT,
+    tableName: 'orders',
+};
+
+describe('draftPersistence', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+        wasAppInitiatedReloadMock.mockReturnValue(true);
+    });
+
+    it('restores a persisted draft after an app-initiated reload', () => {
+        persistExplorerDraft(CHART_UUID, chartVersionStamp(UPDATED_AT), draft);
+
+        expect(readRestorableExplorerDraft(savedChart)).toEqual(draft);
+    });
+
+    it('does not restore after a user-initiated reload', () => {
+        wasAppInitiatedReloadMock.mockReturnValue(false);
+        persistExplorerDraft(CHART_UUID, chartVersionStamp(UPDATED_AT), draft);
+
+        expect(readRestorableExplorerDraft(savedChart)).toBeNull();
+    });
+
+    it('drops the draft when the chart was saved elsewhere since the snapshot', () => {
+        persistExplorerDraft(CHART_UUID, chartVersionStamp(UPDATED_AT), draft);
+
+        const newerChart = {
+            ...savedChart,
+            updatedAt: new Date('2026-08-02T10:00:00.000Z'),
+        };
+        expect(readRestorableExplorerDraft(newerChart)).toBeNull();
+
+        // The stale snapshot is cleared, so even the original version cannot restore it
+        expect(readRestorableExplorerDraft(savedChart)).toBeNull();
+    });
+
+    it('drops the draft when the chart points at a different table', () => {
+        persistExplorerDraft(CHART_UUID, chartVersionStamp(UPDATED_AT), draft);
+
+        expect(
+            readRestorableExplorerDraft({
+                ...savedChart,
+                tableName: 'customers',
+            }),
+        ).toBeNull();
+    });
+
+    it('ignores corrupted snapshots', () => {
+        sessionStorage.setItem(
+            `lightdash-explorer-draft:${CHART_UUID}`,
+            'not-json',
+        );
+
+        expect(readRestorableExplorerDraft(savedChart)).toBeNull();
+    });
+
+    it('clears a draft', () => {
+        persistExplorerDraft(CHART_UUID, chartVersionStamp(UPDATED_AT), draft);
+        clearExplorerDraft(CHART_UUID);
+
+        expect(readRestorableExplorerDraft(savedChart)).toBeNull();
+    });
+
+    it('stamps chart versions identically for Date and string inputs', () => {
+        expect(chartVersionStamp(UPDATED_AT)).toEqual(
+            chartVersionStamp('2026-08-01T10:00:00.000Z'),
+        );
+    });
+});

--- a/packages/frontend/src/features/explorer/draftPersistence.ts
+++ b/packages/frontend/src/features/explorer/draftPersistence.ts
@@ -1,0 +1,96 @@
+import { type CreateSavedChartVersion } from '@lightdash/common';
+import { wasAppInitiatedReload } from '../appReload/appInitiatedReload';
+
+const DRAFT_KEY_PREFIX = 'lightdash-explorer-draft';
+
+type ExplorerDraftSnapshot = {
+    draft: CreateSavedChartVersion;
+    chartUpdatedAt: string;
+};
+
+const draftKey = (chartUuid: string) => `${DRAFT_KEY_PREFIX}:${chartUuid}`;
+
+/** Stable stamp of a chart's server version, used to detect concurrent saves. */
+export const chartVersionStamp = (updatedAt: Date | string): string =>
+    String(new Date(updatedAt).getTime());
+
+export const persistExplorerDraft = (
+    chartUuid: string,
+    chartUpdatedAt: string,
+    draft: CreateSavedChartVersion,
+): void => {
+    try {
+        const snapshot: ExplorerDraftSnapshot = { draft, chartUpdatedAt };
+        sessionStorage.setItem(draftKey(chartUuid), JSON.stringify(snapshot));
+    } catch {
+        // Storage full or unavailable; the draft just won't survive a reload.
+    }
+};
+
+export const clearExplorerDraft = (chartUuid: string): void => {
+    try {
+        sessionStorage.removeItem(draftKey(chartUuid));
+    } catch {
+        // Storage unavailable; nothing to clear.
+    }
+};
+
+const readExplorerDraft = (chartUuid: string): ExplorerDraftSnapshot | null => {
+    try {
+        const raw = sessionStorage.getItem(draftKey(chartUuid));
+        if (raw === null) {
+            return null;
+        }
+
+        const parsed: unknown = JSON.parse(raw);
+        if (typeof parsed !== 'object' || parsed === null) {
+            return null;
+        }
+
+        const { draft, chartUpdatedAt } =
+            parsed as Partial<ExplorerDraftSnapshot>;
+        if (
+            typeof chartUpdatedAt !== 'string' ||
+            typeof draft !== 'object' ||
+            draft === null ||
+            typeof draft.tableName !== 'string' ||
+            typeof draft.metricQuery !== 'object'
+        ) {
+            return null;
+        }
+
+        return { draft, chartUpdatedAt };
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * Return a draft worth restoring for this chart, or null. Restores only after
+ * an app-initiated reload, and only when the chart hasn't been saved elsewhere
+ * since the draft was taken.
+ */
+export const readRestorableExplorerDraft = (savedChart: {
+    uuid: string;
+    updatedAt: Date | string;
+    tableName: string;
+}): CreateSavedChartVersion | null => {
+    const snapshot = readExplorerDraft(savedChart.uuid);
+    if (!snapshot) {
+        return null;
+    }
+
+    if (
+        snapshot.chartUpdatedAt !== chartVersionStamp(savedChart.updatedAt) ||
+        snapshot.draft.tableName !== savedChart.tableName
+    ) {
+        clearExplorerDraft(savedChart.uuid);
+        return null;
+    }
+
+    if (!wasAppInitiatedReload()) {
+        return null;
+    }
+
+    return snapshot.draft;
+};

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -12,12 +12,20 @@ import { useChartGalleryRightSidebar } from '../components/Explorer/ChartGallery
 import LoadingSkeleton from '../components/Explorer/ExploreTree/LoadingSkeleton';
 import SavedChartsHeader from '../components/Explorer/SavedChartsHeader';
 import {
+    chartVersionStamp,
+    clearExplorerDraft,
+    persistExplorerDraft,
+    readRestorableExplorerDraft,
+} from '../features/explorer/draftPersistence';
+import {
     buildInitialExplorerState,
     createExplorerStore,
     explorerActions,
+    selectHasVersionChanges,
 } from '../features/explorer/store';
 import { MergeProvider } from '../features/mergeQuery/context/MergeContext';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
+import useToaster from '../hooks/toaster/useToaster';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
 import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useSavedQuery } from '../hooks/useSavedQuery';
@@ -28,6 +36,8 @@ import { getCandidateExploreNames } from '../utils/exploreSplitError';
 const LazyExplorePanel = lazy(
     () => import('../components/Explorer/ExplorePanel'),
 );
+
+const DRAFT_PERSIST_DEBOUNCE_MS = 500;
 
 const SavedExplorerContent = memo(() => {
     const { mode } = useParams<{ mode?: string }>();
@@ -93,6 +103,8 @@ const SavedExplorer = () => {
     // Create store once with useState
     const [store] = useState(() => createExplorerStore());
 
+    const { showToastInfo } = useToaster();
+
     // Reset store state when data/mode changes
     useEffect(() => {
         if (!data) return;
@@ -109,11 +121,76 @@ const SavedExplorer = () => {
                 expandedSections: [ExplorerSection.VISUALIZATION],
                 defaultLimit: health.data?.query.defaultLimit,
             });
-            store.dispatch(explorerActions.reset(initialState));
+            const draft = isEditMode ? readRestorableExplorerDraft(data) : null;
+
+            if (draft) {
+                store.dispatch(
+                    explorerActions.reset({
+                        ...initialState,
+                        unsavedChartVersion: draft,
+                        cachedChartConfigs: {
+                            [draft.chartConfig.type]: {
+                                chartConfig: draft.chartConfig.config,
+                                pivotConfig: draft.pivotConfig,
+                            },
+                        },
+                    }),
+                );
+                showToastInfo({
+                    key: 'explorer-draft-restored',
+                    title: 'Your unsaved edits were restored',
+                    subtitle:
+                        'The page reloaded to apply a Lightdash update, so we kept your in-progress changes.',
+                    action: {
+                        children: 'Discard edits',
+                        onClick: () => {
+                            clearExplorerDraft(data.uuid);
+                            store.dispatch(explorerActions.reset(initialState));
+                        },
+                    },
+                });
+            } else {
+                store.dispatch(explorerActions.reset(initialState));
+            }
         } else {
             store.dispatch(explorerActions.setSavedChart(data));
         }
-    }, [data, store, isEditMode, health.data?.query.defaultLimit]);
+    }, [
+        data,
+        store,
+        isEditMode,
+        health.data?.query.defaultLimit,
+        showToastInfo,
+    ]);
+
+    // Keep a session-scoped draft of unsaved edits so an app-forced reload
+    // (deploy, chunk error) doesn't lose in-progress work
+    useEffect(() => {
+        let timeoutId: number | undefined;
+        const unsubscribe = store.subscribe(() => {
+            window.clearTimeout(timeoutId);
+            timeoutId = window.setTimeout(() => {
+                const state = store.getState();
+                const { savedChart } = state.explorer;
+                if (!savedChart || !state.explorer.isEditMode) return;
+
+                if (selectHasVersionChanges(state)) {
+                    persistExplorerDraft(
+                        savedChart.uuid,
+                        chartVersionStamp(savedChart.updatedAt),
+                        state.explorer.unsavedChartVersion,
+                    );
+                } else {
+                    clearExplorerDraft(savedChart.uuid);
+                }
+            }, DRAFT_PERSIST_DEBOUNCE_MS);
+        });
+
+        return () => {
+            window.clearTimeout(timeoutId);
+            unsubscribe();
+        };
+    }, [store]);
 
     useEffect(() => {
         store.dispatch(explorerActions.setIsEditMode(isEditMode));


### PR DESCRIPTION
## Problem

When a deploy ships while someone is editing a saved chart, the app force-reloads the page (stale chunk 404 auto-reload, build-skew refresh on navigation, or the "new version" toast). On `/saved/:uuid/edit` the draft lives only in the per-page Redux store, so the reload silently discards all unsaved edits. Multiple customers have reported losing in-progress work this way.

## Fix

Session-scoped draft snapshot with automatic restore, only for reloads the app itself caused:

- `features/appReload/appInitiatedReload.ts` (new): marker written to `sessionStorage` right before any app-initiated reload; consumed once on the next page load. All three reload paths now set it (`triggerChunkErrorReload`, `refreshForBuildSkew`, the `VersionAutoUpdater` toast button).
- `features/explorer/draftPersistence.ts` (new): persists the unsaved chart version to `sessionStorage` keyed by chart uuid, stamped with the chart's `updatedAt` so a draft is dropped if the chart was saved elsewhere in the meantime.
- `SavedExplorer.tsx`: a debounced store subscription persists the draft while dirty in edit mode (and clears it once clean, e.g. after save). On mount, if the page load came from an app-initiated reload and a matching draft exists, the store is seeded with the draft instead of the pristine chart, with a toast offering "Discard edits".

Manual refreshes (F5) intentionally do not restore — the marker only exists after app-forced reloads, so a user refreshing to reset their state still gets the pristine chart.

## Regression analysis

- The reload paths only gained a `sessionStorage` write before `location.reload()`; reload behavior is unchanged (all writes are try/catch-guarded like the existing cooldown flags).
- `SavedExplorer` mount behavior is unchanged unless a restorable draft exists: `readRestorableExplorerDraft` returns null when there is no snapshot, the snapshot is stale (updatedAt/tableName mismatch → cleared), or the reload wasn't app-initiated. The restored state reuses `buildInitialExplorerState` output and only overrides `unsavedChartVersion` + `cachedChartConfigs`, mirroring how that builder derives them.
- The persist subscription is read-only over store state (no dispatches), debounced at 500ms, and scoped to edit mode with a loaded saved chart.
- Color-palette-only changes are not part of `CreateSavedChartVersion` and are not snapshotted; dirty detection for persistence uses `selectHasVersionChanges` accordingly.
- Unit tests cover marker consumption/expiry and draft roundtrip/staleness/corruption; existing chunk-error handler tests still pass.

Follow-ups (not in this PR): same treatment for dashboard edit state, and carrying the full chart config for the unsaved `/tables/` route where the URL truncates `eChartsConfig` past 3000 chars.

Relates: #25011

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbNWRLc7eCERwHE8UhsyqZ
