### PR TITLE
fix(apps): make direct data-app endpoints chart-type-aware

### DIFF
--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -1,5 +1,6 @@
 import {
     AlreadyExistsError,
+    DATA_APP_VIZ_TEMPLATE,
     EXTERNAL_CONNECTION_DEFAULTS,
     generateSlug,
     NotFoundError,
@@ -343,10 +344,26 @@ export class ExternalConnectionModel {
         )
             .select(
                 `${AppExternalConnectionsTableName}.external_connection_uuid`,
-                this.database.raw('COUNT(DISTINCT ??) AS ??', [
-                    `${AppsTableName}.app_id`,
-                    'linked_data_app_count',
-                ]),
+                // Chart types can link connections too — count them apart so
+                // the "linked apps" column doesn't lump them in as data apps.
+                this.database.raw(
+                    'COUNT(DISTINCT ??) FILTER (WHERE ??.template IS DISTINCT FROM ?) AS ??',
+                    [
+                        `${AppsTableName}.app_id`,
+                        AppsTableName,
+                        DATA_APP_VIZ_TEMPLATE,
+                        'linked_data_app_count',
+                    ],
+                ),
+                this.database.raw(
+                    'COUNT(DISTINCT ??) FILTER (WHERE ??.template = ?) AS ??',
+                    [
+                        `${AppsTableName}.app_id`,
+                        AppsTableName,
+                        DATA_APP_VIZ_TEMPLATE,
+                        'linked_chart_type_count',
+                    ],
+                ),
             )
             .innerJoin(
                 AppsTableName,
@@ -382,6 +399,7 @@ export class ExternalConnectionModel {
                     DbExternalConnection & {
                         encrypted_payload: Buffer | null;
                         linked_data_app_count: string;
+                        linked_chart_type_count: string;
                     }
                 >
             >(
@@ -391,6 +409,10 @@ export class ExternalConnectionModel {
                     'linked_data_app_counts.linked_data_app_count',
                     'linked_data_app_count',
                 ]),
+                this.database.raw('COALESCE(??, 0) AS ??', [
+                    'linked_data_app_counts.linked_chart_type_count',
+                    'linked_chart_type_count',
+                ]),
             );
 
         return rows.map((row) => ({
@@ -399,6 +421,7 @@ export class ExternalConnectionModel {
                 row.encrypted_payload !== null,
             ),
             linkedDataAppCount: Number(row.linked_data_app_count),
+            linkedChartTypeCount: Number(row.linked_chart_type_count),
         }));
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7245,12 +7245,23 @@ export class AppGenerateService extends BaseService {
         const resources = AppGenerateService.buildCopiedResources(
             sourceVersion.resources ?? null,
         );
+        // Custom chart types promote like data apps, deliberately: template
+        // and viz_schema are copied below (so the promoted viz appears in the
+        // upstream picker) and vizs are spaceless, so targetSpaceUuid stays
+        // null. Note charts BOUND to a viz do not remap their dataAppVizUuid
+        // when promoted — that's the chart-binding portability gap, tracked
+        // separately.
+        const isChartType = sourceApp.template === DATA_APP_VIZ_TEMPLATE;
         // Frame the production version's chat bubble like a duplicate's: the
         // verb "Promote" plus a markdown link (rendered as an anchor by
         // ChatMessageContent) back to the preview version it came from, for
         // provenance.
-        const sourceDisplayName = sourceApp.name || 'untitled app';
-        const sourcePreviewPath = `/projects/${projectUuid}/apps/${sourceApp.app_id}/versions/${sourceVersion.version}/view`;
+        const sourceDisplayName =
+            sourceApp.name ||
+            (isChartType ? 'untitled chart type' : 'untitled app');
+        const sourcePreviewPath = isChartType
+            ? `/projects/${projectUuid}/chart-types/${sourceApp.app_id}`
+            : `/projects/${projectUuid}/apps/${sourceApp.app_id}/versions/${sourceVersion.version}/view`;
         const prompt = `Promote [${sourceDisplayName}](${sourcePreviewPath})`;
         const { client: s3Client, bucket } = this.getS3Client();
 

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -71,6 +71,7 @@ const connection: ExternalConnection = {
 const listedConnection: ExternalConnectionListItem = {
     ...connection,
     linkedDataAppCount: 2,
+    linkedChartTypeCount: 0,
 };
 
 const sampleRequest = {
@@ -283,6 +284,7 @@ describe('ExternalConnectionService reads (view, not manage)', () => {
             externalConnectionUuid: 'private-connection',
             allowDataAppBuilderLinking: false,
             linkedDataAppCount: 1,
+            linkedChartTypeCount: 0,
         };
         const { service } = buildService({
             connections: [listedConnection, privateConnection],
@@ -300,6 +302,7 @@ describe('ExternalConnectionService reads (view, not manage)', () => {
             externalConnectionUuid: 'private-connection',
             allowDataAppBuilderLinking: false,
             linkedDataAppCount: 1,
+            linkedChartTypeCount: 0,
         };
         const { service } = buildService({
             connections: [listedConnection, privateConnection],

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -994,7 +994,7 @@ export class AppModel {
                 Pick<DbAppVersion, 'data_references'>
         >
     > {
-        return this.joinLatestReadyVersion(this.database(AppsTableName))
+        const query = this.joinLatestReadyVersion(this.database(AppsTableName))
             .where(`${AppsTableName}.project_uuid`, projectUuid)
             .whereNull(`${AppsTableName}.deleted_at`)
             .whereNotNull(`${AppVersionsTableName}.app_version_id`)
@@ -1003,6 +1003,11 @@ export class AppModel {
                 `${AppsTableName}.name`,
                 `${AppVersionsTableName}.data_references`,
             );
+        // Chart types don't run queries of their own (fields arrive via the
+        // host chart's binding), so validating them as data apps would only
+        // report a broken viz as a broken *app*.
+        AppModel.applyDataAppVizsFilter(query, 'exclude');
+        return query;
     }
 
     /**

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -3,6 +3,7 @@ import {
     assertIsAccountWithOrg,
     CreateSchedulerAndTargets,
     CreateSchedulerLog,
+    DATA_APP_VIZ_TEMPLATE,
     ForbiddenError,
     getErrorMessage,
     getSchedulerResourceTypeAndId,
@@ -710,6 +711,15 @@ export class SchedulerService extends BaseService {
         },
     ): Promise<SchedulerAndTargets> {
         const app = await this.checkAppScheduledDeliveryAccess(user, appUuid);
+
+        // Chart types render inside charts, so chart/dashboard schedulers
+        // already cover them — a standalone delivery of a chart type has
+        // nothing to deliver. The UI never offers this; guard the API too.
+        if (app.template === DATA_APP_VIZ_TEMPLATE) {
+            throw new ParameterError(
+                'Custom chart types cannot have scheduled deliveries',
+            );
+        }
 
         SchedulerService.validateAppSchedulerDelivery(newScheduler);
         if (!isValidFrequency(newScheduler.cron)) {

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -88,6 +88,9 @@ export type ExternalConnection = {
 
 export type ExternalConnectionListItem = ExternalConnection & {
     linkedDataAppCount: number;
+    // Custom chart types linking this connection, counted apart from data
+    // apps so the two products' usage stays distinguishable.
+    linkedChartTypeCount: number;
 };
 
 /** WRITE shape — includes the secret. */

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
@@ -62,6 +62,10 @@ const ConnectionRow: FC<
         <Table.Td>
             <Text fz="sm" c="ldGray.6">
                 {connection.linkedDataAppCount}
+                {connection.linkedChartTypeCount > 0 &&
+                    ` (+${connection.linkedChartTypeCount} chart type${
+                        connection.linkedChartTypeCount !== 1 ? 's' : ''
+                    })`}
             </Text>
         </Table.Td>
         <Table.Td>


### PR DESCRIPTION
Closes out the per-route decisions for direct data-app endpoints that accepted custom chart type UUIDs without any guard (stacked on #28091 for the shared service edits).

**Promotion — deliberately kept enabled, now documented and presented correctly.** \`promoteApp\` already does the right thing for a chart type: \`template\` and \`viz_schema\` are copied (so the promoted viz appears in the upstream picker — pinned by the vizSchemaCopy suite), and vizs are spaceless so no upstream space is created. What was missing was the *decision* being recorded and the presentation: the provenance chat bubble said "untitled app" and linked to the data-app viewer route. Both are now chart-type-aware, and a comment documents the intentional allowance plus the known adjacent gap (charts *bound* to a viz don't remap \`dataAppVizUuid\` on promotion — tracked separately, see PROD-10449's notes).

**Schedulers — guarded.** \`POST /{appUuid}/schedulers\` for a chart type now rejects with a clear error: chart types render inside charts, so chart/dashboard schedulers already cover them; a standalone delivery has nothing to deliver. The UI never offered this; the API now agrees.

**Validation — excluded.** \`findAppsForValidation\` skips chart types: they don't run queries of their own (fields arrive via the host chart's binding), so validating them as data apps could only ever report a broken viz as a broken *app*.

**External connections — counted apart.** The connections table's "Linked apps" count lumped chart types in as data apps. The listing now returns \`linkedDataAppCount\` (true to its name) plus a new \`linkedChartTypeCount\`, and the cell appends "(+N chart types)" when present — a chart type using a connection still registers as usage rather than disappearing.

Test plan: 263 tests pass across the ExternalConnectionService, SchedulerService, and app-copy suites (fixtures extended for the new count); typechecks clean on common/backend/frontend.

Closes: GLITCH-688

🤖 Generated with [Claude Code](https://claude.com/claude-code)