### PR TITLE
fix(credentials): refresh the Snowflake SSO credential queries resolve

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -4746,6 +4746,46 @@ describe('UserService', () => {
             );
         });
 
+        it('refreshes the credential queries actually resolve when duplicates exist', async () => {
+            const credentialsModel = createSnowflakeCredentialsModel();
+            // Oldest first, matching getAllByUserUuid's ordering.
+            credentialsModel.getAllByUserUuid.mockResolvedValue([
+                {
+                    uuid: 'stale-sso-credentials-uuid',
+                    name: 'Default',
+                    credentials: {
+                        type: WarehouseTypes.SNOWFLAKE,
+                        authenticationType: SnowflakeAuthenticationType.SSO,
+                    },
+                    project: null,
+                },
+                {
+                    uuid: 'newest-sso-credentials-uuid',
+                    name: 'Default',
+                    credentials: {
+                        type: WarehouseTypes.SNOWFLAKE,
+                        authenticationType: SnowflakeAuthenticationType.SSO,
+                    },
+                    project: null,
+                },
+            ]);
+            const service = createUserService(lightdashConfigMock, {
+                userWarehouseCredentialsModel:
+                    credentialsModel as unknown as UserWarehouseCredentialsModel,
+            });
+
+            await service.createSnowflakeWarehouseCredentials(
+                sessionUser,
+                'new-refresh-token',
+            );
+
+            expect(credentialsModel.update).toHaveBeenCalledWith(
+                sessionUser.userUuid,
+                'newest-sso-credentials-uuid',
+                expect.anything(),
+            );
+        });
+
         it('rejects a callback without a refresh token instead of writing', async () => {
             const credentialsModel = createSnowflakeCredentialsModel();
             const service = createUserService(lightdashConfigMock, {

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -3342,17 +3342,22 @@ export class UserService extends BaseService {
             );
         }
 
+        // getAllByUserUuid returns oldest first, but queries resolve the
+        // newest credential. Refresh that one, or a user who somehow holds two
+        // would keep querying with the stale token we just skipped over.
         const existingSsoCredentials = (
             await this.userWarehouseCredentialsModel.getAllByUserUuid(
                 user.userUuid,
             )
-        ).find(
-            ({ credentials, project }) =>
-                project === null &&
-                credentials.type === WarehouseTypes.SNOWFLAKE &&
-                credentials.authenticationType ===
-                    SnowflakeAuthenticationType.SSO,
-        );
+        )
+            .filter(
+                ({ credentials, project }) =>
+                    project === null &&
+                    credentials.type === WarehouseTypes.SNOWFLAKE &&
+                    credentials.authenticationType ===
+                        SnowflakeAuthenticationType.SSO,
+            )
+            .at(-1);
 
         const snowflakeCredentials: UpsertUserWarehouseCredentials = {
             name: existingSsoCredentials?.name ?? 'Default',


### PR DESCRIPTION
## What changed

Re-authentication picked the wrong Snowflake SSO credential to refresh when a user held more than one.

`getAllByUserUuid` returns credentials **oldest first**, so the `.find()` in `createSnowflakeWarehouseCredentials` landed on the oldest unassigned SSO credential. Query time resolves the **newest** (`_findProjectCredentialCandidates` orders `created_at desc`). A user with two would therefore keep querying with the stale refresh token that re-authentication had just skipped over — and re-authenticating again would never fix it.

Now filters and takes the last, so the credential that gets refreshed is the one queries actually resolve.

## Why it appears now

The previous flow deleted every Snowflake credential before creating a fresh one, which removed duplicates as a side effect. #27929 replaced that with an in-place update to stop re-authentication wiping unrelated connections — correct, but it no longer clears duplicates, so the ordering mismatch became reachable.

Low severity: duplicates should not exist from the old flow, and are only reachable if an extra SSO credential was created directly through the API. Worth closing rather than leaving latent, since the failure is silent and self-perpetuating.

## Testing

Added a unit test asserting the newest duplicate is the one updated. Verified it is not vacuous — with `.at(0)` it fails with `stale-sso-credentials-uuid` instead of `newest-sso-credentials-uuid`.

## References

Relates: PROD-10424
