### PR TITLE
feat(charts): direct-grant write parity for saved explore charts

### DIFF
--- a/packages/backend/src/services/SavedChartsService/SavedChartService.grantWrites.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.grantWrites.test.ts
@@ -121,6 +121,22 @@ const spaceOnlyContext = {
     directOnly: false,
 };
 
+// A space-saved chart reachable only via its OWN direct grant (grantedVia
+// 'saved_chart'), the Stack 3A analogue of the dashboard-owned case above.
+const spaceChart = {
+    ...ownedChart,
+    uuid: 'space-chart-uuid',
+    name: 'Space chart',
+    slug: 'space-chart',
+    dashboardUuid: null,
+    dashboardName: null,
+};
+
+const chartGrantContext = {
+    ...grantContext,
+    access: [{ ...grantRow, grantedVia: 'saved_chart' as const }],
+};
+
 const savedChartModel = {
     getSummary: vi.fn(async () => ownedChart),
     get: vi.fn(async () => ownedChart),
@@ -148,6 +164,7 @@ const projectModel = {
 const spacePermissionService = {
     getSpaceAccessContext: vi.fn(async () => spaceOnlyContext),
     getDashboardAccessContext: vi.fn(async () => grantContext),
+    getChartAccessContext: vi.fn(async () => grantContext),
 };
 
 vi.spyOn(analyticsMock, 'track');
@@ -179,9 +196,11 @@ describe('SavedChartService direct-grant write parity', () => {
 
     afterEach(() => {
         vi.clearAllMocks();
-        spacePermissionService.getDashboardAccessContext.mockResolvedValue(
+        spacePermissionService.getChartAccessContext.mockResolvedValue(
             grantContext,
         );
+        savedChartModel.getSummary.mockResolvedValue(ownedChart);
+        savedChartModel.get.mockResolvedValue(ownedChart);
     });
 
     it('lets a grant-only editor rename a dashboard-owned chart via the dashboard context', async () => {
@@ -192,11 +211,12 @@ describe('SavedChartService direct-grant write parity', () => {
                 description: undefined,
             } as never),
         ).resolves.toBeDefined();
-        // The switched call resolves the OWNING dashboard's grants.
+        // The router resolves the OWNING dashboard's grants for an owned chart.
         expect(
-            spacePermissionService.getDashboardAccessContext,
+            spacePermissionService.getChartAccessContext,
         ).toHaveBeenCalledWith(grantOnlyEditor.userUuid, {
-            uuid: OWNING_DASHBOARD,
+            uuid: ownedChart.uuid,
+            dashboardUuid: OWNING_DASHBOARD,
             spaceUuid: PRIVATE_SPACE,
         });
         // Audit records the grant provenance.
@@ -228,7 +248,7 @@ describe('SavedChartService direct-grant write parity', () => {
     });
 
     it('denies the update when the context carries no grant (space-only)', async () => {
-        spacePermissionService.getDashboardAccessContext.mockResolvedValue(
+        spacePermissionService.getChartAccessContext.mockResolvedValue(
             spaceOnlyContext,
         );
         await expect(
@@ -255,11 +275,80 @@ describe('SavedChartService direct-grant write parity', () => {
     });
 
     it('denies the delete when the context carries no grant (space-only)', async () => {
-        spacePermissionService.getDashboardAccessContext.mockResolvedValue(
+        spacePermissionService.getChartAccessContext.mockResolvedValue(
             spaceOnlyContext,
         );
         await expect(
             service.delete(grantOnlyEditor, ownedChart.uuid),
         ).rejects.toThrow();
+    });
+
+    it('lets a grant-only editor rename a space-saved chart via its own chart grant', async () => {
+        savedChartModel.getSummary.mockResolvedValue(spaceChart as never);
+        spacePermissionService.getChartAccessContext.mockResolvedValue(
+            chartGrantContext,
+        );
+        await expect(
+            service.update(grantOnlyEditor, spaceChart.uuid, {
+                name: 'Renamed in space',
+                description: undefined,
+            } as never),
+        ).resolves.toBeDefined();
+        // The router resolves the chart's OWN grant for a space chart.
+        expect(
+            spacePermissionService.getChartAccessContext,
+        ).toHaveBeenCalledWith(grantOnlyEditor.userUuid, {
+            uuid: spaceChart.uuid,
+            dashboardUuid: null,
+            spaceUuid: PRIVATE_SPACE,
+        });
+        // A saved_chart grant is grant-only but not a dashboard grant.
+        expect(analyticsMock.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'saved_chart.updated',
+                properties: expect.objectContaining({
+                    viaDashboardGrant: false,
+                    grantOnly: true,
+                }),
+            }),
+        );
+    });
+
+    it('denies moving a space-saved chart to another space via its chart grant (boundary)', async () => {
+        savedChartModel.getSummary.mockResolvedValue(spaceChart as never);
+        spacePermissionService.getChartAccessContext.mockResolvedValue(
+            chartGrantContext,
+        );
+        // The chart grant authorizes the edit, but relocating requires space
+        // access to the current space, which a grant-only editor lacks.
+        await expect(
+            service.update(grantOnlyEditor, spaceChart.uuid, {
+                name: 'Renamed',
+                description: undefined,
+                spaceUuid: 'attacker-space-uuid',
+            } as never),
+        ).rejects.toThrow('move this chart out of its space');
+        expect(
+            spacePermissionService.getSpaceAccessContext,
+        ).toHaveBeenCalledWith(grantOnlyEditor.userUuid, PRIVATE_SPACE);
+    });
+
+    it('lets a grant-only editor delete a space-saved chart via its chart grant', async () => {
+        savedChartModel.get.mockResolvedValue(spaceChart as never);
+        spacePermissionService.getChartAccessContext.mockResolvedValue(
+            chartGrantContext,
+        );
+        await expect(
+            service.delete(grantOnlyEditor, spaceChart.uuid),
+        ).resolves.toBeUndefined();
+        expect(analyticsMock.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'saved_chart.deleted',
+                properties: expect.objectContaining({
+                    viaDashboardGrant: false,
+                    grantOnly: true,
+                }),
+            }),
+        );
     });
 });

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -209,10 +209,11 @@ export class SavedChartService
         const savedChart = await this.savedChartModel.getSummary(chartUuid);
         const { organizationUuid, projectUuid } = savedChart;
         const { access, inheritsFromOrgOrProject, directOnly } =
-            await this.spacePermissionService.getDashboardAccessContext(
+            await this.spacePermissionService.getChartAccessContext(
                 user.userUuid,
                 {
-                    uuid: savedChart.dashboardUuid,
+                    uuid: savedChart.uuid,
+                    dashboardUuid: savedChart.dashboardUuid,
                     spaceUuid: savedChart.spaceUuid,
                 },
             );
@@ -664,13 +665,15 @@ export class SavedChartService
         // Embed write actors stay space-only: grant parity for embed
         // identities is a separate decision.
         const { inheritsFromOrgOrProject, access, directOnly } =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                {
-                    uuid: embedWriteActions ? null : dashboardUuid,
-                    spaceUuid,
-                },
-            );
+            embedWriteActions
+                ? await this.spacePermissionService.getDashboardAccessContext(
+                      user.userUuid,
+                      { uuid: null, spaceUuid },
+                  )
+                : await this.spacePermissionService.getChartAccessContext(
+                      user.userUuid,
+                      { uuid: savedChartUuid, dashboardUuid, spaceUuid },
+                  );
 
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -882,9 +885,9 @@ export class SavedChartService
         } = await this.savedChartModel.getSummary(savedChartUuid);
 
         const { inheritsFromOrgOrProject, access, directOnly } =
-            await this.spacePermissionService.getDashboardAccessContext(
+            await this.spacePermissionService.getChartAccessContext(
                 user.userUuid,
-                { uuid: dashboardUuid, spaceUuid },
+                { uuid: savedChartUuid, dashboardUuid, spaceUuid },
             );
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -1262,9 +1265,9 @@ export class SavedChartService
             });
         } else {
             const { inheritsFromOrgOrProject, access, directOnly } =
-                await this.spacePermissionService.getDashboardAccessContext(
+                await this.spacePermissionService.getChartAccessContext(
                     user.userUuid,
-                    { uuid: dashboardUuid, spaceUuid },
+                    { uuid: resolvedUuid, dashboardUuid, spaceUuid },
                 );
             deleteAuditContext = {
                 viaDashboardGrant:
@@ -1354,9 +1357,13 @@ export class SavedChartService
         } else {
             const chart = await this.savedChartModel.get(savedChartUuid);
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getDashboardAccessContext(
+                await this.spacePermissionService.getChartAccessContext(
                     user.userUuid,
-                    { uuid: chart.dashboardUuid, spaceUuid: chart.spaceUuid },
+                    {
+                        uuid: chart.uuid,
+                        dashboardUuid: chart.dashboardUuid,
+                        spaceUuid: chart.spaceUuid,
+                    },
                 );
             const auditedAbility = this.createAuditedAbility(user);
             if (


### PR DESCRIPTION
Part of [SPK-1251](https://linear.app/lightdash/issue/SPK-1251) — Stack 3A (saved explore charts).

Stacks on **#28143** (reads). Followed by **#28145** (grant management + dashboard-owned guard).

## What this PR does

Extends chart direct-grant coverage from reads to the **mutation surface**. A space-saved chart's own grant now authorizes the in-place write ops that stay inside the chart, routed through the same `getChartAccessContext` ownership router — so a dashboard-owned chart still resolves through its owning dashboard's grant, unchanged.

Grant-authorized (inside the chart):

- `createVersion` — edit content
- `update` — edit fields
- `rollback` — rewind to a prior version
- `delete` / `softDelete` — remove the chart (D2 delete parity)

## Boundary rule — fail-closed on anything that creates or relocates content

```
edit / rollback / delete   in-place  →  chart grant authorizes
move to another space      crossing  →  requires space access (denied for grant-only)
create new chart           minting   →  space-only, never a chart grant
duplicate into a space     minting   →  space-only, never a chart grant
```

- `update()` still gates a truthy `spaceUuid` (a detach + relocate) behind real space access to the current space, so a grant-only editor cannot move or exfiltrate the chart.
- `create()` and `duplicate()` stay space-only for space charts: a chart grant never mints new space content.
- Embed write actors stay space-only (SPK-1453 defers embed parity).

## Audit

A `saved_chart` grant is grant-only but not a dashboard grant, so a chart-grant write records `{ viaDashboardGrant: false, grantOnly: true }` — distinguishable from a dashboard-grant write and from a space-derived edit.

## Test plan

- `SavedChartService.grantWrites.test.ts`: space-saved-chart parity (edit, delete, move-denial) alongside the existing dashboard-owned cases; asserts the router args, the move boundary, and the audit shape.
- `pnpm -F backend typecheck` clean; SavedChart / Scheduler / AsyncQuery suites green.
