### PR TITLE
feat: group AI org settings into per-surface sections

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -1,7 +1,6 @@
 import { FeatureFlags } from '@lightdash/common';
 import {
     Anchor,
-    Badge,
     Box,
     Divider,
     Group,
@@ -12,13 +11,16 @@ import {
     Text,
     Title,
 } from '@mantine/core';
-import { IconSparkles } from '@tabler/icons-react';
+import { type FC, type PropsWithChildren } from 'react';
 import { Link } from 'react-router';
 import { BetaBadge } from '../../../../../../components/common/BetaBadge';
-import MantineIcon from '../../../../../../components/common/MantineIcon';
 import { getModelKey } from '../../../../../../components/common/ModelSelector/utils';
 import { SettingsCard } from '../../../../../../components/common/Settings/SettingsCard';
 import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
+import {
+    useGetSlack,
+    useUpdateSlackAppCustomSettingsMutation,
+} from '../../../../../../hooks/slack/useSlack';
 import { useServerFeatureFlag } from '../../../../../../hooks/useServerOrClientFeatureFlag';
 import {
     getAiAgentModelConfig,
@@ -36,8 +38,25 @@ import {
 } from '../../../hooks/useAiRouter';
 import { AiProvidersCard } from './AiProvidersCard';
 import { AiRouterInstructionsCard } from './AiRouterInstructionsCard';
+import { AiSurfacesCard } from './AiSurfacesCard';
 import { ReviewNotificationsSettings } from './ReviewNotificationsSettings';
 import { ThreadRetentionCard } from './ThreadRetentionCard';
+
+const Section: FC<
+    PropsWithChildren<{ label: string; description?: string }>
+> = ({ label, description, children }) => (
+    <Stack gap="sm">
+        <Box>
+            <Title order={6}>{label}</Title>
+            {description ? (
+                <Text c="ldGray.6" fz="xs">
+                    {description}
+                </Text>
+            ) : null}
+        </Box>
+        {children}
+    </Stack>
+);
 
 export const AiGeneralSettingsPage = () => {
     const { data: settings, isInitialLoading: isSettingsLoading } =
@@ -58,6 +77,14 @@ export const AiGeneralSettingsPage = () => {
     const isRouterLoading = aiRouterQuery.isInitialLoading;
     const { mutate: upsertRouter, isLoading: isUpdatingRouter } =
         useUpsertAiRouterConfig();
+
+    const { data: slackInstallation } = useGetSlack();
+    const hasSlack = !!slackInstallation?.organizationUuid;
+    const slackAgentsEnabled =
+        hasSlack && (slackInstallation.aiAgentsEnabled ?? true);
+    const { mutate: updateSlackSettings, isLoading: isUpdatingSlackSettings } =
+        useUpdateSlackAppCustomSettingsMutation();
+
     const defaultModelConfig = settings?.defaultAiAgentModelConfig ?? null;
     const defaultModelOptions = settings?.defaultAiAgentModelOptions;
     // Reviews run on the org's own key; paused when that key can't serve the
@@ -77,6 +104,32 @@ export const AiGeneralSettingsPage = () => {
         modelConfig: defaultModelConfig,
         fallbackLabel: 'System default',
     });
+
+    const anySurface = settings
+        ? settings.aiAgentsVisible ||
+          settings.mcpAgentsEnabled ||
+          slackAgentsEnabled
+        : false;
+
+    // The Slack settings endpoint replaces the whole record, so every stored
+    // value must be echoed back for a single-toggle change.
+    const handleSlackAgentsToggle = (checked: boolean) => {
+        if (!slackInstallation) return;
+        updateSlackSettings({
+            notificationChannel: slackInstallation.notificationChannel ?? null,
+            appProfilePhotoUrl: slackInstallation.appProfilePhotoUrl ?? null,
+            slackChannelProjectMappings:
+                slackInstallation.slackChannelProjectMappings,
+            aiThreadAccessConsent: slackInstallation.aiThreadAccessConsent,
+            aiRequireOAuth: slackInstallation.aiRequireOAuth,
+            aiMultiAgentChannelId: slackInstallation.aiMultiAgentChannelId,
+            aiMultiAgentProjectUuids:
+                slackInstallation.aiMultiAgentProjectUuids,
+            unfurlsEnabled: slackInstallation.unfurlsEnabled,
+            aiAgentsEnabled: checked,
+        });
+    };
+
     return (
         <SettingsPage
             title="Ask AI"
@@ -88,198 +141,180 @@ export const AiGeneralSettingsPage = () => {
                 </Group>
             ) : (
                 <>
-                    <SettingsCard>
-                        <Group
-                            justify="space-between"
-                            wrap="nowrap"
-                            align="flex-start"
-                            gap="md"
-                        >
-                            <Box maw={620}>
-                                <Group gap="xs" mb={4}>
-                                    <Title order={5}>
-                                        Enable AI features for users
-                                    </Title>
-                                    {settings.isTrial && (
-                                        <Badge
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconSparkles}
-                                                    size={12}
-                                                />
-                                            }
-                                            radius="sm"
-                                            variant="light"
-                                            color="gray"
-                                            size="sm"
-                                            tt="none"
-                                            fw={500}
-                                        >
-                                            Free trial
-                                        </Badge>
-                                    )}
+                    <AiSurfacesCard
+                        aiAgentsVisible={settings.aiAgentsVisible}
+                        mcpAgentsEnabled={settings.mcpAgentsEnabled}
+                        slackInstallation={slackInstallation}
+                        slackAgentsEnabled={slackAgentsEnabled}
+                        isTrial={settings.isTrial}
+                        disabled={isUpdatingSettings}
+                        isUpdatingSlack={isUpdatingSlackSettings}
+                        onUpdateAiAgentsVisible={(checked) =>
+                            updateSettings({ aiAgentsVisible: checked })
+                        }
+                        onUpdateMcpAgentsEnabled={(checked) =>
+                            updateSettings({ mcpAgentsEnabled: checked })
+                        }
+                        onUpdateSlackAgentsEnabled={handleSlackAgentsToggle}
+                    />
+
+                    <Section
+                        label="Agent behaviour"
+                        description="Applies on every surface."
+                    >
+                        <SettingsCard>
+                            <Stack gap="md">
+                                <Group
+                                    justify="space-between"
+                                    wrap="nowrap"
+                                    align="flex-start"
+                                    gap="md"
+                                >
+                                    <Box maw={620}>
+                                        <Title order={5} mb={4}>
+                                            AI Router
+                                        </Title>
+                                        <Text c="ldGray.6" fz="xs">
+                                            Route user questions to the best
+                                            agent automatically.
+                                        </Text>
+                                    </Box>
+                                    <Switch
+                                        size="md"
+                                        checked={isRouterEnabled}
+                                        disabled={
+                                            isUpdatingRouter ||
+                                            isRouterLoading ||
+                                            !anySurface
+                                        }
+                                        onChange={(event) =>
+                                            upsertRouter({
+                                                enabled:
+                                                    event.currentTarget.checked,
+                                            })
+                                        }
+                                    />
                                 </Group>
-                                <Text c="dimmed" fz="xs">
-                                    Show AI features (homepage entry, navbar
-                                    action, and agent chat) to everyone in this
-                                    organization. Disable to hide them while
-                                    keeping existing data intact.
-                                </Text>
-                            </Box>
-                            <Switch
-                                size="md"
-                                checked={settings.aiAgentsVisible}
-                                disabled={isUpdatingSettings}
-                                onChange={(event) =>
-                                    updateSettings({
-                                        aiAgentsVisible:
-                                            event.currentTarget.checked,
-                                    })
-                                }
-                            />
-                        </Group>
-                    </SettingsCard>
 
-                    {threadRetentionFlag.data?.enabled && (
-                        <ThreadRetentionCard
-                            current={settings.threadRetentionHours ?? null}
-                        />
-                    )}
+                                {anySurface && isRouterEnabled && (
+                                    <>
+                                        <Divider mx="calc(var(--mantine-spacing-md) * -1)" />
+                                        <AiRouterInstructionsCard />
+                                    </>
+                                )}
+                            </Stack>
+                        </SettingsCard>
 
-                    <SettingsCard>
-                        <Stack gap="md">
-                            <Group
-                                justify="space-between"
-                                wrap="nowrap"
-                                align="flex-start"
-                                gap="md"
-                            >
-                                <Box maw={620}>
-                                    <Title order={5} mb={4}>
-                                        Default AI model
-                                    </Title>
-                                    <Text c="dimmed" fz="xs">
-                                        Choose the model and reasoning default
-                                        for new AI agent chats. Users can still
-                                        change it in each chat.
-                                    </Text>
-                                </Box>
-                                <Select
-                                    w={260}
-                                    size="xs"
-                                    value={selectedDefaultModelKey}
-                                    disabled={
-                                        isUpdatingSettings ||
-                                        !defaultModelOptions?.length
-                                    }
-                                    placeholder={systemDefaultModelLabel}
-                                    clearable
-                                    data={visibleDefaultModelOptions.map(
-                                        (model) => ({
-                                            value: getModelKey(model),
-                                            label: model.displayName,
-                                        }),
-                                    )}
-                                    onChange={(modelKey) => {
-                                        const model = getModelOptionByKey(
-                                            defaultModelOptions,
-                                            modelKey,
-                                        );
-                                        updateSettings({
-                                            defaultAiAgentModelConfig:
-                                                getAiAgentModelConfig(
-                                                    model,
-                                                    defaultModelConfig?.reasoning ??
-                                                        false,
-                                                ) ?? null,
-                                        });
-                                    }}
-                                />
-                            </Group>
+                        <SettingsCard>
+                            <Stack gap="md">
+                                <Group
+                                    justify="space-between"
+                                    wrap="nowrap"
+                                    align="flex-start"
+                                    gap="md"
+                                >
+                                    <Box maw={620}>
+                                        <Title order={5} mb={4}>
+                                            Default AI model
+                                        </Title>
+                                        <Text c="ldGray.6" fz="xs">
+                                            Choose the model and reasoning
+                                            default for new AI agent chats.
+                                            Users can still change it in each
+                                            chat.
+                                        </Text>
+                                    </Box>
+                                    <Select
+                                        w={260}
+                                        size="xs"
+                                        value={selectedDefaultModelKey}
+                                        disabled={
+                                            isUpdatingSettings ||
+                                            !defaultModelOptions?.length
+                                        }
+                                        placeholder={systemDefaultModelLabel}
+                                        clearable
+                                        data={visibleDefaultModelOptions.map(
+                                            (model) => ({
+                                                value: getModelKey(model),
+                                                label: model.displayName,
+                                            }),
+                                        )}
+                                        onChange={(modelKey) => {
+                                            const model = getModelOptionByKey(
+                                                defaultModelOptions,
+                                                modelKey,
+                                            );
+                                            updateSettings({
+                                                defaultAiAgentModelConfig:
+                                                    getAiAgentModelConfig(
+                                                        model,
+                                                        defaultModelConfig?.reasoning ??
+                                                            false,
+                                                    ) ?? null,
+                                            });
+                                        }}
+                                    />
+                                </Group>
 
-                            {showReasoningDefault && (
-                                <>
-                                    <Divider />
-                                    <Group
-                                        justify="space-between"
-                                        wrap="nowrap"
-                                        align="flex-start"
-                                        gap="md"
-                                    >
-                                        <Box maw={620}>
-                                            <Title order={6} mb={4}>
-                                                High reasoning by default
-                                            </Title>
-                                            <Text c="dimmed" fz="xs">
-                                                Start new chats with high
-                                                reasoning enabled for the
-                                                selected model.
-                                            </Text>
-                                        </Box>
-                                        <Switch
-                                            size="md"
-                                            checked={
-                                                defaultModelConfig?.reasoning ===
-                                                true
-                                            }
-                                            disabled={isUpdatingSettings}
-                                            onChange={(event) => {
-                                                if (!selectedDefaultModel)
-                                                    return;
-                                                updateSettings({
-                                                    defaultAiAgentModelConfig: {
-                                                        ...defaultModelConfig,
-                                                        modelName:
-                                                            selectedDefaultModel.name,
-                                                        modelProvider:
-                                                            selectedDefaultModel.provider,
-                                                        reasoning:
-                                                            event.currentTarget
-                                                                .checked,
-                                                    },
-                                                });
-                                            }}
-                                        />
-                                    </Group>
-                                </>
-                            )}
-                        </Stack>
-                    </SettingsCard>
+                                {showReasoningDefault && (
+                                    <>
+                                        <Divider />
+                                        <Group
+                                            justify="space-between"
+                                            wrap="nowrap"
+                                            align="flex-start"
+                                            gap="md"
+                                        >
+                                            <Box maw={620}>
+                                                <Title order={6} mb={4}>
+                                                    High reasoning by default
+                                                </Title>
+                                                <Text c="ldGray.6" fz="xs">
+                                                    Start new chats with high
+                                                    reasoning enabled for the
+                                                    selected model.
+                                                </Text>
+                                            </Box>
+                                            <Switch
+                                                size="md"
+                                                checked={
+                                                    defaultModelConfig?.reasoning ===
+                                                    true
+                                                }
+                                                disabled={isUpdatingSettings}
+                                                onChange={(event) => {
+                                                    if (!selectedDefaultModel)
+                                                        return;
+                                                    updateSettings({
+                                                        defaultAiAgentModelConfig:
+                                                            {
+                                                                ...defaultModelConfig,
+                                                                modelName:
+                                                                    selectedDefaultModel.name,
+                                                                modelProvider:
+                                                                    selectedDefaultModel.provider,
+                                                                reasoning:
+                                                                    event
+                                                                        .currentTarget
+                                                                        .checked,
+                                                            },
+                                                    });
+                                                }}
+                                            />
+                                        </Group>
+                                    </>
+                                )}
+                            </Stack>
+                        </SettingsCard>
 
-                    {orgAiProviderKeysFlag.data?.enabled &&
-                        settings.isCopilotEnabled && (
-                            <AiProvidersCard
-                                providerApiKeysSet={settings.providerApiKeysSet}
-                                providerApiKeyHints={
-                                    settings.providerApiKeyHints
-                                }
-                                modelVisibility={
-                                    settings.modelVisibility ?? null
-                                }
-                                configurableModelOptions={
-                                    settings.configurableModelOptions ?? null
-                                }
-                                dataAppModelVisibility={
-                                    settings.dataAppModelVisibility ?? null
-                                }
-                                showDataAppModels={
-                                    dataAppsFlag.data?.enabled === true
-                                }
-                                disabled={isUpdatingSettings}
-                                onUpdateKeys={(providerApiKeys) =>
-                                    updateSettings({ providerApiKeys })
-                                }
-                                onUpdateVisibility={(modelVisibility) =>
-                                    updateSettings({ modelVisibility })
-                                }
-                                onUpdateDataAppVisibility={(
-                                    dataAppModelVisibility,
-                                ) => updateSettings({ dataAppModelVisibility })}
+                        {threadRetentionFlag.data?.enabled && (
+                            <ThreadRetentionCard
+                                current={settings.threadRetentionHours ?? null}
                             />
                         )}
 
-                    <SettingsCard>
-                        <Stack gap="md">
+                        <SettingsCard>
                             <Group
                                 justify="space-between"
                                 wrap="nowrap"
@@ -289,149 +324,191 @@ export const AiGeneralSettingsPage = () => {
                                 <Box maw={620}>
                                     <Group gap="xs" mb={4}>
                                         <Title order={5}>
-                                            Review AI agent turns
+                                            Enable AI agent memories
                                         </Title>
                                         <BetaBadge />
                                     </Group>
-                                    <Text c="dimmed" fz="xs">
-                                        Process every agent turn to surface
-                                        semantic layer gaps, project context
-                                        improvements, and admin recommendations.
-                                        For connected projects, Lightdash can
-                                        suggest pull requests that improve
-                                        context and dbt definitions.
-                                        {reviewsEffectivelyOn && (
+                                    <Text c="ldGray.6" fz="xs">
+                                        Let Ask AI learn from each user&apos;s
+                                        agent conversations and reuse those
+                                        memories in future answers. Disable to
+                                        stop learning from and using memories
+                                        while keeping existing data intact.
+                                        {aiAgentMemoryEnabled && (
                                             <>
                                                 {' '}
-                                                See issues in{' '}
+                                                Manage them in{' '}
                                                 <Anchor
                                                     component={Link}
-                                                    to="/generalSettings/ai/issues"
+                                                    to="/generalSettings/ai/memories"
                                                 >
-                                                    Ask AI &gt; Issues
+                                                    Ask AI &gt; Memories
                                                 </Anchor>
                                                 .
                                             </>
                                         )}
                                     </Text>
-                                    {reviewsPausedByByok && (
-                                        <Text c="dimmed" fz="xs" mt={4}>
-                                            Paused — your AI provider key
-                                            can&apos;t run the review model
-                                            (Claude Haiku). Reviews run on your
-                                            own key, so they resume when it has
-                                            access.
-                                        </Text>
-                                    )}
                                 </Box>
                                 <Switch
                                     size="md"
-                                    checked={reviewsEffectivelyOn}
-                                    disabled={
-                                        isUpdatingSettings ||
-                                        reviewsPausedByByok
-                                    }
+                                    checked={aiAgentMemoryEnabled}
+                                    disabled={isUpdatingSettings}
                                     onChange={(event) =>
                                         updateSettings({
-                                            aiAgentReviewsEnabled:
+                                            aiAgentMemoryEnabled:
                                                 event.currentTarget.checked,
                                         })
                                     }
                                 />
                             </Group>
+                        </SettingsCard>
 
-                            {reviewsEffectivelyOn && (
-                                <ReviewNotificationsSettings />
-                            )}
-                        </Stack>
-                    </SettingsCard>
-
-                    <SettingsCard>
-                        <Group
-                            justify="space-between"
-                            wrap="nowrap"
-                            align="flex-start"
-                            gap="md"
-                        >
-                            <Box maw={620}>
-                                <Group gap="xs" mb={4}>
-                                    <Title order={5}>
-                                        Enable AI agent memories
-                                    </Title>
-                                    <BetaBadge />
+                        {(settings.isCopilotEnabled || settings.isTrial) && (
+                            <SettingsCard>
+                                <Group
+                                    justify="space-between"
+                                    wrap="nowrap"
+                                    align="flex-start"
+                                    gap="md"
+                                >
+                                    <Box maw={620}>
+                                        <Title order={5} mb={4}>
+                                            Deep research
+                                        </Title>
+                                        <Text c="ldGray.6" fz="xs">
+                                            Run limits and raw SQL access.
+                                        </Text>
+                                    </Box>
+                                    <Anchor
+                                        component={Link}
+                                        to="/generalSettings/ai/deep-research"
+                                        fz="xs"
+                                        fw={500}
+                                    >
+                                        Open settings &rarr;
+                                    </Anchor>
                                 </Group>
-                                <Text c="dimmed" fz="xs">
-                                    Let Ask AI learn from each user&apos;s agent
-                                    conversations and reuse those memories in
-                                    future answers. Disable to stop learning
-                                    from and using memories while keeping
-                                    existing data intact.
-                                    {aiAgentMemoryEnabled && (
-                                        <>
-                                            {' '}
-                                            Manage them in{' '}
-                                            <Anchor
-                                                component={Link}
-                                                to="/generalSettings/ai/memories"
-                                            >
-                                                Ask AI &gt; Memories
-                                            </Anchor>
-                                            .
-                                        </>
-                                    )}
-                                </Text>
-                            </Box>
-                            <Switch
-                                size="md"
-                                checked={aiAgentMemoryEnabled}
-                                disabled={isUpdatingSettings}
-                                onChange={(event) =>
-                                    updateSettings({
-                                        aiAgentMemoryEnabled:
-                                            event.currentTarget.checked,
-                                    })
-                                }
-                            />
-                        </Group>
-                    </SettingsCard>
+                            </SettingsCard>
+                        )}
+                    </Section>
 
-                    <SettingsCard>
-                        <Group
-                            justify="space-between"
-                            wrap="nowrap"
-                            align="flex-start"
-                            gap="md"
-                        >
-                            <Box maw={620}>
-                                <Title order={5} mb={4}>
-                                    Allow content changes via MCP
-                                </Title>
-                                <Text c="dimmed" fz="xs">
-                                    Let MCP clients create and edit charts and
-                                    dashboards in this organization. Disable to
-                                    prevent unintended changes to managed
-                                    content; reading content over MCP stays
-                                    available either way, and individual users
-                                    are still bound by their existing
-                                    permissions.
-                                </Text>
-                            </Box>
-                            <Switch
-                                size="md"
-                                checked={settings.mcpContentWritesEnabled}
-                                disabled={isUpdatingSettings}
-                                onChange={(event) =>
-                                    updateSettings({
-                                        mcpContentWritesEnabled:
-                                            event.currentTarget.checked,
-                                    })
-                                }
-                            />
-                        </Group>
-                    </SettingsCard>
+                    {orgAiProviderKeysFlag.data?.enabled &&
+                        settings.isCopilotEnabled && (
+                            <Section
+                                label="Providers & keys"
+                                description="Your own keys take precedence over the instance keys."
+                            >
+                                <AiProvidersCard
+                                    providerApiKeysSet={
+                                        settings.providerApiKeysSet
+                                    }
+                                    providerApiKeyHints={
+                                        settings.providerApiKeyHints
+                                    }
+                                    modelVisibility={
+                                        settings.modelVisibility ?? null
+                                    }
+                                    configurableModelOptions={
+                                        settings.configurableModelOptions ??
+                                        null
+                                    }
+                                    dataAppModelVisibility={
+                                        settings.dataAppModelVisibility ?? null
+                                    }
+                                    showDataAppModels={
+                                        dataAppsFlag.data?.enabled === true
+                                    }
+                                    disabled={isUpdatingSettings}
+                                    onUpdateKeys={(providerApiKeys) =>
+                                        updateSettings({ providerApiKeys })
+                                    }
+                                    onUpdateVisibility={(modelVisibility) =>
+                                        updateSettings({ modelVisibility })
+                                    }
+                                    onUpdateDataAppVisibility={(
+                                        dataAppModelVisibility,
+                                    ) =>
+                                        updateSettings({
+                                            dataAppModelVisibility,
+                                        })
+                                    }
+                                />
+                            </Section>
+                        )}
 
-                    <SettingsCard>
-                        <Stack gap="md">
+                    <Section label="Quality & review">
+                        <SettingsCard>
+                            <Stack gap="md">
+                                <Group
+                                    justify="space-between"
+                                    wrap="nowrap"
+                                    align="flex-start"
+                                    gap="md"
+                                >
+                                    <Box maw={620}>
+                                        <Group gap="xs" mb={4}>
+                                            <Title order={5}>
+                                                Review AI agent turns
+                                            </Title>
+                                            <BetaBadge />
+                                        </Group>
+                                        <Text c="ldGray.6" fz="xs">
+                                            Process every agent turn to surface
+                                            semantic layer gaps, project context
+                                            improvements, and admin
+                                            recommendations. For connected
+                                            projects, Lightdash can suggest pull
+                                            requests that improve context and
+                                            dbt definitions.
+                                            {reviewsEffectivelyOn && (
+                                                <>
+                                                    {' '}
+                                                    See issues in{' '}
+                                                    <Anchor
+                                                        component={Link}
+                                                        to="/generalSettings/ai/issues"
+                                                    >
+                                                        Ask AI &gt; Issues
+                                                    </Anchor>
+                                                    .
+                                                </>
+                                            )}
+                                        </Text>
+                                        {reviewsPausedByByok && (
+                                            <Text c="ldGray.6" fz="xs" mt={4}>
+                                                Paused — your AI provider key
+                                                can&apos;t run the review model
+                                                (Claude Haiku). Reviews run on
+                                                your own key, so they resume
+                                                when it has access.
+                                            </Text>
+                                        )}
+                                    </Box>
+                                    <Switch
+                                        size="md"
+                                        checked={reviewsEffectivelyOn}
+                                        disabled={
+                                            isUpdatingSettings ||
+                                            reviewsPausedByByok
+                                        }
+                                        onChange={(event) =>
+                                            updateSettings({
+                                                aiAgentReviewsEnabled:
+                                                    event.currentTarget.checked,
+                                            })
+                                        }
+                                    />
+                                </Group>
+
+                                {reviewsEffectivelyOn && (
+                                    <ReviewNotificationsSettings />
+                                )}
+                            </Stack>
+                        </SettingsCard>
+                    </Section>
+
+                    <Section label="Development">
+                        <SettingsCard>
                             <Group
                                 justify="space-between"
                                 wrap="nowrap"
@@ -440,39 +517,32 @@ export const AiGeneralSettingsPage = () => {
                             >
                                 <Box maw={620}>
                                     <Title order={5} mb={4}>
-                                        AI Router
+                                        Allow content changes via MCP
                                     </Title>
-                                    <Text c="dimmed" fz="xs">
-                                        {settings.aiAgentsVisible
-                                            ? 'Route user questions to the best agent automatically, instead of asking users to pick.'
-                                            : 'Enable AI features first to use the Router.'}
+                                    <Text c="ldGray.6" fz="xs">
+                                        Let MCP clients create and edit charts
+                                        and dashboards in this organization.
+                                        Disable to prevent unintended changes to
+                                        managed content; reading content over
+                                        MCP stays available either way, and
+                                        individual users are still bound by
+                                        their existing permissions.
                                     </Text>
                                 </Box>
                                 <Switch
                                     size="md"
-                                    checked={isRouterEnabled}
-                                    disabled={
-                                        isUpdatingRouter ||
-                                        isRouterLoading ||
-                                        !settings.aiAgentsVisible
-                                    }
+                                    checked={settings.mcpContentWritesEnabled}
+                                    disabled={isUpdatingSettings}
                                     onChange={(event) =>
-                                        upsertRouter({
-                                            enabled:
+                                        updateSettings({
+                                            mcpContentWritesEnabled:
                                                 event.currentTarget.checked,
                                         })
                                     }
                                 />
                             </Group>
-
-                            {settings.aiAgentsVisible && isRouterEnabled && (
-                                <>
-                                    <Divider mx="calc(var(--mantine-spacing-md) * -1)" />
-                                    <AiRouterInstructionsCard />
-                                </>
-                            )}
-                        </Stack>
-                    </SettingsCard>
+                        </SettingsCard>
+                    </Section>
                 </>
             )}
         </SettingsPage>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiSurfacesCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiSurfacesCard.tsx
@@ -1,0 +1,138 @@
+import { type SlackSettings } from '@lightdash/common';
+import {
+    Badge,
+    Box,
+    Divider,
+    Group,
+    Stack,
+    Switch,
+    Text,
+    Title,
+} from '@mantine/core';
+import {
+    IconBrandSlack,
+    IconLayoutDashboard,
+    IconPlugConnected,
+    IconSparkles,
+    type Icon,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../../components/common/MantineIcon';
+import { SettingsCard } from '../../../../../../components/common/Settings/SettingsCard';
+
+const SurfaceRow: FC<{
+    icon: Icon;
+    name: string;
+    description: string;
+    checked: boolean;
+    disabled: boolean;
+    onChange: (checked: boolean) => void;
+}> = ({ icon, name, description, checked, disabled, onChange }) => (
+    <Group wrap="nowrap" align="flex-start" gap="sm">
+        <MantineIcon icon={icon} size="lg" color="ldGray.7" />
+        <Stack gap={2} flex={1}>
+            <Title order={6}>{name}</Title>
+            <Text c="ldGray.6" fz="xs">
+                {description}
+            </Text>
+        </Stack>
+        <Switch
+            size="md"
+            checked={checked}
+            disabled={disabled}
+            onChange={(event) => onChange(event.currentTarget.checked)}
+        />
+    </Group>
+);
+
+type AiSurfacesCardProps = {
+    aiAgentsVisible: boolean;
+    mcpAgentsEnabled: boolean;
+    slackInstallation: SlackSettings | undefined;
+    slackAgentsEnabled: boolean;
+    isTrial: boolean;
+    disabled: boolean;
+    isUpdatingSlack: boolean;
+    onUpdateAiAgentsVisible: (checked: boolean) => void;
+    onUpdateMcpAgentsEnabled: (checked: boolean) => void;
+    onUpdateSlackAgentsEnabled: (checked: boolean) => void;
+};
+
+export const AiSurfacesCard: FC<AiSurfacesCardProps> = ({
+    aiAgentsVisible,
+    mcpAgentsEnabled,
+    slackInstallation,
+    slackAgentsEnabled,
+    isTrial,
+    disabled,
+    isUpdatingSlack,
+    onUpdateAiAgentsVisible,
+    onUpdateMcpAgentsEnabled,
+    onUpdateSlackAgentsEnabled,
+}) => {
+    const hasSlack = !!slackInstallation?.organizationUuid;
+
+    return (
+        <SettingsCard>
+            <Stack gap="md">
+                <Box>
+                    <Group gap="xs">
+                        <Title order={5}>Visibility</Title>
+                        {isTrial && (
+                            <Badge
+                                leftSection={
+                                    <MantineIcon
+                                        icon={IconSparkles}
+                                        size={12}
+                                    />
+                                }
+                                radius="sm"
+                                variant="light"
+                                color="gray"
+                                size="sm"
+                                tt="none"
+                                fw={500}
+                            >
+                                Free trial
+                            </Badge>
+                        )}
+                    </Group>
+                    <Text c="ldGray.6" fz="xs">
+                        Where agents can be reached. Per-agent access still
+                        applies on every surface.
+                    </Text>
+                </Box>
+                <SurfaceRow
+                    icon={IconLayoutDashboard}
+                    name="Lightdash UI"
+                    description="Homepage card, navbar action, and agent chat."
+                    checked={aiAgentsVisible}
+                    disabled={disabled}
+                    onChange={onUpdateAiAgentsVisible}
+                />
+                <Divider />
+                <SurfaceRow
+                    icon={IconPlugConnected}
+                    name="MCP"
+                    description="Agent tools and context for MCP."
+                    checked={mcpAgentsEnabled}
+                    disabled={disabled}
+                    onChange={onUpdateMcpAgentsEnabled}
+                />
+                <Divider />
+                <SurfaceRow
+                    icon={IconBrandSlack}
+                    name="Slack"
+                    description={
+                        hasSlack
+                            ? '@mentions and the multi-agent channel.'
+                            : "Slack isn't connected. Add the integration in Integrations → Slack first."
+                    }
+                    checked={slackAgentsEnabled}
+                    disabled={!hasSlack || isUpdatingSlack}
+                    onChange={onUpdateSlackAgentsEnabled}
+                />
+            </Stack>
+        </SettingsCard>
+    );
+};


### PR DESCRIPTION
With per-surface agent controls landing, the Ask AI general settings page had no way to show at a glance where agents can be reached, and the AI Router settings were unreachable for MCP-only orgs because they were gated on the in-app visibility toggle.

Closes: #27800