### PR TITLE
style(frontend): make login page background pink

### DIFF
--- a/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
+++ b/packages/frontend/src/components/common/AuthLayout/AuthLayout.module.css
@@ -3,6 +3,19 @@
     min-height: 100vh;
 }
 
+.pinkPage {
+    min-height: 100vh;
+    background-color: var(--mantine-color-pink-1);
+}
+
+.pinkPage .brandPanel {
+    background-color: var(--mantine-color-pink-6);
+}
+
+.pinkPage .formPanel {
+    background-color: var(--mantine-color-pink-1);
+}
+
 .brandPanel {
     position: relative;
     overflow: hidden;

--- a/packages/frontend/src/components/common/AuthLayout/index.tsx
+++ b/packages/frontend/src/components/common/AuthLayout/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Card, Group, Stack, Text, Title } from '@mantine/core';
 import { IconCheck } from '@tabler/icons-react';
+import { clsx } from 'clsx';
 import { type FC, type PropsWithChildren, type ReactNode } from 'react';
 import LightdashLogo from '../../LightdashLogo/LightdashLogo';
 import PageSpinner from '../../PageSpinner';
@@ -29,6 +30,7 @@ type Props = {
     /** Pages that bring their own cards (Invite) opt out of the legacy card. */
     withLegacyCard?: boolean;
     footer?: ReactNode;
+    withPinkBackground?: boolean;
 };
 
 const AuthLayout: FC<PropsWithChildren<Props>> = ({
@@ -39,16 +41,18 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
     cardId,
     withLegacyCard = true,
     footer,
+    withPinkBackground = false,
     children,
 }) => {
     const { isNewLayout, isInitialLoading } = useAuthLayoutVariant();
+    const pinkPageClass = withPinkBackground ? classes.pinkPage : undefined;
 
     if (isInitialLoading) {
         return <PageSpinner />;
     }
 
     if (!isNewLayout) {
-        return (
+        const legacyPage = (
             <Page title={pageTitle} withCenteredContent withNavbar={false}>
                 <Stack w={400} mt="4xl">
                     <Box mx="auto" my="lg">
@@ -76,13 +80,19 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
                 </Stack>
             </Page>
         );
+
+        if (withPinkBackground) {
+            return <Box className={classes.pinkPage}>{legacyPage}</Box>;
+        }
+
+        return legacyPage;
     }
 
     return (
         <>
             <DocumentTitle title={pageTitle} />
 
-            <Box className={classes.root}>
+            <Box className={clsx(classes.root, pinkPageClass)}>
                 <Box className={classes.brandPanel}>
                     <Box className={classes.decorationTop} aria-hidden />
                     <Box className={classes.decorationBottom} aria-hidden />

--- a/packages/frontend/src/pages/Login.module.css
+++ b/packages/frontend/src/pages/Login.module.css
@@ -1,0 +1,4 @@
+.pinkPage {
+    min-height: 100vh;
+    background-color: var(--mantine-color-pink-1);
+}

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -4,11 +4,12 @@ import { type FC } from 'react';
 import AuthLayout from '../components/common/AuthLayout';
 import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
 import LoginLanding from '../features/users/components/LoginLanding';
+import classes from './Login.module.css';
 
 const Login: FC<{ minimal?: boolean }> = ({ minimal = false }) => {
     if (minimal) {
         return (
-            <Stack m="xl">
+            <Stack className={classes.pinkPage} m="xl">
                 <Box mx="auto" my="lg">
                     <LightdashLogo />
                 </Box>
@@ -35,6 +36,7 @@ const Login: FC<{ minimal?: boolean }> = ({ minimal = false }) => {
             subtitle="Welcome back — pick up where you left off."
             legacyTitle="Sign in"
             cardId={LOGIN_PAGE_ID}
+            withPinkBackground
         >
             <LoginLanding />
         </AuthLayout>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No ticket — small visual request.

### Description:
Login page background is now pink. Split auth layout uses `pink.6` on the brand panel and `pink.1` on the form panel; the legacy centered layout and minimal login use `pink.1`. Other auth pages are unchanged.

[Login page with pink background](https://cursor.com/agents/bc-46c73511-97ee-456b-88ab-002d5f5a530f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flogin_page_pink_background.webp)

### Risk assessment:
- [ ] This is a high-risk change


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46c73511-97ee-456b-88ab-002d5f5a530f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46c73511-97ee-456b-88ab-002d5f5a530f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

