### PR TITLE
fix(backend): resolve user attributes in filter SQL

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -1140,6 +1140,69 @@ describe('Query builder', () => {
         expect(query).toContain('"table1_user_email_metric"');
     });
 
+    test('Should replace user attributes in a dimension used only as a filter target', () => {
+        const explore: Explore = {
+            ...EXPLORE,
+            tables: {
+                ...EXPLORE.tables,
+                table1: {
+                    ...EXPLORE.tables.table1,
+                    dimensions: {
+                        ...EXPLORE.tables.table1.dimensions,
+                        localized_shared: {
+                            type: DimensionType.STRING,
+                            name: 'localized_shared',
+                            label: 'localized_shared',
+                            table: 'table1',
+                            tableLabel: 'table1',
+                            fieldType: FieldType.DIMENSION,
+                            sql: `CASE WHEN \${lightdash.attributes.department} = 'ops' THEN \${ld.user.email} ELSE \${TABLE}.shared END`,
+                            compiledSql: `CASE WHEN \${lightdash.attributes.department} = 'ops' THEN \${ld.user.email} ELSE "table1".shared END`,
+                            tablesReferences: ['table1'],
+                            hidden: false,
+                        },
+                    },
+                },
+            },
+        };
+        const compiledMetricQuery: CompiledMetricQuery = {
+            ...METRIC_QUERY,
+            filters: {
+                dimensions: {
+                    id: 'root',
+                    and: [
+                        {
+                            id: 'filter',
+                            target: {
+                                fieldId: 'table1_localized_shared',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: ['mock@lightdash.com'],
+                        },
+                    ],
+                },
+            },
+        };
+        const buildFilteredQuery = (userAttributes: Record<string, string[]>) =>
+            buildQuery({
+                explore,
+                compiledMetricQuery,
+                warehouseSqlBuilder: warehouseClientMock,
+                userAttributes,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            }).query;
+
+        const query = buildFilteredQuery({ department: ['ops'] });
+
+        expect(query).not.toContain('${lightdash.attributes.department}');
+        expect(query).not.toContain('${ld.user.email}');
+        expect(replaceWhitespace(query)).toContain(
+            `(CASE WHEN 'ops' = 'ops' THEN 'mock@lightdash.com' ELSE "table1".shared END) IN ('mock@lightdash.com')`,
+        );
+        expect(() => buildFilteredQuery({})).toThrow(ForbiddenError);
+    });
+
     it('buildQuery with row() table calculation should order by custom bin _order column', () => {
         const { query } = buildQuery({
             explore: EXPLORE,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -2234,6 +2234,16 @@ export class MetricQueryBuilder {
               )
             : undefined;
         const filterField = resolvedFilterDimension?.field ?? field;
+        const filterFieldWithUserAttributes = {
+            ...filterField,
+            compiledSql: replaceUserAttributesAsStrings(
+                filterField.compiledSql,
+                this.args.intrinsicUserAttributes,
+                this.args.userAttributes ?? {},
+                warehouseSqlBuilder,
+                { noWrap: true },
+            ),
+        };
 
         // For period-to-date filters on truncated dimensions, resolve the
         // base (raw) dimension SQL so EXTRACT operates on the actual date
@@ -2253,7 +2263,13 @@ export class MetricQueryBuilder {
                     }),
             );
             if (baseDimension) {
-                baseDimensionSql = baseDimension.compiledSql;
+                baseDimensionSql = replaceUserAttributesAsStrings(
+                    baseDimension.compiledSql,
+                    this.args.intrinsicUserAttributes,
+                    this.args.userAttributes ?? {},
+                    warehouseSqlBuilder,
+                    { noWrap: true },
+                );
             }
         }
 
@@ -2262,7 +2278,7 @@ export class MetricQueryBuilder {
 
             return renderFilterRuleSqlFromField(
                 filterRuleWithParamReplacedValues,
-                filterField,
+                filterFieldWithUserAttributes,
                 fieldQuoteChar,
                 stringQuoteChar,
                 escapeString,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-10570/filtering-on-a-dimension-whose-sql-references-a-user-attribute-fails

### Description:

- Resolve custom and intrinsic user attributes in filter target SQL, including dimensions that are not selected in the query.
- Apply the same substitution to base dimensions used by period-to-date filters.
- Add regression coverage for filter-only dimensions, warehouse-safe substitution, and missing user attributes.

Before this change, selecting the dimension rendered its user attributes correctly, but using it only as a filter sent an unresolved placeholder to BigQuery and failed with `Syntax error: Unexpected "$"`. After the change, field-value suggestions and the filtered query both execute successfully.

### Validation:

- `MetricQueryBuilder.test.ts`: 241 tests passed.
- Backend typecheck passed.
- Focused Oxfmt and Oxlint checks passed.
- Commit hooks passed, including backend lint, formatting, unused-export checks, and secret scanning.
- Verified before and after in the local F1 BigQuery project on localhost:3000, with the user-attribute dimension used only as a filter.

### Risk assessment:

- [ ] This is a high-risk change

The replacement is a no-op for filter SQL without user-attribute references and reuses the existing warehouse-aware quoting and escaping path used by selected dimensions.