### PR TITLE
fix(apps): drop deprecated baseUrl from the data app scaffold tsconfig

### DIFF
--- a/sandboxes/data-apps/template/tsconfig.json
+++ b/sandboxes/data-apps/template/tsconfig.json
@@ -16,7 +16,6 @@
         "noUnusedParameters": false,
         "noFallthroughCasesInSwitch": true,
         "allowJs": true,
-        "baseUrl": ".",
         "paths": {
             "@/*": ["./src/*"]
         }


### PR DESCRIPTION
The data-app/chart-type scaffold's \`tsconfig.json\` sets \`"baseUrl": "."\`, which TypeScript 6 deprecates and TypeScript 7 rejects outright (\`TS5102: Option 'baseUrl' has been removed\`). The template pins \`typescript: 7.0.2\`, so any typecheck over a downloaded bundle fails immediately with the deprecation error.

Note this hits data apps and custom chart types **equally** (identical scaffold) — reproduced \`TS5102\` on downloaded bundles of both kinds; which folder appears to "have the error" only depends on where a TS pass actually ran.

Fix: remove \`baseUrl\`. \`paths\` resolves relative to the tsconfig without it since TS 5.0, and vite's own \`@\` → \`./src\` alias handles runtime resolution — no behavior change. Verified: \`tsc --noEmit\` (TS 7.0.2) over a patched downloaded bundle no longer reports any config error.

Reach: the CLI vendors this template at build time, so freshly downloaded/created bundles get the fixed file once a CLI release ships; the generation sandbox picks it up with the next image build. Already-downloaded folders keep the old file until re-downloaded (one-line manual fix: delete the \`baseUrl\` line).

Closes: GLITCH-696

🤖 Generated with [Claude Code](https://claude.com/claude-code)