### PR TITLE
chore: replace Corepack with direct pnpm setup

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -66,6 +66,9 @@ fi
 
 ln -sfn "$NODE_ROOT" "$NODE_CURRENT"
 export PATH="$NODE_CURRENT/bin:$PATH"
+PNPM_HOME="$HOME/.local/share/lightdash/pnpm"
+export PNPM_HOME
+export PATH="$PNPM_HOME/bin:$PATH"
 
 profile_marker="# Lightdash orb toolchain"
 if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
@@ -83,15 +86,28 @@ esac
 EOF
 fi
 
+pnpm_profile_marker="# Lightdash orb pnpm"
+if ! grep -Fqx "$pnpm_profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+    cat >> "$HOME/.bash_profile" <<EOF
+
+$pnpm_profile_marker
+export PNPM_HOME="$PNPM_HOME"
+case ":\$PATH:" in
+    *":$PNPM_HOME/bin:"*) ;;
+    *) export PATH="$PNPM_HOME/bin:\$PATH" ;;
+esac
+EOF
+fi
+
 if [[ -n "${LIGHTDASH_ENV_FILE:-}" && ! -f .env.development.local ]]; then
     echo "==> Restoring .env.development.local from the Amp project secret"
     printf '%s' "$LIGHTDASH_ENV_FILE" > .env.development.local
     chmod 600 .env.development.local
 fi
 
-echo "==> Activating the repository's pinned pnpm"
-corepack enable pnpm
-corepack install
+PNPM_VERSION="$(node -p "require('./package.json').packageManager.match(/^pnpm@([^+]+)/)[1]")"
+echo "==> Installing the repository's pinned pnpm ${PNPM_VERSION}"
+curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION="$PNPM_VERSION" sh -
 node --version
 pnpm --version
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,25 +80,35 @@ git checkout main
 git pull upstream main
 ```
 
-4. Install the dependencies with pnpm (npm/yarn isn't supported):
+4. Install pnpm directly using one of the [official installation methods](https://pnpm.io/installation). Do not use
+   Corepack. For example, on supported POSIX systems:
+
+```sh
+curl -fsSL https://get.pnpm.io/install.sh | sh -
+```
+
+When run inside this repository, pnpm reads the root `packageManager` field and switches to the exact version pinned
+there.
+
+5. Install the dependencies with pnpm (npm/yarn isn't supported):
 
 ```sh
 pnpm install
 ```
 
-5. Create a new topic branch:
+6. Create a new topic branch:
 
 ```sh
 git checkout -b my-topic-branch
 ```
 
-6. Make changes, commit and push to your fork:
+7. Make changes, commit and push to your fork:
 
 ```sh
 git push -u origin HEAD
 ```
 
-7. Go to [the repository](https://github.com/lightdash/lightdash/pulls) and make a Pull Request.
+8. Go to [the repository](https://github.com/lightdash/lightdash/pulls) and make a Pull Request.
 
 The core team is monitoring for Pull Requests. We will review your Pull Request and either merge it, request changes to
 it, or close it with an explanation.

--- a/.github/workflows/_setup_node_pnpm_cypress/action.yml
+++ b/.github/workflows/_setup_node_pnpm_cypress/action.yml
@@ -9,7 +9,9 @@ runs:
           uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
         - name: Setup PNPM
-          uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+          with:
+              install: false
         - name: Setup Node
           uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
           with:

--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -41,7 +41,9 @@ jobs:
 
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+            - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+              with:
+                  install: false
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
                   node-version-file: '.nvmrc'
@@ -152,7 +154,9 @@ jobs:
 
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+            - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+              with:
+                  install: false
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
                   node-version-file: '.nvmrc'

--- a/.github/workflows/ai-security-advisories.yml
+++ b/.github/workflows/ai-security-advisories.yml
@@ -122,7 +122,9 @@ jobs:
                     echo "Resolved the immutable Docker digest."
                   fi
 
-            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+            - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+              with:
+                  install: false
 
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:

--- a/.github/workflows/mcp-tools-snapshot-check.yml
+++ b/.github/workflows/mcp-tools-snapshot-check.yml
@@ -40,7 +40,9 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -235,7 +235,9 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -123,7 +123,9 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: ".nvmrc"
@@ -163,7 +165,9 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: ".nvmrc"
@@ -217,7 +221,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: ".nvmrc"
@@ -528,7 +534,9 @@ jobs:
           egress-policy: audit
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/publish-e2b-template.yml
+++ b/.github/workflows/publish-e2b-template.yml
@@ -82,7 +82,9 @@ jobs:
           fi
           echo "action=$ACTION" >> "$GITHUB_OUTPUT"
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -371,7 +371,9 @@ jobs:
         with:
           ref: ${{ needs.changes.outputs.base_sha }}
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: '.nvmrc'
@@ -443,7 +445,9 @@ jobs:
       # resolve the store path — setup-node shells out to pnpm to find it, and
       # fails with "Unable to locate executable file: pnpm" if it runs first.
       # This is the ordering openapi-specs already uses.
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
 
       # The install below was 75% of this job's runtime (255s median) because it
       # re-fetched the whole CLI dependency tree, uncached, on every run — to

--- a/.github/workflows/release-safety-tests.yml
+++ b/.github/workflows/release-safety-tests.yml
@@ -35,7 +35,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
 
       - name: Install root dependencies
         run: pnpm install --frozen-lockfile --filter . --network-concurrency=16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,9 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: '.nvmrc'
@@ -74,7 +76,9 @@ jobs:
           # transferring all 7k+ tags (~63s measured on the 1.152.0 release).
           fetch-tags: true
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -154,7 +158,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || needs.release.outputs.new_release_git_tag }}
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,10 @@
 FROM gitpod/workspace-full
 
-# Pin Node + corepack so the repo packageManager field drives the pnpm version
-RUN bash -c '. /home/gitpod/.nvm/nvm.sh && nvm install 24.18 && nvm alias default 24.18 && npm i -g corepack@latest && corepack enable'
+ENV PNPM_HOME="/home/gitpod/.local/share/pnpm"
+ENV PATH="$PNPM_HOME/bin:$PATH"
+
+# Keep the bootstrap pnpm aligned with the root packageManager field.
+RUN bash -c '. /home/gitpod/.nvm/nvm.sh && nvm install 24.18 && nvm alias default 24.18 && curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=11.20.0 sh -'
 
 # Installing multiple versions of dbt
 # dbt 1.4 is the default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ pnpm -F backend rollback-last
 
 ## Development Workflow
 
-1. **Package Management**: Use `pnpm` (v11.17.0+, pinned via `packageManager` in the root `package.json` — let Corepack pick it up) - never use npm or yarn
+1. **Package Management**: Use `pnpm` (pinned via `packageManager` in the root `package.json`, which pnpm reads directly). Install pnpm directly; do not use Corepack, npm, or yarn for workspace commands.
 2. **Database**: Uses Knex.js for migrations and query building
 3. **API**: TSOA generates OpenAPI specs from TypeScript controllers
 4. **Authentication**: CASL-based authorization with multiple auth providers

--- a/agent-harness/cloud/cloud-init.yml
+++ b/agent-harness/cloud/cloud-init.yml
@@ -146,13 +146,14 @@ runcmd:
       fnm default 24.18
     '
 
-  # -- Install pnpm 11.17.0 ---------------------------------------------------
+  # -- Install pnpm 11.20.0 ---------------------------------------------------
   - |
     su - lightdash -c '
       export PATH="/home/lightdash/.local/share/fnm:$PATH"
       eval "$(fnm env --shell bash)"
-      corepack enable
-      corepack prepare pnpm@11.17.0 --activate
+      export PNPM_HOME="/home/lightdash/.local/share/pnpm"
+      export PATH="$PNPM_HOME/bin:$PATH"
+      curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=11.20.0 sh -
     '
 
   # -- Install PM2 globally ----------------------------------------------------
@@ -207,14 +208,14 @@ runcmd:
 
     # .profile.d/agent-harness.sh
     cat > /home/lightdash/.profile.d/agent-harness.sh << 'PROFILE'
-    # fnm (Fast Node Manager) - must be first to get node/npm/pnpm
+    # fnm (Fast Node Manager) - must be first to get node/npm
     export PATH="/home/lightdash/.local/share/fnm:$PATH"
     if command -v fnm &> /dev/null; then
       eval "$(fnm env --shell bash)"
     fi
     # pnpm
     export PNPM_HOME="/home/lightdash/.local/share/pnpm"
-    export PATH="$PNPM_HOME:$PATH"
+    export PATH="$PNPM_HOME/bin:$PATH"
     # dbt venvs
     if [ -d /opt/lightdash/.venvs/bin ]; then
       export PATH="/opt/lightdash/.venvs/bin:$PATH"

--- a/dockerfile
+++ b/dockerfile
@@ -16,6 +16,9 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:/opt/pnpm:$PATH"
 COPY --from=pnpm-cli /opt/pnpm /opt/pnpm
 COPY --from=pnpm-cli /pnpm /pnpm
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libatomic1 \
+    && rm -rf /var/lib/apt/lists/*
 RUN pnpm config set store-dir /pnpm/store
 
 WORKDIR /usr/app

--- a/dockerfile
+++ b/dockerfile
@@ -5,18 +5,17 @@
 FROM duckdb/duckdb:1.5.2@sha256:5658472bf45cce867048a17201b9d38d4632507e7df4a69994f8236599f69d45 AS duckdb-extensions
 RUN ["/duckdb", "-c", "INSTALL httpfs; INSTALL aws;"]
 
+FROM ghcr.io/pnpm/pnpm:11.20.0@sha256:d77573aba1649491010d3d252214be47197c0706417793cf393ac47cc324f315 AS pnpm-cli
+
 # -----------------------------
 # Stage 0: pnpm setup base
 # -----------------------------
 FROM node:24-bookworm-slim AS pnpm-base
 
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-# Fixed world-readable path so the pnpm cache resolves under any runtime UID (non-root securityContexts)
-ENV COREPACK_HOME="/usr/local/corepack"
-RUN npm i -g corepack@latest
-RUN corepack enable
-RUN corepack prepare pnpm@11.20.0 --activate && chmod -R a+rX "$COREPACK_HOME"
+ENV PATH="$PNPM_HOME/bin:/opt/pnpm:$PATH"
+COPY --from=pnpm-cli /opt/pnpm /opt/pnpm
+COPY --from=pnpm-cli /pnpm /pnpm
 RUN pnpm config set store-dir /pnpm/store
 
 WORKDIR /usr/app
@@ -394,8 +393,7 @@ FROM pnpm-base AS runtime-base
 
 ENV NODE_ENV production
 ENV PLAYGROUND_DATA_DIR=/usr/app/packages/backend/assets/playground
-# Boot must work fully offline: pnpm is baked in, never fetch it from npmjs at runtime
-ENV COREPACK_ENABLE_NETWORK=0
+# Boot works fully offline because the standalone pnpm binary is baked in.
 
 WORKDIR /usr/app
 

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -5,6 +5,8 @@
 FROM duckdb/duckdb:1.5.2@sha256:5658472bf45cce867048a17201b9d38d4632507e7df4a69994f8236599f69d45 AS duckdb-extensions
 RUN ["/duckdb", "-c", "INSTALL httpfs; INSTALL aws;"]
 
+FROM ghcr.io/pnpm/pnpm:11.20.0@sha256:d77573aba1649491010d3d252214be47197c0706417793cf393ac47cc324f315 AS pnpm-cli
+
 # Optimized Multi-Stage Build for PR Previews
 # Uses parallel build stages and cache mounts for maximum caching
 # Okteto uses a cluster of buildkit instances to persist caches across PRs
@@ -17,10 +19,9 @@ RUN ["/duckdb", "-c", "INSTALL httpfs; INSTALL aws;"]
 FROM node:24-bookworm-slim AS pnpm-base
 
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN npm i -g corepack@latest
-RUN corepack enable
-RUN corepack prepare pnpm@11.17.0 --activate
+ENV PATH="$PNPM_HOME/bin:/opt/pnpm:$PATH"
+COPY --from=pnpm-cli /opt/pnpm /opt/pnpm
+COPY --from=pnpm-cli /pnpm /pnpm
 RUN pnpm config set store-dir /pnpm/store
 
 WORKDIR /usr/app

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -22,6 +22,9 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:/opt/pnpm:$PATH"
 COPY --from=pnpm-cli /opt/pnpm /opt/pnpm
 COPY --from=pnpm-cli /pnpm /pnpm
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libatomic1 \
+    && rm -rf /var/lib/apt/lists/*
 RUN pnpm config set store-dir /pnpm/store
 
 WORKDIR /usr/app

--- a/scripts/release-safety-workflow-shape.test.ts
+++ b/scripts/release-safety-workflow-shape.test.ts
@@ -191,7 +191,7 @@ assert.ok(
     "the preview job's setup-node must cache the pnpm store (SPK-1021)",
 );
 assert.ok(
-    previewJob.indexOf('pnpm/action-setup') < previewJob.indexOf('actions/setup-node'),
+    previewJob.indexOf('pnpm/setup') < previewJob.indexOf('actions/setup-node'),
     'pnpm must be set up before setup-node, or cache: pnpm cannot resolve the store path (SPK-1021)',
 );
 


### PR DESCRIPTION
### Description

Replaces the repository Corepack dependency with direct pnpm tooling while retaining the root `packageManager` pin at pnpm 11.20.0.

- use the SHA-pinned `pnpm/setup` action in GitHub Actions, reading the version from `packageManager`
- preserve existing explicit install commands and setup-node cache ordering with `install: false`
- copy pnpm from the official digest-pinned image into the production and PR Dockerfiles
- install the standalone pnpm binary runtime dependency in the slim Node base images
- use the official standalone installer in Gitpod, cloud-init, and agent setup paths
- document direct local installation and version selection for contributors

### Validation

- `pnpm test:release-safety` — all existing script tests passed
- parsed all modified workflow and cloud-init YAML
- `bash -n .agents/setup`
- `shellcheck -e SC1091 .agents/setup`
- validated all 17 `pnpm/setup` blocks retain `install: false`
- verified local Fish resolves standalone pnpm 11.20.0 from `/Users/lukas/Library/pnpm/bin/pnpm`
- inspected the pinned pnpm OCI image manifest, executable paths, and permissions
- `git diff --check`

A Docker build was not run locally because the development stack is user-managed. The first PR Docker Build Test identified the missing `libatomic1` runtime dependency in `node:24-bookworm-slim`; the follow-up commit installs it and the check is rerunning.

### Risk assessment

This touches CI, bootstrap, and container build tooling rather than application runtime logic. Failures should surface during setup or image build, and the change is contained in one reversible PR.

- [ ] This is a high-risk change