### PR TITLE
feat: classify AI prompts that need user input

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -3096,6 +3096,22 @@ export type AiAgentThreadDumpDownloadedEvent = BaseTrack & {
     };
 };
 
+export type AiAgentPromptInputRequestClassifiedEvent = BaseTrack & {
+    event: 'ai_agent.prompt_input_request_classified';
+    userId: string;
+    properties: {
+        organizationUuid: string;
+        projectUuid: string;
+        agentUuid: string;
+        threadUuid: string;
+        promptUuid: string;
+        gateFired: boolean;
+        classified: boolean | null;
+        model: string | null;
+        durationMs: number;
+    };
+};
+
 export type AiAgentReviewEvent =
     | AiAgentReviewItemsListedEvent
     | AiAgentReviewItemStatusChangedEvent
@@ -3506,6 +3522,7 @@ type TypedEvent =
     | AiAgentPullRequestViewedEvent
     | AiAgentReviewEvent
     | AiAgentThreadDumpDownloadedEvent
+    | AiAgentPromptInputRequestClassifiedEvent
     | AiAgentMemoryEvent
     | AiRouterConfigUpdatedEvent
     | AiRouterInstructionsUpdatedEvent

--- a/packages/backend/src/analytics/aiUsage.ts
+++ b/packages/backend/src/analytics/aiUsage.ts
@@ -28,6 +28,7 @@ export type AiCallFeature =
     | 'project-router'
     | 'agent-selector'
     | 'review-classifier'
+    | 'prompt-input-classifier'
     | 'ai-agent-memory'
     | 'llm-judge'
     | 'data-app'

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -293,6 +293,9 @@ export const lightdashConfigMock: LightdashConfig = {
         agentMemory: {
             consolidationDryRun: false,
         },
+        promptInputRequestClassifier: {
+            enabled: false,
+        },
     },
     embedding: {
         enabled: false,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -51,6 +51,22 @@ describe('mobile login config', () => {
     });
 });
 
+describe('AI prompt input request classifier config', () => {
+    it('is disabled by default', () => {
+        expect(parseConfig().ai.promptInputRequestClassifier.enabled).toBe(
+            false,
+        );
+    });
+
+    it('is enabled explicitly', () => {
+        process.env.AI_AGENT_PROMPT_INPUT_REQUEST_CLASSIFIER_ENABLED = 'true';
+
+        expect(parseConfig().ai.promptInputRequestClassifier.enabled).toBe(
+            true,
+        );
+    });
+});
+
 describe('Query phase metrics config', () => {
     it('defaults to an empty project allowlist', () => {
         expect(parseConfig().queryPhaseMetrics).toEqual({ projectUuids: [] });

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1590,6 +1590,9 @@ export type LightdashConfig = {
             /** Consolidation computes and records its operations, applying none. */
             consolidationDryRun: boolean;
         };
+        promptInputRequestClassifier: {
+            enabled: boolean;
+        };
     };
     embedding: {
         enabled: boolean;
@@ -3300,6 +3303,12 @@ export const parseConfig = (): LightdashConfig => {
             agentMemory: {
                 consolidationDryRun:
                     process.env.AI_AGENT_MEMORY_CONSOLIDATION_DRY_RUN ===
+                    'true',
+            },
+            promptInputRequestClassifier: {
+                enabled:
+                    process.env
+                        .AI_AGENT_PROMPT_INPUT_REQUEST_CLASSIFIER_ENABLED ===
                     'true',
             },
         },

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -203,6 +203,13 @@ export type AiWritebackRunTable = Knex.CompositeTableType<
 
 export const AiPromptTableName = 'ai_prompt';
 
+export type AiPromptNeedsUserInputMetadata = {
+    gate: 'match' | 'no_match';
+    model: string | null;
+    durationMs: number;
+    confidence: number | null;
+};
+
 export type DbAiPrompt = {
     ai_prompt_uuid: string;
     created_at: Date;
@@ -221,6 +228,8 @@ export type DbAiPrompt = {
     model_config: { modelName: string; modelProvider: string } | null;
     token_usage: AiPromptTokenUsage | null;
     execution_mode: 'standard' | 'deep_research' | null;
+    needs_user_input: boolean | null;
+    needs_user_input_metadata: AiPromptNeedsUserInputMetadata | null;
     // Hidden turn: the agent receives and responds to the prompt, but the UI
     // doesn't render the user bubble (e.g. the post-merge migration prompt).
     hidden: boolean;
@@ -247,6 +256,8 @@ export type AiPromptTable = Knex.CompositeTableType<
             | 'model_config'
             | 'token_usage'
             | 'execution_mode'
+            | 'needs_user_input'
+            | 'needs_user_input_metadata'
         > & {
             responded_at: Knex.Raw;
         }

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -203,12 +203,21 @@ export type AiWritebackRunTable = Knex.CompositeTableType<
 
 export const AiPromptTableName = 'ai_prompt';
 
-export type AiPromptNeedsUserInputMetadata = {
+export type AiPromptClassifierNeedsUserInputMetadata = {
     gate: 'match' | 'no_match';
     model: string | null;
     durationMs: number;
     confidence: number | null;
 };
+
+export type AiPromptStructuredNeedsUserInputMetadata = {
+    gate: 'structured';
+    reason: 'writeback_source_selection';
+};
+
+export type AiPromptNeedsUserInputMetadata =
+    | AiPromptClassifierNeedsUserInputMetadata
+    | AiPromptStructuredNeedsUserInputMetadata;
 
 export type DbAiPrompt = {
     ai_prompt_uuid: string;
@@ -219,6 +228,7 @@ export type DbAiPrompt = {
     response: string | null;
     error_message: string | null;
     responded_at: Date | null;
+    retried_at: Date | null;
     viz_config_output: object | null;
     filters_output: object | null;
     human_score: number | null;
@@ -260,6 +270,7 @@ export type AiPromptTable = Knex.CompositeTableType<
             | 'needs_user_input_metadata'
         > & {
             responded_at: Knex.Raw;
+            retried_at?: Date | Knex.Raw;
         }
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260826120000_add_ai_prompt_needs_user_input.ts
+++ b/packages/backend/src/ee/database/migrations/20260826120000_add_ai_prompt_needs_user_input.ts
@@ -4,7 +4,7 @@ const TABLE_NAME = 'ai_prompt';
 
 export const classification = {
     kind: 'safe',
-    reason: 'Adds two nullable columns without a default or backfill; existing reads and writes are unchanged.',
+    reason: 'Adds three nullable columns without a default or backfill; existing reads and writes are unchanged.',
 };
 
 export async function up(knex: Knex): Promise<void> {
@@ -13,6 +13,7 @@ export async function up(knex: Knex): Promise<void> {
         await knex.schema.alterTable(TABLE_NAME, (table) => {
             table.boolean('needs_user_input').nullable();
             table.jsonb('needs_user_input_metadata').nullable();
+            table.timestamp('retried_at', { useTz: true }).nullable();
         });
     } finally {
         await knex.raw('RESET lock_timeout');
@@ -25,6 +26,7 @@ export async function down(knex: Knex): Promise<void> {
         await knex.schema.alterTable(TABLE_NAME, (table) => {
             table.dropColumn('needs_user_input');
             table.dropColumn('needs_user_input_metadata');
+            table.dropColumn('retried_at');
         });
     } finally {
         await knex.raw('RESET lock_timeout');

--- a/packages/backend/src/ee/database/migrations/20260826120000_add_ai_prompt_needs_user_input.ts
+++ b/packages/backend/src/ee/database/migrations/20260826120000_add_ai_prompt_needs_user_input.ts
@@ -1,0 +1,32 @@
+import type { Knex } from 'knex';
+
+const TABLE_NAME = 'ai_prompt';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds two nullable columns without a default or backfill; existing reads and writes are unchanged.',
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET lock_timeout = '10s'`);
+    try {
+        await knex.schema.alterTable(TABLE_NAME, (table) => {
+            table.boolean('needs_user_input').nullable();
+            table.jsonb('needs_user_input_metadata').nullable();
+        });
+    } finally {
+        await knex.raw('RESET lock_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET lock_timeout = '10s'`);
+    try {
+        await knex.schema.alterTable(TABLE_NAME, (table) => {
+            table.dropColumn('needs_user_input');
+            table.dropColumn('needs_user_input_metadata');
+        });
+    } finally {
+        await knex.raw('RESET lock_timeout');
+    }
+}

--- a/packages/backend/src/ee/database/migrations/__tests__/20260826120000_add_ai_prompt_needs_user_input.test.ts
+++ b/packages/backend/src/ee/database/migrations/__tests__/20260826120000_add_ai_prompt_needs_user_input.test.ts
@@ -1,0 +1,43 @@
+import knex from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { down, up } from '../20260826120000_add_ai_prompt_needs_user_input';
+
+describe('AI prompt needs-user-input migration', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('adds nullable classification columns', async () => {
+        tracker.on.any(() => true).response({});
+
+        await up(database);
+
+        expect(tracker.history.all.map(({ sql }) => sql)).toContain(
+            'alter table "ai_prompt" add column "needs_user_input" boolean null, add column "needs_user_input_metadata" jsonb null',
+        );
+    });
+
+    it('drops both classification columns', async () => {
+        tracker.on.any(() => true).response({});
+
+        await down(database);
+
+        expect(tracker.history.all.map(({ sql }) => sql)).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining(
+                    'alter table "ai_prompt" drop column "needs_user_input"',
+                ),
+                expect.stringContaining(
+                    'alter table "ai_prompt" drop column "needs_user_input_metadata"',
+                ),
+            ]),
+        );
+    });
+});

--- a/packages/backend/src/ee/database/migrations/__tests__/20260826120000_add_ai_prompt_needs_user_input.test.ts
+++ b/packages/backend/src/ee/database/migrations/__tests__/20260826120000_add_ai_prompt_needs_user_input.test.ts
@@ -14,17 +14,17 @@ describe('AI prompt needs-user-input migration', () => {
         tracker.reset();
     });
 
-    it('adds nullable classification columns', async () => {
+    it('adds nullable classification and retry freshness columns', async () => {
         tracker.on.any(() => true).response({});
 
         await up(database);
 
         expect(tracker.history.all.map(({ sql }) => sql)).toContain(
-            'alter table "ai_prompt" add column "needs_user_input" boolean null, add column "needs_user_input_metadata" jsonb null',
+            'alter table "ai_prompt" add column "needs_user_input" boolean null, add column "needs_user_input_metadata" jsonb null, add column "retried_at" timestamptz null',
         );
     });
 
-    it('drops both classification columns', async () => {
+    it('drops the classification and retry freshness columns', async () => {
         tracker.on.any(() => true).response({});
 
         await down(database);
@@ -36,6 +36,9 @@ describe('AI prompt needs-user-input migration', () => {
                 ),
                 expect.stringContaining(
                     'alter table "ai_prompt" drop column "needs_user_input_metadata"',
+                ),
+                expect.stringContaining(
+                    'alter table "ai_prompt" drop column "retried_at"',
                 ),
             ]),
         );

--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -239,6 +239,91 @@ describe('AiAgentModel prompt activity', () => {
         });
     });
 
+    it('persists a successful terminal response after retrying a failed prompt with token usage', async () => {
+        const threadUuid = await createWebAppThread();
+        const promptUuid = await model.createWebAppPrompt({
+            threadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'Retry a failed response with recorded token usage',
+        });
+        const failedAttemptTokenUsage = {
+            totalTokens: 41,
+            finalStepTotalTokens: 17,
+        };
+        const retriedAttemptTokenUsage = {
+            totalTokens: 23,
+            finalStepTotalTokens: 23,
+        };
+        const readPromptState = async () =>
+            database(AiPromptTableName)
+                .select(['response', 'error_message', 'token_usage'])
+                .select(
+                    database.raw('responded_at::text as responded_at'),
+                    database.raw('retried_at::text as retried_at'),
+                )
+                .where('ai_prompt_uuid', promptUuid)
+                .first<{
+                    response: string | null;
+                    error_message: string | null;
+                    token_usage: typeof failedAttemptTokenUsage | null;
+                    responded_at: string | null;
+                    retried_at: string | null;
+                }>();
+
+        const failedAttemptPersisted = await model.updateModelResponse({
+            promptUuid,
+            errorMessage: 'The agent finished without writing a response.',
+            tokenUsage: failedAttemptTokenUsage,
+        });
+        const failedState = await readPromptState();
+
+        expect(failedAttemptPersisted).toBe(true);
+        expect(failedState).toMatchObject({
+            response: null,
+            error_message: 'The agent finished without writing a response.',
+            token_usage: failedAttemptTokenUsage,
+            retried_at: null,
+        });
+        expect(failedState?.responded_at).not.toBeNull();
+
+        const retryStarted = await model.resetPromptResponseForRetry(
+            promptUuid,
+            {
+                respondedAt: failedState!.responded_at,
+                response: failedState!.response,
+                errorMessage: failedState!.error_message,
+            },
+        );
+        const resetState = await readPromptState();
+
+        expect(retryStarted).toBe(true);
+        expect(resetState).toMatchObject({
+            response: null,
+            error_message: null,
+            responded_at: null,
+        });
+        expect(resetState?.retried_at).not.toBeNull();
+
+        const terminalResponsePersisted = await model.updateModelResponse(
+            {
+                promptUuid,
+                response: 'The retried response completed successfully.',
+                tokenUsage: retriedAttemptTokenUsage,
+            },
+            { onlyIfUnfinalized: true },
+        );
+        const terminalState = await readPromptState();
+
+        expect({ terminalResponsePersisted, ...terminalState }).toEqual({
+            terminalResponsePersisted: true,
+            response: 'The retried response completed successfully.',
+            error_message: null,
+            token_usage: retriedAttemptTokenUsage,
+            responded_at: expect.any(String),
+            retried_at: resetState?.retried_at,
+        });
+    });
+
     it('keeps reused tool call ids scoped to their prompts', async () => {
         const threadUuid = await createWebAppThread();
         const expectedResults = ['first prompt result', 'second prompt result'];

--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -13,6 +13,7 @@ import {
     AiPromptTableName,
     AiThreadTableName,
     AiWritebackRunTableName,
+    type AiPromptNeedsUserInputMetadata,
 } from '../database/entities/ai';
 import { AiAgentModel } from './AiAgentModel';
 import { AiWritebackRunModel } from './AiWritebackRunModel';
@@ -254,9 +255,21 @@ describe('AiAgentModel prompt activity', () => {
             totalTokens: 23,
             finalStepTotalTokens: 23,
         };
+        const classificationMetadata = {
+            gate: 'match',
+            model: 'claude-haiku-4-5',
+            durationMs: 125,
+            confidence: 0.9,
+        } as const;
         const readPromptState = async () =>
             database(AiPromptTableName)
-                .select(['response', 'error_message', 'token_usage'])
+                .select([
+                    'response',
+                    'error_message',
+                    'token_usage',
+                    'needs_user_input',
+                    'needs_user_input_metadata',
+                ])
                 .select(
                     database.raw('responded_at::text as responded_at'),
                     database.raw('retried_at::text as retried_at'),
@@ -266,6 +279,8 @@ describe('AiAgentModel prompt activity', () => {
                     response: string | null;
                     error_message: string | null;
                     token_usage: typeof failedAttemptTokenUsage | null;
+                    needs_user_input: boolean | null;
+                    needs_user_input_metadata: AiPromptNeedsUserInputMetadata | null;
                     responded_at: string | null;
                     retried_at: string | null;
                 }>();
@@ -275,13 +290,23 @@ describe('AiAgentModel prompt activity', () => {
             errorMessage: 'The agent finished without writing a response.',
             tokenUsage: failedAttemptTokenUsage,
         });
+        const classificationPersisted = await model.updatePromptNeedsUserInput({
+            promptUuid,
+            needsUserInput: true,
+            metadata: classificationMetadata,
+        });
         const failedState = await readPromptState();
 
-        expect(failedAttemptPersisted).toBe(true);
+        expect({ failedAttemptPersisted, classificationPersisted }).toEqual({
+            failedAttemptPersisted: true,
+            classificationPersisted: true,
+        });
         expect(failedState).toMatchObject({
             response: null,
             error_message: 'The agent finished without writing a response.',
             token_usage: failedAttemptTokenUsage,
+            needs_user_input: true,
+            needs_user_input_metadata: classificationMetadata,
             retried_at: null,
         });
         expect(failedState?.responded_at).not.toBeNull();
@@ -301,6 +326,8 @@ describe('AiAgentModel prompt activity', () => {
             response: null,
             error_message: null,
             responded_at: null,
+            needs_user_input: null,
+            needs_user_input_metadata: null,
         });
         expect(resetState?.retried_at).not.toBeNull();
 
@@ -319,6 +346,8 @@ describe('AiAgentModel prompt activity', () => {
             response: 'The retried response completed successfully.',
             error_message: null,
             token_usage: retriedAttemptTokenUsage,
+            needs_user_input: null,
+            needs_user_input_metadata: null,
             responded_at: expect.any(String),
             retried_at: resetState?.retried_at,
         });

--- a/packages/backend/src/ee/models/AiAgentModel.promptInputClassification.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.promptInputClassification.test.ts
@@ -48,4 +48,122 @@ describe('AiAgentModel prompt input classification', () => {
             ]),
         );
     });
+
+    it('overwrites an existing verdict with a structured verdict', async () => {
+        tracker.on
+            .update('ai_prompt')
+            .responseOnce([{ ai_prompt_uuid: 'prompt-uuid' }]);
+
+        await expect(
+            model.setPromptNeedsUserInput({
+                promptUuid: 'prompt-uuid',
+                needsUserInput: true,
+                metadata: {
+                    gate: 'structured',
+                    reason: 'writeback_source_selection',
+                },
+            }),
+        ).resolves.toBe(true);
+
+        const statement = tracker.history.update[0];
+        expect(statement.sql).not.toContain('"needs_user_input" is null');
+        expect(statement.bindings).toEqual(
+            expect.arrayContaining([
+                true,
+                'prompt-uuid',
+                {
+                    gate: 'structured',
+                    reason: 'writeback_source_selection',
+                },
+            ]),
+        );
+    });
+
+    it('stamps retry freshness while clearing a failed response', async () => {
+        tracker.on
+            .update('ai_prompt')
+            .responseOnce([{ ai_prompt_uuid: 'prompt-uuid' }]);
+
+        await expect(
+            model.resetPromptResponseForRetry('prompt-uuid', {
+                respondedAt: '2026-08-26 10:00:00+00',
+                response: null,
+                errorMessage: 'Previous failure',
+            }),
+        ).resolves.toBe(true);
+
+        const statement = tracker.history.update[0];
+        expect(statement.sql).toContain('"retried_at" = CURRENT_TIMESTAMP');
+        expect(statement.sql).toContain('"responded_at" = NULL');
+        expect(statement.bindings).toEqual(
+            expect.arrayContaining([
+                'prompt-uuid',
+                '2026-08-26 10:00:00+00',
+                'Previous failure',
+            ]),
+        );
+    });
+
+    it('allows one final response to replace intermediate text', async () => {
+        tracker.on
+            .update('ai_prompt')
+            .responseOnce([{ ai_prompt_uuid: 'prompt-uuid' }]);
+        tracker.on.update('ai_prompt').responseOnce([]);
+
+        await expect(
+            model.updateModelResponse(
+                {
+                    promptUuid: 'prompt-uuid',
+                    response: 'First response',
+                    tokenUsage: {
+                        totalTokens: 20,
+                        finalStepTotalTokens: 5,
+                    },
+                },
+                { onlyIfUnfinalized: true },
+            ),
+        ).resolves.toBe(true);
+        await expect(
+            model.updateModelResponse(
+                {
+                    promptUuid: 'prompt-uuid',
+                    response: 'Duplicate response',
+                    tokenUsage: {
+                        totalTokens: 20,
+                        finalStepTotalTokens: 5,
+                    },
+                },
+                { onlyIfUnfinalized: true },
+            ),
+        ).resolves.toBe(false);
+
+        for (const statement of tracker.history.update) {
+            expect(statement.sql).toContain('"token_usage" is null');
+            expect(statement.sql).toContain('"error_message" is null');
+            expect(statement.sql).not.toContain('"responded_at" is null');
+            expect(statement.sql).not.toContain('"response" is null');
+        }
+    });
+
+    it('blocks finalization after an existing error', async () => {
+        tracker.on.update('ai_prompt').responseOnce([]);
+
+        await expect(
+            model.updateModelResponse(
+                {
+                    promptUuid: 'prompt-uuid',
+                    response: 'Late response',
+                    tokenUsage: {
+                        totalTokens: 20,
+                        finalStepTotalTokens: 5,
+                    },
+                },
+                { onlyIfUnfinalized: true },
+            ),
+        ).resolves.toBe(false);
+
+        expect(tracker.history.update[0].sql).toContain(
+            '"error_message" is null',
+        );
+    });
 });

--- a/packages/backend/src/ee/models/AiAgentModel.promptInputClassification.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.promptInputClassification.test.ts
@@ -1,0 +1,51 @@
+import knex from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { AiAgentModel } from './AiAgentModel';
+
+describe('AiAgentModel prompt input classification', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new AiAgentModel({
+        database,
+        lightdashConfig: lightdashConfigMock,
+        encryptionUtil: {} as never,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('writes a verdict only while the prompt is unclassified', async () => {
+        tracker.on
+            .update('ai_prompt')
+            .responseOnce([{ ai_prompt_uuid: 'prompt-uuid' }]);
+
+        await expect(
+            model.updatePromptNeedsUserInput({
+                promptUuid: 'prompt-uuid',
+                needsUserInput: true,
+                metadata: {
+                    gate: 'match',
+                    model: 'claude-haiku-4-5',
+                    durationMs: 125,
+                    confidence: 0.9,
+                },
+            }),
+        ).resolves.toBe(true);
+
+        const statement = tracker.history.update[0];
+        expect(statement.sql).toContain('"needs_user_input" is null');
+        expect(statement.bindings).toEqual(
+            expect.arrayContaining([
+                true,
+                'prompt-uuid',
+                expect.objectContaining({ gate: 'match' }),
+            ]),
+        );
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -158,6 +158,7 @@ import {
     DbAiThreadShare,
     DbAiWebAppPrompt,
     DbAiWritebackRun,
+    type AiPromptNeedsUserInputMetadata,
     type AiSqlApprovalDecision,
 } from '../database/entities/ai';
 import {
@@ -410,6 +411,7 @@ type AiAgentThreadLiveStateRow = {
     prompt_response: string | null;
     prompt_error_message: string | null;
     prompt_interrupted_at: Date | null;
+    prompt_needs_user_input: boolean | null;
     run_sql_tool_call_created_at: Date | null;
     run_sql_tool_result_uuid: string | null;
     run_sql_approval_decision: AiSqlApprovalDecision | null;
@@ -3067,6 +3069,7 @@ export class AiAgentModel {
                         latest_prompt.responded_at,
                         latest_prompt.response,
                         latest_prompt.error_message,
+                        latest_prompt.needs_user_input,
                         prompt_interrupt.created_at as interrupted_at,
                         latest_prompt.created_by_user_uuid
                     FROM ${AiPromptTableName} as latest_prompt
@@ -3144,6 +3147,7 @@ export class AiAgentModel {
                 'latest_prompt.response as prompt_response',
                 'latest_prompt.error_message as prompt_error_message',
                 'latest_prompt.interrupted_at as prompt_interrupted_at',
+                'latest_prompt.needs_user_input as prompt_needs_user_input',
                 'run_sql_tool_calls.created_at as run_sql_tool_call_created_at',
                 'run_sql_tool_calls.ai_agent_tool_result_uuid as run_sql_tool_result_uuid',
                 'run_sql_tool_calls.decision as run_sql_approval_decision',
@@ -3184,6 +3188,7 @@ export class AiAgentModel {
                               response: row.prompt_response,
                               errorMessage: row.prompt_error_message,
                               interruptedAt: row.prompt_interrupted_at,
+                              needsUserInput: row.prompt_needs_user_input,
                           },
                 runSqlToolCalls: [],
                 pendingWritebackCreatedAt: row.pending_writeback_created_at,
@@ -5540,6 +5545,27 @@ export class AiAgentModel {
         }
 
         await query.returning('ai_prompt_uuid');
+    }
+
+    async updatePromptNeedsUserInput({
+        promptUuid,
+        needsUserInput,
+        metadata,
+    }: {
+        promptUuid: string;
+        needsUserInput: boolean;
+        metadata: AiPromptNeedsUserInputMetadata;
+    }): Promise<boolean> {
+        const rows = await this.database(AiPromptTableName)
+            .update({
+                needs_user_input: needsUserInput,
+                needs_user_input_metadata: metadata,
+            })
+            .where('ai_prompt_uuid', promptUuid)
+            .whereNull('needs_user_input')
+            .returning<{ ai_prompt_uuid: string }[]>('ai_prompt_uuid');
+
+        return rows.length > 0;
     }
 
     async resetPromptResponseForRetry(

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -5616,6 +5616,8 @@ export class AiAgentModel {
                 responded_at: this.database.raw('NULL'),
                 error_message: null,
                 token_usage: null,
+                needs_user_input: null,
+                needs_user_input_metadata: null,
                 retried_at: this.database.fn.now(),
             })
             .where('ai_prompt_uuid', promptUuid)

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -5615,6 +5615,7 @@ export class AiAgentModel {
             .update({
                 responded_at: this.database.raw('NULL'),
                 error_message: null,
+                token_usage: null,
                 retried_at: this.database.fn.now(),
             })
             .where('ai_prompt_uuid', promptUuid)

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -158,7 +158,8 @@ import {
     DbAiThreadShare,
     DbAiWebAppPrompt,
     DbAiWritebackRun,
-    type AiPromptNeedsUserInputMetadata,
+    type AiPromptClassifierNeedsUserInputMetadata,
+    type AiPromptStructuredNeedsUserInputMetadata,
     type AiSqlApprovalDecision,
 } from '../database/entities/ai';
 import {
@@ -407,6 +408,7 @@ type AiAgentThreadLiveStateRow = {
     thread_uuid: string;
     thread_created_at: Date;
     prompt_created_at: Date | null;
+    prompt_retried_at: Date | null;
     prompt_responded_at: Date | null;
     prompt_response: string | null;
     prompt_error_message: string | null;
@@ -3066,6 +3068,7 @@ export class AiAgentModel {
                     SELECT
                         latest_prompt.ai_prompt_uuid,
                         latest_prompt.created_at,
+                        latest_prompt.retried_at,
                         latest_prompt.responded_at,
                         latest_prompt.response,
                         latest_prompt.error_message,
@@ -3143,6 +3146,7 @@ export class AiAgentModel {
                 'live_thread.ai_thread_uuid as thread_uuid',
                 'live_thread.created_at as thread_created_at',
                 'latest_prompt.created_at as prompt_created_at',
+                'latest_prompt.retried_at as prompt_retried_at',
                 'latest_prompt.responded_at as prompt_responded_at',
                 'latest_prompt.response as prompt_response',
                 'latest_prompt.error_message as prompt_error_message',
@@ -3184,6 +3188,7 @@ export class AiAgentModel {
                         ? null
                         : {
                               createdAt: row.prompt_created_at,
+                              retriedAt: row.prompt_retried_at,
                               respondedAt: row.prompt_responded_at,
                               response: row.prompt_response,
                               errorMessage: row.prompt_error_message,
@@ -5504,7 +5509,13 @@ export class AiAgentModel {
 
     async updateModelResponse(
         data: UpdateSlackResponse | UpdateWebAppResponse,
-        { onlyIfPending = false }: { onlyIfPending?: boolean } = {},
+        {
+            onlyIfPending = false,
+            onlyIfUnfinalized = false,
+        }: {
+            onlyIfPending?: boolean;
+            onlyIfUnfinalized?: boolean;
+        } = {},
     ) {
         // A new response supersedes any previous error for this prompt
         const outcome: {
@@ -5543,8 +5554,16 @@ export class AiAgentModel {
                 .whereNull('response')
                 .whereNull('error_message');
         }
+        if (onlyIfUnfinalized) {
+            query.whereNull('token_usage').whereNull('error_message');
+        }
 
-        await query.returning('ai_prompt_uuid');
+        const rows =
+            await query.returning<{ ai_prompt_uuid: string }[]>(
+                'ai_prompt_uuid',
+            );
+
+        return rows.length > 0;
     }
 
     async updatePromptNeedsUserInput({
@@ -5554,7 +5573,7 @@ export class AiAgentModel {
     }: {
         promptUuid: string;
         needsUserInput: boolean;
-        metadata: AiPromptNeedsUserInputMetadata;
+        metadata: AiPromptClassifierNeedsUserInputMetadata;
     }): Promise<boolean> {
         const rows = await this.database(AiPromptTableName)
             .update({
@@ -5568,6 +5587,26 @@ export class AiAgentModel {
         return rows.length > 0;
     }
 
+    async setPromptNeedsUserInput({
+        promptUuid,
+        needsUserInput,
+        metadata,
+    }: {
+        promptUuid: string;
+        needsUserInput: boolean;
+        metadata: AiPromptStructuredNeedsUserInputMetadata;
+    }): Promise<boolean> {
+        const rows = await this.database(AiPromptTableName)
+            .update({
+                needs_user_input: needsUserInput,
+                needs_user_input_metadata: metadata,
+            })
+            .where('ai_prompt_uuid', promptUuid)
+            .returning<{ ai_prompt_uuid: string }[]>('ai_prompt_uuid');
+
+        return rows.length > 0;
+    }
+
     async resetPromptResponseForRetry(
         promptUuid: string,
         previousState: AiPromptResponseState,
@@ -5576,6 +5615,7 @@ export class AiAgentModel {
             .update({
                 responded_at: this.database.raw('NULL'),
                 error_message: null,
+                retried_at: this.database.fn.now(),
             })
             .where('ai_prompt_uuid', promptUuid)
             .modify((query) => wherePromptResponseState(query, previousState))

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.promptInputClassification.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.promptInputClassification.test.ts
@@ -1,0 +1,123 @@
+import type { AiAgentModel } from '../../models/AiAgentModel';
+import { AiAgentService } from './AiAgentService';
+
+type ClassificationContext = {
+    organizationUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    userUuid: string;
+};
+
+type ServiceHarness = {
+    persistTrackedPromptUpdate: (
+        update: Parameters<AiAgentModel['updateModelResponse']>[0],
+        classificationContext: ClassificationContext,
+    ) => Promise<boolean> | undefined;
+    classifyPromptInputRequestAfterResponse: (args: unknown) => void;
+};
+
+describe('AiAgentService prompt input classification persistence', () => {
+    const classificationContext = {
+        organizationUuid: 'organization-uuid',
+        projectUuid: 'project-uuid',
+        agentUuid: 'agent-uuid',
+        threadUuid: 'thread-uuid',
+        userUuid: 'user-uuid',
+    };
+
+    const terminalUpdate = {
+        promptUuid: 'prompt-uuid',
+        response: 'Which project did you mean?',
+        tokenUsage: { totalTokens: 20, finalStepTotalTokens: 5 },
+    };
+
+    it('finalizes and classifies an untracked response after intermediate text', async () => {
+        const updateModelResponse = vi.fn().mockResolvedValue(true);
+        const instance = new AiAgentService({
+            aiAgentModel: { updateModelResponse },
+        } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
+        const service = instance as unknown as ServiceHarness;
+        const classifyPromptInputRequestAfterResponse = vi
+            .spyOn(service, 'classifyPromptInputRequestAfterResponse')
+            .mockImplementation(() => undefined);
+
+        await service.persistTrackedPromptUpdate(
+            {
+                promptUuid: 'prompt-uuid',
+                response: 'Intermediate response',
+            },
+            classificationContext,
+        );
+        await service.persistTrackedPromptUpdate(
+            terminalUpdate,
+            classificationContext,
+        );
+
+        expect(updateModelResponse).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ response: 'Intermediate response' }),
+            { onlyIfPending: false },
+        );
+        expect(updateModelResponse).toHaveBeenNthCalledWith(2, terminalUpdate, {
+            onlyIfUnfinalized: true,
+        });
+        expect(classifyPromptInputRequestAfterResponse).toHaveBeenCalledWith({
+            ...classificationContext,
+            promptUuid: 'prompt-uuid',
+            response: 'Which project did you mean?',
+        });
+    });
+
+    it('classifies only the first of two duplicate final updates', async () => {
+        const updateModelResponse = vi
+            .fn()
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce(false);
+        const instance = new AiAgentService({
+            aiAgentModel: { updateModelResponse },
+        } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
+        const service = instance as unknown as ServiceHarness;
+        const classifyPromptInputRequestAfterResponse = vi
+            .spyOn(service, 'classifyPromptInputRequestAfterResponse')
+            .mockImplementation(() => undefined);
+
+        await service.persistTrackedPromptUpdate(
+            terminalUpdate,
+            classificationContext,
+        );
+        await service.persistTrackedPromptUpdate(
+            terminalUpdate,
+            classificationContext,
+        );
+
+        expect(updateModelResponse).toHaveBeenCalledTimes(2);
+        expect(updateModelResponse).toHaveBeenCalledWith(terminalUpdate, {
+            onlyIfUnfinalized: true,
+        });
+        expect(classifyPromptInputRequestAfterResponse).toHaveBeenCalledTimes(
+            1,
+        );
+    });
+
+    it('does not classify a final update blocked by an existing error', async () => {
+        const updateModelResponse = vi.fn().mockResolvedValue(false);
+        const instance = new AiAgentService({
+            aiAgentModel: { updateModelResponse },
+        } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
+        const service = instance as unknown as ServiceHarness;
+        const classifyPromptInputRequestAfterResponse = vi
+            .spyOn(service, 'classifyPromptInputRequestAfterResponse')
+            .mockImplementation(() => undefined);
+
+        await service.persistTrackedPromptUpdate(
+            terminalUpdate,
+            classificationContext,
+        );
+
+        expect(updateModelResponse).toHaveBeenCalledWith(terminalUpdate, {
+            onlyIfUnfinalized: true,
+        });
+        expect(classifyPromptInputRequestAfterResponse).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.promptInputClassification.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.promptInputClassification.test.ts
@@ -1,3 +1,4 @@
+import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
 import type { AiAgentModel } from '../../models/AiAgentModel';
 import { AiAgentService } from './AiAgentService';
 
@@ -10,6 +11,14 @@ type ClassificationContext = {
 };
 
 type ServiceHarness = {
+    trackStreamPrompt: (
+        promptUuid: string,
+        responseState: {
+            respondedAt: string | null;
+            response: string | null;
+            errorMessage: string | null;
+        },
+    ) => void;
     persistTrackedPromptUpdate: (
         update: Parameters<AiAgentModel['updateModelResponse']>[0],
         classificationContext: ClassificationContext,
@@ -32,12 +41,29 @@ describe('AiAgentService prompt input classification persistence', () => {
         tokenUsage: { totalTokens: 20, finalStepTotalTokens: 5 },
     };
 
-    it('finalizes and classifies an untracked response after intermediate text', async () => {
+    const buildService = (classifierEnabled = true) => {
         const updateModelResponse = vi.fn().mockResolvedValue(true);
         const instance = new AiAgentService({
             aiAgentModel: { updateModelResponse },
+            lightdashConfig: {
+                ...lightdashConfigMock,
+                ai: {
+                    ...lightdashConfigMock.ai,
+                    promptInputRequestClassifier: {
+                        enabled: classifierEnabled,
+                    },
+                },
+            },
         } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
-        const service = instance as unknown as ServiceHarness;
+
+        return {
+            service: instance as unknown as ServiceHarness,
+            updateModelResponse: vi.mocked(updateModelResponse),
+        };
+    };
+
+    it('finalizes and classifies an untracked response after intermediate text', async () => {
+        const { service, updateModelResponse } = buildService();
         const classifyPromptInputRequestAfterResponse = vi
             .spyOn(service, 'classifyPromptInputRequestAfterResponse')
             .mockImplementation(() => undefined);
@@ -70,14 +96,10 @@ describe('AiAgentService prompt input classification persistence', () => {
     });
 
     it('classifies only the first of two duplicate final updates', async () => {
-        const updateModelResponse = vi
-            .fn()
+        const { service, updateModelResponse } = buildService();
+        updateModelResponse
             .mockResolvedValueOnce(true)
             .mockResolvedValueOnce(false);
-        const instance = new AiAgentService({
-            aiAgentModel: { updateModelResponse },
-        } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
-        const service = instance as unknown as ServiceHarness;
         const classifyPromptInputRequestAfterResponse = vi
             .spyOn(service, 'classifyPromptInputRequestAfterResponse')
             .mockImplementation(() => undefined);
@@ -101,11 +123,8 @@ describe('AiAgentService prompt input classification persistence', () => {
     });
 
     it('does not classify a final update blocked by an existing error', async () => {
-        const updateModelResponse = vi.fn().mockResolvedValue(false);
-        const instance = new AiAgentService({
-            aiAgentModel: { updateModelResponse },
-        } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
-        const service = instance as unknown as ServiceHarness;
+        const { service, updateModelResponse } = buildService();
+        updateModelResponse.mockResolvedValueOnce(false);
         const classifyPromptInputRequestAfterResponse = vi
             .spyOn(service, 'classifyPromptInputRequestAfterResponse')
             .mockImplementation(() => undefined);
@@ -119,5 +138,23 @@ describe('AiAgentService prompt input classification persistence', () => {
             onlyIfUnfinalized: true,
         });
         expect(classifyPromptInputRequestAfterResponse).not.toHaveBeenCalled();
+    });
+
+    it('keeps the pending guard for a terminal response when classification is disabled', async () => {
+        const { service, updateModelResponse } = buildService(false);
+        service.trackStreamPrompt('prompt-uuid', {
+            respondedAt: null,
+            response: null,
+            errorMessage: null,
+        });
+
+        await service.persistTrackedPromptUpdate(
+            terminalUpdate,
+            classificationContext,
+        );
+
+        expect(updateModelResponse).toHaveBeenCalledWith(terminalUpdate, {
+            onlyIfPending: true,
+        });
     });
 });

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.shutdown.test.ts
@@ -24,7 +24,7 @@ type ShutdownHarness = {
     ) => void;
     persistTrackedPromptUpdate: (
         update: Parameters<AiAgentModel['updateModelResponse']>[0],
-    ) => Promise<void> | undefined;
+    ) => Promise<boolean> | undefined;
     failInFlightStreamedPrompts: () => Promise<void>;
 };
 
@@ -50,16 +50,16 @@ const pendingState: AiPromptResponseState = {
     errorMessage: null,
 };
 
-const createDeferred = () => {
-    let resolve!: () => void;
-    const promise = new Promise<void>((resolvePromise) => {
+const createDeferred = <T = void>() => {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((resolvePromise) => {
         resolve = resolvePromise;
     });
     return { promise, resolve };
 };
 
 const buildService = () => {
-    const updateModelResponse = vi.fn().mockResolvedValue(undefined);
+    const updateModelResponse = vi.fn().mockResolvedValue(true);
     const failPendingPrompts = vi
         .fn()
         .mockImplementation(async (promptUuids: string[]) => promptUuids);
@@ -182,7 +182,7 @@ describe('AiAgentService streamed prompt shutdown', () => {
     it('lets a terminal write that started first win the shutdown race', async () => {
         const { service, updateModelResponse, failPendingPrompts } =
             buildService();
-        const terminalWrite = createDeferred();
+        const terminalWrite = createDeferred<boolean>();
         updateModelResponse.mockReturnValueOnce(terminalWrite.promise);
         service.trackStreamPrompt('prompt-uuid', pendingState);
 
@@ -193,7 +193,7 @@ describe('AiAgentService streamed prompt shutdown', () => {
         const shutdown = service.failInFlightStreamedPrompts();
         expect(failPendingPrompts).not.toHaveBeenCalled();
 
-        terminalWrite.resolve();
+        terminalWrite.resolve(true);
         await Promise.all([update, shutdown]);
 
         expect(updateModelResponse).toHaveBeenCalledWith(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -417,6 +417,11 @@ import {
 import { canAccessAiAgent, canAccessAiAgentThread } from './aiAgentAccess';
 import { deriveAiAgentThreadLiveStatus } from './aiAgentThreadLiveStatus';
 import {
+    responseMatchesPromptInputRequestGate,
+    runPromptInputRequestClassification,
+    shouldClassifyPromptInputRequestForUpdate,
+} from './promptInputRequestClassifier';
+import {
     canGeneratePostResponseSuggestions,
     filterSuggestionsByEnabledTools,
     getEnabledSuggestionTools,
@@ -658,9 +663,6 @@ function cleanupOAuthCache(): void {
     });
 }
 
-const CLARIFYING_QUESTION_RE =
-    /(\?\s*$)|(could you clarify)|(did you mean)|(which (one|of these))|(let me know which)|(what would you like)/i;
-
 const REFUSAL_RE =
     /(doesn't have)|(does not have)|(couldn't (find|locate))|(could not (find|locate))|(no .{0,40}(field|data|column|metric|dimension))|(not available)|(doesn't seem to)|(does not seem to)|(unable to)|(i can't)|(i cannot)|(this dataset)/i;
 
@@ -684,7 +686,7 @@ If the user asks to set up Lightdash preview deploys / preview projects for pull
 After a writeback, tell the user which Lightdash project and which GitHub repository the change was made against (the tool result includes both), so they can confirm it went to the right place.`;
 
 function detectClarifyingQuestion(text: string): boolean {
-    return CLARIFYING_QUESTION_RE.test(text);
+    return responseMatchesPromptInputRequestGate(text);
 }
 
 function detectRefusal(text: string): boolean {
@@ -1386,6 +1388,31 @@ export class AiAgentService extends BaseService {
                     error,
                 );
             });
+    }
+
+    private classifyPromptInputRequestAfterResponse(args: {
+        response: string;
+        organizationUuid: string;
+        projectUuid: string;
+        agentUuid: string;
+        threadUuid: string;
+        promptUuid: string;
+        userUuid: string;
+    }): void {
+        void runPromptInputRequestClassification({
+            ...args,
+            enabled:
+                this.lightdashConfig.ai.promptInputRequestClassifier.enabled,
+            orgAiCopilotConfigResolver: this.orgAiCopilotConfigResolver,
+            instanceCopilotConfig: this.lightdashConfig.ai.copilot,
+            aiAgentModel: this.aiAgentModel,
+            analytics: this.analytics,
+        }).catch((error) => {
+            Logger.error(
+                'Failed to persist AI agent prompt input request classification',
+                error,
+            );
+        });
     }
 
     /**
@@ -10946,6 +10973,32 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         .catch((error) => {
                             Logger.error(
                                 'Failed to enqueue AI agent review classifier after response save',
+                                error,
+                            );
+                        });
+                }
+
+                const completedResponse = update.response;
+                if (
+                    completedResponse !== undefined &&
+                    shouldClassifyPromptInputRequestForUpdate(update)
+                ) {
+                    void updatePromise
+                        .then(() => {
+                            this.classifyPromptInputRequestAfterResponse({
+                                response: completedResponse,
+                                organizationUuid:
+                                    agentSettings.organizationUuid,
+                                projectUuid: prompt.projectUuid,
+                                agentUuid: agentSettings.uuid,
+                                threadUuid: prompt.threadUuid,
+                                promptUuid: update.promptUuid,
+                                userUuid: user.userUuid,
+                            });
+                        })
+                        .catch((error) => {
+                            Logger.error(
+                                'Failed to start AI agent prompt input request classification',
                                 error,
                             );
                         });

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6003,9 +6003,12 @@ export class AiAgentService extends BaseService {
                 update.errorMessage !== undefined);
         const isClassifiableTerminalUpdate =
             shouldClassifyPromptInputRequestForUpdate(update);
+        const shouldUseUnfinalizedGuard =
+            isClassifiableTerminalUpdate &&
+            this.lightdashConfig.ai.promptInputRequestClassifier.enabled;
         const modelUpdatePromise = this.aiAgentModel.updateModelResponse(
             update,
-            isClassifiableTerminalUpdate
+            shouldUseUnfinalizedGuard
                 ? { onlyIfUnfinalized: true }
                 : { onlyIfPending: isTerminalStreamUpdate },
         );

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -825,7 +825,10 @@ export class AiAgentService extends BaseService {
 
     private readonly shutdownFailedPromptUuids = new Set<string>();
 
-    private readonly terminalStreamUpdates = new Map<string, Promise<void>>();
+    private readonly terminalStreamUpdates = new Map<
+        string,
+        Promise<boolean>
+    >();
 
     private activeStreamPreparations = 0;
 
@@ -5978,7 +5981,14 @@ export class AiAgentService extends BaseService {
 
     private persistTrackedPromptUpdate(
         update: UpdateSlackResponse | UpdateWebAppResponse,
-    ): Promise<void> | undefined {
+        classificationContext?: {
+            organizationUuid: string;
+            projectUuid: string;
+            agentUuid: string;
+            threadUuid: string;
+            userUuid: string;
+        },
+    ): Promise<boolean> | undefined {
         if (
             this.shutdownFailedPromptUuids.has(update.promptUuid) ||
             (this.isShuttingDown &&
@@ -5991,19 +6001,37 @@ export class AiAgentService extends BaseService {
             this.inFlightStreamPrompts.has(update.promptUuid) &&
             (update.response !== undefined ||
                 update.errorMessage !== undefined);
+        const isClassifiableTerminalUpdate =
+            shouldClassifyPromptInputRequestForUpdate(update);
         const modelUpdatePromise = this.aiAgentModel.updateModelResponse(
             update,
-            {
-                onlyIfPending: isTerminalStreamUpdate,
-            },
+            isClassifiableTerminalUpdate
+                ? { onlyIfUnfinalized: true }
+                : { onlyIfPending: isTerminalStreamUpdate },
         );
+        const persistedUpdatePromise = modelUpdatePromise.then((persisted) => {
+            if (
+                persisted &&
+                isClassifiableTerminalUpdate &&
+                classificationContext !== undefined &&
+                update.response !== undefined
+            ) {
+                this.classifyPromptInputRequestAfterResponse({
+                    ...classificationContext,
+                    promptUuid: update.promptUuid,
+                    response: update.response,
+                });
+            }
+            return persisted;
+        });
         if (!isTerminalStreamUpdate) {
-            return modelUpdatePromise;
+            return persistedUpdatePromise;
         }
 
-        const terminalUpdatePromise = modelUpdatePromise
-            .then(() => {
+        const terminalUpdatePromise = persistedUpdatePromise
+            .then((persisted) => {
                 this.inFlightStreamPrompts.delete(update.promptUuid);
+                return persisted;
             })
             .finally(() => {
                 if (
@@ -9185,6 +9213,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     ? `This project has more than one dbt source: ${sourceNames}. Reply naming one and I'll try again.`
                     : "This project has more than one dbt source, so I couldn't tell which one to change. Reply naming one and I'll try again.",
             });
+            await this.aiAgentModel.setPromptNeedsUserInput({
+                promptUuid,
+                needsUserInput: true,
+                metadata: {
+                    gate: 'structured',
+                    reason: 'writeback_source_selection',
+                },
+            });
         }
     }
 
@@ -10874,7 +10910,20 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             updatePrompt: (
                 update: UpdateSlackResponse | UpdateWebAppResponse,
             ) => {
-                const updatePromise = this.persistTrackedPromptUpdate(update);
+                const completedResponse = update.response;
+                const updatePromise = this.persistTrackedPromptUpdate(
+                    update,
+                    completedResponse !== undefined &&
+                        shouldClassifyPromptInputRequestForUpdate(update)
+                        ? {
+                              organizationUuid: agentSettings.organizationUuid,
+                              projectUuid: prompt.projectUuid,
+                              agentUuid: agentSettings.uuid,
+                              threadUuid: prompt.threadUuid,
+                              userUuid: user.userUuid,
+                          }
+                        : undefined,
+                );
                 if (!updatePromise) {
                     return Promise.resolve();
                 }
@@ -10978,32 +11027,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         });
                 }
 
-                const completedResponse = update.response;
-                if (
-                    completedResponse !== undefined &&
-                    shouldClassifyPromptInputRequestForUpdate(update)
-                ) {
-                    void updatePromise
-                        .then(() => {
-                            this.classifyPromptInputRequestAfterResponse({
-                                response: completedResponse,
-                                organizationUuid:
-                                    agentSettings.organizationUuid,
-                                projectUuid: prompt.projectUuid,
-                                agentUuid: agentSettings.uuid,
-                                threadUuid: prompt.threadUuid,
-                                promptUuid: update.promptUuid,
-                                userUuid: user.userUuid,
-                            });
-                        })
-                        .catch((error) => {
-                            Logger.error(
-                                'Failed to start AI agent prompt input request classification',
-                                error,
-                            );
-                        });
-                }
-
                 // Error-only updates add no distillable content — distill only
                 // after a successful terminal turn write.
                 if (
@@ -11029,7 +11052,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         });
                 }
 
-                return updateWithCitationTelemetryPromise;
+                return updateWithCitationTelemetryPromise.then(() => undefined);
             },
             trackEvent: (
                 event:

--- a/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatus.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatus.test.ts
@@ -9,6 +9,7 @@ const liveStateSignals = () => ({
     threadCreatedAt: THREAD_CREATED_AT,
     latestPrompt: {
         createdAt: PROMPT_CREATED_AT,
+        retriedAt: null,
         respondedAt: null,
         response: null,
         errorMessage: null,
@@ -64,6 +65,27 @@ describe('deriveAiAgentThreadLiveStatus', () => {
             threadUuid: 'thread-uuid',
             state: 'idle',
             stateChangedAt: '2026-08-26T10:00:00.000Z',
+            source: 'deterministic',
+        });
+    });
+
+    it('reports an old failed prompt as freshly working after retry', () => {
+        expect(
+            deriveAiAgentThreadLiveStatus(
+                {
+                    ...liveStateSignals(),
+                    latestPrompt: {
+                        ...liveStateSignals().latestPrompt,
+                        createdAt: new Date('2026-08-26T10:00:00.000Z'),
+                        retriedAt: new Date('2026-08-26T11:59:00.000Z'),
+                    },
+                },
+                NOW,
+            ),
+        ).toEqual({
+            threadUuid: 'thread-uuid',
+            state: 'working',
+            stateChangedAt: '2026-08-26T11:59:00.000Z',
             source: 'deterministic',
         });
     });
@@ -159,6 +181,9 @@ describe('deriveAiAgentThreadLiveStatus', () => {
                         latestPrompt: {
                             ...liveStateSignals().latestPrompt,
                             createdAt: new Date('2026-08-26T11:00:00.000Z'),
+                            response: 'Which source should I use?',
+                            respondedAt: new Date('2026-08-26T11:05:00.000Z'),
+                            needsUserInput: true,
                         },
                         activeDeepResearchRun: {
                             status,
@@ -173,6 +198,7 @@ describe('deriveAiAgentThreadLiveStatus', () => {
                 ),
             ).toMatchObject({
                 state: 'working',
+                source: 'deterministic',
                 stateChangedAt:
                     status === 'running'
                         ? '2026-08-26T11:31:00.000Z'
@@ -243,14 +269,15 @@ describe('deriveAiAgentThreadLiveStatus', () => {
         });
     });
 
-    it('reports a classified terminal response as waiting for the user', () => {
+    it('reports a completed writeback source-selection response as waiting for the user', () => {
         expect(
             deriveAiAgentThreadLiveStatus(
                 {
                     ...liveStateSignals(),
                     latestPrompt: {
                         ...liveStateSignals().latestPrompt,
-                        response: 'Which project did you mean?',
+                        response:
+                            "This project has more than one dbt source. Reply naming one and I'll try again.",
                         respondedAt: new Date('2026-08-26T11:59:00.000Z'),
                         needsUserInput: true,
                     },
@@ -403,6 +430,7 @@ describe('deriveAiAgentThreadLiveStatus', () => {
                         ...liveStateSignals().latestPrompt,
                         response: 'Started',
                         respondedAt: new Date('2026-08-26T11:58:10.000Z'),
+                        needsUserInput: true,
                     },
                     pendingWritebackCreatedAt: new Date(
                         '2026-08-26T11:58:05.000Z',
@@ -413,6 +441,7 @@ describe('deriveAiAgentThreadLiveStatus', () => {
         ).toMatchObject({
             state: 'working',
             stateChangedAt: '2026-08-26T11:58:05.000Z',
+            source: 'deterministic',
         });
     });
 });

--- a/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatus.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatus.test.ts
@@ -13,6 +13,7 @@ const liveStateSignals = () => ({
         response: null,
         errorMessage: null,
         interruptedAt: null,
+        needsUserInput: null,
     },
     runSqlToolCalls: [],
     pendingWritebackCreatedAt: null,
@@ -239,6 +240,88 @@ describe('deriveAiAgentThreadLiveStatus', () => {
         ).toMatchObject({
             state: 'idle',
             stateChangedAt: '2026-08-26T11:59:00.000Z',
+        });
+    });
+
+    it('reports a classified terminal response as waiting for the user', () => {
+        expect(
+            deriveAiAgentThreadLiveStatus(
+                {
+                    ...liveStateSignals(),
+                    latestPrompt: {
+                        ...liveStateSignals().latestPrompt,
+                        response: 'Which project did you mean?',
+                        respondedAt: new Date('2026-08-26T11:59:00.000Z'),
+                        needsUserInput: true,
+                    },
+                },
+                NOW,
+            ),
+        ).toEqual({
+            threadUuid: 'thread-uuid',
+            state: 'waiting_for_you',
+            stateChangedAt: '2026-08-26T11:59:00.000Z',
+            source: 'classified',
+        });
+    });
+
+    it('keeps a classified non-terminal response working', () => {
+        expect(
+            deriveAiAgentThreadLiveStatus(
+                {
+                    ...liveStateSignals(),
+                    latestPrompt: {
+                        ...liveStateSignals().latestPrompt,
+                        needsUserInput: true,
+                    },
+                },
+                NOW,
+            ).state,
+        ).toBe('working');
+    });
+
+    it.each([false, null])(
+        'reports a terminal response classified as %s as idle',
+        (needsUserInput) => {
+            expect(
+                deriveAiAgentThreadLiveStatus(
+                    {
+                        ...liveStateSignals(),
+                        latestPrompt: {
+                            ...liveStateSignals().latestPrompt,
+                            response: 'Done',
+                            respondedAt: new Date('2026-08-26T11:59:00.000Z'),
+                            needsUserInput,
+                        },
+                    },
+                    NOW,
+                ).state,
+            ).toBe('idle');
+        },
+    );
+
+    it('prioritizes deterministic SQL approval over classification', () => {
+        expect(
+            deriveAiAgentThreadLiveStatus(
+                {
+                    ...liveStateSignals(),
+                    latestPrompt: {
+                        ...liveStateSignals().latestPrompt,
+                        needsUserInput: true,
+                    },
+                    runSqlToolCalls: [
+                        {
+                            createdAt: new Date('2026-08-26T11:59:00.000Z'),
+                            toolResultUuid: null,
+                            approvalDecision: null,
+                        },
+                    ],
+                },
+                NOW,
+            ),
+        ).toMatchObject({
+            state: 'waiting_for_you',
+            source: 'deterministic',
         });
     });
 

--- a/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatus.ts
+++ b/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatus.ts
@@ -14,6 +14,7 @@ export type AiAgentThreadLiveStateSignals = {
         response: string | null;
         errorMessage: string | null;
         interruptedAt: Date | null;
+        needsUserInput: boolean | null;
     } | null;
     runSqlToolCalls: {
         createdAt: Date;
@@ -107,6 +108,22 @@ export const deriveAiAgentThreadLiveStatus = (
                 signals.activeDeepResearchRun.createdAt
             ).toISOString(),
             source: 'deterministic',
+        };
+    }
+
+    if (
+        latestPrompt !== null &&
+        latestPrompt.response !== null &&
+        latestPrompt.errorMessage === null &&
+        latestPrompt.interruptedAt === null &&
+        latestPrompt.respondedAt !== null &&
+        latestPrompt.needsUserInput === true
+    ) {
+        return {
+            threadUuid: signals.threadUuid,
+            state: 'waiting_for_you',
+            stateChangedAt: latestPrompt.respondedAt.toISOString(),
+            source: 'classified',
         };
     }
 

--- a/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatus.ts
+++ b/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatus.ts
@@ -10,6 +10,7 @@ export type AiAgentThreadLiveStateSignals = {
     threadCreatedAt: Date;
     latestPrompt: {
         createdAt: Date;
+        retriedAt: Date | null;
         respondedAt: Date | null;
         response: string | null;
         errorMessage: string | null;
@@ -49,6 +50,9 @@ export const deriveAiAgentThreadLiveStatus = (
     now: Date = new Date(),
 ): AiAgentThreadLiveStatus => {
     const { latestPrompt } = signals;
+    const latestPromptStartedAt = latestPrompt
+        ? (latestPrompt.retriedAt ?? latestPrompt.createdAt)
+        : null;
     const pendingSqlApproval = signals.runSqlToolCalls
         .filter(
             (toolCall) =>
@@ -83,13 +87,14 @@ export const deriveAiAgentThreadLiveStatus = (
 
     if (
         isLatestPromptNonTerminal(latestPrompt) &&
-        now.getTime() - latestPrompt.createdAt.getTime() <=
+        latestPromptStartedAt !== null &&
+        now.getTime() - latestPromptStartedAt.getTime() <=
             AI_AGENT_THREAD_PENDING_TIMEOUT_MS
     ) {
         return {
             threadUuid: signals.threadUuid,
             state: 'working',
-            stateChangedAt: latestPrompt.createdAt.toISOString(),
+            stateChangedAt: latestPromptStartedAt.toISOString(),
             source: 'deterministic',
         };
     }

--- a/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatuses.service.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatuses.service.test.ts
@@ -64,6 +64,7 @@ describe('AiAgentService.getAgentThreadLiveStatuses', () => {
                 threadCreatedAt: new Date('2026-08-26T10:00:00.000Z'),
                 latestPrompt: {
                     createdAt: new Date('2026-08-26T11:58:00.000Z'),
+                    retriedAt: null,
                     respondedAt: new Date('2026-08-26T11:59:00.000Z'),
                     response: 'Done',
                     errorMessage: null,

--- a/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatuses.service.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/aiAgentThreadLiveStatuses.service.test.ts
@@ -68,6 +68,7 @@ describe('AiAgentService.getAgentThreadLiveStatuses', () => {
                     response: 'Done',
                     errorMessage: null,
                     interruptedAt: null,
+                    needsUserInput: null,
                 },
                 runSqlToolCalls: [],
                 pendingWritebackCreatedAt: null,

--- a/packages/backend/src/ee/services/AiAgentService/promptInputRequestClassifier.fixtures.ts
+++ b/packages/backend/src/ee/services/AiAgentService/promptInputRequestClassifier.fixtures.ts
@@ -1,0 +1,151 @@
+export const promptInputRequestClassifierEvalCases = [
+    {
+        name: 'asks which project',
+        response: 'I found several projects. Which project did you mean?',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'asks for metric clarification',
+        response: 'Could you clarify which revenue metric you want?',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'asks which explore',
+        response:
+            'I found the Orders and Invoices explores. Which one should I use?',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'asks for a date range',
+        response: 'What date range should I use?',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'asks gross or net',
+        response: 'Did you mean gross revenue or net revenue?',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'asks which workspace',
+        response: 'Let me know which workspace you want me to query.',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'asks what to compare',
+        response: 'What would you like me to compare against last quarter?',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'asks which region',
+        response:
+            'There are three matching regions. Which of these should I use?',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'asks which customer field',
+        response: 'The model has two customer identifiers. Could you clarify?',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'asks which source',
+        response: 'Should I use orders or invoices?',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'asks for a business definition',
+        response: 'What does active customer mean here?',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'requires a choice',
+        response: 'I cannot continue until you choose a dataset. Which one?',
+        blocking: true,
+        gateFired: true,
+    },
+    {
+        name: 'offers a chart',
+        response: 'Revenue increased by 12%. Want a chart of that too?',
+        blocking: false,
+        gateFired: true,
+    },
+    {
+        name: 'offers a regional breakdown',
+        response:
+            'The total is £1.2m. Would you like me to break it down by region?',
+        blocking: false,
+        gateFired: true,
+    },
+    {
+        name: 'checks whether the answer helped',
+        response:
+            'The decline came from enterprise accounts. Does that answer your question?',
+        blocking: false,
+        gateFired: true,
+    },
+    {
+        name: 'offers more help',
+        response: 'The dashboard is ready. Anything else?',
+        blocking: false,
+        gateFired: true,
+    },
+    {
+        name: 'refuses inaccessible data',
+        response: "I can't access that data.",
+        blocking: false,
+        gateFired: false,
+    },
+    {
+        name: 'refuses an unsafe request',
+        response:
+            "I can't help with that request, but I can explain the available metrics.",
+        blocking: false,
+        gateFired: false,
+    },
+    {
+        name: 'answers with a complete summary',
+        response: 'Revenue increased by 12% year over year.',
+        blocking: false,
+        gateFired: false,
+    },
+    {
+        name: 'answers with a complete comparison',
+        response: 'Enterprise grew while self-serve remained flat.',
+        blocking: false,
+        gateFired: false,
+    },
+    {
+        name: 'answers with a number',
+        response: 'The result is 42.',
+        blocking: false,
+        gateFired: false,
+    },
+    {
+        name: 'reports a missing metric',
+        response: "I couldn't find that metric in this dataset.",
+        blocking: false,
+        gateFired: false,
+    },
+    {
+        name: 'reports no matching rows',
+        response: 'No matching rows were found.',
+        blocking: false,
+        gateFired: false,
+    },
+    {
+        name: 'delivers a chart',
+        response: 'Revenue grew 12%; the chart is attached.',
+        blocking: false,
+        gateFired: false,
+    },
+] as const;

--- a/packages/backend/src/ee/services/AiAgentService/promptInputRequestClassifier.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/promptInputRequestClassifier.test.ts
@@ -1,0 +1,331 @@
+import { generateObject } from 'ai';
+import type { AiAgentPromptInputRequestClassifiedEvent } from '../../../analytics/LightdashAnalytics';
+import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
+import type { AiAgentModel } from '../../models/AiAgentModel';
+import { getModel } from '../ai/models';
+import {
+    classifyPromptInputRequest,
+    promptInputRequestClassifierOutputSchema,
+    responseMatchesPromptInputRequestGate,
+    runPromptInputRequestClassification,
+    shouldClassifyPromptInputRequestForUpdate,
+} from './promptInputRequestClassifier';
+import { promptInputRequestClassifierEvalCases } from './promptInputRequestClassifier.fixtures';
+
+vi.mock('ai', () => ({ generateObject: vi.fn() }));
+vi.mock('../ai/models', () => ({ getModel: vi.fn() }));
+
+const generateObjectMock = vi.mocked(generateObject);
+const getModelMock = vi.mocked(getModel);
+const model = {
+    model: { modelId: 'claude-haiku-4-5', provider: 'anthropic.messages' },
+    callOptions: {},
+    providerOptions: {},
+    keyManagement: 'lightdash-managed',
+};
+const orgAiCopilotConfigResolver = {
+    getReviewJudgeAvailability: vi.fn().mockResolvedValue({
+        hasActiveByoKey: false,
+        canJudgeOnByoKey: false,
+    }),
+    getCopilotConfig: vi.fn(),
+};
+const context = {
+    organizationUuid: 'organization-uuid',
+    projectUuid: 'project-uuid',
+    agentUuid: 'agent-uuid',
+    threadUuid: 'thread-uuid',
+    promptUuid: 'prompt-uuid',
+};
+const updatePromptNeedsUserInput =
+    vi.fn<AiAgentModel['updatePromptNeedsUserInput']>();
+const track =
+    vi.fn<(event: AiAgentPromptInputRequestClassifiedEvent) => void>();
+
+describe('prompt input request gate', () => {
+    it.each(promptInputRequestClassifierEvalCases)(
+        'matches $name as expected',
+        ({ response, gateFired }) => {
+            expect(responseMatchesPromptInputRequestGate(response)).toBe(
+                gateFired,
+            );
+        },
+    );
+
+    it('records the gate evaluation distribution', () => {
+        const gatedCases = promptInputRequestClassifierEvalCases.filter(
+            ({ response }) => responseMatchesPromptInputRequestGate(response),
+        );
+        const falsePositives = gatedCases.filter(({ blocking }) => !blocking);
+        const nonBlockingCases = promptInputRequestClassifierEvalCases.filter(
+            ({ blocking }) => !blocking,
+        );
+
+        expect(promptInputRequestClassifierEvalCases).toHaveLength(24);
+        expect(gatedCases).toHaveLength(16);
+        expect(falsePositives).toHaveLength(4);
+        expect(nonBlockingCases).toHaveLength(12);
+    });
+});
+
+describe('prompt input request completion trigger', () => {
+    it('ignores intermediate response writes', () => {
+        expect(
+            shouldClassifyPromptInputRequestForUpdate({
+                promptUuid: 'prompt-uuid',
+                response: 'Draft response',
+            }),
+        ).toBe(false);
+    });
+
+    it('accepts final response writes', () => {
+        expect(
+            shouldClassifyPromptInputRequestForUpdate({
+                promptUuid: 'prompt-uuid',
+                response: 'Final response',
+                tokenUsage: { totalTokens: 123, finalStepTotalTokens: 123 },
+            }),
+        ).toBe(true);
+    });
+
+    it('ignores failed response writes', () => {
+        expect(
+            shouldClassifyPromptInputRequestForUpdate({
+                promptUuid: 'prompt-uuid',
+                errorMessage: 'Provider failed',
+            }),
+        ).toBe(false);
+    });
+});
+
+describe('prompt input request classifier', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getModelMock.mockReturnValue(model as never);
+    });
+
+    it('persists a free negative result when the gate does not fire', async () => {
+        const result = await classifyPromptInputRequest({
+            ...context,
+            response: 'Revenue increased by 12%.',
+            orgAiCopilotConfigResolver,
+            instanceCopilotConfig: lightdashConfigMock.ai.copilot,
+        });
+
+        expect(result).toMatchObject({
+            gateFired: false,
+            classified: false,
+            model: null,
+            confidence: null,
+        });
+        expect(getModelMock).not.toHaveBeenCalled();
+        expect(generateObjectMock).not.toHaveBeenCalled();
+    });
+
+    it('asks the fast judge for a strict blocking verdict', async () => {
+        generateObjectMock.mockResolvedValue({
+            object: { needsUserInput: true, confidence: 0.92 },
+            usage: {},
+        } as never);
+
+        const result = await classifyPromptInputRequest({
+            ...context,
+            response: 'Which project did you mean?',
+            orgAiCopilotConfigResolver,
+            instanceCopilotConfig: lightdashConfigMock.ai.copilot,
+        });
+
+        expect(getModelMock).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ useFastModel: true }),
+        );
+        expect(generateObjectMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                model: model.model,
+                schema: promptInputRequestClassifierOutputSchema,
+                abortSignal: expect.any(AbortSignal),
+                messages: [
+                    expect.objectContaining({
+                        role: 'system',
+                        content: expect.stringContaining('blocking'),
+                    }),
+                    { role: 'user', content: 'Which project did you mean?' },
+                ],
+            }),
+        );
+        expect(result).toMatchObject({
+            gateFired: true,
+            classified: true,
+            model: 'claude-haiku-4-5',
+            confidence: 0.92,
+        });
+    });
+
+    it('rejects output outside the strict schema', async () => {
+        generateObjectMock.mockResolvedValue({
+            object: { needsUserInput: 'yes', confidence: 2 },
+            usage: {},
+        } as never);
+
+        await expect(
+            classifyPromptInputRequest({
+                ...context,
+                response: 'Which project did you mean?',
+                orgAiCopilotConfigResolver,
+                instanceCopilotConfig: lightdashConfigMock.ai.copilot,
+            }),
+        ).resolves.toMatchObject({
+            gateFired: true,
+            classified: null,
+            confidence: null,
+        });
+    });
+
+    it('returns null when the model times out', async () => {
+        const timeoutSignal = AbortSignal.abort(
+            new DOMException('Timed out', 'TimeoutError'),
+        );
+        const timeoutSpy = vi
+            .spyOn(AbortSignal, 'timeout')
+            .mockReturnValue(timeoutSignal);
+        generateObjectMock.mockImplementation(({ abortSignal }) =>
+            Promise.reject(abortSignal?.reason),
+        );
+
+        await expect(
+            classifyPromptInputRequest({
+                ...context,
+                response: 'Which project did you mean?',
+                orgAiCopilotConfigResolver,
+                instanceCopilotConfig: lightdashConfigMock.ai.copilot,
+            }),
+        ).resolves.toMatchObject({
+            gateFired: true,
+            classified: null,
+            confidence: null,
+        });
+        expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    });
+
+    it('returns null when the model fails', async () => {
+        generateObjectMock.mockRejectedValue(new Error('provider failed'));
+
+        await expect(
+            classifyPromptInputRequest({
+                ...context,
+                response: 'Which project did you mean?',
+                orgAiCopilotConfigResolver,
+                instanceCopilotConfig: lightdashConfigMock.ai.copilot,
+            }),
+        ).resolves.toMatchObject({
+            gateFired: true,
+            classified: null,
+            confidence: null,
+        });
+    });
+});
+
+describe('prompt input request classification run', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getModelMock.mockReturnValue(model as never);
+        updatePromptNeedsUserInput.mockResolvedValue(true);
+    });
+
+    const runClassification = (enabled: boolean, response: string) =>
+        runPromptInputRequestClassification({
+            ...context,
+            enabled,
+            response,
+            userUuid: 'user-uuid',
+            orgAiCopilotConfigResolver,
+            instanceCopilotConfig: lightdashConfigMock.ai.copilot,
+            aiAgentModel: { updatePromptNeedsUserInput },
+            analytics: { track },
+        });
+
+    it('does nothing while the kill switch is off', async () => {
+        await runClassification(false, 'Which project did you mean?');
+
+        expect(getModelMock).not.toHaveBeenCalled();
+        expect(generateObjectMock).not.toHaveBeenCalled();
+        expect(updatePromptNeedsUserInput).not.toHaveBeenCalled();
+        expect(track).not.toHaveBeenCalled();
+    });
+
+    it('persists and tracks a gate miss without calling the model', async () => {
+        await runClassification(true, 'Revenue increased by 12%.');
+
+        expect(generateObjectMock).not.toHaveBeenCalled();
+        expect(updatePromptNeedsUserInput).toHaveBeenCalledWith({
+            promptUuid: 'prompt-uuid',
+            needsUserInput: false,
+            metadata: {
+                gate: 'no_match',
+                model: null,
+                durationMs: expect.any(Number),
+                confidence: null,
+            },
+        });
+        expect(track).toHaveBeenCalledWith({
+            event: 'ai_agent.prompt_input_request_classified',
+            userId: 'user-uuid',
+            properties: {
+                organizationUuid: 'organization-uuid',
+                projectUuid: 'project-uuid',
+                agentUuid: 'agent-uuid',
+                threadUuid: 'thread-uuid',
+                promptUuid: 'prompt-uuid',
+                gateFired: false,
+                classified: false,
+                model: null,
+                durationMs: expect.any(Number),
+            },
+        });
+    });
+
+    it('tracks a failed model call without persisting a verdict', async () => {
+        generateObjectMock.mockRejectedValue(new Error('provider failed'));
+
+        await runClassification(true, 'Which project did you mean?');
+
+        expect(updatePromptNeedsUserInput).not.toHaveBeenCalled();
+        expect(track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                properties: expect.objectContaining({
+                    gateFired: true,
+                    classified: null,
+                    model: 'claude-haiku-4-5',
+                }),
+            }),
+        );
+    });
+
+    it('records when the model disagrees with the gate', async () => {
+        generateObjectMock.mockResolvedValue({
+            object: { needsUserInput: false, confidence: 0.88 },
+            usage: {},
+        } as never);
+
+        await runClassification(true, 'Want a chart of that too?');
+
+        expect(updatePromptNeedsUserInput).toHaveBeenCalledWith({
+            promptUuid: 'prompt-uuid',
+            needsUserInput: false,
+            metadata: {
+                gate: 'match',
+                model: 'claude-haiku-4-5',
+                durationMs: expect.any(Number),
+                confidence: 0.88,
+            },
+        });
+        expect(track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                properties: expect.objectContaining({
+                    gateFired: true,
+                    classified: false,
+                }),
+            }),
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentService/promptInputRequestClassifier.ts
+++ b/packages/backend/src/ee/services/AiAgentService/promptInputRequestClassifier.ts
@@ -11,7 +11,7 @@ import {
 import type { AiAgentPromptInputRequestClassifiedEvent } from '../../../analytics/LightdashAnalytics';
 import type { LightdashConfig } from '../../../config/parseConfig';
 import Logger from '../../../logging/logger';
-import type { AiPromptNeedsUserInputMetadata } from '../../database/entities/ai';
+import type { AiPromptClassifierNeedsUserInputMetadata } from '../../database/entities/ai';
 import {
     resolveReviewJudgeModel,
     type ReviewJudgeConfigResolver,
@@ -61,7 +61,7 @@ type PromptInputRequestClassificationModel = {
     updatePromptNeedsUserInput: (args: {
         promptUuid: string;
         needsUserInput: boolean;
-        metadata: AiPromptNeedsUserInputMetadata;
+        metadata: AiPromptClassifierNeedsUserInputMetadata;
     }) => Promise<boolean>;
 };
 

--- a/packages/backend/src/ee/services/AiAgentService/promptInputRequestClassifier.ts
+++ b/packages/backend/src/ee/services/AiAgentService/promptInputRequestClassifier.ts
@@ -1,0 +1,240 @@
+import type {
+    UpdateSlackResponse,
+    UpdateWebAppResponse,
+} from '@lightdash/common';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import {
+    emitAiUsage,
+    languageModelUsageToTokens,
+} from '../../../analytics/aiUsage';
+import type { AiAgentPromptInputRequestClassifiedEvent } from '../../../analytics/LightdashAnalytics';
+import type { LightdashConfig } from '../../../config/parseConfig';
+import Logger from '../../../logging/logger';
+import type { AiPromptNeedsUserInputMetadata } from '../../database/entities/ai';
+import {
+    resolveReviewJudgeModel,
+    type ReviewJudgeConfigResolver,
+} from '../ai/reviewJudgeModel';
+import {
+    getAiCallTelemetry,
+    getLanguageModelAttribution,
+} from '../ai/utils/aiCallTelemetry';
+
+const PROMPT_INPUT_REQUEST_CLASSIFIER_TIMEOUT_MS = 10_000;
+const elapsedMilliseconds = (startedAt: number) =>
+    Math.round(performance.now() - startedAt);
+
+export const CLARIFYING_QUESTION_RE =
+    /(\?\s*$)|(could you clarify)|(did you mean)|(which (one|of these))|(let me know which)|(what would you like)/i;
+
+export const responseMatchesPromptInputRequestGate = (response: string) =>
+    CLARIFYING_QUESTION_RE.test(response);
+
+export const shouldClassifyPromptInputRequestForUpdate = (
+    update: UpdateSlackResponse | UpdateWebAppResponse,
+) =>
+    update.response !== undefined &&
+    update.errorMessage === undefined &&
+    update.tokenUsage !== undefined;
+
+export const promptInputRequestClassifierOutputSchema = z
+    .object({
+        needsUserInput: z.boolean(),
+        confidence: z.number().min(0).max(1).nullable(),
+    })
+    .strict();
+
+export type PromptInputRequestClassification = {
+    gateFired: boolean;
+    classified: boolean | null;
+    model: string | null;
+    durationMs: number;
+    confidence: number | null;
+};
+
+type PromptInputRequestClassificationAnalytics = {
+    track: (event: AiAgentPromptInputRequestClassifiedEvent) => void;
+};
+
+type PromptInputRequestClassificationModel = {
+    updatePromptNeedsUserInput: (args: {
+        promptUuid: string;
+        needsUserInput: boolean;
+        metadata: AiPromptNeedsUserInputMetadata;
+    }) => Promise<boolean>;
+};
+
+export const classifyPromptInputRequest = async ({
+    response,
+    organizationUuid,
+    projectUuid,
+    agentUuid,
+    threadUuid,
+    promptUuid,
+    orgAiCopilotConfigResolver,
+    instanceCopilotConfig,
+}: {
+    response: string;
+    organizationUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+    orgAiCopilotConfigResolver: ReviewJudgeConfigResolver;
+    instanceCopilotConfig: LightdashConfig['ai']['copilot'];
+}): Promise<PromptInputRequestClassification> => {
+    const startedAt = performance.now();
+    if (!responseMatchesPromptInputRequestGate(response)) {
+        return {
+            gateFired: false,
+            classified: false,
+            model: null,
+            durationMs: elapsedMilliseconds(startedAt),
+            confidence: null,
+        };
+    }
+
+    let modelName: string | null = null;
+    try {
+        const model = await resolveReviewJudgeModel({
+            organizationUuid,
+            orgAiCopilotConfigResolver,
+            instanceCopilotConfig,
+        });
+        const attribution = getLanguageModelAttribution(model.model.model);
+        modelName = attribution.model ?? null;
+        const telemetry = getAiCallTelemetry({
+            functionId: 'aiAgentPromptInputRequestClassifier',
+            feature: 'prompt-input-classifier',
+            organizationUuid,
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            promptUuid,
+            ...attribution,
+            keyManagement: model.model.keyManagement,
+        });
+        const result = await generateObject({
+            model: model.model.model,
+            maxRetries: 1,
+            ...model.model.callOptions,
+            providerOptions: model.model.providerOptions,
+            experimental_telemetry: telemetry,
+            schema: promptInputRequestClassifierOutputSchema,
+            abortSignal: AbortSignal.timeout(
+                PROMPT_INPUT_REQUEST_CLASSIFIER_TIMEOUT_MS,
+            ),
+            messages: [
+                {
+                    role: 'system',
+                    content:
+                        'Classify the assistant response. Set needsUserInput=true only when it ends with a blocking question whose answer is required before the assistant can continue the current task. Set false for complete answers, rhetorical questions, optional offers, refusals, and invitations for additional work. Return confidence from 0 to 1, or null when unavailable.',
+                },
+                { role: 'user', content: response },
+            ],
+        });
+        const output = promptInputRequestClassifierOutputSchema.parse(
+            result.object,
+        );
+        emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+
+        return {
+            gateFired: true,
+            classified: output.needsUserInput,
+            model: modelName,
+            durationMs: elapsedMilliseconds(startedAt),
+            confidence: output.confidence,
+        };
+    } catch (error) {
+        Logger.warn('AI agent prompt input request classification failed', {
+            organizationUuid,
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            promptUuid,
+            error: error instanceof Error ? error.message : String(error),
+        });
+        return {
+            gateFired: true,
+            classified: null,
+            model: modelName,
+            durationMs: elapsedMilliseconds(startedAt),
+            confidence: null,
+        };
+    }
+};
+
+export const runPromptInputRequestClassification = async ({
+    enabled,
+    response,
+    organizationUuid,
+    projectUuid,
+    agentUuid,
+    threadUuid,
+    promptUuid,
+    userUuid,
+    orgAiCopilotConfigResolver,
+    instanceCopilotConfig,
+    aiAgentModel,
+    analytics,
+}: {
+    enabled: boolean;
+    response: string;
+    organizationUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    promptUuid: string;
+    userUuid: string;
+    orgAiCopilotConfigResolver: ReviewJudgeConfigResolver;
+    instanceCopilotConfig: LightdashConfig['ai']['copilot'];
+    aiAgentModel: PromptInputRequestClassificationModel;
+    analytics: PromptInputRequestClassificationAnalytics;
+}): Promise<void> => {
+    if (!enabled) {
+        return;
+    }
+
+    const classification = await classifyPromptInputRequest({
+        response,
+        organizationUuid,
+        projectUuid,
+        agentUuid,
+        threadUuid,
+        promptUuid,
+        orgAiCopilotConfigResolver,
+        instanceCopilotConfig,
+    });
+
+    analytics.track({
+        event: 'ai_agent.prompt_input_request_classified',
+        userId: userUuid,
+        properties: {
+            organizationUuid,
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            promptUuid,
+            gateFired: classification.gateFired,
+            classified: classification.classified,
+            model: classification.model,
+            durationMs: classification.durationMs,
+        },
+    });
+
+    if (classification.classified === null) {
+        return;
+    }
+
+    await aiAgentModel.updatePromptNeedsUserInput({
+        promptUuid,
+        needsUserInput: classification.classified,
+        metadata: {
+            gate: classification.gateFired ? 'match' : 'no_match',
+            model: classification.model,
+            durationMs: classification.durationMs,
+            confidence: classification.confidence,
+        },
+    });
+};

--- a/packages/backend/src/ee/services/AiAgentService/runEditDbtProjectPipeline.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/runEditDbtProjectPipeline.test.ts
@@ -73,6 +73,7 @@ const buildService = (overrides: {
     const promptFound = overrides.promptFound ?? true;
     const updateToolResult = vi.fn().mockResolvedValue(undefined);
     const updateModelResponse = vi.fn().mockResolvedValue(undefined);
+    const setPromptNeedsUserInput = vi.fn().mockResolvedValue(true);
     const addReaction = vi.fn().mockResolvedValue(undefined);
     const postMessage = vi.fn().mockResolvedValue(undefined);
     const hasToolResult = vi.fn().mockResolvedValue(true);
@@ -114,6 +115,7 @@ const buildService = (overrides: {
             ),
         updateToolResult,
         updateModelResponse,
+        setPromptNeedsUserInput,
         hasToolResult,
         getToolResultsForPrompt: vi
             .fn()
@@ -176,6 +178,7 @@ const buildService = (overrides: {
         service,
         updateToolResult,
         updateModelResponse,
+        setPromptNeedsUserInput,
         addReaction,
         postMessage,
         hasToolResult,
@@ -432,9 +435,12 @@ describe('AiAgentService.runEditDbtProjectPipeline', () => {
             needsDbtSourceSelection: true,
             dbtSourceOptions: options,
         });
-        const { service, updateToolResult, updateModelResponse } = buildService(
-            { run, getRunStatus: getRunStatusMock('error') },
-        );
+        const {
+            service,
+            updateToolResult,
+            updateModelResponse,
+            setPromptNeedsUserInput,
+        } = buildService({ run, getRunStatus: getRunStatusMock('error') });
 
         await service.runEditDbtProjectPipeline(PAYLOAD);
 
@@ -455,6 +461,14 @@ describe('AiAgentService.runEditDbtProjectPipeline', () => {
                 response: expect.stringContaining('jaffle-2'),
             }),
         );
+        expect(setPromptNeedsUserInput).toHaveBeenCalledWith({
+            promptUuid: 'prompt-1',
+            needsUserInput: true,
+            metadata: {
+                gate: 'structured',
+                reason: 'writeback_source_selection',
+            },
+        });
     });
 
     it('skips a stale success once the run was already finalized as an error', async () => {


### PR DESCRIPTION
Stacked on #28090. Adds the classified path for the `waiting_for_you` live state.

A finished response that ends in a blocking clarifying question ("Which project did you mean?") needs user input, but the runtime has no structured signal for it. This PR classifies that case server-side, once per completed response, and persists the result so reads never infer.

## How it works

- **Trigger**: only on the successful final-response transition (web stream, generate, and Slack share one hook; per-step text and errors never trigger it). Fire-and-forget, so it cannot delay a response.
- **Stage 1, free**: the existing clarifying-question regex over the final text. No match persists `needs_user_input = false` with no model call.
- **Stage 2, model**: only when the gate fires. Uses the same judge-model resolver as the review classifier, a strict binary output schema, one retry, and a 10 second timeout.
- **Fallback**: a model failure or timeout persists nothing. The derivation treats null and false the same, so the thread stays `idle`.
- **Kill switch**: `AI_AGENT_PROMPT_INPUT_REQUEST_CLASSIFIER_ENABLED`, default off. Off means no gate, no model call, no writes, and the existing response persistence guard remains unchanged.
- **Derivation**: a classified `waiting_for_you` ranks below every deterministic `working` rule, so an active run can never look blocked because an earlier response asked a question. The API reports `source: "classified"` for these states.

## Measurement

Every classification run emits `ai_agent.prompt_input_request_classified` with org/project/agent/thread/prompt UUIDs, whether the gate fired, the model verdict, the model name, and duration. This answers: how often the gate fires, how often the model disagrees with the gate, and per-org classifier use.

## Evaluation set

24 curated final-response fixtures, half blocking and half non-blocking. The regex gate alone detects 12/12 blocking cases but false-positives on 4/12 non-blocking ones — that gap is what the model stage exists to close. Model calls are mocked in CI; the fixture file is the eval set for judging future prompt or model changes.

## Storage

Additive nullable columns on `ai_prompt`: `needs_user_input`, `needs_user_input_metadata`, and `retried_at`. `retried_at` records when a failed prompt starts a fresh attempt, which restarts the five-minute `working` clock for live-status derivation.

A retry clears the previous attempt's response timestamp, error, and token usage. This lets the successful retried response persist its own output and token total. The classifier-only finalization guard now applies only when the classifier flag is enabled.

## Tests

55 unit tests (gate behaviour over the full eval set, schema parse, timeout and failure fallback, derivation priority) plus migration and model-write tests. Full backend and common typechecks pass.

Linear: SPK-1444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
