### PR TITLE
fix(explorer): mark gallery selection and group its shelves

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.module.css
@@ -119,7 +119,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .card {
+    .card,
+    .cardEdit {
         transition: none;
     }
 

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
@@ -1,6 +1,6 @@
 import { ChartType, type DataAppViz, type ItemsMap } from '@lightdash/common';
 import { IconChartBar } from '@tabler/icons-react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type * as ReactRouter from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -203,6 +203,77 @@ describe('ChartTypeGallery', () => {
         expect(
             screen.getByRole('button', { name: 'Create new chart type' }),
         ).toBeInTheDocument();
+    });
+
+    it('groups each shelf under its own label', () => {
+        renderWithProviders(
+            <ChartTypeGallery
+                search=""
+                onSearchChange={vi.fn()}
+                sections={[
+                    gallerySection({ items: [galleryItem('Bar chart')] }),
+                    gallerySection({
+                        label: 'Project',
+                        items: [galleryItem('Event pulse')],
+                    }),
+                ]}
+            />,
+        );
+
+        expect(
+            within(screen.getByRole('group', { name: 'Built in' })).getByRole(
+                'button',
+                { name: 'Bar chart' },
+            ),
+        ).toBeInTheDocument();
+        expect(
+            within(screen.getByRole('group', { name: 'Project' })).getByRole(
+                'button',
+                { name: 'Event pulse' },
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('marks the picked card as pressed, like the other card pickers', () => {
+        renderWithProviders(
+            <ChartTypeGallery
+                search=""
+                onSearchChange={vi.fn()}
+                sections={[
+                    gallerySection({
+                        items: [
+                            { ...galleryItem('Bar chart'), selected: true },
+                            galleryItem('Line chart'),
+                        ],
+                    }),
+                ]}
+            />,
+        );
+
+        expect(
+            screen.getByRole('button', { name: 'Bar chart', pressed: true }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Line chart', pressed: false }),
+        ).toBeInTheDocument();
+    });
+
+    it('flags a section that failed to load', () => {
+        renderWithProviders(
+            <ChartTypeGallery
+                search=""
+                onSearchChange={vi.fn()}
+                sections={[
+                    gallerySection({
+                        errorMessage: 'Failed to load project chart types',
+                    }),
+                ]}
+            />,
+        );
+
+        expect(screen.getByRole('alert')).toHaveTextContent(
+            'Failed to load project chart types',
+        );
     });
 
     it('shows the empty message when a section has no items', () => {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -20,7 +20,7 @@ import {
     IconSearch,
 } from '@tabler/icons-react';
 import clsx from 'clsx';
-import { useEffect, useMemo, useRef, useState, type FC } from 'react';
+import { useEffect, useId, useMemo, useRef, useState, type FC } from 'react';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataAppChecker } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualizations } from '../../../features/chartTypes/hooks/useDataAppVisualizations';
@@ -30,6 +30,7 @@ import {
 } from '../../../features/explorer/store';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { CHART_GALLERY_SEARCH_ID } from '../../common/ChartGallery/ChartGalleryContext';
 import MantineIcon from '../../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -116,6 +117,7 @@ const GalleryCard: FC<{ item: ChartTypeGalleryItem }> = ({ item }) => (
             <UnstyledButton
                 className={classes.card}
                 data-selected={item.selected}
+                aria-pressed={item.selected}
                 disabled={item.disabled}
                 onClick={item.select}
             >
@@ -170,7 +172,7 @@ const SectionBody: FC<{ section: ChartTypeGallerySection }> = ({ section }) => {
 
     if (section.loading) {
         return (
-            <Group gap="xs">
+            <Group gap="xs" role="status">
                 <Loader size="xs" />
                 <Text fz="xs" c="dimmed">
                     Loading chart types…
@@ -181,7 +183,7 @@ const SectionBody: FC<{ section: ChartTypeGallerySection }> = ({ section }) => {
     // A transient refetch failure must not hide types already on screen.
     if (section.errorMessage !== null && section.items.length === 0) {
         return (
-            <Group justify="space-between" wrap="nowrap">
+            <Group justify="space-between" wrap="nowrap" role="alert">
                 <Text fz="xs" c="red">
                     {section.errorMessage}
                 </Text>
@@ -263,6 +265,23 @@ const SectionBody: FC<{ section: ChartTypeGallerySection }> = ({ section }) => {
     );
 };
 
+/* Grouped and named after its own heading, like the builder's question
+   sheet, so the shelves stay distinct rather than one flat run of cards. */
+const GallerySection: FC<{ section: ChartTypeGallerySection }> = ({
+    section,
+}) => {
+    const labelId = useId();
+    return (
+        <Stack gap="xs" role="group" aria-labelledby={labelId}>
+            <Text id={labelId} fz="xs" fw={600} c="dimmed">
+                {section.label}
+            </Text>
+
+            <SectionBody section={section} />
+        </Stack>
+    );
+};
+
 type GalleryProps = {
     search: string;
     onSearchChange: (search: string) => void;
@@ -276,6 +295,7 @@ export const ChartTypeGallery: FC<GalleryProps> = ({
 }) => (
     <Stack className={classes.root} gap="md">
         <TextInput
+            id={CHART_GALLERY_SEARCH_ID}
             size="xs"
             value={search}
             onChange={(event) => onSearchChange(event.currentTarget.value)}
@@ -294,13 +314,7 @@ export const ChartTypeGallery: FC<GalleryProps> = ({
         >
             <Stack gap="lg" pb="xs">
                 {sections.map((section) => (
-                    <Stack key={section.label} gap="xs">
-                        <Text fz="xs" fw={600} c="dimmed">
-                            {section.label}
-                        </Text>
-
-                        <SectionBody section={section} />
-                    </Stack>
+                    <GallerySection key={section.label} section={section} />
                 ))}
             </Stack>
         </ScrollArea>

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.test.tsx
@@ -1,6 +1,6 @@
 import { ChartKind, ChartType } from '@lightdash/common';
 import { IconTable } from '@tabler/icons-react';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState, type ReactNode } from 'react';
 import { Provider } from 'react-redux';
@@ -11,6 +11,7 @@ import {
     explorerActions,
 } from '../../../features/explorer/store';
 import { renderWithProviders } from '../../../testing/testUtils';
+import { CHART_GALLERY_SEARCH_ID } from '../../common/ChartGallery/ChartGalleryContext';
 import ExplorerChartSidebar from './ExplorerChartSidebar';
 
 vi.mock('../VisualizationCard/VisualizationConfig', () => ({
@@ -18,7 +19,15 @@ vi.mock('../VisualizationCard/VisualizationConfig', () => ({
 }));
 vi.mock('./ChartTypeGallery', () => ({
     default: ({ onSelected }: { onSelected: () => void }) => (
-        <button onClick={onSelected}>Select chart</button>
+        <>
+            {/* The real gallery's search carries this id; the sidebar sends
+                focus to it by id when the step opens. */}
+            <input
+                id={CHART_GALLERY_SEARCH_ID}
+                aria-label="Search chart types"
+            />
+            <button onClick={onSelected}>Select chart</button>
+        </>
     ),
     ChartTypeThumbnail: () => <span>Table thumbnail</span>,
 }));
@@ -205,6 +214,51 @@ describe('ExplorerChartSidebar', () => {
         );
 
         expect(screen.getByText('Configure controls')).toBeInTheDocument();
+    });
+
+    it('follows the step into the gallery search and back onto Change', async () => {
+        renderSidebar(
+            <ExplorerChartSidebar
+                chartType={ChartType.TABLE}
+                onClose={vi.fn()}
+            />,
+        );
+
+        // Nothing is stolen on mount; Configure is where the panel opens.
+        expect(document.body).toHaveFocus();
+
+        await userEvent.click(screen.getByText('Change'));
+        expect(
+            screen.getByRole('textbox', { name: 'Search chart types' }),
+        ).toHaveFocus();
+
+        await userEvent.click(screen.getByText('Select chart'));
+        expect(screen.getByText('Change')).toHaveFocus();
+    });
+
+    it('falls back to the panel title when Change is not on screen', async () => {
+        const store = createExplorerStore();
+        store.dispatch(explorerActions.setIsEditMode(true));
+        renderSidebar(
+            <ExplorerChartSidebar
+                chartType={ChartType.TABLE}
+                onClose={vi.fn()}
+            />,
+            store,
+        );
+
+        await userEvent.click(screen.getByText('Change'));
+        // Authoring returns to Configure and takes Change away with it; the
+        // step still has somewhere to land.
+        await act(async () =>
+            store.dispatch(
+                explorerActions.startChartTypeAuthoring({
+                    dataAppVizUuid: null,
+                }),
+            ),
+        );
+
+        expect(screen.getByText('Generated options')).toHaveFocus();
     });
 
     it('reopens in Configure after closing from Choose', async () => {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -6,7 +6,7 @@ import {
     IconSettings,
     IconX,
 } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useEffect, useRef, type FC } from 'react';
 import { useCanEditDataAppChecker } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
 import {
@@ -19,6 +19,7 @@ import {
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import {
+    CHART_GALLERY_SEARCH_ID,
     CHART_GALLERY_SIDEBAR_TITLE_ID,
     ChartGalleryContext,
 } from '../../common/ChartGallery/ChartGalleryContext';
@@ -47,6 +48,25 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
         dispatch(explorerActions.setChartSidebarStep('choose'));
     const showConfigure = () =>
         dispatch(explorerActions.setChartSidebarStep('configure'));
+
+    // The step swaps the panel's whole body, so whatever was clicked unmounts.
+    // Follow it: into the gallery's search, back onto the control that opened
+    // it. Only on a change, so restoring a step from the URL cannot steal
+    // focus on load.
+    const changeRef = useRef<HTMLButtonElement>(null);
+    const previousStep = useRef(step);
+    useEffect(() => {
+        if (previousStep.current === step) return;
+        previousStep.current = step;
+        if (step === 'choose') {
+            document.getElementById(CHART_GALLERY_SEARCH_ID)?.focus();
+        } else {
+            (
+                changeRef.current ??
+                document.getElementById(CHART_GALLERY_SIDEBAR_TITLE_ID)
+            )?.focus();
+        }
+    }, [step]);
     const handleClose = () => {
         showConfigure();
         onClose();
@@ -181,6 +201,7 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
                                 )}
                                 {!isAuthoring && (
                                     <Anchor
+                                        ref={changeRef}
                                         component="button"
                                         type="button"
                                         className={classes.buttonAnchor}

--- a/packages/frontend/src/components/common/ChartGallery/ChartGalleryContext.ts
+++ b/packages/frontend/src/components/common/ChartGallery/ChartGalleryContext.ts
@@ -8,3 +8,6 @@ export const useIsInsideChartGallery = () => useContext(ChartGalleryContext);
 
 /** Focus lands here when chart type authoring hands back to the sidebar. */
 export const CHART_GALLERY_SIDEBAR_TITLE_ID = 'chart-gallery-sidebar-title';
+
+/** Focus lands here when the sidebar moves to the Choose step. */
+export const CHART_GALLERY_SEARCH_ID = 'chart-gallery-search';


### PR DESCRIPTION
Hardening pass on the flagged Explorer chart gallery, ahead of any rollout.

The gallery's cards carried their selected state only in a data attribute, and its shelves ran together as one flat list of buttons. This brings it in line with the pickers the app already has, rather than inventing anything for it:

- Pressed state on the card, the same pair of `aria-pressed` + `data-selected` that `AppTemplatePicker` uses.
- A named group per shelf, like the builder's clarifying-questions sheet.
- The builder's existing `status` and `alert` roles on the loading and failure states.
- Focus follows the step. Change lands in the gallery search; picking a type, or going back without picking, lands on the control that opened it. This is the same handoff authoring already does when it hands focus back to the sidebar, and neither fires on mount, so restoring a step from the URL cannot steal focus on load.
- The existing reduced-motion block now covers the per-card edit affordance as well as the card.

Checked in the browser as well as in jsdom: every card and every per-card edit action is tab reachable with a visible focus ring, and the gallery's own scroll area is the only scroller in the right sidebar.

Behind `explorer-chart-gallery`, which is off by default and excluded from preview environments.

Relates: GLITCH-678
