### PR TITLE
fix(mcp): let viewers read saved content definitions via read_content

### DIFF
--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -421,7 +421,7 @@ export class ProjectCoderController extends BaseController {
         return codeSuccess(
             await this.services
                 .getCoderService()
-                .getCharts(
+                .getChartsForExport(
                     toSessionUser(req.account),
                     projectUuid,
                     ids,
@@ -452,7 +452,7 @@ export class ProjectCoderController extends BaseController {
         return codeSuccess(
             await this.services
                 .getCoderService()
-                .getDashboards(
+                .getDashboardsForExport(
                     toSessionUser(req.account),
                     projectUuid,
                     ids,

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -1504,7 +1504,7 @@ describe('AiAgentToolsService', () => {
             spaceModel: denySpaceAccessModel(),
             dashboardService,
             coderService: {
-                getDashboards: vi.fn().mockResolvedValue({
+                getDashboardsForRead: vi.fn().mockResolvedValue({
                     dashboards: [makeDashboardContent('blocked-space')],
                 }),
             },
@@ -1778,7 +1778,7 @@ describe('AiAgentToolsService', () => {
                     .mockResolvedValue({ uuid: 'dashboard-uuid' }),
             },
             coderService: {
-                getDashboards: vi.fn().mockResolvedValue({
+                getDashboardsForRead: vi.fn().mockResolvedValue({
                     dashboards: [makeDashboardContent('allowed-space')],
                 }),
                 getCurrentContentVersionBySlug: vi.fn().mockResolvedValue({
@@ -1846,7 +1846,7 @@ describe('AiAgentToolsService', () => {
                 get: vi.fn().mockResolvedValue({ uuid: 'chart-uuid' }),
             },
             coderService: {
-                getCharts: vi
+                getChartsForRead: vi
                     .fn()
                     .mockResolvedValue({ charts: [makeChartContent(null)] }),
                 getCurrentContentVersionBySlug: vi

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -1637,11 +1637,12 @@ export class AiAgentToolsService extends BaseService {
     > {
         switch (type) {
             case 'dashboard': {
-                const { dashboards } = await this.coderService.getDashboards(
-                    context.user,
-                    context.projectUuid,
-                    [slug],
-                );
+                const { dashboards } =
+                    await this.coderService.getDashboardsForRead(
+                        context.user,
+                        context.projectUuid,
+                        [slug],
+                    );
                 const dashboard = dashboards[0];
                 if (!dashboard) {
                     throw new NotFoundError(
@@ -1670,7 +1671,7 @@ export class AiAgentToolsService extends BaseService {
                 };
             }
             case 'chart': {
-                const { charts } = await this.coderService.getCharts(
+                const { charts } = await this.coderService.getChartsForRead(
                     context.user,
                     context.projectUuid,
                     [slug],

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -2063,3 +2063,47 @@ describe('CoderService', () => {
         });
     });
 });
+
+describe('content-as-code access split', () => {
+    const viewer = {
+        userUuid: 'user-uuid',
+        organizationUuid: 'org-uuid',
+        ability: {
+            can: vi.fn(() => false),
+            cannot: vi.fn(() => true),
+            relevantRuleFor: vi.fn(() => ({ inverted: true })),
+            rules: [],
+        },
+    } as AnyType;
+
+    const service = new CoderService({
+        projectModel: {
+            get: vi.fn().mockResolvedValue({
+                projectUuid: 'project-uuid',
+                organizationUuid: 'org-uuid',
+            }),
+            getSummary: vi.fn().mockResolvedValue({
+                projectUuid: 'project-uuid',
+                organizationUuid: 'org-uuid',
+            }),
+        },
+    } as AnyType);
+
+    it('blocks export without view:ContentAsCode', async () => {
+        await expect(
+            service.getChartsForExport(viewer, 'project-uuid', []),
+        ).rejects.toThrow('You are not allowed to download charts');
+        await expect(
+            service.getDashboardsForExport(viewer, 'project-uuid', []),
+        ).rejects.toThrow('You are not allowed to download dashboards');
+    });
+
+    it('allows read without view:ContentAsCode', async () => {
+        await expect(
+            service.getChartsForRead(viewer, 'project-uuid', []),
+        ).resolves.toMatchObject({ charts: [] });
+        await expect(
+            service.getDashboardsForRead(viewer, 'project-uuid', []),
+        ).resolves.toMatchObject({ dashboards: [] });
+    });
+});

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -2029,7 +2029,59 @@ export class CoderService extends BaseService {
     @param dashboardIds: Dashboard ids can be uuids or slugs, if undefined return all dashboards, if [] we return no dashboards
     @returns: DashboardAsCode[]
     */
-    async getDashboards(
+    async getDashboardsForExport(
+        user: SessionUser,
+        projectUuid: string,
+        dashboardIds: string[] | undefined,
+        offset?: number,
+        languageMap?: boolean,
+    ): Promise<ApiDashboardAsCodeListResponse['results']> {
+        await this.assertCanDownloadContentAsCode(
+            user,
+            projectUuid,
+            'You are not allowed to download dashboards',
+        );
+        return this.findDashboardsAsCode(
+            user,
+            projectUuid,
+            dashboardIds,
+            offset,
+            languageMap,
+        );
+    }
+
+    // Single-item read for AI/MCP read_content: no export gate; callers
+    // enforce per-item view access and private-space filtering still applies.
+    async getDashboardsForRead(
+        user: SessionUser,
+        projectUuid: string,
+        slugs: string[],
+    ): Promise<ApiDashboardAsCodeListResponse['results']> {
+        return this.findDashboardsAsCode(user, projectUuid, slugs);
+    }
+
+    private async assertCanDownloadContentAsCode(
+        user: SessionUser,
+        projectUuid: string,
+        forbiddenMessage: string,
+    ): Promise<void> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('ContentAsCode', {
+                    projectUuid,
+                    organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(forbiddenMessage);
+        }
+    }
+
+    private async findDashboardsAsCode(
         user: SessionUser,
         projectUuid: string,
         dashboardIds: string[] | undefined,
@@ -2039,21 +2091,6 @@ export class CoderService extends BaseService {
         const project = await this.projectModel.get(projectUuid);
         if (!project) {
             throw new NotFoundError(`Project ${projectUuid} not found`);
-        }
-
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('ContentAsCode', {
-                    projectUuid: project.projectUuid,
-                    organizationUuid: project.organizationUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'You are not allowed to download dashboards',
-            );
         }
 
         const slugs = await this.convertIdsToSlugs('dashboard', dashboardIds);
@@ -2278,7 +2315,38 @@ export class CoderService extends BaseService {
         );
     }
 
-    async getCharts(
+    async getChartsForExport(
+        user: SessionUser,
+        projectUuid: string,
+        chartIds?: string[],
+        offset?: number,
+        languageMap?: boolean,
+    ): Promise<ApiChartAsCodeListResponse['results']> {
+        await this.assertCanDownloadContentAsCode(
+            user,
+            projectUuid,
+            'You are not allowed to download charts',
+        );
+        return this.findChartsAsCode(
+            user,
+            projectUuid,
+            chartIds,
+            offset,
+            languageMap,
+        );
+    }
+
+    // Single-item read for AI/MCP read_content: no export gate; callers
+    // enforce per-item view access and private-space filtering still applies.
+    async getChartsForRead(
+        user: SessionUser,
+        projectUuid: string,
+        slugs: string[],
+    ): Promise<ApiChartAsCodeListResponse['results']> {
+        return this.findChartsAsCode(user, projectUuid, slugs);
+    }
+
+    private async findChartsAsCode(
         user: SessionUser,
         projectUuid: string,
         chartIds?: string[],
@@ -2288,20 +2356,6 @@ export class CoderService extends BaseService {
         const project = await this.projectModel.get(projectUuid);
         if (!project) {
             throw new NotFoundError(`Project ${projectUuid} not found`);
-        }
-
-        // Filter charts based on user permissions (from private spaces)
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('ContentAsCode', {
-                    projectUuid: project.projectUuid,
-                    organizationUuid: project.organizationUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError('You are not allowed to download charts');
         }
 
         const slugs = await this.convertIdsToSlugs('chart', chartIds);


### PR DESCRIPTION
read_content always failed with ForbiddenError for viewers and interactive viewers because it fetches content through the content-as-code download gate (view:ContentAsCode, granted at editor+), even though everything it returns is already visible to those users in the app. Affected both MCP and Ask AI.

Relates: #27801