### PR TITLE
fix(explorer): show details for selected fields

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.test.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.test.tsx
@@ -1,4 +1,10 @@
-import { DimensionType, FieldType, type Dimension } from '@lightdash/common';
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    type Dimension,
+    type Metric,
+} from '@lightdash/common';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
@@ -17,7 +23,53 @@ const item = {
     hidden: false,
 } as Dimension;
 
+const metric = {
+    table: 'payments',
+    tableLabel: 'Payments',
+    name: 'unique_payment_count',
+    label: 'Unique payment count',
+    description: 'Count of all payments',
+    fieldType: FieldType.METRIC,
+    type: MetricType.COUNT_DISTINCT,
+    hidden: false,
+    sql: '${TABLE}.payment_id',
+    compiledSql: 'payments.payment_id',
+    filters: [],
+} as Metric;
+
 describe('SelectedFieldsSection source-aware actions', () => {
+    it('shows field details for a selected metric on hover', async () => {
+        const user = userEvent.setup();
+
+        renderWithProviders(
+            <Provider store={createExplorerStore()}>
+                <SelectedFieldsSection
+                    fields={[
+                        {
+                            fieldId: 'payments_unique_payment_count',
+                            item: metric,
+                            tableLabel: 'Payments',
+                            isDimension: false,
+                        },
+                    ]}
+                    onDeselect={vi.fn()}
+                />
+            </Provider>,
+        );
+
+        await user.hover(screen.getByTitle('Unique payment count'));
+
+        expect(await screen.findByText('Count of all payments')).toBeVisible();
+        expect(screen.getByText('${TABLE}.payment_id')).toBeVisible();
+
+        await user.click(screen.getByRole('button', { name: 'Compiled SQL' }));
+
+        expect(screen.getByText('payments.payment_id')).toBeVisible();
+        expect(
+            screen.getByTestId('selected-field-payments_unique_payment_count'),
+        ).toBeInTheDocument();
+    });
+
     it('shows filter and basic overflow actions for a merged source field', async () => {
         const user = userEvent.setup();
         const onAddFilter = vi.fn();
@@ -44,6 +96,12 @@ describe('SelectedFieldsSection source-aware actions', () => {
         await user.hover(
             screen.getByTestId('selected-field-b:subscriptions_customer_id'),
         );
+        await user.hover(screen.getByTitle('Customer id'));
+
+        expect(
+            await screen.findByText('The customer identifier'),
+        ).toBeVisible();
+
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
 
         expect(onAddFilter).toHaveBeenCalledWith(item);

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -1,13 +1,16 @@
 import {
     isAdditionalMetric,
+    isCompiledMetric,
     isCustomDimension,
     isDimension,
     isField,
     isFilterableField,
     isMetric,
+    MetricType,
+    type Dimension,
     type FilterableField,
 } from '@lightdash/common';
-import { UnstyledButton, ActionIcon, Tooltip } from '@mantine/core';
+import { ActionIcon, HoverCard, Tooltip, UnstyledButton } from '@mantine/core';
 import { IconFilter, IconTrash } from '@tabler/icons-react';
 import {
     Fragment,
@@ -23,16 +26,19 @@ import { useToggle } from 'react-use';
 import {
     explorerActions,
     selectIsFieldFiltered,
+    selectTableName,
     useExplorerDispatch,
     useExplorerSelector,
     type ExplorerStoreState,
 } from '../../../features/explorer/store';
+import { useExplore } from '../../../hooks/useExplore';
 import { useAddFilter } from '../../../hooks/useFilters';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import FieldIcon from '../../common/Filters/FieldIcon';
 import MantineIcon from '../../common/MantineIcon';
 import classes from './SelectedFieldsSection.module.css';
+import { ItemDetailPreview } from './TableTree/ItemDetailPreview';
 import TreeSingleNodeActions from './TableTree/Tree/TreeSingleNodeActions';
 import { type NodeItem } from './TableTree/Tree/types';
 import { useCustomMetricDelete } from './useCustomMetricDelete';
@@ -69,6 +75,25 @@ const getFieldLabel = (item: NodeItem): string =>
         ? item.label || item.name
         : item.name;
 
+const renderAggregatedSql = (sql: string, type: MetricType): string => {
+    switch (type) {
+        case MetricType.AVERAGE:
+            return `AVG(${sql})`;
+        case MetricType.COUNT:
+            return `COUNT(${sql})`;
+        case MetricType.COUNT_DISTINCT:
+            return `COUNT(DISTINCT ${sql})`;
+        case MetricType.MAX:
+            return `MAX(${sql})`;
+        case MetricType.MIN:
+            return `MIN(${sql})`;
+        case MetricType.SUM:
+            return `SUM(${sql})`;
+        default:
+            return sql;
+    }
+};
+
 type RowProps = {
     row: RenderedRow;
     onDeselect: (fieldId: string, isDimension: boolean) => void;
@@ -91,6 +116,8 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
     const dispatch = useExplorerDispatch();
     const addFilter = useAddFilter();
     const { track } = useTracking();
+    const activeTableName = useExplorerSelector(selectTableName);
+    const { data: exploreData } = useExplore(activeTableName);
 
     const [isHover, toggleHover] = useToggle(false);
     const [isMenuOpen, toggleMenu] = useToggle(false);
@@ -124,6 +151,44 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
             ? item.description
             : undefined;
 
+    const metricInfo = useMemo(() => {
+        if (isCompiledMetric(item)) {
+            return {
+                type: item.type,
+                sql: item.sql,
+                compiledSql: item.compiledSql,
+                filters: item.filters,
+                table: item.table,
+                name: item.name,
+            };
+        }
+        if (isAdditionalMetric(item)) {
+            const baseDimensionCandidate =
+                item.baseDimensionName && exploreData
+                    ? exploreData.tables[item.table]?.dimensions[
+                          item.baseDimensionName
+                      ]
+                    : undefined;
+            const baseDimension: Dimension | undefined =
+                baseDimensionCandidate && isDimension(baseDimensionCandidate)
+                    ? baseDimensionCandidate
+                    : undefined;
+            const baseSql = item.sql ?? '';
+            return {
+                type: item.type,
+                sql: baseSql,
+                compiledSql: renderAggregatedSql(baseSql, item.type),
+                filters: item.filters,
+                table: item.table,
+                name: item.name,
+                baseDimension,
+            };
+        }
+        return undefined;
+    }, [item, exploreData]);
+
+    const isHoverCardDisabled = !description && !metricInfo;
+
     const label = getFieldLabel(item);
 
     const handleClick = useCallback(() => {
@@ -137,6 +202,10 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
     const handleMouseLeave = useCallback(
         () => toggleHover(false),
         [toggleHover],
+    );
+    const handleDropdownClick = useCallback(
+        (e: React.MouseEvent) => e.stopPropagation(),
+        [],
     );
 
     const handleFilterClick = useCallback(
@@ -184,9 +253,37 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
             data-testid={`selected-field-${selectionKey ?? fieldId}`}
         >
             <FieldIcon item={item} size="md" />
-            <span className={classes.label} title={label}>
-                {label}
-            </span>
+            <HoverCard
+                openDelay={300}
+                keepMounted={false}
+                shadow="subtle"
+                withinPortal
+                withArrow
+                disabled={isHoverCardDisabled}
+                position="right"
+                radius="md"
+                offset={70}
+            >
+                <HoverCard.Target>
+                    <span className={classes.label} title={label}>
+                        {label}
+                    </span>
+                </HoverCard.Target>
+                <HoverCard.Dropdown
+                    hidden={!isHover}
+                    p="xs"
+                    miw={400}
+                    mah={500}
+                    maw={500}
+                    onClick={handleDropdownClick}
+                >
+                    <ItemDetailPreview
+                        onViewDescription={onOpenDescriptionView}
+                        description={description}
+                        metricInfo={metricInfo}
+                    />
+                </HoverCard.Dropdown>
+            </HoverCard>
             <span className={classes.actions}>
                 {showFilterAction && (
                     <Tooltip


### PR DESCRIPTION
## Description

Fixes #28059.

Linear: https://linear.app/lightdash/issue/PROD-10585/show-field-details-after-selection-in-explorer

Explorer's general field list already exposes a field-detail hover card, but the pinned `Selected` rendering path omitted it. This adds the same `ItemDetailPreview` to selected rows for metrics and dimensions, including original/compiled SQL for metrics. Existing selected-field actions and query selection behavior are unchanged.

## Reproduction before the fix

1. Start Lightdash with the seeded Jaffle Shop project and sign in as the demo user.
2. Open Jaffle Shop → Explore → Payments.
3. Hover the unselected `Unique payment count` metric. Confirm the card shows `unique_payment_count`, `Count distinct`, description `count of all payments`, and SQL `${TABLE}.payment_id`.
4. Select `Unique payment count` so it moves to `Selected`.
5. Hover the same field in `Selected`.

Before: no field-detail card appears in step 5.

## Validation after the fix

Repeat the same five steps. The selected row now shows the same name, type, description, and SQL detail. Clicking `Compiled SQL` shows `COUNT(DISTINCT "payments".payment_id)` without deselecting the metric.

Additional public-surface checks:

- Selected-row overflow still exposes Add filter, Create custom metric, and View description.
- Running the selected metric query returns one row with value `208`.
- A seeded saved chart still runs and displays total revenue `2,397` across five result rows.
- A freshly cleared browser console records no errors during the changed flow.
- Dimension hover behavior is covered by the focused component test.

## Screenshots

Before — selected metric has no detail card:


<img width="1440" height="1000" alt="image" src="https://github.com/user-attachments/assets/35187cd7-0d8f-4b1f-bceb-98a5a9209559" />

After — selected metric exposes description and SQL:

<img width="1440" height="1000" alt="image" src="https://github.com/user-attachments/assets/75fa9f14-2b0d-470a-9374-3f7807d3d37c" />


## Automated checks

- `pnpm -F frontend test --run src/components/Explorer/ExploreTree/SelectedFieldsSection.test.tsx` — 2 tests passed
- `pnpm -F frontend exec oxlint src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx src/components/Explorer/ExploreTree/SelectedFieldsSection.test.tsx` — 0 warnings/errors
- `pnpm -F frontend typecheck` — passed
- `pnpm -F frontend exec oxfmt ...` and `git diff --check` — passed

## Compatibility, security, and rollout

- No API, schema, generated artifact, dependency, database, migration, feature-flag, or persisted-content changes.
- No authentication, authorization, permission, tenant-isolation, or external-input boundary changes.
- The detail is already available for the same field in the same Explorer; this only makes the selected rendering path consistent.
- No rollout steps are required. Residual risk is limited to hover-card layout/interaction, covered through the real Explorer flow and focused regression tests.
