### PR TITLE
refactor: collapse AI preview state into one discriminated union

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactDetail.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactDetail.tsx
@@ -5,7 +5,11 @@ import { useNavigate, useParams, useSearchParams } from 'react-router';
 import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { useAiAgentArtifact } from '../../hooks/useAiAgentArtifacts';
-import { clearArtifact, setArtifact } from '../../store/aiArtifactSlice';
+import {
+    clearPreview,
+    selectArtifactPreview,
+    setPreview,
+} from '../../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -18,9 +22,7 @@ export const VerifiedArtifactDetail: FC = () => {
     const projectUuid = useProjectUuid();
     const [searchParams] = useSearchParams();
     const dispatch = useAiAgentStoreDispatch();
-    const artifact = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.artifact,
-    );
+    const artifact = useAiAgentStoreSelector(selectArtifactPreview);
 
     const versionUuid = searchParams.get('versionUuid');
     const threadUuid = searchParams.get('threadUuid');
@@ -51,7 +53,8 @@ export const VerifiedArtifactDetail: FC = () => {
             promptUuid
         ) {
             dispatch(
-                setArtifact({
+                setPreview({
+                    type: 'artifact',
                     projectUuid,
                     agentUuid,
                     artifactUuid,
@@ -63,7 +66,7 @@ export const VerifiedArtifactDetail: FC = () => {
         }
 
         return () => {
-            dispatch(clearArtifact());
+            dispatch(clearPreview());
         };
     }, [
         dispatch,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/VerifiedArtifactsLayout.tsx
@@ -7,7 +7,11 @@ import { useParams } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
-import { clearArtifact, setArtifact } from '../../store/aiArtifactSlice';
+import {
+    clearPreview,
+    selectArtifactPreview,
+    setPreview,
+} from '../../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -21,15 +25,14 @@ export const VerifiedArtifactsLayout: FC = () => {
     const { agentUuid } = useParams();
     const projectUuid = useProjectUuid();
     const dispatch = useAiAgentStoreDispatch();
-    const artifact = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.artifact,
-    );
+    const artifact = useAiAgentStoreSelector(selectArtifactPreview);
 
     const handleArtifactSelect = (
         selectedArtifact: AiAgentVerifiedArtifact,
     ) => {
         dispatch(
-            setArtifact({
+            setPreview({
+                type: 'artifact',
                 projectUuid: projectUuid!,
                 agentUuid: agentUuid!,
                 artifactUuid: selectedArtifact.artifactUuid,
@@ -42,7 +45,7 @@ export const VerifiedArtifactsLayout: FC = () => {
 
     useEffect(() => {
         return () => {
-            dispatch(clearArtifact());
+            dispatch(clearPreview());
         };
     }, [dispatch]);
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -1,3 +1,4 @@
+import { assertUnreachable } from '@lightdash/common';
 import { Box, Drawer, Flex } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import {
@@ -20,7 +21,11 @@ import {
 } from 'react-resizable-panels';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
-import { clearPreview } from '../../store/aiArtifactSlice';
+import {
+    clearPreview,
+    selectPreview,
+    type AiPreview,
+} from '../../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -30,6 +35,19 @@ import { AiDataAppPreviewPanel } from '../ChatElements/AiDataAppPreviewPanel';
 import { AiSavedChartPreviewPanel } from '../ChatElements/AiSavedChartPreviewPanel';
 import styles from './aiAgentPageLayout.module.css';
 import { SidebarButton } from './SidebarButton';
+
+const renderPreviewPanel = (preview: AiPreview) => {
+    switch (preview.type) {
+        case 'artifact':
+            return <AiArtifactPanel artifact={preview} />;
+        case 'savedChart':
+            return <AiSavedChartPreviewPanel savedChartPreview={preview} />;
+        case 'dataApp':
+            return <AiDataAppPreviewPanel dataAppPreview={preview} />;
+        default:
+            return assertUnreachable(preview, 'Unknown preview type');
+    }
+};
 
 interface Props extends PropsWithChildren {
     Sidebar?: React.ReactNode;
@@ -52,16 +70,7 @@ export const AiAgentPageLayout: React.FC<Props> = ({
 
     const [isResizing, setIsResizing] = useState(false);
 
-    const artifact = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.artifact,
-    );
-    const savedChart = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.savedChart,
-    );
-    const dataApp = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.dataApp,
-    );
-    const preview = artifact || savedChart || dataApp;
+    const preview = useAiAgentStoreSelector(selectPreview);
     const isMobile = useMediaQuery('(max-width: 768px)');
 
     const toggleSidebar = useCallback(() => {
@@ -191,26 +200,22 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                                 to a wider default; chart/artifact switches keep
                                 the user's size. */}
                             <Panel
-                                key={dataApp ? 'data-app' : 'chart-artifact'}
+                                key={
+                                    preview.type === 'dataApp'
+                                        ? 'data-app'
+                                        : 'chart-artifact'
+                                }
                                 className={styles.floatingArtifactRegion}
-                                defaultSize={dataApp ? 60 : 46}
+                                defaultSize={
+                                    preview.type === 'dataApp' ? 60 : 46
+                                }
                                 id="artifact"
                                 minSize={32}
                                 maxSize={64}
                                 order={3}
                             >
                                 <Box className={styles.floatingArtifactWrap}>
-                                    {artifact ? (
-                                        <AiArtifactPanel artifact={artifact} />
-                                    ) : savedChart ? (
-                                        <AiSavedChartPreviewPanel
-                                            savedChartPreview={savedChart}
-                                        />
-                                    ) : dataApp ? (
-                                        <AiDataAppPreviewPanel
-                                            dataAppPreview={dataApp}
-                                        />
-                                    ) : null}
+                                    {renderPreviewPanel(preview)}
                                 </Box>
                             </Panel>
                         </ErrorBoundary>
@@ -239,15 +244,7 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                         },
                     }}
                 >
-                    {artifact ? (
-                        <AiArtifactPanel artifact={artifact} />
-                    ) : savedChart ? (
-                        <AiSavedChartPreviewPanel
-                            savedChartPreview={savedChart}
-                        />
-                    ) : dataApp ? (
-                        <AiDataAppPreviewPanel dataAppPreview={dataApp} />
-                    ) : null}
+                    {preview && renderPreviewPanel(preview)}
                 </Drawer>
             )}
         </div>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -48,7 +48,11 @@ import {
     useUpdatePromptFeedbackMutation,
 } from '../../hooks/useProjectAiAgents';
 import { type StreamPart } from '../../store/aiAgentThreadStreamSlice';
-import { clearArtifact, setArtifact } from '../../store/aiArtifactSlice';
+import {
+    clearPreview,
+    selectArtifactPreview,
+    setPreview,
+} from '../../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -960,9 +964,7 @@ export const AssistantBubble: FC<Props> = memo(
         mcpServers,
         onDashboardLinkClick,
     }) => {
-        const artifact = useAiAgentStoreSelector(
-            (state) => state.aiArtifact.artifact,
-        );
+        const artifact = useAiAgentStoreSelector(selectArtifactPreview);
         const dispatch = useAiAgentStoreDispatch();
 
         if (!projectUuid) throw new Error(`Project Uuid not found`);
@@ -1084,11 +1086,12 @@ export const AssistantBubble: FC<Props> = memo(
                                               artifact?.versionUuid ===
                                                   messageArtifact.versionUuid;
                                           if (isThisArtifactOpen) {
-                                              dispatch(clearArtifact());
+                                              dispatch(clearPreview());
                                               return;
                                           }
                                           dispatch(
-                                              setArtifact({
+                                              setPreview({
+                                                  type: 'artifact',
                                                   artifactUuid:
                                                       messageArtifact.artifactUuid,
                                                   versionUuid:

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiArtifactPanel.tsx
@@ -35,7 +35,7 @@ import {
     useAiAgentArtifactVizQuery,
     useAiAgentThread,
 } from '../../hooks/useProjectAiAgents';
-import { clearArtifact } from '../../store/aiArtifactSlice';
+import { clearPreview } from '../../store/aiArtifactSlice';
 import { useAiAgentStoreDispatch } from '../../store/hooks';
 import { AgentVisualizationChartTypeSwitcher } from './AgentVisualizationChartTypeSwitcher';
 import styles from './AiArtifactPanel.module.css';
@@ -298,7 +298,7 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                                 size="sm"
                                 variant="subtle"
                                 color="ldGray.6"
-                                onClick={() => dispatch(clearArtifact())}
+                                onClick={() => dispatch(clearPreview())}
                                 aria-label="Close"
                             >
                                 <MantineIcon icon={IconX} />
@@ -437,7 +437,7 @@ export const AiArtifactPanel: FC<AiArtifactPanelProps> = memo(
                                 size="sm"
                                 variant="subtle"
                                 color="ldGray.6"
-                                onClick={() => dispatch(clearArtifact())}
+                                onClick={() => dispatch(clearPreview())}
                                 aria-label="Close"
                             >
                                 <MantineIcon icon={IconX} />

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartVisualization.tsx
@@ -26,7 +26,7 @@ import {
     useAiArtifactCompiledSql,
 } from '../../hooks/useAiArtifactChart';
 import { useAiAgentArtifactVizQuery } from '../../hooks/useProjectAiAgents';
-import { clearArtifact } from '../../store/aiArtifactSlice';
+import { clearPreview } from '../../store/aiArtifactSlice';
 import { useAiAgentStoreDispatch } from '../../store/hooks';
 import { AiChartQuickOptions } from './AiChartQuickOptions';
 import {
@@ -126,7 +126,7 @@ export const AiChartVisualization: FC<Props> = ({
                         size="sm"
                         variant="subtle"
                         color="ldGray.9"
-                        onClick={() => dispatch(clearArtifact())}
+                        onClick={() => dispatch(clearPreview())}
                     >
                         <MantineIcon icon={IconX} />
                     </ActionIcon>
@@ -179,7 +179,7 @@ export const AiChartVisualization: FC<Props> = ({
                             size="sm"
                             variant="subtle"
                             color="ldGray.4"
-                            onClick={() => dispatch(clearArtifact())}
+                            onClick={() => dispatch(clearPreview())}
                         >
                             <MantineIcon icon={IconX} />
                         </ActionIcon>
@@ -238,7 +238,7 @@ export const AiChartVisualization: FC<Props> = ({
                         size="sm"
                         variant="subtle"
                         color="ldGray.4"
-                        onClick={() => dispatch(clearArtifact())}
+                        onClick={() => dispatch(clearPreview())}
                     >
                         <MantineIcon icon={IconX} />
                     </ActionIcon>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardVisualization.tsx
@@ -17,7 +17,7 @@ import { IconX } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
-import { clearArtifact } from '../../store/aiArtifactSlice';
+import { clearPreview } from '../../store/aiArtifactSlice';
 import { useAiAgentStoreDispatch } from '../../store/hooks';
 import { AiDashboardQuickOptions } from './AiDashboardQuickOptions';
 import styles from './AiDashboardVisualization.module.css';
@@ -77,7 +77,7 @@ export const AiDashboardVisualization: FC<Props> = memo(
                                     size="sm"
                                     variant="subtle"
                                     color="gray"
-                                    onClick={() => dispatch(clearArtifact())}
+                                    onClick={() => dispatch(clearPreview())}
                                 >
                                     <MantineIcon icon={IconX} color="gray" />
                                 </ActionIcon>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDataAppPreviewPanel.tsx
@@ -20,7 +20,7 @@ import { useAppPreviewToken } from '../../../../../features/apps/hooks/useAppPre
 import { useGetApp } from '../../../../../features/apps/hooks/useGetApp';
 import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
 import {
-    clearDataAppPreview,
+    clearPreview,
     type DataAppPreviewData,
 } from '../../store/aiArtifactSlice';
 import { useAiAgentStoreDispatch } from '../../store/hooks';
@@ -70,7 +70,7 @@ export const AiDataAppPreviewPanel: FC<Props> = ({ dataAppPreview }) => {
             size="sm"
             variant="subtle"
             color="ldGray.6"
-            onClick={() => dispatch(clearDataAppPreview())}
+            onClick={() => dispatch(clearPreview())}
             aria-label="Close"
         >
             <MantineIcon icon={IconX} />

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartPreviewPanel.tsx
@@ -21,7 +21,7 @@ import MantineIcon from '../../../../../components/common/MantineIcon';
 import TruncatedText from '../../../../../components/common/TruncatedText';
 import { useSavedQuery } from '../../../../../hooks/useSavedQuery';
 import {
-    clearSavedChartPreview,
+    clearPreview,
     type SavedChartPreviewData,
 } from '../../store/aiArtifactSlice';
 import { useAiAgentStoreDispatch } from '../../store/hooks';
@@ -71,7 +71,7 @@ export const AiSavedChartPreviewPanel: FC<Props> = ({ savedChartPreview }) => {
             size="sm"
             variant="subtle"
             color="ldGray.6"
-            onClick={() => dispatch(clearSavedChartPreview())}
+            onClick={() => dispatch(clearPreview())}
             aria-label="Close"
         >
             <MantineIcon icon={IconX} />

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.dataApp.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.dataApp.test.tsx
@@ -5,11 +5,7 @@ import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
 import { store } from '../../store';
-import {
-    clearPreview,
-    setDataAppPreview,
-    setSavedChartPreview,
-} from '../../store/aiArtifactSlice';
+import { clearPreview, setPreview } from '../../store/aiArtifactSlice';
 import { ContentLink } from './ContentLink';
 
 const APP_UUID = 'app-uuid-1';
@@ -65,7 +61,8 @@ describe('ContentLink data-app chip', () => {
         const defaultNotPrevented = fireEvent.click(chip);
 
         expect(defaultNotPrevented).toBe(false);
-        expect(store.getState().aiArtifact.dataApp).toEqual({
+        expect(store.getState().aiArtifact.preview).toEqual({
+            type: 'dataApp',
             appUuid: APP_UUID,
             messageUuid: 'message-1',
             threadUuid: 'thread-1',
@@ -86,7 +83,7 @@ describe('ContentLink data-app chip', () => {
         const defaultNotPrevented = fireEvent.click(chip, eventInit);
 
         expect(defaultNotPrevented).toBe(true);
-        expect(store.getState().aiArtifact.dataApp).toBeNull();
+        expect(store.getState().aiArtifact.preview).toBeNull();
     });
 
     it('shows the active indicator only while its app is previewed', () => {
@@ -108,6 +105,7 @@ describe('ContentLink data-app chip', () => {
         renderDataAppChip();
 
         const chartPreview = {
+            type: 'savedChart' as const,
             savedChartUuid: 'chart-1',
             messageUuid: 'message-1',
             threadUuid: 'thread-1',
@@ -116,33 +114,15 @@ describe('ContentLink data-app chip', () => {
         };
 
         act(() => {
-            store.dispatch(setSavedChartPreview(chartPreview));
+            store.dispatch(setPreview(chartPreview));
         });
 
         fireEvent.click(screen.getByRole('link', { name: /Revenue explorer/ }));
-        expect(store.getState().aiArtifact.savedChart).toBeNull();
-        expect(store.getState().aiArtifact.dataApp).not.toBeNull();
+        expect(store.getState().aiArtifact.preview?.type).toBe('dataApp');
 
         act(() => {
-            store.dispatch(setSavedChartPreview(chartPreview));
+            store.dispatch(setPreview(chartPreview));
         });
-        expect(store.getState().aiArtifact.dataApp).toBeNull();
-        expect(store.getState().aiArtifact.savedChart).not.toBeNull();
-    });
-
-    it('clears the artifact preview when a data app opens', () => {
-        store.dispatch(
-            setDataAppPreview({
-                appUuid: APP_UUID,
-                messageUuid: 'message-1',
-                threadUuid: 'thread-1',
-                projectUuid: 'project-1',
-                agentUuid: 'agent-1',
-            }),
-        );
-
-        expect(store.getState().aiArtifact.artifact).toBeNull();
-        expect(store.getState().aiArtifact.savedChart).toBeNull();
-        expect(store.getState().aiArtifact.dataApp).not.toBeNull();
+        expect(store.getState().aiArtifact.preview?.type).toBe('savedChart');
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -12,11 +12,7 @@ import {
 import { type FC, type MouseEvent, type ReactNode } from 'react';
 import { Link, createPath, useLocation, useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import {
-    setArtifact,
-    setDataAppPreview,
-    setSavedChartPreview,
-} from '../../store/aiArtifactSlice';
+import { selectPreview, setPreview } from '../../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -70,15 +66,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
     const resourceHref = typeof props.href === 'string' ? props.href : '';
     const title = typeof props.title === 'string' ? props.title : undefined;
     const dispatch = useAiAgentStoreDispatch();
-    const currentArtifact = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.artifact,
-    );
-    const currentSavedChart = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.savedChart,
-    );
-    const currentDataApp = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.dataApp,
-    );
+    const currentPreview = useAiAgentStoreSelector(selectPreview);
 
     const handleResourceClick = (e: MouseEvent<HTMLAnchorElement>) => {
         if (!resourceHref || !isPlainLeftClick(e)) {
@@ -130,7 +118,10 @@ export const ContentLink: FC<ContentLinkProps> = ({
                 typeof props['data-app-uuid'] === 'string'
                     ? props['data-app-uuid']
                     : undefined;
-            const isActive = !!appUuid && currentDataApp?.appUuid === appUuid;
+            const isActive =
+                !!appUuid &&
+                currentPreview?.type === 'dataApp' &&
+                currentPreview.appUuid === appUuid;
 
             // Modified clicks fall through to the anchor and open the full
             // page in a new tab.
@@ -141,7 +132,8 @@ export const ContentLink: FC<ContentLinkProps> = ({
 
                 e.preventDefault();
                 dispatch(
-                    setDataAppPreview({
+                    setPreview({
+                        type: 'dataApp',
                         appUuid,
                         messageUuid: message.uuid,
                         threadUuid: message.threadUuid,
@@ -191,7 +183,9 @@ export const ContentLink: FC<ContentLinkProps> = ({
             const href = typeof props.href === 'string' ? props.href : '';
             const isSavedChart = chartSource !== 'sql-runner' && !!chartUuid;
             const isActive =
-                isSavedChart && currentSavedChart?.savedChartUuid === chartUuid;
+                isSavedChart &&
+                currentPreview?.type === 'savedChart' &&
+                currentPreview.savedChartUuid === chartUuid;
 
             const handleChartClick = (e: MouseEvent<HTMLAnchorElement>) => {
                 if (!isSavedChart || !chartUuid || !isPlainLeftClick(e)) {
@@ -200,7 +194,8 @@ export const ContentLink: FC<ContentLinkProps> = ({
 
                 e.preventDefault();
                 dispatch(
-                    setSavedChartPreview({
+                    setPreview({
+                        type: 'savedChart',
                         savedChartUuid: chartUuid,
                         messageUuid: message.uuid,
                         threadUuid: message.threadUuid,
@@ -251,9 +246,9 @@ export const ContentLink: FC<ContentLinkProps> = ({
                       : IconChartBar;
 
             const isActive =
-                currentArtifact &&
-                currentArtifact.artifactUuid === artifactUuid &&
-                currentArtifact.versionUuid === versionUuid;
+                currentPreview?.type === 'artifact' &&
+                currentPreview.artifactUuid === artifactUuid &&
+                currentPreview.versionUuid === versionUuid;
 
             return (
                 <Anchor
@@ -271,7 +266,8 @@ export const ContentLink: FC<ContentLinkProps> = ({
                         e.preventDefault();
                         if (artifactUuid && versionUuid) {
                             dispatch(
-                                setArtifact({
+                                setPreview({
+                                    type: 'artifact',
                                     artifactUuid,
                                     versionUuid,
                                     messageUuid: message.uuid,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
@@ -9,6 +9,10 @@ import {
     setActiveAgent,
 } from '../../store/aiAgentLauncherSlice';
 import {
+    selectDataAppPreview,
+    selectSavedChartPreview,
+} from '../../store/aiArtifactSlice';
+import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
@@ -60,12 +64,8 @@ const AiAgentsLauncherInner: FC = () => {
     const activeAgentUuid = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.activeAgentUuid,
     );
-    const savedChartPreview = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.savedChart,
-    );
-    const dataAppPreview = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.dataApp,
-    );
+    const savedChartPreview = useAiAgentStoreSelector(selectSavedChartPreview);
+    const dataAppPreview = useAiAgentStoreSelector(selectDataAppPreview);
     const currentDashboard = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.currentDashboard,
     );

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.test.tsx
@@ -15,7 +15,8 @@ vi.mock('../store/hooks', () => ({
 
 vi.mock('../store/aiArtifactSlice', () => ({
     clearPreview: () => ({ type: 'clearPreview' }),
-    setArtifact: (payload: unknown) => ({ type: 'setArtifact', payload }),
+    setPreview: (payload: unknown) => ({ type: 'setPreview', payload }),
+    selectArtifactPreview: () => null,
 }));
 
 vi.mock('./useDeepResearch', () => ({
@@ -91,7 +92,7 @@ describe('useAiAgentThreadArtifact', () => {
         );
 
         expect(dispatchMock).not.toHaveBeenCalledWith(
-            expect.objectContaining({ type: 'setArtifact' }),
+            expect.objectContaining({ type: 'setPreview' }),
         );
     });
 
@@ -106,8 +107,9 @@ describe('useAiAgentThreadArtifact', () => {
         );
 
         expect(dispatchMock).toHaveBeenCalledWith({
-            type: 'setArtifact',
+            type: 'setPreview',
             payload: {
+                type: 'artifact',
                 artifactUuid: 'regular-artifact',
                 versionUuid: 'regular-version',
                 messageUuid: 'regular-prompt',
@@ -134,7 +136,7 @@ describe('useAiAgentThreadArtifact', () => {
         );
 
         expect(dispatchMock).not.toHaveBeenCalledWith(
-            expect.objectContaining({ type: 'setArtifact' }),
+            expect.objectContaining({ type: 'setPreview' }),
         );
     });
 
@@ -165,7 +167,7 @@ describe('useAiAgentThreadArtifact', () => {
         rerender();
 
         expect(dispatchMock).not.toHaveBeenCalledWith(
-            expect.objectContaining({ type: 'setArtifact' }),
+            expect.objectContaining({ type: 'setPreview' }),
         );
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.ts
@@ -1,6 +1,10 @@
 import { type AiAgentThread } from '@lightdash/common';
 import { useEffect, useMemo, useRef } from 'react';
-import { clearPreview, setArtifact } from '../store/aiArtifactSlice';
+import {
+    clearPreview,
+    selectArtifactPreview,
+    setPreview,
+} from '../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -21,9 +25,7 @@ export const useAiAgentThreadArtifact = ({
     thread,
 }: UseAiAgentThreadArtifactOptions) => {
     const dispatch = useAiAgentStoreDispatch();
-    const artifact = useAiAgentStoreSelector(
-        (state) => state.aiArtifact.artifact,
-    );
+    const artifact = useAiAgentStoreSelector(selectArtifactPreview);
     const {
         registrations: deepResearchRegistrations,
         isReady: isDeepResearchRegistrationLookupReady,
@@ -103,7 +105,8 @@ export const useAiAgentThreadArtifact = ({
         const latestArtifact = latestAssistantMessage.artifacts?.at(-1);
         if (!latestArtifact) return;
         dispatch(
-            setArtifact({
+            setPreview({
+                type: 'artifact',
                 artifactUuid: latestArtifact.artifactUuid,
                 versionUuid: latestArtifact.versionUuid,
                 messageUuid: latestAssistantMessage.uuid,

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
@@ -9,18 +9,6 @@ export interface ArtifactData {
     agentUuid: string;
 }
 
-export interface AiArtifactState {
-    artifact: ArtifactData | null;
-    savedChart: SavedChartPreviewData | null;
-    dataApp: DataAppPreviewData | null;
-}
-
-const initialState: AiArtifactState = {
-    artifact: null,
-    savedChart: null,
-    dataApp: null,
-};
-
 export interface SavedChartPreviewData {
     savedChartUuid: string;
     messageUuid: string;
@@ -37,79 +25,50 @@ export interface DataAppPreviewData {
     agentUuid: string;
 }
 
+export type AiPreview =
+    | ({ type: 'artifact' } & ArtifactData)
+    | ({ type: 'savedChart' } & SavedChartPreviewData)
+    | ({ type: 'dataApp' } & DataAppPreviewData);
+
+export interface AiArtifactState {
+    preview: AiPreview | null;
+}
+
+const initialState: AiArtifactState = {
+    preview: null,
+};
+
 export const aiArtifactSlice = createSlice({
     name: 'aiArtifact',
     initialState,
     reducers: {
-        setArtifact: (
-            state,
-            action: PayloadAction<{
-                artifactUuid: string;
-                versionUuid: string;
-                messageUuid: string;
-                threadUuid: string;
-                projectUuid: string;
-                agentUuid: string;
-            }>,
-        ) => {
-            const {
-                artifactUuid,
-                versionUuid,
-                messageUuid,
-                threadUuid,
-                projectUuid,
-                agentUuid,
-            } = action.payload;
-            state.artifact = {
-                artifactUuid,
-                versionUuid,
-                messageUuid,
-                threadUuid,
-                projectUuid,
-                agentUuid,
-            };
-            state.savedChart = null;
-            state.dataApp = null;
-        },
-        setSavedChartPreview: (
-            state,
-            action: PayloadAction<SavedChartPreviewData>,
-        ) => {
-            state.savedChart = action.payload;
-            state.artifact = null;
-            state.dataApp = null;
-        },
-        setDataAppPreview: (
-            state,
-            action: PayloadAction<DataAppPreviewData>,
-        ) => {
-            state.dataApp = action.payload;
-            state.artifact = null;
-            state.savedChart = null;
-        },
-        clearArtifact: (state) => {
-            state.artifact = null;
-        },
-        clearSavedChartPreview: (state) => {
-            state.savedChart = null;
-        },
-        clearDataAppPreview: (state) => {
-            state.dataApp = null;
+        setPreview: (state, action: PayloadAction<AiPreview>) => {
+            state.preview = action.payload;
         },
         clearPreview: (state) => {
-            state.artifact = null;
-            state.savedChart = null;
-            state.dataApp = null;
+            state.preview = null;
         },
     },
 });
 
-export const {
-    setArtifact,
-    setSavedChartPreview,
-    setDataAppPreview,
-    clearArtifact,
-    clearSavedChartPreview,
-    clearDataAppPreview,
-    clearPreview,
-} = aiArtifactSlice.actions;
+export const { setPreview, clearPreview } = aiArtifactSlice.actions;
+
+type StateWithAiArtifact = { aiArtifact: AiArtifactState };
+
+export const selectPreview = (state: StateWithAiArtifact) =>
+    state.aiArtifact.preview;
+
+export const selectArtifactPreview = (state: StateWithAiArtifact) =>
+    state.aiArtifact.preview?.type === 'artifact'
+        ? state.aiArtifact.preview
+        : null;
+
+export const selectSavedChartPreview = (state: StateWithAiArtifact) =>
+    state.aiArtifact.preview?.type === 'savedChart'
+        ? state.aiArtifact.preview
+        : null;
+
+export const selectDataAppPreview = (state: StateWithAiArtifact) =>
+    state.aiArtifact.preview?.type === 'dataApp'
+        ? state.aiArtifact.preview
+        : null;


### PR DESCRIPTION
## Summary

Stacked on #28110. `aiArtifactSlice` held `artifact` / `savedChart` / `dataApp` as three nullable fields where every setter had to cross-null the other two. This collapses them into a single discriminated union:

```ts
preview: ({ type: 'artifact' } & ArtifactData)
       | ({ type: 'savedChart' } & SavedChartPreviewData)
       | ({ type: 'dataApp' } & DataAppPreviewData)
       | null
```

- One `setPreview` / `clearPreview` pair replaces three setters and four clear actions; mutual exclusion of preview kinds is now structurally impossible to violate rather than maintained by hand.
- Narrowing selectors (`selectPreview`, `selectArtifactPreview`, `selectSavedChartPreview`, `selectDataAppPreview`) exported from the slice; they return state by reference, so no re-render regressions.
- `AiAgentPageLayout` gains a `renderPreviewPanel` helper shared by the desktop panel and mobile drawer, exhaustive via `assertUnreachable`.
- All 13 consumer files migrated (thread layout, launcher, `ContentLink`, assistant bubble, panels, admin verified-artifacts pages, auto-open hook). Behavior unchanged, including the wider default panel for data apps. Net −54 lines.
- Dropped one test that asserted cross-nulling, since that state is no longer representable; replace semantics remain covered.

## Testing

- Full frontend vitest suite, typecheck, lint, format all pass.
- Verified in the running app: data-app/chart/artifact previews still open, replace each other, and keep active chip indicators; modified clicks still open a new tab.

Relates: ZAP-947

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtnMDHsGN1qKsZ365f8L3E