### PR TITLE
feat(cli): fail validate on warnings via --severity

### DIFF
--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -385,6 +385,8 @@ type CliValidateStarted = BaseTrack & {
         validateWarehouseColumns: boolean;
         includedSpacesCount: number;
         excludedSpacesCount: number;
+        severity: 'error' | 'warning';
+        treatWarningsAsErrors: boolean;
     };
 };
 /** `success` indicates whether 0 validation errors were found, not whether the process ran without crashing (crashes fire `validate.error` instead). */
@@ -401,10 +403,13 @@ type CliValidateCompleted = BaseTrack & {
         durationMs: number;
         success: boolean;
         totalErrors: number;
+        totalWarnings: number;
         tableErrors: number;
         chartErrors: number;
         dashboardErrors: number;
         appErrors: number;
+        severity: 'error' | 'warning';
+        treatWarningsAsErrors: boolean;
     };
 };
 type CliValidateError = BaseTrack & {

--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -386,7 +386,6 @@ type CliValidateStarted = BaseTrack & {
         includedSpacesCount: number;
         excludedSpacesCount: number;
         severity: 'error' | 'warning';
-        treatWarningsAsErrors: boolean;
     };
 };
 /** `success` indicates whether 0 validation errors were found, not whether the process ran without crashing (crashes fire `validate.error` instead). */
@@ -409,7 +408,6 @@ type CliValidateCompleted = BaseTrack & {
         dashboardErrors: number;
         appErrors: number;
         severity: 'error' | 'warning';
-        treatWarningsAsErrors: boolean;
     };
 };
 type CliValidateError = BaseTrack & {

--- a/packages/cli/src/handlers/validate.test.ts
+++ b/packages/cli/src/handlers/validate.test.ts
@@ -27,7 +27,6 @@ const baseOptions: ValidateOptions = {
     preview: false,
     only: Object.values(ValidationTarget),
     validateWarehouseColumns: false,
-    showChartConfigurationWarnings: false,
     severity: 'error',
     projectDir: '.',
     profilesDir: '.',
@@ -329,19 +328,6 @@ describe('validateHandler warehouse column validation', () => {
         expect(output).toContain('1 warning');
     });
 
-    test('still fails on --show-chart-configuration-warnings', async () => {
-        validationResults = [chartConfigurationWarning];
-        vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
-        await validateHandler({
-            ...baseOptions,
-            showChartConfigurationWarnings: true,
-        });
-
-        expect(process.exit).toHaveBeenCalledWith(1);
-        expect(errorOutput.join('\n')).toContain('Chart configuration warning');
-    });
-
     test('fails on blocking errors even when warnings stay hidden', async () => {
         validationResults = [brokenChartError, chartConfigurationWarning];
         vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
@@ -386,15 +372,11 @@ describe('resolveValidationSeverity', () => {
 
 describe('shouldTreatWarningsAsErrors', () => {
     test('is off by default', () => {
-        expect(shouldTreatWarningsAsErrors({})).toBe(false);
+        expect(shouldTreatWarningsAsErrors()).toBe(false);
+        expect(shouldTreatWarningsAsErrors('error')).toBe(false);
     });
 
-    test('is on for --severity warning and the show flag', () => {
-        expect(shouldTreatWarningsAsErrors({ severity: 'warning' })).toBe(true);
-        expect(
-            shouldTreatWarningsAsErrors({
-                showChartConfigurationWarnings: true,
-            }),
-        ).toBe(true);
+    test('is on for --severity warning', () => {
+        expect(shouldTreatWarningsAsErrors('warning')).toBe(true);
     });
 });

--- a/packages/cli/src/handlers/validate.test.ts
+++ b/packages/cli/src/handlers/validate.test.ts
@@ -29,7 +29,6 @@ const baseOptions: ValidateOptions = {
     validateWarehouseColumns: false,
     showChartConfigurationWarnings: false,
     severity: 'error',
-    warningsAsErrors: false,
     projectDir: '.',
     profilesDir: '.',
     target: undefined,
@@ -330,19 +329,6 @@ describe('validateHandler warehouse column validation', () => {
         expect(output).toContain('1 warning');
     });
 
-    test('fails when --warnings-as-errors is set and warnings exist', async () => {
-        validationResults = [chartConfigurationWarning];
-        vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-
-        await validateHandler({
-            ...baseOptions,
-            warningsAsErrors: true,
-        });
-
-        expect(process.exit).toHaveBeenCalledWith(1);
-        expect(errorOutput.join('\n')).toContain('Chart configuration warning');
-    });
-
     test('still fails on --show-chart-configuration-warnings', async () => {
         validationResults = [chartConfigurationWarning];
         vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
@@ -389,23 +375,12 @@ describe('validateHandler warehouse column validation', () => {
 
 describe('resolveValidationSeverity', () => {
     test('defaults to error', () => {
-        expect(resolveValidationSeverity({})).toBe('error');
-        expect(resolveValidationSeverity({ severity: 'error' })).toBe('error');
+        expect(resolveValidationSeverity()).toBe('error');
+        expect(resolveValidationSeverity('error')).toBe('error');
     });
 
     test('uses warning when --severity warning is set', () => {
-        expect(resolveValidationSeverity({ severity: 'warning' })).toBe(
-            'warning',
-        );
-    });
-
-    test('treats --warnings-as-errors as warning even if severity is error', () => {
-        expect(
-            resolveValidationSeverity({
-                severity: 'error',
-                warningsAsErrors: true,
-            }),
-        ).toBe('warning');
+        expect(resolveValidationSeverity('warning')).toBe('warning');
     });
 });
 
@@ -414,11 +389,8 @@ describe('shouldTreatWarningsAsErrors', () => {
         expect(shouldTreatWarningsAsErrors({})).toBe(false);
     });
 
-    test('is on for --severity warning, --warnings-as-errors, and the show flag', () => {
+    test('is on for --severity warning and the show flag', () => {
         expect(shouldTreatWarningsAsErrors({ severity: 'warning' })).toBe(true);
-        expect(shouldTreatWarningsAsErrors({ warningsAsErrors: true })).toBe(
-            true,
-        );
         expect(
             shouldTreatWarningsAsErrors({
                 showChartConfigurationWarnings: true,

--- a/packages/cli/src/handlers/validate.test.ts
+++ b/packages/cli/src/handlers/validate.test.ts
@@ -6,7 +6,11 @@ import {
 } from '@lightdash/common';
 import { compile } from './compile';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
-import { validateHandler } from './validate';
+import {
+    resolveValidationSeverity,
+    shouldTreatWarningsAsErrors,
+    validateHandler,
+} from './validate';
 
 vi.mock('../analytics/analytics');
 vi.mock('../config', () => ({
@@ -24,6 +28,8 @@ const baseOptions: ValidateOptions = {
     only: Object.values(ValidationTarget),
     validateWarehouseColumns: false,
     showChartConfigurationWarnings: false,
+    severity: 'error',
+    warningsAsErrors: false,
     projectDir: '.',
     profilesDir: '.',
     target: undefined,
@@ -55,6 +61,7 @@ const TARGET_SKIP_WARNING =
 
 describe('validateHandler warehouse column validation', () => {
     let errorOutput: string[];
+    let validationResults: unknown[] = [];
 
     const skipWarnings = () =>
         errorOutput.filter((line) =>
@@ -73,12 +80,13 @@ describe('validateHandler warehouse column validation', () => {
                 return { status: SchedulerJobStatus.COMPLETED, details: null };
             }
             if (url.includes('/validate?jobId=')) {
-                return [];
+                return validationResults;
             }
             throw new Error(`Unexpected API call: ${method} ${url}`);
         });
 
         errorOutput = [];
+        validationResults = [];
         vi.spyOn(console, 'error').mockImplementation((...args) => {
             errorOutput.push(args.map(String).join(' '));
         });
@@ -260,5 +268,161 @@ describe('validateHandler warehouse column validation', () => {
         const output = errorOutput.join('\n');
         expect(output).toContain('Ada Lovelace');
         expect(output).toContain('2026-08-06');
+    });
+
+    test('succeeds when only chart configuration warnings exist at default severity', async () => {
+        validationResults = [chartConfigurationWarning];
+        const exitSpy = vi
+            .spyOn(process, 'exit')
+            .mockImplementation(() => undefined as never);
+
+        await validateHandler({ ...baseOptions });
+
+        expect(exitSpy).not.toHaveBeenCalled();
+        expect(errorOutput.join('\n')).not.toContain('orders.unused_dim');
+    });
+
+    test('fails when --severity warning is set and warnings exist', async () => {
+        validationResults = [chartConfigurationWarning];
+        vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+        await validateHandler({
+            ...baseOptions,
+            severity: 'warning',
+        });
+
+        expect(process.exit).toHaveBeenCalledWith(1);
+        const output = errorOutput.join('\n');
+        expect(output).toContain('Chart configuration warning');
+        expect(output).toContain('orders.unused_dim');
+        expect(output).toContain('1 warning');
+    });
+
+    test('fails when --warnings-as-errors is set and warnings exist', async () => {
+        validationResults = [chartConfigurationWarning];
+        vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+        await validateHandler({
+            ...baseOptions,
+            warningsAsErrors: true,
+        });
+
+        expect(process.exit).toHaveBeenCalledWith(1);
+        expect(errorOutput.join('\n')).toContain('Chart configuration warning');
+    });
+
+    test('still fails on --show-chart-configuration-warnings', async () => {
+        validationResults = [chartConfigurationWarning];
+        vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+        await validateHandler({
+            ...baseOptions,
+            showChartConfigurationWarnings: true,
+        });
+
+        expect(process.exit).toHaveBeenCalledWith(1);
+        expect(errorOutput.join('\n')).toContain('Chart configuration warning');
+    });
+
+    test('fails on blocking errors even when warnings stay hidden', async () => {
+        validationResults = [brokenChartError, chartConfigurationWarning];
+        vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+        await validateHandler({ ...baseOptions });
+
+        expect(process.exit).toHaveBeenCalledWith(1);
+        const output = errorOutput.join('\n');
+        expect(output).toContain('Broken chart');
+        expect(output).not.toContain('orders.unused_dim');
+        expect(output).toContain('chart configuration warning hidden');
+    });
+
+    test('reports errors and warnings together when severity is warning', async () => {
+        validationResults = [brokenChartError, chartConfigurationWarning];
+        vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+        await validateHandler({
+            ...baseOptions,
+            severity: 'warning',
+        });
+
+        expect(process.exit).toHaveBeenCalledWith(1);
+        const output = errorOutput.join('\n');
+        expect(output).toContain('Broken chart');
+        expect(output).toContain('orders.unused_dim');
+        expect(output).toContain('1 error');
+        expect(output).toContain('1 warning');
+    });
+});
+
+const chartConfigurationWarning = {
+    validationUuid: 'warning-uuid',
+    validationId: null,
+    createdAt: new Date('2026-08-26T12:00:00Z'),
+    projectUuid: 'test-project-uuid',
+    name: 'Orders over time',
+    error: 'dimension is not used in the chart configuration',
+    errorType: ValidationErrorType.ChartConfiguration,
+    source: ValidationSourceType.Chart,
+    chartUuid: 'chart-uuid',
+    fieldName: 'orders.unused_dim',
+    chartViews: 3,
+    lastUpdatedBy: 'Ada Lovelace',
+    lastUpdatedAt: new Date('2026-08-06T15:30:00Z'),
+};
+
+const brokenChartError = {
+    validationUuid: 'error-uuid',
+    validationId: null,
+    createdAt: new Date('2026-08-26T12:00:00Z'),
+    projectUuid: 'test-project-uuid',
+    name: 'Broken chart',
+    error: 'Dimension does not exist',
+    errorType: ValidationErrorType.Dimension,
+    source: ValidationSourceType.Chart,
+    chartUuid: 'broken-chart-uuid',
+    fieldName: 'orders.missing',
+    chartViews: 1,
+    lastUpdatedBy: 'Ada Lovelace',
+    lastUpdatedAt: new Date('2026-08-06T15:30:00Z'),
+};
+
+describe('resolveValidationSeverity', () => {
+    test('defaults to error', () => {
+        expect(resolveValidationSeverity({})).toBe('error');
+        expect(resolveValidationSeverity({ severity: 'error' })).toBe('error');
+    });
+
+    test('uses warning when --severity warning is set', () => {
+        expect(resolveValidationSeverity({ severity: 'warning' })).toBe(
+            'warning',
+        );
+    });
+
+    test('treats --warnings-as-errors as warning even if severity is error', () => {
+        expect(
+            resolveValidationSeverity({
+                severity: 'error',
+                warningsAsErrors: true,
+            }),
+        ).toBe('warning');
+    });
+});
+
+describe('shouldTreatWarningsAsErrors', () => {
+    test('is off by default', () => {
+        expect(shouldTreatWarningsAsErrors({})).toBe(false);
+    });
+
+    test('is on for --severity warning, --warnings-as-errors, and the show flag', () => {
+        expect(shouldTreatWarningsAsErrors({ severity: 'warning' })).toBe(true);
+        expect(shouldTreatWarningsAsErrors({ warningsAsErrors: true })).toBe(
+            true,
+        );
+        expect(
+            shouldTreatWarningsAsErrors({
+                showChartConfigurationWarnings: true,
+            }),
+        ).toBe(true);
     });
 });

--- a/packages/cli/src/handlers/validate.test.ts
+++ b/packages/cli/src/handlers/validate.test.ts
@@ -59,6 +59,38 @@ const baseOptions: ValidateOptions = {
 const TARGET_SKIP_WARNING =
     'Skipping warehouse column validation because --only does not include the tables validation target';
 
+const chartConfigurationWarning = {
+    validationUuid: 'warning-uuid',
+    validationId: null,
+    createdAt: new Date('2026-08-26T12:00:00Z'),
+    projectUuid: 'test-project-uuid',
+    name: 'Orders over time',
+    error: 'dimension is not used in the chart configuration',
+    errorType: ValidationErrorType.ChartConfiguration,
+    source: ValidationSourceType.Chart,
+    chartUuid: 'chart-uuid',
+    fieldName: 'orders.unused_dim',
+    chartViews: 3,
+    lastUpdatedBy: 'Ada Lovelace',
+    lastUpdatedAt: new Date('2026-08-06T15:30:00Z'),
+};
+
+const brokenChartError = {
+    validationUuid: 'error-uuid',
+    validationId: null,
+    createdAt: new Date('2026-08-26T12:00:00Z'),
+    projectUuid: 'test-project-uuid',
+    name: 'Broken chart',
+    error: 'Dimension does not exist',
+    errorType: ValidationErrorType.Dimension,
+    source: ValidationSourceType.Chart,
+    chartUuid: 'broken-chart-uuid',
+    fieldName: 'orders.missing',
+    chartViews: 1,
+    lastUpdatedBy: 'Ada Lovelace',
+    lastUpdatedAt: new Date('2026-08-06T15:30:00Z'),
+};
+
 describe('validateHandler warehouse column validation', () => {
     let errorOutput: string[];
     let validationResults: unknown[] = [];
@@ -354,38 +386,6 @@ describe('validateHandler warehouse column validation', () => {
         expect(output).toContain('1 warning');
     });
 });
-
-const chartConfigurationWarning = {
-    validationUuid: 'warning-uuid',
-    validationId: null,
-    createdAt: new Date('2026-08-26T12:00:00Z'),
-    projectUuid: 'test-project-uuid',
-    name: 'Orders over time',
-    error: 'dimension is not used in the chart configuration',
-    errorType: ValidationErrorType.ChartConfiguration,
-    source: ValidationSourceType.Chart,
-    chartUuid: 'chart-uuid',
-    fieldName: 'orders.unused_dim',
-    chartViews: 3,
-    lastUpdatedBy: 'Ada Lovelace',
-    lastUpdatedAt: new Date('2026-08-06T15:30:00Z'),
-};
-
-const brokenChartError = {
-    validationUuid: 'error-uuid',
-    validationId: null,
-    createdAt: new Date('2026-08-26T12:00:00Z'),
-    projectUuid: 'test-project-uuid',
-    name: 'Broken chart',
-    error: 'Dimension does not exist',
-    errorType: ValidationErrorType.Dimension,
-    source: ValidationSourceType.Chart,
-    chartUuid: 'broken-chart-uuid',
-    fieldName: 'orders.missing',
-    chartViews: 1,
-    lastUpdatedBy: 'Ada Lovelace',
-    lastUpdatedAt: new Date('2026-08-06T15:30:00Z'),
-};
 
 describe('resolveValidationSeverity', () => {
     test('defaults to error', () => {

--- a/packages/cli/src/handlers/validate.test.ts
+++ b/packages/cli/src/handlers/validate.test.ts
@@ -6,11 +6,7 @@ import {
 } from '@lightdash/common';
 import { compile } from './compile';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
-import {
-    resolveValidationSeverity,
-    shouldTreatWarningsAsErrors,
-    validateHandler,
-} from './validate';
+import { validateHandler } from './validate';
 
 vi.mock('../analytics/analytics');
 vi.mock('../config', () => ({
@@ -356,27 +352,5 @@ describe('validateHandler warehouse column validation', () => {
         expect(output).toContain('orders.unused_dim');
         expect(output).toContain('1 error');
         expect(output).toContain('1 warning');
-    });
-});
-
-describe('resolveValidationSeverity', () => {
-    test('defaults to error', () => {
-        expect(resolveValidationSeverity()).toBe('error');
-        expect(resolveValidationSeverity('error')).toBe('error');
-    });
-
-    test('uses warning when --severity warning is set', () => {
-        expect(resolveValidationSeverity('warning')).toBe('warning');
-    });
-});
-
-describe('shouldTreatWarningsAsErrors', () => {
-    test('is off by default', () => {
-        expect(shouldTreatWarningsAsErrors()).toBe(false);
-        expect(shouldTreatWarningsAsErrors('error')).toBe(false);
-    });
-
-    test('is on for --severity warning', () => {
-        expect(shouldTreatWarningsAsErrors('warning')).toBe(true);
     });
 });

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -99,7 +99,6 @@ type ValidateHandlerOptions = CompileHandlerOptions & {
     preview: boolean;
     only: ValidationTarget[];
     validateWarehouseColumns: boolean;
-    showChartConfigurationWarnings: boolean;
     severity?: ValidationSeverity;
     includeSpaces?: string[];
     excludeSpaces?: string[];
@@ -109,15 +108,9 @@ export const resolveValidationSeverity = (
     severity?: ValidationSeverity,
 ): ValidationSeverity => severity ?? 'error';
 
-export const shouldTreatWarningsAsErrors = ({
-    severity,
-    showChartConfigurationWarnings,
-}: {
-    severity?: ValidationSeverity;
-    showChartConfigurationWarnings?: boolean;
-}): boolean =>
-    resolveValidationSeverity(severity) === 'warning' ||
-    showChartConfigurationWarnings === true;
+export const shouldTreatWarningsAsErrors = (
+    severity?: ValidationSeverity,
+): boolean => resolveValidationSeverity(severity) === 'warning';
 
 type WaitUntilFinishedOptions = {
     jobUuid: string;
@@ -243,7 +236,7 @@ export const validateHandler = async (
     }
 
     const severity = resolveValidationSeverity(options.severity);
-    const treatWarningsAsErrors = shouldTreatWarningsAsErrors(options);
+    const treatWarningsAsErrors = shouldTreatWarningsAsErrors(severity);
 
     await LightdashAnalytics.track({
         event: 'validate.started',
@@ -374,8 +367,7 @@ export const validateHandler = async (
             },
         });
 
-        const hiddenWarningHint =
-            'use --show-chart-configuration-warnings or --severity warning to show';
+        const hiddenWarningHint = 'use --severity warning to show';
 
         if (!hasBlockingErrors && !hasFailingWarnings) {
             const elapsedMs = Date.now() - startTime;
@@ -517,7 +509,7 @@ export const validateHandler = async (
                     `\n${styles.secondary(
                         `Note: ${hiddenWarningsCount} chart configuration warning${
                             hiddenWarningsCount > 1 ? 's' : ''
-                        } hidden. Use --show-chart-configuration-warnings or --severity warning to show.`,
+                        } hidden. Use --severity warning to show.`,
                     )}`,
                 );
             }

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -349,7 +349,9 @@ export const validateHandler = async (
                 validationWithoutConfigWarnings.length - validation.length;
         }
         const warningIssues = validation.filter(isValidationWarning);
-        const blockingIssues = validation.filter((v) => !isValidationWarning(v));
+        const blockingIssues = validation.filter(
+            (v) => !isValidationWarning(v),
+        );
         const tableErrors = blockingIssues.filter(isTableValidationError);
         const chartErrors = blockingIssues.filter(isChartValidationError);
         const chartWarnings = warningIssues.filter(isChartValidationError);

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -104,14 +104,6 @@ type ValidateHandlerOptions = CompileHandlerOptions & {
     excludeSpaces?: string[];
 };
 
-export const resolveValidationSeverity = (
-    severity?: ValidationSeverity,
-): ValidationSeverity => severity ?? 'error';
-
-export const shouldTreatWarningsAsErrors = (
-    severity?: ValidationSeverity,
-): boolean => resolveValidationSeverity(severity) === 'warning';
-
 type WaitUntilFinishedOptions = {
     jobUuid: string;
     refetchIntervalMs: number;
@@ -235,8 +227,7 @@ export const validateHandler = async (
         );
     }
 
-    const severity = resolveValidationSeverity(options.severity);
-    const treatWarningsAsErrors = shouldTreatWarningsAsErrors(severity);
+    const severity = options.severity ?? 'error';
 
     await LightdashAnalytics.track({
         event: 'validate.started',
@@ -249,7 +240,6 @@ export const validateHandler = async (
             includedSpacesCount: options.includeSpaces?.length ?? 0,
             excludedSpacesCount: options.excludeSpaces?.length ?? 0,
             severity,
-            treatWarningsAsErrors,
         },
     });
 
@@ -310,10 +300,10 @@ export const validateHandler = async (
 
         const allValidation = await getValidation(projectUuid, jobId);
 
-        // Hide chart configuration warnings unless shown or treated as errors
-        const validationWithoutConfigWarnings = treatWarningsAsErrors
-            ? allValidation
-            : allValidation.filter((v) => !isValidationWarning(v));
+        const validationWithoutConfigWarnings =
+            severity === 'warning'
+                ? allValidation
+                : allValidation.filter((v) => !isValidationWarning(v));
 
         const hiddenWarningsCount =
             allValidation.length - validationWithoutConfigWarnings.length;
@@ -335,14 +325,10 @@ export const validateHandler = async (
         );
         const tableErrors = blockingIssues.filter(isTableValidationError);
         const chartErrors = blockingIssues.filter(isChartValidationError);
-        const chartWarnings = warningIssues.filter(isChartValidationError);
         const dashboardErrors = blockingIssues.filter(
             isDashboardValidationError,
         );
         const appErrors = blockingIssues.filter(isDataAppValidationError);
-        const hasBlockingErrors = blockingIssues.length > 0;
-        const hasFailingWarnings =
-            treatWarningsAsErrors && warningIssues.length > 0;
 
         await LightdashAnalytics.track({
             event: 'validate.completed',
@@ -355,7 +341,7 @@ export const validateHandler = async (
                 includedSpacesCount: options.includeSpaces?.length ?? 0,
                 excludedSpacesCount: options.excludeSpaces?.length ?? 0,
                 durationMs: Date.now() - startTime,
-                success: !hasBlockingErrors && !hasFailingWarnings,
+                success: validation.length === 0,
                 totalErrors: blockingIssues.length,
                 totalWarnings: warningIssues.length,
                 tableErrors: tableErrors.length,
@@ -363,19 +349,16 @@ export const validateHandler = async (
                 dashboardErrors: dashboardErrors.length,
                 appErrors: appErrors.length,
                 severity,
-                treatWarningsAsErrors,
             },
         });
 
-        const hiddenWarningHint = 'use --severity warning to show';
-
-        if (!hasBlockingErrors && !hasFailingWarnings) {
+        if (validation.length === 0) {
             const elapsedMs = Date.now() - startTime;
             const hiddenMessage =
                 hiddenWarningsCount > 0
                     ? ` (${hiddenWarningsCount} chart configuration warning${
                           hiddenWarningsCount > 1 ? 's' : ''
-                      } hidden, ${hiddenWarningHint})`
+                      } hidden, use --severity warning to show)`
                     : '';
             const spaceFilteredMessage =
                 spaceFilteredCount > 0
@@ -425,7 +408,7 @@ export const validateHandler = async (
                 console.error(
                     `- Charts: ${styleIssueCounts(
                         chartErrors.length,
-                        chartWarnings.length,
+                        warningIssues.length,
                     )}`,
                 );
             }

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -11,10 +11,10 @@ import {
     isDashboardValidationError,
     isDataAppValidationError,
     isTableValidationError,
+    isValidationWarning,
     ParameterError,
     SchedulerJobStatus,
     UnexpectedServerError,
-    ValidationErrorType,
     ValidationTarget,
 } from '@lightdash/common';
 import columnify from 'columnify';
@@ -77,7 +77,21 @@ function styleTotalErrors(total: number) {
     return styles.success(`${styles.bold(total)} errors`);
 }
 
+function styleIssueCounts(errorCount: number, warningCount: number) {
+    const errorLabel = styleTotalErrors(errorCount);
+    if (warningCount === 0) {
+        return errorLabel;
+    }
+    const warningLabel = styles.warning(
+        `${styles.bold(warningCount)} warning${warningCount === 1 ? '' : 's'}`,
+    );
+    return `${errorLabel}, ${warningLabel}`;
+}
+
 const REFETCH_JOB_INTERVAL = 3000;
+
+export const VALIDATION_SEVERITIES = ['error', 'warning'] as const;
+export type ValidationSeverity = (typeof VALIDATION_SEVERITIES)[number];
 
 type ValidateHandlerOptions = CompileHandlerOptions & {
     project?: string;
@@ -86,9 +100,36 @@ type ValidateHandlerOptions = CompileHandlerOptions & {
     only: ValidationTarget[];
     validateWarehouseColumns: boolean;
     showChartConfigurationWarnings: boolean;
+    severity?: ValidationSeverity;
+    warningsAsErrors?: boolean;
     includeSpaces?: string[];
     excludeSpaces?: string[];
 };
+
+export const resolveValidationSeverity = ({
+    severity,
+    warningsAsErrors,
+}: {
+    severity?: ValidationSeverity;
+    warningsAsErrors?: boolean;
+}): ValidationSeverity => {
+    if (warningsAsErrors) {
+        return 'warning';
+    }
+    return severity ?? 'error';
+};
+
+export const shouldTreatWarningsAsErrors = ({
+    severity,
+    warningsAsErrors,
+    showChartConfigurationWarnings,
+}: {
+    severity?: ValidationSeverity;
+    warningsAsErrors?: boolean;
+    showChartConfigurationWarnings?: boolean;
+}): boolean =>
+    resolveValidationSeverity({ severity, warningsAsErrors }) === 'warning' ||
+    showChartConfigurationWarnings === true;
 
 type WaitUntilFinishedOptions = {
     jobUuid: string;
@@ -213,6 +254,9 @@ export const validateHandler = async (
         );
     }
 
+    const severity = resolveValidationSeverity(options);
+    const treatWarningsAsErrors = shouldTreatWarningsAsErrors(options);
+
     await LightdashAnalytics.track({
         event: 'validate.started',
         properties: {
@@ -223,6 +267,8 @@ export const validateHandler = async (
             validateWarehouseColumns: options.validateWarehouseColumns,
             includedSpacesCount: options.includeSpaces?.length ?? 0,
             excludedSpacesCount: options.excludeSpaces?.length ?? 0,
+            severity,
+            treatWarningsAsErrors,
         },
     });
 
@@ -283,16 +329,10 @@ export const validateHandler = async (
 
         const allValidation = await getValidation(projectUuid, jobId);
 
-        // Filter out chart configuration warnings unless explicitly requested
-        const validationWithoutConfigWarnings =
-            options.showChartConfigurationWarnings
-                ? allValidation
-                : allValidation.filter(
-                      (v) =>
-                          !isChartValidationError(v) ||
-                          v.errorType !==
-                              ValidationErrorType.ChartConfiguration,
-                  );
+        // Hide chart configuration warnings unless shown or treated as errors
+        const validationWithoutConfigWarnings = treatWarningsAsErrors
+            ? allValidation
+            : allValidation.filter((v) => !isValidationWarning(v));
 
         const hiddenWarningsCount =
             allValidation.length - validationWithoutConfigWarnings.length;
@@ -308,10 +348,18 @@ export const validateHandler = async (
             spaceFilteredCount =
                 validationWithoutConfigWarnings.length - validation.length;
         }
-        const tableErrors = validation.filter(isTableValidationError);
-        const chartErrors = validation.filter(isChartValidationError);
-        const dashboardErrors = validation.filter(isDashboardValidationError);
-        const appErrors = validation.filter(isDataAppValidationError);
+        const warningIssues = validation.filter(isValidationWarning);
+        const blockingIssues = validation.filter((v) => !isValidationWarning(v));
+        const tableErrors = blockingIssues.filter(isTableValidationError);
+        const chartErrors = blockingIssues.filter(isChartValidationError);
+        const chartWarnings = warningIssues.filter(isChartValidationError);
+        const dashboardErrors = blockingIssues.filter(
+            isDashboardValidationError,
+        );
+        const appErrors = blockingIssues.filter(isDataAppValidationError);
+        const hasBlockingErrors = blockingIssues.length > 0;
+        const hasFailingWarnings =
+            treatWarningsAsErrors && warningIssues.length > 0;
 
         await LightdashAnalytics.track({
             event: 'validate.completed',
@@ -324,22 +372,28 @@ export const validateHandler = async (
                 includedSpacesCount: options.includeSpaces?.length ?? 0,
                 excludedSpacesCount: options.excludeSpaces?.length ?? 0,
                 durationMs: Date.now() - startTime,
-                success: validation.length === 0,
-                totalErrors: validation.length,
+                success: !hasBlockingErrors && !hasFailingWarnings,
+                totalErrors: blockingIssues.length,
+                totalWarnings: warningIssues.length,
                 tableErrors: tableErrors.length,
                 chartErrors: chartErrors.length,
                 dashboardErrors: dashboardErrors.length,
                 appErrors: appErrors.length,
+                severity,
+                treatWarningsAsErrors,
             },
         });
 
-        if (validation.length === 0) {
+        const hiddenWarningHint =
+            'use --show-chart-configuration-warnings or --severity warning to show';
+
+        if (!hasBlockingErrors && !hasFailingWarnings) {
             const elapsedMs = Date.now() - startTime;
             const hiddenMessage =
                 hiddenWarningsCount > 0
                     ? ` (${hiddenWarningsCount} chart configuration warning${
                           hiddenWarningsCount > 1 ? 's' : ''
-                      } hidden, use --show-chart-configuration-warnings to show)`
+                      } hidden, ${hiddenWarningHint})`
                     : '';
             const spaceFilteredMessage =
                 spaceFilteredCount > 0
@@ -357,7 +411,15 @@ export const validateHandler = async (
             spinner?.fail(
                 `  Validation finished in ${Math.trunc(
                     elapsedMs / 1000,
-                )}s with ${validation.length} errors`,
+                )}s with ${
+                    warningIssues.length > 0
+                        ? `${blockingIssues.length} error${
+                              blockingIssues.length === 1 ? '' : 's'
+                          } and ${warningIssues.length} warning${
+                              warningIssues.length === 1 ? '' : 's'
+                          }`
+                        : `${blockingIssues.length} errors`
+                }`,
             );
 
             const validationTargetsSet = new Set(validationTargets);
@@ -379,7 +441,10 @@ export const validateHandler = async (
                 validationTargetsSet.has(ValidationTarget.CHARTS)
             ) {
                 console.error(
-                    `- Charts: ${styleTotalErrors(chartErrors.length)}`,
+                    `- Charts: ${styleIssueCounts(
+                        chartErrors.length,
+                        chartWarnings.length,
+                    )}`,
                 );
             }
 
@@ -414,12 +479,11 @@ export const validateHandler = async (
             console.error('\n');
 
             const validationOutput = validation.map((v) => ({
-                name: styles.error(v.name),
+                name: isValidationWarning(v)
+                    ? styles.warning(v.name)
+                    : styles.error(v.name),
                 error: styles.warning(
-                    isChartValidationError(v) &&
-                        v.errorType ===
-                            ValidationErrorType.ChartConfiguration &&
-                        v.fieldName
+                    isValidationWarning(v) && v.fieldName
                         ? `Chart configuration warning: '${v.fieldName}' - ${v.error}`
                         : v.error,
                 ),
@@ -463,7 +527,7 @@ export const validateHandler = async (
                     `\n${styles.secondary(
                         `Note: ${hiddenWarningsCount} chart configuration warning${
                             hiddenWarningsCount > 1 ? 's' : ''
-                        } hidden. Use --show-chart-configuration-warnings to show.`,
+                        } hidden. Use --show-chart-configuration-warnings or --severity warning to show.`,
                     )}`,
                 );
             }

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -101,34 +101,22 @@ type ValidateHandlerOptions = CompileHandlerOptions & {
     validateWarehouseColumns: boolean;
     showChartConfigurationWarnings: boolean;
     severity?: ValidationSeverity;
-    warningsAsErrors?: boolean;
     includeSpaces?: string[];
     excludeSpaces?: string[];
 };
 
-export const resolveValidationSeverity = ({
-    severity,
-    warningsAsErrors,
-}: {
-    severity?: ValidationSeverity;
-    warningsAsErrors?: boolean;
-}): ValidationSeverity => {
-    if (warningsAsErrors) {
-        return 'warning';
-    }
-    return severity ?? 'error';
-};
+export const resolveValidationSeverity = (
+    severity?: ValidationSeverity,
+): ValidationSeverity => severity ?? 'error';
 
 export const shouldTreatWarningsAsErrors = ({
     severity,
-    warningsAsErrors,
     showChartConfigurationWarnings,
 }: {
     severity?: ValidationSeverity;
-    warningsAsErrors?: boolean;
     showChartConfigurationWarnings?: boolean;
 }): boolean =>
-    resolveValidationSeverity({ severity, warningsAsErrors }) === 'warning' ||
+    resolveValidationSeverity(severity) === 'warning' ||
     showChartConfigurationWarnings === true;
 
 type WaitUntilFinishedOptions = {
@@ -254,7 +242,7 @@ export const validateHandler = async (
         );
     }
 
-    const severity = resolveValidationSeverity(options);
+    const severity = resolveValidationSeverity(options.severity);
     const treatWarningsAsErrors = shouldTreatWarningsAsErrors(options);
 
     await LightdashAnalytics.track({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,7 +55,10 @@ import { setWarehouseHandler } from './handlers/setWarehouse';
 import { slugUpdateHandler } from './handlers/slugUpdate';
 import { sqlHandler } from './handlers/sql';
 import { registerUpgradeCheckCommand } from './handlers/upgradeCheck';
-import { validateHandler } from './handlers/validate';
+import {
+    validateHandler,
+    VALIDATION_SEVERITIES,
+} from './handlers/validate';
 import { warehouseCatalogHandler } from './handlers/warehouseCatalog';
 import * as styles from './styles';
 // Trigger CLI tests
@@ -1434,7 +1437,20 @@ program
     )
     .option(
         '--show-chart-configuration-warnings',
-        'Show chart configuration warnings (e.g., unused dimensions). These are hidden by default.',
+        'Show chart configuration warnings (e.g., unused dimensions). These are hidden by default. Also fails the command when any are present.',
+        false,
+    )
+    .addOption(
+        new Option(
+            '--severity <level>',
+            'Minimum issue level that fails the command. "error" (default) only fails on errors. "warning" shows chart configuration warnings and treats them as errors.',
+        )
+            .choices([...VALIDATION_SEVERITIES])
+            .default('error'),
+    )
+    .option(
+        '--warnings-as-errors',
+        'Treat chart configuration warnings as errors. Equivalent to --severity warning.',
         false,
     )
     .addOption(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1432,11 +1432,6 @@ program
             .argParser(parseDisableTimestampConversionOption)
             .hideHelp(),
     )
-    .option(
-        '--show-chart-configuration-warnings',
-        'Show chart configuration warnings (e.g., unused dimensions). These are hidden by default. Also fails the command when any are present.',
-        false,
-    )
     .addOption(
         new Option(
             '--severity <level>',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1445,11 +1445,6 @@ program
             .choices([...VALIDATION_SEVERITIES])
             .default('error'),
     )
-    .option(
-        '--warnings-as-errors',
-        'Treat chart configuration warnings as errors. Equivalent to --severity warning.',
-        false,
-    )
     .addOption(
         new Option('--only <elems...>', 'Specify project elements to validate')
             .choices(Object.values(ValidationTarget))

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,10 +55,7 @@ import { setWarehouseHandler } from './handlers/setWarehouse';
 import { slugUpdateHandler } from './handlers/slugUpdate';
 import { sqlHandler } from './handlers/sql';
 import { registerUpgradeCheckCommand } from './handlers/upgradeCheck';
-import {
-    validateHandler,
-    VALIDATION_SEVERITIES,
-} from './handlers/validate';
+import { validateHandler, VALIDATION_SEVERITIES } from './handlers/validate';
 import { warehouseCatalogHandler } from './handlers/warehouseCatalog';
 import * as styles from './styles';
 // Trigger CLI tests

--- a/packages/common/src/types/validation.ts
+++ b/packages/common/src/types/validation.ts
@@ -213,6 +213,13 @@ export const isChartValidationError = (
 ): error is ValidationErrorChartResponse | CreateChartValidation =>
     error.source === ValidationSourceType.Chart;
 
+/** Advisory issues that do not break content, e.g. unused chart fields. */
+export const isValidationWarning = (
+    error: ValidationResponse | CreateValidation,
+): error is ValidationErrorChartResponse | CreateChartValidation =>
+    isChartValidationError(error) &&
+    error.errorType === ValidationErrorType.ChartConfiguration;
+
 export const isDashboardValidationError = (
     error: ValidationResponse | CreateValidation,
 ): error is ValidationErrorDashboardResponse | CreateDashboardValidation =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description:
`lightdash validate` can fail on advisory chart configuration warnings via `--severity`.

- `--severity warning` shows chart configuration warnings (unused dimensions / table calculations) and exits `1` when any are present
- `--severity error` (default) still hides those warnings and only fails on blocking errors

`--show-chart-configuration-warnings` is removed; use `--severity warning` instead.

No existing GitHub issue or Linear ticket was found for this request.

### Risk assessment:
- [ ] This is a high-risk change

Backwards-compatible default. Anyone already passing `--show-chart-configuration-warnings` needs to switch to `--severity warning`.

### Testing:
CLI unit tests in `packages/cli/src/handlers/validate.test.ts` cover default hide/succeed and `--severity warning`. `pnpm -F cli test src/handlers/validate.test.ts` — 18 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bcabf03-a2af-407a-858d-68fbda3a1b01?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bcabf03-a2af-407a-858d-68fbda3a1b01&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

