### PR TITLE
fix(explorer): name what the chart is missing on a field it cannot fill

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -36,6 +36,8 @@ type PickerProps = {
 type FieldSelectProps = {
     items: Item[];
     onChange: (item: Item | null) => void;
+    disabled: boolean;
+    placeholder: string;
 };
 
 const {
@@ -300,6 +302,72 @@ describe('DataAppVizConfigTabs', () => {
         expect(fieldSelectItems.map((items) => items.map(getItemId))).toEqual([
             ['orders_visible', 'custom-dimension'],
             ['orders_visible_metric', 'table_calculation'],
+        ]);
+    });
+
+    it('names what the chart is missing on a select it cannot offer', () => {
+        // Only dimensions in play, so the metric slot has no candidate at all.
+        mockContext({ orders_visible: makeDimension('visible', false) });
+        renderWithProviders(<ConfigTabs />);
+
+        expect(
+            fieldSelectProps.map((props) => [
+                props.disabled,
+                props.placeholder,
+            ]),
+        ).toEqual([
+            [false, 'Select source'],
+            [
+                true,
+                'You need at least one metric in your chart to set this field',
+            ],
+        ]);
+    });
+
+    it('stays quiet about a slot the user can still fill by hand', () => {
+        vi.mocked(useDataAppVisualization).mockReturnValue({
+            data: {
+                dataAppVizUuid: 'data-app-viz-uuid',
+                name: 'Radial gauge',
+                description: '',
+                spaceUuid: null,
+                createdByUserUuid: MOCK_USER_UUID,
+                schema: {
+                    fields: [
+                        {
+                            name: 'first',
+                            label: 'First',
+                            type: 'metric',
+                            required: true,
+                        },
+                        {
+                            name: 'second',
+                            label: 'Second',
+                            type: 'metric',
+                            required: true,
+                        },
+                    ],
+                    configOptions: [],
+                    colorPalette: null,
+                },
+            },
+        } as unknown as ReturnType<typeof useDataAppVisualization>);
+        // One metric between two required metric slots: auto-binding spreads
+        // columns, so the second is left unbound.
+        mockContext({
+            orders_visible_metric: makeMetric('visible_metric', false),
+        });
+        renderWithProviders(<ConfigTabs />);
+
+        // Both selects still offer it, because a column may serve more than
+        // one slot, so neither claims the chart is missing anything.
+        expect(fieldSelectItems.map((items) => items.map(getItemId))).toEqual([
+            ['orders_visible_metric'],
+            ['orders_visible_metric'],
+        ]);
+        expect(fieldSelectProps.map((props) => props.placeholder)).toEqual([
+            'Select first',
+            'Select second',
         ]);
     });
 

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizSettings.tsx
@@ -61,7 +61,14 @@ const DataAppVizSettings: FC<Props> = ({
                             <Config.Heading>{field.label}</Config.Heading>
                             <FieldSelect
                                 size="xs"
-                                placeholder={`Select ${field.label.toLowerCase()}`}
+                                // A disabled, empty select says nothing on its
+                                // own; the placeholder names what the chart is
+                                // missing, as the cartesian layout does.
+                                placeholder={
+                                    items.length === 0
+                                        ? `You need at least one ${poolKeyForSlot(field)} in your chart to set this field`
+                                        : `Select ${field.label.toLowerCase()}`
+                                }
                                 disabled={items.length === 0}
                                 item={selectedItem}
                                 items={items}


### PR DESCRIPTION
A field slot whose column pool is empty renders a disabled, empty select and says nothing. When that slot is required, the chart draws without it.

The reason now goes in the select's own placeholder, which is what the cartesian layout panel already does when there is no metric to pivot on:

```
You need at least one metric in your chart to set this field
```

An empty pool is the only case that earns it. A slot left unbound while columns are still on offer is one the user can fill by hand, so claiming the chart is missing something there would be untrue: auto-binding spreads columns across slots so it will not reuse one, but a column may serve more than one slot, and every select still offers it. `reconcileDataAppVizFieldMapping` keeps such bindings deliberately, on the grounds that which columns a chart uses is the user's call.

Relates: GLITCH-678
