### PR TITLE
fix(frontend): make agent thread sidebar work on mobile

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
@@ -1,4 +1,5 @@
 import { ActionIcon, Button, Divider, Group, Tooltip } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import {
     IconNotebook,
     IconSettings,
@@ -29,7 +30,14 @@ export const AgentPageHeader: FC<Props> = ({
     settingsHref,
 }) => {
     const settingsLinkState = useAgentSettingsLinkState();
-    const hasAgentActions = Boolean(onOpenMemories || settingsHref);
+    const isMobile = useMediaQuery('(max-width: 768px)', undefined, {
+        getInitialValueInEffect: false,
+    });
+    // Memories and minimize are desktop affordances — the mobile header only
+    // has room for the agent selector, sidebar toggle and share.
+    const showMemories = Boolean(onOpenMemories) && !isMobile;
+    const showMinimize = Boolean(onMinimize) && !isMobile;
+    const hasAgentActions = showMemories || Boolean(settingsHref);
 
     return (
         <Group align="center" justify="space-between" className={styles.root}>
@@ -40,7 +48,7 @@ export const AgentPageHeader: FC<Props> = ({
                 )}
                 {hasAgentActions && (
                     <Group gap={4}>
-                        {onOpenMemories && (
+                        {showMemories && (
                             <Button
                                 variant="default"
                                 className={styles.action}
@@ -97,7 +105,7 @@ export const AgentPageHeader: FC<Props> = ({
                         </ActionIcon>
                     </Tooltip>
                 )}
-                {onMinimize && (
+                {showMinimize && (
                     <Tooltip label="Minimize" position="bottom">
                         <ActionIcon
                             variant="subtle"

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -1,6 +1,6 @@
 import { assertUnreachable } from '@lightdash/common';
-import { Box, Drawer, Flex } from '@mantine/core';
-import { useMediaQuery } from '@mantine/hooks';
+import { Box, Drawer, Flex, Group } from '@mantine/core';
+import { useDisclosure, useMediaQuery } from '@mantine/hooks';
 import {
     IconLayoutSidebarLeftCollapse,
     IconLayoutSidebarLeftExpand,
@@ -8,6 +8,7 @@ import {
 import {
     Fragment,
     useCallback,
+    useEffect,
     useLayoutEffect,
     useRef,
     useState,
@@ -19,6 +20,7 @@ import {
     PanelResizeHandle,
     type ImperativePanelHandle,
 } from 'react-resizable-panels';
+import { useLocation } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
 import {
@@ -71,7 +73,20 @@ export const AiAgentPageLayout: React.FC<Props> = ({
     const [isResizing, setIsResizing] = useState(false);
 
     const preview = useAiAgentStoreSelector(selectPreview);
-    const isMobile = useMediaQuery('(max-width: 768px)');
+    // Resolved on first render so the sidebar never flashes open on mobile
+    const isMobile = useMediaQuery('(max-width: 768px)', undefined, {
+        getInitialValueInEffect: false,
+    });
+    const [
+        isMobileSidebarOpened,
+        { close: closeMobileSidebar, toggle: toggleMobileSidebar },
+    ] = useDisclosure(false);
+    const { pathname } = useLocation();
+
+    // Navigating from a thread link inside the drawer should dismiss it
+    useEffect(() => {
+        closeMobileSidebar();
+    }, [pathname, closeMobileSidebar]);
 
     const toggleSidebar = useCallback(() => {
         setIsAgentSidebarCollapsed?.(!isAgentSidebarCollapsed);
@@ -83,7 +98,7 @@ export const AiAgentPageLayout: React.FC<Props> = ({
     }, [setIsAgentSidebarCollapsed, isAgentSidebarCollapsed]);
 
     useLayoutEffect(() => {
-        if (!preview) return;
+        if (!preview || isMobile) return;
 
         const frame = requestAnimationFrame(() => {
             sidebarPanelRef.current?.collapse();
@@ -91,7 +106,7 @@ export const AiAgentPageLayout: React.FC<Props> = ({
         });
 
         return () => cancelAnimationFrame(frame);
-    }, [preview, setIsAgentSidebarCollapsed]);
+    }, [preview, isMobile, setIsAgentSidebarCollapsed]);
 
     return (
         <div
@@ -104,7 +119,7 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                 className={styles.panelGroup}
                 style={{ flex: 1, minWidth: 0 }}
             >
-                {Sidebar && (
+                {Sidebar && !isMobile && (
                     <Fragment>
                         <ErrorBoundary>
                             <Panel
@@ -176,8 +191,33 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                         minSize={25}
                         order={2}
                     >
-                        {Header && (
-                            <Box className={styles.chatHeader}>{Header}</Box>
+                        {(Header || (isMobile && Sidebar)) && (
+                            <Box className={styles.chatHeader}>
+                                <Group gap="xs" wrap="nowrap" align="center">
+                                    {isMobile && Sidebar && (
+                                        <SidebarButton
+                                            aria-label="Open Ask AI sidebar"
+                                            size="sm"
+                                            leftSection={
+                                                <MantineIcon
+                                                    size="md"
+                                                    icon={
+                                                        IconLayoutSidebarLeftExpand
+                                                    }
+                                                    stroke={1.8}
+                                                    color="ldGray.7"
+                                                />
+                                            }
+                                            onClick={toggleMobileSidebar}
+                                        />
+                                    )}
+                                    {Header && (
+                                        <Box flex={1} miw={0}>
+                                            {Header}
+                                        </Box>
+                                    )}
+                                </Group>
+                            </Box>
                         )}
 
                         <Box className={styles.chatContent}>{children}</Box>
@@ -222,6 +262,23 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                     </Fragment>
                 )}
             </PanelGroup>
+
+            {isMobile && Sidebar && (
+                <Drawer
+                    opened={isMobileSidebarOpened}
+                    onClose={closeMobileSidebar}
+                    position="left"
+                    size="85%"
+                    title="Threads"
+                    classNames={{
+                        content: styles.mobileSidebarContent,
+                        header: styles.mobileSidebarHeader,
+                        body: styles.mobileSidebarBody,
+                    }}
+                >
+                    {Sidebar}
+                </Drawer>
+            )}
 
             {isMobile && (
                 <Drawer

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -1,5 +1,5 @@
 import { assertUnreachable } from '@lightdash/common';
-import { Box, Drawer, Flex, Group } from '@mantine/core';
+import { Box, Drawer, Flex, Group, Text } from '@mantine/core';
 import { useDisclosure, useMediaQuery } from '@mantine/hooks';
 import {
     IconLayoutSidebarLeftCollapse,
@@ -269,7 +269,11 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                     onClose={closeMobileSidebar}
                     position="left"
                     size="85%"
-                    title="Threads"
+                    title={
+                        <Text fw={600} fz="sm">
+                            Threads
+                        </Text>
+                    }
                     classNames={{
                         content: styles.mobileSidebarContent,
                         header: styles.mobileSidebarHeader,

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
@@ -30,6 +30,32 @@
     }
 }
 
+.mobileSidebarContent {
+    display: flex;
+    flex-direction: column;
+
+    @mixin light {
+        background: var(--mantine-color-ldGray-0);
+    }
+    @mixin dark {
+        background: var(--mantine-color-ldDark-2);
+    }
+}
+
+.mobileSidebarHeader {
+    background: transparent;
+    min-height: 0;
+    padding-bottom: var(--mantine-spacing-xs);
+}
+
+.mobileSidebarBody {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    padding: 0 var(--mantine-spacing-sm) var(--mantine-spacing-sm);
+}
+
 .sidebarTransition {
     transition: all 300ms ease-in-out;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -28,6 +28,21 @@
     display: none;
 }
 
+/* Everything to the left of the send button. It shrinks so the send button
+   stays in view when the toolbar runs out of room on narrow viewports. */
+.toolbarSelectors {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    min-width: 0;
+}
+
+@media (max-width: 48em) {
+    .toolbarSelectors {
+        overflow: hidden;
+    }
+}
+
 .controlsReveal {
     transition:
         opacity 160ms ease,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -28,6 +28,7 @@ import {
     IconPaperclip,
     IconPlayerStop,
     IconPlus,
+    IconTelescope,
     IconTerminal2,
 } from '@tabler/icons-react';
 import Mention from '@tiptap/extension-mention';
@@ -602,8 +603,14 @@ export const AgentChatInput = ({
     );
     // The mobile toolbar has no room for these inline, so they move into a
     // single overflow menu and the send button keeps its place.
+    const showDeepResearchInMobileMenu = Boolean(
+        isMobile && canStartDeepResearch,
+    );
     const showMobileToolsMenu = Boolean(
-        isMobile && (showSqlModeControl || canShowAttachControl),
+        isMobile &&
+        (showSqlModeControl ||
+            canShowAttachControl ||
+            showDeepResearchInMobileMenu),
     );
 
     const handleStartDeepResearch = async () => {
@@ -745,7 +752,9 @@ export const AgentChatInput = ({
     const shouldShowDeepResearchBelowComposer =
         isThreadInput || showDeepResearchBelowComposer;
     const deepResearchControl =
-        canStartDeepResearch && !shouldShowDeepResearchBelowComposer ? (
+        canStartDeepResearch &&
+        !shouldShowDeepResearchBelowComposer &&
+        !showDeepResearchInMobileMenu ? (
             <DeepResearchModeControl
                 mode={composerMode}
                 onModeChange={setComposerMode}
@@ -755,7 +764,9 @@ export const AgentChatInput = ({
             />
         ) : null;
     const compactDeepResearchControl =
-        canStartDeepResearch && shouldShowDeepResearchBelowComposer ? (
+        canStartDeepResearch &&
+        shouldShowDeepResearchBelowComposer &&
+        !showDeepResearchInMobileMenu ? (
             <DeepResearchModeControl
                 mode={composerMode}
                 onModeChange={setComposerMode}
@@ -969,6 +980,40 @@ export const AgentChatInput = ({
                             }
                         >
                             SQL Runner
+                        </Menu.Item>
+                    )}
+                    {showDeepResearchInMobileMenu && (
+                        <Menu.Item
+                            disabled={hasActiveDeepResearchRun}
+                            onClick={() =>
+                                setComposerMode(
+                                    composerMode === 'deep_research'
+                                        ? 'ask'
+                                        : 'deep_research',
+                                )
+                            }
+                            leftSection={
+                                <MantineIcon
+                                    icon={IconTelescope}
+                                    size={14}
+                                    color={
+                                        composerMode === 'deep_research'
+                                            ? 'indigo.5'
+                                            : 'ldGray.6'
+                                    }
+                                />
+                            }
+                            rightSection={
+                                composerMode === 'deep_research' ? (
+                                    <MantineIcon
+                                        icon={IconCheck}
+                                        size={14}
+                                        color="indigo.5"
+                                    />
+                                ) : null
+                            }
+                        >
+                            Deep research
                         </Menu.Item>
                     )}
                 </Menu.Dropdown>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -15,15 +15,19 @@ import {
     FileButton,
     Group,
     Loader,
+    Menu,
     Paper,
     Pill,
     Text,
     Tooltip,
 } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import {
     IconArrowUp,
+    IconCheck,
     IconPaperclip,
     IconPlayerStop,
+    IconPlus,
     IconTerminal2,
 } from '@tabler/icons-react';
 import Mention from '@tiptap/extension-mention';
@@ -204,6 +208,11 @@ export const AgentChatInput = ({
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const app = useApp();
+    // Resolved on first render so the toolbar never renders the desktop layout
+    // on a phone before settling.
+    const isMobile = useMediaQuery('(max-width: 768px)', undefined, {
+        getInitialValueInEffect: false,
+    });
     const [value, setValueState] = useState(defaultValue ?? '');
     const [externalSourceAttachments, setExternalSourceAttachments] = useState<
         ExternalSourceAttachment[]
@@ -585,6 +594,17 @@ export const AgentChatInput = ({
             }),
         ),
     );
+    const canShowAttachControl = Boolean(
+        canAttachExternalSource &&
+        !disabled &&
+        !canSteer &&
+        composerMode === 'ask',
+    );
+    // The mobile toolbar has no room for these inline, so they move into a
+    // single overflow menu and the send button keeps its place.
+    const showMobileToolsMenu = Boolean(
+        isMobile && (showSqlModeControl || canShowAttachControl),
+    );
 
     const handleStartDeepResearch = async () => {
         const ed = editorRef.current;
@@ -796,7 +816,7 @@ export const AgentChatInput = ({
         actionSize: number | 'sm' | 'md';
         iconSize: number;
     }) => {
-        if (!onSqlModeChange || disabled) return null;
+        if (!showSqlModeControl || showMobileToolsMenu) return null;
 
         return (
             <Tooltip
@@ -812,7 +832,7 @@ export const AgentChatInput = ({
                         color={sqlMode ? 'indigo' : 'gray'}
                         size={actionSize}
                         className={styles.sqlModeButton}
-                        onClick={() => onSqlModeChange(!sqlMode)}
+                        onClick={() => onSqlModeChange?.(!sqlMode)}
                         aria-label="Toggle SQL Runner"
                         aria-pressed={sqlMode}
                     >
@@ -834,12 +854,7 @@ export const AgentChatInput = ({
         actionSize: number | 'sm' | 'md';
         iconSize: number;
     }) => {
-        if (
-            !canAttachExternalSource ||
-            disabled ||
-            canSteer ||
-            composerMode !== 'ask'
-        ) {
+        if (!canShowAttachControl || showMobileToolsMenu) {
             return null;
         }
         return (
@@ -876,6 +891,88 @@ export const AgentChatInput = ({
                     </Tooltip>
                 )}
             </FileButton>
+        );
+    };
+
+    const renderMobileToolsMenu = ({
+        actionSize,
+        iconSize,
+    }: {
+        actionSize: number | 'sm' | 'md';
+        iconSize: number;
+    }) => {
+        if (!showMobileToolsMenu) return null;
+
+        return (
+            <Menu position="top-start" withinPortal shadow="md" width={220}>
+                <Menu.Target>
+                    <ActionIcon
+                        variant="subtle"
+                        color="ldGray.6"
+                        size={actionSize}
+                        aria-label="Composer options"
+                    >
+                        <MantineIcon
+                            icon={IconPlus}
+                            size={iconSize}
+                            color="ldGray.6"
+                        />
+                    </ActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                    {canShowAttachControl && (
+                        <FileButton
+                            accept=".csv,.tsv,text/csv,text/tab-separated-values"
+                            multiple
+                            resetRef={resetCsvFileInputRef}
+                            onChange={(files) => {
+                                resetCsvFileInputRef.current?.();
+                                if (files.length > 0) {
+                                    void attachCsvFiles(files);
+                                }
+                            }}
+                        >
+                            {(fileButtonProps) => (
+                                <Menu.Item
+                                    {...fileButtonProps}
+                                    disabled={isPreparingCsv}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconPaperclip}
+                                            size={14}
+                                        />
+                                    }
+                                >
+                                    Attach CSV
+                                </Menu.Item>
+                            )}
+                        </FileButton>
+                    )}
+                    {showSqlModeControl && (
+                        <Menu.Item
+                            onClick={() => onSqlModeChange?.(!sqlMode)}
+                            leftSection={
+                                <MantineIcon
+                                    icon={IconTerminal2}
+                                    size={14}
+                                    color={sqlMode ? 'indigo.5' : 'ldGray.6'}
+                                />
+                            }
+                            rightSection={
+                                sqlMode ? (
+                                    <MantineIcon
+                                        icon={IconCheck}
+                                        size={14}
+                                        color="indigo.5"
+                                    />
+                                ) : null
+                            }
+                        >
+                            SQL Runner
+                        </Menu.Item>
+                    )}
+                </Menu.Dropdown>
+            </Menu>
         );
     };
 
@@ -919,7 +1016,10 @@ export const AgentChatInput = ({
     const hasExternalModeControls =
         !disabled &&
         shouldShowDeepResearchBelowComposer &&
-        Boolean(compactDeepResearchControl || showSqlModeControl);
+        Boolean(
+            compactDeepResearchControl ||
+            (showSqlModeControl && !showMobileToolsMenu),
+        );
 
     const renderExternalModeControls = ({
         actionSize,
@@ -1020,6 +1120,10 @@ export const AgentChatInput = ({
                         attachments={renderedAttachments}
                         toolbarRight={
                             <Group gap={4} align="center" wrap="nowrap">
+                                {renderMobileToolsMenu({
+                                    actionSize: 'sm',
+                                    iconSize: 14,
+                                })}
                                 {renderAttachDataControl({
                                     actionSize: 'sm',
                                     iconSize: 14,
@@ -1083,6 +1187,10 @@ export const AgentChatInput = ({
                 attachments={renderedAttachments}
                 toolbarLeft={
                     <Group gap="xs" align="center" wrap="nowrap">
+                        {renderMobileToolsMenu({
+                            actionSize: 30,
+                            iconSize: 16,
+                        })}
                         {renderAttachDataControl({
                             actionSize: 30,
                             iconSize: 15,
@@ -1096,44 +1204,50 @@ export const AgentChatInput = ({
                 }
                 toolbarRight={
                     <Group gap="xs" align="center" wrap="nowrap">
-                        {(deepResearchControl || showAgentSelector) && (
-                            <Box
-                                className={styles.controlsReveal}
-                                data-visible={hasClickedInput}
-                            >
-                                <Group gap="xs" align="center" wrap="nowrap">
-                                    {deepResearchControl}
+                        <Box className={styles.toolbarSelectors}>
+                            {(deepResearchControl || showAgentSelector) && (
+                                <Box
+                                    className={styles.controlsReveal}
+                                    data-visible={hasClickedInput}
+                                >
+                                    <Group
+                                        gap="xs"
+                                        align="center"
+                                        wrap="nowrap"
+                                    >
+                                        {deepResearchControl}
 
-                                    {showAgentSelector && (
-                                        <AgentSelector
-                                            projectUuid={projectUuid!}
-                                            agents={agents!}
-                                            selectedAgent={selectedAgent!}
-                                            compact
-                                        />
-                                    )}
-                                </Group>
-                            </Box>
-                        )}
-
-                        {(showModelSelector || onExtendedThinkingChange) &&
-                            models &&
-                            onModelChange && (
-                                <Box className={styles.modelGroup}>
-                                    <ModelSelector
-                                        models={models}
-                                        value={selectedModelId ?? null}
-                                        onChange={onModelChange}
-                                        variant="subtle"
-                                        color="gray"
-                                        size="xs"
-                                        reasoningEnabled={extendedThinking}
-                                        onReasoningChange={
-                                            onExtendedThinkingChange
-                                        }
-                                    />
+                                        {showAgentSelector && (
+                                            <AgentSelector
+                                                projectUuid={projectUuid!}
+                                                agents={agents!}
+                                                selectedAgent={selectedAgent!}
+                                                compact
+                                            />
+                                        )}
+                                    </Group>
                                 </Box>
                             )}
+
+                            {(showModelSelector || onExtendedThinkingChange) &&
+                                models &&
+                                onModelChange && (
+                                    <Box className={styles.modelGroup}>
+                                        <ModelSelector
+                                            models={models}
+                                            value={selectedModelId ?? null}
+                                            onChange={onModelChange}
+                                            variant="subtle"
+                                            color="gray"
+                                            size="xs"
+                                            reasoningEnabled={extendedThinking}
+                                            onReasoningChange={
+                                                onExtendedThinkingChange
+                                            }
+                                        />
+                                    </Box>
+                                )}
+                        </Box>
 
                         {renderComposerAction('lg')}
                     </Group>


### PR DESCRIPTION
### Description:

On small viewports the agent thread list was still rendered as a resizable panel next to the chat, so it ended up squeezed into a sliver of the screen. Below 768px the panel is now dropped entirely and the same sidebar content renders in a left `Drawer`, closed by default and opened from a toggle button in the chat header (also shown on the auto-mode page, which has no header otherwise). The drawer closes when the route changes, so picking a thread takes you straight to it.

Also skipped the &#34;collapse sidebar when a preview opens&#34; effect on mobile, since there is no panel to collapse there and it would blank the drawer contents.

Follow-up commits tidy the rest of the mobile agent UI. The composer toolbar was overflowing the card and clipping the send button, so everything left of it now shrinks, and the SQL Runner, CSV attachment and Deep research controls collapse into a single overflow menu next to the input instead of competing for toolbar space. Memories and minimize are hidden from the page header, and the Threads drawer title now uses the same weight and size as other drawer titles in the app rather than Mantine's default heading. All of this is gated on the same 768px breakpoint, so the desktop toolbar and header are unchanged.

### Risk assessment:

- [ ] This is a high-risk change

Frontend-only, scoped to viewports under 768px; desktop layout is unchanged. Verified with frontend typecheck, lint, formatting and the agent chat tests — no local environment was available to drive the app in a browser.
