### PR TITLE
fix(explorer): say why the chart gallery is dead before a query runs

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
@@ -40,8 +40,13 @@ const projectChartType = {
 const itemsMap = { orders_status: { name: 'status' } } as unknown as ItemsMap;
 
 vi.mock('../../../features/chartTypes/hooks/useDataAppVisualizations');
+const { dataAppsEnabled } = vi.hoisted(() => ({
+    dataAppsEnabled: { current: true },
+}));
 vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
-    useServerFeatureFlag: () => ({ data: { enabled: true } }),
+    useServerFeatureFlag: () => ({
+        data: { enabled: dataAppsEnabled.current },
+    }),
 }));
 vi.mock('../../LightdashVisualization/useVisualizationContext', () => ({
     useVisualizationContext: () => ({
@@ -120,6 +125,7 @@ describe('ChartTypeGallery', () => {
             <ChartTypeGallery
                 search=""
                 onSearchChange={vi.fn()}
+                disabledReason={null}
                 sections={[
                     gallerySection({
                         items: [galleryItem('Bar chart')],
@@ -162,6 +168,7 @@ describe('ChartTypeGallery', () => {
             <ChartTypeGallery
                 search=""
                 onSearchChange={vi.fn()}
+                disabledReason={null}
                 sections={[
                     gallerySection({
                         items: [
@@ -187,6 +194,7 @@ describe('ChartTypeGallery', () => {
             <ChartTypeGallery
                 search=""
                 onSearchChange={vi.fn()}
+                disabledReason={null}
                 sections={[
                     gallerySection({
                         label: 'Project',
@@ -210,6 +218,7 @@ describe('ChartTypeGallery', () => {
             <ChartTypeGallery
                 search=""
                 onSearchChange={vi.fn()}
+                disabledReason={null}
                 sections={[
                     gallerySection({ items: [galleryItem('Bar chart')] }),
                     gallerySection({
@@ -239,6 +248,7 @@ describe('ChartTypeGallery', () => {
             <ChartTypeGallery
                 search=""
                 onSearchChange={vi.fn()}
+                disabledReason={null}
                 sections={[
                     gallerySection({
                         items: [
@@ -263,6 +273,7 @@ describe('ChartTypeGallery', () => {
             <ChartTypeGallery
                 search=""
                 onSearchChange={vi.fn()}
+                disabledReason={null}
                 sections={[
                     gallerySection({
                         errorMessage: 'Failed to load project chart types',
@@ -281,6 +292,7 @@ describe('ChartTypeGallery', () => {
             <ChartTypeGallery
                 search="zzz"
                 onSearchChange={vi.fn()}
+                disabledReason={null}
                 sections={[
                     gallerySection({
                         emptyMessage:
@@ -334,6 +346,7 @@ const renderGallery = () => {
 describe('ExplorerChartTypeGallery', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        dataAppsEnabled.current = true;
         mocks.canCreateDataApp.mockReturnValue(true);
         setProjectQuery();
     });
@@ -530,6 +543,41 @@ describe('ExplorerChartTypeGallery', () => {
         );
 
         expect(mocks.fetchNextPage).toHaveBeenCalled();
+    });
+
+    it('says why nothing can be picked before a query has run', () => {
+        renderWithProviders(
+            <ChartTypeGallery
+                search=""
+                onSearchChange={vi.fn()}
+                disabledReason="Run your query to pick a chart type."
+                sections={[
+                    gallerySection({
+                        items: [{ ...galleryItem('Bar'), disabled: true }],
+                    }),
+                ]}
+            />,
+        );
+
+        expect(
+            screen.getByText('Run your query to pick a chart type.'),
+        ).toBeInTheDocument();
+    });
+
+    it('leaves the project shelf out entirely while data-apps is off', () => {
+        dataAppsEnabled.current = false;
+        renderGallery();
+
+        expect(screen.queryByText('Project')).not.toBeInTheDocument();
+        expect(screen.getByText('Built in')).toBeInTheDocument();
+        // No project shelf means no reason to ask the server for one.
+        expect(mockedUseDataAppVisualizations).toHaveBeenCalledWith(
+            undefined,
+            '',
+        );
+        expect(
+            screen.queryByRole('button', { name: 'Create new chart type' }),
+        ).not.toBeInTheDocument();
     });
 
     it('keeps built-in choices usable when project types fail to load', async () => {

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -286,12 +286,15 @@ type GalleryProps = {
     search: string;
     onSearchChange: (search: string) => void;
     sections: ChartTypeGallerySection[];
+    /** Why nothing here can be picked; null while the gallery is usable. */
+    disabledReason: string | null;
 };
 
 export const ChartTypeGallery: FC<GalleryProps> = ({
     search,
     onSearchChange,
     sections,
+    disabledReason,
 }) => (
     <Stack className={classes.root} gap="md">
         <TextInput
@@ -303,6 +306,14 @@ export const ChartTypeGallery: FC<GalleryProps> = ({
             leftSection={<MantineIcon icon={IconSearch} />}
             aria-label="Search chart types"
         />
+
+        {/* Disabled cards drop out of the tab order, so the reason has to
+            live outside the grid. */}
+        {disabledReason !== null ? (
+            <Text fz="xs" c="dimmed" role="status">
+                {disabledReason}
+            </Text>
+        ) : null}
 
         <ScrollArea
             className={classes.scrollArea}
@@ -485,6 +496,9 @@ const ExplorerChartTypeGallery: FC<ExplorerChartTypeGalleryProps> = ({
             search={search}
             onSearchChange={setSearch}
             sections={sections}
+            disabledReason={
+                disabled ? 'Run your query to pick a chart type.' : null
+            }
         />
     );
 };

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -55,9 +55,12 @@ vi.mock('../VisualizationCard/useExplorerResultsData', () => ({
 vi.mock('../VisualizationCard/useExplorerChartColorPalette', () => ({
     useExplorerChartColorPalette: () => ['#explorer-1', '#explorer-2'],
 }));
+const { dataAppsEnabled } = vi.hoisted(() => ({
+    dataAppsEnabled: { current: true },
+}));
 vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
     useServerFeatureFlag: () => ({
-        data: { enabled: true },
+        data: { enabled: dataAppsEnabled.current },
         isLoading: false,
     }),
 }));
@@ -276,6 +279,7 @@ describe('ExplorerChartTypeAuthoring', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         previewContexts.length = 0;
+        dataAppsEnabled.current = true;
         vi.mocked(useCanCreateDataApp).mockReturnValue(true);
         vi.mocked(useCanEditDataApp).mockReturnValue(true);
         vi.mocked(useChartTypeBuilderWorkspace).mockReturnValue(
@@ -579,6 +583,22 @@ describe('ExplorerChartTypeAuthoring', () => {
             newTypeWorkspace(),
         );
         const store = renderAuthoring({ dataAppVizUuid: null });
+
+        expect(showToastError).toHaveBeenCalled();
+        expect(store.getState().explorer.chartTypeAuthoring).toBeNull();
+    });
+
+    it('leaves authoring when the user may not edit this type', () => {
+        vi.mocked(useCanEditDataApp).mockReturnValue(false);
+        const store = renderAuthoring({ dataAppVizUuid: 'viz-1' });
+
+        expect(showToastError).toHaveBeenCalled();
+        expect(store.getState().explorer.chartTypeAuthoring).toBeNull();
+    });
+
+    it('leaves authoring when data-apps is switched off under it', () => {
+        dataAppsEnabled.current = false;
+        const store = renderAuthoring({ dataAppVizUuid: 'viz-1' });
 
         expect(showToastError).toHaveBeenCalled();
         expect(store.getState().explorer.chartTypeAuthoring).toBeNull();


### PR DESCRIPTION
Before a query has run, every card in the gallery is disabled and nothing says why.

The legacy picker always explained itself here ("Run your query to pick a custom chart type."); the gallery just greyed the cards out. Disabled cards also drop out of the tab order, so the reason had nowhere to live inside the grid. It now sits above it.

Also covers the flag matrix and the two side doors the gallery can be pushed through, which had no tests:

- `explorer-chart-gallery` on with `EnableDataApps` off: no Project shelf, no create action, and no request for project types.
- Data apps switched off underneath an open builder.
- Opening the builder on a type the user may not edit.

The last two both leave authoring and say so; only the create-permission case was covered before.

Relates: GLITCH-678
