### PR TITLE
fix(promote): promote and remap chart-bound custom chart types

### DIFF
--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -1,5 +1,6 @@
 import { Ability } from '@casl/ability';
 import {
+    ChartType,
     DashboardTileTypes,
     OrganizationMemberRole,
     PossibleAbilities,
@@ -1731,5 +1732,63 @@ describe('PromoteService data app promotion', () => {
                 promotedDashboard.projectUuid,
             ),
         ).rejects.toThrow(/Data apps are not available/);
+    });
+
+    const vizChartChanges = (): PromotionChanges => ({
+        spaces: [],
+        dashboards: [],
+        charts: [
+            {
+                action: PromotionAction.CREATE,
+                data: {
+                    uuid: 'chart-uuid',
+                    chartConfig: {
+                        type: ChartType.DATA_APP_VIZ,
+                        config: {
+                            dataAppVizUuid: promotedAppUuid,
+                            fieldMapping: {},
+                        },
+                    },
+                } as unknown as PromotionChanges['charts'][number]['data'],
+            },
+        ],
+    });
+
+    test('promotes the chart-bound custom chart type and remaps dataAppVizUuid', async () => {
+        const newChanges = await serviceWithApps.upsertDataApps(
+            user,
+            vizChartChanges(),
+            promotedDashboard.projectUuid,
+        );
+
+        expect(appGenerateService.promoteAppsForDashboard).toHaveBeenCalledWith(
+            user,
+            promotedDashboard.projectUuid,
+            [promotedAppUuid],
+        );
+
+        const { chartConfig } = newChanges.charts[0].data;
+        expect(
+            chartConfig.type === ChartType.DATA_APP_VIZ
+                ? chartConfig.config?.dataAppVizUuid
+                : undefined,
+        ).toBe(upstreamAppUuid);
+    });
+
+    test('keeps the chart binding when the referenced viz was skipped (soft-deleted)', async () => {
+        appGenerateService.promoteAppsForDashboard.mockResolvedValueOnce([]);
+
+        const newChanges = await serviceWithApps.upsertDataApps(
+            user,
+            vizChartChanges(),
+            promotedDashboard.projectUuid,
+        );
+
+        const { chartConfig } = newChanges.charts[0].data;
+        expect(
+            chartConfig.type === ChartType.DATA_APP_VIZ
+                ? chartConfig.config?.dataAppVizUuid
+                : undefined,
+        ).toBe(promotedAppUuid);
     });
 });

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -2,6 +2,7 @@ import { Ability, subject } from '@casl/ability';
 import {
     AlreadyExistsError,
     ChartSummary,
+    ChartType,
     DashboardDAO,
     DashboardTileTypes,
     ForbiddenError,
@@ -1105,37 +1106,49 @@ export class PromoteService extends BaseService {
     private static getDataAppUuidsFromChanges(
         promotionChanges: PromotionChanges,
     ): string[] {
-        return Array.from(
-            promotionChanges.dashboards.reduce<Set<string>>(
-                (acc, dashboardChange) => {
-                    dashboardChange.data.tiles.forEach((tile) => {
-                        if (
-                            isDashboardDataAppTileType(tile) &&
-                            tile.properties.appUuid
-                        ) {
-                            acc.add(tile.properties.appUuid);
-                        }
-                    });
-                    return acc;
-                },
-                new Set<string>(),
-            ),
+        const appUuids = promotionChanges.dashboards.reduce<Set<string>>(
+            (acc, dashboardChange) => {
+                dashboardChange.data.tiles.forEach((tile) => {
+                    if (
+                        isDashboardDataAppTileType(tile) &&
+                        tile.properties.appUuid
+                    ) {
+                        acc.add(tile.properties.appUuid);
+                    }
+                });
+                return acc;
+            },
+            new Set<string>(),
         );
+        // Charts bound to a custom chart type reference it via chartConfig —
+        // the viz must promote with the chart or the upstream copy points at
+        // a viz that only exists in the preview.
+        promotionChanges.charts.forEach((chartChange) => {
+            const { chartConfig } = chartChange.data;
+            if (
+                chartConfig.type === ChartType.DATA_APP_VIZ &&
+                chartConfig.config?.dataAppVizUuid
+            ) {
+                appUuids.add(chartConfig.config.dataAppVizUuid);
+            }
+        });
+        return Array.from(appUuids);
     }
 
     /**
-     * Promote the data apps referenced by a dashboard's DATA_APP tiles into the
-     * upstream project, then remap each tile's `appUuid` to the freshly promoted
-     * upstream app — the data-app equivalent of `upsertCharts`/`upsertSqlCharts`.
+     * Promote the apps a promotion references — DATA_APP dashboard tiles and
+     * the custom chart types bound by charts' DATA_APP_VIZ configs — into the
+     * upstream project, then remap each tile's `appUuid` and each chart's
+     * `dataAppVizUuid` to the freshly promoted upstream app.
      *
-     * Runs after the upstream dashboard exists but before `updateDashboard`
-     * persists the tiles, so the upstream `apps` row is in place before the
-     * `dashboard_tile_data_apps` FK references it.
+     * Must run before `upsertCharts` persists chart configs and before
+     * `updateDashboard` persists the tiles, so the remapped references (and
+     * the `dashboard_tile_data_apps` FK) point at rows that exist upstream.
      *
      * The actual app promotion (S3 copy, versioning, permission checks) lives in
      * the EE AppGenerateService, reached via the injected accessor. Apps whose
      * referenced row no longer exists (soft-deleted placeholder tiles) are left
-     * untouched rather than failing the whole dashboard promotion.
+     * untouched rather than failing the whole promotion.
      */
     async upsertDataApps(
         user: SessionUser,
@@ -1201,9 +1214,41 @@ export class PromoteService extends BaseService {
             }),
         );
 
+        const updatedCharts = promotionChanges.charts.map((chartChange) => {
+            const { chartConfig } = chartChange.data;
+            if (
+                chartConfig.type !== ChartType.DATA_APP_VIZ ||
+                !chartConfig.config?.dataAppVizUuid
+            ) {
+                return chartChange;
+            }
+            const upstreamAppUuid = appUuidMap.get(
+                chartConfig.config.dataAppVizUuid,
+            );
+            // No mapping → the viz was soft-deleted and skipped; keep the
+            // original reference (renders the viz-not-found state upstream).
+            if (!upstreamAppUuid) {
+                return chartChange;
+            }
+            return {
+                ...chartChange,
+                data: {
+                    ...chartChange.data,
+                    chartConfig: {
+                        ...chartConfig,
+                        config: {
+                            ...chartConfig.config,
+                            dataAppVizUuid: upstreamAppUuid,
+                        },
+                    },
+                },
+            };
+        });
+
         return {
             ...promotionChanges,
             dashboards: updatedDashboards,
+            charts: updatedCharts,
         };
     }
 
@@ -1289,6 +1334,14 @@ export class PromoteService extends BaseService {
                 promotionChanges,
             );
 
+            // Promote the chart's custom chart type (if any) and remap the
+            // viz binding before the chart config is persisted upstream.
+            promotionChanges = await this.upsertDataApps(
+                user,
+                promotionChanges,
+                projectUuid,
+            );
+
             promotionChanges = await this.upsertCharts(user, promotionChanges);
 
             await this.trackAnalytics(
@@ -1341,8 +1394,16 @@ export class PromoteService extends BaseService {
             upstreamChart,
         );
 
+        // A chart bound to a custom chart type promotes that viz with it.
+        const dataApps = await this.getDataAppDiffChanges(
+            user,
+            projectUuid,
+            promotionChanges,
+        );
+
         return {
             ...promotionChanges,
+            dataApps,
             spaces: PromoteService.sortSpaceChanges(promotionChanges.spaces),
         };
     }
@@ -2568,6 +2629,16 @@ export class PromoteService extends BaseService {
                 promotionChanges,
             );
 
+            // Promote embedded data apps and chart types, remapping tiles and
+            // chart viz bindings. Must run before upsertCharts persists chart
+            // configs and before updateDashboard persists tiles (the tile FK
+            // needs the upstream apps row).
+            promotionChanges = await this.upsertDataApps(
+                user,
+                promotionChanges,
+                dashboard.projectUuid,
+            );
+
             // Update or create charts
             // and return the list of dashboard.tiles updates with the new chart uuids
             promotionChanges = await this.upsertCharts(
@@ -2580,14 +2651,6 @@ export class PromoteService extends BaseService {
                 user,
                 promotionChanges,
                 sqlChanges,
-            );
-
-            // Promote embedded data apps and remap their tiles. Must run before
-            // updateDashboard so the upstream apps row exists for the tile FK.
-            promotionChanges = await this.upsertDataApps(
-                user,
-                promotionChanges,
-                dashboard.projectUuid,
             );
 
             promotionChanges = await this.updateDashboard(

--- a/packages/common/src/types/promotion.ts
+++ b/packages/common/src/types/promotion.ts
@@ -54,8 +54,9 @@ export type PromotionChanges = {
         action: PromotionAction;
         data: PromotedSqlChart;
     }[];
-    // Data apps referenced by DATA_APP dashboard tiles. Only populated for
-    // dashboard promotion; charts/SQL charts never carry apps.
+    // Apps the promotion carries along: data apps referenced by DATA_APP
+    // dashboard tiles, and custom chart types bound by charts' DATA_APP_VIZ
+    // configs. SQL charts never carry apps.
     dataApps?: {
         action: PromotionAction;
         data: PromotedApp;


### PR DESCRIPTION
Follow-up to #28095's promote decision: promoting a chart bound to a custom chart type now carries the chart type with it and remaps the binding — previously the promoted chart arrived upstream pointing at the **preview's** viz UUID, invisible to the upstream project's viz endpoints, rendering viz-not-found in production.

This extends the exact machinery dashboard promotion already uses for DATA_APP tiles:

- \`getDataAppUuidsFromChanges\` also collects viz UUIDs from promoted charts' \`DATA_APP_VIZ\` configs.
- \`upsertDataApps\` remaps \`chartConfig.config.dataAppVizUuid\` to the promoted upstream viz, alongside the existing tile remap (soft-deleted vizs are skipped and keep their original reference, matching tile behavior).
- **Ordering fix in dashboard promotion:** \`upsertDataApps\` now runs *before* \`upsertCharts\` — previously it ran after, which was fine for tiles (persisted later by \`updateDashboard\`) but would have persisted chart configs before the remap. It has no dependency on charts existing, and still runs before \`updateDashboard\` for the tile FK.
- **Chart promotion** (\`promoteChart\`) now runs the same pass — a viz-bound chart promotes its chart type automatically, like dashboards promote their tile apps.
- The chart promote **diff** includes the chart type (\`dataApps\` changes), so the confirmation dialog shows it; the stale "charts never carry apps" comment on \`PromotionChanges\` is corrected.

\`promoteApp\` itself already handles vizs correctly (template, viz_schema, spacelessness — per #28095), so no changes there.

Test plan: two new \`upsertDataApps\` tests (chart-binding remap; soft-deleted viz keeps original reference); all 43 PromoteService tests pass; typechecks clean.

Closes: GLITCH-697

🤖 Generated with [Claude Code](https://claude.com/claude-code)