### PR TITLE
fix(cli): reject option-like values for variadic reference options

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -57,6 +57,7 @@ import { sqlHandler } from './handlers/sql';
 import { registerUpgradeCheckCommand } from './handlers/upgradeCheck';
 import { validateHandler } from './handlers/validate';
 import { warehouseCatalogHandler } from './handlers/warehouseCatalog';
+import { parseRefsArgument } from './refsArgument';
 import * as styles from './styles';
 // Trigger CLI tests
 // Suppress AWS SDK V2 warning, imported by snowflake SDK
@@ -839,38 +840,54 @@ const downloadCommand = program
     .option(
         '-c, --charts <charts...>',
         'specify chart slugs, uuids, or urls to download',
+        parseRefsArgument,
         [],
     )
     .option(
         '-d, --dashboards <dashboards...>',
         'specify dashboard slugs, uuids or urls to download',
+        parseRefsArgument,
         [],
     )
-    .option('--agents <slugs...>', 'specify AI agent slugs to download', [])
+    .option(
+        '--agents <slugs...>',
+        'specify AI agent slugs to download',
+        parseRefsArgument,
+        [],
+    )
     .option(
         '--include-agents',
         "include all of the project's AI agents (enterprise)",
         false,
     )
-    .option('--alerts <slugs...>', 'specify alert slugs to download', [])
+    .option(
+        '--alerts <slugs...>',
+        'specify alert slugs to download',
+        parseRefsArgument,
+        [],
+    )
     .option(
         '--virtual-views <slugs...>',
         'specify virtual view slugs to download',
+        parseRefsArgument,
         [],
     )
     .option(
         '--google-sheets <slugs...>',
         'specify Google Sheets sync slugs to download',
+        parseRefsArgument,
         [],
     )
     .option(
         '--scheduled-deliveries <slugs...>',
         'specify scheduled delivery slugs to download',
+        parseRefsArgument,
         [],
     )
     .option(
         '--external-connections <slugs...>',
         'specify external connection slugs to download (enterprise)',
+        parseRefsArgument,
         [],
     )
     .option(
@@ -945,6 +962,7 @@ const downloadCommand = program
     .option(
         '--apps <appReferences...>',
         'Download only the specified data apps, by slug, app URL, or UUID (enterprise). Works for apps not added to a space.',
+        parseRefsArgument,
     )
     .option(
         '--include-apps',
@@ -964,6 +982,7 @@ const downloadCommand = program
     .option(
         '--chart-types <chartTypeReferences...>',
         'Download only the specified custom chart types, by slug, URL, or UUID (enterprise).',
+        parseRefsArgument,
     )
     .option(
         '--include-chart-types',
@@ -995,33 +1014,49 @@ const uploadCommand = program
     .option(
         '-c, --charts <charts...>',
         'specify chart slugs to force upload',
+        parseRefsArgument,
         [],
     )
     .option(
         '-d, --dashboards <dashboards...>',
         'specify dashboard slugs to force upload',
+        parseRefsArgument,
         [],
     )
-    .option('--agents <slugs...>', 'specify AI agent slugs to upload', [])
-    .option('--alerts <slugs...>', 'specify alert slugs to upload', [])
+    .option(
+        '--agents <slugs...>',
+        'specify AI agent slugs to upload',
+        parseRefsArgument,
+        [],
+    )
+    .option(
+        '--alerts <slugs...>',
+        'specify alert slugs to upload',
+        parseRefsArgument,
+        [],
+    )
     .option(
         '--virtual-views <slugs...>',
         'specify virtual view slugs to upload',
+        parseRefsArgument,
         [],
     )
     .option(
         '--google-sheets <slugs...>',
         'specify Google Sheets sync slugs to upload',
+        parseRefsArgument,
         [],
     )
     .option(
         '--scheduled-deliveries <slugs...>',
         'specify scheduled delivery slugs to upload',
+        parseRefsArgument,
         [],
     )
     .option(
         '--external-connections <slugs...>',
         'specify external connection slugs to upload (enterprise)',
+        parseRefsArgument,
         [],
     )
     .option(
@@ -1091,6 +1126,7 @@ const uploadCommand = program
     .option(
         '--apps <appReferences...>',
         'Upload only the specified data apps, by slug (the app folder name), app URL, or UUID (enterprise). URL and UUID refs are resolved against the target project.',
+        parseRefsArgument,
     )
     .option(
         '--include-apps',
@@ -1105,6 +1141,7 @@ const uploadCommand = program
     .option(
         '--chart-types <chartTypeReferences...>',
         'Upload only the specified custom chart types, by slug (the chart type folder name), URL, or UUID (enterprise). URL and UUID refs are resolved against the target project.',
+        parseRefsArgument,
     )
     .option(
         '--include-chart-types',

--- a/packages/cli/src/refsArgument.test.ts
+++ b/packages/cli/src/refsArgument.test.ts
@@ -1,0 +1,54 @@
+import { Command } from 'commander';
+import { parseRefsArgument } from './refsArgument';
+
+const buildCommand = () => {
+    const command = new Command('upload')
+        .exitOverride()
+        .configureOutput({ writeErr: () => {} })
+        .option('--force', 'force upload', false)
+        .option('-c, --charts <charts...>', 'chart refs', parseRefsArgument, [])
+        .option(
+            '--chart-types <chartTypeReferences...>',
+            'chart type refs',
+            parseRefsArgument,
+        );
+    return command;
+};
+
+describe('parseRefsArgument', () => {
+    it('rejects a bare flag followed by another option', () => {
+        const command = buildCommand();
+        expect(() =>
+            command.parse(['--chart-types', '--force'], { from: 'user' }),
+        ).toThrow(/argument '--force' is invalid/);
+    });
+
+    it('does not consume the following boolean flag as a value', () => {
+        const command = buildCommand();
+        command.parse(['--chart-types', 'one', 'two', '--force'], {
+            from: 'user',
+        });
+        expect(command.opts().chartTypes).toEqual(['one', 'two']);
+        expect(command.opts().force).toBe(true);
+    });
+
+    it('rejects option-like values on options with array defaults', () => {
+        const command = buildCommand();
+        expect(() =>
+            command.parse(['--charts', '--force'], { from: 'user' }),
+        ).toThrow(/argument '--force' is invalid/);
+    });
+
+    it('accumulates values onto the default array', () => {
+        const command = buildCommand();
+        command.parse(['-c', 'a', '-c', 'b'], { from: 'user' });
+        expect(command.opts().charts).toEqual(['a', 'b']);
+    });
+
+    it('leaves unset options at their defaults', () => {
+        const command = buildCommand();
+        command.parse([], { from: 'user' });
+        expect(command.opts().charts).toEqual([]);
+        expect(command.opts().chartTypes).toBeUndefined();
+    });
+});

--- a/packages/cli/src/refsArgument.ts
+++ b/packages/cli/src/refsArgument.ts
@@ -1,0 +1,19 @@
+import { InvalidArgumentError } from 'commander';
+
+/**
+ * Coercion for variadic reference options (--charts, --chart-types, --apps, ...).
+ * Commander's required-value parsing consumes the next argv token even when it
+ * is another option (e.g. `--chart-types --force` reads "--force" as a ref),
+ * so reject option-like values with a clear missing-value error.
+ */
+export function parseRefsArgument(
+    value: string,
+    previous: string[] = [],
+): string[] {
+    if (value.startsWith('-')) {
+        throw new InvalidArgumentError(
+            'Expected a reference value but got another option. Pass one or more references after this flag, or use the matching --include-* flag to select all.',
+        );
+    }
+    return [...previous, value];
+}


### PR DESCRIPTION
## Problem

Commander's required-value parsing unconditionally consumes the next argv token, even when it is another option. So in

```
lightdash upload ... --include-charts --chart-types --force
```

`--force` was parsed as the value of `--chart-types`: the CLI printed `No local app folder matched: --force.`, uploaded no chart types, and ran without force.

## Fix

A shared `parseRefsArgument` coercion is attached to every variadic reference option on `upload` and `download` (`--charts`, `--dashboards`, `--agents`, `--alerts`, `--virtual-views`, `--google-sheets`, `--scheduled-deliveries`, `--external-connections`, `--apps`, `--chart-types`). A value starting with `-` now fails fast with a clear missing-value error; the `--include-*` flags remain the way to say "all". Bare `--chart-types` at the end of the command still gets commander's native missing-argument error.

## Verification

- `upload --include-charts --chart-types --force` → `error: option '--chart-types <chartTypeReferences...>' argument '--force' is invalid. Expected a reference value but got another option...`, exit 1, `--force` no longer consumed.
- New parse-level tests in `refsArgument.test.ts` (bare flag before another option, values + trailing boolean flag, defaults untouched).

Closes: PROD-10619

🤖 Generated with [Claude Code](https://claude.com/claude-code)