### PR TITLE
feat(ai): cover filter expression errors

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/filterExpressions/renderFilterExpressionError.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/filterExpressions/renderFilterExpressionError.test.ts
@@ -1,0 +1,179 @@
+import {
+    FILTER_EXPRESSION_MAX_RULES,
+    FilterOperator,
+    FilterType,
+    type FilterExpressionSpan,
+} from '@lightdash/common';
+import type {
+    FilterExpressionResolutionError,
+    FilterExpressionSource,
+} from './errors';
+import { formatFilterExpressionError } from './renderFilterExpressionError';
+
+const dimensionSource = {
+    kind: 'queryFilter',
+    exploreName: 'orders',
+    category: 'dimensions',
+} satisfies FilterExpressionSource;
+
+const metricSource = {
+    kind: 'queryFilter',
+    exploreName: 'orders',
+    category: 'metrics',
+} satisfies FilterExpressionSource;
+
+const tableCalculationSource = {
+    kind: 'queryFilter',
+    exploreName: 'orders',
+    category: 'tableCalculations',
+} satisfies FilterExpressionSource;
+
+const customMetricSource = {
+    kind: 'customMetricFilter',
+    exploreName: 'orders',
+    category: 'customMetric',
+    customMetricName: 'completed_revenue',
+} satisfies FilterExpressionSource;
+
+const span = {
+    start: { offset: 12, line: 2, column: 3 },
+    end: { offset: 16, line: 2, column: 7 },
+} satisfies FilterExpressionSpan;
+
+const details = {
+    span,
+    problem: 'The expression is invalid.',
+    guidance: 'Correct the expression.',
+    example: 'field equals=value',
+};
+
+const errorsByCode: Record<
+    FilterExpressionResolutionError['code'],
+    FilterExpressionResolutionError
+> = {
+    FILTER_EXPRESSION_SYNTAX: {
+        ...details,
+        code: 'FILTER_EXPRESSION_SYNTAX',
+        source: dimensionSource,
+        parserMessage: 'Parser syntax error',
+    },
+    FILTER_EXPRESSION_MIXED_CONNECTORS: {
+        ...details,
+        code: 'FILTER_EXPRESSION_MIXED_CONNECTORS',
+        source: metricSource,
+        parserMessage: 'Mixed connectors',
+    },
+    FILTER_EXPRESSION_BOUNDS_EXCEEDED: {
+        ...details,
+        code: 'FILTER_EXPRESSION_BOUNDS_EXCEEDED',
+        source: tableCalculationSource,
+        limit: 'ruleCount',
+        maximum: FILTER_EXPRESSION_MAX_RULES,
+        actual: FILTER_EXPRESSION_MAX_RULES + 1,
+    },
+    FILTER_EXPRESSION_UNKNOWN_FIELD: {
+        ...details,
+        code: 'FILTER_EXPRESSION_UNKNOWN_FIELD',
+        source: customMetricSource,
+        fieldId: 'orders_statu',
+        reason: 'notFound',
+        suggestions: ['orders_status'],
+    },
+    FILTER_EXPRESSION_WRONG_CATEGORY: {
+        ...details,
+        code: 'FILTER_EXPRESSION_WRONG_CATEGORY',
+        source: dimensionSource,
+        fieldId: 'orders_total_revenue',
+        expectedCategory: 'metrics',
+        actualCategory: 'dimensions',
+    },
+    FILTER_EXPRESSION_INVALID_VALUE: {
+        ...details,
+        code: 'FILTER_EXPRESSION_INVALID_VALUE',
+        source: metricSource,
+        fieldId: 'orders_total_revenue',
+        operator: FilterOperator.GREATER_THAN,
+        filterType: FilterType.NUMBER,
+    },
+    FILTER_EXPRESSION_WRONG_ARITY: {
+        ...details,
+        code: 'FILTER_EXPRESSION_WRONG_ARITY',
+        source: tableCalculationSource,
+        fieldId: 'profit_margin',
+        operator: FilterOperator.IN_BETWEEN,
+        expected: 2,
+        actual: 1,
+    },
+    FILTER_EXPRESSION_CUSTOM_METRIC_OR: {
+        ...details,
+        code: 'FILTER_EXPRESSION_CUSTOM_METRIC_OR',
+        source: customMetricSource,
+    },
+};
+
+const expectedByCode = {
+    FILTER_EXPRESSION_SYNTAX: `[FILTER_EXPRESSION_SYNTAX]
+Invalid dimension filter expression.
+
+Location: line 2, column 3
+Problem: The expression is invalid.
+How to fix: Correct the expression.
+Example: field equals=value`,
+    FILTER_EXPRESSION_MIXED_CONNECTORS: `[FILTER_EXPRESSION_MIXED_CONNECTORS]
+Invalid metric filter expression.
+
+Location: line 2, column 3
+Problem: The expression is invalid.
+How to fix: Correct the expression.
+Example: field equals=value`,
+    FILTER_EXPRESSION_BOUNDS_EXCEEDED: `[FILTER_EXPRESSION_BOUNDS_EXCEEDED]
+Invalid table calculation filter expression.
+
+Location: line 2, column 3
+Problem: The expression is invalid.
+How to fix: Correct the expression.
+Example: field equals=value`,
+    FILTER_EXPRESSION_UNKNOWN_FIELD: `[FILTER_EXPRESSION_UNKNOWN_FIELD]
+Invalid custom metric "completed_revenue" filter expression for field "orders_statu".
+
+Location: line 2, column 3
+Problem: The expression is invalid.
+How to fix: Correct the expression.
+Example: field equals=value`,
+    FILTER_EXPRESSION_WRONG_CATEGORY: `[FILTER_EXPRESSION_WRONG_CATEGORY]
+Invalid dimension filter expression for field "orders_total_revenue".
+
+Location: line 2, column 3
+Problem: The expression is invalid.
+How to fix: Correct the expression.
+Example: field equals=value`,
+    FILTER_EXPRESSION_INVALID_VALUE: `[FILTER_EXPRESSION_INVALID_VALUE]
+Invalid metric filter expression for field "orders_total_revenue".
+
+Location: line 2, column 3
+Problem: The expression is invalid.
+How to fix: Correct the expression.
+Example: field equals=value`,
+    FILTER_EXPRESSION_WRONG_ARITY: `[FILTER_EXPRESSION_WRONG_ARITY]
+Invalid table calculation filter expression for field "profit_margin".
+
+Location: line 2, column 3
+Problem: The expression is invalid.
+How to fix: Correct the expression.
+Example: field equals=value`,
+    FILTER_EXPRESSION_CUSTOM_METRIC_OR: `[FILTER_EXPRESSION_CUSTOM_METRIC_OR]
+Invalid custom metric "completed_revenue" filter expression.
+
+Location: line 2, column 3
+Problem: The expression is invalid.
+How to fix: Correct the expression.
+Example: field equals=value`,
+} satisfies Record<FilterExpressionResolutionError['code'], string>;
+
+describe('formatFilterExpressionError', () => {
+    it.each(Object.values(errorsByCode))('formats $code exactly', (error) => {
+        expect(formatFilterExpressionError(error)).toBe(
+            expectedByCode[error.code],
+        );
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/filterExpressions/resolveFilterExpressionArgs.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/filterExpressions/resolveFilterExpressionArgs.test.ts
@@ -1,6 +1,7 @@
 import {
     DimensionType,
     FieldType,
+    FILTER_EXPRESSION_MAX_RULES,
     FilterOperator,
     FilterType,
     getTotalFilterRules,
@@ -389,6 +390,89 @@ describe('resolveFilterExpressionArgs', () => {
                 { target: { fieldId: 'orders_total_revenue' } },
                 { target: { fieldId: 'orders_order_count' } },
             ],
+        });
+    });
+
+    it('propagates malformed parser syntax with its source and span', async () => {
+        const malformedLine = 'orders_product_category equals=';
+        const expression = `orders_customer_name equals=Acme AND\n${malformedLine}`;
+        const error = await expectResolutionError(
+            expressionArgs({
+                filters: {
+                    dimensions: expression,
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            }),
+        );
+
+        expect(error.code).toBe('FILTER_EXPRESSION_SYNTAX');
+        if (error.code !== 'FILTER_EXPRESSION_SYNTAX') {
+            throw new Error('Expected a syntax resolution error');
+        }
+
+        const endPosition = {
+            offset: expression.length,
+            line: 2,
+            column: malformedLine.length + 1,
+        };
+        expect(error).toMatchObject({
+            source: {
+                kind: 'queryFilter',
+                exploreName: mockOrdersExplore.name,
+                category: 'dimensions',
+            },
+            span: { start: endPosition, end: endPosition },
+        });
+        expect(error.parserMessage).toContain('end of input');
+        expect(error.problem).toBe(error.parserMessage);
+    });
+
+    it('propagates parser bounds errors with source, span, and limit metadata', async () => {
+        const rule = 'f equals=1';
+        const connector = ' AND ';
+        const rulesBeforeExcess = Array.from(
+            { length: FILTER_EXPRESSION_MAX_RULES },
+            () => rule,
+        ).join(connector);
+        const expression = `${rulesBeforeExcess}${connector}${rule}`;
+        const firstExcessRuleOffset =
+            rulesBeforeExcess.length + connector.length;
+        const error = await expectResolutionError(
+            expressionArgs({
+                filters: {
+                    dimensions: expression,
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            }),
+        );
+
+        expect(error.code).toBe('FILTER_EXPRESSION_BOUNDS_EXCEEDED');
+        if (error.code !== 'FILTER_EXPRESSION_BOUNDS_EXCEEDED') {
+            throw new Error('Expected a parser bounds resolution error');
+        }
+        expect(error).toMatchObject({
+            source: {
+                kind: 'queryFilter',
+                exploreName: mockOrdersExplore.name,
+                category: 'dimensions',
+            },
+            span: {
+                start: {
+                    offset: firstExcessRuleOffset,
+                    line: 1,
+                    column: firstExcessRuleOffset + 1,
+                },
+                end: {
+                    offset: firstExcessRuleOffset + rule.length,
+                    line: 1,
+                    column: firstExcessRuleOffset + rule.length + 1,
+                },
+            },
+            limit: 'ruleCount',
+            maximum: FILTER_EXPRESSION_MAX_RULES,
+            actual: FILTER_EXPRESSION_MAX_RULES + 1,
         });
     });
 
@@ -1105,24 +1189,40 @@ describe('strict expression value interpretation', () => {
         );
     });
 
-    it('reports wrong arity separately from invalid values', async () => {
-        const error = await expectResolutionError(
-            expressionArgs({
-                filters: {
-                    dimensions: 'orders_amount greaterThan=1,2',
-                    metrics: null,
-                    tableCalculations: null,
-                },
-            }),
-        );
-
-        expect(error).toMatchObject({
-            code: 'FILTER_EXPRESSION_WRONG_ARITY',
+    it.each([
+        {
+            expression: 'orders_amount greaterThan=1,2',
             operator: FilterOperator.GREATER_THAN,
             expected: 1,
             actual: 2,
-        });
-    });
+        },
+        {
+            expression: 'orders_amount inBetween=1',
+            operator: FilterOperator.IN_BETWEEN,
+            expected: 2,
+            actual: 1,
+        },
+    ])(
+        'reports wrong arity for $operator separately from invalid values',
+        async ({ expression, operator, expected, actual }) => {
+            const error = await expectResolutionError(
+                expressionArgs({
+                    filters: {
+                        dimensions: expression,
+                        metrics: null,
+                        tableCalculations: null,
+                    },
+                }),
+            );
+
+            expect(error).toMatchObject({
+                code: 'FILTER_EXPRESSION_WRONG_ARITY',
+                operator,
+                expected,
+                actual,
+            });
+        },
+    );
 
     it('rejects nonnumeric table-calculation filters explicitly', async () => {
         const error = await expectResolutionError(


### PR DESCRIPTION
Related: ZAP-963
Related: ZAP-920
Related: #28262

## Summary
- Cover resolver propagation for syntax and parser-bound errors.
- Exercise every filter-expression error formatter discriminator exactly.
- Strengthen connector-conflict and wrong-arity coverage.

## Tests
- `pnpm -F common test src/ee/AiAgent/schemas/filterExpressions/parse.test.ts`
- `pnpm -F backend test src/ee/services/ai/utils/filterExpressions/resolveFilterExpressionArgs.test.ts src/ee/services/ai/utils/filterExpressions/renderFilterExpressionError.test.ts`
- `pnpm -F backend typecheck`
- `pnpm -F backend format`
- `NODE_OPTIONS="--max-old-space-size=8192" pnpm -F backend lint`

Risk: low — test-only coverage; no runtime behavior changes.
