### PR TITLE
fix(dashboards): scope dashboard grants to the owning dashboard

### DIFF
--- a/packages/backend/src/models/DashboardAccessModel.ts
+++ b/packages/backend/src/models/DashboardAccessModel.ts
@@ -285,6 +285,7 @@ export class DashboardAccessModel {
                 resourceUuid: `${DashboardUserAccessTableName}.dashboard_uuid`,
                 organizationUuid: `${OrganizationTableName}.organization_uuid`,
                 projectUuid: `${ProjectTableName}.project_uuid`,
+                spaceUuid: `${SpaceTableName}.space_uuid`,
                 role: `${DashboardUserAccessTableName}.space_role`,
                 groupUuid: trx.raw('NULL'),
             })
@@ -342,6 +343,7 @@ export class DashboardAccessModel {
                         resourceUuid: `${DashboardGroupAccessTableName}.dashboard_uuid`,
                         organizationUuid: `${OrganizationTableName}.organization_uuid`,
                         projectUuid: `${ProjectTableName}.project_uuid`,
+                        spaceUuid: `${SpaceTableName}.space_uuid`,
                         role: `${DashboardGroupAccessTableName}.space_role`,
                         groupUuid: `${DashboardGroupAccessTableName}.group_uuid`,
                     })

--- a/packages/backend/src/models/directAccessModelUtils.ts
+++ b/packages/backend/src/models/directAccessModelUtils.ts
@@ -16,6 +16,9 @@ import { UserTableName } from '../database/entities/users';
 export type DirectAccess = {
     organizationUuid: UUID;
     projectUuid: UUID;
+    // Space the granted resource actually lives in; lets callers verify the
+    // grant belongs to the space context they are extending.
+    spaceUuid: UUID;
     userRole: SpaceMemberRole | null;
     groupRoles: SpaceMemberRole[];
 };
@@ -24,6 +27,7 @@ export type DirectAccessRow = {
     resourceUuid: UUID;
     organizationUuid: UUID;
     projectUuid: UUID;
+    spaceUuid: UUID;
     role: SpaceMemberRole;
     groupUuid: UUID | null;
 };
@@ -206,6 +210,7 @@ export const groupDirectAccessRows = (
         const access = accessByResource[row.resourceUuid] ?? {
             organizationUuid: row.organizationUuid,
             projectUuid: row.projectUuid,
+            spaceUuid: row.spaceUuid,
             userRole: null,
             groupRoles: [],
         };

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -386,6 +386,14 @@ const getMockedAsyncQueryService = (
                 inheritsFromOrgOrProject: true,
                 access: [],
             })),
+            getDashboardAccessContext: vi.fn(async () => ({
+                organizationUuid: projectSummary.organizationUuid,
+                projectUuid,
+                inheritsFromOrgOrProject: true,
+                access: [],
+                admins: [],
+                directOnly: false,
+            })),
         } as unknown as SpacePermissionService,
         organizationSettingsModel: {
             get: vi.fn(async () => ({
@@ -5113,10 +5121,10 @@ describe('checkDashboardChartQueryPermissions', () => {
             ),
         ).rejects.toThrow(ForbiddenError);
         expect(
-            spacePermissionService.getSpaceAccessContext,
-        ).toHaveBeenCalledWith(account.user.id, chartSpace.uuid);
-        expect(
             spacePermissionService.getDashboardAccessContext,
-        ).not.toHaveBeenCalled();
+        ).toHaveBeenCalledWith(account.user.id, {
+            uuid: null,
+            spaceUuid: chartSpace.uuid,
+        });
     });
 });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -742,23 +742,12 @@ export class AsyncQueryService extends ProjectService {
             project: Pick<Project, 'projectUuid'>;
             organization: Pick<Organization, 'organizationUuid'>;
             space: Pick<SpaceSummaryBase, 'uuid'>;
-            // Charts owned by a dashboard are covered by that dashboard's
-            // direct grants.
-            dashboard: { uuid: string } | null;
         },
     ) {
-        const ctx = savedChart.dashboard?.uuid
-            ? await this.spacePermissionService.getDashboardAccessContext(
-                  account.user.id,
-                  {
-                      uuid: savedChart.dashboard.uuid,
-                      spaceUuid: savedChart.space.uuid,
-                  },
-              )
-            : await this.spacePermissionService.getSpaceAccessContext(
-                  account.user.id,
-                  savedChart.space.uuid,
-              );
+        const ctx = await this.spacePermissionService.getSpaceAccessContext(
+            account.user.id,
+            savedChart.space.uuid,
+        );
 
         const auditedAbility = this.createAuditedAbility(account);
         if (
@@ -5713,10 +5702,14 @@ export class AsyncQueryService extends ProjectService {
                 );
             inheritsFromOrgOrProject = spaceCtx.inheritsFromOrgOrProject;
         } else {
-            const ctx = await this.spacePermissionService.getSpaceAccessContext(
-                account.user.id,
-                savedChartSpaceUuid,
-            );
+            const ctx =
+                await this.spacePermissionService.getDashboardAccessContext(
+                    account.user.id,
+                    {
+                        uuid: savedChart.dashboardUuid,
+                        spaceUuid: savedChartSpaceUuid,
+                    },
+                );
             access = ctx.access;
             inheritsFromOrgOrProject = ctx.inheritsFromOrgOrProject;
         }
@@ -6048,15 +6041,11 @@ export class AsyncQueryService extends ProjectService {
             );
         } else {
             const auditedAbility = this.createAuditedAbility(account);
-            const ctx = owningDashboardUuid
-                ? await this.spacePermissionService.getDashboardAccessContext(
-                      account.user.id,
-                      { uuid: owningDashboardUuid, spaceUuid: space.uuid },
-                  )
-                : await this.spacePermissionService.getSpaceAccessContext(
-                      account.user.id,
-                      space.uuid,
-                  );
+            const ctx =
+                await this.spacePermissionService.getDashboardAccessContext(
+                    account.user.id,
+                    { uuid: owningDashboardUuid, spaceUuid: space.uuid },
+                );
 
             if (
                 auditedAbility.cannot(

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -185,6 +185,9 @@ type UpsertContentAsCodeOptions = {
     mode?: 'upsert' | 'create';
 };
 
+// Content-as-code moves content wholesale in and out of the instance, so
+// every access check in this service is deliberately space-only: direct
+// content grants must never count.
 export class CoderService extends BaseService {
     lightdashConfig: LightdashConfig;
 

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -177,7 +177,10 @@ const spacePermissionService = {
         lookupSpaceContext(spaceUuid),
     ),
     getDashboardAccessContext: vi.fn(
-        async (_userUuid: string, dashboardRef: { spaceUuid: string }) => ({
+        async (
+            _userUuid: string,
+            dashboardRef: { uuid: string | null; spaceUuid: string },
+        ) => ({
             ...lookupSpaceContext(dashboardRef.spaceUuid),
             directOnly: false,
         }),
@@ -265,6 +268,110 @@ describe('DashboardService', () => {
         expect(savedChartModel.create).not.toHaveBeenCalled();
     });
 
+    test('a dashboard grant does not authorize copying the chart into a different dashboard', async () => {
+        const grantOnlyUser = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                {
+                    subject: 'SavedChart',
+                    action: ['view'],
+                    conditions: {
+                        access: { $elemMatch: { userUuid: user.userUuid } },
+                    },
+                },
+            ]),
+        };
+        savedChartModel.get.mockResolvedValueOnce({
+            ...chart,
+            dashboardUuid: 'other-dashboard-uuid',
+            spaceUuid: privateSpace.uuid,
+        });
+        // The user holds a viewer grant on the chart's owning dashboard; the
+        // grant must still not authorize copying it into another dashboard.
+        spacePermissionService.getDashboardAccessContext.mockImplementationOnce(
+            async (_userUuid: string, ref: { uuid: string | null }) =>
+                ({
+                    ...spaceContexts[privateSpace.uuid],
+                    access:
+                        ref.uuid === 'other-dashboard-uuid'
+                            ? [
+                                  {
+                                      userUuid: user.userUuid,
+                                      role: SpaceMemberRole.VIEWER,
+                                      hasDirectAccess: true,
+                                      grantedVia: 'dashboard',
+                                  },
+                              ]
+                            : [],
+                    directOnly: ref.uuid === 'other-dashboard-uuid',
+                }) as never,
+        );
+
+        await expect(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).duplicateChartForDashboard({
+                chartUuid: chart.uuid,
+                projectUuid,
+                dashboardUuid,
+                user: grantOnlyUser,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(
+            spacePermissionService.getDashboardAccessContext,
+        ).toHaveBeenCalledWith(user.userUuid, {
+            uuid: null,
+            spaceUuid: privateSpace.uuid,
+        });
+        expect(savedChartModel.create).not.toHaveBeenCalled();
+    });
+
+    test('a dashboard grant authorizes duplication within the owning dashboard', async () => {
+        const grantOnlyUser = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                {
+                    subject: 'SavedChart',
+                    action: ['view'],
+                    conditions: {
+                        access: { $elemMatch: { userUuid: user.userUuid } },
+                    },
+                },
+            ]),
+        };
+        savedChartModel.get.mockResolvedValueOnce({
+            ...chart,
+            spaceUuid: privateSpace.uuid,
+        });
+        spacePermissionService.getDashboardAccessContext.mockResolvedValueOnce({
+            ...spaceContexts[privateSpace.uuid],
+            access: [
+                {
+                    userUuid: user.userUuid,
+                    role: SpaceMemberRole.VIEWER,
+                    hasDirectAccess: true,
+                    grantedVia: 'dashboard',
+                },
+            ],
+            directOnly: true,
+        } as never);
+
+        await expect(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).duplicateChartForDashboard({
+                chartUuid: chart.uuid,
+                projectUuid,
+                dashboardUuid,
+                user: grantOnlyUser,
+            }),
+        ).resolves.toBe('duplicated-chart-uuid');
+        expect(
+            spacePermissionService.getDashboardAccessContext,
+        ).toHaveBeenCalledWith(user.userUuid, {
+            uuid: dashboardUuid,
+            spaceUuid: privateSpace.uuid,
+        });
+    });
+
     test('should get dashboard by uuid', async () => {
         const result = await service.getByIdOrSlug(user, dashboard.uuid);
 
@@ -323,7 +430,7 @@ describe('DashboardService', () => {
         expect(result).toMatchObject({
             uuid: privateDashboard.uuid,
             spaceUuid: privateSpace.uuid,
-            spaceName: '',
+            spaceName: 'Private finance',
             access: [
                 expect.objectContaining({
                     userUuid: user.userUuid,
@@ -492,7 +599,7 @@ describe('DashboardService', () => {
         expect(dashboardModel.update).not.toHaveBeenCalled();
     });
 
-    test('blanks the space name in the update response for a grant-only editor', async () => {
+    test('keeps the space name in the update response for a grant-only editor', async () => {
         spacePermissionService.getDashboardAccessContext
             .mockResolvedValueOnce({
                 ...lookupSpaceContext(dashboard.spaceUuid),
@@ -507,7 +614,7 @@ describe('DashboardService', () => {
             name: 'renamed',
         });
 
-        expect(result.spaceName).toBe('');
+        expect(result.spaceName).toBe(dashboard.spaceName);
     });
 
     test('should get dashboard charts after dashboard access check', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -484,18 +484,17 @@ export class DashboardService
             undefined,
             { projectUuid },
         );
-        if (!chartToDuplicate.dashboardUuid) {
-            throw new ParameterError(
-                'We cannot duplicate a chart that is not part of a dashboard',
-            );
-        }
         // Tile payloads can name any chart uuid; require view access on the
-        // source chart before copying it into the target dashboard.
+        // source chart before copying it into the target dashboard. Dashboard
+        // grants only count while the copy stays inside the owning dashboard:
+        // a grant must never move content beyond the dashboard it covers.
+        const staysInOwningDashboard =
+            chartToDuplicate.dashboardUuid === dashboardUuid;
         const sourceContext =
             await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
                 {
-                    uuid: chartToDuplicate.dashboardUuid,
+                    uuid: staysInOwningDashboard ? dashboardUuid : null,
                     spaceUuid: chartToDuplicate.spaceUuid,
                 },
             );
@@ -517,6 +516,11 @@ export class DashboardService
         ) {
             throw new ForbiddenError(
                 "You don't have access to the chart being duplicated",
+            );
+        }
+        if (!chartToDuplicate.dashboardUuid) {
+            throw new ParameterError(
+                'We cannot duplicate a chart that is not part of a dashboard',
             );
         }
         const duplicatedChart = await this.savedChartModel.create(
@@ -637,7 +641,7 @@ export class DashboardService
             },
         );
 
-        const { inheritsFromOrgOrProject, access, directOnly } =
+        const { inheritsFromOrgOrProject, access } =
             await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
                 { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
@@ -646,9 +650,6 @@ export class DashboardService
             ...dashboardDao,
             inheritsFromOrgOrProject,
             access,
-            // Grant-only readers can open the dashboard but must not learn
-            // the private space's name.
-            spaceName: directOnly ? '' : dashboardDao.spaceName,
         };
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -1713,9 +1714,6 @@ export class DashboardService
 
         return {
             ...updatedNewDashboard,
-            spaceName: updatedSpace.directOnly
-                ? ''
-                : updatedNewDashboard.spaceName,
             inheritsFromOrgOrProject: updatedSpace.inheritsFromOrgOrProject,
             access: updatedSpace.access,
         };
@@ -1930,9 +1928,6 @@ export class DashboardService
                     );
                 return {
                     ...dashboard,
-                    spaceName: dashboardSpaceContext.directOnly
-                        ? ''
-                        : dashboard.spaceName,
                     inheritsFromOrgOrProject:
                         dashboardSpaceContext.inheritsFromOrgOrProject,
                     access: dashboardSpaceContext.access,
@@ -2568,7 +2563,7 @@ export class DashboardService
     ): Promise<DashboardVersion> {
         const dashboardDao =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
-        const { inheritsFromOrgOrProject, access, directOnly } =
+        const { inheritsFromOrgOrProject, access } =
             await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
                 { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
@@ -2620,7 +2615,6 @@ export class DashboardService
             updatedByUser: dashboard.updatedByUser,
             inheritsFromOrgOrProject,
             access,
-            spaceName: directOnly ? '' : dashboardDao.spaceName,
         };
 
         // Check if this is the current version

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6577,18 +6577,13 @@ export class ProjectService extends BaseService {
         const { organizationUuid, projectUuid } = savedChart;
 
         const [spaceCtx, explore] = await Promise.all([
-            savedChart.dashboardUuid
-                ? this.spacePermissionService.getDashboardAccessContext(
-                      account.user.id,
-                      {
-                          uuid: savedChart.dashboardUuid,
-                          spaceUuid: savedChart.spaceUuid,
-                      },
-                  )
-                : this.spacePermissionService.getSpaceAccessContext(
-                      account.user.id,
-                      savedChart.spaceUuid,
-                  ),
+            this.spacePermissionService.getDashboardAccessContext(
+                account.user.id,
+                {
+                    uuid: savedChart.dashboardUuid,
+                    spaceUuid: savedChart.spaceUuid,
+                },
+            ),
             this.getExplore(
                 account,
                 projectUuid,
@@ -6685,18 +6680,13 @@ export class ProjectService extends BaseService {
         const { organizationUuid, projectUuid } = savedChart;
 
         const [spaceCtx, explore] = await Promise.all([
-            savedChart.dashboardUuid
-                ? this.spacePermissionService.getDashboardAccessContext(
-                      account.user.id,
-                      {
-                          uuid: savedChart.dashboardUuid,
-                          spaceUuid: savedChart.spaceUuid,
-                      },
-                  )
-                : this.spacePermissionService.getSpaceAccessContext(
-                      account.user.id,
-                      savedChart.spaceUuid,
-                  ),
+            this.spacePermissionService.getDashboardAccessContext(
+                account.user.id,
+                {
+                    uuid: savedChart.dashboardUuid,
+                    spaceUuid: savedChart.spaceUuid,
+                },
+            ),
             this.getExplore(
                 account,
                 projectUuid,

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -126,6 +126,8 @@ type SavedSqlChart = Awaited<ReturnType<SavedSqlModel['getByUuid']>>;
 const isChartWithinDashboard = (chart: Pick<SavedChartDAO, 'dashboardUuid'>) =>
     chart.dashboardUuid !== null;
 
+// Promotion copies content across projects, so every access check in this
+// service is deliberately space-only: direct content grants must never count.
 export class PromoteService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
@@ -130,6 +130,14 @@ const spacePermissionService = {
         inheritsFromOrgOrProject: true,
         access: [],
     })),
+    getDashboardAccessContext: vi.fn(async () => ({
+        organizationUuid: 'org-uuid',
+        projectUuid: 'project-uuid',
+        inheritsFromOrgOrProject: true,
+        access: [],
+        admins: [],
+        directOnly: false,
+    })),
     getFirstViewableSpaceUuid: vi.fn(async () => 'space-uuid'),
 };
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -261,6 +261,9 @@ export class SavedChartService
         return savedChart;
     }
 
+    // Deliberately space-only: used by pinning and standalone-chart
+    // scheduled-delivery creation, neither of which applies to
+    // dashboard-owned charts, so direct grants must never count here.
     async hasChartSpaceAccess(
         user: SessionUser,
         spaceUuid: string,
@@ -1258,9 +1261,12 @@ export class SavedChartService
         const savedChart =
             await this.savedChartModel.getSummary(savedChartUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                savedChart.spaceUuid,
+                {
+                    uuid: savedChart.dashboardUuid,
+                    spaceUuid: savedChart.spaceUuid,
+                },
             );
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -1291,11 +1297,9 @@ export class SavedChartService
     ): Promise<{
         access: SpaceAccess[];
         inheritsFromOrgOrProject: boolean;
-        directOnly: boolean;
     }> {
         let access;
         let inheritsFromOrgOrProject: boolean;
-        let directOnly = false;
         let permissionActor: Account | SessionUser = account;
         if (isJwtUser(account)) {
             const { embedWriteUser } = account;
@@ -1329,7 +1333,7 @@ export class SavedChartService
                     );
                 inheritsFromOrgOrProject = spaceCtx.inheritsFromOrgOrProject;
             }
-        } else if (savedChart.dashboardUuid) {
+        } else {
             const ctx =
                 await this.spacePermissionService.getDashboardAccessContext(
                     account.user.userUuid,
@@ -1338,14 +1342,6 @@ export class SavedChartService
                         spaceUuid: savedChart.spaceUuid,
                     },
                 );
-            access = ctx.access;
-            inheritsFromOrgOrProject = ctx.inheritsFromOrgOrProject;
-            directOnly = ctx.directOnly;
-        } else {
-            const ctx = await this.spacePermissionService.getSpaceAccessContext(
-                account.user.userUuid,
-                savedChart.spaceUuid,
-            );
             access = ctx.access;
             inheritsFromOrgOrProject = ctx.inheritsFromOrgOrProject;
         }
@@ -1373,7 +1369,6 @@ export class SavedChartService
         return {
             access: isJwtUser(account) ? [] : (access as SpaceAccess[]),
             inheritsFromOrgOrProject,
-            directOnly,
         };
     }
 
@@ -1391,7 +1386,7 @@ export class SavedChartService
             savedChart.spaceUuid,
         );
 
-        const { access, inheritsFromOrgOrProject, directOnly } =
+        const { access, inheritsFromOrgOrProject } =
             await this.checkPermissions(account, space, savedChart);
 
         try {
@@ -1428,7 +1423,6 @@ export class SavedChartService
 
         return {
             ...savedChart,
-            spaceName: directOnly ? '' : savedChart.spaceName,
             inheritsFromOrgOrProject,
             access,
         };
@@ -2145,9 +2139,9 @@ export class SavedChartService
     ): Promise<ChartHistory> {
         const chart = await this.savedChartModel.getSummary(chartUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                chart.spaceUuid,
+                { uuid: chart.dashboardUuid, spaceUuid: chart.spaceUuid },
             );
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -2192,9 +2186,9 @@ export class SavedChartService
     ): Promise<ChartVersion> {
         const chart = await this.savedChartModel.getSummary(chartUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                chart.spaceUuid,
+                { uuid: chart.dashboardUuid, spaceUuid: chart.spaceUuid },
             );
         const auditedAbility = this.createAuditedAbility(user);
         if (

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -26,7 +26,6 @@ const sqlChart = {
     organization: { organizationUuid },
     project: { projectUuid },
     space: { uuid: spaceUuid, name: 'Space' },
-    dashboard: null as { uuid: string; name: string } | null,
 };
 
 const baseUser = {
@@ -234,112 +233,5 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             );
             expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
         });
-    });
-});
-
-describe('SavedSqlService - dashboard-owned chart access', () => {
-    const owningDashboardUuid = 'owning-dashboard-uuid';
-    const accessContext = {
-        organizationUuid,
-        projectUuid,
-        inheritsFromOrgOrProject: true,
-        access: [],
-    };
-    const directAccessModel = {
-        getByUuid: vi.fn(async () => sqlChart),
-        resolveColorPalette: vi.fn(async () => null),
-    };
-    const directAccessPermissionService = {
-        getDashboardAccessContext: vi.fn(async () => ({
-            ...accessContext,
-            directOnly: true,
-        })),
-        getSpacesAccessContext: vi.fn(async () => ({
-            [spaceUuid]: accessContext,
-        })),
-    };
-    const service = new SavedSqlService({
-        lightdashConfig: lightdashConfigMock,
-        analytics: analyticsMock,
-        projectModel: {} as unknown as ProjectModel,
-        savedSqlModel: directAccessModel as unknown as SavedSqlModel,
-        schedulerClient: {} as unknown as SchedulerClient,
-        schedulerModel: {} as unknown as SchedulerModel,
-        analyticsModel: {} as unknown as AnalyticsModel,
-        spacePermissionService:
-            directAccessPermissionService as unknown as SpacePermissionService,
-    });
-    const chartViewer = {
-        ...baseUser,
-        role: OrganizationMemberRole.VIEWER,
-        ability: new Ability<PossibleAbilities>([
-            { subject: 'SavedChart', action: 'view' },
-        ]),
-    };
-
-    afterEach(() => vi.clearAllMocks());
-
-    it('authorizes a dashboard-owned sql chart through its dashboard access context', async () => {
-        directAccessModel.getByUuid.mockResolvedValueOnce({
-            ...sqlChart,
-            dashboard: { uuid: owningDashboardUuid, name: 'Dashboard' },
-        });
-
-        await expect(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (service as any).hasAccess(
-                'view',
-                { user: chartViewer, projectUuid },
-                { savedSqlUuid },
-            ),
-        ).resolves.toEqual({ ...accessContext, directOnly: true });
-        expect(
-            directAccessPermissionService.getDashboardAccessContext,
-        ).toHaveBeenCalledWith(chartViewer.userUuid, {
-            uuid: owningDashboardUuid,
-            spaceUuid,
-        });
-        expect(
-            directAccessPermissionService.getSpacesAccessContext,
-        ).not.toHaveBeenCalled();
-    });
-
-    it('authorizes a space sql chart through its space access context', async () => {
-        directAccessModel.getByUuid.mockResolvedValueOnce({
-            ...sqlChart,
-            dashboard: null,
-        });
-
-        await expect(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (service as any).hasAccess(
-                'view',
-                { user: chartViewer, projectUuid },
-                { savedSqlUuid },
-            ),
-        ).resolves.toEqual({ ...accessContext, directOnly: false });
-        expect(
-            directAccessPermissionService.getDashboardAccessContext,
-        ).not.toHaveBeenCalled();
-        expect(
-            directAccessPermissionService.getSpacesAccessContext,
-        ).toHaveBeenCalledWith(chartViewer.userUuid, [spaceUuid]);
-    });
-
-    it('does not expose the private space name to a grant-only user', async () => {
-        const ownedChart = {
-            ...sqlChart,
-            dashboard: { uuid: owningDashboardUuid, name: 'Dashboard' },
-        };
-        directAccessModel.getByUuid.mockResolvedValue(ownedChart);
-
-        const result = await service.getSqlChart(
-            chartViewer,
-            projectUuid,
-            savedSqlUuid,
-        );
-
-        expect(result.space.name).toBe('');
-        expect(result.space.uuid).toBe(spaceUuid);
     });
 });

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -156,7 +156,6 @@ export class SavedSqlService
               },
     ) {
         let { spaceUuid } = resource;
-        let owningDashboardUuid: string | null = null;
 
         if (resource.savedSqlUuid !== null) {
             const savedSql = await this.savedSqlModel.getByUuid(
@@ -171,7 +170,6 @@ export class SavedSqlService
             }
 
             spaceUuid = savedSql.space.uuid;
-            owningDashboardUuid = savedSql.dashboard?.uuid ?? null;
         }
 
         if (!spaceUuid) {
@@ -181,22 +179,15 @@ export class SavedSqlService
         const needsNewSpaceCheck =
             resource.spaceUuid && spaceUuid !== resource.spaceUuid;
 
-        // Charts owned by a dashboard are covered by that dashboard's
-        // direct grants.
-        const currentCtx = owningDashboardUuid
-            ? await this.spacePermissionService.getDashboardAccessContext(
+        const ctx = needsNewSpaceCheck
+            ? await this.spacePermissionService.getSpacesAccessContext(
                   actor.user.userUuid,
-                  { uuid: owningDashboardUuid, spaceUuid },
+                  [spaceUuid, resource.spaceUuid!],
               )
-            : {
-                  ...(
-                      await this.spacePermissionService.getSpacesAccessContext(
-                          actor.user.userUuid,
-                          [spaceUuid],
-                      )
-                  )[spaceUuid],
-                  directOnly: false,
-              };
+            : await this.spacePermissionService.getSpacesAccessContext(
+                  actor.user.userUuid,
+                  [spaceUuid],
+              );
 
         const auditedAbility = this.createAuditedAbility(actor.user);
 
@@ -204,7 +195,7 @@ export class SavedSqlService
             auditedAbility.cannot(
                 action,
                 subject('SavedChart', {
-                    ...currentCtx,
+                    ...ctx[spaceUuid],
                     metadata: { savedSqlUuid: resource.savedSqlUuid ?? '' },
                 }),
             )
@@ -215,17 +206,11 @@ export class SavedSqlService
         }
 
         if (needsNewSpaceCheck) {
-            const newSpaceCtx = (
-                await this.spacePermissionService.getSpacesAccessContext(
-                    actor.user.userUuid,
-                    [resource.spaceUuid!],
-                )
-            )[resource.spaceUuid!];
             if (
                 auditedAbility.cannot(
                     action,
                     subject('SavedChart', {
-                        ...newSpaceCtx,
+                        ...ctx[resource.spaceUuid!],
                         metadata: { savedSqlUuid: resource.savedSqlUuid ?? '' },
                     }),
                 )
@@ -236,7 +221,7 @@ export class SavedSqlService
             }
         }
 
-        return currentCtx;
+        return ctx[spaceUuid];
     }
 
     async getSqlChart(
@@ -288,7 +273,6 @@ export class SavedSqlService
             ...savedChart,
             space: {
                 ...savedChart.space,
-                name: spaceCtx.directOnly ? '' : savedChart.space.name,
                 userAccess: spaceCtx.access[0],
             },
             resolvedColorPalette,
@@ -355,7 +339,6 @@ export class SavedSqlService
             ...savedChart,
             space: {
                 ...savedChart.space,
-                name: spaceCtx.directOnly ? '' : savedChart.space.name,
                 userAccess: embedWriteActions ? undefined : spaceCtx.access[0],
             },
             resolvedColorPalette,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -388,13 +388,13 @@ export class SchedulerService extends BaseService {
     ) {
         const auditedAbility = this.createAuditedAbility(user);
         if (scheduler.savedChartUuid) {
-            const { organizationUuid, spaceUuid, projectUuid } =
+            const { organizationUuid, spaceUuid, projectUuid, dashboardUuid } =
                 await this.savedChartModel.getSummary(scheduler.savedChartUuid);
 
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getSpaceAccessContext(
+                await this.spacePermissionService.getDashboardAccessContext(
                     user.userUuid,
-                    spaceUuid,
+                    { uuid: dashboardUuid, spaceUuid },
                 );
             if (
                 auditedAbility.cannot(

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -2,6 +2,7 @@ import { Ability } from '@casl/ability';
 import {
     DirectSpaceAccessOrigin,
     NotFoundError,
+    ParameterError,
     ProjectSpaceAccessOrigin,
     SpaceMemberRole,
     type DirectSpaceAccess,
@@ -9,6 +10,7 @@ import {
     type PossibleAbilities,
     type ProjectMemberRole,
     type SessionUser,
+    type SpaceAccess,
     type SpaceInheritanceChain,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
@@ -1760,6 +1762,14 @@ describe('SpacePermissionService', () => {
     });
 });
 
+// Boundary-crossing operations must receive contexts free of synthesized
+// grant rows; assert it wherever a space-only context is expected.
+const expectNoGrantRows = (context: { access: SpaceAccess[] }) => {
+    expect(
+        context.access.filter((row) => row.grantedVia !== undefined),
+    ).toEqual([]);
+};
+
 describe('getDashboardAccessContext', () => {
     const spaceContext: SpaceAccessContextForCasl = {
         organizationUuid: 'organization-uuid',
@@ -1823,6 +1833,7 @@ describe('getDashboardAccessContext', () => {
                 'dashboard-uuid': {
                     organizationUuid: 'organization-uuid',
                     projectUuid: 'project-uuid',
+                    spaceUuid: 'space-uuid',
                     userRole: SpaceMemberRole.VIEWER,
                     groupRoles: [SpaceMemberRole.EDITOR],
                 },
@@ -1841,6 +1852,7 @@ describe('getDashboardAccessContext', () => {
                     projectRole: undefined,
                     inheritedRole: undefined,
                     inheritedFrom: undefined,
+                    grantedVia: 'dashboard',
                 },
                 {
                     userUuid: 'user-uuid',
@@ -1849,6 +1861,7 @@ describe('getDashboardAccessContext', () => {
                     projectRole: undefined,
                     inheritedRole: undefined,
                     inheritedFrom: undefined,
+                    grantedVia: 'dashboard',
                 },
             ],
             directOnly: true,
@@ -1881,6 +1894,7 @@ describe('getDashboardAccessContext', () => {
                 'dashboard-uuid': {
                     organizationUuid: 'organization-uuid',
                     projectUuid: 'project-uuid',
+                    spaceUuid: 'space-uuid',
                     userRole: SpaceMemberRole.EDITOR,
                     groupRoles: [],
                 },
@@ -1904,6 +1918,7 @@ describe('getDashboardAccessContext', () => {
                 'dashboard-uuid': {
                     organizationUuid: 'organization-uuid',
                     projectUuid: 'project-uuid',
+                    spaceUuid: 'space-uuid',
                     userRole: SpaceMemberRole.EDITOR,
                     groupRoles: [],
                 },
@@ -1912,5 +1927,39 @@ describe('getDashboardAccessContext', () => {
         await expect(
             adminService.getDashboardAccessContext('user-uuid', dashboardRef),
         ).resolves.toMatchObject({ directOnly: false });
+    });
+
+    test('a null dashboard uuid returns the space-only context without any grant lookup', async () => {
+        const { service, dashboardAccessModel, directAccessFeatureGate } =
+            createService({ enabled: true });
+
+        const result = await service.getDashboardAccessContext('user-uuid', {
+            uuid: null,
+            spaceUuid: 'space-uuid',
+        });
+
+        expect(result).toEqual({ ...spaceContext, directOnly: false });
+        expectNoGrantRows(result);
+        expect(directAccessFeatureGate.isEnabledForUser).not.toHaveBeenCalled();
+        expect(dashboardAccessModel.getUserAccess).not.toHaveBeenCalled();
+    });
+
+    test('throws when the granted dashboard does not belong to the given space', async () => {
+        const { service } = createService({
+            enabled: true,
+            grants: {
+                'dashboard-uuid': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    spaceUuid: 'another-space-uuid',
+                    userRole: SpaceMemberRole.EDITOR,
+                    groupRoles: [],
+                },
+            },
+        });
+
+        await expect(
+            service.getDashboardAccessContext('user-uuid', dashboardRef),
+        ).rejects.toThrow(ParameterError);
     });
 });

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -5,10 +5,12 @@ import {
     getProjectRoleForRoleSetSpaceAccess,
     NotFoundError,
     OrganizationMemberRole,
+    ParameterError,
     ProjectMemberRole,
     resolveSpaceAccess,
     SpaceMemberRole,
     type AbilityAction,
+    type GrantSource,
     type KnexPaginateArgs,
     type KnexPaginatedData,
     type OrganizationSpaceAccess,
@@ -48,9 +50,9 @@ export type SpaceAccessContextForCasl = {
 
 export type DashboardAccessContextForCasl = SpaceAccessContextForCasl & {
     /**
-     * True when the requester reaches the dashboard only through direct
-     * grants: no space access path and no org/project admin standing.
-     * Callers use it to suppress private space names in responses.
+     * True when the requester has no space-derived access path (membership,
+     * inheritance, or admin standing) and reaches the content only through
+     * direct content grants.
      */
     directOnly: boolean;
 };
@@ -195,16 +197,24 @@ export class SpacePermissionService extends BaseService {
      * so the existing `access` elemMatch ability rules interpret them with
      * no dashboard-specific rules. Behind the direct-access feature gate;
      * with the flag off the result equals the plain space context.
+     *
+     * Pass `uuid: null` for content without an owning dashboard, or when a
+     * boundary-crossing operation (copying or moving content out of the
+     * dashboard) must not honor grants: the space-only context is returned
+     * and no grant lookup runs.
      */
     async getDashboardAccessContext(
         userUuid: string,
-        dashboard: { uuid: string; spaceUuid: string },
+        dashboard: { uuid: string | null; spaceUuid: string },
     ): Promise<DashboardAccessContextForCasl> {
         const spaceContext = await this.getSpaceAccessContext(
             userUuid,
             dashboard.spaceUuid,
         );
         const spaceOnlyContext = { ...spaceContext, directOnly: false };
+        if (dashboard.uuid === null) {
+            return spaceOnlyContext;
+        }
         if (
             !(await this.directAccessFeatureGate.isEnabledForUser({
                 userUuid,
@@ -220,14 +230,38 @@ export class SpacePermissionService extends BaseService {
             { organizationUuid: spaceContext.organizationUuid },
         );
         const grant = grants[dashboard.uuid];
+        if (grant === undefined) {
+            return spaceOnlyContext;
+        }
         const grantRoles = [
-            ...(grant?.userRole ? [grant.userRole] : []),
-            ...(grant?.groupRoles ?? []),
+            ...(grant.userRole ? [grant.userRole] : []),
+            ...grant.groupRoles,
         ];
         if (grantRoles.length === 0) {
             return spaceOnlyContext;
         }
+        // Grants must never extend a context for a space the dashboard does
+        // not live in; a mismatch is a caller bug, so fail loudly.
+        if (grant.spaceUuid !== dashboard.spaceUuid) {
+            throw new ParameterError(
+                `Dashboard ${dashboard.uuid} does not belong to space ${dashboard.spaceUuid}`,
+            );
+        }
 
+        return SpacePermissionService.withGrantAccess(
+            spaceContext,
+            userUuid,
+            grantRoles,
+            'dashboard',
+        );
+    }
+
+    private static withGrantAccess(
+        spaceContext: SpaceAccessContextForCasl,
+        userUuid: string,
+        grantRoles: SpaceMemberRole[],
+        grantedVia: GrantSource,
+    ): DashboardAccessContextForCasl {
         const hasSpacePath =
             spaceContext.access.some(
                 (access) => access.userUuid === userUuid,
@@ -244,6 +278,7 @@ export class SpacePermissionService extends BaseService {
                     projectRole: undefined,
                     inheritedRole: undefined,
                     inheritedFrom: undefined,
+                    grantedVia,
                 })),
             ],
             directOnly: !hasSpacePath,

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1035,9 +1035,9 @@ export class UnfurlService extends BaseService {
             projectUuid ? { projectUuid } : undefined,
         );
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                chart.spaceUuid,
+                { uuid: chart.dashboardUuid, spaceUuid: chart.spaceUuid },
             );
 
         const auditedAbility = this.createAuditedAbility(user);

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -154,6 +154,10 @@ export type SpaceInheritanceChain = {
     inheritsFromOrgOrProject: boolean;
 };
 
+// Which content type's direct grant synthesized an access row. Grows one
+// member per content type that ships direct grants.
+export type GrantSource = 'dashboard';
+
 // Access data for checking Space access permissions with CASL where only the role/access data matters.
 export type SpaceAccess = {
     userUuid: string;
@@ -168,6 +172,9 @@ export type SpaceAccess = {
         | 'space_group'
         | 'parent_space'
         | undefined;
+    // Present only on rows synthesized from a direct content grant; absent on
+    // space-derived rows. CASL rules never match on it.
+    grantedVia?: GrantSource;
 };
 
 // Full space share with user metadata, used for frontend display


### PR DESCRIPTION
Closes: [SPK-1417](https://linear.app/lightdash/issue/SPK-1417)

Stacks on top of #28052. Hardening pass over the dashboard-owned-chart grant path that #28052 introduced — no product behaviour beyond what that PR already gated behind the direct-access feature flag. Everything here is inert while the flag is off.

## Why

#28052 routed dashboard-owned charts through `getDashboardAccessContext` on a handful of paths but applied it unevenly. A review of the full change surfaced one privilege escalation, a set of fail-closed gaps where reads succeed but sibling reads 403, and a dead SQL-chart branch.

## What changed

**Escalation — grants must stay inside the owning dashboard.**
`duplicateChartForDashboard` built the source-chart view check from the chart's owning dashboard unconditionally, so a viewer grant on a private dashboard authorised copying that dashboard's chart into a *different* dashboard the user controls — exfiltrating the chart's full definition into a wider-audience space. A grant now counts only when the copy stays inside the owning dashboard; otherwise the check falls back to space-only access. The access check also runs before the "not part of a dashboard" shape check, so probing chart uuids can no longer distinguish existence without access.

```
target dashboard == owning dashboard  ->  grant may authorise (stays in bounds)
target dashboard != owning dashboard  ->  space access only (grant ignored)
```

**Nullable-uuid helper.**
`getDashboardAccessContext(userUuid, { uuid: string | null, spaceUuid })` — `uuid: null` returns the space-only context with no feature-gate or grant lookup. Boundary-crossing callers pass `null` to express "grants must not count", and the six hand-rolled `dashboardUuid ? … : …` forks at call sites collapse into one unconditional call.

**Fail-closed gaps closed (read parity).**
The v2 saved-chart query (`executeAsyncSavedChartQuery`, behind the chart page and scheduled deliveries), view stats, history, version, chart image export, and the scheduler chart-view check now honour dashboard grants — matching the tile and chart-page reads that #28052 already switched.

**Provenance + invariant.**
Synthesized grant rows carry `grantedVia: 'dashboard'` (a CASL-invisible tag; `GrantSource` grows one member per future content type), and the helper asserts the granted dashboard actually belongs to the space being extended (the grants query already joins through to the space; a mismatch throws).

**Space name visible.**
Grant-only readers may see the containing space's name, so the `spaceName` blanking is removed. `getChartAndResults` returns the requester's own access rows (a per-user context), not the space roster, so nothing sensitive is exposed there.

**Dead code removed.**
The `saved_sql` dashboard-grant branch is unreachable (`saved_sql.dashboard_uuid` is never written); it and its fixtures are reverted to the pre-#28052 batched space check.

## Out of scope (later in the stack)

Write-path parity (edit/create/delete/move), the available-filters and custom-SQL-provenance model changes, embed/JWT parity, and Shared-with-me / search discoverability — tracked as SPK-1449/1450/1451/1452/1453.

## Test plan

```
Before/after oracle: with the duplicate fix stashed, the new cross-dashboard
regression test fails ("promise resolved 'duplicated-chart-uuid' instead of
rejecting"); with the fix it passes.
```

- New: cross-dashboard copy denied for a grant-only user (asserts `ForbiddenError`, `create` not called, helper called with `uuid: null`); same-dashboard duplication allowed via grant; helper null-path (no gate/grant calls) and space-mismatch (throws) tests; `expectNoGrantRows` tripwire.
- Updated: D9 assertions pin the space name staying visible; `SavedSqlService` grant-branch fixtures removed.
- `pnpm -F backend typecheck` / `-F common typecheck`: clean. Lint clean. `pnpm generate-api` succeeds (generated files intentionally not committed).
- Backend tests green across every touched suite (Dashboard, SavedChart, SpacePermission, AsyncQuery, Scheduler, Project, Embed, Promote, Coder, Space, Rename). Pre-existing `ee/postgresWire` env failures (Node 20 vs 24) are unrelated and reproduce on the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)