### PR TITLE
fix: keep builder status label on one line for long prompts

### DIFF
--- a/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.module.css
+++ b/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.module.css
@@ -127,6 +127,7 @@
 
 .queueState {
     flex-shrink: 0;
+    white-space: nowrap;
     color: var(--mantine-color-ldGray-5);
 }
 
@@ -155,12 +156,18 @@
     box-shadow: var(--mantine-shadow-subtle);
 }
 
+.buildingLabel {
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
 .buildingPrompt {
     min-width: 0;
 }
 
 .queuedCount {
     flex-shrink: 0;
+    white-space: nowrap;
 }
 
 .cancelBuild {

--- a/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/BuilderPromptBar.tsx
@@ -354,7 +354,13 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                                 className={`${classes.stackRow} ${classes.buildingStatus}`}
                             >
                                 <Loader size={13} color="ldGray.6" />
-                                <Text fz="xs" fw={600} c="ldGray.9" inherit>
+                                <Text
+                                    className={classes.buildingLabel}
+                                    fz="xs"
+                                    fw={600}
+                                    c="ldGray.9"
+                                    inherit
+                                >
                                     Reading your prompt…
                                 </Text>
                                 <Text
@@ -384,7 +390,13 @@ const PromptPill = forwardRef<BuilderPromptBarHandle, Props>(
                                 data-has-narration={hasNarration || undefined}
                             >
                                 <Loader size={13} color="ldGray.6" />
-                                <Text fz="xs" fw={600} c="ldGray.9" inherit>
+                                <Text
+                                    className={classes.buildingLabel}
+                                    fz="xs"
+                                    fw={600}
+                                    c="ldGray.9"
+                                    inherit
+                                >
                                     Building…{elapsed ? ` ${elapsed}` : ''}
                                 </Text>
                                 {build.cancelError ? (


### PR DESCRIPTION
## Summary

With a long prompt, the chart type builder's build status row squeezed the `Building… 0:20` label until the elapsed time wrapped onto a second line. The label was an ordinary flex item, so it shrank along with the prompt text instead of the prompt text truncating alone.

- Pin the `Building…` / `Reading your prompt…` labels (`flex-shrink: 0; white-space: nowrap`) so only the quoted prompt gives up space; it already truncates with `lineClamp={1}`.
- Same treatment for the queued-row state text (`Queued` / `Next up` / `Sending…`) and the `· N queued` count, which had the same latent problem.

Applies to both the standalone builder page and the explorer's chart type authoring, which share `BuilderPromptBar`.

## Before

<img width="1663" height="1104" alt="before-full" src="https://github.com/user-attachments/assets/533fbeb5-fe63-4ed7-a0ec-ee9d5392fb92" />
<img width="620" height="40" alt="before-row" src="https://github.com/user-attachments/assets/129c60f5-12f3-484b-9223-5ff7a1cdd131" />

## After
<img width="1663" height="1104" alt="after-full" src="https://github.com/user-attachments/assets/707d7525-1832-44e7-b6f8-324043ba3a66" />
<img width="620" height="40" alt="after-row" src="https://github.com/user-attachments/assets/eb10183b-6765-4769-8070-a34073353ff8" />


## Testing

- `BuilderPromptBar.test.tsx`, oxlint and frontend typecheck pass.
- Verified live with a long prompt on `main` (label wraps) and on this branch (label stays on one line, prompt ellipsises).

Relates: GLITCH-673