### PR TITLE
fix(activity): distinguish custom chart type builds in the data app activity log

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -123,6 +123,7 @@ export type DbAppActivityRow = Pick<
     | 'created_by_user_uuid'
 > & {
     app_name: string;
+    app_template: DbApp['template'];
     app_deleted_at: Date | null;
     project_uuid: string;
     project_name: string;

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -1110,6 +1110,7 @@ export class OrgAppsController extends BaseController {
         @Query() models?: DataAppActivityFilters['models'],
         @Query() dateFrom?: DataAppActivityFilters['dateFrom'],
         @Query() dateTo?: DataAppActivityFilters['dateTo'],
+        @Query() dataAppVizsFilter?: 'exclude' | 'only',
     ): Promise<ApiDataAppActivityResponse> {
         assertRegisteredAccount(req.account);
         validateUuidFilter('projectUuids', projectUuids);
@@ -1129,6 +1130,7 @@ export class OrgAppsController extends BaseController {
             ...(models && { models }),
             ...(dateFrom && { dateFrom }),
             ...(dateTo && { dateTo }),
+            ...(dataAppVizsFilter && { dataAppVizsFilter }),
         };
         const results = await this.services
             .getAppGenerateService<AppGenerateService>()

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.activity.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.activity.test.ts
@@ -13,6 +13,7 @@ vi.mock('ai', () => ({
 const BASE_ROW = {
     app_id: 'app-1',
     app_name: 'Revenue',
+    app_template: null,
     app_deleted_at: null,
     version: 1,
     status: 'ready',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -8576,6 +8576,7 @@ export class AppGenerateService extends BaseService {
             appUuid: row.app_id,
             appName: row.app_name,
             appDeleted: row.app_deleted_at !== null,
+            template: row.app_template,
             version: row.version,
             status: row.status,
             prompt: row.prompt,

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1561,6 +1561,10 @@ export class AppModel {
                         filters.dateTo,
                     );
                 }
+                AppModel.applyDataAppVizsFilter(
+                    queryBuilder,
+                    filters?.dataAppVizsFilter,
+                );
             })
             .select<DbAppActivityRow[]>(
                 `${AppVersionsTableName}.app_id`,
@@ -1572,6 +1576,7 @@ export class AppModel {
                 `${AppVersionsTableName}.created_at`,
                 `${AppVersionsTableName}.created_by_user_uuid`,
                 `${AppsTableName}.name as app_name`,
+                `${AppsTableName}.template as app_template`,
                 `${AppsTableName}.deleted_at as app_deleted_at`,
                 `${AppsTableName}.project_uuid`,
                 `${ProjectTableName}.name as project_name`,

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -733,6 +733,10 @@ export type DataAppActivityEvent = {
     // Activity outlives the app: a deleted app's generations still show, so the
     // log stays a complete record of what the org spent effort on.
     appDeleted: boolean;
+    // 'data_app_viz' marks a custom chart type build rather than a data app,
+    // so admins can tell the two products' spend apart. Null for "Custom" or
+    // pre-template apps.
+    template: Exclude<DataAppTemplate, 'custom'> | null;
     // Version 1 created the app; every later version iterated on it.
     version: number;
     status: AppVersionStatus;
@@ -766,6 +770,9 @@ export type DataAppActivityFilters = {
     // ISO-8601, inclusive.
     dateFrom?: string;
     dateTo?: string;
+    // 'exclude' = data app builds only, 'only' = custom chart type builds
+    // only. Omitted = both.
+    dataAppVizsFilter?: DataAppVizsFilter;
 };
 
 export type ApiDataAppActivityResponse = ApiSuccess<{

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTable.tsx
@@ -1,4 +1,5 @@
 import {
+    DATA_APP_VIZ_TEMPLATE,
     getAppDisplayName,
     type DataAppActivityEvent,
     type DataAppGenerationUsage,
@@ -12,6 +13,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from '@mantine/core';
+import { IconAppWindow, IconPuzzle } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useMemo, type FC } from 'react';
 import { Link } from 'react-router';
@@ -21,6 +23,7 @@ import {
     type ContentTableColumnDef,
 } from '../../../components/common/ContentTable';
 import ErrorState from '../../../components/common/ErrorState';
+import MantineIcon from '../../../components/common/MantineIcon';
 import { useInfiniteScroll } from '../../../hooks/useInfiniteScroll';
 import { useIsTruncated } from '../../../hooks/useIsTruncated/index';
 import { useInfiniteDataAppActivity } from '../hooks/useDataAppActivity';
@@ -194,8 +197,26 @@ export const DataAppActivityTable: FC = () => {
                         row.original.appName,
                         row.original.appUuid,
                     );
+                    const isChartType =
+                        row.original.template === DATA_APP_VIZ_TEMPLATE;
                     return (
                         <Group gap="xs" wrap="nowrap">
+                            <Tooltip
+                                label={
+                                    isChartType
+                                        ? 'Custom chart type'
+                                        : 'Data app'
+                                }
+                                withinPortal
+                            >
+                                <MantineIcon
+                                    icon={
+                                        isChartType ? IconPuzzle : IconAppWindow
+                                    }
+                                    color="ldGray.6"
+                                    style={{ flex: '0 0 auto' }}
+                                />
+                            </Tooltip>
                             {row.original.appDeleted ? (
                                 // Deleted apps have nothing to open.
                                 <Text fz="sm" c="ldGray.9" truncate>
@@ -204,7 +225,11 @@ export const DataAppActivityTable: FC = () => {
                             ) : (
                                 <Anchor
                                     component={Link}
-                                    to={`/projects/${row.original.projectUuid}/apps/${row.original.appUuid}`}
+                                    to={
+                                        isChartType
+                                            ? `/projects/${row.original.projectUuid}/chart-types/${row.original.appUuid}`
+                                            : `/projects/${row.original.projectUuid}/apps/${row.original.appUuid}`
+                                    }
                                     fz="sm"
                                     c="inherit"
                                     underline="hover"
@@ -372,10 +397,12 @@ export const DataAppActivityTable: FC = () => {
                 selectedUserUuids={filters.selectedUserUuids}
                 selectedModels={filters.selectedModels}
                 selectedPeriod={filters.selectedPeriod}
+                selectedKind={filters.selectedKind}
                 setSelectedProjectUuids={filters.setSelectedProjectUuids}
                 setSelectedUserUuids={filters.setSelectedUserUuids}
                 setSelectedModels={filters.setSelectedModels}
                 setSelectedPeriod={filters.setSelectedPeriod}
+                setSelectedKind={filters.setSelectedKind}
                 hasActiveFilters={filters.hasActiveFilters}
                 resetFilters={filters.resetFilters}
                 totalResults={totalResults}

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTopToolbar.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTopToolbar.tsx
@@ -25,7 +25,9 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import { useProjects } from '../../../hooks/useProjects';
 import {
+    DATA_APP_ACTIVITY_KINDS,
     DATA_APP_ACTIVITY_PERIODS,
+    type DataAppActivityKind,
     type useDataAppActivityFilters,
 } from '../hooks/useDataAppActivityFilters';
 
@@ -39,16 +41,24 @@ const PERIOD_LABELS: Record<
     '90d': '90 days',
 };
 
+const KIND_LABELS: Record<DataAppActivityKind, string> = {
+    all: 'All builds',
+    apps: 'Apps',
+    chartTypes: 'Chart types',
+};
+
 type DataAppActivityTopToolbarProps = Pick<
     ReturnType<typeof useDataAppActivityFilters>,
     | 'selectedProjectUuids'
     | 'selectedUserUuids'
     | 'selectedModels'
     | 'selectedPeriod'
+    | 'selectedKind'
     | 'setSelectedProjectUuids'
     | 'setSelectedUserUuids'
     | 'setSelectedModels'
     | 'setSelectedPeriod'
+    | 'setSelectedKind'
     | 'hasActiveFilters'
     | 'resetFilters'
 > & {
@@ -63,10 +73,12 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
     selectedUserUuids,
     selectedModels,
     selectedPeriod,
+    selectedKind,
     setSelectedProjectUuids,
     setSelectedUserUuids,
     setSelectedModels,
     setSelectedPeriod,
+    setSelectedKind,
     hasActiveFilters,
     resetFilters,
     totalResults,
@@ -178,6 +190,24 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
                         data={DATA_APP_ACTIVITY_PERIODS.map((period) => ({
                             label: PERIOD_LABELS[period],
                             value: period,
+                        }))}
+                    />
+                    <Divider
+                        orientation="vertical"
+                        w={1}
+                        h={20}
+                        style={{ alignSelf: 'center' }}
+                    />
+                    <SegmentedControl
+                        size="xs"
+                        radius="md"
+                        value={selectedKind}
+                        onChange={(value) =>
+                            setSelectedKind(value as DataAppActivityKind)
+                        }
+                        data={DATA_APP_ACTIVITY_KINDS.map((kind) => ({
+                            label: KIND_LABELS[kind],
+                            value: kind,
                         }))}
                     />
                     {hasActiveFilters && (

--- a/packages/frontend/src/features/dataAppActivity/hooks/useDataAppActivityFilters.ts
+++ b/packages/frontend/src/features/dataAppActivity/hooks/useDataAppActivityFilters.ts
@@ -25,16 +25,27 @@ const PERIOD_DAYS: Record<Exclude<DataAppActivityPeriod, 'all'>, number> = {
 
 const DEFAULT_PERIOD: DataAppActivityPeriod = 'all';
 
+/** Which product's builds to show — data apps and chart types share the log. */
+export const DATA_APP_ACTIVITY_KINDS = ['all', 'apps', 'chartTypes'] as const;
+export type DataAppActivityKind = (typeof DATA_APP_ACTIVITY_KINDS)[number];
+
+const DEFAULT_KIND: DataAppActivityKind = 'all';
+
 type DataAppActivityFiltersState = {
     projectUuids: string[];
     userUuids: string[];
     models: DataAppCodingAgentModel[];
     period: DataAppActivityPeriod;
+    kind: DataAppActivityKind;
 };
 
 const isPeriod = (value: string | null): value is DataAppActivityPeriod =>
     value !== null &&
     (DATA_APP_ACTIVITY_PERIODS as readonly string[]).includes(value);
+
+const isKind = (value: string | null): value is DataAppActivityKind =>
+    value !== null &&
+    (DATA_APP_ACTIVITY_KINDS as readonly string[]).includes(value);
 
 const isModel = (value: string): value is DataAppCodingAgentModel =>
     [...DATA_APP_CLAUDE_MODELS, ...DATA_APP_CODEX_MODELS].includes(
@@ -50,6 +61,7 @@ export const useDataAppActivityFilters = () => {
     const usersParam = useSearchParams<string>('users');
     const modelsParam = useSearchParams<string>('models');
     const periodParam = useSearchParams<string>('period');
+    const kindParam = useSearchParams<string>('kind');
 
     // Values that can't match anything (hand-edited URLs) are dropped rather
     // than sent on, so the filter UI never shows a selection it can't render.
@@ -68,6 +80,9 @@ export const useDataAppActivityFilters = () => {
     const selectedPeriod: DataAppActivityPeriod = isPeriod(periodParam)
         ? periodParam
         : DEFAULT_PERIOD;
+    const selectedKind: DataAppActivityKind = isKind(kindParam)
+        ? kindParam
+        : DEFAULT_KIND;
 
     const updateUrl = useCallback(
         (patch: Partial<DataAppActivityFiltersState>) => {
@@ -76,6 +91,7 @@ export const useDataAppActivityFilters = () => {
                 userUuids: selectedUserUuids,
                 models: selectedModels,
                 period: selectedPeriod,
+                kind: selectedKind,
                 ...patch,
             };
             const searchParams = new URLSearchParams();
@@ -91,6 +107,9 @@ export const useDataAppActivityFilters = () => {
             if (next.period !== DEFAULT_PERIOD) {
                 searchParams.set('period', next.period);
             }
+            if (next.kind !== DEFAULT_KIND) {
+                searchParams.set('kind', next.kind);
+            }
             const search = searchParams.toString();
             void navigate(
                 { pathname, search: search ? `?${search}` : '' },
@@ -104,6 +123,7 @@ export const useDataAppActivityFilters = () => {
             selectedUserUuids,
             selectedModels,
             selectedPeriod,
+            selectedKind,
         ],
     );
 
@@ -123,6 +143,10 @@ export const useDataAppActivityFilters = () => {
         (period: DataAppActivityPeriod) => updateUrl({ period }),
         [updateUrl],
     );
+    const setSelectedKind = useCallback(
+        (kind: DataAppActivityKind) => updateUrl({ kind }),
+        [updateUrl],
+    );
     const resetFilters = useCallback(
         () =>
             updateUrl({
@@ -130,6 +154,7 @@ export const useDataAppActivityFilters = () => {
                 userUuids: [],
                 models: [],
                 period: DEFAULT_PERIOD,
+                kind: DEFAULT_KIND,
             }),
         [updateUrl],
     );
@@ -138,7 +163,8 @@ export const useDataAppActivityFilters = () => {
         selectedProjectUuids.length > 0 ||
         selectedUserUuids.length > 0 ||
         selectedModels.length > 0 ||
-        selectedPeriod !== DEFAULT_PERIOD;
+        selectedPeriod !== DEFAULT_PERIOD ||
+        selectedKind !== DEFAULT_KIND;
 
     // Memoised on the selections, not per render: this object is the react-query
     // key, and a `dateFrom` that moved every render would refetch forever.
@@ -159,12 +185,19 @@ export const useDataAppActivityFilters = () => {
             }),
             ...(selectedModels.length > 0 && { models: selectedModels }),
             ...(dateFrom && { dateFrom }),
+            ...(selectedKind === 'apps' && {
+                dataAppVizsFilter: 'exclude' as const,
+            }),
+            ...(selectedKind === 'chartTypes' && {
+                dataAppVizsFilter: 'only' as const,
+            }),
         };
     }, [
         selectedProjectUuids,
         selectedUserUuids,
         selectedModels,
         selectedPeriod,
+        selectedKind,
     ]);
 
     return {
@@ -172,10 +205,12 @@ export const useDataAppActivityFilters = () => {
         selectedUserUuids,
         selectedModels,
         selectedPeriod,
+        selectedKind,
         setSelectedProjectUuids,
         setSelectedUserUuids,
         setSelectedModels,
         setSelectedPeriod,
+        setSelectedKind,
         resetFilters,
         hasActiveFilters,
         apiFilters,


### PR DESCRIPTION
The org-level Data app activity log mixed custom chart type builds in with data app generations with no way to tell them apart — no discriminator on the response, no filter, and every row linked to the data-app viewer. Including both is right (the log audits LLM build spend across both products); the gap was distinguishing them.

**Backend:**
- \`DataAppActivityEvent\` gains \`template\` ('data_app_viz' marks a chart type build), selected through \`AppModel.getOrganizationActivity\`.
- \`GET /ee/org/apps/activity\` accepts \`dataAppVizsFilter=exclude|only\` (reusing the established vocabulary and the shared \`applyDataAppVizsFilter\` helper).

**Frontend (activity table):**
- Each row's Name cell gets a kind icon with tooltip — puzzle for chart types, app window for data apps — and chart-type rows now link to the builder (\`/chart-types/:uuid\`) instead of the app viewer.
- New toolbar segment **All builds | Apps | Chart types**, URL-persisted (\`?kind=\`) like the existing filters, wired to the new query param.

Test plan: activity mapping tests updated and passing; typechecks clean across common/backend/frontend; live-verified — mixed feed shows \`template\` per row, \`exclude\` returns only the data app builds.

Closes: GLITCH-686

🤖 Generated with [Claude Code](https://claude.com/claude-code)