### PR TITLE
feat(charts): direct-grant access kernel and reads for saved explore charts

### DIFF
--- a/packages/backend/src/database/entities/savedChartAccess.ts
+++ b/packages/backend/src/database/entities/savedChartAccess.ts
@@ -1,0 +1,41 @@
+import { type SpaceMemberRole } from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const SavedChartUserAccessTableName = 'saved_chart_user_access';
+export const SavedChartGroupAccessTableName = 'saved_chart_group_access';
+
+export type DbSavedChartUserAccess = {
+    saved_chart_uuid: string;
+    user_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type SavedChartUserAccessTable = Knex.CompositeTableType<
+    DbSavedChartUserAccess,
+    Omit<DbSavedChartUserAccess, 'created_at' | 'updated_at'>,
+    Pick<
+        DbSavedChartUserAccess,
+        'space_role' | 'granted_by_user_uuid' | 'updated_at'
+    >
+>;
+
+export type DbSavedChartGroupAccess = {
+    saved_chart_uuid: string;
+    group_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type SavedChartGroupAccessTable = Knex.CompositeTableType<
+    DbSavedChartGroupAccess,
+    Omit<DbSavedChartGroupAccess, 'created_at' | 'updated_at'>,
+    Pick<
+        DbSavedChartGroupAccess,
+        'space_role' | 'granted_by_user_uuid' | 'updated_at'
+    >
+>;

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -50,6 +50,7 @@ import { PullRequestsModel } from './PullRequestsModel';
 import { QueryHistoryModel } from './QueryHistoryModel/QueryHistoryModel';
 import { ResourceViewItemModel } from './ResourceViewItemModel';
 import { RolesModel } from './RolesModel';
+import { SavedChartAccessModel } from './SavedChartAccessModel';
 import { SavedChartModel } from './SavedChartModel';
 import { SavedSqlModel } from './SavedSqlModel';
 import { SchedulerModel } from './SchedulerModel';
@@ -85,6 +86,7 @@ export type ModelManifest = {
     commentModel: CommentModel;
     dashboardModel: DashboardModel;
     dashboardAccessModel: DashboardAccessModel;
+    savedChartAccessModel: SavedChartAccessModel;
     deploySessionModel: DeploySessionModel;
     downloadFileModel: DownloadFileModel;
     downloadAuditModel: DownloadAuditModel;
@@ -310,6 +312,13 @@ export class ModelRepository
         return this.getModel(
             'dashboardAccessModel',
             () => new DashboardAccessModel(this.database),
+        );
+    }
+
+    public getSavedChartAccessModel(): SavedChartAccessModel {
+        return this.getModel(
+            'savedChartAccessModel',
+            () => new SavedChartAccessModel(this.database),
         );
     }
 

--- a/packages/backend/src/models/SavedChartAccessModel.ts
+++ b/packages/backend/src/models/SavedChartAccessModel.ts
@@ -1,0 +1,186 @@
+import { type Knex } from 'knex';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectTableName } from '../database/entities/projects';
+import {
+    SavedChartGroupAccessTableName,
+    SavedChartUserAccessTableName,
+} from '../database/entities/savedChartAccess';
+import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { SpaceTableName } from '../database/entities/spaces';
+import { UserTableName } from '../database/entities/users';
+import {
+    getActiveGrantedGroupPredicate,
+    getActiveProjectMemberPredicate,
+    groupDirectAccessRows,
+    type DirectAccess,
+    type DirectAccessRow,
+} from './directAccessModelUtils';
+
+export type SavedChartDirectAccess = DirectAccess;
+
+/**
+ * Pure data access for saved (explore) chart direct grants. Mirrors
+ * DashboardAccessModel: authorization (CASL, role delegation) is the calling
+ * service's responsibility; the model enforces tenant safety only —
+ * organization scoping and current-membership checks. Only space-saved charts
+ * carry grants; the space join excludes dashboard-owned definitions
+ * (`saved_queries.space_id` null).
+ */
+export class SavedChartAccessModel {
+    constructor(private readonly database: Knex) {}
+
+    async getUserAccess(
+        savedChartUuids: string[],
+        userUuid: string,
+        {
+            trx = this.database,
+            organizationUuid,
+        }: {
+            trx?: Knex;
+            organizationUuid: string;
+        },
+    ): Promise<Record<string, SavedChartDirectAccess>> {
+        const uniqueUuids = [...new Set(savedChartUuids)];
+        if (uniqueUuids.length === 0) {
+            return {};
+        }
+
+        const rows: DirectAccessRow[] = await trx(SavedChartUserAccessTableName)
+            .select({
+                resourceUuid: `${SavedChartUserAccessTableName}.saved_chart_uuid`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+                spaceUuid: `${SpaceTableName}.space_uuid`,
+                role: `${SavedChartUserAccessTableName}.space_role`,
+                groupUuid: trx.raw('NULL'),
+            })
+            .innerJoin(
+                SavedChartsTableName,
+                `${SavedChartsTableName}.saved_query_uuid`,
+                `${SavedChartUserAccessTableName}.saved_chart_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_id`,
+                `${SavedChartsTableName}.space_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${SavedChartUserAccessTableName}.user_uuid`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                function joinCurrentOrganizationMembership() {
+                    this.on(
+                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOn(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    );
+                },
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .whereIn(
+                `${SavedChartUserAccessTableName}.saved_chart_uuid`,
+                uniqueUuids,
+            )
+            .where(`${SavedChartUserAccessTableName}.user_uuid`, userUuid)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(getActiveProjectMemberPredicate(trx))
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .unionAll(
+                trx(SavedChartGroupAccessTableName)
+                    .select({
+                        resourceUuid: `${SavedChartGroupAccessTableName}.saved_chart_uuid`,
+                        organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                        projectUuid: `${ProjectTableName}.project_uuid`,
+                        spaceUuid: `${SpaceTableName}.space_uuid`,
+                        role: `${SavedChartGroupAccessTableName}.space_role`,
+                        groupUuid: `${SavedChartGroupAccessTableName}.group_uuid`,
+                    })
+                    .innerJoin(
+                        SavedChartsTableName,
+                        `${SavedChartsTableName}.saved_query_uuid`,
+                        `${SavedChartGroupAccessTableName}.saved_chart_uuid`,
+                    )
+                    .innerJoin(
+                        SpaceTableName,
+                        `${SpaceTableName}.space_id`,
+                        `${SavedChartsTableName}.space_id`,
+                    )
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_id`,
+                        `${SpaceTableName}.project_id`,
+                    )
+                    .innerJoin(
+                        OrganizationTableName,
+                        `${OrganizationTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    )
+                    .innerJoin(
+                        GroupMembershipTableName,
+                        `${GroupMembershipTableName}.group_uuid`,
+                        `${SavedChartGroupAccessTableName}.group_uuid`,
+                    )
+                    .innerJoin(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${GroupMembershipTableName}.user_id`,
+                    )
+                    .innerJoin(
+                        OrganizationMembershipsTableName,
+                        function joinCurrentOrganizationMembership() {
+                            this.on(
+                                `${OrganizationMembershipsTableName}.user_id`,
+                                `${UserTableName}.user_id`,
+                            ).andOn(
+                                `${OrganizationMembershipsTableName}.organization_id`,
+                                `${ProjectTableName}.organization_id`,
+                            );
+                        },
+                    )
+                    .whereIn(
+                        `${SavedChartGroupAccessTableName}.saved_chart_uuid`,
+                        uniqueUuids,
+                    )
+                    .where(`${UserTableName}.user_uuid`, userUuid)
+                    .where(
+                        `${OrganizationTableName}.organization_uuid`,
+                        organizationUuid,
+                    )
+                    .where(getActiveProjectMemberPredicate(trx))
+                    .where(
+                        `${GroupMembershipTableName}.organization_id`,
+                        trx.ref(`${ProjectTableName}.organization_id`),
+                    )
+                    .where(
+                        getActiveGrantedGroupPredicate(
+                            trx,
+                            SavedChartGroupAccessTableName,
+                        ),
+                    )
+                    .whereNull(`${SavedChartsTableName}.deleted_at`)
+                    .whereNull(`${SpaceTableName}.deleted_at`),
+            );
+
+        return groupDirectAccessRows(rows);
+    }
+}

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -394,6 +394,14 @@ const getMockedAsyncQueryService = (
                 admins: [],
                 directOnly: false,
             })),
+            getChartAccessContext: vi.fn(async () => ({
+                organizationUuid: projectSummary.organizationUuid,
+                projectUuid,
+                inheritsFromOrgOrProject: true,
+                access: [],
+                admins: [],
+                directOnly: false,
+            })),
         } as unknown as SpacePermissionService,
         organizationSettingsModel: {
             get: vi.fn(async () => ({
@@ -4302,6 +4310,14 @@ describe('AsyncQueryService', () => {
                         admins: [],
                         directOnly: false,
                     }),
+                    getChartAccessContext: vi.fn().mockResolvedValue({
+                        organizationUuid: projectSummary.organizationUuid,
+                        projectUuid,
+                        inheritsFromOrgOrProject: true,
+                        access: [],
+                        admins: [],
+                        directOnly: false,
+                    }),
                 };
                 service.pollForQueryCompletion = vi
                     .fn()
@@ -5049,7 +5065,7 @@ describe('checkDashboardChartQueryPermissions', () => {
     const buildSpacePermissionService = (
         dashboardAccess: { userUuid: string }[],
     ) => ({
-        getDashboardAccessContext: vi.fn(async () => ({
+        getChartAccessContext: vi.fn(async () => ({
             organizationUuid: projectSummary.organizationUuid,
             projectUuid: projectSummary.projectUuid,
             inheritsFromOrgOrProject: false,
@@ -5088,9 +5104,10 @@ describe('checkDashboardChartQueryPermissions', () => {
             ),
         ).resolves.toBeUndefined();
         expect(
-            spacePermissionService.getDashboardAccessContext,
+            spacePermissionService.getChartAccessContext,
         ).toHaveBeenCalledWith(account.user.id, {
-            uuid: owningDashboardUuid,
+            uuid: 'chart-uuid',
+            dashboardUuid: owningDashboardUuid,
             spaceUuid: chartSpace.uuid,
         });
         expect(
@@ -5115,7 +5132,7 @@ describe('checkDashboardChartQueryPermissions', () => {
         ).rejects.toThrow(ForbiddenError);
     });
 
-    it('keeps the space check for reusable charts', async () => {
+    it('routes a reusable chart through its own chart context and denies without a grant', async () => {
         const account = buildGrantOnlyAccount();
         const service = getMockedAsyncQueryService(lightdashConfigMock);
         const spacePermissionService = buildSpacePermissionService([]);
@@ -5131,9 +5148,10 @@ describe('checkDashboardChartQueryPermissions', () => {
             ),
         ).rejects.toThrow(ForbiddenError);
         expect(
-            spacePermissionService.getDashboardAccessContext,
+            spacePermissionService.getChartAccessContext,
         ).toHaveBeenCalledWith(account.user.id, {
-            uuid: null,
+            uuid: 'chart-uuid',
+            dashboardUuid: null,
             spaceUuid: chartSpace.uuid,
         });
     });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -5698,14 +5698,14 @@ export class AsyncQueryService extends ProjectService {
                 );
             inheritsFromOrgOrProject = spaceCtx.inheritsFromOrgOrProject;
         } else {
-            const ctx =
-                await this.spacePermissionService.getDashboardAccessContext(
-                    account.user.id,
-                    {
-                        uuid: savedChart.dashboardUuid,
-                        spaceUuid: savedChartSpaceUuid,
-                    },
-                );
+            const ctx = await this.spacePermissionService.getChartAccessContext(
+                account.user.id,
+                {
+                    uuid: savedChart.uuid,
+                    dashboardUuid: savedChart.dashboardUuid,
+                    spaceUuid: savedChartSpaceUuid,
+                },
+            );
             access = ctx.access;
             inheritsFromOrgOrProject = ctx.inheritsFromOrgOrProject;
         }
@@ -6037,11 +6037,14 @@ export class AsyncQueryService extends ProjectService {
             );
         } else {
             const auditedAbility = this.createAuditedAbility(account);
-            const ctx =
-                await this.spacePermissionService.getDashboardAccessContext(
-                    account.user.id,
-                    { uuid: owningDashboardUuid, spaceUuid: space.uuid },
-                );
+            const ctx = await this.spacePermissionService.getChartAccessContext(
+                account.user.id,
+                {
+                    uuid: savedChartUuid,
+                    dashboardUuid: owningDashboardUuid,
+                    spaceUuid: space.uuid,
+                },
+            );
 
             if (
                 auditedAbility.cannot(
@@ -9584,10 +9587,11 @@ export class AsyncQueryService extends ProjectService {
             : savedChart.metricQuery;
 
         const spaceCtx =
-            await this.spacePermissionService.getDashboardAccessContext(
+            await this.spacePermissionService.getChartAccessContext(
                 account.user.id,
                 {
-                    uuid: savedChart.dashboardUuid,
+                    uuid: savedChart.uuid,
+                    dashboardUuid: savedChart.dashboardUuid,
                     spaceUuid: savedChart.spaceUuid,
                 },
             );

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6636,13 +6636,11 @@ export class ProjectService extends BaseService {
         const { organizationUuid, projectUuid } = savedChart;
 
         const [spaceCtx, explore] = await Promise.all([
-            this.spacePermissionService.getDashboardAccessContext(
-                account.user.id,
-                {
-                    uuid: savedChart.dashboardUuid,
-                    spaceUuid: savedChart.spaceUuid,
-                },
-            ),
+            this.spacePermissionService.getChartAccessContext(account.user.id, {
+                uuid: savedChart.uuid,
+                dashboardUuid: savedChart.dashboardUuid,
+                spaceUuid: savedChart.spaceUuid,
+            }),
             this.getExplore(
                 account,
                 projectUuid,
@@ -6739,13 +6737,11 @@ export class ProjectService extends BaseService {
         const { organizationUuid, projectUuid } = savedChart;
 
         const [spaceCtx, explore] = await Promise.all([
-            this.spacePermissionService.getDashboardAccessContext(
-                account.user.id,
-                {
-                    uuid: savedChart.dashboardUuid,
-                    spaceUuid: savedChart.spaceUuid,
-                },
-            ),
+            this.spacePermissionService.getChartAccessContext(account.user.id, {
+                uuid: savedChart.uuid,
+                dashboardUuid: savedChart.dashboardUuid,
+                spaceUuid: savedChart.spaceUuid,
+            }),
             this.getExplore(
                 account,
                 projectUuid,
@@ -9766,10 +9762,11 @@ export class ProjectService extends BaseService {
                     ]);
 
                 const spaceCtx =
-                    await this.spacePermissionService.getDashboardAccessContext(
+                    await this.spacePermissionService.getChartAccessContext(
                         account.user.id,
                         {
-                            uuid: savedChart.dashboardUuid,
+                            uuid: savedChart.uuid,
+                            dashboardUuid: savedChart.dashboardUuid,
                             spaceUuid: savedChart.spaceUuid,
                         },
                     );
@@ -9839,10 +9836,11 @@ export class ProjectService extends BaseService {
                 }
 
                 const [chartContexts, exploresMap] = await Promise.all([
-                    this.spacePermissionService.getDashboardsAccessContext(
+                    this.spacePermissionService.getChartsAccessContext(
                         account.user.id,
                         savedCharts.map((chart) => ({
-                            uuid: chart.dashboardUuid,
+                            uuid: chart.uuid,
+                            dashboardUuid: chart.dashboardUuid,
                             spaceUuid: chart.spaceUuid,
                         })),
                     ),

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
@@ -139,6 +139,14 @@ const spacePermissionService = {
         admins: [],
         directOnly: false,
     })),
+    getChartAccessContext: vi.fn(async () => ({
+        organizationUuid: 'org-uuid',
+        projectUuid: 'project-uuid',
+        inheritsFromOrgOrProject: true,
+        access: [],
+        admins: [],
+        directOnly: false,
+    })),
     getFirstViewableSpaceUuid: vi.fn(async () => 'space-uuid'),
 };
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -1408,10 +1408,11 @@ export class SavedChartService
         const savedChart =
             await this.savedChartModel.getSummary(savedChartUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
+            await this.spacePermissionService.getChartAccessContext(
                 user.userUuid,
                 {
-                    uuid: savedChart.dashboardUuid,
+                    uuid: savedChart.uuid,
+                    dashboardUuid: savedChart.dashboardUuid,
                     spaceUuid: savedChart.spaceUuid,
                 },
             );
@@ -1481,14 +1482,14 @@ export class SavedChartService
                 inheritsFromOrgOrProject = spaceCtx.inheritsFromOrgOrProject;
             }
         } else {
-            const ctx =
-                await this.spacePermissionService.getDashboardAccessContext(
-                    account.user.userUuid,
-                    {
-                        uuid: savedChart.dashboardUuid,
-                        spaceUuid: savedChart.spaceUuid,
-                    },
-                );
+            const ctx = await this.spacePermissionService.getChartAccessContext(
+                account.user.userUuid,
+                {
+                    uuid: savedChart.uuid,
+                    dashboardUuid: savedChart.dashboardUuid,
+                    spaceUuid: savedChart.spaceUuid,
+                },
+            );
             access = ctx.access;
             inheritsFromOrgOrProject = ctx.inheritsFromOrgOrProject;
         }
@@ -2312,9 +2313,13 @@ export class SavedChartService
     ): Promise<ChartHistory> {
         const chart = await this.savedChartModel.getSummary(chartUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
+            await this.spacePermissionService.getChartAccessContext(
                 user.userUuid,
-                { uuid: chart.dashboardUuid, spaceUuid: chart.spaceUuid },
+                {
+                    uuid: chart.uuid,
+                    dashboardUuid: chart.dashboardUuid,
+                    spaceUuid: chart.spaceUuid,
+                },
             );
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -2359,9 +2364,13 @@ export class SavedChartService
     ): Promise<ChartVersion> {
         const chart = await this.savedChartModel.getSummary(chartUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
+            await this.spacePermissionService.getChartAccessContext(
                 user.userUuid,
-                { uuid: chart.dashboardUuid, spaceUuid: chart.spaceUuid },
+                {
+                    uuid: chart.uuid,
+                    dashboardUuid: chart.dashboardUuid,
+                    spaceUuid: chart.spaceUuid,
+                },
             );
         const auditedAbility = this.createAuditedAbility(user);
         if (

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -139,6 +139,11 @@ const spacePermissionService = {
         access: [],
         directOnly: false,
     })),
+    getChartAccessContext: vi.fn(async () => ({
+        inheritsFromOrgOrProject: false,
+        access: [],
+        directOnly: false,
+    })),
 };
 
 const schedulerClient = {
@@ -539,20 +544,18 @@ describe('SchedulerService', () => {
                 dashboardUuid: 'owningDashboardUuid',
             } as never);
             // Grant-only user: no space access, only a viewer grant row.
-            spacePermissionService.getDashboardAccessContext.mockResolvedValueOnce(
-                {
-                    inheritsFromOrgOrProject: false,
-                    access: [
-                        {
-                            userUuid: 'userUuid',
-                            role: SpaceMemberRole.VIEWER,
-                            hasDirectAccess: true,
-                            grantedVia: 'dashboard',
-                        },
-                    ],
-                    directOnly: true,
-                } as never,
-            );
+            spacePermissionService.getChartAccessContext.mockResolvedValueOnce({
+                inheritsFromOrgOrProject: false,
+                access: [
+                    {
+                        userUuid: 'userUuid',
+                        role: SpaceMemberRole.VIEWER,
+                        hasDirectAccess: true,
+                        grantedVia: 'dashboard',
+                    },
+                ],
+                directOnly: true,
+            } as never);
             const user = buildUser([
                 {
                     subject: 'SavedChart',
@@ -567,9 +570,10 @@ describe('SchedulerService', () => {
                 service.getScheduler(user, 'schedulerUuid'),
             ).resolves.toEqual(chartScheduler);
             expect(
-                spacePermissionService.getDashboardAccessContext,
+                spacePermissionService.getChartAccessContext,
             ).toHaveBeenCalledWith('userUuid', {
-                uuid: 'owningDashboardUuid',
+                uuid: savedChartUuid,
+                dashboardUuid: 'owningDashboardUuid',
                 spaceUuid: privateSpaceUuid,
             });
         });

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -393,9 +393,13 @@ export class SchedulerService extends BaseService {
                 await this.savedChartModel.getSummary(scheduler.savedChartUuid);
 
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getDashboardAccessContext(
+                await this.spacePermissionService.getChartAccessContext(
                     user.userUuid,
-                    { uuid: dashboardUuid, spaceUuid },
+                    {
+                        uuid: scheduler.savedChartUuid,
+                        dashboardUuid,
+                        spaceUuid,
+                    },
                 );
             if (
                 auditedAbility.cannot(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1117,6 +1117,8 @@ export class ServiceRepository
                     spaceModel: this.models.getSpaceModel(),
                     spacePermissionModel: this.models.getSpacePermissionModel(),
                     dashboardAccessModel: this.models.getDashboardAccessModel(),
+                    savedChartAccessModel:
+                        this.models.getSavedChartAccessModel(),
                     directAccessFeatureGate: new DirectAccessFeatureGate(
                         this.models.getFeatureFlagModel(),
                         this.getLicenseService(),

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -2222,3 +2222,126 @@ describe('getSavedChartAccessContext', () => {
         ).rejects.toThrow(ParameterError);
     });
 });
+
+describe('getChartAccessContext (ownership routing)', () => {
+    const baseContext: SpaceAccessContextForCasl = {
+        organizationUuid: 'organization-uuid',
+        projectUuid: 'project-uuid',
+        inheritsFromOrgOrProject: false,
+        access: [],
+        admins: [],
+    };
+
+    const editorGrant = (spaceUuid: string) => ({
+        organizationUuid: 'organization-uuid',
+        projectUuid: 'project-uuid',
+        spaceUuid,
+        userRole: SpaceMemberRole.EDITOR,
+        groupRoles: [],
+    });
+
+    const createService = ({
+        dashboardGrants = {},
+        chartGrants = {},
+        contexts,
+    }: {
+        dashboardGrants?: Record<string, unknown>;
+        chartGrants?: Record<string, unknown>;
+        contexts: Record<string, SpaceAccessContextForCasl>;
+    }) => {
+        const dashboardAccessModel = {
+            getUserAccess: vi.fn(async () => dashboardGrants),
+        };
+        const savedChartAccessModel = {
+            getUserAccess: vi.fn(async () => chartGrants),
+        };
+        const service = new SpacePermissionService({
+            spaceModel: {} as SpaceModel,
+            spacePermissionModel: {} as unknown as SpacePermissionModel,
+            dashboardAccessModel: dashboardAccessModel as never,
+            savedChartAccessModel: savedChartAccessModel as never,
+            directAccessFeatureGate: {
+                isEnabledForUser: vi.fn(async () => true),
+            } as unknown as DirectAccessFeatureGate,
+        });
+        vi.spyOn(service, 'getSpaceAccessContext').mockImplementation(
+            async (_userUuid, spaceUuid) => contexts[spaceUuid],
+        );
+        vi.spyOn(service, 'getSpacesAccessContext').mockResolvedValue(contexts);
+        return { service, dashboardAccessModel, savedChartAccessModel };
+    };
+
+    test('an owned chart resolves through its dashboard grant, never the chart grant', async () => {
+        const { service, dashboardAccessModel, savedChartAccessModel } =
+            createService({
+                contexts: { 'space-uuid': baseContext },
+                dashboardGrants: {
+                    'dashboard-uuid': editorGrant('space-uuid'),
+                },
+            });
+
+        const result = await service.getChartAccessContext('user-uuid', {
+            uuid: 'chart-uuid',
+            dashboardUuid: 'dashboard-uuid',
+            spaceUuid: 'space-uuid',
+        });
+
+        expect(result.access).toEqual([
+            expect.objectContaining({ grantedVia: 'dashboard' }),
+        ]);
+        expect(dashboardAccessModel.getUserAccess).toHaveBeenCalledWith(
+            ['dashboard-uuid'],
+            'user-uuid',
+            { organizationUuid: 'organization-uuid' },
+        );
+        expect(savedChartAccessModel.getUserAccess).not.toHaveBeenCalled();
+    });
+
+    test('a space chart resolves through its own chart grant, never a dashboard grant', async () => {
+        const { service, dashboardAccessModel, savedChartAccessModel } =
+            createService({
+                contexts: { 'space-uuid': baseContext },
+                chartGrants: { 'chart-uuid': editorGrant('space-uuid') },
+            });
+
+        const result = await service.getChartAccessContext('user-uuid', {
+            uuid: 'chart-uuid',
+            dashboardUuid: null,
+            spaceUuid: 'space-uuid',
+        });
+
+        expect(result.access).toEqual([
+            expect.objectContaining({ grantedVia: 'saved_chart' }),
+        ]);
+        expect(savedChartAccessModel.getUserAccess).toHaveBeenCalledWith(
+            ['chart-uuid'],
+            'user-uuid',
+            { organizationUuid: 'organization-uuid' },
+        );
+        expect(dashboardAccessModel.getUserAccess).not.toHaveBeenCalled();
+    });
+
+    test('batched routing stays aligned across a mixed owned/space set', async () => {
+        const { service } = createService({
+            contexts: { 'space-a': baseContext, 'space-b': baseContext },
+            dashboardGrants: { 'dashboard-uuid': editorGrant('space-a') },
+            chartGrants: { 'chart-b': editorGrant('space-b') },
+        });
+
+        const result = await service.getChartsAccessContext('user-uuid', [
+            {
+                uuid: 'chart-a',
+                dashboardUuid: 'dashboard-uuid',
+                spaceUuid: 'space-a',
+            },
+            { uuid: 'chart-b', dashboardUuid: null, spaceUuid: 'space-b' },
+        ]);
+
+        expect(result[0]?.access).toEqual([
+            expect.objectContaining({ grantedVia: 'dashboard' }),
+        ]);
+        expect(result[1]?.access).toEqual([
+            expect.objectContaining({ grantedVia: 'saved_chart' }),
+        ]);
+    });
+});

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -102,6 +102,9 @@ describe('SpacePermissionService', () => {
             mockPermissionModel as unknown as SpacePermissionModel,
         dashboardAccessModel:
             dashboardAccessModel as unknown as DashboardAccessModel,
+        savedChartAccessModel: {
+            getUserAccess: vi.fn(async () => ({})),
+        } as never,
         directAccessFeatureGate:
             directAccessFeatureGate as unknown as DirectAccessFeatureGate,
     });
@@ -1800,6 +1803,9 @@ describe('getDashboardAccessContext', () => {
             spacePermissionModel: {} as unknown as SpacePermissionModel,
             dashboardAccessModel:
                 dashboardAccessModel as unknown as DashboardAccessModel,
+            savedChartAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
             directAccessFeatureGate:
                 directAccessFeatureGate as unknown as DirectAccessFeatureGate,
         });
@@ -1993,6 +1999,9 @@ describe('getDashboardsAccessContext', () => {
             spacePermissionModel: {} as unknown as SpacePermissionModel,
             dashboardAccessModel:
                 dashboardAccessModel as unknown as DashboardAccessModel,
+            savedChartAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
             directAccessFeatureGate:
                 directAccessFeatureGate as unknown as DirectAccessFeatureGate,
         });
@@ -2115,5 +2124,101 @@ describe('getDashboardsAccessContext', () => {
         ]);
 
         expect(result).toEqual([undefined]);
+    });
+});
+
+describe('getSavedChartAccessContext', () => {
+    const spaceContext: SpaceAccessContextForCasl = {
+        organizationUuid: 'organization-uuid',
+        projectUuid: 'project-uuid',
+        inheritsFromOrgOrProject: false,
+        access: [],
+        admins: [],
+    };
+    const chartRef = { uuid: 'chart-uuid', spaceUuid: 'space-uuid' };
+
+    const createService = ({
+        enabled,
+        grants = {},
+    }: {
+        enabled: boolean;
+        grants?: Record<string, unknown>;
+    }) => {
+        const savedChartAccessModel = {
+            getUserAccess: vi.fn(async () => grants),
+        };
+        const service = new SpacePermissionService({
+            spaceModel: {} as SpaceModel,
+            spacePermissionModel: {} as unknown as SpacePermissionModel,
+            dashboardAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
+            savedChartAccessModel: savedChartAccessModel as never,
+            directAccessFeatureGate: {
+                isEnabledForUser: vi.fn(async () => enabled),
+            } as unknown as DirectAccessFeatureGate,
+        });
+        vi.spyOn(service, 'getSpaceAccessContext').mockResolvedValue(
+            spaceContext,
+        );
+        return { service, savedChartAccessModel };
+    };
+
+    test('null uuid returns the space-only context with no grant lookup', async () => {
+        const { service, savedChartAccessModel } = createService({
+            enabled: true,
+        });
+        const result = await service.getSavedChartAccessContext('user-uuid', {
+            uuid: null,
+            spaceUuid: 'space-uuid',
+        });
+        expect(result).toEqual({ ...spaceContext, directOnly: false });
+        expectNoGrantRows(result);
+        expect(savedChartAccessModel.getUserAccess).not.toHaveBeenCalled();
+    });
+
+    test('appends a grant row tagged saved_chart and marks grant-only', async () => {
+        const { service } = createService({
+            enabled: true,
+            grants: {
+                'chart-uuid': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    spaceUuid: 'space-uuid',
+                    userRole: SpaceMemberRole.EDITOR,
+                    groupRoles: [],
+                },
+            },
+        });
+        const result = await service.getSavedChartAccessContext(
+            'user-uuid',
+            chartRef,
+        );
+        expect(result.access).toEqual([
+            expect.objectContaining({
+                userUuid: 'user-uuid',
+                role: SpaceMemberRole.EDITOR,
+                grantedVia: 'saved_chart',
+            }),
+        ]);
+        expect(result.directOnly).toBe(true);
+    });
+
+    test('throws when the grant does not belong to the given space', async () => {
+        const { service } = createService({
+            enabled: true,
+            grants: {
+                'chart-uuid': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    spaceUuid: 'another-space',
+                    userRole: SpaceMemberRole.EDITOR,
+                    groupRoles: [],
+                },
+            },
+        });
+        await expect(
+            service.getSavedChartAccessContext('user-uuid', chartRef),
+        ).rejects.toThrow(ParameterError);
     });
 });

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -282,6 +282,69 @@ export class SpacePermissionService extends BaseService {
     }
 
     /**
+     * Access context for a chart, routed by ownership: a dashboard-owned chart
+     * (`dashboardUuid` set) resolves through the owning dashboard's grants; a
+     * space-saved chart resolves through its own grants. Callers pass the
+     * chart's own uuid, its dashboardUuid, and its space; this is the entry
+     * point every chart read/write path should use.
+     */
+    async getChartAccessContext(
+        userUuid: string,
+        chart: {
+            uuid: string;
+            dashboardUuid: string | null;
+            spaceUuid: string;
+        },
+    ): Promise<DashboardAccessContextForCasl> {
+        return chart.dashboardUuid
+            ? this.getDashboardAccessContext(userUuid, {
+                  uuid: chart.dashboardUuid,
+                  spaceUuid: chart.spaceUuid,
+              })
+            : this.getSavedChartAccessContext(userUuid, {
+                  uuid: chart.uuid,
+                  spaceUuid: chart.spaceUuid,
+              });
+    }
+
+    /**
+     * Batched `getChartAccessContext`, aligned with the input. Owned charts
+     * resolve in one dashboard-grant batch and space charts in one
+     * chart-grant batch (non-applicable entries take the no-lookup null path),
+     * so a mixed dashboard load costs two grant queries, never N+1.
+     */
+    async getChartsAccessContext(
+        userUuid: string,
+        charts: {
+            uuid: string;
+            dashboardUuid: string | null;
+            spaceUuid: string;
+        }[],
+    ): Promise<(DashboardAccessContextForCasl | undefined)[]> {
+        const [dashboardContexts, chartContexts] = await Promise.all([
+            this.getDashboardsAccessContext(
+                userUuid,
+                charts.map((chart) => ({
+                    uuid: chart.dashboardUuid,
+                    spaceUuid: chart.spaceUuid,
+                })),
+            ),
+            this.getSavedChartsAccessContext(
+                userUuid,
+                charts.map((chart) => ({
+                    uuid: chart.dashboardUuid ? null : chart.uuid,
+                    spaceUuid: chart.spaceUuid,
+                })),
+            ),
+        ]);
+        return charts.map((chart, index) =>
+            chart.dashboardUuid
+                ? dashboardContexts[index]
+                : chartContexts[index],
+        );
+    }
+
+    /**
      * Batched `getDashboardAccessContext` for hot paths that resolve many
      * (dashboard, space) refs at once. Returns contexts aligned with the input;
      * undefined where the space context could not be resolved. Doubtful refs

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -24,6 +24,8 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { type DashboardAccessModel } from '../../models/DashboardAccessModel';
+import { type DirectAccess } from '../../models/directAccessModelUtils';
+import { type SavedChartAccessModel } from '../../models/SavedChartAccessModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import {
     SpacePermissionModel,
@@ -48,6 +50,13 @@ export type SpaceAccessContextForCasl = {
     admins: SpaceAdmin[];
 };
 
+// A content type's direct-grant lookup (e.g. DashboardAccessModel.getUserAccess
+// or SavedChartAccessModel.getUserAccess), pre-bound to the requesting user.
+type GrantLookup = (
+    resourceUuids: string[],
+    opts: { organizationUuid: string },
+) => Promise<Record<string, DirectAccess>>;
+
 export type DashboardAccessContextForCasl = SpaceAccessContextForCasl & {
     /**
      * True when the requester has no space-derived access path (membership,
@@ -64,23 +73,28 @@ export class SpacePermissionService extends BaseService {
 
     private readonly dashboardAccessModel: DashboardAccessModel;
 
+    private readonly savedChartAccessModel: SavedChartAccessModel;
+
     private readonly directAccessFeatureGate: DirectAccessFeatureGate;
 
     constructor({
         spaceModel,
         spacePermissionModel,
         dashboardAccessModel,
+        savedChartAccessModel,
         directAccessFeatureGate,
     }: {
         spaceModel: SpaceModel;
         spacePermissionModel: SpacePermissionModel;
         dashboardAccessModel: DashboardAccessModel;
+        savedChartAccessModel: SavedChartAccessModel;
         directAccessFeatureGate: DirectAccessFeatureGate;
     }) {
         super();
         this.spaceModel = spaceModel;
         this.spacePermissionModel = spacePermissionModel;
         this.dashboardAccessModel = dashboardAccessModel;
+        this.savedChartAccessModel = savedChartAccessModel;
         this.directAccessFeatureGate = directAccessFeatureGate;
     }
 
@@ -228,12 +242,85 @@ export class SpacePermissionService extends BaseService {
         userUuid: string,
         dashboard: { uuid: string | null; spaceUuid: string },
     ): Promise<DashboardAccessContextForCasl> {
+        return this.resolveGrantAccessContext(userUuid, dashboard, {
+            grantedVia: 'dashboard',
+            resourceLabel: 'Dashboard',
+            lookupGrants: (uuids, opts) =>
+                this.dashboardAccessModel.getUserAccess(uuids, userUuid, opts),
+        });
+    }
+
+    /**
+     * Direct-grant access context for a saved (explore) chart. Same kernel and
+     * boundary rule as `getDashboardAccessContext` (read its doc); grants are
+     * tagged `grantedVia: 'saved_chart'`. Pass `uuid: null` for a chart with no
+     * direct policy, or at a boundary-crossing site where grants must not
+     * count.
+     */
+    async getSavedChartAccessContext(
+        userUuid: string,
+        chart: { uuid: string | null; spaceUuid: string },
+    ): Promise<DashboardAccessContextForCasl> {
+        return this.resolveGrantAccessContext(userUuid, chart, {
+            grantedVia: 'saved_chart',
+            resourceLabel: 'Saved chart',
+            lookupGrants: (uuids, opts) =>
+                this.savedChartAccessModel.getUserAccess(uuids, userUuid, opts),
+        });
+    }
+
+    /** Batched `getSavedChartAccessContext` for hot paths (listings, tiles). */
+    async getSavedChartsAccessContext(
+        userUuid: string,
+        charts: { uuid: string | null; spaceUuid: string }[],
+    ): Promise<(DashboardAccessContextForCasl | undefined)[]> {
+        return this.resolveGrantsAccessContext(userUuid, charts, {
+            grantedVia: 'saved_chart',
+            lookupGrants: (uuids, opts) =>
+                this.savedChartAccessModel.getUserAccess(uuids, userUuid, opts),
+        });
+    }
+
+    /**
+     * Batched `getDashboardAccessContext` for hot paths that resolve many
+     * (dashboard, space) refs at once. Returns contexts aligned with the input;
+     * undefined where the space context could not be resolved. Doubtful refs
+     * degrade to the space-only context — never to more access.
+     */
+    async getDashboardsAccessContext(
+        userUuid: string,
+        dashboards: { uuid: string | null; spaceUuid: string }[],
+    ): Promise<(DashboardAccessContextForCasl | undefined)[]> {
+        return this.resolveGrantsAccessContext(userUuid, dashboards, {
+            grantedVia: 'dashboard',
+            lookupGrants: (uuids, opts) =>
+                this.dashboardAccessModel.getUserAccess(uuids, userUuid, opts),
+        });
+    }
+
+    // The canonical single-ref grant kernel that every getXAccessContext
+    // delegates to. See the getDashboardAccessContext doc for the boundary
+    // rule. One space fetch, one gate check, one grant lookup; a space the
+    // resource does not belong to is a caller bug and throws.
+    private async resolveGrantAccessContext(
+        userUuid: string,
+        ref: { uuid: string | null; spaceUuid: string },
+        {
+            grantedVia,
+            resourceLabel,
+            lookupGrants,
+        }: {
+            grantedVia: GrantSource;
+            resourceLabel: string;
+            lookupGrants: GrantLookup;
+        },
+    ): Promise<DashboardAccessContextForCasl> {
         const spaceContext = await this.getSpaceAccessContext(
             userUuid,
-            dashboard.spaceUuid,
+            ref.spaceUuid,
         );
         const spaceOnlyContext = { ...spaceContext, directOnly: false };
-        if (dashboard.uuid === null) {
+        if (ref.uuid === null) {
             return spaceOnlyContext;
         }
         if (
@@ -244,13 +331,10 @@ export class SpacePermissionService extends BaseService {
         ) {
             return spaceOnlyContext;
         }
-
-        const grants = await this.dashboardAccessModel.getUserAccess(
-            [dashboard.uuid],
-            userUuid,
-            { organizationUuid: spaceContext.organizationUuid },
-        );
-        const grant = grants[dashboard.uuid];
+        const grants = await lookupGrants([ref.uuid], {
+            organizationUuid: spaceContext.organizationUuid,
+        });
+        const grant = grants[ref.uuid];
         if (grant === undefined) {
             return spaceOnlyContext;
         }
@@ -261,38 +345,31 @@ export class SpacePermissionService extends BaseService {
         if (grantRoles.length === 0) {
             return spaceOnlyContext;
         }
-        // Grants must never extend a context for a space the dashboard does
-        // not live in; a mismatch is a caller bug, so fail loudly.
-        if (grant.spaceUuid !== dashboard.spaceUuid) {
+        if (grant.spaceUuid !== ref.spaceUuid) {
             throw new ParameterError(
-                `Dashboard ${dashboard.uuid} does not belong to space ${dashboard.spaceUuid}`,
+                `${resourceLabel} ${ref.uuid} does not belong to space ${ref.spaceUuid}`,
             );
         }
-
         return SpacePermissionService.withGrantAccess(
             spaceContext,
             userUuid,
             grantRoles,
-            'dashboard',
+            grantedVia,
         );
     }
 
-    /**
-     * Batched getDashboardAccessContext for hot paths that resolve many
-     * (dashboard, space) refs at once: one space-context batch, one gate
-     * check, and one grant lookup. Returns contexts aligned with the input;
-     * undefined where the space context could not be resolved. Anything
-     * doubtful (missing grant, organization mismatch, dashboard not in the
-     * given space) degrades to the space-only context — never to more
-     * access.
-     */
-    async getDashboardsAccessContext(
+    // Batched sibling of resolveGrantAccessContext: one space batch, one gate
+    // check, one grant lookup. Doubtful refs degrade to space-only rather than
+    // throwing, so one bad ref never fails a whole hot-path request.
+    private async resolveGrantsAccessContext(
         userUuid: string,
-        dashboards: { uuid: string | null; spaceUuid: string }[],
+        refs: { uuid: string | null; spaceUuid: string }[],
+        {
+            grantedVia,
+            lookupGrants,
+        }: { grantedVia: GrantSource; lookupGrants: GrantLookup },
     ): Promise<(DashboardAccessContextForCasl | undefined)[]> {
-        const uniqueSpaceUuids = [
-            ...new Set(dashboards.map((ref) => ref.spaceUuid)),
-        ];
+        const uniqueSpaceUuids = [...new Set(refs.map((ref) => ref.spaceUuid))];
         const spaceContexts = await this.getSpacesAccessContext(
             userUuid,
             uniqueSpaceUuids,
@@ -304,35 +381,31 @@ export class SpacePermissionService extends BaseService {
             return ctx ? { ...ctx, directOnly: false } : undefined;
         };
 
-        const dashboardUuids = [
+        const resourceUuids = [
             ...new Set(
-                dashboards.flatMap((ref) =>
+                refs.flatMap((ref) =>
                     ref.uuid !== null && spaceContexts[ref.spaceUuid]
                         ? [ref.uuid]
                         : [],
                 ),
             ),
         ];
-        const organizationUuid = dashboards
+        const organizationUuid = refs
             .map((ref) => spaceContexts[ref.spaceUuid]?.organizationUuid)
             .find((uuid) => uuid !== undefined);
         if (
-            dashboardUuids.length === 0 ||
+            resourceUuids.length === 0 ||
             organizationUuid === undefined ||
             !(await this.directAccessFeatureGate.isEnabledForUser({
                 userUuid,
                 organizationUuid,
             }))
         ) {
-            return dashboards.map(spaceOnly);
+            return refs.map(spaceOnly);
         }
 
-        const grants = await this.dashboardAccessModel.getUserAccess(
-            dashboardUuids,
-            userUuid,
-            { organizationUuid },
-        );
-        return dashboards.map((ref) => {
+        const grants = await lookupGrants(resourceUuids, { organizationUuid });
+        return refs.map((ref) => {
             const spaceContext = spaceContexts[ref.spaceUuid];
             if (spaceContext === undefined || ref.uuid === null) {
                 return spaceOnly(ref);
@@ -356,7 +429,7 @@ export class SpacePermissionService extends BaseService {
                 spaceContext,
                 userUuid,
                 grantRoles,
-                'dashboard',
+                grantedVia,
             );
         });
     }

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1069,9 +1069,13 @@ export class UnfurlService extends BaseService {
             projectUuid ? { projectUuid } : undefined,
         );
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
+            await this.spacePermissionService.getChartAccessContext(
                 user.userUuid,
-                { uuid: chart.dashboardUuid, spaceUuid: chart.spaceUuid },
+                {
+                    uuid: chart.uuid,
+                    dashboardUuid: chart.dashboardUuid,
+                    spaceUuid: chart.spaceUuid,
+                },
             );
 
         const auditedAbility = this.createAuditedAbility(user);

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -156,7 +156,7 @@ export type SpaceInheritanceChain = {
 
 // Which content type's direct grant synthesized an access row. Grows one
 // member per content type that ships direct grants.
-export type GrantSource = 'dashboard';
+export type GrantSource = 'dashboard' | 'saved_chart';
 
 // Access data for checking Space access permissions with CASL where only the role/access data matters.
 export type SpaceAccess = {


### PR DESCRIPTION
Part of [SPK-1251](https://linear.app/lightdash/issue/SPK-1251) — Stack 3A (saved explore charts). Extends the CASL-access-array kernel that Stack 2A shipped for dashboards (#28122–#28124, merged).

Stacks on `main`. Followed by **#28144** (write parity) and **#28145** (grant management + dashboard-owned guard).

## What this PR does

Adds the read half of native direct grants for **space-saved explore charts**: a chart's own direct grant lets a grant-only project member load, execute, and inspect it — the same way a dashboard grant works for a dashboard, and with no chart-specific CASL logic (existing `access` `$elemMatch` rules enforce it).

**Kernel.** A new `SavedChartAccessModel.getUserAccess` reads `saved_chart_user_access` / `saved_chart_group_access` through the shared `directAccessModelUtils`, and `SpacePermissionService` gains choke-point helpers that append those grants to the plain space CASL context tagged `grantedVia: 'saved_chart'`:

- `getSavedChartAccessContext(userUuid, { uuid, spaceUuid })` + a batched sibling.
- An ownership router that every chart read/write path now calls:

```
getChartAccessContext(chart)
├── dashboardUuid set   → owning dashboard's grants   (dashboard-owned tile)
└── dashboardUuid null  → the chart's own grants       (space-saved chart)
```

- A batched `getChartsAccessContext` splits owned vs space charts into one dashboard-grant batch and one chart-grant batch, so a mixed dashboard load costs two grant queries, never N+1.

All four grant helpers now delegate to one shared `resolveGrant(s)AccessContext`, unifying the dashboard and chart paths.

## Read sites wired to the router

- `SavedChartService`: view (`checkPermissions`), view stats, history, version.
- `AsyncQueryService`: saved-chart query, dashboard-tile chart query, calculate-total.
- `ProjectService`: chart query, chart-and-results, available filters (single + batched).
- `SchedulerService`: chart scheduler view branch. `UnfurlService`: chart export.

Genuine dashboard reads, embed/JWT actors, and the Autopilot AI actor are deliberately untouched (fail-closed, space-only).

## Boundary & fail-closed

- A dashboard-owned chart has no `space_id`, so it structurally cannot accrue chart grants — the router sends it through the dashboard path only, and no access context ever mixes `GrantSource` kinds.
- Behind the default-off `direct-access` flag every context equals the plain space context.

## Test plan

- `SpacePermissionService.test.ts` (43): saved-chart context (null path, tagged grant, space-mismatch throw) and ownership routing (owned→dashboard, space→chart, batched order alignment).
- Read wiring exercised through the SavedChart / AsyncQuery / Scheduler suites.
- `pnpm -F backend typecheck` clean; 549 tests green across affected suites.
