### PR TITLE
fix: resolve project slugs in minimal dashboards

### DIFF
--- a/packages/frontend/src/pages/MinimalDashboard.projectSlug.test.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.projectSlug.test.tsx
@@ -1,0 +1,124 @@
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+
+const PROJECT_UUID = '3675b69e-8324-4110-bdca-059031aa8da3';
+const DASHBOARD_UUID = 'a1b2c3d4-e5f6-47a8-9b0c-d1e2f3a4b5c6';
+
+const state = vi.hoisted(() => ({
+    useDashboardQuery: vi.fn(),
+    useProject: vi.fn(),
+    useProjects: vi.fn(),
+}));
+
+vi.mock('../ee/providers/Embed/useEmbed', () => ({
+    default: () => ({}),
+}));
+
+vi.mock('../features/scheduler/hooks/useScheduler', () => ({
+    useScheduler: () => ({
+        data: undefined,
+        isError: false,
+        error: undefined,
+    }),
+}));
+
+vi.mock('../hooks/dashboard/useDashboard', () => ({
+    useDashboardQuery: state.useDashboardQuery,
+}));
+
+vi.mock('../hooks/useProject', () => ({
+    useProject: state.useProject,
+}));
+
+vi.mock('../hooks/useProjects', () => ({
+    useProjects: state.useProjects,
+}));
+
+// eslint-disable-next-line import/first
+import MinimalDashboard from './MinimalDashboard';
+
+const renderMinimalDashboard = (projectIdentifier: string) =>
+    render(
+        <MantineProvider>
+            <MemoryRouter
+                initialEntries={[
+                    `/minimal/projects/${projectIdentifier}/dashboards/${DASHBOARD_UUID}`,
+                ]}
+            >
+                <Routes>
+                    <Route
+                        path="/minimal/projects/:projectUuid/dashboards/:dashboardUuid"
+                        element={<MinimalDashboard />}
+                    />
+                </Routes>
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+describe('MinimalDashboard project routes', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        state.useProjects.mockReturnValue({
+            data: [{ projectUuid: PROJECT_UUID, slug: 'jaffle-shop' }],
+            isInitialLoading: false,
+            isError: false,
+            error: undefined,
+        });
+        state.useProject.mockReturnValue({
+            data: {
+                projectUuid: PROJECT_UUID,
+                slug: 'jaffle-shop',
+            },
+            isInitialLoading: false,
+            isError: false,
+            error: undefined,
+        });
+        state.useDashboardQuery.mockReturnValue({
+            data: undefined,
+            isError: false,
+            error: undefined,
+        });
+    });
+
+    it('resolves a project slug before loading the dashboard', () => {
+        renderMinimalDashboard('jaffle-shop');
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+        expect(state.useProjects).toHaveBeenCalledWith({ enabled: true });
+        expect(state.useProject).toHaveBeenCalledWith(PROJECT_UUID);
+        expect(state.useDashboardQuery).toHaveBeenCalledWith({
+            uuidOrSlug: DASHBOARD_UUID,
+            projectUuid: PROJECT_UUID,
+        });
+    });
+
+    it('keeps UUID routes working without loading the project list', () => {
+        renderMinimalDashboard(PROJECT_UUID);
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+        expect(state.useProjects).toHaveBeenCalledWith({ enabled: false });
+        expect(state.useProject).toHaveBeenCalledWith(undefined);
+        expect(state.useDashboardQuery).toHaveBeenCalledWith({
+            uuidOrSlug: DASHBOARD_UUID,
+            projectUuid: PROJECT_UUID,
+        });
+    });
+
+    it('does not request a dashboard when the project slug is unknown', () => {
+        state.useProjects.mockReturnValue({
+            data: [],
+            isInitialLoading: false,
+            isError: false,
+            error: undefined,
+        });
+
+        renderMinimalDashboard('missing-project');
+
+        expect(
+            screen.getByText('Cannot find project: missing-project'),
+        ).toBeInTheDocument();
+        expect(state.useProject).toHaveBeenCalledWith(undefined);
+        expect(state.useDashboardQuery).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -28,6 +28,7 @@ import {
 } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import { useParams } from 'react-router';
+import { validate as isUuidString } from 'uuid';
 import ScreenshotProgressIndicator from '../components/common/ScreenshotProgressIndicator';
 import ScreenshotReadyIndicator from '../components/common/ScreenshotReadyIndicator';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
@@ -45,6 +46,12 @@ import {
 import { useScheduler } from '../features/scheduler/hooks/useScheduler';
 import { useDashboardQuery } from '../hooks/dashboard/useDashboard';
 import { useDateZoomGranularitySearch } from '../hooks/useExplorerRoute';
+import { useProject } from '../hooks/useProject';
+import {
+    ProjectRouteContext,
+    useOptionalProjectRoute,
+} from '../hooks/useProjectRoute';
+import { useProjects } from '../hooks/useProjects';
 import { useProjectUuid } from '../hooks/useProjectUuid';
 import useSearchParams from '../hooks/useSearchParams';
 import DashboardProvider from '../providers/Dashboard/DashboardProvider';
@@ -52,6 +59,7 @@ import useDashboardContext from '../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../providers/Dashboard/useDashboardTileStatusContext';
 import '../styles/export-paged-tabs.css';
 import '../styles/react-grid.css';
+import { getProjectUrlIdentifier } from '../utils/projectUrl';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
@@ -312,6 +320,8 @@ const MinimalDashboardContent: FC<MinimalDashboardContentProps> = ({
 const MinimalDashboard: FC = () => {
     const { dashboardUuid, tabUuid } = useParams();
     const projectUuid = useProjectUuid();
+    const projectUrlIdentifier =
+        useOptionalProjectRoute()?.projectUrlIdentifier ?? projectUuid;
 
     const schedulerUuid = useSearchParams('schedulerUuid');
 
@@ -405,8 +415,8 @@ const MinimalDashboard: FC = () => {
 
     const generateTabUrl = useCallback(
         (tabId: string) =>
-            `/minimal/projects/${projectUuid}/dashboards/${dashboard?.slug ?? dashboardUuid}/view/tabs/${tabId}`,
-        [projectUuid, dashboard?.slug, dashboardUuid],
+            `/minimal/projects/${projectUrlIdentifier}/dashboards/${dashboard?.slug ?? dashboardUuid}/view/tabs/${tabId}`,
+        [projectUrlIdentifier, dashboard?.slug, dashboardUuid],
     );
 
     const sortedTabs = useMemo(
@@ -631,4 +641,70 @@ const MinimalDashboard: FC = () => {
     );
 };
 
-export default MinimalDashboard;
+const MinimalDashboardRoute: FC = () => {
+    const projectIdentifier = useProjectUuid();
+    const isProjectUuid = isUuidString(projectIdentifier ?? '');
+    const projectsQuery = useProjects({
+        enabled: !!projectIdentifier && !isProjectUuid,
+    });
+    const projectUuid = isProjectUuid
+        ? projectIdentifier
+        : projectsQuery.data?.find(
+              (project) => project.slug === projectIdentifier,
+          )?.projectUuid;
+    const projectQuery = useProject(isProjectUuid ? undefined : projectUuid);
+    const projectRouteContext = useMemo(
+        () =>
+            projectUuid && projectQuery.data
+                ? {
+                      project: projectQuery.data,
+                      projectUuid,
+                      projectUrlIdentifier: getProjectUrlIdentifier(
+                          projectQuery.data,
+                      ),
+                  }
+                : null,
+        [projectQuery.data, projectUuid],
+    );
+
+    if (
+        projectsQuery.isError ||
+        (!isProjectUuid && projectQuery.isError) ||
+        (!projectUuid && !projectsQuery.isInitialLoading)
+    ) {
+        return (
+            <>
+                <Text>
+                    {projectsQuery.error?.error.message ??
+                        projectQuery.error?.error.message ??
+                        `Cannot find project: ${projectIdentifier}`}
+                </Text>
+                <ScreenshotReadyIndicator
+                    tilesTotal={1}
+                    tilesReady={0}
+                    tilesErrored={1}
+                />
+            </>
+        );
+    }
+
+    if (isProjectUuid) {
+        return <MinimalDashboard />;
+    }
+
+    if (
+        projectsQuery.isInitialLoading ||
+        projectQuery.isInitialLoading ||
+        !projectRouteContext
+    ) {
+        return null;
+    }
+
+    return (
+        <ProjectRouteContext.Provider value={projectRouteContext}>
+            <MinimalDashboard />
+        </ProjectRouteContext.Provider>
+    );
+};
+
+export default MinimalDashboardRoute;


### PR DESCRIPTION
Closes SPK-1447

## Summary
- resolve project slugs before minimal dashboard queries run
- provide the canonical project UUID to dashboard descendants
- preserve readable project slugs in minimal tab navigation
- keep UUID routes on the existing zero-extra-request path
- signal screenshot completion when slug resolution fails

## Tests
- `pnpm -F frontend exec vitest run src/pages/MinimalDashboard.projectSlug.test.tsx`
- `pnpm -F frontend typecheck`
- focused oxfmt and oxlint checks