### PR TITLE
fix(homepage): resolve group-priority ties and relabel project default

### DIFF
--- a/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
@@ -8,9 +8,13 @@ import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { DatabaseError } from 'pg';
 import {
     AnnouncementsTableName,
+    HomepageAssignmentsTableName,
     HomepagesTableName,
 } from '../database/entities/projectHomepages';
-import { ProjectHomepageModel } from './ProjectHomepageModel';
+import {
+    ProjectHomepageModel,
+    rankGroupPriorities,
+} from './ProjectHomepageModel';
 
 // Covers only behavior beyond a thin Knex wrapper: NotFoundError
 // contracts and the publish draft→published copy the service depends on.
@@ -271,5 +275,97 @@ describe('ProjectHomepageModel', () => {
                 model.getPublishedDefault(PROJECT_UUID),
             ).resolves.toBeUndefined();
         });
+    });
+
+    describe('resolvePublished', () => {
+        it('breaks group-priority ties by created_at then assignment_uuid', async () => {
+            tracker.on.select(HomepageAssignmentsTableName).responseOnce([]);
+            tracker.on.select(HomepagesTableName).responseOnce([]);
+
+            await model.resolvePublished(PROJECT_UUID, {
+                groupUuids: ['group-a', 'group-b'],
+                role: undefined,
+            });
+
+            const selectQuery = tracker.history.select[0];
+            expect(selectQuery.sql).toContain('priority');
+            expect(selectQuery.sql).toContain('created_at');
+            expect(selectQuery.sql).toContain('assignment_uuid');
+        });
+    });
+});
+
+describe('rankGroupPriorities', () => {
+    const assignment = (
+        groupUuid: string,
+        priority: number,
+        createdAt: string,
+        assignmentUuid: string,
+    ) => ({
+        groupUuid,
+        priority,
+        createdAt: new Date(createdAt),
+        assignmentUuid,
+    });
+
+    it('assigns unique sequential priorities to the full project set', () => {
+        const ranked = rankGroupPriorities(
+            [
+                assignment('group-a', 0, '2026-01-01T00:00:00Z', 'aaa'),
+                assignment('group-b', 0, '2026-01-02T00:00:00Z', 'bbb'),
+                assignment('group-c', 1, '2026-01-03T00:00:00Z', 'ccc'),
+            ],
+            ['group-c'],
+        );
+
+        expect(ranked).toEqual([
+            { groupUuid: 'group-c', priority: 0 },
+            { groupUuid: 'group-a', priority: 1 },
+            { groupUuid: 'group-b', priority: 2 },
+        ]);
+    });
+
+    it('honors the requested order and appends omitted groups', () => {
+        const ranked = rankGroupPriorities(
+            [
+                assignment('group-a', 2, '2026-01-01T00:00:00Z', 'aaa'),
+                assignment('group-b', 0, '2026-01-01T00:00:00Z', 'bbb'),
+                assignment('group-c', 1, '2026-01-01T00:00:00Z', 'ccc'),
+            ],
+            ['group-c', 'group-a'],
+        );
+
+        expect(ranked.map((row) => row.groupUuid)).toEqual([
+            'group-c',
+            'group-a',
+            'group-b',
+        ]);
+        expect(ranked.map((row) => row.priority)).toEqual([0, 1, 2]);
+    });
+
+    it('breaks remaining ties by created_at then assignment uuid', () => {
+        const ranked = rankGroupPriorities(
+            [
+                assignment('group-z', 3, '2026-01-01T00:00:00Z', 'zzz'),
+                assignment('group-a', 3, '2026-01-01T00:00:00Z', 'aaa'),
+                assignment('group-m', 3, '2026-01-02T00:00:00Z', 'mmm'),
+            ],
+            [],
+        );
+
+        expect(ranked.map((row) => row.groupUuid)).toEqual([
+            'group-a',
+            'group-z',
+            'group-m',
+        ]);
+    });
+
+    it('ignores unknown and duplicate requested group uuids', () => {
+        const ranked = rankGroupPriorities(
+            [assignment('group-a', 0, '2026-01-01T00:00:00Z', 'aaa')],
+            ['missing', 'group-a', 'group-a'],
+        );
+
+        expect(ranked).toEqual([{ groupUuid: 'group-a', priority: 0 }]);
     });
 });

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -36,6 +36,57 @@ import {
 const RECENTLY_VIEWED_STATEMENT_TIMEOUT_MS = 10_000;
 const RECENTLY_VIEWED_WINDOW_DAYS = 90;
 
+type RankableGroupAssignment = {
+    groupUuid: string;
+    priority: number;
+    createdAt: Date;
+    assignmentUuid: string;
+};
+
+const compareGroupAssignmentPriority = (
+    left: RankableGroupAssignment,
+    right: RankableGroupAssignment,
+): number => {
+    if (left.priority !== right.priority) {
+        return left.priority - right.priority;
+    }
+    const createdDelta = left.createdAt.getTime() - right.createdAt.getTime();
+    if (createdDelta !== 0) {
+        return createdDelta;
+    }
+    return left.assignmentUuid.localeCompare(right.assignmentUuid);
+};
+
+// Always rewrite every group in the project so a partial reorder cannot
+// leave two groups sharing a priority.
+export const rankGroupPriorities = (
+    existing: RankableGroupAssignment[],
+    requestedOrder: string[],
+): { groupUuid: string; priority: number }[] => {
+    const existingByUuid = new Map(
+        existing.map((assignment) => [assignment.groupUuid, assignment]),
+    );
+    const ranked: string[] = [];
+    const seen = new Set<string>();
+
+    for (const groupUuid of requestedOrder) {
+        if (existingByUuid.has(groupUuid) && !seen.has(groupUuid)) {
+            ranked.push(groupUuid);
+            seen.add(groupUuid);
+        }
+    }
+
+    const remaining = existing
+        .filter((assignment) => !seen.has(assignment.groupUuid))
+        .sort(compareGroupAssignmentPriority)
+        .map((assignment) => assignment.groupUuid);
+
+    return [...ranked, ...remaining].map((groupUuid, priority) => ({
+        groupUuid,
+        priority,
+    }));
+};
+
 export class ProjectHomepageModel {
     private readonly database: Knex;
 
@@ -517,7 +568,20 @@ export class ProjectHomepageModel {
                 `${HomepageAssignmentsTableName}.group_uuid`,
             )
             .where(`${HomepageAssignmentsTableName}.project_uuid`, projectUuid)
-            .orderBy(`${HomepageAssignmentsTableName}.priority`, 'asc')
+            .orderBy([
+                {
+                    column: `${HomepageAssignmentsTableName}.priority`,
+                    order: 'asc',
+                },
+                {
+                    column: `${HomepageAssignmentsTableName}.created_at`,
+                    order: 'asc',
+                },
+                {
+                    column: `${HomepageAssignmentsTableName}.assignment_uuid`,
+                    order: 'asc',
+                },
+            ])
             .select(
                 `${HomepageAssignmentsTableName}.assignment_uuid`,
                 `${HomepageAssignmentsTableName}.homepage_uuid`,
@@ -545,15 +609,43 @@ export class ProjectHomepageModel {
         groupUuids: string[],
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
+            const existing = await trx(HomepageAssignmentsTableName)
+                .where({
+                    project_uuid: projectUuid,
+                    target_type: 'group',
+                })
+                .select(
+                    'group_uuid',
+                    'priority',
+                    'created_at',
+                    'assignment_uuid',
+                );
+
+            const ranked = rankGroupPriorities(
+                existing.flatMap((row) =>
+                    row.group_uuid
+                        ? [
+                              {
+                                  groupUuid: row.group_uuid,
+                                  priority: row.priority,
+                                  createdAt: row.created_at,
+                                  assignmentUuid: row.assignment_uuid,
+                              },
+                          ]
+                        : [],
+                ),
+                groupUuids,
+            );
+
             await Promise.all(
-                groupUuids.map((groupUuid, index) =>
+                ranked.map(({ groupUuid, priority }) =>
                     trx(HomepageAssignmentsTableName)
                         .where({
                             project_uuid: projectUuid,
                             target_type: 'group',
                             group_uuid: groupUuid,
                         })
-                        .update({ priority: index }),
+                        .update({ priority }),
                 ),
             );
         });
@@ -578,7 +670,20 @@ export class ProjectHomepageModel {
                     projectUuid,
                 )
                 .whereNotNull(`${HomepagesTableName}.published_config`)
-                .orderBy(`${HomepageAssignmentsTableName}.priority`, 'asc')
+                .orderBy([
+                    {
+                        column: `${HomepageAssignmentsTableName}.priority`,
+                        order: 'asc',
+                    },
+                    {
+                        column: `${HomepageAssignmentsTableName}.created_at`,
+                        order: 'asc',
+                    },
+                    {
+                        column: `${HomepageAssignmentsTableName}.assignment_uuid`,
+                        order: 'asc',
+                    },
+                ])
                 .select(
                     `${HomepagesTableName}.*`,
                     `${HomepageAssignmentsTableName}.group_uuid as assignment_group_uuid`,

--- a/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.test.ts
@@ -1,0 +1,21 @@
+import { reasonLabel } from './PreviewPane';
+
+const groupNames = new Map([['group-1', 'Finance']]);
+
+it('labels the last resolution tier as the project default', () => {
+    expect(reasonLabel({ type: 'default' }, groupNames)).toBe(
+        'project default',
+    );
+});
+
+it('keeps group and role reason labels', () => {
+    expect(
+        reasonLabel(
+            { type: 'group', groupUuid: 'group-1', priority: 2 },
+            groupNames,
+        ),
+    ).toBe('via group Finance (priority 2)');
+    expect(
+        reasonLabel({ type: 'role', role: 'editor' }, groupNames),
+    ).toBe('via role Editor');
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
@@ -24,7 +24,7 @@ import { PublishedHomepage } from './PublishedHomepage';
 
 export type HomepageViewType = 'everyone' | 'user' | 'group' | 'role';
 
-const reasonLabel = (
+export const reasonLabel = (
     reason: HomepageViewAsReason,
     groupNames: Map<string, string>,
 ): string => {
@@ -34,7 +34,7 @@ const reasonLabel = (
         case 'role':
             return `via role ${ProjectMemberRoleLabels[reason.role]}`;
         case 'default':
-            return 'org default';
+            return 'project default';
         default:
             return assertUnreachable(reason, 'Unknown view-as reason');
     }

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.test.ts
@@ -1,0 +1,9 @@
+import { RESOLUTION_STEPS } from './PublishModal';
+
+it('labels the last resolution tier as the project default', () => {
+    expect(RESOLUTION_STEPS).toEqual([
+        'Group priority',
+        'Role',
+        'Project default',
+    ]);
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -38,7 +38,11 @@ import {
 } from './hooks/useProjectHomepage';
 import classes from './PublishModal.module.css';
 
-const RESOLUTION_STEPS = ['Group priority', 'Role', 'Org default'];
+export const RESOLUTION_STEPS = [
+    'Group priority',
+    'Role',
+    'Project default',
+];
 
 const ROLE_DESCRIPTIONS: Record<ProjectMemberRole, string> = {
     [ProjectMemberRole.VIEWER]: 'Read-only consumers of dashboards',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: #28089

### Description:

Two homepage audience-resolution papercuts:

1. **Group priority ties.** `resolvePublished` / `getAssignments` now break equal `priority` values with `created_at`, then `assignment_uuid`. `updateGroupPriorities` rewrites the **full** project group set to unique `0..n` ranks, so a partial `PATCH .../group-priorities` cannot leave two groups sharing a priority.

2. **Mislabel.** The last resolution tier is the project's `is_default` homepage, not an org-wide default. Publish modal copy and the view-as reason badge now say "Project default" / "project default".

Verified in the homepage builder publish modal (Everyone / By group / By role all show the new last step):

[Publish modal Resolves bar says Project default](https://cursor.com/agents/bc-2a688c72-ff63-442b-a384-2e0a3cc52fd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublish_modal_everyone_project_default.webp)

[publish_modal_project_default_label.mp4](https://cursor.com/agents/bc-2a688c72-ff63-442b-a384-2e0a3cc52fd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublish_modal_project_default_label.mp4)

### Risk assessment:

- [ ] This is a high-risk change


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a688c72-ff63-442b-a384-2e0a3cc52fd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a688c72-ff63-442b-a384-2e0a3cc52fd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

