### PR TITLE
fix(frontend): make mobile sidebar follow the app colour scheme

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -89,108 +89,112 @@ export const MobileNavBar: FC = () => {
     });
 
     return (
-        <Box id="mobile-navbar" data-mantine-color-scheme="dark">
-            <MantineBaseProvider
-                forceColorScheme="dark"
-                cssVariablesSelector="#mobile-navbar"
-                getRootElement={getMobileNavBarRootElement}
-            >
-                <Box
-                    component="header"
-                    className={classes.header}
-                    h={50}
-                    mah={50}
-                    display="flex"
-                    px="md"
-                    style={{ zIndex: getDefaultZIndex('app') }}
+        <>
+            {/* The header bar is always dark, like the desktop navbar. The
+                drawer below stays outside this provider so it follows the
+                app's colour scheme. */}
+            <Box id="mobile-navbar" data-mantine-color-scheme="dark">
+                <MantineBaseProvider
+                    forceColorScheme="dark"
+                    cssVariablesSelector="#mobile-navbar"
+                    getRootElement={getMobileNavBarRootElement}
                 >
-                    <Group align="center" justify="space-between" flex={1}>
-                        <ActionIcon
-                            variant="subtle"
-                            color="gray"
-                            component={Link}
-                            to={'/'}
-                            title="Home"
-                            size="lg"
-                        >
-                            <Logo />
-                        </ActionIcon>
-                        <Burger
-                            opened={isMenuOpen}
-                            onClick={toggleMenu}
-                            color="white"
-                            aria-label={
-                                isMenuOpen
-                                    ? 'Close navigation menu'
-                                    : 'Open navigation menu'
-                            }
-                            aria-expanded={isMenuOpen}
-                            aria-controls="mobile-navigation"
-                        />
-                    </Group>
-                </Box>
-
-                <Drawer
-                    id="mobile-navigation"
-                    title={<ThemeSwitcher />}
-                    opened={isMenuOpen}
-                    onClose={toggleMenu}
-                    size="75%"
-                    portalProps={{ target: '#mobile-navbar' }}
-                >
-                    <Title order={6} fw={600} mb="xs">
-                        Project
-                    </Title>
-                    <ProjectSwitcher />
-                    <Divider my="lg" />
-                    <RouterNavLink
-                        exact
-                        label="Home"
-                        to={`/`}
-                        leftSection={<MantineIcon icon={IconHome} />}
-                        onClick={toggleMenu}
-                    />
-                    <RouterNavLink
-                        exact
-                        label="Spaces"
-                        to={`/projects/${activeProjectUuid}/spaces`}
-                        leftSection={<MantineIcon icon={IconFolders} />}
-                        onClick={toggleMenu}
-                    />
-                    <RouterNavLink
-                        exact
-                        label="Dashboards"
-                        to={`/projects/${activeProjectUuid}/dashboards`}
-                        leftSection={<MantineIcon icon={IconLayoutDashboard} />}
-                        onClick={toggleMenu}
-                    />
-                    <RouterNavLink
-                        exact
-                        label="Charts"
-                        to={`/projects/${activeProjectUuid}/saved`}
-                        leftSection={<MantineIcon icon={IconChartAreaLine} />}
-                        onClick={toggleMenu}
-                    />
-                    {isMenuOpen && (
-                        <Suspense fallback={null}>
-                            <MobileAiAgentsNavLink
-                                activeProjectUuid={activeProjectUuid}
+                    <Box
+                        component="header"
+                        className={classes.header}
+                        h={50}
+                        mah={50}
+                        display="flex"
+                        px="md"
+                        style={{ zIndex: getDefaultZIndex('app') }}
+                    >
+                        <Group align="center" justify="space-between" flex={1}>
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                component={Link}
+                                to={'/'}
+                                title="Home"
+                                size="lg"
+                            >
+                                <Logo />
+                            </ActionIcon>
+                            <Burger
+                                opened={isMenuOpen}
                                 onClick={toggleMenu}
+                                color="white"
+                                aria-label={
+                                    isMenuOpen
+                                        ? 'Close navigation menu'
+                                        : 'Open navigation menu'
+                                }
+                                aria-expanded={isMenuOpen}
+                                aria-controls="mobile-navigation"
                             />
-                        </Suspense>
-                    )}
-                    <Divider my="lg" />
+                        </Group>
+                    </Box>
+                </MantineBaseProvider>
+            </Box>
 
-                    <RouterNavLink
-                        exact
-                        label="Logout"
-                        to={`/`}
-                        leftSection={<MantineIcon icon={IconLogout} />}
-                        onClick={() => logout()}
-                    />
-                </Drawer>
-            </MantineBaseProvider>
-        </Box>
+            <Drawer
+                id="mobile-navigation"
+                title={<ThemeSwitcher />}
+                opened={isMenuOpen}
+                onClose={toggleMenu}
+                size="75%"
+            >
+                <Title order={6} fw={600} mb="xs">
+                    Project
+                </Title>
+                <ProjectSwitcher portalTarget={null} />
+                <Divider my="lg" />
+                <RouterNavLink
+                    exact
+                    label="Home"
+                    to={`/`}
+                    leftSection={<MantineIcon icon={IconHome} />}
+                    onClick={toggleMenu}
+                />
+                <RouterNavLink
+                    exact
+                    label="Spaces"
+                    to={`/projects/${activeProjectUuid}/spaces`}
+                    leftSection={<MantineIcon icon={IconFolders} />}
+                    onClick={toggleMenu}
+                />
+                <RouterNavLink
+                    exact
+                    label="Dashboards"
+                    to={`/projects/${activeProjectUuid}/dashboards`}
+                    leftSection={<MantineIcon icon={IconLayoutDashboard} />}
+                    onClick={toggleMenu}
+                />
+                <RouterNavLink
+                    exact
+                    label="Charts"
+                    to={`/projects/${activeProjectUuid}/saved`}
+                    leftSection={<MantineIcon icon={IconChartAreaLine} />}
+                    onClick={toggleMenu}
+                />
+                {isMenuOpen && (
+                    <Suspense fallback={null}>
+                        <MobileAiAgentsNavLink
+                            activeProjectUuid={activeProjectUuid}
+                            onClick={toggleMenu}
+                        />
+                    </Suspense>
+                )}
+                <Divider my="lg" />
+
+                <RouterNavLink
+                    exact
+                    label="Logout"
+                    to={`/`}
+                    leftSection={<MantineIcon icon={IconLogout} />}
+                    onClick={() => logout()}
+                />
+            </Drawer>
+        </>
     );
 };
 

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -103,7 +103,7 @@ export const MainNavBarContent: FC<Props> = ({
                             <HeadwayMenuItem projectUuid={activeProjectUuid} />
                         )}
 
-                    <ProjectSwitcher />
+                    <ProjectSwitcher portalTarget="#navbar-header" />
 
                     <UserCredentialsSwitcher />
                 </Button.Group>

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.module.css
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.module.css
@@ -15,9 +15,18 @@
     max-width: 260px;
 
     &:disabled {
-        color: var(--mantine-color-white);
-        background-color: var(--mantine-color-ldDark-6);
-        border-color: var(--mantine-color-ldDark-4);
+        color: light-dark(
+            var(--mantine-color-ldGray-6),
+            var(--mantine-color-white)
+        );
+        background-color: light-dark(
+            var(--mantine-color-ldGray-1),
+            var(--mantine-color-ldDark-6)
+        );
+        border-color: light-dark(
+            var(--mantine-color-ldGray-3),
+            var(--mantine-color-ldDark-4)
+        );
     }
 }
 
@@ -41,12 +50,14 @@
 
 .searchHeader {
     padding: var(--mantine-spacing-sm);
-    border-bottom: 1px solid var(--mantine-color-dark-4);
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-dark-4));
 }
 
 .searchInput {
     background-color: transparent;
-    border: 1px solid var(--mantine-color-dark-4);
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-dark-4));
 
     &:focus {
         border-color: var(--mantine-color-blue-6);
@@ -64,7 +75,10 @@
     cursor: pointer;
 
     &:hover {
-        background-color: var(--mantine-color-ldDark-4);
+        background-color: light-dark(
+            var(--mantine-color-ldGray-1),
+            var(--mantine-color-ldDark-4)
+        );
         color: var(--mantine-color-ldGray-9);
     }
 }
@@ -78,7 +92,10 @@
     cursor: pointer;
 
     &:hover {
-        background-color: var(--mantine-color-ldDark-3);
+        background-color: light-dark(
+            var(--mantine-color-ldGray-1),
+            var(--mantine-color-ldDark-3)
+        );
     }
 }
 
@@ -88,5 +105,6 @@
 }
 
 .stickyFooter {
-    border-top: 1px solid var(--mantine-color-dark-4);
+    border-top: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-dark-4));
 }

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -319,7 +319,13 @@ const swappableProjectRoutes = (
     ].map((path) => ({ path, handle: { useProjectSlug: false } })),
 ];
 
-const ProjectSwitcher = () => {
+type ProjectSwitcherProps = {
+    /** Selector the dropdown is portaled into, or null to portal into the body.
+     *  The desktop navbar targets its own forced-dark subtree. */
+    portalTarget: string | null;
+};
+
+const ProjectSwitcher: FC<ProjectSwitcherProps> = ({ portalTarget }) => {
     const { showToastSuccess } = useToaster();
     const navigate = useNavigate();
 
@@ -632,7 +638,7 @@ const ProjectSwitcher = () => {
                 }}
                 classNames={{ dropdown: classes.dropdown }}
                 zIndex={getDefaultZIndex('max')}
-                portalProps={{ target: '#navbar-header' }}
+                portalProps={portalTarget ? { target: portalTarget } : undefined}
             >
                 <Menu.Target>
                     <Button

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -638,7 +638,9 @@ const ProjectSwitcher: FC<ProjectSwitcherProps> = ({ portalTarget }) => {
                 }}
                 classNames={{ dropdown: classes.dropdown }}
                 zIndex={getDefaultZIndex('max')}
-                portalProps={portalTarget ? { target: portalTarget } : undefined}
+                portalProps={
+                    portalTarget ? { target: portalTarget } : undefined
+                }
             >
                 <Menu.Target>
                     <Button


### PR DESCRIPTION
Closes:

### Description:

The mobile drawer was portaled into `#mobile-navbar`, the navbar's forced-dark subtree, so it inherited dark CSS variables and rendered with a dark background and low-contrast links while the app was in light mode. The header bar stays dark (like the desktop navbar); the drawer now renders outside that provider and portals to the body, so it follows the app colour scheme in both modes.

While in there: the project switcher's dropdown targeted `#navbar-header`, which doesn't exist on mobile — Mantine's portal falls back to a detached node, so the dropdown never appeared. The portal target is now an explicit `portalTarget` prop (desktop passes `#navbar-header`, mobile passes `null`), and the switcher's dark-only surfaces use `light-dark()` so they work on a light drawer. Compiled CSS keeps the previous values under `[data-mantine-color-scheme='dark']`, so the desktop navbar is unchanged.

Verified with `pnpm -F frontend typecheck` and `pnpm -F frontend lint`, plus compiling `ProjectSwitcher.module.css` through the repo's postcss preset to check the light/dark branches. I couldn't render the app in this environment (no database or docker daemon available), so the mobile drawer hasn't been visually confirmed.

### Risk assessment:

- [ ] This is a high-risk change
