### PR TITLE
fix(recently-deleted): distinguish custom chart types from data apps

### DIFF
--- a/packages/backend/src/controllers/v2/ContentController.ts
+++ b/packages/backend/src/controllers/v2/ContentController.ts
@@ -235,6 +235,7 @@ export class ContentController extends BaseController {
         @Query() search?: string,
         @Query() contentTypes?: ContentType[],
         @Query() deletedByUserUuids?: string[],
+        @Query() dataAppVizsFilter?: 'exclude' | 'only',
     ): Promise<ApiDeletedContentResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -247,6 +248,7 @@ export class ContentController extends BaseController {
                     search,
                     contentTypes,
                     deletedByUserUuids,
+                    dataAppVizsFilter,
                 },
                 {
                     page: page || 1,

--- a/packages/backend/src/models/ContentModel/ContentModel.ts
+++ b/packages/backend/src/models/ContentModel/ContentModel.ts
@@ -7,6 +7,7 @@ import {
     KnexPaginateArgs,
     KnexPaginatedData,
     SummaryContentBase,
+    type DeletedDataAppContentSummary,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import KnexPaginate from '../../database/pagination';
@@ -247,6 +248,10 @@ export class ContentModel {
                 return {
                     ...base,
                     contentType: ContentType.DATA_APP,
+                    template:
+                        (row.metadata.template as
+                            | DeletedDataAppContentSummary['template']
+                            | null) ?? null,
                 };
             default:
                 throw new Error(

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -646,6 +646,7 @@ export class ContentService extends BaseService {
                 contentTypes,
                 search: filters.search,
                 deletedByUserUuids,
+                dataAppVizsFilter: filters.dataAppVizsFilter,
             },
             paginateArgs,
         );

--- a/packages/common/src/types/softDelete.ts
+++ b/packages/common/src/types/softDelete.ts
@@ -1,3 +1,4 @@
+import type { DataAppTemplate, DataAppVizsFilter } from '../ee/apps/types';
 import type { ChartSourceType, ContentType } from './content';
 import type { KnexPaginatedData } from './knex-paginate';
 import type { ChartKind } from './savedCharts';
@@ -103,6 +104,9 @@ export type DeletedDataAppContentSummary = {
     spaceName: string | null;
     projectUuid: string;
     organizationUuid: string;
+    // 'data_app_viz' marks a reusable custom chart type rather than a
+    // standalone app — labelled and restored differently in the UI.
+    template: DataAppTemplate | null;
 };
 
 export type DeletedContentSummary =
@@ -132,6 +136,9 @@ export type DeletedContentFilters = {
     search?: string;
     contentTypes?: ContentType[];
     deletedByUserUuids?: string[];
+    // Narrows DATA_APP rows: 'exclude' = data apps only, 'only' = custom
+    // chart types only. Omitted = both (labelled distinctly by the UI).
+    dataAppVizsFilter?: DataAppVizsFilter;
 };
 
 // API types

--- a/packages/frontend/src/features/recentlyDeleted/api/deletedContent.ts
+++ b/packages/frontend/src/features/recentlyDeleted/api/deletedContent.ts
@@ -1,5 +1,6 @@
 import {
     type ContentType,
+    type DataAppVizsFilter,
     type DeletedContentItem,
     type DeletedContentWithDescendants,
     type KnexPaginatedData,
@@ -13,6 +14,7 @@ export type DeletedContentApiParams = {
     search?: string;
     contentTypes?: ContentType[];
     deletedByUserUuids?: string[];
+    dataAppVizsFilter?: DataAppVizsFilter;
 };
 
 type DeletedContentApiResponse = KnexPaginatedData<
@@ -50,6 +52,10 @@ export async function getDeletedContent(
         params.deletedByUserUuids.forEach((uuid) =>
             searchParams.append('deletedByUserUuids', uuid),
         );
+    }
+
+    if (params.dataAppVizsFilter) {
+        searchParams.set('dataAppVizsFilter', params.dataAppVizsFilter);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
@@ -5,18 +5,16 @@ import {
     IconChartBar,
     IconFolder,
     IconLayoutDashboard,
+    IconPuzzle,
 } from '@tabler/icons-react';
 import type { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import {
+    CHART_TYPES_FILTER_VALUE,
+    type DeletedContentTypeFilter,
+} from '../types';
 import classes from './ContentTypeFilter.module.css';
-
-type DeletedContentTypeFilter =
-    | 'all'
-    | ContentType.CHART
-    | ContentType.DASHBOARD
-    | ContentType.SPACE
-    | ContentType.DATA_APP;
 
 type ContentTypeFilterProps = {
     selectedContentType: DeletedContentTypeFilter;
@@ -88,6 +86,22 @@ export const ContentTypeFilter: FC<ContentTypeFilterProps> = ({
                               <Box>
                                   <MantineIcon
                                       icon={IconAppWindow}
+                                      {...iconProps}
+                                  />
+                              </Box>
+                          </Tooltip>
+                      ),
+                  },
+                  {
+                      value: CHART_TYPES_FILTER_VALUE,
+                      label: (
+                          <Tooltip
+                              label="Show only deleted custom chart types"
+                              withinPortal
+                          >
+                              <Box>
+                                  <MantineIcon
+                                      icon={IconPuzzle}
                                       {...iconProps}
                                   />
                               </Box>

--- a/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
@@ -2,7 +2,9 @@ import {
     assertUnreachable,
     ChartSourceType,
     ContentType,
+    DATA_APP_VIZ_TEMPLATE,
     FeatureFlags,
+    type DataAppVizsFilter,
     type DeletedContentWithDescendants,
 } from '@lightdash/common';
 import {
@@ -23,6 +25,7 @@ import {
     IconClock,
     IconFolder,
     IconLayoutDashboard,
+    IconPuzzle,
     IconRefresh,
     IconSearch,
     IconTextCaption,
@@ -48,6 +51,10 @@ import {
     useRestoreDeletedContent,
 } from '../hooks/useDeletedContent';
 import { useDeletedContentFilters } from '../hooks/useDeletedContentFilters';
+import {
+    CHART_TYPES_FILTER_VALUE,
+    type DeletedContentTypeFilter,
+} from '../types';
 import { ContentTypeFilter } from './ContentTypeFilter';
 import { DeletedByFilter } from './DeletedByFilter';
 import DeletedContentActionMenu from './DeletedContentActionMenu';
@@ -132,13 +139,8 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const dataAppsEnabled = dataAppsFlag.data?.enabled ?? false;
 
-    const [selectedContentType, setSelectedContentType] = useState<
-        | 'all'
-        | ContentType.CHART
-        | ContentType.DASHBOARD
-        | ContentType.SPACE
-        | ContentType.DATA_APP
-    >('all');
+    const [selectedContentType, setSelectedContentType] =
+        useState<DeletedContentTypeFilter>('all');
 
     const {
         search,
@@ -158,12 +160,28 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
         300,
     );
 
-    // Convert selectedContentType to array format for API
+    // Convert selectedContentType to array format for API. Custom chart
+    // types share ContentType.DATA_APP; the dataAppVizsFilter splits them.
     const contentTypesFilter = useMemo(() => {
-        if (debouncedSearchAndFilters.selectedContentType === 'all') {
+        const selected = debouncedSearchAndFilters.selectedContentType;
+        if (selected === 'all') {
             return debouncedSearchAndFilters.apiFilters.contentTypes;
         }
-        return [debouncedSearchAndFilters.selectedContentType];
+        if (selected === CHART_TYPES_FILTER_VALUE) {
+            return [ContentType.DATA_APP];
+        }
+        return [selected];
+    }, [debouncedSearchAndFilters]);
+
+    const dataAppVizsFilter = useMemo<DataAppVizsFilter | undefined>(() => {
+        switch (debouncedSearchAndFilters.selectedContentType) {
+            case ContentType.DATA_APP:
+                return 'exclude';
+            case CHART_TYPES_FILTER_VALUE:
+                return 'only';
+            default:
+                return undefined;
+        }
     }, [debouncedSearchAndFilters]);
 
     const { data, fetchNextPage, isError, isFetching, isLoading, refetch } =
@@ -174,6 +192,7 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
             contentTypes: contentTypesFilter,
             deletedByUserUuids:
                 debouncedSearchAndFilters.apiFilters.deletedByUserUuids,
+            dataAppVizsFilter,
         });
 
     const flatData = useMemo<DeletedContentWithDescendants[]>(
@@ -247,7 +266,15 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
                                     />
                                 );
                             case ContentType.DATA_APP:
-                                return (
+                                // Custom chart types share the content type;
+                                // give them their own icon so rows read right.
+                                return row.original.template ===
+                                    DATA_APP_VIZ_TEMPLATE ? (
+                                    <IconBox
+                                        icon={IconPuzzle}
+                                        color="indigo.6"
+                                    />
+                                ) : (
                                     <IconBox
                                         icon={IconAppWindow}
                                         color="orange.6"
@@ -398,6 +425,9 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
                                         restoreContent({
                                             uuid: item.uuid,
                                             contentType: item.contentType,
+                                            isChartType:
+                                                item.template ===
+                                                DATA_APP_VIZ_TEMPLATE,
                                         });
                                         break;
                                     default:

--- a/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
+++ b/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
@@ -1,6 +1,7 @@
 import {
     ContentType,
     type ApiError,
+    type DataAppVizsFilter,
     type DeletedContentItem,
     type DeletedContentWithDescendants,
     type KnexPaginatedData,
@@ -28,6 +29,7 @@ type UseInfiniteDeletedContentParams = {
     search?: string;
     contentTypes?: ContentType[];
     deletedByUserUuids?: string[];
+    dataAppVizsFilter?: DataAppVizsFilter;
 };
 
 export function useInfiniteDeletedContent(
@@ -44,6 +46,7 @@ export function useInfiniteDeletedContent(
             params.search,
             params.contentTypes,
             params.deletedByUserUuids,
+            params.dataAppVizsFilter,
         ],
         queryFn: async ({ pageParam = 1 }) => {
             return getDeletedContent({
@@ -53,6 +56,7 @@ export function useInfiniteDeletedContent(
                 search: params.search,
                 contentTypes: params.contentTypes,
                 deletedByUserUuids: params.deletedByUserUuids,
+                dataAppVizsFilter: params.dataAppVizsFilter,
             });
         },
         getNextPageParam: (_lastGroup, groups) => {
@@ -65,13 +69,22 @@ export function useInfiniteDeletedContent(
     });
 }
 
+/**
+ * `isChartType` is presentation-only (custom chart types restore to the
+ * builder route, not the app viewer) — it is stripped before the API call.
+ */
+export type RestoreDeletedContentItem = DeletedContentItem & {
+    isChartType?: boolean;
+};
+
 export function useRestoreDeletedContent(projectUuid: string) {
     const queryClient = useQueryClient();
     const navigate = useNavigate();
     const { showToastSuccess, showToastApiError } = useToaster();
 
-    return useMutation<undefined, ApiError, DeletedContentItem>({
-        mutationFn: (item) => restoreDeletedContent(projectUuid, item),
+    return useMutation<undefined, ApiError, RestoreDeletedContentItem>({
+        mutationFn: ({ isChartType, ...item }) =>
+            restoreDeletedContent(projectUuid, item),
         onSuccess: async (_data, item) => {
             showToastSuccess({
                 title: 'Content restored',
@@ -106,11 +119,15 @@ export function useRestoreDeletedContent(projectUuid: string) {
                               }
                             : item.contentType === ContentType.DATA_APP
                               ? {
-                                    children: 'Go to app',
+                                    children: item.isChartType
+                                        ? 'Go to chart type'
+                                        : 'Go to app',
                                     icon: IconArrowRight,
                                     onClick: () =>
                                         navigate(
-                                            `/projects/${projectUuid}/apps/${item.uuid}`,
+                                            item.isChartType
+                                                ? `/projects/${projectUuid}/chart-types/${item.uuid}`
+                                                : `/projects/${projectUuid}/apps/${item.uuid}`,
                                         ),
                                 }
                               : undefined,

--- a/packages/frontend/src/features/recentlyDeleted/types.ts
+++ b/packages/frontend/src/features/recentlyDeleted/types.ts
@@ -1,0 +1,12 @@
+import type { ContentType } from '@lightdash/common';
+
+/** Custom chart types share ContentType.DATA_APP, split via dataAppVizsFilter. */
+export const CHART_TYPES_FILTER_VALUE = 'chartTypes' as const;
+
+export type DeletedContentTypeFilter =
+    | 'all'
+    | ContentType.CHART
+    | ContentType.DASHBOARD
+    | ContentType.SPACE
+    | ContentType.DATA_APP
+    | typeof CHART_TYPES_FILTER_VALUE;


### PR DESCRIPTION
Deleted custom chart types appeared in Recently deleted indistinguishable from data apps — same icon, "Go to app" restore action pointing at the data-app viewer, and no way to filter them apart (\`/api/v2/content/deleted\` had no \`dataAppVizsFilter\` param at all, unlike the non-deleted content listing). The rows themselves are correct — the chart-type delete modal explicitly promises they land here.

**Backend:**
- \`DeletedDataAppContentSummary\` gains \`template\` (the discriminator already flowed through the content configuration's metadata; the deleted-summary mapping just dropped it).
- \`GET /content/deleted\` accepts \`dataAppVizsFilter=exclude|only\`, plumbed through \`ContentService.findDeleted\` into the existing template filter in \`DataAppContentConfiguration\`.

**Frontend (Recently deleted page):**
- Chart-type rows get their own icon (puzzle, matching the nav's "Chart types" entry) instead of the app icon.
- The type filter gains a **Custom chart types** segment ("Data apps" now excludes them; "All" shows both, distinctly labelled).
- Restoring a chart type offers **"Go to chart type"** → \`/chart-types/:uuid\` (the builder) instead of "Go to app" → the app viewer. The presentation-only flag is stripped before the restore API call.

Test plan: typechecks clean across common/backend/frontend; live-verified against local dev — a soft-deleted chart type returns \`template: data_app_viz\` from \`/content/deleted\`, appears under \`only\`, and disappears under \`exclude\` (test row restored afterwards).

Closes: GLITCH-685

🤖 Generated with [Claude Code](https://claude.com/claude-code)