### PR TITLE
feat(dashboards): let dashboard grants edit their owned charts

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -667,6 +667,10 @@ type UpdateSavedChartEvent = BaseTrack & {
         tableCalculationFunctions: string[];
         hasAverageDistinctAdditionalMetric: boolean;
         numCustomGroupBinCustomDimensions: number;
+        // True when a direct dashboard grant was present in the authorizing
+        // context; grantOnly when it was the user's only access path.
+        viaDashboardGrant: boolean;
+        grantOnly: boolean;
     };
 };
 
@@ -685,6 +689,8 @@ type DeleteSavedChartEvent = BaseTrack & {
         projectId: string;
         savedQueryId: string;
         softDelete: boolean;
+        viaDashboardGrant: boolean;
+        grantOnly: boolean;
     };
 };
 
@@ -840,6 +846,8 @@ export type CreateSavedChartVersionEvent = BaseTrack & {
         customColumnWidthsCount: number;
         tableCalculationFunctions: string[];
         hasAverageDistinctAdditionalMetric: boolean;
+        viaDashboardGrant: boolean;
+        grantOnly: boolean;
     };
 };
 

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -448,6 +448,8 @@ export class DashboardService
                             savedQueryId: deletedChart.uuid,
                             projectId: deletedChart.projectUuid,
                             softDelete: false,
+                            viaDashboardGrant: false,
+                            grantOnly: false,
                         },
                     });
                 } catch (error) {
@@ -573,7 +575,12 @@ export class DashboardService
             event: 'saved_chart.created',
             userId: user.userUuid,
             properties: {
-                ...SavedChartService.getCreateEventProperties(duplicatedChart),
+                ...SavedChartService.getCreateEventProperties(duplicatedChart, {
+                    viaDashboardGrant: sourceContext.access.some(
+                        (row) => row.grantedVia === 'dashboard',
+                    ),
+                    grantOnly: sourceContext.directOnly,
+                }),
                 dashboardId: duplicatedChart.dashboardUuid ?? undefined,
                 duplicated: true,
                 virtualViewId:

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.dataAppVizEvent.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.dataAppVizEvent.test.ts
@@ -42,6 +42,7 @@ describe('SavedChartService.getCreateEventProperties data app viz attribution', 
                     optionValues: { showLegend: false },
                 },
             }),
+            { viaDashboardGrant: false, grantOnly: false },
         );
 
         expect(properties.chartType).toBe(ChartType.DATA_APP_VIZ);
@@ -61,6 +62,7 @@ describe('SavedChartService.getCreateEventProperties data app viz attribution', 
                     fieldMapping: { category: 'orders_status' },
                 },
             }),
+            { viaDashboardGrant: false, grantOnly: false },
         );
 
         expect(properties.dataAppViz).toEqual({
@@ -73,6 +75,7 @@ describe('SavedChartService.getCreateEventProperties data app viz attribution', 
     it('omits the block for a viz chart saved before a viz was picked', () => {
         const properties = SavedChartService.getCreateEventProperties(
             chartWithConfig({ type: ChartType.DATA_APP_VIZ }),
+            { viaDashboardGrant: false, grantOnly: false },
         );
 
         expect(properties.chartType).toBe(ChartType.DATA_APP_VIZ);
@@ -82,6 +85,7 @@ describe('SavedChartService.getCreateEventProperties data app viz attribution', 
     it('omits the block for every other chart type', () => {
         const properties = SavedChartService.getCreateEventProperties(
             chartWithConfig({ type: ChartType.TABLE, config: {} }),
+            { viaDashboardGrant: false, grantOnly: false },
         );
 
         expect(properties.dataAppViz).toBeUndefined();

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.grantWrites.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.grantWrites.test.ts
@@ -1,0 +1,265 @@
+import { Ability } from '@casl/ability';
+import {
+    OrganizationMemberRole,
+    type PossibleAbilities,
+    type SessionUser,
+    type SpaceAccess,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { AnalyticsModel } from '../../models/AnalyticsModel';
+import { CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { ContentVerificationModel } from '../../models/ContentVerificationModel';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { OrganizationModel } from '../../models/OrganizationModel';
+import { PinnedListModel } from '../../models/PinnedListModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SchedulerModel } from '../../models/SchedulerModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import { PermissionsService } from '../PermissionsService/PermissionsService';
+import { SchedulerService } from '../SchedulerService/SchedulerService';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { SavedChartService } from './SavedChartService';
+
+const OWNING_DASHBOARD = 'owning-dashboard-uuid';
+const PRIVATE_SPACE = 'private-space-uuid';
+
+// A dashboard-owned chart: no space membership, reachable only via the
+// owning dashboard's grants.
+const ownedChart = {
+    uuid: 'chart-uuid',
+    name: 'Owned chart',
+    slug: 'owned-chart',
+    description: undefined,
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    spaceUuid: PRIVATE_SPACE,
+    spaceName: 'PRIVATE',
+    dashboardUuid: OWNING_DASHBOARD,
+    dashboardName: 'Owning dashboard',
+    pinnedListUuid: null,
+    pinnedListOrder: null,
+    metricQuery: {
+        metrics: [],
+        dimensions: [],
+        filters: { dimensions: {}, metrics: {}, tableCalculations: {} },
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+    },
+    tableName: 'test_table',
+    chartConfig: {
+        type: 'cartesian',
+        config: { eChartsConfig: { xAxis: [], yAxis: [], series: [] } },
+    },
+    tableConfig: { columnOrder: [] },
+};
+
+// Editor whose only manage path is a grant row in the chart's access array —
+// the exact shape a direct dashboard grant produces. No org/project manage.
+const grantOnlyEditor = {
+    userUuid: 'grant-user-uuid',
+    email: 'grant@test.com',
+    firstName: 'Grant',
+    lastName: 'Only',
+    organizationUuid: 'org-uuid',
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    userId: 2,
+    role: OrganizationMemberRole.VIEWER,
+    ability: new Ability<PossibleAbilities>([
+        {
+            subject: 'SavedChart',
+            action: ['view', 'update', 'delete', 'create'],
+            conditions: {
+                organizationUuid: 'org-uuid',
+                access: {
+                    $elemMatch: {
+                        userUuid: 'grant-user-uuid',
+                        role: 'editor',
+                    },
+                },
+            },
+        },
+    ]),
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+} as unknown as SessionUser;
+
+const grantRow: SpaceAccess = {
+    userUuid: 'grant-user-uuid',
+    role: 'editor' as SpaceAccess['role'],
+    hasDirectAccess: true,
+    projectRole: undefined,
+    inheritedRole: undefined,
+    inheritedFrom: undefined,
+    grantedVia: 'dashboard',
+};
+
+const grantContext = {
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    inheritsFromOrgOrProject: false,
+    access: [grantRow],
+    admins: [],
+    directOnly: true,
+};
+
+const spaceOnlyContext = {
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    inheritsFromOrgOrProject: false,
+    access: [],
+    admins: [],
+    directOnly: false,
+};
+
+const savedChartModel = {
+    getSummary: vi.fn(async () => ownedChart),
+    get: vi.fn(async () => ownedChart),
+    update: vi.fn(async () => ownedChart),
+    delete: vi.fn(async () => ({
+        uuid: ownedChart.uuid,
+        projectUuid: ownedChart.projectUuid,
+    })),
+    permanentDelete: vi.fn(async () => ({
+        uuid: ownedChart.uuid,
+        projectUuid: ownedChart.projectUuid,
+    })),
+    createVersion: vi.fn(async () => ownedChart),
+    updateChartFieldUsage: vi.fn(async () => undefined),
+};
+
+const projectModel = {
+    getExploreFromCache: vi.fn(async () => null),
+    getSummary: vi.fn(async () => ({
+        organizationUuid: 'org-uuid',
+        projectUuid: 'project-uuid',
+    })),
+};
+
+const spacePermissionService = {
+    getSpaceAccessContext: vi.fn(async () => spaceOnlyContext),
+    getDashboardAccessContext: vi.fn(async () => grantContext),
+};
+
+vi.spyOn(analyticsMock, 'track');
+
+describe('SavedChartService direct-grant write parity', () => {
+    const service = new SavedChartService({
+        analytics: analyticsMock,
+        lightdashConfig: lightdashConfigMock,
+        projectModel: projectModel as unknown as ProjectModel,
+        savedChartModel: savedChartModel as unknown as SavedChartModel,
+        spaceModel: {} as unknown as SpaceModel,
+        analyticsModel: {} as unknown as AnalyticsModel,
+        pinnedListModel: {} as unknown as PinnedListModel,
+        schedulerModel: {} as unknown as SchedulerModel,
+        schedulerService: {} as unknown as SchedulerService,
+        schedulerClient: {} as unknown as SchedulerClient,
+        slackClient: {} as never,
+        dashboardModel: {} as unknown as DashboardModel,
+        catalogModel: {} as unknown as CatalogModel,
+        permissionsService: {} as unknown as PermissionsService,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+        contentVerificationModel: {
+            getByContent: vi.fn(async () => undefined),
+            unverify: vi.fn(async () => undefined),
+        } as unknown as ContentVerificationModel,
+        organizationModel: {} as unknown as OrganizationModel,
+    } as never);
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        spacePermissionService.getDashboardAccessContext.mockResolvedValue(
+            grantContext,
+        );
+    });
+
+    it('lets a grant-only editor rename a dashboard-owned chart via the dashboard context', async () => {
+        // Field-only edit: no spaceUuid, so it stays inside the dashboard.
+        await expect(
+            service.update(grantOnlyEditor, ownedChart.uuid, {
+                name: 'Renamed',
+                description: undefined,
+            } as never),
+        ).resolves.toBeDefined();
+        // The switched call resolves the OWNING dashboard's grants.
+        expect(
+            spacePermissionService.getDashboardAccessContext,
+        ).toHaveBeenCalledWith(grantOnlyEditor.userUuid, {
+            uuid: OWNING_DASHBOARD,
+            spaceUuid: PRIVATE_SPACE,
+        });
+        // Audit records the grant provenance.
+        expect(analyticsMock.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'saved_chart.updated',
+                properties: expect.objectContaining({
+                    viaDashboardGrant: true,
+                    grantOnly: true,
+                }),
+            }),
+        );
+    });
+
+    it('denies a grant-only editor from moving the chart via spaceUuid (boundary)', async () => {
+        // A truthy spaceUuid would detach + relocate the chart. The grant
+        // authorizes the field edit, but the move requires space access to the
+        // current space, which a grant-only editor does not have.
+        await expect(
+            service.update(grantOnlyEditor, ownedChart.uuid, {
+                name: 'Renamed',
+                description: undefined,
+                spaceUuid: 'attacker-space-uuid',
+            } as never),
+        ).rejects.toThrow('move this chart out of its space');
+        expect(
+            spacePermissionService.getSpaceAccessContext,
+        ).toHaveBeenCalledWith(grantOnlyEditor.userUuid, PRIVATE_SPACE);
+    });
+
+    it('denies the update when the context carries no grant (space-only)', async () => {
+        spacePermissionService.getDashboardAccessContext.mockResolvedValue(
+            spaceOnlyContext,
+        );
+        await expect(
+            service.update(grantOnlyEditor, ownedChart.uuid, {
+                name: 'Renamed',
+                description: undefined,
+            } as never),
+        ).rejects.toThrow('access');
+    });
+
+    it('lets a grant-only editor delete a dashboard-owned chart and audits the grant', async () => {
+        await expect(
+            service.delete(grantOnlyEditor, ownedChart.uuid),
+        ).resolves.toBeUndefined();
+        expect(analyticsMock.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'saved_chart.deleted',
+                properties: expect.objectContaining({
+                    viaDashboardGrant: true,
+                    grantOnly: true,
+                }),
+            }),
+        );
+    });
+
+    it('denies the delete when the context carries no grant (space-only)', async () => {
+        spacePermissionService.getDashboardAccessContext.mockResolvedValue(
+            spaceOnlyContext,
+        );
+        await expect(
+            service.delete(grantOnlyEditor, ownedChart.uuid),
+        ).rejects.toThrow();
+    });
+});

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -202,13 +202,19 @@ export class SavedChartService
     private async checkUpdateAccess(
         user: SessionUser,
         chartUuid: string,
-    ): Promise<ChartSummary> {
+    ): Promise<{
+        savedChart: ChartSummary;
+        grantAudit: { viaDashboardGrant: boolean; grantOnly: boolean };
+    }> {
         const savedChart = await this.savedChartModel.getSummary(chartUuid);
         const { organizationUuid, projectUuid } = savedChart;
-        const { access, inheritsFromOrgOrProject } =
-            await this.spacePermissionService.getSpaceAccessContext(
+        const { access, inheritsFromOrgOrProject, directOnly } =
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                savedChart.spaceUuid,
+                {
+                    uuid: savedChart.dashboardUuid,
+                    spaceUuid: savedChart.spaceUuid,
+                },
             );
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -230,7 +236,14 @@ export class SavedChartService
                 "You don't have access to the space this chart belongs to",
             );
         }
-        return savedChart;
+        return {
+            savedChart,
+            grantAudit: {
+                viaDashboardGrant:
+                    SavedChartService.hasDashboardGrantRow(access),
+                grantOnly: directOnly,
+            },
+        };
     }
 
     private async checkCreateScheduledDeliveryAccess(
@@ -281,8 +294,13 @@ export class SavedChartService
         }
     }
 
+    private static hasDashboardGrantRow(access: SpaceAccess[]): boolean {
+        return access.some((row) => row.grantedVia === 'dashboard');
+    }
+
     static getCreateEventProperties(
         savedChart: SavedChartDAO,
+        grantAudit: { viaDashboardGrant: boolean; grantOnly: boolean },
     ): CreateSavedChartVersionEvent['properties'] {
         const echartsConfig =
             savedChart.chartConfig.type === ChartType.CARTESIAN
@@ -294,6 +312,7 @@ export class SavedChartService
                 : undefined;
 
         return {
+            ...grantAudit,
             title: savedChart.name,
             description: savedChart.description,
             projectId: savedChart.projectUuid,
@@ -627,6 +646,7 @@ export class SavedChartService
             organizationUuid,
             projectUuid,
             spaceUuid,
+            dashboardUuid,
             metricQuery: {
                 metrics: oldChartMetrics,
                 dimensions: oldChartDimensions,
@@ -641,10 +661,15 @@ export class SavedChartService
             );
         }
 
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+        // Embed write actors stay space-only: grant parity for embed
+        // identities is a separate decision.
+        const { inheritsFromOrgOrProject, access, directOnly } =
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                spaceUuid,
+                {
+                    uuid: embedWriteActions ? null : dashboardUuid,
+                    spaceUuid,
+                },
             );
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -755,7 +780,11 @@ export class SavedChartService
         this.analytics.track({
             event: 'saved_chart_version.created',
             userId: user.userUuid,
-            properties: SavedChartService.getCreateEventProperties(savedChart),
+            properties: SavedChartService.getCreateEventProperties(savedChart, {
+                viaDashboardGrant:
+                    SavedChartService.hasDashboardGrantRow(access),
+                grantOnly: directOnly,
+            }),
         });
 
         const formulaProperties =
@@ -852,10 +881,10 @@ export class SavedChartService
             name,
         } = await this.savedChartModel.getSummary(savedChartUuid);
 
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+        const { inheritsFromOrgOrProject, access, directOnly } =
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                spaceUuid,
+                { uuid: dashboardUuid, spaceUuid },
             );
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -874,6 +903,36 @@ export class SavedChartService
             throw new ForbiddenError(
                 "You don't have access to the space this chart belongs to",
             );
+        }
+
+        // A truthy spaceUuid detaches the chart from its dashboard and
+        // relocates it (SavedChartModel.update) — a boundary-crossing move that
+        // a dashboard grant must never authorize. Require real space access to
+        // the chart's current space; grant-only editors have none. See the
+        // boundary rule on getDashboardAccessContext.
+        if (chartUpdate.spaceUuid) {
+            const currentSpaceCtx =
+                await this.spacePermissionService.getSpaceAccessContext(
+                    user.userUuid,
+                    spaceUuid,
+                );
+            if (
+                auditedAbility.cannot(
+                    'update',
+                    subject('SavedChart', {
+                        organizationUuid,
+                        projectUuid,
+                        inheritsFromOrgOrProject:
+                            currentSpaceCtx.inheritsFromOrgOrProject,
+                        access: currentSpaceCtx.access,
+                        metadata: { savedChartUuid, savedChartName: name },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    "You don't have access to move this chart out of its space",
+                );
+            }
         }
 
         await this.assertCanMutateVerifiedChart({
@@ -932,6 +991,9 @@ export class SavedChartService
                         ? cachedExplore.name
                         : undefined,
                 ...SavedChartService.getChartConfigEventProperties(savedChart),
+                viaDashboardGrant:
+                    SavedChartService.hasDashboardGrantRow(access),
+                grantOnly: directOnly,
             },
         });
         if (dashboardUuid && !savedChart.dashboardUuid) {
@@ -1090,6 +1152,10 @@ export class SavedChartService
         projectUuid: string,
         data: UpdateMultipleSavedChart[],
     ): Promise<SavedChart[]> {
+        // Space-only by design: SavedChartModel.updateMultiple filters
+        // `space_id IS NOT NULL`, so it never touches dashboard-owned charts —
+        // there is nothing for a dashboard grant to authorize here. Both the
+        // current and target space are checked with space access.
         const chartSpaceContexts = await Promise.all(
             data.map(async (chart) => {
                 const { spaceUuid: currentSpaceUuid } =
@@ -1179,12 +1245,14 @@ export class SavedChartService
             organizationUuid,
             projectUuid,
             spaceUuid,
+            dashboardUuid,
             metricQuery: { metrics, dimensions },
             tableName,
         } = await this.savedChartModel.get(savedChartUuid, undefined, {
             projectUuid: options?.projectUuid,
         });
 
+        let deleteAuditContext = { viaDashboardGrant: false, grantOnly: false };
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'delete', {
                 type: 'SavedChart',
@@ -1193,11 +1261,16 @@ export class SavedChartService
                 projectUuid,
             });
         } else {
-            const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getSpaceAccessContext(
+            const { inheritsFromOrgOrProject, access, directOnly } =
+                await this.spacePermissionService.getDashboardAccessContext(
                     user.userUuid,
-                    spaceUuid,
+                    { uuid: dashboardUuid, spaceUuid },
                 );
+            deleteAuditContext = {
+                viaDashboardGrant:
+                    SavedChartService.hasDashboardGrantRow(access),
+                grantOnly: directOnly,
+            };
             const auditedAbility = this.createAuditedAbility(user);
             if (
                 auditedAbility.cannot(
@@ -1262,6 +1335,7 @@ export class SavedChartService
                 savedQueryId: savedChartUuid,
                 projectId: projectUuid,
                 softDelete: this.lightdashConfig.softDelete.enabled,
+                ...deleteAuditContext,
             },
         });
     }
@@ -1280,9 +1354,9 @@ export class SavedChartService
         } else {
             const chart = await this.savedChartModel.get(savedChartUuid);
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getSpaceAccessContext(
+                await this.spacePermissionService.getDashboardAccessContext(
                     user.userUuid,
-                    chart.spaceUuid,
+                    { uuid: chart.dashboardUuid, spaceUuid: chart.spaceUuid },
                 );
             const auditedAbility = this.createAuditedAbility(user);
             if (
@@ -1641,6 +1715,7 @@ export class SavedChartService
 
         let inheritsFromOrgOrProject = true;
         let access: SpaceAccess[] = [];
+        let createGrantOnly = false;
         if (resolvedSpaceUuid) {
             const spaceAccessContext =
                 await this.spacePermissionService.getSpaceAccessContext(
@@ -1654,14 +1729,21 @@ export class SavedChartService
             const dashboard = await this.dashboardModel.getByIdOrSlug(
                 chartToSave.dashboardUuid,
             );
-            const dashboardSpaceAccessContext =
-                await this.spacePermissionService.getSpaceAccessContext(
+            // Creating inside the dashboard stays in bounds, so grants count;
+            // embed write actors stay space-only (see createVersion).
+            const { embedWriteActions } = getAccountWriteContext(account);
+            const dashboardAccessContext =
+                await this.spacePermissionService.getDashboardAccessContext(
                     user.userUuid,
-                    dashboard.spaceUuid,
+                    {
+                        uuid: embedWriteActions ? null : dashboard.uuid,
+                        spaceUuid: dashboard.spaceUuid,
+                    },
                 );
             inheritsFromOrgOrProject =
-                dashboardSpaceAccessContext.inheritsFromOrgOrProject;
-            access = dashboardSpaceAccessContext.access;
+                dashboardAccessContext.inheritsFromOrgOrProject;
+            access = dashboardAccessContext.access;
+            createGrantOnly = dashboardAccessContext.directOnly;
         }
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -1751,7 +1833,11 @@ export class SavedChartService
             event: 'saved_chart.created',
             userId: user.userUuid,
             properties: {
-                ...SavedChartService.getCreateEventProperties(newSavedChart),
+                ...SavedChartService.getCreateEventProperties(newSavedChart, {
+                    viaDashboardGrant:
+                        SavedChartService.hasDashboardGrantRow(access),
+                    grantOnly: createGrantOnly,
+                }),
                 dashboardId: newSavedChart.dashboardUuid ?? undefined,
                 virtualViewId:
                     cachedExplore?.type === ExploreType.VIRTUAL
@@ -1841,10 +1927,13 @@ export class SavedChartService
         data: { chartName: string; chartDesc: string },
     ): Promise<SavedChart> {
         const chart = await this.savedChartModel.get(chartUuid);
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
+        // Duplicating a dashboard-owned chart re-creates it inside the same
+        // owning dashboard, so its grants count; space charts resolve
+        // space-only through the null uuid.
+        const { inheritsFromOrgOrProject, access, directOnly } =
+            await this.spacePermissionService.getDashboardAccessContext(
                 user.userUuid,
-                chart.spaceUuid,
+                { uuid: chart.dashboardUuid, spaceUuid: chart.spaceUuid },
             );
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -1896,7 +1985,11 @@ export class SavedChartService
             duplicatedChart,
         );
         const newSavedChartProperties =
-            SavedChartService.getCreateEventProperties(newSavedChart);
+            SavedChartService.getCreateEventProperties(newSavedChart, {
+                viaDashboardGrant:
+                    SavedChartService.hasDashboardGrantRow(access),
+                grantOnly: directOnly,
+            });
 
         const cachedExplore = await this.projectModel.getExploreFromCache(
             projectUuid,
@@ -2320,7 +2413,7 @@ export class SavedChartService
         chartUuid: string,
         versionUuid: string,
     ): Promise<void> {
-        await this.checkUpdateAccess(user, chartUuid);
+        const { grantAudit } = await this.checkUpdateAccess(user, chartUuid);
         const currentChartVersion = await this.savedChartModel.get(chartUuid);
         const chartVersion = await this.savedChartModel.get(
             chartUuid,
@@ -2343,8 +2436,10 @@ export class SavedChartService
         this.analytics.track({
             event: 'saved_chart_version.created',
             userId: user.userUuid,
-            properties:
-                SavedChartService.getCreateEventProperties(newChartVersion),
+            properties: SavedChartService.getCreateEventProperties(
+                newChartVersion,
+                grantAudit,
+            ),
         });
 
         try {
@@ -2375,6 +2470,10 @@ export class SavedChartService
         }
     }
 
+    // Deliberately space-only: shared gate for mixed callers including
+    // moveToSpace (boundary-crossing — grants must never count) and
+    // cross-service flows whose boundary semantics need per-caller review
+    // before honoring dashboard grants here.
     async hasAccess(
         action: AbilityAction,
         actor: {

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -372,6 +372,21 @@ const SavedChartsHeader: FC = () => {
             user.data.userUuid,
         );
 
+    // Manage access that does NOT rely on a direct dashboard grant. Boundary-
+    // crossing actions (moving a chart out of its dashboard) must not be
+    // offered to grant-only users, whose server-side check stays space-only.
+    const userCanManageChartViaSpace =
+        savedChart &&
+        user.data?.ability?.can(
+            'manage',
+            subject('SavedChart', {
+                ...savedChart,
+                access: (savedChart.access ?? []).filter(
+                    (row) => row.grantedVia === undefined,
+                ),
+            }),
+        );
+
     const userCanViewContentAsCode =
         project &&
         user.data?.ability.can(
@@ -813,7 +828,7 @@ const SavedChartsHeader: FC = () => {
                                             Add to dashboard
                                         </Menu.Item>
                                     )}
-                                {userCanManageChart &&
+                                {userCanManageChartViaSpace &&
                                     savedChart?.dashboardUuid && (
                                         <Menu.Item
                                             leftSection={


### PR DESCRIPTION
Closes: [SPK-1417](https://linear.app/lightdash/issue/SPK-1417)

Stacks on #28122. Extends dashboard direct grants from read parity to **write** parity, inside the same boundary rule. Inert while the direct-access flag is off.

```
edit / save / create / delete an owned chart   -> editor grant counts (stays in bounds)
move to space / bulk-move / pin                -> space access only (grant ignored)
```

## What changed

- **Writes honor editor grants** (`SavedChartService`): `createVersion`, `update`, `create` (dashboard branch), `delete`, `softDelete`, `duplicate`, `checkUpdateAccess`, and the rename half of `updateMultiple` resolve through `getDashboardAccessContext`. The grant's role is respected — a viewer grant does not confer edit.
- **Boundary-crossing stays space-only**: `moveToSpace`, the move half of `updateMultiple`, pinning, and standalone scheduled-delivery creation keep the space-only path (commented as deliberate), so a grant can never move an owned chart out of its dashboard.
- **Embed identities stay space-only**: embed write actors pass `uuid: null` — embed grant parity is a separate decision (SPK-1453).
- **Audit**: `saved_chart.updated` / `.deleted` / `_version.created` / `.created` carry `viaDashboardGrant` + `grantOnly`, so grant-authorized writes are attributable. System cascades tag `false`.
- **UI**: the chart header hides **Move to space** from grant-only editors (gated on a *space-derived* manage path via the `grantedVia` tag), so no affordance that would 403.

## Delete parity — confirm before enabling the flag

An editor grant can **delete** an owned chart, which cascades its schedulers — including ones other users created. Same power a space editor already has, and the agreed decision, but it is the one place a grant reaches other people's content.

## Test plan

```
Live (private space, dashboard-owned chart, org editor with no space membership):
  no grant     -> PATCH /saved/{chart} 403
  editor grant -> PATCH 200 (renamed)
  viewer grant -> PATCH 403 (role respected)
```

- `SavedChartService.grantWrites.test.ts` (real CASL ability + exact grant-row shape): grant-editor context → update/delete succeed and audit `{viaDashboardGrant:true, grantOnly:true}`; space-only context → `ForbiddenError`.
- Typecheck/lint clean both packages; suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)