### PR TITLE
fix(pgwire): log describe failures so extended-protocol errors are visible

### DIFF
--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.test.ts
@@ -108,6 +108,26 @@ describe('lightdash pgwire handlers: describe vs query', () => {
         expect(runExploreQuery).toHaveBeenCalledTimes(1);
     });
 
+    it('logs describe failures with redacted sql so extended-protocol errors are visible', async () => {
+        const Logger = (await import('../../logging/logger')).default;
+        const warn = vi.spyOn(Logger, 'warn');
+        try {
+            await expect(
+                handlers.describe(
+                    session,
+                    "SELECT (i.keys).n FROM orders WHERE orders_status = 'secret'",
+                ),
+            ).rejects.toThrow();
+            expect(warn).toHaveBeenCalledWith(
+                expect.stringMatching(/pgwire: describe failed \(/),
+            );
+            const logged = String(warn.mock.calls.at(-1)?.[0]);
+            expect(logged).not.toContain('secret');
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
     it('describes the placeholder shapes Describe(S) produces before Bind', async () => {
         runExploreQuery.mockClear();
         await expect(

--- a/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
+++ b/packages/backend/src/ee/postgresWire/lightdashHandlers.ts
@@ -504,13 +504,22 @@ export const createLightdashPgWireHandlers = (
         },
 
         describe: async (session, sql) => {
-            const resolved = resolveStatement(session, sql);
-            if (resolved.kind === 'result') {
-                return resolved.result.type === 'rows'
-                    ? resolved.result.fields
-                    : null;
+            try {
+                const resolved = resolveStatement(session, sql);
+                if (resolved.kind === 'result') {
+                    return resolved.result.type === 'rows'
+                        ? resolved.result.fields
+                        : null;
+                }
+                return fieldsOf(resolved.compiled);
+            } catch (e) {
+                // Parse/Describe failures never reach the query handler, so
+                // extended-protocol clients (pgjdbc) would fail invisibly
+                Logger.warn(
+                    `pgwire: describe failed (${e instanceof PgWireServerError ? e.code : 'unexpected'}: ${e instanceof Error ? redactLiterals(e.message).slice(0, 300) : e}) sql: ${redactLiterals(sql).slice(0, 300)}`,
+                );
+                throw e;
             }
-            return fieldsOf(resolved.compiled);
         },
 
         query: async (session, sql) => {
@@ -523,7 +532,7 @@ export const createLightdashPgWireHandlers = (
                 // failures are otherwise only visible to the client; log the
                 // shape (literals redacted) so production issues are diagnosable
                 Logger.warn(
-                    `pgwire: query failed (${e instanceof PgWireServerError ? e.code : 'unexpected'}: ${e instanceof Error ? e.message.slice(0, 200) : e}) sql: ${redactLiterals(sql).slice(0, 300)}`,
+                    `pgwire: query failed (${e instanceof PgWireServerError ? e.code : 'unexpected'}: ${e instanceof Error ? redactLiterals(e.message).slice(0, 200) : e}) sql: ${redactLiterals(sql).slice(0, 300)}`,
                 );
                 throw e;
             }


### PR DESCRIPTION
## Summary

Statements that fail at Parse/Describe time in the Metrics SQL API produce **zero server logs**. pgjdbc (the driver behind every JDBC-based BI tool, including Looker Studio) runs everything through the extended protocol, so a tool erroring on each post-connect metadata statement is indistinguishable in production logs from a tool that connected and sent nothing. This gap surfaced while debugging a customer's Looker Studio "hang": six clean authenticated sessions, then silence.

## Root cause

Failure logging lives in the `query` handler, which only the Execute phase reaches:

```
simple query      → handlers.query    → "pgwire: query failed …"    logged
extended Execute  → handlers.query    → "pgwire: query failed …"    logged
extended Parse    → handlers.describe → ErrorResponse, skipUntilSync   NOT logged
extended Describe → handlers.describe → ErrorResponse                  NOT logged
```

After a Parse error the server skips until Sync, so Execute never runs and nothing is written to the log.

## How it works

- `describe` failures now log at warn: `pgwire: describe failed (<code>: <message>) sql: <sql>` — both the message and the SQL pass through `redactLiterals` (compile errors embed the offending SQL, so the message needs redaction too)
- The existing query-failure log now also redacts literals inside the error message

## Test plan

- New handler test: a failing describe logs the warn line and the log contains no literal values from the SQL; full postgresWire suite passes (226 tests); typecheck + lint clean
- Verified live: pgjdbc 42.2.5's `getPrimaryKeys()` (whose SQL our parser rejects) previously produced no log; with this change the instance logs `pgwire: describe failed (42601: SQL syntax error: …)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)