### PR TITLE
fix(dbt): support package-qualified Mesh explores

### DIFF
--- a/packages/backend/src/models/CatalogModel/utils/index.test.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.test.ts
@@ -1,0 +1,80 @@
+import { FieldType, type Explore } from '@lightdash/common';
+import { getChartFieldUsageChanges } from './index';
+
+describe('getChartFieldUsageChanges', () => {
+    it('attributes qualified base and aliased join fields to their canonical explores', async () => {
+        const explore = {
+            name: 'analytics__orders',
+            baseTable: 'analytics__orders',
+            tables: {
+                analytics__orders: {
+                    name: 'analytics__orders',
+                    originalName: 'orders',
+                    dimensions: {
+                        order_id: {
+                            name: 'order_id',
+                            table: 'analytics__orders',
+                        },
+                    },
+                    metrics: {},
+                },
+                payments_alias: {
+                    name: 'payments_alias',
+                    originalName: 'payments',
+                    canonicalName: 'finance__payments',
+                    dimensions: {},
+                    metrics: {
+                        payment_total: {
+                            name: 'payment_total',
+                            table: 'payments_alias',
+                        },
+                    },
+                },
+            },
+        } as unknown as Explore;
+        const getCachedExploresTableNameMap = vi.fn(
+            async (_projectUuid: string, tableNames: string[]) =>
+                Object.fromEntries(
+                    tableNames.map((tableName) => [
+                        tableName,
+                        `${tableName}-uuid`,
+                    ]),
+                ),
+        );
+
+        const result = await getChartFieldUsageChanges(
+            'project-uuid',
+            explore,
+            {
+                oldChartFields: { dimensions: [], metrics: [] },
+                newChartFields: {
+                    dimensions: ['analytics__orders_order_id'],
+                    metrics: ['payments_alias_payment_total'],
+                },
+            },
+            getCachedExploresTableNameMap,
+        );
+
+        expect(getCachedExploresTableNameMap).toHaveBeenCalledWith(
+            'project-uuid',
+            expect.arrayContaining(['analytics__orders', 'finance__payments']),
+        );
+        expect(getCachedExploresTableNameMap.mock.calls[0][1]).toHaveLength(2);
+        expect(result.fieldsToIncrement).toHaveLength(2);
+        expect(result.fieldsToIncrement).toEqual(
+            expect.arrayContaining([
+                {
+                    cachedExploreUuid: 'analytics__orders-uuid',
+                    fieldName: 'order_id',
+                    fieldType: FieldType.DIMENSION,
+                },
+                {
+                    cachedExploreUuid: 'finance__payments-uuid',
+                    fieldName: 'payment_total',
+                    fieldType: FieldType.METRIC,
+                },
+            ]),
+        );
+        expect(result.fieldsToDecrement).toEqual([]);
+    });
+});

--- a/packages/backend/src/models/CatalogModel/utils/index.ts
+++ b/packages/backend/src/models/CatalogModel/utils/index.ts
@@ -252,7 +252,12 @@ export const convertExploresToCatalog = (
     };
 };
 
-export function getTableNamesByFieldIds(
+type CatalogFieldIdentity = {
+    tableName: string;
+    fieldName: string;
+};
+
+export function getCatalogFieldsByFieldIds(
     fieldIds: string[],
     fieldType: FieldType,
     explore: Explore | ExploreError,
@@ -261,38 +266,46 @@ export function getTableNamesByFieldIds(
         return {};
     }
 
-    const tableNameByFieldIdEntries = fieldIds.map<
-        [string, string | undefined]
+    const catalogFieldByFieldIdEntries = fieldIds.map<
+        [string, CatalogFieldIdentity | undefined]
     >((fieldId) => {
-        const table = Object.values(explore.tables).find((exploreTable) => {
-            if (fieldType === FieldType.DIMENSION) {
-                return Object.values(exploreTable.dimensions).some(
-                    (dimension) =>
-                        getItemId({
-                            table:
-                                exploreTable.originalName ?? exploreTable.name,
-                            name: dimension.name,
-                        }) === fieldId,
-                );
-            }
-
-            return Object.values(exploreTable.metrics).some(
-                (metric) =>
-                    getItemId({
-                        table: exploreTable.originalName ?? exploreTable.name,
-                        name: metric.name,
-                    }) === fieldId,
+        const tableAndField = Object.values(explore.tables).reduce<
+            | {
+                  table: Explore['tables'][string];
+                  field: { name: string };
+              }
+            | undefined
+        >((match, exploreTable) => {
+            if (match) return match;
+            const fields =
+                fieldType === FieldType.DIMENSION
+                    ? exploreTable.dimensions
+                    : exploreTable.metrics;
+            const field = Object.values(fields).find(
+                (candidate) => getItemId(candidate) === fieldId,
             );
-        });
+            return field ? { table: exploreTable, field } : undefined;
+        }, undefined);
 
-        if (!table) {
+        if (!tableAndField) {
             return [fieldId, undefined];
         }
 
-        return [fieldId, table.originalName ?? table.name];
+        return [
+            fieldId,
+            {
+                tableName:
+                    tableAndField.table.canonicalName ??
+                    (tableAndField.table.name === explore.baseTable
+                        ? tableAndField.table.name
+                        : (tableAndField.table.originalName ??
+                          tableAndField.table.name)),
+                fieldName: tableAndField.field.name,
+            },
+        ];
     });
 
-    return Object.fromEntries(tableNameByFieldIdEntries);
+    return Object.fromEntries(catalogFieldByFieldIdEntries);
 }
 
 export function getChartFieldChanges({
@@ -329,23 +342,24 @@ export function getChartFieldChanges({
 
 export function getCatalogFieldWhereStatements(
     fieldIds: string[],
-    fieldTableNameMap: Record<string, string | undefined>,
+    catalogFieldByFieldId: Record<string, CatalogFieldIdentity | undefined>,
     cachedExploreUuidTableNameMap: Record<string, string>,
     fieldType: FieldType,
 ): Array<CatalogFieldWhere> {
     return fieldIds
         .map((fieldId) => {
-            const tableName = fieldTableNameMap[fieldId];
+            const catalogField = catalogFieldByFieldId[fieldId];
             const cachedExploreUuid =
-                tableName && cachedExploreUuidTableNameMap[tableName];
+                catalogField &&
+                cachedExploreUuidTableNameMap[catalogField.tableName];
 
-            if (!cachedExploreUuid) {
+            if (!cachedExploreUuid || !catalogField) {
                 return undefined;
             }
 
             return {
                 cachedExploreUuid,
-                fieldName: fieldId.replace(`${tableName}_`, ''),
+                fieldName: catalogField.fieldName,
                 fieldType,
             };
         })
@@ -364,13 +378,13 @@ export async function getChartFieldUsageChanges(
     const chartFieldChanges = getChartFieldChanges(chartFields);
     const { added, removed } = chartFieldChanges;
 
-    const metricTableNameMap = getTableNamesByFieldIds(
+    const metricCatalogFields = getCatalogFieldsByFieldIds(
         [...added.metrics, ...removed.metrics],
         FieldType.METRIC,
         chartExplore,
     );
 
-    const dimensionTableNameMap = getTableNamesByFieldIds(
+    const dimensionCatalogFields = getCatalogFieldsByFieldIds(
         [...added.dimensions, ...removed.dimensions],
         FieldType.DIMENSION,
         chartExplore,
@@ -380,38 +394,40 @@ export async function getChartFieldUsageChanges(
         projectUuid,
         uniq(
             [
-                ...Object.values(dimensionTableNameMap),
-                ...Object.values(metricTableNameMap),
-            ].filter(
-                (tableName): tableName is string => tableName !== undefined,
-            ),
+                ...Object.values(dimensionCatalogFields),
+                ...Object.values(metricCatalogFields),
+            ]
+                .map((field) => field?.tableName)
+                .filter(
+                    (tableName): tableName is string => tableName !== undefined,
+                ),
         ),
     );
 
     const metricsToIncrement = getCatalogFieldWhereStatements(
         chartFieldChanges.added.metrics,
-        metricTableNameMap,
+        metricCatalogFields,
         cachedExploreUuidTableNameMap,
         FieldType.METRIC,
     );
 
     const metricsToDecrement = getCatalogFieldWhereStatements(
         chartFieldChanges.removed.metrics,
-        metricTableNameMap,
+        metricCatalogFields,
         cachedExploreUuidTableNameMap,
         FieldType.METRIC,
     );
 
     const dimensionsToIncrement = getCatalogFieldWhereStatements(
         chartFieldChanges.added.dimensions,
-        dimensionTableNameMap,
+        dimensionCatalogFields,
         cachedExploreUuidTableNameMap,
         FieldType.DIMENSION,
     );
 
     const dimensionsToDecrement = getCatalogFieldWhereStatements(
         chartFieldChanges.removed.dimensions,
-        dimensionTableNameMap,
+        dimensionCatalogFields,
         cachedExploreUuidTableNameMap,
         FieldType.DIMENSION,
     );

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -572,6 +572,14 @@ export class ExploreCompiler {
                         originalName:
                             tables[join.table].originalName ??
                             tables[join.table].name,
+                        ...(tables[join.table].originalName !== undefined ||
+                        tables[join.table].canonicalName !== undefined
+                            ? {
+                                  canonicalName:
+                                      tables[join.table].canonicalName ??
+                                      tables[join.table].name,
+                              }
+                            : {}),
                         name: joinTableName,
                         label: joinTableLabel,
                         ...(joinDescription !== undefined && {

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -1,5 +1,9 @@
 import { SupportedDbtAdapter, type DbtModelNode } from '../types/dbt';
-import { InlineErrorType, type Explore } from '../types/explore';
+import {
+    getExploreSplitCandidates,
+    InlineErrorType,
+    type Explore,
+} from '../types/explore';
 import {
     DimensionType,
     FieldType,
@@ -1603,6 +1607,129 @@ describe('merged manifest model qualification', () => {
             ),
         ).rejects.toThrow(
             'Merged dbt model name "analytics__orders" is ambiguous after qualification: model "orders" from source "analytics" (model.pkg_a.orders) and model "analytics__orders" from source "warehouse" (model.pkg_c.analytics__orders). Rename the source or model before deploying.',
+        );
+    });
+});
+
+describe('dbt Mesh model qualification', () => {
+    const buildMeshModel = ({
+        packageName,
+        name,
+        columnName = 'id',
+        joins = [],
+    }: {
+        packageName: string;
+        name: string;
+        columnName?: string;
+        joins?: DbtModelNode['meta']['joins'];
+    }): DbtModelNode => ({
+        ...model,
+        unique_id: `model.${packageName}.${name}`,
+        package_name: packageName,
+        name,
+        alias: name,
+        relation_name: `${packageName}.${name}`,
+        columns: {
+            [columnName]: {
+                name: columnName,
+                data_type: DimensionType.NUMBER,
+                meta: {},
+            },
+        },
+        meta: { joins },
+    });
+
+    it('qualifies cross-package models and keeps bare joins package-local', async () => {
+        const explores = await convertExplores(
+            [
+                buildMeshModel({
+                    packageName: 'marketing__core',
+                    name: 'customers',
+                    joins: [
+                        {
+                            join: 'orders',
+                            sql_on: '${customers.id} = ${orders.marketing_id}',
+                        },
+                    ],
+                }),
+                buildMeshModel({
+                    packageName: 'marketing__core',
+                    name: 'orders',
+                    columnName: 'marketing_id',
+                }),
+                buildMeshModel({
+                    packageName: 'finance',
+                    name: 'orders',
+                    columnName: 'finance_id',
+                }),
+            ],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            warehouseClientMock,
+            { spotlight: DEFAULT_SPOTLIGHT_CONFIG },
+        );
+
+        expect(explores.map(({ name }) => name).sort()).toEqual([
+            'customers',
+            'finance__orders',
+            'marketing__core__orders',
+        ]);
+
+        const marketingOrders = explores.find(
+            (explore) => explore.name === 'marketing__core__orders',
+        ) as Explore;
+        expect(
+            Object.keys(
+                marketingOrders.tables.marketing__core__orders.dimensions,
+            ),
+        ).toContain('marketing_id');
+        expect(
+            Object.keys(
+                marketingOrders.tables.marketing__core__orders.dimensions,
+            ),
+        ).not.toContain('finance_id');
+
+        expect(getExploreSplitCandidates('orders', explores)).toEqual([
+            'finance__orders',
+            'marketing__core__orders',
+        ]);
+
+        const customers = explores.find(
+            (explore) => explore.name === 'customers',
+        ) as Explore;
+        expect(customers.tables.orders.sqlTable).toBe('marketing__core.orders');
+        expect(customers.tables.orders.canonicalName).toBe(
+            'marketing__core__orders',
+        );
+        expect(customers.joinedTables[0].compiledSqlOn).toBe(
+            '("customers".id) = ("orders".marketing_id)',
+        );
+    });
+
+    it('rejects a package-qualified name that still collides', async () => {
+        await expect(
+            convertExplores(
+                [
+                    buildMeshModel({
+                        packageName: 'analytics',
+                        name: 'orders',
+                    }),
+                    buildMeshModel({
+                        packageName: 'finance',
+                        name: 'orders',
+                    }),
+                    buildMeshModel({
+                        packageName: 'warehouse',
+                        name: 'analytics__orders',
+                    }),
+                ],
+                false,
+                SupportedDbtAdapter.POSTGRES,
+                warehouseClientMock,
+                { spotlight: DEFAULT_SPOTLIGHT_CONFIG },
+            ),
+        ).rejects.toThrow(
+            'dbt Mesh model name "analytics__orders" is ambiguous after qualification: model "orders" from package "analytics" (model.analytics.orders) and model "analytics__orders" from package "warehouse" (model.warehouse.analytics__orders). Rename the package or model before deploying.',
         );
     });
 });

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1,6 +1,9 @@
 import merge from 'lodash/merge';
 import partition from 'lodash/partition';
-import { qualifyMergedManifestNames } from '../dbt/qualifiedName';
+import {
+    getManifestNamespaceKey,
+    qualifyManifestNames,
+} from '../dbt/qualifiedName';
 import {
     buildModelGraph,
     convertColumnMetric,
@@ -1142,21 +1145,20 @@ export const convertExplores = async (
         allowPartialCompilation,
         postProcessors,
     } = options ?? {};
-    const resolvedNamesByUniqueId = qualifyMergedManifestNames(
+    const resolvedNamesByUniqueId = qualifyManifestNames(
         models.map((model) => ({
             uniqueId: model.unique_id,
             name: model.name,
-            sourceName: model.lightdash_source_name,
+            lightdash_source_name: model.lightdash_source_name,
+            package_name: model.package_name,
         })),
         'model',
     );
-    const modelsBySourceAndName = new Map<string, DbtModelNode>();
+    const modelsByNamespaceAndName = new Map<string, DbtModelNode>();
     models.forEach((model) => {
-        if (model.lightdash_source_name !== undefined) {
-            modelsBySourceAndName.set(
-                `${model.lightdash_source_name}\u0000${model.name}`,
-                model,
-            );
+        const namespaceKey = getManifestNamespaceKey(model, model.name);
+        if (namespaceKey !== undefined) {
+            modelsByNamespaceAndName.set(namespaceKey, model);
         }
     });
     const resolveJoins = (
@@ -1164,12 +1166,11 @@ export const convertExplores = async (
         joins: DbtModelNode['meta']['joins'],
     ): DbtModelNode['meta']['joins'] =>
         joins?.map((join) => {
-            if (model.lightdash_source_name === undefined) {
+            const namespaceKey = getManifestNamespaceKey(model, join.join);
+            if (namespaceKey === undefined) {
                 return join;
             }
-            const joinedModel = modelsBySourceAndName.get(
-                `${model.lightdash_source_name}\u0000${join.join}`,
-            );
+            const joinedModel = modelsByNamespaceAndName.get(namespaceKey);
             const resolvedJoinName = joinedModel
                 ? resolvedNamesByUniqueId.get(joinedModel.unique_id)
                 : undefined;

--- a/packages/common/src/dbt/metricFlow.test.ts
+++ b/packages/common/src/dbt/metricFlow.test.ts
@@ -1310,6 +1310,38 @@ describe('applyMetricFlowMetricsToModels', () => {
         unique_id: 'model.jaffle.orders',
         name: 'orders',
     };
+    const buildMeshMetricFixture = (createMetric = false) => {
+        const models = ['analytics', 'finance'].map<DbtModelNode>(
+            (packageName) => ({
+                ...ordersModel,
+                unique_id: `model.${packageName}.orders`,
+                package_name: packageName,
+                relation_name: `${packageName}.orders`,
+                meta: {},
+            }),
+        );
+        const semanticModels = Object.fromEntries(
+            models.map((model) => {
+                const packageName = model.package_name!;
+                const semanticModel: DbtSemanticModel = {
+                    ...ordersSemanticModel,
+                    unique_id: `semantic_model.${packageName}.orders`,
+                    package_name: packageName,
+                    depends_on: { nodes: [model.unique_id] },
+                    measures: [
+                        {
+                            name: 'revenue',
+                            agg: MetricFlowAggregation.SUM,
+                            expr: `${packageName}_amount`,
+                            create_metric: createMetric,
+                        },
+                    ],
+                };
+                return [semanticModel.unique_id, semanticModel];
+            }),
+        );
+        return { models, semanticModels };
+    };
 
     it('is a no-op when the manifest has no semantic models', () => {
         const result = applyMetricFlowMetricsToModels([ordersModel], {
@@ -1361,6 +1393,131 @@ describe('applyMetricFlowMetricsToModels', () => {
         expect(metrics?.unique_customers).toMatchObject({
             type: MetricType.COUNT_DISTINCT,
         });
+    });
+
+    it('keeps same-named Mesh metrics associated with their package model', () => {
+        const { models, semanticModels } = buildMeshMetricFixture();
+
+        const result = applyMetricFlowMetricsToModels(models, {
+            semantic_models: semanticModels,
+            metrics: {
+                'metric.analytics.revenue': {
+                    name: 'revenue',
+                    unique_id: 'metric.analytics.revenue',
+                    package_name: 'analytics',
+                    type: 'simple',
+                    type_params: { measure: { name: 'revenue' } },
+                },
+                'metric.finance.revenue': {
+                    name: 'revenue',
+                    unique_id: 'metric.finance.revenue',
+                    package_name: 'finance',
+                    type: 'simple',
+                    type_params: { measure: { name: 'revenue' } },
+                },
+            },
+        });
+
+        expect(result.error).toBeNull();
+        expect(result.models[0].meta.metrics).toEqual({
+            analytics__revenue: expect.objectContaining({
+                sql: '${TABLE}.analytics_amount',
+            }),
+        });
+        expect(result.models[1].meta.metrics).toEqual({
+            finance__revenue: expect.objectContaining({
+                sql: '${TABLE}.finance_amount',
+            }),
+        });
+    });
+
+    it('qualifies create_metric measures and resolves derived inputs package-locally', () => {
+        const { models, semanticModels } = buildMeshMetricFixture(true);
+        const result = applyMetricFlowMetricsToModels(models, {
+            semantic_models: semanticModels,
+            metrics: {
+                'metric.analytics.double_revenue': {
+                    name: 'double_revenue',
+                    unique_id: 'metric.analytics.double_revenue',
+                    package_name: 'analytics',
+                    type: 'derived',
+                    type_params: {
+                        expr: 'revenue * 2',
+                        metrics: [{ name: 'revenue' }],
+                    },
+                },
+            },
+        });
+
+        expect(result.error).toBeNull();
+        expect(result.models[0].meta.metrics).toMatchObject({
+            analytics__revenue: { sql: '${TABLE}.analytics_amount' },
+            double_revenue: { sql: '${analytics__revenue} * 2' },
+        });
+        expect(result.models[1].meta.metrics).toEqual({
+            finance__revenue: expect.objectContaining({
+                sql: '${TABLE}.finance_amount',
+            }),
+        });
+    });
+
+    it("does not let one package's explicit metric suppress another package's create_metric measure", () => {
+        const { models, semanticModels } = buildMeshMetricFixture(true);
+        const result = applyMetricFlowMetricsToModels(models, {
+            semantic_models: semanticModels,
+            metrics: {
+                'metric.analytics.revenue': {
+                    name: 'revenue',
+                    unique_id: 'metric.analytics.revenue',
+                    package_name: 'analytics',
+                    type: 'simple',
+                    type_params: { measure: { name: 'revenue' } },
+                },
+            },
+        });
+
+        expect(result.error).toBeNull();
+        expect(result.models[0].meta.metrics?.analytics__revenue).toMatchObject(
+            {
+                sql: '${TABLE}.analytics_amount',
+            },
+        );
+        expect(result.models[1].meta.metrics?.finance__revenue).toMatchObject({
+            sql: '${TABLE}.finance_amount',
+        });
+    });
+
+    it('resolves filtered create_metric inputs within the parent metric package', () => {
+        const { models, semanticModels } = buildMeshMetricFixture(true);
+        const result = applyMetricFlowMetricsToModels(models, {
+            semantic_models: semanticModels,
+            metrics: {
+                'metric.analytics.filtered_revenue': {
+                    name: 'filtered_revenue',
+                    unique_id: 'metric.analytics.filtered_revenue',
+                    package_name: 'analytics',
+                    type: 'derived',
+                    type_params: {
+                        expr: 'revenue',
+                        metrics: [{ name: 'revenue', filter: '1 = 1' }],
+                    },
+                },
+            },
+        });
+
+        expect(result.error).toBeNull();
+        expect(
+            result.models[0].meta.metrics?.filtered_revenue_revenue,
+        ).toMatchObject({
+            sql: 'CASE WHEN (1 = 1) THEN (${TABLE}.analytics_amount) END',
+            hidden: true,
+        });
+        expect(result.models[0].meta.metrics?.filtered_revenue).toMatchObject({
+            sql: '${filtered_revenue_revenue}',
+        });
+        expect(result.models[1].meta.metrics).not.toHaveProperty(
+            'filtered_revenue',
+        );
     });
 
     it('returns models untouched with error set when translation crashes', () => {

--- a/packages/common/src/dbt/metricFlow.ts
+++ b/packages/common/src/dbt/metricFlow.ts
@@ -13,7 +13,7 @@ import {
     type DbtSemanticModel,
 } from '../types/dbtSemanticLayer';
 import { MetricType } from '../types/field';
-import { qualifyMergedManifestNames } from './qualifiedName';
+import { getManifestNamespaceKey, qualifyManifestNames } from './qualifiedName';
 
 /**
  * Translation for dbt's MetricFlow semantic layer as it appears in the dbt
@@ -268,27 +268,129 @@ export const translateMetricFlowMetrics = ({
     let translatedCount = 0;
     let skippedCount = 0;
     const semanticMetrics = Object.values(metrics).filter(isSemanticMetric);
-    const resolvedMetricNamesByUniqueId = qualifyMergedManifestNames(
-        semanticMetrics.map((metric) => ({
-            uniqueId: metric.unique_id,
-            name: metric.name,
-            sourceName: metric.lightdash_source_name,
-        })),
+    const getAutoMetricUniqueId = (
+        semanticModel: DbtSemanticModel,
+        measure: DbtSemanticMeasure,
+    ): string =>
+        `${semanticModel.unique_id}\u0000create_metric\u0000${measure.name}`;
+    const explicitMetricNamespaceKeys = new Set(
+        semanticMetrics
+            .map((metric) => getManifestNamespaceKey(metric, metric.name))
+            .filter((key): key is string => key !== undefined),
+    );
+    const unnamespacedExplicitMetricNames = new Set(
+        semanticMetrics
+            .filter(
+                (metric) =>
+                    getManifestNamespaceKey(metric, metric.name) === undefined,
+            )
+            .map((metric) => metric.name),
+    );
+    const autoMetricCandidates = Object.values(semanticModels).flatMap(
+        (semanticModel) =>
+            measuresOf(semanticModel)
+                .filter((measure) => {
+                    if (!measure.create_metric) return false;
+                    const namespaceKey = getManifestNamespaceKey(
+                        semanticModel,
+                        measure.name,
+                    );
+                    return namespaceKey !== undefined
+                        ? !explicitMetricNamespaceKeys.has(namespaceKey)
+                        : !unnamespacedExplicitMetricNames.has(measure.name);
+                })
+                .map((measure) => ({ semanticModel, measure })),
+    );
+    const resolvedMetricNamesByUniqueId = qualifyManifestNames(
+        [
+            ...semanticMetrics.map((metric) => ({
+                uniqueId: metric.unique_id,
+                name: metric.name,
+                lightdash_source_name: metric.lightdash_source_name,
+                package_name: metric.package_name,
+            })),
+            ...autoMetricCandidates.map(({ semanticModel, measure }) => ({
+                uniqueId: getAutoMetricUniqueId(semanticModel, measure),
+                name: measure.name,
+                lightdash_source_name: semanticModel.lightdash_source_name,
+                package_name: semanticModel.package_name,
+            })),
+        ],
         'metric',
     );
     const getMetricName = (metric: DbtSemanticMetric): string =>
         resolvedMetricNamesByUniqueId.get(metric.unique_id) ?? metric.name;
+    const getAutoMetricName = (
+        semanticModel: DbtSemanticModel,
+        measure: DbtSemanticMeasure,
+    ): string =>
+        resolvedMetricNamesByUniqueId.get(
+            getAutoMetricUniqueId(semanticModel, measure),
+        ) ?? measure.name;
+
+    const autoMetricNamesByName = new Map<string, string>();
+    const autoMetricNamesByNamespaceAndName = new Map<string, string>();
+    autoMetricCandidates.forEach(({ semanticModel, measure }) => {
+        const resolvedName = getAutoMetricName(semanticModel, measure);
+        autoMetricNamesByName.set(measure.name, resolvedName);
+        const namespaceKey = getManifestNamespaceKey(
+            semanticModel,
+            measure.name,
+        );
+        if (namespaceKey !== undefined) {
+            autoMetricNamesByNamespaceAndName.set(namespaceKey, resolvedName);
+        }
+    });
+    const resolveAutoMetricName = (
+        parentMetric: DbtSemanticMetric,
+        metricName: string,
+    ): string | undefined => {
+        const namespaceKey = getManifestNamespaceKey(parentMetric, metricName);
+        return (
+            (namespaceKey !== undefined
+                ? autoMetricNamesByNamespaceAndName.get(namespaceKey)
+                : undefined) ?? autoMetricNamesByName.get(metricName)
+        );
+    };
 
     // Index measures by name and remember which semantic model owns each one.
     const measureIndex = new Map<
         string,
         { semanticModel: DbtSemanticModel; measure: DbtSemanticMeasure }
     >();
+    const measureIndexByNamespaceAndName = new Map<
+        string,
+        { semanticModel: DbtSemanticModel; measure: DbtSemanticMeasure }
+    >();
     const semanticModelsByName = new Map<string, DbtSemanticModel>();
+    const semanticModelsByNamespaceAndName = new Map<
+        string,
+        DbtSemanticModel
+    >();
     Object.values(semanticModels).forEach((semanticModel) => {
         semanticModelsByName.set(semanticModel.name, semanticModel);
+        const semanticModelKey = getManifestNamespaceKey(
+            semanticModel,
+            semanticModel.name,
+        );
+        if (semanticModelKey !== undefined) {
+            semanticModelsByNamespaceAndName.set(
+                semanticModelKey,
+                semanticModel,
+            );
+        }
         measuresOf(semanticModel).forEach((measure) => {
             measureIndex.set(measure.name, { semanticModel, measure });
+            const measureKey = getManifestNamespaceKey(
+                semanticModel,
+                measure.name,
+            );
+            if (measureKey !== undefined) {
+                measureIndexByNamespaceAndName.set(measureKey, {
+                    semanticModel,
+                    measure,
+                });
+            }
         });
     });
 
@@ -296,25 +398,25 @@ export const translateMetricFlowMetrics = ({
     // these are owned by the metrics pass — translating the bare measure would
     // silently drop metric-level config such as filters.
     const metricDefsByName = new Map<string, DbtSemanticMetric>();
-    const metricDefsBySourceAndName = new Map<string, DbtSemanticMetric>();
+    const metricDefsByNamespaceAndName = new Map<string, DbtSemanticMetric>();
     semanticMetrics.forEach((metric) => {
         metricDefsByName.set(metric.name, metric);
-        if (metric.lightdash_source_name !== undefined) {
-            metricDefsBySourceAndName.set(
-                `${metric.lightdash_source_name}\u0000${metric.name}`,
-                metric,
-            );
+        const namespaceKey = getManifestNamespaceKey(metric, metric.name);
+        if (namespaceKey !== undefined) {
+            metricDefsByNamespaceAndName.set(namespaceKey, metric);
         }
     });
     const resolveMetricDefinition = (
         parentMetric: DbtSemanticMetric,
         metricName: string,
-    ): DbtSemanticMetric | undefined =>
-        (parentMetric.lightdash_source_name !== undefined
-            ? metricDefsBySourceAndName.get(
-                  `${parentMetric.lightdash_source_name}\u0000${metricName}`,
-              )
-            : undefined) ?? metricDefsByName.get(metricName);
+    ): DbtSemanticMetric | undefined => {
+        const namespaceKey = getManifestNamespaceKey(parentMetric, metricName);
+        return (
+            (namespaceKey !== undefined
+                ? metricDefsByNamespaceAndName.get(namespaceKey)
+                : undefined) ?? metricDefsByName.get(metricName)
+        );
+    };
 
     // Which model each successfully translated metric landed on — ratio and
     // derived metrics reference their inputs through this.
@@ -430,7 +532,14 @@ export const translateMetricFlowMetrics = ({
             if (measureRef.filter !== null && measureRef.filter !== undefined) {
                 filters.push(measureRef.filter);
             }
-            const indexed = measureIndex.get(measureRef.name);
+            const namespaceKey = getManifestNamespaceKey(
+                metric,
+                measureRef.name,
+            );
+            const indexed =
+                (namespaceKey !== undefined
+                    ? measureIndexByNamespaceAndName.get(namespaceKey)
+                    : undefined) ?? measureIndex.get(measureRef.name);
             if (!indexed) {
                 return {
                     error: `referenced measure "${measureRef.name}" was not found in any semantic model`,
@@ -439,9 +548,15 @@ export const translateMetricFlowMetrics = ({
             return { ...indexed, filters };
         }
         if (inlineAggParams) {
-            const semanticModel = semanticModelsByName.get(
+            const namespaceKey = getManifestNamespaceKey(
+                metric,
                 inlineAggParams.semantic_model,
             );
+            const semanticModel =
+                (namespaceKey !== undefined
+                    ? semanticModelsByNamespaceAndName.get(namespaceKey)
+                    : undefined) ??
+                semanticModelsByName.get(inlineAggParams.semantic_model);
             if (!semanticModel) {
                 return {
                     error: `semantic model "${inlineAggParams.semantic_model}" was not found`,
@@ -538,7 +653,15 @@ export const translateMetricFlowMetrics = ({
             if (!measure.create_metric) {
                 return;
             }
-            if (metricDefsByName.has(measure.name)) {
+            const namespaceKey = getManifestNamespaceKey(
+                semanticModel,
+                measure.name,
+            );
+            const hasExplicitMetric =
+                namespaceKey !== undefined
+                    ? metricDefsByNamespaceAndName.has(namespaceKey)
+                    : metricDefsByName.has(measure.name);
+            if (hasExplicitMetric) {
                 // An explicit manifest metric owns this name — the metrics
                 // pass above already translated or skipped it.
                 return;
@@ -551,11 +674,12 @@ export const translateMetricFlowMetrics = ({
                 skip(measure.name, built.error);
                 return;
             }
-            if (metricsByModel[built.modelName]?.[measure.name]) {
+            const metricName = getAutoMetricName(semanticModel, measure);
+            if (metricsByModel[built.modelName]?.[metricName]) {
                 // Already translated as an explicit metric.
                 return;
             }
-            addMetric(built.modelName, measure.name, built.definition);
+            addMetric(built.modelName, metricName, built.definition);
             translatedCount += 1;
         });
     });
@@ -599,7 +723,8 @@ export const translateMetricFlowMetrics = ({
             );
             const inputMetricName = inputMetric
                 ? getMetricName(inputMetric)
-                : input.name;
+                : (resolveAutoMetricName(parentMetric, input.name) ??
+                  input.name);
             const modelName = modelByTranslatedMetric.get(inputMetricName);
             if (!modelName) {
                 return {
@@ -633,7 +758,14 @@ export const translateMetricFlowMetrics = ({
             }
             resolved = resolvedSimple;
         } else {
-            const indexed = measureIndex.get(input.name);
+            const namespaceKey = getManifestNamespaceKey(
+                parentMetric,
+                input.name,
+            );
+            const indexed =
+                (namespaceKey !== undefined
+                    ? measureIndexByNamespaceAndName.get(namespaceKey)
+                    : undefined) ?? measureIndex.get(input.name);
             if (!indexed) {
                 return {
                     error: `input metric "${input.name}" was not found in the manifest`,
@@ -885,12 +1017,24 @@ export const applyMetricFlowMetricsToModels = (
         return noop;
     }
 
-    const modelNamesByUniqueId = Object.fromEntries(
-        models.map((model) => [model.unique_id, model.name]),
-    );
-
+    let modelNamesByUniqueId: Record<string, string>;
     let translation: TranslateMetricFlowResult;
     try {
+        const resolvedModelNamesByUniqueId = qualifyManifestNames(
+            models.map((model) => ({
+                uniqueId: model.unique_id,
+                name: model.name,
+                lightdash_source_name: model.lightdash_source_name,
+                package_name: model.package_name,
+            })),
+            'model',
+        );
+        modelNamesByUniqueId = Object.fromEntries(
+            models.map((model) => [
+                model.unique_id,
+                resolvedModelNamesByUniqueId.get(model.unique_id) ?? model.name,
+            ]),
+        );
         translation = translateMetricFlowMetrics({
             semanticModels,
             metrics: manifest.metrics ?? {},
@@ -908,7 +1052,9 @@ export const applyMetricFlowMetricsToModels = (
 
     return {
         models: models.map((model) => {
-            const modelMetrics = metricsByModel[model.name];
+            const resolvedModelName =
+                modelNamesByUniqueId[model.unique_id] ?? model.name;
+            const modelMetrics = metricsByModel[resolvedModelName];
             if (!modelMetrics) {
                 return model;
             }

--- a/packages/common/src/dbt/qualifiedName.ts
+++ b/packages/common/src/dbt/qualifiedName.ts
@@ -3,35 +3,72 @@ import { ParameterError } from '../types/errors';
 type ManifestNamedItem = {
     uniqueId: string;
     name: string;
-    sourceName?: string;
+} & ManifestNamespaceFields;
+
+export type ManifestNamespaceFields = {
+    lightdash_source_name?: string;
+    package_name?: string;
 };
 
-export const qualifyMergedManifestNames = (
+export type ManifestNamespace = {
+    kind: 'source' | 'package';
+    name: string;
+};
+
+export const getManifestNamespace = (
+    item: ManifestNamespaceFields,
+): ManifestNamespace | undefined => {
+    // Merged-source manifests use the Lightdash source name. Native dbt Mesh
+    // manifests have no source annotation, so the dbt package is their namespace.
+    if (item.lightdash_source_name !== undefined) {
+        return { kind: 'source', name: item.lightdash_source_name };
+    }
+    if (item.package_name !== undefined) {
+        return { kind: 'package', name: item.package_name };
+    }
+    return undefined;
+};
+
+export const getManifestNamespaceKey = (
+    item: ManifestNamespaceFields,
+    name: string,
+): string | undefined => {
+    const namespace = getManifestNamespace(item);
+    return namespace
+        ? `${namespace.kind}\u0000${namespace.name}\u0000${name}`
+        : undefined;
+};
+
+export const qualifyManifestNames = (
     items: ManifestNamedItem[],
     itemType: 'model' | 'metric',
 ): Map<string, string> => {
-    const sourceNamesByName = new Map<string, Set<string>>();
-    items.forEach(({ name, sourceName }) => {
-        if (sourceName === undefined) {
+    const namespacesByName = new Map<string, Set<string>>();
+    items.forEach((item) => {
+        const namespace = getManifestNamespace(item);
+        if (namespace === undefined) {
             return;
         }
-        const sourceNames = sourceNamesByName.get(name) ?? new Set<string>();
-        sourceNames.add(sourceName);
-        sourceNamesByName.set(name, sourceNames);
+        const namespaces = namespacesByName.get(item.name) ?? new Set<string>();
+        namespaces.add(`${namespace.kind}\u0000${namespace.name}`);
+        namespacesByName.set(item.name, namespaces);
     });
 
     const collidingNames = new Set(
-        Array.from(sourceNamesByName)
-            .filter(([, sourceNames]) => sourceNames.size > 1)
+        Array.from(namespacesByName)
+            .filter(([, namespaces]) => namespaces.size > 1)
             .map(([name]) => name),
     );
     const resolvedNames = new Map(
-        items.map((item) => [
-            item.uniqueId,
-            item.sourceName !== undefined && collidingNames.has(item.name)
-                ? `${item.sourceName}__${item.name}`
-                : item.name,
-        ]),
+        items.map((item) => {
+            const namespace = getManifestNamespace(item);
+            return [
+                item.uniqueId,
+                namespace !== undefined && collidingNames.has(item.name)
+                    ? `${namespace.name}__${item.name}`
+                    : item.name,
+            ];
+        }),
     );
 
     const itemsByResolvedName = new Map<string, ManifestNamedItem[]>();
@@ -51,23 +88,41 @@ export const qualifyMergedManifestNames = (
         .sort(([left], [right]) => left.localeCompare(right))[0];
     if (postQualificationCollision) {
         const [resolvedName, resolvedItems] = postQualificationCollision;
+        const namespaceKinds = new Set(
+            resolvedItems
+                .map((item) => getManifestNamespace(item)?.kind)
+                .filter((kind): kind is ManifestNamespace['kind'] => !!kind),
+        );
+        let collisionContext = 'dbt';
+        let renameTarget = 'source, package';
+        if (namespaceKinds.size === 1 && namespaceKinds.has('source')) {
+            collisionContext = 'Merged dbt';
+            renameTarget = 'source';
+        } else if (namespaceKinds.size === 1 && namespaceKinds.has('package')) {
+            collisionContext = 'dbt Mesh';
+            renameTarget = 'package';
+        }
         const parties = [...resolvedItems]
             .sort(
                 (left, right) =>
-                    (left.sourceName ?? '').localeCompare(
-                        right.sourceName ?? '',
+                    (getManifestNamespace(left)?.name ?? '').localeCompare(
+                        getManifestNamespace(right)?.name ?? '',
                     ) ||
                     left.name.localeCompare(right.name) ||
                     left.uniqueId.localeCompare(right.uniqueId),
             )
-            .map(
-                (item) =>
-                    `${itemType} "${item.name}" from source "${item.sourceName}" (${item.uniqueId})`,
-            );
+            .map((item) => {
+                const namespace = getManifestNamespace(item);
+                return `${itemType} "${item.name}"${
+                    namespace
+                        ? ` from ${namespace.kind} "${namespace.name}"`
+                        : ''
+                } (${item.uniqueId})`;
+            });
         throw new ParameterError(
-            `Merged dbt ${itemType} name "${resolvedName}" is ambiguous after qualification: ${parties.slice(0, -1).join(', ')}${
+            `${collisionContext} ${itemType} name "${resolvedName}" is ambiguous after qualification: ${parties.slice(0, -1).join(', ')}${
                 parties.length > 1 ? ' and ' : ''
-            }${parties.at(-1)}. Rename the source or ${itemType} before deploying.`,
+            }${parties.at(-1)}. Rename the ${renameTarget} or ${itemType} before deploying.`,
         );
     }
 

--- a/packages/common/src/types/dbtSemanticLayer.ts
+++ b/packages/common/src/types/dbtSemanticLayer.ts
@@ -65,6 +65,8 @@ export type DbtSemanticDimension = {
 export type DbtSemanticModel = {
     name: string;
     unique_id: string;
+    package_name?: string;
+    lightdash_source_name?: string;
     /** dbt ref string for the underlying model, e.g. "ref('orders')". */
     model: string;
     node_relation: {
@@ -144,6 +146,7 @@ export type DbtSemanticMetricType =
 export type DbtSemanticMetric = {
     name: string;
     unique_id: string;
+    package_name?: string;
     lightdash_source_name?: string;
     type: DbtSemanticMetricType;
     type_params: DbtSemanticMetricTypeParams;

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -176,13 +176,10 @@ export const getExploreSplitCandidates = (
     const candidates = explores.flatMap((explore) => {
         if (isExploreError(explore)) return [];
         const baseTable = explore.tables[explore.baseTable];
-        const separatorIndex = explore.name.indexOf('__');
-        const originalExploreName =
-            separatorIndex === -1
-                ? undefined
-                : explore.name.slice(separatorIndex + 2);
+        // Package names can contain `__`, so match the qualified suffix rather
+        // than treating the separator as something we can parse.
         return baseTable?.originalName === exploreName &&
-            originalExploreName === exploreName
+            explore.name.endsWith(`__${exploreName}`)
             ? [explore.name]
             : [];
     });

--- a/packages/common/src/types/table.ts
+++ b/packages/common/src/types/table.ts
@@ -22,6 +22,7 @@ export type TableBase = {
     name: string; // Must be sql friendly (a-Z, 0-9, _)
     label: string; // Friendly name
     originalName?: string; // Original name from dbt, without alias
+    canonicalName?: string; // Qualified table name before applying a join alias
     description?: string; // Optional description of table
     /*
         @deprecated


### PR DESCRIPTION
## Summary

- qualify colliding dbt Mesh models and MetricFlow metrics by package
- resolve bare joins and derived, ratio, and filtered metric inputs within their package namespace
- preserve canonical compiled table identity for catalog usage attribution

## Testing

- `pnpm -F common test -- --run` (148 files, 3,772 passed, 1 skipped)
- `pnpm -F common exec vitest run src/compiler/translator.test.ts src/dbt/metricFlow.test.ts` (161 passed after rebasing onto `origin/main`)
- `pnpm -F backend exec vitest run src/models/CatalogModel/utils/index.test.ts`
- `pnpm -F common typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F common lint`
- `NODE_OPTIONS="--max-old-space-size=8192" pnpm -F backend lint`
- `pnpm -F common format`
- `pnpm -F backend format`
- live local Mesh smoke: compiled 2 qualified explores and 6 metrics; verified package-specific base, derived, and filtered metric queries; verified catalog usage moved 0 to 1 on chart save and back to 0 on deletion; restored the original project state

## Issue

- [PROD-10300](https://linear.app/lightdash/issue/PROD-10300/dbt-mesh-support-same-named-models-with-package-qualified-explores)
