### PR TITLE
fix(explorer): keep chart type names reachable at laptop widths

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.test.tsx
@@ -213,6 +213,68 @@ describe('ChartTypeGallery', () => {
         ).toBeInTheDocument();
     });
 
+    it('carries a name the card had to clamp into the tooltip', async () => {
+        // jsdom has no layout, so stand in for the clamp the CSS applies.
+        const clientHeight = vi
+            .spyOn(HTMLElement.prototype, 'clientHeight', 'get')
+            .mockReturnValue(20);
+        const scrollHeight = vi
+            .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+            .mockReturnValue(60);
+
+        renderWithProviders(
+            <ChartTypeGallery
+                search=""
+                onSearchChange={vi.fn()}
+                disabledReason={null}
+                sections={[
+                    gallerySection({
+                        items: [
+                            galleryItem(
+                                'Revenue changes over time',
+                                'Reusable ranked bars',
+                            ),
+                        ],
+                    }),
+                ]}
+            />,
+        );
+
+        await userEvent.hover(
+            screen.getByRole('button', {
+                name: 'Revenue changes over time',
+            }),
+        );
+        // Both lines of the tooltip: the name the card had to cut, then what
+        // the card never showed.
+        const tooltip = await screen.findByRole('tooltip');
+        expect(tooltip).toHaveTextContent('Revenue changes over time');
+        expect(tooltip).toHaveTextContent('Reusable ranked bars');
+
+        clientHeight.mockRestore();
+        scrollHeight.mockRestore();
+    });
+
+    it('leaves a name the card shows in full out of the tooltip', async () => {
+        renderWithProviders(
+            <ChartTypeGallery
+                search=""
+                onSearchChange={vi.fn()}
+                disabledReason={null}
+                sections={[
+                    gallerySection({
+                        items: [galleryItem('Bar', 'Reusable ranked bars')],
+                    }),
+                ]}
+            />,
+        );
+
+        await userEvent.hover(screen.getByRole('button', { name: 'Bar' }));
+        expect(
+            await screen.findByText('Reusable ranked bars'),
+        ).toBeInTheDocument();
+    });
+
     it('groups each shelf under its own label', () => {
         renderWithProviders(
             <ChartTypeGallery

--- a/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ChartTypeGallery.tsx
@@ -100,49 +100,85 @@ export type ChartTypeGallerySection = {
     onCreateNew: (() => void) | null;
 };
 
-const GalleryCard: FC<{ item: ChartTypeGalleryItem }> = ({ item }) => (
-    <Box className={classes.cardWrapper}>
-        <Tooltip
-            label={item.description}
-            withinPortal
-            position="top"
-            withArrow
-            openDelay={500}
-            color="dark"
-            events={{ hover: true, focus: true, touch: false }}
-            disabled={item.description === null}
-            maw={300}
-            multiline
-        >
-            <UnstyledButton
-                className={classes.card}
-                data-selected={item.selected}
-                aria-pressed={item.selected}
-                disabled={item.disabled}
-                onClick={item.select}
+const GalleryCard: FC<{ item: ChartTypeGalleryItem }> = ({ item }) => {
+    // A clamped name has nowhere else to go: the card face is the only place
+    // it appears, so the tooltip carries it whenever the card cannot.
+    const labelRef = useRef<HTMLParagraphElement>(null);
+    const [isLabelClamped, setIsLabelClamped] = useState(false);
+    useEffect(() => {
+        const label = labelRef.current;
+        if (!label) return;
+        const measure = () =>
+            setIsLabelClamped(label.scrollHeight > label.clientHeight + 1);
+        measure();
+        const observer = new ResizeObserver(measure);
+        observer.observe(label);
+        return () => observer.disconnect();
+    }, [item.label]);
+
+    const clampedLabel = isLabelClamped ? item.label : null;
+
+    return (
+        <Box className={classes.cardWrapper}>
+            <Tooltip
+                label={
+                    <>
+                        {clampedLabel !== null ? (
+                            <Text fz="xs" fw={600}>
+                                {clampedLabel}
+                            </Text>
+                        ) : null}
+                        {item.description !== null ? (
+                            <Text fz="xs">{item.description}</Text>
+                        ) : null}
+                    </>
+                }
+                withinPortal
+                position="top"
+                withArrow
+                openDelay={500}
+                color="dark"
+                events={{ hover: true, focus: true, touch: false }}
+                disabled={clampedLabel === null && item.description === null}
+                maw={300}
+                multiline
             >
-                <ChartTypeIcon
-                    icon={item.icon}
-                    rotatedIcon={item.rotatedIcon}
-                />
-                <Text fz="xs" fw={500} lh={1.2} lineClamp={2}>
-                    {item.label}
-                </Text>
-            </UnstyledButton>
-        </Tooltip>
-        {item.onEdit !== null ? (
-            <ActionIcon
-                className={classes.cardEdit}
-                variant="default"
-                size="sm"
-                aria-label={`Edit ${item.label}`}
-                onClick={item.onEdit}
-            >
-                <MantineIcon icon={IconFilePencil} size={14} />
-            </ActionIcon>
-        ) : null}
-    </Box>
-);
+                <UnstyledButton
+                    className={classes.card}
+                    data-selected={item.selected}
+                    aria-pressed={item.selected}
+                    disabled={item.disabled}
+                    onClick={item.select}
+                >
+                    <ChartTypeIcon
+                        icon={item.icon}
+                        rotatedIcon={item.rotatedIcon}
+                    />
+                    <Text
+                        ref={labelRef}
+                        fz="xs"
+                        fw={500}
+                        lh={1.2}
+                        lineClamp={2}
+                    >
+                        {item.label}
+                    </Text>
+                </UnstyledButton>
+            </Tooltip>
+            {item.onEdit !== null ? (
+                <ActionIcon
+                    className={classes.cardEdit}
+                    variant="default"
+                    size="sm"
+                    aria-label={`Edit ${item.label}`}
+                    onClick={item.onEdit}
+                >
+                    <MantineIcon icon={IconFilePencil} size={14} />
+                </ActionIcon>
+            ) : null}
+        </Box>
+    );
+};
 
 const SectionEmpty: FC<{ message: string }> = ({ message }) => (
     <Text fz="xs" c="dimmed">

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.module.css
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.module.css
@@ -6,6 +6,12 @@
     background: var(--mantine-color-background-0);
 }
 
+/* The only way out of authoring; the name beside it absorbs the squeeze
+   instead, where an ellipsis costs nothing. */
+.exit {
+    flex: 0 0 auto;
+}
+
 .divider {
     width: 1px;
     height: 22px;

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoringHeader.tsx
@@ -74,6 +74,7 @@ const ExplorerChartTypeAuthoringHeader: FC<Props> = ({
     return (
         <Group className={classes.header} gap="sm" wrap="nowrap">
             <Button
+                className={classes.exit}
                 size="xs"
                 variant="default"
                 leftSection={<MantineIcon icon={IconChevronLeft} size={15} />}


### PR DESCRIPTION
Two things found by reviewing the workflow at 1280x720, 1366x768 and 1440x900 with both Explorer sidebars open.

**Project names were unrecoverable at 1280.** The sidebar clamps most of them to a stub ("Line Something...", "Share Over Time Strea..."), and the card face is the only place the name appears. The tooltip carried only the description, so the full name had nowhere to go. A clamped name is now carried into the tooltip, on its own line above the description rather than in place of it. A card whose name fits and has no description still shows no tooltip.

Clamping is measured rather than guessed, so the tooltip appears exactly when the card cannot show the whole name.

**The builder's only exit was shrinking.** At 1280 "Back to chart" was squeezed to "Back to cha...". The name beside it can take an ellipsis at no cost, so the exit is pinned and the name absorbs the squeeze instead.

Relates: GLITCH-678
