### PR TITLE
fix(cli): skip dashboards whose dependent charts failed to upload

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -1064,6 +1064,70 @@ describe('CoderService', () => {
             expect(result[1].uuid).toEqual(expect.any(String));
         });
 
+        it('warns when a chart tile slug does not resolve in the project', async () => {
+            const service = new CoderService({
+                analytics: {} as AnyType,
+                contentVerificationModel: {} as AnyType,
+                dashboardModel: {} as AnyType,
+                lightdashConfig: {} as AnyType,
+                projectModel: {} as AnyType,
+                promoteService: {} as AnyType,
+                savedChartModel: {
+                    find: vi.fn(async () => []),
+                    getSlugAliasMappingsForUuids: vi.fn(async () => []),
+                } as AnyType,
+                savedSqlModel: {
+                    find: vi.fn(async () => []),
+                } as AnyType,
+                appModel: {
+                    findAppsBySlugs: vi.fn(async () => []),
+                } as AnyType,
+                schedulerModel: {} as AnyType,
+                schedulerService: {} as AnyType,
+                savedChartService: {} as AnyType,
+                dashboardService: {} as AnyType,
+                schedulerClient: {} as AnyType,
+                spaceModel: {} as AnyType,
+                spacePermissionService: {} as AnyType,
+                groupsModel: {} as AnyType,
+                organizationMemberProfileModel: {} as AnyType,
+                userModel: {} as AnyType,
+            });
+
+            const { tiles, warnings } =
+                await service.convertTileWithSlugsToUuids('project-uuid', [
+                    {
+                        type: DashboardTileTypes.SAVED_CHART,
+                        uuid: undefined,
+                        tileSlug: undefined,
+                        x: 0,
+                        y: 0,
+                        h: 2,
+                        w: 4,
+                        tabUuid: null,
+                        properties: {
+                            chartSlug: 'missing-chart',
+                            chartName: 'Missing chart',
+                        },
+                    },
+                ] as AnyType);
+
+            expect(tiles).toMatchObject([
+                {
+                    type: DashboardTileTypes.SAVED_CHART,
+                    properties: {
+                        chartSlug: 'missing-chart',
+                        savedChartUuid: null,
+                    },
+                },
+            ]);
+            expect(warnings).toEqual([
+                expect.stringContaining(
+                    'Chart "missing-chart" was not found in this project',
+                ),
+            ]);
+        });
+
         it('resolves portable tab slugs and still accepts legacy tab UUIDs', async () => {
             const service = new CoderService({
                 analytics: {} as AnyType,

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1802,6 +1802,12 @@ export class CoderService extends BaseService {
                 } as DashboardTileWithSlug;
             }
 
+            if (tile.properties.chartSlug != null && chartInfo === undefined) {
+                warnings.push(
+                    `Chart "${tile.properties.chartSlug}" was not found in this project — the tile was saved without a chart. Upload the chart first, then re-upload the dashboard.`,
+                );
+            }
+
             const isSqlChart =
                 chartInfo?.isSql ?? tile.type === DashboardTileTypes.SQL_CHART;
 

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -122,9 +122,10 @@ export const resolveUploadFilterUuids = (
  */
 export const unmatchedUploadRefsWarning = (
     unmatched: string[],
+    noun: string = 'app',
 ): string | null => {
     if (unmatched.length === 0) return null;
-    const base = `No local app folder matched: ${unmatched.join(', ')}.`;
+    const base = `No local ${noun} folder matched: ${unmatched.join(', ')}.`;
     return unmatched.some((ref) => isUuid(ref))
         ? `${base} Bundles downloaded with slug identity carry no uuid — select them by slug (the folder name) instead of a UUID or app URL.`
         : base;

--- a/packages/cli/src/handlers/apps/validate.test.ts
+++ b/packages/cli/src/handlers/apps/validate.test.ts
@@ -1,5 +1,6 @@
 import {
     buildDataAppExploreIndexFromModelFiles,
+    DATA_APP_VIZ_TEMPLATE,
     type DataAppCode,
     type DataAppManifest,
 } from '@lightdash/common';
@@ -13,6 +14,7 @@ import {
     renderAppsValidationJson,
     validateDataAppBuild,
     validateLocalDataApp,
+    type AppValidationResult,
     type RunDataAppBuildCommand,
 } from './validate';
 
@@ -519,6 +521,7 @@ describe('renderAppsValidationHuman', () => {
                 path: '/tmp/orders-app',
                 name: 'Orders app',
                 projectUuid: 'project-uuid',
+                template: null,
                 valid: true,
                 errors: [],
                 warnings: [],
@@ -594,6 +597,67 @@ describe('renderAppsValidationHuman', () => {
 
         expect(JSON.parse(output)).not.toHaveProperty(
             'apps.0.unanalyzedReferences',
+        );
+    });
+
+    const buildResult = (
+        template: AppValidationResult['template'],
+        overrides: Partial<AppValidationResult> = {},
+    ): AppValidationResult => ({
+        path: '/tmp/bundle',
+        name: 'Bundle',
+        projectUuid: null,
+        template,
+        valid: true,
+        errors: [],
+        warnings: [],
+        coverage: {
+            callSites: 0,
+            fullyResolved: 0,
+            partiallyResolved: 0,
+            unresolved: 0,
+            unanalyzed: 0,
+        },
+        unanalyzedReferences: [],
+        ...overrides,
+    });
+
+    it('describes an all-chart-type run as custom chart types', () => {
+        const vizReport = buildAppsValidationReport(
+            [buildResult(DATA_APP_VIZ_TEMPLATE)],
+            false,
+        );
+        const output = renderAppsValidationHuman(vizReport);
+
+        expect(output).toContain('Validating 1 custom chart type(s)');
+        expect(output).toContain(
+            'Validation passed for 1 custom chart type(s)',
+        );
+        expect(output).not.toContain('data app(s)');
+        expect(vizReport.summary.chartTypes).toBe(1);
+        expect(vizReport.summary.dataApps).toBe(0);
+    });
+
+    it('describes a mixed run with both nouns', () => {
+        const mixedReport = buildAppsValidationReport(
+            [
+                buildResult(DATA_APP_VIZ_TEMPLATE, {
+                    valid: false,
+                    errors: [
+                        { code: 'manifest', message: 'bad', location: null },
+                    ],
+                }),
+                buildResult(null),
+            ],
+            false,
+        );
+        const output = renderAppsValidationHuman(mixedReport);
+
+        expect(output).toContain(
+            'Validating 1 data app(s) and 1 custom chart type(s)',
+        );
+        expect(output).toContain(
+            'Validation failed with 1 error(s) across 1 data app(s) and 1 custom chart type(s).',
         );
     });
 });

--- a/packages/cli/src/handlers/apps/validate.ts
+++ b/packages/cli/src/handlers/apps/validate.ts
@@ -3,6 +3,7 @@ import {
     buildDataAppExploreIndexFromModelFiles,
     checkDataAppDataReferences,
     computeCustomDependencies,
+    DATA_APP_VIZ_TEMPLATE,
     dataAppVizSchema,
     extractDataAppDataReferences,
     getErrorMessage,
@@ -80,6 +81,7 @@ export type AppValidationResult = {
     path: string;
     name: string | null;
     projectUuid: string | null;
+    template: DataAppManifest['template'] | null;
     valid: boolean;
     errors: AppsValidationIssue[];
     warnings: AppsValidationIssue[];
@@ -93,6 +95,8 @@ export type AppsValidationReport = {
     mode: 'live' | 'offline';
     summary: {
         apps: number;
+        dataApps: number;
+        chartTypes: number;
         errors: number;
         warnings: number;
         callSites: number;
@@ -549,6 +553,7 @@ export const validateLocalDataApp = async (
             path: appDir,
             name: null,
             projectUuid: null,
+            template: null,
             valid: false,
             errors: [issue('bundle', getErrorMessage(error))],
             warnings,
@@ -674,6 +679,7 @@ export const validateLocalDataApp = async (
         path: appDir,
         name: typeof manifest.name === 'string' ? manifest.name : null,
         projectUuid,
+        template: manifest.template ?? null,
         valid: errors.length === 0,
         errors,
         warnings,
@@ -692,12 +698,17 @@ export const buildAppsValidationReport = (
         (count, app) => count + app.warnings.length,
         0,
     );
+    const chartTypes = apps.filter(
+        (app) => app.template === DATA_APP_VIZ_TEMPLATE,
+    ).length;
     return {
         build,
         valid: errors === 0,
         mode: live ? 'live' : 'offline',
         summary: {
             apps: apps.length,
+            dataApps: apps.length - chartTypes,
+            chartTypes,
             errors,
             warnings,
             callSites: apps.reduce(
@@ -745,12 +756,31 @@ const formatUnanalyzedReference = (
 ): string =>
     `${reference.location.path}:${reference.location.line}:${reference.location.column} — ${referenceKindLabels[reference.kind]} (unresolved: ${reference.unresolved.join(', ')})`;
 
+/** "2 data app(s)", "1 custom chart type(s)", or both — driven by manifest templates. */
+export const describeValidatedBundles = (
+    summary: AppsValidationReport['summary'],
+): string => {
+    if (summary.chartTypes > 0 && summary.dataApps > 0) {
+        return `${summary.dataApps} data app(s) and ${summary.chartTypes} custom chart type(s)`;
+    }
+    if (summary.chartTypes > 0) {
+        return `${summary.chartTypes} custom chart type(s)`;
+    }
+    return `${summary.dataApps} data app(s)`;
+};
+
+const bundleKindLabel = (summary: AppsValidationReport['summary']): string => {
+    if (summary.chartTypes > 0 && summary.dataApps > 0) return 'App bundle';
+    if (summary.chartTypes > 0) return 'Custom chart type';
+    return 'Data app';
+};
+
 export const renderAppsValidationHuman = (
     report: AppsValidationReport,
     verbose = false,
 ): string => {
     const lines = [
-        `Validating ${report.summary.apps} data app(s) using ${
+        `Validating ${describeValidatedBundles(report.summary)} using ${
             report.mode === 'live'
                 ? 'the live project semantic layer'
                 : 'local semantic layer snapshots'
@@ -791,10 +821,10 @@ export const renderAppsValidationHuman = (
     lines.push(
         report.valid
             ? styles.success(
-                  `Validation passed for ${report.summary.apps} data app(s) with ${report.summary.warnings} warning(s).`,
+                  `Validation passed for ${describeValidatedBundles(report.summary)} with ${report.summary.warnings} warning(s).`,
               )
             : styles.error(
-                  `Validation failed with ${report.summary.errors} error(s) across ${report.summary.apps} data app(s).`,
+                  `Validation failed with ${report.summary.errors} error(s) across ${describeValidatedBundles(report.summary)}.`,
               ),
     );
     return `${lines.join('\n')}\n`;
@@ -853,7 +883,7 @@ export const appsValidateHandler = async (
 
     if (!report.valid) {
         throw new ParameterError(
-            `Data app validation failed with ${report.summary.errors} error(s).`,
+            `${bundleKindLabel(report.summary)} validation failed with ${report.summary.errors} error(s).`,
         );
     }
 };

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -3004,14 +3004,14 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
     publicSpaceCreate?: boolean,
     validate?: boolean,
     spaceNames?: Record<string, string>,
-): Promise<void> => {
+): Promise<'upserted' | 'skipped' | 'failed'> => {
     try {
         if (!force && !item.needsUpdating) {
             GlobalState.debug(
                 `Skipping ${type} "${item.slug}" with no local changes`,
             );
             changes[`${type} skipped`] = (changes[`${type} skipped`] ?? 0) + 1;
-            return;
+            return 'skipped';
         }
         GlobalState.debug(`Upserting ${type} ${item.slug}`);
 
@@ -3119,10 +3119,15 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
                 }
             }
         }
+        return 'upserted';
     } catch (error: unknown) {
         if (
             error instanceof LightdashError &&
             error.name === 'NotFoundError' &&
+            // Only the missing-space NotFoundError counts as a space skip;
+            // other NotFoundErrors (e.g. a missing custom chart type) are
+            // real failures even with --skip-space-create.
+            error.message.startsWith('Space ') &&
             skipSpaceCreate
         ) {
             GlobalState.log(
@@ -3131,28 +3136,29 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
                 ),
             );
             changes[`${type} skipped`] = (changes[`${type} skipped`] ?? 0) + 1;
-        } else {
-            changes[`${type} with errors`] =
-                (changes[`${type} with errors`] ?? 0) + 1;
-            GlobalState.log(
-                styles.error(
-                    `Error upserting ${type}:\n\t"${item.name}" (slug: "${
-                        item.slug
-                    }")\n\t${getErrorMessage(error)}`,
-                ),
-            );
-
-            await LightdashAnalytics.track({
-                event: 'download.error',
-                properties: {
-                    userId: config.user?.userUuid,
-                    organizationId: config.user?.organizationUuid,
-                    projectId,
-                    type,
-                    error: getErrorMessage(error),
-                },
-            });
+            return 'skipped';
         }
+        changes[`${type} with errors`] =
+            (changes[`${type} with errors`] ?? 0) + 1;
+        GlobalState.log(
+            styles.error(
+                `Error upserting ${type}:\n\t"${item.name}" (slug: "${
+                    item.slug
+                }")\n\t${getErrorMessage(error)}`,
+            ),
+        );
+
+        await LightdashAnalytics.track({
+            event: 'download.error',
+            properties: {
+                userId: config.user?.userUuid,
+                organizationId: config.user?.organizationUuid,
+                projectId,
+                type,
+                error: getErrorMessage(error),
+            },
+        });
+        return 'failed';
     }
 };
 
@@ -3174,7 +3180,12 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
     concurrency: number = 1,
     extraItems: (T & { needsUpdating: boolean })[] = [],
     spaceNames?: Record<string, string>,
-): Promise<{ changes: Record<string, number>; total: number }> => {
+    skipSlugs?: ReadonlySet<string>,
+): Promise<{
+    changes: Record<string, number>;
+    total: number;
+    failedSlugs: string[];
+}> => {
     const config = await getConfig();
 
     const folderItems = await readCodeFiles<T>(type, customPath);
@@ -3208,14 +3219,42 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 `Error uploading ${type}: the ${requiredPermission} permission is required`,
             ),
         );
-        return { changes, total: filteredItems.length };
+        return { changes, total: filteredItems.length, failedSlugs: [] };
     }
+
+    // Items whose dependencies failed earlier in the upload are held back so
+    // they are not created in a broken state (e.g. dashboards with null
+    // chart tiles).
+    const uploadableItems = skipSlugs
+        ? filteredItems.filter((item) => !skipSlugs.has(item.slug))
+        : filteredItems;
+    filteredItems
+        .filter((item) => !uploadableItems.includes(item))
+        .forEach((item) => {
+            changes[`${type} dependency skipped`] =
+                (changes[`${type} dependency skipped`] ?? 0) + 1;
+            GlobalState.log(
+                styles.warning(
+                    `Skipped ${type.slice(0, -1)} "${item.slug}" because a chart it references failed to upload`,
+                ),
+            );
+        });
+
+    const failedSlugs: string[] = [];
+    const trackOutcome = (
+        item: T & { needsUpdating: boolean },
+        outcome: 'upserted' | 'skipped' | 'failed',
+    ) => {
+        if (outcome === 'failed') {
+            failedSlugs.push(item.slug);
+        }
+    };
 
     if (concurrency <= 1) {
         // Sequential path — preserves original behavior exactly
-        for (const item of filteredItems) {
+        for (const item of uploadableItems) {
             // eslint-disable-next-line no-await-in-loop
-            await upsertSingleItem(
+            const outcome = await upsertSingleItem(
                 item,
                 type,
                 projectId,
@@ -3227,6 +3266,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 validate,
                 spaceNames,
             );
+            trackOutcome(item, outcome);
         }
     } else {
         // Two-phase parallel path
@@ -3235,7 +3275,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
         // and in placeholder dashboard creation for charts within dashboards.
         type ItemWithUpdate = T & { needsUpdating: boolean };
         const grouped = groupBy(
-            filteredItems,
+            uploadableItems,
             (item: ItemWithUpdate) => item.spaceSlug,
         ) as Record<string, ItemWithUpdate[]>;
         const seedItems = new Set<T & { needsUpdating: boolean }>();
@@ -3297,7 +3337,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
         // Phase 1: Sequential seeding (spaces + dashboard placeholders)
         for (const item of seedItems) {
             // eslint-disable-next-line no-await-in-loop
-            await upsertSingleItem(
+            const outcome = await upsertSingleItem(
                 item,
                 type,
                 projectId,
@@ -3309,6 +3349,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 validate,
                 spaceNames,
             );
+            trackOutcome(item, outcome);
         }
 
         // Phase 2: Parallel bulk upload of remaining items
@@ -3316,7 +3357,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
         await Promise.all(
             remainingItems.map((item) =>
                 limit(async () => {
-                    await upsertSingleItem(
+                    const outcome = await upsertSingleItem(
                         item,
                         type,
                         projectId,
@@ -3328,12 +3369,13 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                         validate,
                         spaceNames,
                     );
+                    trackOutcome(item, outcome);
                 }),
             ),
         );
     }
 
-    return { changes, total: filteredItems.length };
+    return { changes, total: filteredItems.length, failedSlugs };
 };
 
 // readCodeFiles walks the whole download folder recursively, so callers that
@@ -4357,6 +4399,11 @@ export const uploadHandler = async (
             }
         }
 
+        // Chart slugs that failed to upload in the Charts phase; dashboards
+        // referencing them are held back so they are not created with broken
+        // (null chart) tiles.
+        const failedChartSlugs = new Set<string>();
+
         changes = await runUploadChangesPhase({
             output,
             label: 'Charts',
@@ -4394,6 +4441,9 @@ export const uploadHandler = async (
                     looseFiles.charts,
                     spaceNames,
                 );
+                result.failedSlugs.forEach((slug) =>
+                    failedChartSlugs.add(slug),
+                );
                 counts.chartsNum = result.total;
                 return result.changes;
             },
@@ -4412,6 +4462,24 @@ export const uploadHandler = async (
                     );
                     return changes;
                 }
+                let dashboardsToSkip: Set<string> | undefined;
+                if (failedChartSlugs.size > 0) {
+                    dashboardsToSkip = new Set(
+                        (await loadDashboardItems())
+                            .filter((dashboard) =>
+                                dashboard.tiles.some(
+                                    (tile) =>
+                                        'chartSlug' in tile.properties &&
+                                        typeof tile.properties.chartSlug ===
+                                            'string' &&
+                                        failedChartSlugs.has(
+                                            tile.properties.chartSlug,
+                                        ),
+                                ),
+                            )
+                            .map((dashboard) => dashboard.slug),
+                    );
+                }
                 const result = await upsertResources<DashboardAsCode>(
                     'dashboards',
                     projectId,
@@ -4426,6 +4494,7 @@ export const uploadHandler = async (
                     concurrency,
                     looseFiles.dashboards,
                     spaceNames,
+                    dashboardsToSkip,
                 );
                 counts.dashboardsNum = result.total;
                 return result.changes;

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -4276,6 +4276,7 @@ export const uploadHandler = async (
             if (uploadFilter) {
                 const unmatchedWarning = unmatchedUploadRefsWarning(
                     [...uploadFilter].filter((ref) => !matchedRefs.has(ref)),
+                    phase.noun,
                 );
                 if (unmatchedWarning) {
                     GlobalState.log(styles.warning(unmatchedWarning));

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -1967,6 +1967,9 @@ export const downloadHandler = async (
     const projectName = generateSlug(project.name);
 
     const counts: ProjectContentAsCodeCounts = {};
+    // Per-resource app/chart-type failures are reported inline and tallied
+    // here so the process can exit non-zero without aborting the download.
+    let downloadFailures = 0;
     const start = Date.now();
 
     await LightdashAnalytics.track({
@@ -2495,6 +2498,7 @@ export const downloadHandler = async (
                     skippedNotBuiltCount + skippedWrongKindCount,
                 );
                 counts.appsNum = successCount;
+                downloadFailures += failures.length;
                 output.completeItem(
                     `${successCount} downloaded${
                         skippedNotBuiltCount + skippedWrongKindCount > 0
@@ -2654,6 +2658,7 @@ export const downloadHandler = async (
                     'custom chart type',
                 );
                 counts.chartTypesNum = chartTypesOutcome.successCount;
+                downloadFailures += chartTypesOutcome.failures.length;
                 const chartTypesSkipped =
                     chartTypesOutcome.skippedNotBuiltCount +
                     chartTypesOutcome.skippedWrongKindCount;
@@ -2720,6 +2725,7 @@ export const downloadHandler = async (
                 linkedSkipped,
             );
             counts.appsNum = (counts.appsNum ?? 0) + outcome.successCount;
+            downloadFailures += outcome.failures.length;
             output.completeItem(
                 `${outcome.successCount} downloaded${
                     linkedSkipped > 0 ? `, ${linkedSkipped} skipped` : ''
@@ -2789,6 +2795,7 @@ export const downloadHandler = async (
             counts.chartTypesNum =
                 (counts.chartTypesNum ?? 0) +
                 linkedChartTypesOutcome.successCount;
+            downloadFailures += linkedChartTypesOutcome.failures.length;
             output.completeItem(
                 `${linkedChartTypesOutcome.successCount} downloaded${
                     linkedChartTypesSkipped > 0
@@ -2841,6 +2848,14 @@ export const downloadHandler = async (
             GlobalState.log(
                 styles.success(`Downloaded content saved to ${downloadRoot}`),
             );
+        }
+        if (downloadFailures > 0) {
+            GlobalState.log(
+                styles.error(
+                    `${downloadFailures} resource(s) failed to download — see errors above.`,
+                ),
+            );
+            process.exitCode = 1;
         }
 
         await LightdashAnalytics.track({
@@ -2948,6 +2963,13 @@ const summarizeUploadChanges = (
     );
     return { detail, variant: hasFailures ? 'warning' : undefined };
 };
+
+const hasUploadFailures = (changes: Record<string, number>): boolean =>
+    Object.entries(changes).some(
+        ([key, value]) =>
+            value > 0 &&
+            (key.endsWith('with errors') || key.endsWith('failed')),
+    );
 
 const runUploadChangesPhase = async ({
     output,
@@ -3570,6 +3592,14 @@ export const uploadHandler = async (
             GlobalState.log(
                 styles.success(`Uploaded content from ${uploadRoot}`),
             );
+        }
+        if (hasUploadFailures(changes)) {
+            GlobalState.log(
+                styles.error(
+                    'Upload completed with failures — see errors above.',
+                ),
+            );
+            process.exitCode = 1;
         }
     };
 

--- a/packages/cli/src/handlers/metadataFile.test.ts
+++ b/packages/cli/src/handlers/metadataFile.test.ts
@@ -1,0 +1,57 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    METADATA_FILENAME,
+    readMetadataFile,
+    writeMetadataFile,
+} from './metadataFile';
+
+describe('writeMetadataFile', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ld-metadata-'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('creates the output root when it does not exist yet', async () => {
+        const baseDir = path.join(tmpDir, 'brand-new-dir');
+
+        await writeMetadataFile(baseDir, {
+            version: 1,
+            charts: {},
+            dashboards: {},
+        });
+
+        const written = JSON.parse(
+            await fs.readFile(path.join(baseDir, METADATA_FILENAME), 'utf-8'),
+        );
+        expect(written).toEqual({ version: 1, charts: {}, dashboards: {} });
+    });
+
+    it('merges with existing metadata', async () => {
+        await writeMetadataFile(tmpDir, {
+            version: 1,
+            charts: { 'chart-a': '2026-01-01T00:00:00Z' },
+            dashboards: {},
+        });
+        await writeMetadataFile(tmpDir, {
+            version: 1,
+            charts: { 'chart-b': '2026-02-02T00:00:00Z' },
+            dashboards: { 'dash-a': '2026-02-02T00:00:00Z' },
+        });
+
+        expect(await readMetadataFile(tmpDir)).toEqual({
+            version: 1,
+            charts: {
+                'chart-a': '2026-01-01T00:00:00Z',
+                'chart-b': '2026-02-02T00:00:00Z',
+            },
+            dashboards: { 'dash-a': '2026-02-02T00:00:00Z' },
+        });
+    });
+});

--- a/packages/cli/src/handlers/metadataFile.ts
+++ b/packages/cli/src/handlers/metadataFile.ts
@@ -38,5 +38,8 @@ export const writeMetadataFile = async (
         dashboards: { ...existing.dashboards, ...metadata.dashboards },
     };
     const filePath = path.join(baseDir, METADATA_FILENAME);
+    // An all-skipped download creates no bundle folders, so the output root
+    // may not exist yet when the metadata file is written.
+    await fs.mkdir(baseDir, { recursive: true });
     await fs.writeFile(filePath, JSON.stringify(merged, null, 2));
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -57,6 +57,7 @@ import { sqlHandler } from './handlers/sql';
 import { registerUpgradeCheckCommand } from './handlers/upgradeCheck';
 import { validateHandler } from './handlers/validate';
 import { warehouseCatalogHandler } from './handlers/warehouseCatalog';
+import { parseRefsArgument } from './refsArgument';
 import * as styles from './styles';
 // Trigger CLI tests
 // Suppress AWS SDK V2 warning, imported by snowflake SDK
@@ -839,38 +840,54 @@ const downloadCommand = program
     .option(
         '-c, --charts <charts...>',
         'specify chart slugs, uuids, or urls to download',
+        parseRefsArgument,
         [],
     )
     .option(
         '-d, --dashboards <dashboards...>',
         'specify dashboard slugs, uuids or urls to download',
+        parseRefsArgument,
         [],
     )
-    .option('--agents <slugs...>', 'specify AI agent slugs to download', [])
+    .option(
+        '--agents <slugs...>',
+        'specify AI agent slugs to download',
+        parseRefsArgument,
+        [],
+    )
     .option(
         '--include-agents',
         "include all of the project's AI agents (enterprise)",
         false,
     )
-    .option('--alerts <slugs...>', 'specify alert slugs to download', [])
+    .option(
+        '--alerts <slugs...>',
+        'specify alert slugs to download',
+        parseRefsArgument,
+        [],
+    )
     .option(
         '--virtual-views <slugs...>',
         'specify virtual view slugs to download',
+        parseRefsArgument,
         [],
     )
     .option(
         '--google-sheets <slugs...>',
         'specify Google Sheets sync slugs to download',
+        parseRefsArgument,
         [],
     )
     .option(
         '--scheduled-deliveries <slugs...>',
         'specify scheduled delivery slugs to download',
+        parseRefsArgument,
         [],
     )
     .option(
         '--external-connections <slugs...>',
         'specify external connection slugs to download (enterprise)',
+        parseRefsArgument,
         [],
     )
     .option(
@@ -945,6 +962,7 @@ const downloadCommand = program
     .option(
         '--apps <appReferences...>',
         'Download only the specified data apps, by slug, app URL, or UUID (enterprise). Works for apps not added to a space.',
+        parseRefsArgument,
     )
     .option(
         '--include-apps',
@@ -964,6 +982,7 @@ const downloadCommand = program
     .option(
         '--chart-types <chartTypeReferences...>',
         'Download only the specified custom chart types, by slug, URL, or UUID (enterprise).',
+        parseRefsArgument,
     )
     .option(
         '--include-chart-types',
@@ -995,33 +1014,49 @@ const uploadCommand = program
     .option(
         '-c, --charts <charts...>',
         'specify chart slugs to force upload',
+        parseRefsArgument,
         [],
     )
     .option(
         '-d, --dashboards <dashboards...>',
         'specify dashboard slugs to force upload',
+        parseRefsArgument,
         [],
     )
-    .option('--agents <slugs...>', 'specify AI agent slugs to upload', [])
-    .option('--alerts <slugs...>', 'specify alert slugs to upload', [])
+    .option(
+        '--agents <slugs...>',
+        'specify AI agent slugs to upload',
+        parseRefsArgument,
+        [],
+    )
+    .option(
+        '--alerts <slugs...>',
+        'specify alert slugs to upload',
+        parseRefsArgument,
+        [],
+    )
     .option(
         '--virtual-views <slugs...>',
         'specify virtual view slugs to upload',
+        parseRefsArgument,
         [],
     )
     .option(
         '--google-sheets <slugs...>',
         'specify Google Sheets sync slugs to upload',
+        parseRefsArgument,
         [],
     )
     .option(
         '--scheduled-deliveries <slugs...>',
         'specify scheduled delivery slugs to upload',
+        parseRefsArgument,
         [],
     )
     .option(
         '--external-connections <slugs...>',
         'specify external connection slugs to upload (enterprise)',
+        parseRefsArgument,
         [],
     )
     .option(
@@ -1091,6 +1126,7 @@ const uploadCommand = program
     .option(
         '--apps <appReferences...>',
         'Upload only the specified data apps, by slug (the app folder name), app URL, or UUID (enterprise). URL and UUID refs are resolved against the target project.',
+        parseRefsArgument,
     )
     .option(
         '--include-apps',
@@ -1105,6 +1141,7 @@ const uploadCommand = program
     .option(
         '--chart-types <chartTypeReferences...>',
         'Upload only the specified custom chart types, by slug (the chart type folder name), URL, or UUID (enterprise). URL and UUID refs are resolved against the target project.',
+        parseRefsArgument,
     )
     .option(
         '--include-chart-types',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2108,7 +2108,9 @@ const successHandler = () => {
         process.exit(0);
     }
     console.error(`Done 🕶`);
-    process.exit(0);
+    // Handlers report partial failures (e.g. some uploads failed) via
+    // process.exitCode; an unconditional exit(0) would wipe it.
+    process.exit(process.exitCode ?? 0);
 };
 
 program.parseAsync().then(successHandler).catch(errorHandler);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1239,7 +1239,7 @@ appsProgram
 appsProgram
     .command('validate [paths...]')
     .description(
-        'Validate data app source, manifests, dependencies, and semantic-layer references locally.',
+        'Validate data app and custom chart type source, manifests, dependencies, and semantic-layer references locally.',
     )
     .option(
         '--live',

--- a/packages/cli/src/refsArgument.test.ts
+++ b/packages/cli/src/refsArgument.test.ts
@@ -1,0 +1,54 @@
+import { Command } from 'commander';
+import { parseRefsArgument } from './refsArgument';
+
+const buildCommand = () => {
+    const command = new Command('upload')
+        .exitOverride()
+        .configureOutput({ writeErr: () => {} })
+        .option('--force', 'force upload', false)
+        .option('-c, --charts <charts...>', 'chart refs', parseRefsArgument, [])
+        .option(
+            '--chart-types <chartTypeReferences...>',
+            'chart type refs',
+            parseRefsArgument,
+        );
+    return command;
+};
+
+describe('parseRefsArgument', () => {
+    it('rejects a bare flag followed by another option', () => {
+        const command = buildCommand();
+        expect(() =>
+            command.parse(['--chart-types', '--force'], { from: 'user' }),
+        ).toThrow(/argument '--force' is invalid/);
+    });
+
+    it('does not consume the following boolean flag as a value', () => {
+        const command = buildCommand();
+        command.parse(['--chart-types', 'one', 'two', '--force'], {
+            from: 'user',
+        });
+        expect(command.opts().chartTypes).toEqual(['one', 'two']);
+        expect(command.opts().force).toBe(true);
+    });
+
+    it('rejects option-like values on options with array defaults', () => {
+        const command = buildCommand();
+        expect(() =>
+            command.parse(['--charts', '--force'], { from: 'user' }),
+        ).toThrow(/argument '--force' is invalid/);
+    });
+
+    it('accumulates values onto the default array', () => {
+        const command = buildCommand();
+        command.parse(['-c', 'a', '-c', 'b'], { from: 'user' });
+        expect(command.opts().charts).toEqual(['a', 'b']);
+    });
+
+    it('leaves unset options at their defaults', () => {
+        const command = buildCommand();
+        command.parse([], { from: 'user' });
+        expect(command.opts().charts).toEqual([]);
+        expect(command.opts().chartTypes).toBeUndefined();
+    });
+});

--- a/packages/cli/src/refsArgument.ts
+++ b/packages/cli/src/refsArgument.ts
@@ -1,0 +1,19 @@
+import { InvalidArgumentError } from 'commander';
+
+/**
+ * Coercion for variadic reference options (--charts, --chart-types, --apps, ...).
+ * Commander's required-value parsing consumes the next argv token even when it
+ * is another option (e.g. `--chart-types --force` reads "--force" as a ref),
+ * so reject option-like values with a clear missing-value error.
+ */
+export function parseRefsArgument(
+    value: string,
+    previous: string[] = [],
+): string[] {
+    if (value.startsWith('-')) {
+        throw new InvalidArgumentError(
+            'Expected a reference value but got another option. Pass one or more references after this flag, or use the matching --include-* flag to select all.',
+        );
+    }
+    return [...previous, value];
+}


### PR DESCRIPTION
## Problem

`upload --dashboards X --include-charts` kept going after a dependent chart failed (e.g. its custom chart type is missing in the target): the dashboard phase ran anyway and created a dashboard whose tile has `chartSlug: null` — a permanently broken tile that survives round-tripping.

## Fix

**CLI** — the Charts phase now reports which slugs failed (`upsertSingleItem` returns a per-item outcome, `upsertResources` collects failures), and the Dashboards phase skips any dashboard whose tiles reference a failed chart. Skips are recorded as `dashboards dependency skipped` (the suffix already renders in the summary) with a per-dashboard warning — mirroring the existing spaces-phase dependency gate. Combined with the exit-code fix below in the stack, such uploads exit non-zero via the chart errors.

Also narrowed the `--skip-space-create` catch: previously any `NotFoundError` was classified as a missing-space skip, so a missing chart type with `--skip-space-create` would have been silently miscounted as skipped. It now only matches the backend's actual missing-space error.

**Backend** — `convertTileWithSlugsToUuids` now pushes a warning when a chart tile's slug does not resolve in the project (parity with the existing data-app tile warning), so non-CLI callers of the dashboard upsert see the problem too.

## Verification (live)

Dashboard whose linked chart references a missing chart type, uploaded with `--include-charts --force`:
- chart fails with the missing-chart-type error, the four healthy sibling charts still upload
- `Skipped dashboard "<slug>" because a chart it references failed to upload`, `Dashboards: 1 dependency skipped`
- dashboard version count unchanged (no broken dashboard written), exit 1

New backend test: unresolved chart tile slug → warning + `savedChartUuid: null`.

Closes: PROD-10617

🤖 Generated with [Claude Code](https://claude.com/claude-code)