### PR TITLE
fix(ai-agents): show strict Slack channel warning on first top-level mention

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -13653,7 +13653,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         organizationUuid: string;
         userUuid: string;
         channelId: string;
-        threadTs: string;
+        // The mention's own ts, used as the thread anchor for replies.
+        messageTs: string;
+        // Set only when the mention happened inside an existing thread.
+        threadTs: string | undefined;
         say: SayFn;
         client: WebClient;
         slackUserId: string;
@@ -13664,6 +13667,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             organizationUuid,
             userUuid,
             channelId,
+            messageTs,
             threadTs,
             say,
             client,
@@ -13671,16 +13675,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             promptText,
             visibleProjectUuids,
         } = args;
+        const threadAnchorTs = threadTs ?? messageTs;
 
         if (
             await this.aiOrganizationSettingsService.isExplicitSlackChannelLinkingRequired(
                 organizationUuid,
             )
         ) {
+            // Slack only renders ephemeral thread replies in an already-active
+            // thread; for a top-level mention post to the channel instead.
             await client.chat.postEphemeral({
                 channel: channelId,
                 user: slackUserId,
-                thread_ts: threadTs,
+                ...(threadTs ? { thread_ts: threadTs } : {}),
                 text: this.getExplicitSlackChannelLinkingMessage(),
             });
             return 'handled';
@@ -13692,7 +13699,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             projectUuids: undefined,
             say,
             slackChannelId: channelId,
-            threadTs,
+            threadTs: threadAnchorTs,
             promptText,
         });
         if (fallback === 'handled') {
@@ -13706,7 +13713,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             organizationUuid,
             userUuid,
             channelId,
-            threadTs,
+            threadTs: threadAnchorTs,
             say,
             visibleProjectUuids,
         });
@@ -15590,7 +15597,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         organizationUuid,
                         userUuid,
                         channelId,
-                        threadTs: threadTs || messageTs,
+                        messageTs,
+                        threadTs: threadTs || undefined,
                         say,
                         client,
                         slackUserId,
@@ -15854,7 +15862,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             organizationUuid,
                             userUuid,
                             channelId: event.channel,
-                            threadTs: event.thread_ts ?? event.ts,
+                            messageTs: event.ts,
+                            threadTs: event.thread_ts,
                             say,
                             client,
                             slackUserId: event.user,

--- a/packages/backend/src/ee/services/AiAgentService/slackChannelLinkStrictMode.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/slackChannelLinkStrictMode.test.ts
@@ -21,6 +21,7 @@ const AGENT_UUID = 'agent-uuid';
 const CHANNEL_ID = 'C12345';
 const SLACK_USER_ID = 'U12345';
 const THREAD_TS = '1700000000.000100';
+const MESSAGE_TS = '1700000000.000200';
 const SITE_URL = 'https://app.example.com';
 
 const adminUser: SessionUser = {
@@ -93,7 +94,7 @@ const buildService = ({
     return { service, aiAgentModel };
 };
 
-const buildUnmappedChannelArgs = () => {
+const buildUnmappedChannelArgs = ({ threadTs }: { threadTs?: string } = {}) => {
     const say = vi.fn().mockResolvedValue(undefined);
     const postEphemeral = vi.fn().mockResolvedValue(undefined);
     const client = { chat: { postEphemeral } };
@@ -102,7 +103,8 @@ const buildUnmappedChannelArgs = () => {
             organizationUuid: ORGANIZATION_UUID,
             userUuid: adminUser.userUuid,
             channelId: CHANNEL_ID,
-            threadTs: THREAD_TS,
+            messageTs: MESSAGE_TS,
+            threadTs,
             say,
             client,
             slackUserId: SLACK_USER_ID,
@@ -157,7 +159,9 @@ describe('resolveAgentForUnmappedSlackChannel strict mode', () => {
             requireExplicitLinking: true,
             systemAgentFallbackEnabled: true,
         });
-        const { args, say, postEphemeral } = buildUnmappedChannelArgs();
+        const { args, say, postEphemeral } = buildUnmappedChannelArgs({
+            threadTs: THREAD_TS,
+        });
 
         const result = await (
             service as unknown as {
@@ -180,6 +184,29 @@ describe('resolveAgentForUnmappedSlackChannel strict mode', () => {
         expect(aiAgentModel.addSlackChannelIntegration).not.toHaveBeenCalled();
         expect(aiAgentModel.findAllAgents).not.toHaveBeenCalled();
         expect(say).not.toHaveBeenCalled();
+    });
+
+    it('posts the ephemeral without thread_ts for a top-level mention', async () => {
+        // Slack drops ephemeral thread replies when the thread is not active
+        // yet, so a first mention must get a channel-level ephemeral.
+        const { service } = buildService({ requireExplicitLinking: true });
+        const { args, postEphemeral } = buildUnmappedChannelArgs();
+
+        const result = await (
+            service as unknown as {
+                resolveAgentForUnmappedSlackChannel: (
+                    a: typeof args,
+                ) => Promise<unknown>;
+            }
+        ).resolveAgentForUnmappedSlackChannel(args);
+
+        expect(result).toBe('handled');
+        expect(postEphemeral).toHaveBeenCalledTimes(1);
+        expect(postEphemeral.mock.calls[0][0]).not.toHaveProperty('thread_ts');
+        expect(postEphemeral.mock.calls[0][0]).toMatchObject({
+            channel: CHANNEL_ID,
+            user: SLACK_USER_ID,
+        });
     });
 
     it('auto-links the single manageable agent when strict mode is off', async () => {


### PR DESCRIPTION
### Description:
When an org requires explicit Slack channel linking, mentioning the agent in an unlinked channel with a new top-level message produced no visible response: the strict-channel warning was posted via `chat.postEphemeral` with `thread_ts` set to the mention's own `ts`. Slack accepts the call but only renders ephemeral thread replies in an already-active thread, so the warning was silently dropped.

`resolveAgentForUnmappedSlackChannel` now takes `messageTs` and the real (optional) `threadTs` separately:

- The strict-mode ephemeral includes `thread_ts` only when the mention happened inside an existing thread; a top-level mention gets a channel-level ephemeral, visible only to the triggering user.
- Non-ephemeral replies (system-agent fallback, link-agent picker) keep anchoring to `threadTs ?? messageTs` as before.
- The channel stays unlinked and no agent run starts, unchanged.

Tests cover both the top-level (no `thread_ts`) and in-thread (with `thread_ts`) strict-mode cases.

### Risk assessment:

- [ ] This is a high-risk change

Closes: ZAP-946
