### PR TITLE
fix: settings sidebar follows the project in the URL

### DIFF
--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
+import { matchPath, useLocation } from 'react-router';
 import { useIsGitProject } from '../../components/Explorer/WriteBackModal/hooks';
 import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import useApp from '../../providers/App/useApp';
@@ -113,13 +114,21 @@ export const useSettingsContext = (): SettingsContext => {
     } = useOrganization();
     const { activeProjectUuid, isLoading: isActiveProjectUuidLoading } =
         useActiveProjectUuid();
+    // When viewing a specific project's settings, the sidebar follows the
+    // project in the URL rather than the session's active project.
+    const { pathname } = useLocation();
+    const routeProjectUuid = matchPath(
+        { path: '/generalSettings/projectManagement/:projectUuid/*' },
+        pathname,
+    )?.params.projectUuid;
+    const settingsProjectUuid = routeProjectUuid ?? activeProjectUuid;
     const {
         data: project,
         isInitialLoading: isProjectLoading,
         error: projectError,
-    } = useProject(activeProjectUuid);
+    } = useProject(settingsProjectUuid);
 
-    const isGitProject = useIsGitProject(activeProjectUuid ?? '');
+    const isGitProject = useIsGitProject(settingsProjectUuid ?? '');
 
     // "Ask AI" settings are visible to org AI admins (all projects) and to
     // project-scoped AI admins (only the projects they can reach). These are


### PR DESCRIPTION
## Summary

The settings sidebar's current-project section was keyed to the session's *active* project, not the project in the URL. When viewing another project's settings (`/generalSettings/projectManagement/:projectUuid/*`), project-gated items were evaluated against the wrong project and could be invisible — today this hides the **Pull requests** item for git-backed projects unless they happen to be the active project.

The fix resolves the project UUID from the route when present, falling back to the active project.

## Regression analysis

- The only behavioural change is which project UUID feeds `useProject` / `useIsGitProject` inside `useSettingsContext`. When the URL has no project segment (org-level settings pages), `matchPath` returns no match and the behaviour is byte-for-byte the previous one (active project).
- When the URL *does* name a project, the sidebar previously showed items for a different project than the settings being viewed — that was the bug. Showing items for the routed project is strictly more correct; no items are newly hidden for the active-project case.
- No API, type, or cross-package changes; single frontend hook touched.

Closes: PROD-10630

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TC8AemHDy3B3ovKSmVbtG1