### PR TITLE
feat: open data app links in the agent thread preview panel

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -26,6 +26,7 @@ import {
     useAiAgentStoreSelector,
 } from '../../store/hooks';
 import { AiArtifactPanel } from '../ChatElements/AiArtifactPanel';
+import { AiDataAppPreviewPanel } from '../ChatElements/AiDataAppPreviewPanel';
 import { AiSavedChartPreviewPanel } from '../ChatElements/AiSavedChartPreviewPanel';
 import styles from './aiAgentPageLayout.module.css';
 import { SidebarButton } from './SidebarButton';
@@ -57,7 +58,10 @@ export const AiAgentPageLayout: React.FC<Props> = ({
     const savedChart = useAiAgentStoreSelector(
         (state) => state.aiArtifact.savedChart,
     );
-    const preview = artifact || savedChart;
+    const dataApp = useAiAgentStoreSelector(
+        (state) => state.aiArtifact.dataApp,
+    );
+    const preview = artifact || savedChart || dataApp;
     const isMobile = useMediaQuery('(max-width: 768px)');
 
     const toggleSidebar = useCallback(() => {
@@ -198,6 +202,10 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                                         <AiSavedChartPreviewPanel
                                             savedChartPreview={savedChart}
                                         />
+                                    ) : dataApp ? (
+                                        <AiDataAppPreviewPanel
+                                            dataAppPreview={dataApp}
+                                        />
                                     ) : null}
                                 </Box>
                             </Panel>
@@ -233,6 +241,8 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                         <AiSavedChartPreviewPanel
                             savedChartPreview={savedChart}
                         />
+                    ) : dataApp ? (
+                        <AiDataAppPreviewPanel dataAppPreview={dataApp} />
                     ) : null}
                 </Drawer>
             )}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -187,9 +187,13 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                         />
 
                         <ErrorBoundary>
+                            {/* Keyed by preview kind: interactive apps remount
+                                to a wider default; chart/artifact switches keep
+                                the user's size. */}
                             <Panel
+                                key={dataApp ? 'data-app' : 'chart-artifact'}
                                 className={styles.floatingArtifactRegion}
-                                defaultSize={46}
+                                defaultSize={dataApp ? 60 : 46}
                                 id="artifact"
                                 minSize={32}
                                 maxSize={64}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.module.css
@@ -28,14 +28,15 @@
 .floatingContent {
     height: 100%;
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-md)
-        calc(var(--mantine-spacing-md) + 40px);
+        var(--mantine-spacing-md);
     display: flex;
     flex-direction: column;
     min-height: 0;
 }
 
-.sqlArtifactContent {
-    padding-bottom: var(--mantine-spacing-md);
+/* Room for the floating chart-type pill overlaying the content bottom. */
+.withPillClearance {
+    padding-bottom: calc(var(--mantine-spacing-md) + 40px);
 }
 
 /* Same outer chrome as the chart panel, but no pill clearance — the

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
@@ -309,9 +309,7 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
             );
             return (
                 <Box className={styles.floatingPanel}>
-                    <Box
-                        className={`${styles.floatingContent} ${styles.sqlArtifactContent}`}
-                    >
+                    <Box className={styles.floatingContent}>
                         <AiComposerArtifactVisualization
                             results={queryResults}
                             headerContent={composerHead}
@@ -453,9 +451,7 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
         if (sqlVizQueryData) {
             return (
                 <div className={styles.floatingPanel}>
-                    <div
-                        className={`${styles.floatingContent} ${styles.sqlArtifactContent}`}
-                    >
+                    <div className={styles.floatingContent}>
                         <AiSqlArtifactVisualization
                             results={queryResults}
                             headerContent={floatingHead}
@@ -471,7 +467,11 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
 
         return (
             <div className={styles.floatingPanel}>
-                <div className={styles.floatingContent}>
+                <div
+                    className={`${styles.floatingContent} ${
+                        shouldShowPill ? styles.withPillClearance : ''
+                    }`}
+                >
                     <AiVisualizationRenderer
                         vizQueryData={semanticVizQueryData}
                         results={queryResults}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
@@ -1,0 +1,208 @@
+import { getAppDisplayName } from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    Center,
+    Group,
+    Loader,
+    Menu,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import { IconDots, IconExternalLink, IconX } from '@tabler/icons-react';
+import { type FC, type ReactNode } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import TruncatedText from '../../../../../components/common/TruncatedText';
+import AppIframePreview from '../../../../../features/apps/AppIframePreview';
+import { getVisiblePreviewTokenError } from '../../../../../features/apps/hooks/previewTokenQueryOptions';
+import { useAppPreviewToken } from '../../../../../features/apps/hooks/useAppPreviewToken';
+import { useGetApp } from '../../../../../features/apps/hooks/useGetApp';
+import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
+import {
+    clearDataAppPreview,
+    type DataAppPreviewData,
+} from '../../store/aiArtifactSlice';
+import { useAiAgentStoreDispatch } from '../../store/hooks';
+import artifactStyles from './AiArtifactPanel.module.css';
+
+type Props = {
+    dataAppPreview: DataAppPreviewData;
+};
+
+export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
+    const dispatch = useAiAgentStoreDispatch();
+    const { appUuid, projectUuid } = dataAppPreview;
+
+    const previewOrigin = usePreviewOrigin();
+    const appQuery = useGetApp(projectUuid, appUuid);
+    const app = appQuery.data?.pages[0];
+
+    // Authoritative across ALL versions — the ready version may be older than
+    // the fetched page of versions, so never scan `versions` for it.
+    const latestReadyVersion = app?.latestReadyVersion ?? undefined;
+
+    const {
+        data: token,
+        isLoading: isTokenLoading,
+        error: tokenError,
+    } = useAppPreviewToken(projectUuid, appUuid, latestReadyVersion);
+    const visibleTokenError = getVisiblePreviewTokenError(tokenError, !!token);
+
+    const isForbidden =
+        appQuery.error?.error?.statusCode === 403 ||
+        visibleTokenError?.error?.statusCode === 403;
+    const isNotFound =
+        appQuery.error?.error?.statusCode === 404 ||
+        visibleTokenError?.error?.statusCode === 404;
+    const hasNoReadyVersion =
+        !appQuery.isLoading && !appQuery.error && !latestReadyVersion;
+    const otherError =
+        !isForbidden && !isNotFound && (appQuery.error || visibleTokenError);
+
+    const previewUrl =
+        token && latestReadyVersion
+            ? `${previewOrigin}/api/apps/${appUuid}/versions/${latestReadyVersion}/t/${token}/#transport=postMessage&projectUuid=${projectUuid}`
+            : undefined;
+
+    const closeButton = (
+        <ActionIcon
+            size="sm"
+            variant="subtle"
+            color="ldGray.6"
+            onClick={() => dispatch(clearDataAppPreview())}
+            aria-label="Close"
+        >
+            <MantineIcon icon={IconX} />
+        </ActionIcon>
+    );
+
+    const renderMessage = (message: string) => (
+        <div className={artifactStyles.floatingPanel}>
+            <Center className={artifactStyles.loading}>
+                <Stack gap="xs" align="center">
+                    <Text size="xs" c="dimmed" ta="center">
+                        {message}
+                    </Text>
+                    {closeButton}
+                </Stack>
+            </Center>
+        </div>
+    );
+
+    if (isNotFound) {
+        return renderMessage('This data app no longer exists.');
+    }
+    if (isForbidden) {
+        return renderMessage(
+            "You don't have permission to view this data app.",
+        );
+    }
+    if (hasNoReadyVersion) {
+        return renderMessage("This data app hasn't finished building yet.");
+    }
+    if (otherError) {
+        return renderMessage('Failed to load data app. Please try again.');
+    }
+
+    if (appQuery.isLoading || !app) {
+        return (
+            <div className={artifactStyles.floatingPanel}>
+                <Center className={artifactStyles.loading}>
+                    <Stack gap="xs" align="center">
+                        <Loader
+                            type="dots"
+                            color="gray"
+                            delayedMessage="Loading data app..."
+                        />
+                        {closeButton}
+                    </Stack>
+                </Center>
+            </div>
+        );
+    }
+
+    let body: ReactNode;
+    if (isTokenLoading || !previewUrl || !token) {
+        body = (
+            <Center h="100%">
+                <Loader
+                    type="dots"
+                    color="gray"
+                    delayedMessage="Loading data app..."
+                />
+            </Center>
+        );
+    } else {
+        body = (
+            <AppIframePreview
+                src={previewUrl}
+                previewToken={token}
+                expectedPreviewOrigin={previewOrigin}
+                projectUuid={projectUuid}
+                appUuid={appUuid}
+                identityKey={`${appUuid}:${latestReadyVersion}`}
+                capabilities={{ gsheetExport: true }}
+            />
+        );
+    }
+
+    const appUrl = `/projects/${projectUuid}/apps/${appUuid}/view`;
+
+    return (
+        <div className={artifactStyles.floatingPanel}>
+            <div className={artifactStyles.floatingContent}>
+                <div className={artifactStyles.head}>
+                    <Stack gap={0} flex={1} miw={0}>
+                        <TruncatedText fz="sm" fw={600} maxWidth="100%">
+                            {getAppDisplayName(app.name, appUuid)}
+                        </TruncatedText>
+                        {app.description && (
+                            <TruncatedText fz="xs" c="dimmed" maxWidth="100%">
+                                {app.description}
+                            </TruncatedText>
+                        )}
+                    </Stack>
+
+                    <Group gap={2} className={artifactStyles.headRight}>
+                        <Menu withinPortal position="bottom-end">
+                            <Menu.Target>
+                                <Tooltip withinPortal label="More options">
+                                    <ActionIcon
+                                        size="sm"
+                                        variant="subtle"
+                                        color="ldGray.6"
+                                        aria-label="More options"
+                                    >
+                                        <MantineIcon icon={IconDots} />
+                                    </ActionIcon>
+                                </Tooltip>
+                            </Menu.Target>
+                            <Menu.Dropdown>
+                                <Menu.Item
+                                    component="a"
+                                    href={appUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconExternalLink}
+                                            size="sm"
+                                        />
+                                    }
+                                >
+                                    Open in new tab
+                                </Menu.Item>
+                            </Menu.Dropdown>
+                        </Menu>
+                        {closeButton}
+                    </Group>
+                </div>
+
+                <Box flex={1} mih={0}>
+                    {body}
+                </Box>
+            </div>
+        </div>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
@@ -78,7 +78,7 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
     );
 
     const renderMessage = (message: string) => (
-        <div className={artifactStyles.floatingPanel}>
+        <Box className={artifactStyles.floatingPanel}>
             <Center className={artifactStyles.loading}>
                 <Stack gap="xs" align="center">
                     <Text size="xs" c="dimmed" ta="center">
@@ -87,7 +87,7 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
                     {closeButton}
                 </Stack>
             </Center>
-        </div>
+        </Box>
     );
 
     if (isNotFound) {
@@ -107,18 +107,18 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
 
     if (appQuery.isLoading || !app) {
         return (
-            <div className={artifactStyles.floatingPanel}>
+            <Box className={artifactStyles.floatingPanel}>
                 <Center className={artifactStyles.loading}>
                     <Stack gap="xs" align="center">
                         <Loader
                             type="dots"
-                            color="gray"
+                            color="ldGray.6"
                             delayedMessage="Loading data app..."
                         />
                         {closeButton}
                     </Stack>
                 </Center>
-            </div>
+            </Box>
         );
     }
 
@@ -128,7 +128,7 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
             <Center h="100%">
                 <Loader
                     type="dots"
-                    color="gray"
+                    color="ldGray.6"
                     delayedMessage="Loading data app..."
                 />
             </Center>
@@ -150,9 +150,9 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
     const appUrl = `/projects/${projectUuid}/apps/${appUuid}/view`;
 
     return (
-        <div className={artifactStyles.floatingPanel}>
-            <div className={artifactStyles.floatingContent}>
-                <div className={artifactStyles.head}>
+        <Box className={artifactStyles.floatingPanel}>
+            <Box className={artifactStyles.floatingContent}>
+                <Box className={artifactStyles.head}>
                     <Stack gap={0} flex={1} miw={0}>
                         <TruncatedText fz="sm" fw={600} maxWidth="100%">
                             {getAppDisplayName(app.name, appUuid)}
@@ -197,12 +197,12 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
                         </Menu>
                         {closeButton}
                     </Group>
-                </div>
+                </Box>
 
                 <Box flex={1} mih={0}>
                     {body}
                 </Box>
-            </div>
-        </div>
+            </Box>
+        </Box>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.dataApp.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.dataApp.test.tsx
@@ -1,0 +1,148 @@
+import { type AiAgentMessageAssistant } from '@lightdash/common';
+import { act, fireEvent, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { store } from '../../store';
+import {
+    clearPreview,
+    setDataAppPreview,
+    setSavedChartPreview,
+} from '../../store/aiArtifactSlice';
+import { ContentLink } from './ContentLink';
+
+const APP_UUID = 'app-uuid-1';
+const APP_HREF = `/projects/project-1/apps/${APP_UUID}/view`;
+
+const message: AiAgentMessageAssistant = {
+    role: 'assistant',
+    status: 'idle',
+    uuid: 'message-1',
+    threadUuid: 'thread-1',
+    message: 'Here is your app',
+    errorMessage: null,
+    interrupted: false,
+    createdAt: '2026-08-26T09:00:00.000Z',
+    humanScore: null,
+    humanFeedback: null,
+    toolCalls: [],
+    toolResults: [],
+    reasoning: [],
+    savedQueryUuid: null,
+    artifacts: null,
+    referencedArtifacts: null,
+    modelConfig: null,
+    tokenUsage: null,
+};
+
+const renderDataAppChip = () =>
+    renderWithProviders(
+        <Provider store={store}>
+            <MemoryRouter>
+                <ContentLink
+                    contentType="data-app-link"
+                    props={{ href: APP_HREF, 'data-app-uuid': APP_UUID }}
+                    message={message}
+                    projectUuid="project-1"
+                    agentUuid="agent-1"
+                >
+                    Revenue explorer
+                </ContentLink>
+            </MemoryRouter>
+        </Provider>,
+    );
+
+describe('ContentLink data-app chip', () => {
+    beforeEach(() => {
+        store.dispatch(clearPreview());
+    });
+
+    it('opens the preview panel on plain left-click without navigating', () => {
+        renderDataAppChip();
+
+        const chip = screen.getByRole('link', { name: /Revenue explorer/ });
+        const defaultNotPrevented = fireEvent.click(chip);
+
+        expect(defaultNotPrevented).toBe(false);
+        expect(store.getState().aiArtifact.dataApp).toEqual({
+            appUuid: APP_UUID,
+            messageUuid: 'message-1',
+            threadUuid: 'thread-1',
+            projectUuid: 'project-1',
+            agentUuid: 'agent-1',
+        });
+    });
+
+    it.each([
+        ['meta', { metaKey: true }],
+        ['ctrl', { ctrlKey: true }],
+        ['shift', { shiftKey: true }],
+        ['middle-click', { button: 1 }],
+    ])('leaves the store untouched on %s click', (_label, eventInit) => {
+        renderDataAppChip();
+
+        const chip = screen.getByRole('link', { name: /Revenue explorer/ });
+        const defaultNotPrevented = fireEvent.click(chip, eventInit);
+
+        expect(defaultNotPrevented).toBe(true);
+        expect(store.getState().aiArtifact.dataApp).toBeNull();
+    });
+
+    it('shows the active indicator only while its app is previewed', () => {
+        renderDataAppChip();
+
+        const chip = screen.getByRole('link', { name: /Revenue explorer/ });
+        expect(chip).not.toHaveAttribute('data-app-active');
+
+        fireEvent.click(chip);
+        expect(chip).toHaveAttribute('data-app-active', 'true');
+
+        act(() => {
+            store.dispatch(clearPreview());
+        });
+        expect(chip).not.toHaveAttribute('data-app-active');
+    });
+
+    it('replaces a chart preview and is replaced by one', () => {
+        renderDataAppChip();
+
+        const chartPreview = {
+            savedChartUuid: 'chart-1',
+            messageUuid: 'message-1',
+            threadUuid: 'thread-1',
+            projectUuid: 'project-1',
+            agentUuid: 'agent-1',
+        };
+
+        act(() => {
+            store.dispatch(setSavedChartPreview(chartPreview));
+        });
+
+        fireEvent.click(screen.getByRole('link', { name: /Revenue explorer/ }));
+        expect(store.getState().aiArtifact.savedChart).toBeNull();
+        expect(store.getState().aiArtifact.dataApp).not.toBeNull();
+
+        act(() => {
+            store.dispatch(setSavedChartPreview(chartPreview));
+        });
+        expect(store.getState().aiArtifact.dataApp).toBeNull();
+        expect(store.getState().aiArtifact.savedChart).not.toBeNull();
+    });
+
+    it('clears the artifact preview when a data app opens', () => {
+        store.dispatch(
+            setDataAppPreview({
+                appUuid: APP_UUID,
+                messageUuid: 'message-1',
+                threadUuid: 'thread-1',
+                projectUuid: 'project-1',
+                agentUuid: 'agent-1',
+            }),
+        );
+
+        expect(store.getState().aiArtifact.artifact).toBeNull();
+        expect(store.getState().aiArtifact.savedChart).toBeNull();
+        expect(store.getState().aiArtifact.dataApp).not.toBeNull();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.module.css
@@ -64,6 +64,25 @@
     );
 }
 
+.contentLink[data-app-active='true'] {
+    background-color: light-dark(
+        color-mix(
+            in srgb,
+            var(--mantine-color-orange-6) 3.5%,
+            var(--mantine-color-white)
+        ),
+        var(--mantine-color-dark-6)
+    ) !important;
+    border-color: light-dark(
+        color-mix(
+            in srgb,
+            var(--mantine-color-orange-6) 18%,
+            var(--mantine-color-ldGray-2)
+        ),
+        var(--mantine-color-ldGray-3)
+    );
+}
+
 .contentLink[data-chart-active='true'] {
     background-color: light-dark(
         color-mix(

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -30,6 +30,14 @@ export type SqlRunnerLinkState = {
     limit?: number;
 };
 
+const isPlainLeftClick = (e: MouseEvent<HTMLAnchorElement>) =>
+    !e.defaultPrevented &&
+    e.button === 0 &&
+    !e.metaKey &&
+    !e.altKey &&
+    !e.ctrlKey &&
+    !e.shiftKey;
+
 const REFERENCE_LINK_KINDS = {
     'dashboard-link': 'dashboard',
     'data-app-link': 'data_app',
@@ -73,15 +81,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
     );
 
     const handleResourceClick = (e: MouseEvent<HTMLAnchorElement>) => {
-        if (
-            !resourceHref ||
-            e.defaultPrevented ||
-            e.button !== 0 ||
-            e.metaKey ||
-            e.altKey ||
-            e.ctrlKey ||
-            e.shiftKey
-        ) {
+        if (!resourceHref || !isPlainLeftClick(e)) {
             return;
         }
 
@@ -132,19 +132,10 @@ export const ContentLink: FC<ContentLinkProps> = ({
                     : undefined;
             const isActive = !!appUuid && currentDataApp?.appUuid === appUuid;
 
-            // Plain left-click previews the app in the thread panel; modified
-            // clicks fall through to the anchor and open the full page in a
-            // new tab.
+            // Modified clicks fall through to the anchor and open the full
+            // page in a new tab.
             const handleDataAppClick = (e: MouseEvent<HTMLAnchorElement>) => {
-                if (
-                    !appUuid ||
-                    e.defaultPrevented ||
-                    e.button !== 0 ||
-                    e.metaKey ||
-                    e.altKey ||
-                    e.ctrlKey ||
-                    e.shiftKey
-                ) {
+                if (!appUuid || !isPlainLeftClick(e)) {
                     return;
                 }
 
@@ -203,16 +194,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
                 isSavedChart && currentSavedChart?.savedChartUuid === chartUuid;
 
             const handleChartClick = (e: MouseEvent<HTMLAnchorElement>) => {
-                if (
-                    !isSavedChart ||
-                    !chartUuid ||
-                    e.defaultPrevented ||
-                    e.button !== 0 ||
-                    e.metaKey ||
-                    e.altKey ||
-                    e.ctrlKey ||
-                    e.shiftKey
-                ) {
+                if (!isSavedChart || !chartUuid || !isPlainLeftClick(e)) {
                     return;
                 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -12,7 +12,11 @@ import {
 import { type FC, type MouseEvent, type ReactNode } from 'react';
 import { Link, createPath, useLocation, useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { setArtifact, setSavedChartPreview } from '../../store/aiArtifactSlice';
+import {
+    setArtifact,
+    setDataAppPreview,
+    setSavedChartPreview,
+} from '../../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -63,6 +67,9 @@ export const ContentLink: FC<ContentLinkProps> = ({
     );
     const currentSavedChart = useAiAgentStoreSelector(
         (state) => state.aiArtifact.savedChart,
+    );
+    const currentDataApp = useAiAgentStoreSelector(
+        (state) => state.aiArtifact.dataApp,
     );
 
     const handleResourceClick = (e: MouseEvent<HTMLAnchorElement>) => {
@@ -117,13 +124,48 @@ export const ContentLink: FC<ContentLinkProps> = ({
                 </ContentReferenceLink>
             );
 
-        case 'data-app-link':
-            // Apps are full-page experiences — open in a new tab so the chat
-            // thread stays put.
+        case 'data-app-link': {
+            const appUuid =
+                'data-app-uuid' in props &&
+                typeof props['data-app-uuid'] === 'string'
+                    ? props['data-app-uuid']
+                    : undefined;
+            const isActive = !!appUuid && currentDataApp?.appUuid === appUuid;
+
+            // Plain left-click previews the app in the thread panel; modified
+            // clicks fall through to the anchor and open the full page in a
+            // new tab.
+            const handleDataAppClick = (e: MouseEvent<HTMLAnchorElement>) => {
+                if (
+                    !appUuid ||
+                    e.defaultPrevented ||
+                    e.button !== 0 ||
+                    e.metaKey ||
+                    e.altKey ||
+                    e.ctrlKey ||
+                    e.shiftKey
+                ) {
+                    return;
+                }
+
+                e.preventDefault();
+                dispatch(
+                    setDataAppPreview({
+                        appUuid,
+                        messageUuid: message.uuid,
+                        threadUuid: message.threadUuid,
+                        projectUuid,
+                        agentUuid,
+                    }),
+                );
+            };
+
             return (
                 <ContentReferenceLink
                     to={resourceHref || undefined}
                     kind={REFERENCE_LINK_KINDS[contentType]}
+                    data-app-active={isActive || undefined}
+                    onClick={handleDataAppClick}
                     target="_blank"
                     rel="noreferrer"
                     title={title}
@@ -131,6 +173,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
                     {children}
                 </ContentReferenceLink>
             );
+        }
 
         case 'chart-link': {
             const chartUuid =

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
@@ -12,6 +12,7 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
+import { AiDataAppPreviewPanel } from '../ChatElements/AiDataAppPreviewPanel';
 import { AiSavedChartPreviewPanel } from '../ChatElements/AiSavedChartPreviewPanel';
 import styles from './AiAgentsLauncher.module.css';
 import {
@@ -61,6 +62,9 @@ const AiAgentsLauncherInner: FC = () => {
     );
     const savedChartPreview = useAiAgentStoreSelector(
         (state) => state.aiArtifact.savedChart,
+    );
+    const dataAppPreview = useAiAgentStoreSelector(
+        (state) => state.aiArtifact.dataApp,
     );
     const currentDashboard = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.currentDashboard,
@@ -151,6 +155,16 @@ const AiAgentsLauncherInner: FC = () => {
     }
     const transitionSavedChartPreview =
         activeSavedChartPreview ?? lastSavedChartPreviewRef.current;
+    const activeDataAppPreview =
+        dataAppPreview?.projectUuid === activeProjectUuid
+            ? dataAppPreview
+            : null;
+    const lastDataAppPreviewRef = useRef(activeDataAppPreview);
+    if (activeDataAppPreview) {
+        lastDataAppPreviewRef.current = activeDataAppPreview;
+    }
+    const transitionDataAppPreview =
+        activeDataAppPreview ?? lastDataAppPreviewRef.current;
     const isDashboardPage = currentDashboard?.projectUuid === activeProjectUuid;
 
     if (!isAllowed || !activeProjectUuid) return null;
@@ -188,6 +202,25 @@ const AiAgentsLauncherInner: FC = () => {
                         >
                             <AiSavedChartPreviewPanel
                                 savedChartPreview={transitionSavedChartPreview}
+                            />
+                        </Box>
+                    )}
+                </Transition>
+            )}
+            {transitionDataAppPreview && (
+                <Transition
+                    mounted={isPanelOpenSafe && activeDataAppPreview !== null}
+                    transition="slide-up"
+                    duration={180}
+                    timingFunction="ease"
+                >
+                    {(transitionStyle) => (
+                        <Box
+                            className={styles.previewPanel}
+                            style={transitionStyle}
+                        >
+                            <AiDataAppPreviewPanel
+                                dataAppPreview={transitionDataAppPreview}
                             />
                         </Box>
                     )}

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
@@ -12,15 +12,25 @@ export interface ArtifactData {
 export interface AiArtifactState {
     artifact: ArtifactData | null;
     savedChart: SavedChartPreviewData | null;
+    dataApp: DataAppPreviewData | null;
 }
 
 const initialState: AiArtifactState = {
     artifact: null,
     savedChart: null,
+    dataApp: null,
 };
 
 export interface SavedChartPreviewData {
     savedChartUuid: string;
+    messageUuid: string;
+    threadUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+}
+
+export interface DataAppPreviewData {
+    appUuid: string;
     messageUuid: string;
     threadUuid: string;
     projectUuid: string;
@@ -59,6 +69,7 @@ export const aiArtifactSlice = createSlice({
                 agentUuid,
             };
             state.savedChart = null;
+            state.dataApp = null;
         },
         setSavedChartPreview: (
             state,
@@ -66,6 +77,15 @@ export const aiArtifactSlice = createSlice({
         ) => {
             state.savedChart = action.payload;
             state.artifact = null;
+            state.dataApp = null;
+        },
+        setDataAppPreview: (
+            state,
+            action: PayloadAction<DataAppPreviewData>,
+        ) => {
+            state.dataApp = action.payload;
+            state.artifact = null;
+            state.savedChart = null;
         },
         clearArtifact: (state) => {
             state.artifact = null;
@@ -73,9 +93,13 @@ export const aiArtifactSlice = createSlice({
         clearSavedChartPreview: (state) => {
             state.savedChart = null;
         },
+        clearDataAppPreview: (state) => {
+            state.dataApp = null;
+        },
         clearPreview: (state) => {
             state.artifact = null;
             state.savedChart = null;
+            state.dataApp = null;
         },
     },
 });
@@ -83,7 +107,9 @@ export const aiArtifactSlice = createSlice({
 export const {
     setArtifact,
     setSavedChartPreview,
+    setDataAppPreview,
     clearArtifact,
     clearSavedChartPreview,
+    clearDataAppPreview,
     clearPreview,
 } = aiArtifactSlice.actions;


### PR DESCRIPTION
## Summary

- plain left-click on a data-app chip opens the interactive app in the same right-hand preview panel charts use; modified clicks (Cmd/Ctrl/Shift/middle) still open the full page in a new tab
- new `AiDataAppPreviewPanel` reuses the dashboard-tile flow (fetch app → latest ready version → preview token → sandboxed iframe) with loading / deleted / no-access / no-ready-version states; chrome is name, description, open-in-new-tab, close
- third mutually-exclusive preview member in the AI artifact store; chip shows an active indicator; thread URL never changes
- renders in the existing desktop resizable panel, mobile bottom drawer, and the floating launcher's preview surface (a plain click there would otherwise be a dead click)
- data apps open at a wider default (60% vs 46%), same resize bounds
- dropped the stale 40px pill clearance from preview panels that never render the chart-type pill

## Testing

- new seam test: chip + real Redux store (click semantics, modified clicks, active indicator, mutual exclusion)
- full frontend suite, typecheck, lint, format
- verified end-to-end locally in a thread with a real data app

Closes: ZAP-947

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtnMDHsGN1qKsZ365f8L3E