### PR TITLE
feat(dashboards): include grant-covered charts in dashboard filters

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -2629,7 +2629,10 @@ export class SavedChartModel {
     async getInfoForAvailableFilters(savedChartUuids: string[]): Promise<
         ({
             spaceUuid: Space['uuid'];
-        } & Pick<SavedChartDAO, 'uuid' | 'name' | 'tableName'> &
+        } & Pick<
+            SavedChartDAO,
+            'uuid' | 'name' | 'tableName' | 'dashboardUuid'
+        > &
             Pick<Project, 'projectUuid'> &
             Pick<Organization, 'organizationUuid'>)[]
     > {
@@ -2642,6 +2645,7 @@ export class SavedChartModel {
                 uuid: `${SavedChartsTableName}.saved_query_uuid`,
                 name: `${SavedChartsTableName}.name`,
                 spaceUuid: `${SpaceTableName}.space_uuid`,
+                dashboardUuid: `${SavedChartsTableName}.dashboard_uuid`,
                 tableName: `${SavedChartVersionsTableName}.explore_name`,
                 projectUuid: `${SavedChartsTableName}.project_uuid`,
                 organizationUuid: 'organizations.organization_uuid',

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -9730,9 +9730,12 @@ export class ProjectService extends BaseService {
                     ]);
 
                 const spaceCtx =
-                    await this.spacePermissionService.getSpaceAccessContext(
+                    await this.spacePermissionService.getDashboardAccessContext(
                         account.user.id,
-                        savedChart.spaceUuid,
+                        {
+                            uuid: savedChart.dashboardUuid,
+                            spaceUuid: savedChart.spaceUuid,
+                        },
                     );
 
                 const auditedAbility = this.createAuditedAbility(account);
@@ -9794,18 +9797,18 @@ export class ProjectService extends BaseService {
                     await this.savedChartModel.getInfoForAvailableFilters(
                         savedQueryUuids,
                     );
-                const uniqueSpaceUuids = [
-                    ...new Set(savedCharts.map((chart) => chart.spaceUuid)),
-                ];
 
                 if (savedCharts.length === 0) {
                     return [];
                 }
 
-                const [spacesCtx, exploresMap] = await Promise.all([
-                    this.spacePermissionService.getSpacesAccessContext(
+                const [chartContexts, exploresMap] = await Promise.all([
+                    this.spacePermissionService.getDashboardsAccessContext(
                         account.user.id,
-                        uniqueSpaceUuids,
+                        savedCharts.map((chart) => ({
+                            uuid: chart.dashboardUuid,
+                            spaceUuid: chart.spaceUuid,
+                        })),
                     ),
                     this.findExplores({
                         account,
@@ -9818,8 +9821,8 @@ export class ProjectService extends BaseService {
                 ]);
 
                 const chartsWithSpaceContext = savedCharts.flatMap(
-                    (savedChart) => {
-                        const spaceCtx = spacesCtx[savedChart.spaceUuid];
+                    (savedChart, index) => {
+                        const spaceCtx = chartContexts[index];
                         return spaceCtx ? [{ savedChart, spaceCtx }] : [];
                     },
                 );

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -1963,3 +1963,157 @@ describe('getDashboardAccessContext', () => {
         ).rejects.toThrow(ParameterError);
     });
 });
+
+describe('getDashboardsAccessContext', () => {
+    const baseContext: SpaceAccessContextForCasl = {
+        organizationUuid: 'organization-uuid',
+        projectUuid: 'project-uuid',
+        inheritsFromOrgOrProject: false,
+        access: [],
+        admins: [],
+    };
+
+    const createService = ({
+        enabled,
+        grants = {},
+        contexts,
+    }: {
+        enabled: boolean;
+        grants?: Record<string, unknown>;
+        contexts: Record<string, SpaceAccessContextForCasl>;
+    }) => {
+        const dashboardAccessModel = {
+            getUserAccess: vi.fn(async () => grants),
+        };
+        const directAccessFeatureGate = {
+            isEnabledForUser: vi.fn(async () => enabled),
+        };
+        const service = new SpacePermissionService({
+            spaceModel: {} as SpaceModel,
+            spacePermissionModel: {} as unknown as SpacePermissionModel,
+            dashboardAccessModel:
+                dashboardAccessModel as unknown as DashboardAccessModel,
+            directAccessFeatureGate:
+                directAccessFeatureGate as unknown as DirectAccessFeatureGate,
+        });
+        vi.spyOn(service, 'getSpacesAccessContext').mockResolvedValue(contexts);
+        return { service, dashboardAccessModel, directAccessFeatureGate };
+    };
+
+    test('null uuids return space-only contexts with no gate or grant lookup', async () => {
+        const { service, dashboardAccessModel, directAccessFeatureGate } =
+            createService({
+                enabled: true,
+                contexts: { 'space-a': baseContext },
+            });
+
+        const result = await service.getDashboardsAccessContext('user-uuid', [
+            { uuid: null, spaceUuid: 'space-a' },
+            { uuid: null, spaceUuid: 'space-a' },
+        ]);
+
+        expect(result).toEqual([
+            { ...baseContext, directOnly: false },
+            { ...baseContext, directOnly: false },
+        ]);
+        result.forEach((context) => {
+            if (context) expectNoGrantRows(context);
+        });
+        expect(directAccessFeatureGate.isEnabledForUser).not.toHaveBeenCalled();
+        expect(dashboardAccessModel.getUserAccess).not.toHaveBeenCalled();
+    });
+
+    test('feature off returns space-only for every ref without a grant lookup', async () => {
+        const { service, dashboardAccessModel } = createService({
+            enabled: false,
+            contexts: { 'space-a': baseContext },
+            grants: {
+                'dash-1': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    spaceUuid: 'space-a',
+                    userRole: SpaceMemberRole.EDITOR,
+                    groupRoles: [],
+                },
+            },
+        });
+
+        const result = await service.getDashboardsAccessContext('user-uuid', [
+            { uuid: 'dash-1', spaceUuid: 'space-a' },
+        ]);
+
+        expect(result[0]).toEqual({ ...baseContext, directOnly: false });
+        expect(dashboardAccessModel.getUserAccess).not.toHaveBeenCalled();
+    });
+
+    test('appends tagged grant rows per granted dashboard from one batched lookup, aligned with input order', async () => {
+        const { service, dashboardAccessModel } = createService({
+            enabled: true,
+            contexts: { 'space-a': baseContext, 'space-b': baseContext },
+            grants: {
+                'dash-1': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    spaceUuid: 'space-a',
+                    userRole: SpaceMemberRole.VIEWER,
+                    groupRoles: [],
+                },
+            },
+        });
+
+        const result = await service.getDashboardsAccessContext('user-uuid', [
+            { uuid: 'dash-2', spaceUuid: 'space-b' },
+            { uuid: 'dash-1', spaceUuid: 'space-a' },
+        ]);
+
+        // Order preserved: dash-2 (no grant) first, dash-1 (grant) second.
+        expect(result[0]).toEqual({ ...baseContext, directOnly: false });
+        expect(result[1]?.access).toEqual([
+            expect.objectContaining({
+                userUuid: 'user-uuid',
+                role: SpaceMemberRole.VIEWER,
+                grantedVia: 'dashboard',
+            }),
+        ]);
+        expect(result[1]?.directOnly).toBe(true);
+        expect(dashboardAccessModel.getUserAccess).toHaveBeenCalledTimes(1);
+        expect(dashboardAccessModel.getUserAccess).toHaveBeenCalledWith(
+            ['dash-2', 'dash-1'],
+            'user-uuid',
+            { organizationUuid: 'organization-uuid' },
+        );
+    });
+
+    test('degrades to space-only when the grant does not belong to the given space', async () => {
+        const { service } = createService({
+            enabled: true,
+            contexts: { 'space-a': baseContext },
+            grants: {
+                'dash-1': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    spaceUuid: 'another-space',
+                    userRole: SpaceMemberRole.EDITOR,
+                    groupRoles: [],
+                },
+            },
+        });
+
+        const result = await service.getDashboardsAccessContext('user-uuid', [
+            { uuid: 'dash-1', spaceUuid: 'space-a' },
+        ]);
+
+        expect(result[0]).toEqual({ ...baseContext, directOnly: false });
+        expectNoGrantRows(result[0]!);
+    });
+
+    test('unresolvable spaces map to undefined', async () => {
+        const { service } = createService({ enabled: true, contexts: {} });
+
+        const result = await service.getDashboardsAccessContext('user-uuid', [
+            { uuid: 'dash-1', spaceUuid: 'missing-space' },
+        ]);
+
+        expect(result).toEqual([undefined]);
+    });
+});

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -277,6 +277,90 @@ export class SpacePermissionService extends BaseService {
         );
     }
 
+    /**
+     * Batched getDashboardAccessContext for hot paths that resolve many
+     * (dashboard, space) refs at once: one space-context batch, one gate
+     * check, and one grant lookup. Returns contexts aligned with the input;
+     * undefined where the space context could not be resolved. Anything
+     * doubtful (missing grant, organization mismatch, dashboard not in the
+     * given space) degrades to the space-only context — never to more
+     * access.
+     */
+    async getDashboardsAccessContext(
+        userUuid: string,
+        dashboards: { uuid: string | null; spaceUuid: string }[],
+    ): Promise<(DashboardAccessContextForCasl | undefined)[]> {
+        const uniqueSpaceUuids = [
+            ...new Set(dashboards.map((ref) => ref.spaceUuid)),
+        ];
+        const spaceContexts = await this.getSpacesAccessContext(
+            userUuid,
+            uniqueSpaceUuids,
+        );
+        const spaceOnly = (ref: {
+            spaceUuid: string;
+        }): DashboardAccessContextForCasl | undefined => {
+            const ctx = spaceContexts[ref.spaceUuid];
+            return ctx ? { ...ctx, directOnly: false } : undefined;
+        };
+
+        const dashboardUuids = [
+            ...new Set(
+                dashboards.flatMap((ref) =>
+                    ref.uuid !== null && spaceContexts[ref.spaceUuid]
+                        ? [ref.uuid]
+                        : [],
+                ),
+            ),
+        ];
+        const organizationUuid = dashboards
+            .map((ref) => spaceContexts[ref.spaceUuid]?.organizationUuid)
+            .find((uuid) => uuid !== undefined);
+        if (
+            dashboardUuids.length === 0 ||
+            organizationUuid === undefined ||
+            !(await this.directAccessFeatureGate.isEnabledForUser({
+                userUuid,
+                organizationUuid,
+            }))
+        ) {
+            return dashboards.map(spaceOnly);
+        }
+
+        const grants = await this.dashboardAccessModel.getUserAccess(
+            dashboardUuids,
+            userUuid,
+            { organizationUuid },
+        );
+        return dashboards.map((ref) => {
+            const spaceContext = spaceContexts[ref.spaceUuid];
+            if (spaceContext === undefined || ref.uuid === null) {
+                return spaceOnly(ref);
+            }
+            const grant = grants[ref.uuid];
+            if (grant === undefined) {
+                return spaceOnly(ref);
+            }
+            const grantRoles = [
+                ...(grant.userRole ? [grant.userRole] : []),
+                ...grant.groupRoles,
+            ];
+            if (
+                grantRoles.length === 0 ||
+                grant.spaceUuid !== ref.spaceUuid ||
+                spaceContext.organizationUuid !== organizationUuid
+            ) {
+                return spaceOnly(ref);
+            }
+            return SpacePermissionService.withGrantAccess(
+                spaceContext,
+                userUuid,
+                grantRoles,
+                'dashboard',
+            );
+        });
+    }
+
     private static withGrantAccess(
         spaceContext: SpaceAccessContextForCasl,
         userUuid: string,


### PR DESCRIPTION
Closes: [SPK-1417](https://linear.app/lightdash/issue/SPK-1417)

Stacks on #28123. Fixes the last user-visible gap for grant-only viewers: dashboard filters.

## Why

The available-filters computation resolved space-only context, denied every dashboard-owned chart for a grant-only viewer, and silently mapped them to empty filter sets — so a dashboard the grant made viewable rendered with an empty filter bar (HTTP 200, no error).

## What changed

- `getInfoForAvailableFilters` also returns the owning `dashboardUuid` (the dashboards join already existed — one selected column).
- New `getDashboardsAccessContext(userUuid, refs[])`: resolves many (dashboard, space) refs with **one** space batch, **one** gate check, and **one** grant lookup — this runs on every dashboard load, so it never loops per chart. Anything doubtful (missing grant, organization mismatch, dashboard not in the given space) degrades to the space-only context — **never to more access**.
- Both available-filters paths resolve through the grant-aware context. Denied charts still map to empty filter sets exactly as before.

## Deliberately not here

Custom-SQL provenance for grant-only "Explore from here" stays fail-closed (known limitation, to revisit on demand) — this PR only restores the core dashboard-filter flow.

## Test plan

- Helper unit tests: null refs → space-only with no gate/grant calls; tagged grant rows from a single batched lookup; grant-space mismatch degrades to space-only (fail-closed); unresolved spaces map to `undefined`.
- Typecheck/lint clean; SpacePermissionService suite green (32 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)