### PR TITLE
fix(homepage): resolve group-priority ties and relabel project default

### DIFF
--- a/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
@@ -8,9 +8,13 @@ import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { DatabaseError } from 'pg';
 import {
     AnnouncementsTableName,
+    HomepageAssignmentsTableName,
     HomepagesTableName,
 } from '../database/entities/projectHomepages';
-import { ProjectHomepageModel } from './ProjectHomepageModel';
+import {
+    ProjectHomepageModel,
+    rankGroupPriorities,
+} from './ProjectHomepageModel';
 
 // Covers only behavior beyond a thin Knex wrapper: NotFoundError
 // contracts and the publish draft→published copy the service depends on.
@@ -271,5 +275,97 @@ describe('ProjectHomepageModel', () => {
                 model.getPublishedDefault(PROJECT_UUID),
             ).resolves.toBeUndefined();
         });
+    });
+
+    describe('resolvePublished', () => {
+        it('breaks group-priority ties by created_at then assignment_uuid', async () => {
+            tracker.on.select(HomepageAssignmentsTableName).responseOnce([]);
+            tracker.on.select(HomepagesTableName).responseOnce([]);
+
+            await model.resolvePublished(PROJECT_UUID, {
+                groupUuids: ['group-a', 'group-b'],
+                role: undefined,
+            });
+
+            const selectQuery = tracker.history.select[0];
+            expect(selectQuery.sql).toContain('priority');
+            expect(selectQuery.sql).toContain('created_at');
+            expect(selectQuery.sql).toContain('assignment_uuid');
+        });
+    });
+});
+
+describe('rankGroupPriorities', () => {
+    const assignment = (
+        groupUuid: string,
+        priority: number,
+        createdAt: string,
+        assignmentUuid: string,
+    ) => ({
+        groupUuid,
+        priority,
+        createdAt: new Date(createdAt),
+        assignmentUuid,
+    });
+
+    it('assigns unique sequential priorities to the full project set', () => {
+        const ranked = rankGroupPriorities(
+            [
+                assignment('group-a', 0, '2026-01-01T00:00:00Z', 'aaa'),
+                assignment('group-b', 0, '2026-01-02T00:00:00Z', 'bbb'),
+                assignment('group-c', 1, '2026-01-03T00:00:00Z', 'ccc'),
+            ],
+            ['group-c'],
+        );
+
+        expect(ranked).toEqual([
+            { groupUuid: 'group-c', priority: 0 },
+            { groupUuid: 'group-a', priority: 1 },
+            { groupUuid: 'group-b', priority: 2 },
+        ]);
+    });
+
+    it('honors the requested order and appends omitted groups', () => {
+        const ranked = rankGroupPriorities(
+            [
+                assignment('group-a', 2, '2026-01-01T00:00:00Z', 'aaa'),
+                assignment('group-b', 0, '2026-01-01T00:00:00Z', 'bbb'),
+                assignment('group-c', 1, '2026-01-01T00:00:00Z', 'ccc'),
+            ],
+            ['group-c', 'group-a'],
+        );
+
+        expect(ranked.map((row) => row.groupUuid)).toEqual([
+            'group-c',
+            'group-a',
+            'group-b',
+        ]);
+        expect(ranked.map((row) => row.priority)).toEqual([0, 1, 2]);
+    });
+
+    it('breaks remaining ties by created_at then assignment uuid', () => {
+        const ranked = rankGroupPriorities(
+            [
+                assignment('group-z', 3, '2026-01-01T00:00:00Z', 'zzz'),
+                assignment('group-a', 3, '2026-01-01T00:00:00Z', 'aaa'),
+                assignment('group-m', 3, '2026-01-02T00:00:00Z', 'mmm'),
+            ],
+            [],
+        );
+
+        expect(ranked.map((row) => row.groupUuid)).toEqual([
+            'group-a',
+            'group-z',
+            'group-m',
+        ]);
+    });
+
+    it('ignores unknown and duplicate requested group uuids', () => {
+        const ranked = rankGroupPriorities(
+            [assignment('group-a', 0, '2026-01-01T00:00:00Z', 'aaa')],
+            ['missing', 'group-a', 'group-a'],
+        );
+
+        expect(ranked).toEqual([{ groupUuid: 'group-a', priority: 0 }]);
     });
 });

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -36,6 +36,57 @@ import {
 const RECENTLY_VIEWED_STATEMENT_TIMEOUT_MS = 10_000;
 const RECENTLY_VIEWED_WINDOW_DAYS = 90;
 
+type RankableGroupAssignment = {
+    groupUuid: string;
+    priority: number;
+    createdAt: Date;
+    assignmentUuid: string;
+};
+
+const compareGroupAssignmentPriority = (
+    left: RankableGroupAssignment,
+    right: RankableGroupAssignment,
+): number => {
+    if (left.priority !== right.priority) {
+        return left.priority - right.priority;
+    }
+    const createdDelta = left.createdAt.getTime() - right.createdAt.getTime();
+    if (createdDelta !== 0) {
+        return createdDelta;
+    }
+    return left.assignmentUuid.localeCompare(right.assignmentUuid);
+};
+
+// Always rewrite every group in the project so a partial reorder cannot
+// leave two groups sharing a priority.
+export const rankGroupPriorities = (
+    existing: RankableGroupAssignment[],
+    requestedOrder: string[],
+): { groupUuid: string; priority: number }[] => {
+    const existingByUuid = new Map(
+        existing.map((assignment) => [assignment.groupUuid, assignment]),
+    );
+    const ranked: string[] = [];
+    const seen = new Set<string>();
+
+    for (const groupUuid of requestedOrder) {
+        if (existingByUuid.has(groupUuid) && !seen.has(groupUuid)) {
+            ranked.push(groupUuid);
+            seen.add(groupUuid);
+        }
+    }
+
+    const remaining = existing
+        .filter((assignment) => !seen.has(assignment.groupUuid))
+        .sort(compareGroupAssignmentPriority)
+        .map((assignment) => assignment.groupUuid);
+
+    return [...ranked, ...remaining].map((groupUuid, priority) => ({
+        groupUuid,
+        priority,
+    }));
+};
+
 export class ProjectHomepageModel {
     private readonly database: Knex;
 
@@ -517,7 +568,20 @@ export class ProjectHomepageModel {
                 `${HomepageAssignmentsTableName}.group_uuid`,
             )
             .where(`${HomepageAssignmentsTableName}.project_uuid`, projectUuid)
-            .orderBy(`${HomepageAssignmentsTableName}.priority`, 'asc')
+            .orderBy([
+                {
+                    column: `${HomepageAssignmentsTableName}.priority`,
+                    order: 'asc',
+                },
+                {
+                    column: `${HomepageAssignmentsTableName}.created_at`,
+                    order: 'asc',
+                },
+                {
+                    column: `${HomepageAssignmentsTableName}.assignment_uuid`,
+                    order: 'asc',
+                },
+            ])
             .select(
                 `${HomepageAssignmentsTableName}.assignment_uuid`,
                 `${HomepageAssignmentsTableName}.homepage_uuid`,
@@ -545,15 +609,43 @@ export class ProjectHomepageModel {
         groupUuids: string[],
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
+            const existing = await trx(HomepageAssignmentsTableName)
+                .where({
+                    project_uuid: projectUuid,
+                    target_type: 'group',
+                })
+                .select(
+                    'group_uuid',
+                    'priority',
+                    'created_at',
+                    'assignment_uuid',
+                );
+
+            const ranked = rankGroupPriorities(
+                existing.flatMap((row) =>
+                    row.group_uuid
+                        ? [
+                              {
+                                  groupUuid: row.group_uuid,
+                                  priority: row.priority,
+                                  createdAt: row.created_at,
+                                  assignmentUuid: row.assignment_uuid,
+                              },
+                          ]
+                        : [],
+                ),
+                groupUuids,
+            );
+
             await Promise.all(
-                groupUuids.map((groupUuid, index) =>
+                ranked.map(({ groupUuid, priority }) =>
                     trx(HomepageAssignmentsTableName)
                         .where({
                             project_uuid: projectUuid,
                             target_type: 'group',
                             group_uuid: groupUuid,
                         })
-                        .update({ priority: index }),
+                        .update({ priority }),
                 ),
             );
         });
@@ -578,7 +670,20 @@ export class ProjectHomepageModel {
                     projectUuid,
                 )
                 .whereNotNull(`${HomepagesTableName}.published_config`)
-                .orderBy(`${HomepageAssignmentsTableName}.priority`, 'asc')
+                .orderBy([
+                    {
+                        column: `${HomepageAssignmentsTableName}.priority`,
+                        order: 'asc',
+                    },
+                    {
+                        column: `${HomepageAssignmentsTableName}.created_at`,
+                        order: 'asc',
+                    },
+                    {
+                        column: `${HomepageAssignmentsTableName}.assignment_uuid`,
+                        order: 'asc',
+                    },
+                ])
                 .select(
                     `${HomepagesTableName}.*`,
                     `${HomepageAssignmentsTableName}.group_uuid as assignment_group_uuid`,

--- a/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
@@ -1,9 +1,7 @@
 import {
-    assertUnreachable,
     ProjectMemberRole,
     ProjectMemberRoleLabels,
     type HomepageConfig,
-    type HomepageViewAsReason,
     type HomepageViewAsTarget,
 } from '@lightdash/common';
 import {
@@ -21,24 +19,9 @@ import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import classes from './HomepageEditor.module.css';
 import { useHomepageViewAs } from './hooks/useProjectHomepage';
 import { PublishedHomepage } from './PublishedHomepage';
+import { reasonLabel } from './resolution';
 
 export type HomepageViewType = 'everyone' | 'user' | 'group' | 'role';
-
-const reasonLabel = (
-    reason: HomepageViewAsReason,
-    groupNames: Map<string, string>,
-): string => {
-    switch (reason.type) {
-        case 'group':
-            return `via group ${groupNames.get(reason.groupUuid) ?? 'unknown'} (priority ${reason.priority})`;
-        case 'role':
-            return `via role ${ProjectMemberRoleLabels[reason.role]}`;
-        case 'default':
-            return 'org default';
-        default:
-            return assertUnreachable(reason, 'Unknown view-as reason');
-    }
-};
 
 // The "Viewing as" switcher — lives in the builder toolbar during preview so
 // the canvas below stays the real rendered homepage.

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -37,8 +37,7 @@ import {
     useUpdateGroupPriorities,
 } from './hooks/useProjectHomepage';
 import classes from './PublishModal.module.css';
-
-const RESOLUTION_STEPS = ['Group priority', 'Role', 'Org default'];
+import { RESOLUTION_STEPS } from './resolution';
 
 const ROLE_DESCRIPTIONS: Record<ProjectMemberRole, string> = {
     [ProjectMemberRole.VIEWER]: 'Read-only consumers of dashboards',

--- a/packages/frontend/src/ee/features/homepageBuilder/resolution.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolution.test.ts
@@ -1,0 +1,30 @@
+import { ProjectMemberRole } from '@lightdash/common';
+import { reasonLabel, RESOLUTION_STEPS } from './resolution';
+
+const groupNames = new Map([['group-1', 'Finance']]);
+
+it('labels the last resolution tier as the project default', () => {
+    expect(RESOLUTION_STEPS).toEqual([
+        'Group priority',
+        'Role',
+        'Project default',
+    ]);
+    expect(reasonLabel({ type: 'default' }, groupNames)).toBe(
+        'project default',
+    );
+});
+
+it('keeps group and role reason labels', () => {
+    expect(
+        reasonLabel(
+            { type: 'group', groupUuid: 'group-1', priority: 2 },
+            groupNames,
+        ),
+    ).toBe('via group Finance (priority 2)');
+    expect(
+        reasonLabel(
+            { type: 'role', role: ProjectMemberRole.EDITOR },
+            groupNames,
+        ),
+    ).toBe('via role Editor');
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/resolution.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolution.ts
@@ -1,0 +1,23 @@
+import {
+    assertUnreachable,
+    ProjectMemberRoleLabels,
+    type HomepageViewAsReason,
+} from '@lightdash/common';
+
+export const RESOLUTION_STEPS = ['Group priority', 'Role', 'Project default'];
+
+export const reasonLabel = (
+    reason: HomepageViewAsReason,
+    groupNames: Map<string, string>,
+): string => {
+    switch (reason.type) {
+        case 'group':
+            return `via group ${groupNames.get(reason.groupUuid) ?? 'unknown'} (priority ${reason.priority})`;
+        case 'role':
+            return `via role ${ProjectMemberRoleLabels[reason.role]}`;
+        case 'default':
+            return 'project default';
+        default:
+            return assertUnreachable(reason, 'Unknown view-as reason');
+    }
+};


### PR DESCRIPTION
Admins ranking group homepages could end up with two groups sharing a priority (a partial `PATCH .../homepage/group-priorities` only rewrote the uuids it received), and the resolver had no tiebreaker, so a user in both groups could land on a different homepage between requests. The publish modal and view-as badge also called the final fallback "Org default", which suggested one homepage covers all projects when it is really the per-project default.

<img width="663" alt="Publish modal resolution bar reading Group priority › Role › Project default" src="https://github.com/user-attachments/assets/af097200-2a7a-47c3-9e87-3aa1eecf3eda" />

<img width="784" alt="View-as badge reading Homepage · project default" src="https://github.com/user-attachments/assets/5c9bf797-7c17-4988-a60c-5e81367ed18b" />

Closes: #28089
