### PR TITLE
fix(embed): preserve custom SQL chart provenance

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.test.ts
+++ b/packages/backend/src/controllers/v2/QueryController.test.ts
@@ -1,6 +1,7 @@
 import {
     ChartType,
     LightdashAppPreviewTokenHeader,
+    LightdashCustomSqlProvenanceChartUuidHeader,
     MergeJoinType,
     QueryExecutionContext,
     type ApiExecuteAsyncMergeQueryRequest,
@@ -86,6 +87,43 @@ describe('QueryController', () => {
         expect(executeAsyncMetricQuery).toHaveBeenCalledWith(
             expect.objectContaining({
                 dataAppPreviewToken: 'signed-preview-token',
+            }),
+        );
+    });
+
+    it('forwards the embedded chart provenance candidate to metric-query execution', async () => {
+        const executeAsyncMetricQuery = vi.fn().mockResolvedValue({
+            queryUuid: 'query-uuid',
+        });
+        const controller = new QueryController({
+            getAsyncQueryService: () => ({ executeAsyncMetricQuery }),
+        } as unknown as ConstructorParameters<typeof QueryController>[0]);
+        controller.setStatus = vi.fn();
+        const req = {
+            account: {},
+            headers: {},
+            header: vi.fn((headerName: string) =>
+                headerName === LightdashCustomSqlProvenanceChartUuidHeader
+                    ? 'chart-uuid'
+                    : undefined,
+            ),
+        } as unknown as express.Request;
+
+        await controller.executeAsyncMetricQuery(
+            {
+                query: {
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: [],
+                },
+            } as never,
+            'project-uuid',
+            req,
+        );
+
+        expect(executeAsyncMetricQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                customSqlProvenanceChartUuid: 'chart-uuid',
             }),
         );
     });

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -16,6 +16,7 @@ import {
     isExecuteAsyncSqlChartByUuidParams,
     isJwtUser,
     LightdashAppPreviewTokenHeader,
+    LightdashCustomSqlProvenanceChartUuidHeader,
     LightdashSignedDownloadHeader,
     PersistentDownloadFileAccessMode,
     QueryExecutionContext,
@@ -339,6 +340,9 @@ export class QueryController extends BaseController {
             typeof previewTokenHeader === 'string'
                 ? previewTokenHeader
                 : undefined;
+        const customSqlProvenanceChartUuid: UUID | undefined = req.header(
+            LightdashCustomSqlProvenanceChartUuidHeader,
+        );
 
         const metricQuery: MetricQuery = {
             exploreName: body.query.exploreName,
@@ -370,6 +374,7 @@ export class QueryController extends BaseController {
                 pivotConfiguration: body.pivotConfiguration,
                 dashboardFilters: body.dashboardFilters,
                 dataAppPreviewToken,
+                customSqlProvenanceChartUuid,
             });
 
         return {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -883,6 +883,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectCompileLogModel: models.getProjectCompileLogModel(),
                     adminNotificationService:
                         repository.getAdminNotificationService(),
+                    permissionsService: repository.getPermissionsService(),
                     spacePermissionService:
                         repository.getSpacePermissionService(),
                     contentVerificationModel:

--- a/packages/backend/src/ee/models/SavedChartModel.integration.test.ts
+++ b/packages/backend/src/ee/models/SavedChartModel.integration.test.ts
@@ -168,6 +168,20 @@ describe('SavedChartModel custom SQL provenance', () => {
         expect(provenance.tableCalculations).toHaveLength(2);
     });
 
+    it('loads only the latest chart custom SQL provenance', async () => {
+        const provenance = await model.getCustomSqlProvenanceForChart({
+            projectUuid: SEED_PROJECT.project_uuid,
+            savedChartUuid: dashboardChartUuid,
+        });
+
+        expect(provenance).toEqual({
+            exploreName: 'orders',
+            tableCalculations: [{ sql: dashboardSql }],
+            customSqlDimensions: [],
+            additionalMetrics: [],
+        });
+    });
+
     it('does not resolve modified SQL', async () => {
         const provenance = await findTableCalculationProvenance([
             `${dashboardSql} + 1`,

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -52,6 +52,7 @@ import {
     UpdatedByUser,
     UpdateMultipleSavedChart,
     UpdateSavedChart,
+    type UUID,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { Knex } from 'knex';
@@ -822,6 +823,70 @@ export class SavedChartModel {
             tableCalculations,
             customSqlDimensions: customSqlDimensionMatches,
             additionalMetrics: additionalMetricMatches,
+        };
+    }
+
+    /**
+     * Gets only the persisted custom SQL needed to validate an embedded
+     * Explore. The caller authorizes the chart first; this lookup stays scoped
+     * to its project and latest version without hydrating the full chart.
+     */
+    async getCustomSqlProvenanceForChart({
+        projectUuid,
+        savedChartUuid,
+    }: {
+        projectUuid: UUID;
+        savedChartUuid: UUID;
+    }): Promise<{
+        exploreName: string;
+        tableCalculations: { sql: string }[];
+        customSqlDimensions: { sql: string; table: string }[];
+        additionalMetrics: { sql: string; table: string }[];
+    }> {
+        const version = await this.database(SavedChartsTableName)
+            .innerJoin(
+                SavedChartVersionsTableName,
+                `${SavedChartVersionsTableName}.saved_query_id`,
+                `${SavedChartsTableName}.saved_query_id`,
+            )
+            .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
+            .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .orderBy(`${SavedChartVersionsTableName}.created_at`, 'desc')
+            .orderBy(
+                `${SavedChartVersionsTableName}.saved_queries_version_id`,
+                'desc',
+            )
+            .first<{
+                versionId: number;
+                exploreName: string;
+            }>({
+                versionId: `${SavedChartVersionsTableName}.saved_queries_version_id`,
+                exploreName: `${SavedChartVersionsTableName}.explore_name`,
+            });
+
+        if (!version) {
+            throw new NotFoundError('Saved chart not found');
+        }
+
+        const [tableCalculations, customSqlDimensions, additionalMetrics] =
+            await Promise.all([
+                this.database(SavedChartTableCalculationTableName)
+                    .where('saved_queries_version_id', version.versionId)
+                    .select<{ sql: string }[]>('calculation_raw_sql as sql'),
+                this.database(SavedChartCustomSqlDimensionsTableName)
+                    .where('saved_queries_version_id', version.versionId)
+                    .select<{ sql: string; table: string }[]>('sql', 'table'),
+                this.database(SavedChartAdditionalMetricTableName)
+                    .where('saved_queries_version_id', version.versionId)
+                    .select<{ sql: string; table: string }[]>('sql', 'table'),
+            ]);
+
+        return {
+            exploreName: version.exploreName,
+            tableCalculations,
+            customSqlDimensions,
+            additionalMetrics,
         };
     }
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1690,7 +1690,7 @@ describe('AsyncQueryService', () => {
     });
 
     describe('executeAsyncMetricQuery', () => {
-        test('forwards the Data App preview token to custom SQL authorization', async () => {
+        test('forwards trusted provenance inputs to custom SQL authorization', async () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock);
             const assertCustomSqlAuthorizedForQuery = vi
                 .spyOn(service as AnyType, 'assertCustomSqlAuthorizedForQuery')
@@ -1705,11 +1705,13 @@ describe('AsyncQueryService', () => {
                 metricQuery: metricQueryMock,
                 context: QueryExecutionContext.EXPLORE,
                 dataAppPreviewToken: 'signed-preview-token',
+                customSqlProvenanceChartUuid: 'chart-uuid',
             });
 
             expect(assertCustomSqlAuthorizedForQuery).toHaveBeenCalledWith(
                 expect.objectContaining({
                     dataAppPreviewToken: 'signed-preview-token',
+                    customSqlProvenanceChartUuid: 'chart-uuid',
                 }),
             );
         });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -225,7 +225,6 @@ import { CsvService } from '../CsvService/CsvService';
 import { ExcelService } from '../ExcelService/ExcelService';
 import { OrganizationAccessService } from '../OrganizationAccessService/OrganizationAccessService';
 import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
-import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
 import { getFieldValuesMetricQuery } from '../ProjectService/fieldValuesQueryBuilder';
@@ -392,7 +391,6 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     prometheusMetrics?: PrometheusMetrics;
     schedulerClient: SchedulerClient;
     natsClient: INatsClient;
-    permissionsService: PermissionsService;
     persistentDownloadFileService: PersistentDownloadFileService;
     organizationAccessService: OrganizationAccessService;
     preAggregateStrategy?: PreAggregateStrategy;
@@ -522,8 +520,6 @@ export class AsyncQueryService extends ProjectService {
 
     natsClient: INatsClient;
 
-    permissionsService: PermissionsService;
-
     persistentDownloadFileService: PersistentDownloadFileService;
 
     private readonly organizationAccessService: OrganizationAccessService;
@@ -544,7 +540,6 @@ export class AsyncQueryService extends ProjectService {
         this.prometheusMetrics = args.prometheusMetrics;
         this.schedulerClient = args.schedulerClient;
         this.natsClient = args.natsClient;
-        this.permissionsService = args.permissionsService;
         this.persistentDownloadFileService = args.persistentDownloadFileService;
         this.organizationAccessService = args.organizationAccessService;
         this.preAggregateStrategy =
@@ -5039,6 +5034,7 @@ export class AsyncQueryService extends ProjectService {
             exploreName: inputMetricQuery.exploreName,
             metricQuery: inputMetricQuery,
             dataAppPreviewToken: args.dataAppPreviewToken,
+            customSqlProvenanceChartUuid: args.customSqlProvenanceChartUuid,
         });
 
         return this.runAsyncMetricQueryWithoutPermissionCheck(

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -94,6 +94,7 @@ export type ExecuteAsyncFieldValueSearchArgs = CommonAsyncQueryArgs & {
 export type ExecuteAsyncMetricQueryArgs = CommonAsyncQueryArgs & {
     metricQuery: MetricQuery;
     dataAppPreviewToken?: string;
+    customSqlProvenanceChartUuid?: UUID;
     dateZoom?: DateZoom;
     pivotConfiguration?: PivotConfiguration;
     materializationRole?: UserAccessControls;

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -43,6 +43,7 @@ import { WarehouseAvailableTablesModel } from '../../models/WarehouseAvailableTa
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
+import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { PersistentDownloadFileService } from '../PersistentDownloadFileService/PersistentDownloadFileService';
 import { PivotTableService } from '../PivotTableService/PivotTableService';
 import { ProjectService } from '../ProjectService/ProjectService';
@@ -96,6 +97,9 @@ describe('Csv service', () => {
             organizationModel: {} as OrganizationModel,
             projectCompileLogModel: {} as ProjectCompileLogModel,
             adminNotificationService: {} as AdminNotificationService,
+            permissionsService: new PermissionsService({
+                dashboardModel: {} as DashboardModel,
+            }),
             spacePermissionService: {} as SpacePermissionService,
             organizationSettingsModel: {} as OrganizationSettingsModel,
             getDataAppCustomSqlProvenance: async () => ({

--- a/packages/backend/src/services/PermissionsService/PermissionsService.ts
+++ b/packages/backend/src/services/PermissionsService/PermissionsService.ts
@@ -3,6 +3,7 @@ import {
     assertUnreachable,
     ForbiddenError,
     OssEmbed,
+    type UUID,
 } from '@lightdash/common';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { BaseService } from '../BaseService';
@@ -20,8 +21,8 @@ export class PermissionsService extends BaseService {
     }
 
     private async checkEmbeddedDashboardPermission(
-        dashboardUuid: string,
-        savedChartUuid: string,
+        dashboardUuid: UUID,
+        savedChartUuid: UUID,
         embed: OssEmbed,
     ) {
         if (
@@ -47,7 +48,7 @@ export class PermissionsService extends BaseService {
     }
 
     private static checkEmbeddedChartPermissions(
-        savedChartUuid: string,
+        savedChartUuid: UUID,
         embed: OssEmbed,
     ) {
         if (
@@ -63,7 +64,7 @@ export class PermissionsService extends BaseService {
      */
     async checkEmbedPermissions(
         account: AnonymousAccount,
-        savedChartUuid: string,
+        savedChartUuid: UUID,
     ) {
         const { embed } = account;
         const { content } = account.access;
@@ -87,6 +88,11 @@ export class PermissionsService extends BaseService {
                     embed,
                 );
             case 'chart':
+                if (!content.chartUuids.includes(savedChartUuid)) {
+                    throw new ForbiddenError(
+                        `Chart ${savedChartUuid} is not authorized by this token`,
+                    );
+                }
                 return PermissionsService.checkEmbeddedChartPermissions(
                     savedChartUuid,
                     embed,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -99,6 +99,7 @@ import {
 } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
 import { QueryComposer } from '../../utils/QueryBuilder/QueryComposer';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
+import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { UserService } from '../UserService';
 import { ProjectService } from './ProjectService';
@@ -285,6 +286,7 @@ const onboardingModel = {
 const savedChartModel = {
     getAllSpaces: vi.fn(async () => spacesWithSavedCharts),
     find: vi.fn(async () => [] as ChartSummary[]),
+    getCustomSqlProvenanceForChart: vi.fn(),
     findCustomSqlProvenance: vi.fn(async () => ({
         tableCalculations: [] as { sql: string; spaceUuid: string }[],
         customSqlDimensions: [] as {
@@ -298,6 +300,9 @@ const savedChartModel = {
             spaceUuid: string;
         }[],
     })),
+};
+const dashboardModel = {
+    savedChartExistsInDashboard: vi.fn(async () => false),
 };
 const jobModel = {
     get: vi.fn(async () => job),
@@ -414,7 +419,7 @@ const getMockedProjectService = (
             userAttributesModel as unknown as UserAttributesModel,
         s3CacheClient: {} as S3CacheClient,
         analyticsModel: {} as AnalyticsModel,
-        dashboardModel: {} as DashboardModel,
+        dashboardModel: dashboardModel as unknown as DashboardModel,
         userWarehouseCredentialsModel: {
             findForProjectWithSecrets: vi.fn(async () => undefined),
         } as unknown as UserWarehouseCredentialsModel,
@@ -466,6 +471,9 @@ const getMockedProjectService = (
         adminNotificationService: {
             notifyConnectionSettingsChange: vi.fn(async () => undefined),
         } as unknown as AdminNotificationService,
+        permissionsService: new PermissionsService({
+            dashboardModel: dashboardModel as unknown as DashboardModel,
+        }),
         spacePermissionService:
             overrides.spacePermissionService ?? ({} as SpacePermissionService),
         provisionPlaygroundProject: overrides.provisionPlaygroundProject,
@@ -6118,6 +6126,7 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
         organizationUuid: string;
         exploreName: string;
         dataAppPreviewToken?: string;
+        customSqlProvenanceChartUuid?: string;
         metricQuery: {
             tableCalculations?: (typeof sqlTableCalculation)[];
             customDimensions?: (typeof sqlCustomDimension)[];
@@ -6185,6 +6194,27 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
         ],
         { accountType: 'jwt', userType: 'anonymous' },
     );
+    const dashboardUuid = 'embedded-dashboard-uuid';
+    const chartUuid = 'embedded-chart-uuid';
+    const dashboardEmbed = {
+        projectUuid,
+        allowAllDashboards: false,
+        dashboardUuids: [dashboardUuid],
+        allowAllCharts: false,
+        chartUuids: [],
+    };
+    const dashboardJwtAccount = {
+        ...jwtAccount,
+        access: {
+            content: {
+                type: 'dashboard',
+                dashboardUuid,
+                chartUuids: [],
+                explores: [exploreName],
+            },
+        },
+        embed: dashboardEmbed,
+    } as unknown as ReturnType<typeof buildAccount>;
 
     const spacePermissionService = {
         getSpaceAccessContext: vi.fn(async () => ({
@@ -6226,6 +6256,9 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
             customSqlDimensions: [],
             additionalMetrics: [],
         });
+        savedChartModel.getCustomSqlProvenanceForChart.mockReset();
+        dashboardModel.savedChartExistsInDashboard.mockReset();
+        dashboardModel.savedChartExistsInDashboard.mockResolvedValue(false);
     });
 
     it('resolves and skips the provenance lookup when there is no custom SQL', async () => {
@@ -6439,6 +6472,183 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
             }),
         ).rejects.toThrow(ForbiddenError);
         expect(savedChartModel.findCustomSqlProvenance).not.toHaveBeenCalled();
+    });
+
+    it('allows current custom SQL from a chart on the embedded dashboard', async () => {
+        dashboardModel.savedChartExistsInDashboard.mockResolvedValue(true);
+        savedChartModel.getCustomSqlProvenanceForChart.mockResolvedValue({
+            exploreName,
+            tableCalculations: [sqlTableCalculation],
+            customSqlDimensions: [sqlCustomDimension],
+            additionalMetrics: [sqlAdditionalMetric],
+        });
+
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: dashboardJwtAccount,
+                customSqlProvenanceChartUuid: chartUuid,
+                metricQuery: {
+                    tableCalculations: [sqlTableCalculation],
+                    customDimensions: [sqlCustomDimension],
+                    additionalMetrics: [sqlAdditionalMetric],
+                },
+            }),
+        ).resolves.toBeUndefined();
+        expect(dashboardModel.savedChartExistsInDashboard).toHaveBeenCalledWith(
+            projectUuid,
+            dashboardUuid,
+            chartUuid,
+        );
+        expect(
+            savedChartModel.getCustomSqlProvenanceForChart,
+        ).toHaveBeenCalledWith({
+            projectUuid,
+            savedChartUuid: chartUuid,
+        });
+    });
+
+    it('rejects substituted SQL from an otherwise authorized embedded chart', async () => {
+        dashboardModel.savedChartExistsInDashboard.mockResolvedValue(true);
+        savedChartModel.getCustomSqlProvenanceForChart.mockResolvedValue({
+            exploreName,
+            tableCalculations: [],
+            customSqlDimensions: [
+                { ...sqlCustomDimension, sql: 'persisted SQL' },
+            ],
+            additionalMetrics: [],
+        });
+
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: dashboardJwtAccount,
+                customSqlProvenanceChartUuid: chartUuid,
+                metricQuery: { customDimensions: [sqlCustomDimension] },
+            }),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
+    });
+
+    it('rejects custom SQL from a chart outside the embedded dashboard', async () => {
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: dashboardJwtAccount,
+                customSqlProvenanceChartUuid: chartUuid,
+                metricQuery: { customDimensions: [sqlCustomDimension] },
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(
+            savedChartModel.getCustomSqlProvenanceForChart,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('rejects provenance when the dashboard is not on the embed allowlist', async () => {
+        const dashboardNotAllowlistedAccount = {
+            ...dashboardJwtAccount,
+            embed: {
+                ...dashboardEmbed,
+                dashboardUuids: [],
+            },
+        } as unknown as typeof dashboardJwtAccount;
+
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: dashboardNotAllowlistedAccount,
+                customSqlProvenanceChartUuid: chartUuid,
+                metricQuery: { customDimensions: [sqlCustomDimension] },
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(
+            dashboardModel.savedChartExistsInDashboard,
+        ).not.toHaveBeenCalled();
+        expect(
+            savedChartModel.getCustomSqlProvenanceForChart,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('rejects provenance from a chart on a different explore', async () => {
+        dashboardModel.savedChartExistsInDashboard.mockResolvedValue(true);
+        savedChartModel.getCustomSqlProvenanceForChart.mockResolvedValue({
+            exploreName: 'another_explore',
+            tableCalculations: [],
+            customSqlDimensions: [sqlCustomDimension],
+            additionalMetrics: [],
+        });
+
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: dashboardJwtAccount,
+                customSqlProvenanceChartUuid: chartUuid,
+                metricQuery: { customDimensions: [sqlCustomDimension] },
+            }),
+        ).rejects.toThrow(CustomSqlQueryForbiddenError);
+    });
+
+    it('allows current custom SQL from a chart-scoped embed token', async () => {
+        const chartJwtAccount = {
+            ...jwtAccount,
+            access: {
+                content: {
+                    type: 'chart',
+                    chartUuids: [chartUuid],
+                    explores: [exploreName],
+                },
+            },
+            embed: {
+                ...dashboardEmbed,
+                dashboardUuids: [],
+                chartUuids: [chartUuid],
+            },
+        } as unknown as ReturnType<typeof buildAccount>;
+        savedChartModel.getCustomSqlProvenanceForChart.mockResolvedValue({
+            exploreName,
+            tableCalculations: [],
+            customSqlDimensions: [sqlCustomDimension],
+            additionalMetrics: [],
+        });
+
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: chartJwtAccount,
+                customSqlProvenanceChartUuid: chartUuid,
+                metricQuery: { customDimensions: [sqlCustomDimension] },
+            }),
+        ).resolves.toBeUndefined();
+    });
+
+    it('rejects a globally embedded chart not authorized by the chart token', async () => {
+        const otherChartUuid = 'another-embedded-chart-uuid';
+        const chartJwtAccount = {
+            ...jwtAccount,
+            access: {
+                content: {
+                    type: 'chart',
+                    chartUuids: [chartUuid],
+                    explores: [exploreName],
+                },
+            },
+            embed: {
+                ...dashboardEmbed,
+                dashboardUuids: [],
+                chartUuids: [chartUuid, otherChartUuid],
+            },
+        } as unknown as ReturnType<typeof buildAccount>;
+
+        await expect(
+            assertCustomSql(service, {
+                ...baseArgs,
+                account: chartJwtAccount,
+                customSqlProvenanceChartUuid: otherChartUuid,
+                metricQuery: { customDimensions: [sqlCustomDimension] },
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(
+            savedChartModel.getCustomSqlProvenanceForChart,
+        ).not.toHaveBeenCalled();
     });
 
     // --- additional metrics (PR2) ---

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -247,6 +247,7 @@ import {
     type ParametersValuesMap,
     type RunQueryTags,
     type Tag,
+    type UUID,
     type WarehouseLocation,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
@@ -344,6 +345,7 @@ import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import { BaseService } from '../BaseService';
 import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
+import { type PermissionsService } from '../PermissionsService/PermissionsService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import {
     doesExploreMatchRequiredAttributes,
@@ -424,6 +426,7 @@ export type ProjectServiceArguments = {
     organizationModel: OrganizationModel;
     projectCompileLogModel: ProjectCompileLogModel;
     adminNotificationService: AdminNotificationService;
+    permissionsService: PermissionsService;
     spacePermissionService: SpacePermissionService;
     natsClient?: INatsClient;
     contentVerificationModel?: ContentVerificationModel;
@@ -564,6 +567,8 @@ export class ProjectService extends BaseService {
 
     adminNotificationService: AdminNotificationService;
 
+    permissionsService: PermissionsService;
+
     spacePermissionService: SpacePermissionService;
 
     contentVerificationModel: ContentVerificationModel | undefined;
@@ -630,6 +635,7 @@ export class ProjectService extends BaseService {
         organizationWarehouseCredentialsModel,
         organizationModel,
         adminNotificationService,
+        permissionsService,
         spacePermissionService,
         contentVerificationModel,
         organizationSettingsModel,
@@ -679,6 +685,7 @@ export class ProjectService extends BaseService {
             organizationWarehouseCredentialsModel;
         this.organizationModel = organizationModel;
         this.adminNotificationService = adminNotificationService;
+        this.permissionsService = permissionsService;
         this.spacePermissionService = spacePermissionService;
         this.contentVerificationModel = contentVerificationModel;
         this.organizationSettingsModel = organizationSettingsModel;
@@ -5081,8 +5088,11 @@ export class ProjectService extends BaseService {
      * A caller who lacks the scope may still run SQL that is byte-identical to SQL
      * already persisted in a saved chart they can view (same project + explore), so
      * editors can re-run and filter existing saved charts in Explore edit mode
-     * without gaining authoring rights. The exemption is only granted to registered
-     * users, never to JWT/embed callers.
+     * without gaining authoring rights. That general exemption is only granted to
+     * registered users. Embedded Explore has a narrower path: it may use only the
+     * current SQL from the exact saved chart it was opened from, after the backend
+     * verifies that the chart is part of the dashboard (or standalone chart)
+     * authorized by the JWT.
      */
     protected async assertCustomSqlAuthorizedForQuery({
         account,
@@ -5091,9 +5101,10 @@ export class ProjectService extends BaseService {
         exploreName,
         metricQuery,
         dataAppPreviewToken,
+        customSqlProvenanceChartUuid,
     }: {
         account: Account;
-        projectUuid: string;
+        projectUuid: UUID;
         organizationUuid: string;
         exploreName: string;
         metricQuery: Pick<
@@ -5101,6 +5112,7 @@ export class ProjectService extends BaseService {
             'tableCalculations' | 'customDimensions' | 'additionalMetrics'
         >;
         dataAppPreviewToken?: string;
+        customSqlProvenanceChartUuid?: UUID;
     }): Promise<void> {
         const sqlTableCalculations = (
             metricQuery.tableCalculations ?? []
@@ -5162,7 +5174,6 @@ export class ProjectService extends BaseService {
         let viewableCustomDimensionKeys = new Set<string>();
         let viewableAdditionalMetricKeys = new Set<string>();
         // The provenance exemption trusts saved-chart SQL the caller can view.
-        // Never extend it to JWT/embed callers.
         if (account.isRegisteredUser()) {
             const provenance =
                 await this.savedChartModel.findCustomSqlProvenance({
@@ -5241,6 +5252,31 @@ export class ProjectService extends BaseService {
             }
             for (const key of appProvenance?.additionalMetrics ?? []) {
                 viewableAdditionalMetricKeys.add(key);
+            }
+        } else if (
+            isJwtUser(account) &&
+            customSqlProvenanceChartUuid !== undefined
+        ) {
+            await this.permissionsService.checkEmbedPermissions(
+                account,
+                customSqlProvenanceChartUuid,
+            );
+            const provenance =
+                await this.savedChartModel.getCustomSqlProvenanceForChart({
+                    projectUuid,
+                    savedChartUuid: customSqlProvenanceChartUuid,
+                });
+
+            if (provenance.exploreName === exploreName) {
+                viewableTableCalculationSqls = new Set(
+                    provenance.tableCalculations.map((tc) => tc.sql),
+                );
+                viewableCustomDimensionKeys = new Set(
+                    provenance.customSqlDimensions.map(getCustomSqlFieldKey),
+                );
+                viewableAdditionalMetricKeys = new Set(
+                    provenance.additionalMetrics.map(getCustomSqlFieldKey),
+                );
             }
         }
 

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -870,6 +870,7 @@ export class ServiceRepository
                         this.models.getProjectCompileLogModel(),
                     adminNotificationService:
                         this.getAdminNotificationService(),
+                    permissionsService: this.getPermissionsService(),
                     spacePermissionService: this.getSpacePermissionService(),
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),

--- a/packages/common/src/utils/api.ts
+++ b/packages/common/src/utils/api.ts
@@ -10,6 +10,11 @@ export const LightdashCliVersionHeader = 'Lightdash-CLI-Version';
 // authenticated, so it must not gate access or feed anything authoritative.
 export const LightdashAppUuidHeader = 'Lightdash-App-Uuid';
 export const LightdashAppPreviewTokenHeader = 'Lightdash-App-Preview-Token';
+// Identifies the saved chart whose persisted custom SQL seeded an embedded
+// Explore. This is an untrusted client hint: the backend must verify both the
+// embed's access to the chart and an exact SQL match before authorizing it.
+export const LightdashCustomSqlProvenanceChartUuidHeader =
+    'Lightdash-Custom-Sql-Provenance-Chart-Uuid';
 export const LIGHTDASH_APP_PREVIEW_TOKEN_MAX_AGE_SECONDS = 60 * 60;
 
 // Declares that the file produced by a schedule-download request will be

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -21,6 +21,7 @@ import {
     isTableChartConfig,
     type ApiChartAndResults,
     type ApiError,
+    type CreateSavedChartVersion,
     type Dashboard,
     type QueryExecutionContext,
     type DashboardFilterRule,
@@ -2279,6 +2280,19 @@ export const GenericDashboardChartTile: FC<
         (c) => c.dashboard?.uuid,
     );
     const chartUuid = dashboardChartReadyQuery?.chart.uuid;
+    const embeddedOnDrillDownExplore =
+        embeddedDashboardInteractions?.onDrillDownExplore;
+    const onDrillDownExplore = useMemo(
+        () =>
+            embeddedOnDrillDownExplore && chartUuid
+                ? (options: { chart: CreateSavedChartVersion }) =>
+                      embeddedOnDrillDownExplore({
+                          ...options,
+                          customSqlProvenanceChartUuid: chartUuid,
+                      })
+                : undefined,
+        [embeddedOnDrillDownExplore, chartUuid],
+    );
     // Skip the resolver fetch when the parent already supplied a palette
     // (embeds, screenshots, SDK minimal): the override always wins below,
     // and the endpoint 403s for JWT/embed auth.
@@ -2422,9 +2436,7 @@ export const GenericDashboardChartTile: FC<
                 />
             )}
             <UnderlyingDataModal />
-            <DrillDownModal
-                onExplore={embeddedDashboardInteractions?.onDrillDownExplore}
-            />
+            <DrillDownModal onExplore={onDrillDownExplore} />
         </MetricQueryDataProvider>
     );
 };

--- a/packages/frontend/src/components/DashboardTiles/EmbeddedDashboardChartInteractions.tsx
+++ b/packages/frontend/src/components/DashboardTiles/EmbeddedDashboardChartInteractions.tsx
@@ -1,11 +1,11 @@
 import {
-    type CreateSavedChartVersion,
     type DashboardFilterRule,
     type EChartsSeries,
     type SavedChart,
 } from '@lightdash/common';
 import { Menu, Portal } from '@mantine/core';
 import React, { useCallback, useState, type FC, type ReactNode } from 'react';
+import { type EmbedExploreOptions } from '../../ee/providers/Embed/types';
 import { FilterDashboardTo } from '../../features/dashboardFilters/FilterDashboardTo';
 import { type DashboardChartReadyQuery } from '../../hooks/dashboard/useDashboardChartReadyQuery';
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
@@ -26,7 +26,7 @@ import {
 import { UnderlyingDataMenuItem } from './UnderlyingDataMenuItem';
 
 export type EmbeddedDashboardInteractions = EmbeddedDashboardInteractivity & {
-    onDrillDownExplore?: (options: { chart: CreateSavedChartVersion }) => void;
+    onDrillDownExplore?: (options: EmbedExploreOptions) => void;
 };
 
 type Props = {

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -39,7 +39,7 @@ import {
     useUpdateDashboard,
 } from '../../../../../hooks/dashboard/useDashboard';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
-import { type EmbedExploreChart } from '../../../../providers/Embed/types';
+import { type EmbedExploreOptions } from '../../../../providers/Embed/types';
 import useEmbed from '../../../../providers/Embed/useEmbed';
 import { embedContractClass } from '../../styles/embedClassContract';
 import { useEmbedDashboard } from '../hooks';
@@ -76,7 +76,7 @@ const EmbedDashboardGrid: FC<{
     onDeleteTile: (tile: DashboardTile) => void;
     onEditTile: (tile: DashboardTile) => void;
     onEditChart?: (chart: SavedChart) => void;
-    onExplore?: (options: { chart: EmbedExploreChart }) => void;
+    onExplore?: (options: EmbedExploreOptions) => void;
     useDashboardEditorTileQueries: boolean;
 }> = ({
     filteredTiles,

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartEditorModal.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartEditorModal.tsx
@@ -44,10 +44,11 @@ const EmbedDashboardChartEditorModal: FC<Props> = ({
             ...embedContext,
             onBackToDashboard: undefined,
             savedChart: undefined,
+            customSqlProvenanceChartUuid: editChart?.uuid,
             savedQueryUuid: undefined,
             onChartSaved,
         }),
-        [embedContext, onChartSaved],
+        [editChart?.uuid, embedContext, onChartSaved],
     );
 
     return (

--- a/packages/frontend/src/ee/features/embed/EmbeddedApp.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbeddedApp.tsx
@@ -1,7 +1,11 @@
+import { type UUID } from '@lightdash/common';
 import { useEffect, useState, type FC } from 'react';
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router';
 import EmbedProvider from '../../providers/Embed/EmbedProvider';
-import { type EmbedExploreChart } from '../../providers/Embed/types';
+import {
+    type EmbedExploreChart,
+    type EmbedExploreOptions,
+} from '../../providers/Embed/types';
 import useEmbed from '../../providers/Embed/useEmbed';
 
 type EmbedExploreLocationState = {
@@ -41,11 +45,17 @@ const EmbedBackgroundColorSync: FC<React.PropsWithChildren> = ({
 const EmbeddedApp: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [savedChart, setSavedChart] = useState<EmbedExploreChart>();
+    const [customSqlProvenanceChartUuid, setCustomSqlProvenanceChartUuid] =
+        useState<UUID>();
     const navigate = useNavigate();
     const location = useLocation();
 
-    const handleExplore = (options: { chart: EmbedExploreChart }) => {
+    const handleExplore = (options: EmbedExploreOptions) => {
         setSavedChart(options.chart);
+        setCustomSqlProvenanceChartUuid(
+            options.customSqlProvenanceChartUuid ??
+                ('uuid' in options.chart ? options.chart.uuid : undefined),
+        );
         void navigate(
             `/embed/${projectUuid}/explore/${options.chart.tableName}`,
             {
@@ -69,6 +79,7 @@ const EmbeddedApp: FC = () => {
     return (
         <EmbedProvider
             savedChart={savedChart}
+            customSqlProvenanceChartUuid={customSqlProvenanceChartUuid}
             projectUuid={projectUuid}
             onExplore={handleExplore}
             onBackToDashboard={handleBackToDashboard}

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -1,8 +1,7 @@
 import {
     type CreateEmbedJwt,
-    type CreateSavedChartVersion,
     type LanguageMap,
-    type SavedChart,
+    type UUID,
 } from '@lightdash/common';
 import get from 'lodash/get';
 import { useEffect, useMemo, useState, type FC } from 'react';
@@ -19,7 +18,13 @@ import { useEmbedEventEmitter } from '../../features/embed/hooks/useEmbedEventEm
 import EmbedProviderContext from './context';
 import { parseEmbedThemeParams } from './parseEmbedThemeParams';
 import { parseEmbedTimezoneParam } from './parseEmbedTimezoneParam';
-import { EMBED_KEY, type EmbedMode, type InMemoryEmbed } from './types';
+import {
+    EMBED_KEY,
+    type EmbedExploreChart,
+    type EmbedExploreOptions,
+    type EmbedMode,
+    type InMemoryEmbed,
+} from './types';
 
 type Props = {
     embedToken?: string;
@@ -28,11 +33,10 @@ type Props = {
     paletteUuid?: string;
     contentOverrides?: LanguageMap;
     embedHeaders?: Record<string, string>;
-    onExplore?: (options: {
-        chart: SavedChart | CreateSavedChartVersion;
-    }) => void;
+    onExplore?: (options: EmbedExploreOptions) => void;
     onBackToDashboard?: () => void;
-    savedChart?: SavedChart | CreateSavedChartVersion;
+    savedChart?: EmbedExploreChart;
+    customSqlProvenanceChartUuid?: UUID;
     savedQueryUuid?: string;
     appUuid?: string;
 };
@@ -70,6 +74,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     onExplore,
     onBackToDashboard,
     savedChart,
+    customSqlProvenanceChartUuid,
     savedQueryUuid,
     appUuid,
 }) => {
@@ -158,6 +163,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
             languageMap: contentOverrides,
             onExplore,
             savedChart,
+            customSqlProvenanceChartUuid,
             savedQueryUuid,
             appUuid,
             onBackToDashboard,
@@ -178,6 +184,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
         contentOverrides,
         onExplore,
         savedChart,
+        customSqlProvenanceChartUuid,
         savedQueryUuid,
         appUuid,
         onBackToDashboard,

--- a/packages/frontend/src/ee/providers/Embed/types.ts
+++ b/packages/frontend/src/ee/providers/Embed/types.ts
@@ -4,6 +4,7 @@ import {
     type CreateSavedChartVersion,
     type LanguageMap,
     type SavedChart,
+    type UUID,
 } from '@lightdash/common';
 import { type SdkFilter } from '../../features/embed/EmbedDashboard/types';
 
@@ -19,6 +20,11 @@ export type InMemoryEmbed = {
 export type EmbedMode = 'sdk' | 'direct';
 
 export type EmbedExploreChart = SavedChart | CreateSavedChartVersion;
+
+export type EmbedExploreOptions = {
+    chart: EmbedExploreChart;
+    customSqlProvenanceChartUuid?: UUID;
+};
 
 export interface EmbedContext {
     // The JWT token used to authenticate the user
@@ -38,7 +44,7 @@ export interface EmbedContext {
     // Powers localization of the dashboard
     languageMap?: LanguageMap;
     // The function to call when the user clicks "Explore from here"
-    onExplore?: (options: { chart: EmbedExploreChart }) => void;
+    onExplore?: (options: EmbedExploreOptions) => void;
     // Localization function
     t: (input: string) => string | undefined;
     // The function to call when the user clicks "Back to dashboard" from an Explore
@@ -48,6 +54,9 @@ export interface EmbedContext {
     onChartSaved?: (chart: SavedChart) => void;
     // The chart that the user is exploring
     savedChart?: EmbedExploreChart;
+    // The saved chart whose persisted custom SQL seeded this Explore. This is
+    // carried separately because derived drill-down charts have no UUID.
+    customSqlProvenanceChartUuid?: UUID;
     // The UUID of the saved query being viewed in an embedded Chart
     savedQueryUuid?: string;
     // The UUID of the data app being viewed in a standalone embedded App

--- a/packages/frontend/src/hooks/explorer/buildQueryArgs.test.ts
+++ b/packages/frontend/src/hooks/explorer/buildQueryArgs.test.ts
@@ -93,6 +93,7 @@ describe('buildQueryArgs', () => {
             parameters: undefined,
             isEditMode: true,
             minimal: false,
+            customSqlProvenanceChartUuid: 'chart-uuid',
             savedChart,
         });
 
@@ -104,6 +105,7 @@ describe('buildQueryArgs', () => {
         expect(result).toEqual(
             expect.objectContaining({
                 pivotConfiguration,
+                customSqlProvenanceChartUuid: 'chart-uuid',
                 query: expect.objectContaining({
                     pivotDimensions: ['orders_status'],
                 }),

--- a/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
+++ b/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
@@ -8,6 +8,7 @@ import {
     type ParametersValuesMap,
     type QueryExecutionContext,
     type SavedChartDAO,
+    type UUID,
 } from '@lightdash/common';
 import type { QueryResultsProps } from '../useQueryResults';
 
@@ -31,6 +32,7 @@ export function buildQueryArgs(options: {
     dateZoomGranularity?: DateGranularity | string;
     minimal: boolean;
     usePreAggregateCache?: boolean;
+    customSqlProvenanceChartUuid?: UUID;
     savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>;
 }): QueryResultsProps | null {
     const {
@@ -77,6 +79,7 @@ export function buildQueryArgs(options: {
         dateZoomGranularity,
         invalidateCache: savedChartArgs ? minimal : true,
         usePreAggregateCache: options.usePreAggregateCache,
+        customSqlProvenanceChartUuid: options.customSqlProvenanceChartUuid,
         parameters: parameters || {},
         pivotConfiguration,
     };

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -70,6 +70,11 @@ export const useExplorerQueryManager = ({
     );
 
     const embed = useEmbed();
+    const customSqlProvenanceChartUuid =
+        embed?.customSqlProvenanceChartUuid ??
+        (embed?.savedChart && 'uuid' in embed.savedChart
+            ? embed.savedChart.uuid
+            : undefined);
     const routeProjectUuid = useProjectUuid();
     const params = useParams<{
         savedQueryUuid: string;
@@ -181,6 +186,7 @@ export const useExplorerQueryManager = ({
             dateZoomGranularity,
             minimal,
             usePreAggregateCache: preAggCacheEnabled,
+            customSqlProvenanceChartUuid,
             savedChart: chartConfigForQuery,
         });
 
@@ -201,6 +207,7 @@ export const useExplorerQueryManager = ({
         dateZoomGranularity,
         minimal,
         preAggCacheEnabled,
+        customSqlProvenanceChartUuid,
         chartConfigForQuery,
         dispatch,
     ]);

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     DEFAULT_RESULTS_PAGE_SIZE,
     DownloadFileType,
+    LightdashCustomSqlProvenanceChartUuidHeader,
     MAX_SAFE_INTEGER,
     ParameterError,
     QueryExecutionContext,
@@ -21,6 +22,7 @@ import {
     type PivotConfiguration,
     type ReadyQueryResultsPage,
     type ResultRow,
+    type UUID,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -43,6 +45,7 @@ export type QueryResultsProps = {
     parameters?: ParametersValuesMap;
     pivotConfiguration?: PivotConfiguration;
     pivotResults?: boolean;
+    customSqlProvenanceChartUuid?: UUID;
 };
 
 /**
@@ -81,13 +84,22 @@ const getAsyncQueryError = (message: string | null): ApiError => {
 const executeAsyncMetricQuery = async (
     projectUuid: string,
     data: ExecuteAsyncMetricQueryRequestParams,
-    options: { signal?: AbortSignal },
+    options: {
+        signal?: AbortSignal;
+        customSqlProvenanceChartUuid?: UUID;
+    },
 ): Promise<ApiExecuteAsyncMetricQueryResults> => {
     return lightdashApi<ApiExecuteAsyncMetricQueryResults>({
         url: `/projects/${projectUuid}/query/metric-query`,
         version: 'v2',
         method: 'POST',
         body: JSON.stringify(data),
+        headers: options.customSqlProvenanceChartUuid
+            ? {
+                  [LightdashCustomSqlProvenanceChartUuidHeader]:
+                      options.customSqlProvenanceChartUuid,
+              }
+            : undefined,
         signal: options.signal,
     });
 };
@@ -194,7 +206,10 @@ const executeAsyncQuery = (
                 parameters: data.parameters,
                 pivotConfiguration: data.pivotConfiguration,
             },
-            { signal },
+            {
+                signal,
+                customSqlProvenanceChartUuid: data.customSqlProvenanceChartUuid,
+            },
         );
     }
     return Promise.reject(new ParameterError('Missing QueryResultsProps'));


### PR DESCRIPTION
## Summary

Fixes PROD-10539 by allowing embedded Explore queries to reuse only the byte-identical custom SQL persisted on the chart they originated from.

- preserve the source chart UUID through standard Explore, the embedded chart editor, and drill-down navigation
- authorize the source chart with the shared embed policy and require an exact saved-SQL and explore match
- use a focused latest-version provenance lookup instead of hydrating the full chart
- cover dashboard/chart allowlists, dashboard membership, explore mismatch, and SQL-substitution deny paths

## Validation

- [x] common, backend, and frontend typechecks
- [x] backend focused suites: 264 tests
- [x] frontend focused suite: 1 test
- [x] common/backend/frontend pre-commit lint and formatting checks
- [x] API generation with no generated diff
- [x] localhost dashboard embed: Explore from here returned the expected result (total 151)
- [x] localhost dashboard embed: drill-by returned the expected result (total 83)
- [x] localhost dashboard embed chart editor: Run query sent the Lightdash-Custom-Sql-Provenance-Chart-Uuid header, returned 200, and rendered the expected result (total 151)
- [x] localhost dashboard embed chart editor: Save changes created the chart version successfully (200)
- [x] SavedChartModel integration suite: 8 tests passed
