### PR TITLE
fix(explorer): persist chart sidebar state in URL

### DIFF
--- a/packages/frontend/src/hooks/useExplorerRoute.test.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.test.ts
@@ -49,6 +49,31 @@ const ExplorerRouteHarness = () => {
     );
 };
 
+const renderExplorerRouteAt = (initialPath: string) => {
+    window.history.replaceState({}, '', initialPath);
+
+    renderWithProviders(
+        createElement(
+            MemoryRouter,
+            { initialEntries: [initialPath] },
+            createElement(
+                Routes,
+                null,
+                createElement(Route, {
+                    path: '/projects/:projectUuid/tables/:tableId',
+                    element: createElement(ExplorerRouteHarness),
+                }),
+            ),
+        ),
+    );
+};
+
+const currentDestination = () =>
+    new URL(
+        screen.getByTestId('location').textContent ?? '',
+        'http://lightdash.local',
+    );
+
 describe('useExplorerRoute', () => {
     it('applies and consumes a chart type preview hint when it serializes chart state', async () => {
         const dataAppVizUuid = '1e9a3b2c-0000-4000-8000-000000000001';
@@ -91,6 +116,68 @@ describe('useExplorerRoute', () => {
                     optionValues: {},
                 },
             });
+        });
+    });
+
+    it('keeps the chart sidebar step in the URL when restored from query params', async () => {
+        renderExplorerRouteAt(
+            '/projects/project-1/tables/orders?chartSidebar=configure&fromSpace=space-1',
+        );
+
+        await waitFor(() => {
+            const destination = currentDestination();
+            expect(destination.pathname).toBe(
+                '/projects/project-1/tables/orders',
+            );
+            expect(destination.searchParams.get('fromSpace')).toBe('space-1');
+            expect(destination.searchParams.get('chartSidebar')).toBe(
+                'configure',
+            );
+            expect(
+                destination.searchParams.get('create_saved_chart_version'),
+            ).not.toBeNull();
+        });
+    });
+
+    it('restores the chart type gallery step from the URL', async () => {
+        renderExplorerRouteAt(
+            '/projects/project-1/tables/orders?chartSidebar=choose',
+        );
+
+        await waitFor(() => {
+            expect(currentDestination().searchParams.get('chartSidebar')).toBe(
+                'choose',
+            );
+        });
+    });
+
+    it('omits the chart sidebar param when the panel is closed', async () => {
+        renderExplorerRouteAt(
+            '/projects/project-1/tables/orders?fromSpace=space-1',
+        );
+
+        await waitFor(() => {
+            const destination = currentDestination();
+            expect(destination.pathname).toBe(
+                '/projects/project-1/tables/orders',
+            );
+            expect(destination.searchParams.get('fromSpace')).toBe('space-1');
+            expect(destination.searchParams.get('chartSidebar')).toBeNull();
+            expect(
+                destination.searchParams.get('create_saved_chart_version'),
+            ).not.toBeNull();
+        });
+    });
+
+    it('treats an unknown chart sidebar step as a closed panel', async () => {
+        renderExplorerRouteAt(
+            '/projects/project-1/tables/orders?chartSidebar=nope',
+        );
+
+        await waitFor(() => {
+            expect(
+                currentDestination().searchParams.get('chartSidebar'),
+            ).toBeNull();
         });
     });
 });

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -22,6 +22,8 @@ import {
 import { validate as isUuidString } from 'uuid';
 import {
     explorerActions,
+    selectChartSidebarStep,
+    selectIsVisualizationConfigOpen,
     selectMetricQuery,
     selectTableName,
     selectUnsavedChartVersion,
@@ -38,6 +40,8 @@ import {
     type ExplorerReduceState,
 } from '../providers/Explorer/types';
 import useToaster from './toaster/useToaster';
+
+const CHART_SIDEBAR_PARAM = 'chartSidebar';
 
 export const DEFAULT_EMPTY_EXPLORE_CONFIG: CreateSavedChartVersion = {
     tableName: '',
@@ -174,6 +178,28 @@ export const parseDataAppVizUuidFromSearchParams = (
         : null;
 };
 
+// The param carries the open step, so its absence means a closed sidebar.
+const parseChartSidebarFromSearchParams = (
+    search: string,
+): Pick<
+    ExplorerReduceState,
+    'isVisualizationConfigOpen' | 'chartSidebarStep'
+> => {
+    const step = new URLSearchParams(search).get(CHART_SIDEBAR_PARAM);
+
+    if (step === 'choose' || step === 'configure') {
+        return {
+            isVisualizationConfigOpen: true,
+            chartSidebarStep: step,
+        };
+    }
+
+    return {
+        isVisualizationConfigOpen: false,
+        chartSidebarStep: defaultState.chartSidebarStep,
+    };
+};
+
 export const parseChartFromExplorerSearchParams = (
     search: string,
 ): CreateSavedChartVersion | undefined => {
@@ -264,6 +290,10 @@ export const useExplorerRoute = () => {
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
     const metricQuery = useExplorerSelector(selectMetricQuery);
     const tableName = useExplorerSelector(selectTableName);
+    const isVisualizationConfigOpen = useExplorerSelector(
+        selectIsVisualizationConfigOpen,
+    );
+    const chartSidebarStep = useExplorerSelector(selectChartSidebarStep);
 
     // Update url params based on pristine state
     // Only sync URL when we're actually on a table page (pathParams.tableId exists)
@@ -275,6 +305,11 @@ export const useExplorerRoute = () => {
             );
             const searchParams = new URLSearchParams(explorerUrl.search);
             searchParams.delete('dataAppVizUuid');
+            if (isVisualizationConfigOpen) {
+                searchParams.set(CHART_SIDEBAR_PARAM, chartSidebarStep);
+            } else {
+                searchParams.delete(CHART_SIDEBAR_PARAM);
+            }
             void navigate(
                 {
                     ...explorerUrl,
@@ -290,6 +325,8 @@ export const useExplorerRoute = () => {
         pathParams.tableId,
         unsavedChartVersion,
         tableName,
+        isVisualizationConfigOpen,
+        chartSidebarStep,
     ]);
 
     useEffect(() => {
@@ -393,9 +430,9 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                     parameters: {},
                     fromDashboard: fromDashboard ?? undefined,
                     isExploreFromHere: isExploreFromHere,
+                    ...parseChartSidebarFromSearchParams(search),
                     queryExecution: defaultQueryExecution,
                     preAggregate: defaultState.preAggregate,
-                    chartSidebarStep: defaultState.chartSidebarStep,
                     chartTypeAuthoring: null,
                 };
             } catch (e: any) {


### PR DESCRIPTION
## Summary
- Persist the Explorer chart sidebar in the URL via `chartSidebar=configure|choose`. The param carries the open step, so its absence means a closed sidebar.
- Restore both the open state and the step on initial Explorer load, so a reload comes back to the same panel.
- Add route-hook tests for each step, the closed default, and an unrecognized value.

## Test plan
- [x] `pnpm -F frontend exec vitest run src/hooks/useExplorerRoute.test.ts`
- [x] Open Explorer with `explore-chart-gallery` enabled, toggle Configure, switch to the chart type gallery, reload, verify the sidebar and its step persist.

Closes: [PROD-10494](https://linear.app/lightdash/issue/PROD-10494/persist-panel-open-state-in-the-url)