### PR TITLE
fix(frontend): make login background pink

### DIFF
--- a/packages/frontend/src/components/common/AuthLayout/index.tsx
+++ b/packages/frontend/src/components/common/AuthLayout/index.tsx
@@ -1,4 +1,12 @@
-import { Box, Card, Group, Stack, Text, Title } from '@mantine/core';
+import {
+    Box,
+    Card,
+    Group,
+    Stack,
+    Text,
+    Title,
+    type MantineColor,
+} from '@mantine/core';
 import { IconCheck } from '@tabler/icons-react';
 import { type FC, type PropsWithChildren, type ReactNode } from 'react';
 import LightdashLogo from '../../LightdashLogo/LightdashLogo';
@@ -28,6 +36,7 @@ type Props = {
     cardId?: string;
     /** Pages that bring their own cards (Invite) opt out of the legacy card. */
     withLegacyCard?: boolean;
+    backgroundColor?: MantineColor;
     footer?: ReactNode;
 };
 
@@ -38,43 +47,50 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
     legacyTitle,
     cardId,
     withLegacyCard = true,
+    backgroundColor,
     footer,
     children,
 }) => {
     const { isNewLayout, isInitialLoading } = useAuthLayoutVariant();
 
     if (isInitialLoading) {
-        return <PageSpinner />;
+        return (
+            <Box bg={backgroundColor} mih="100vh">
+                <PageSpinner />
+            </Box>
+        );
     }
 
     if (!isNewLayout) {
         return (
-            <Page title={pageTitle} withCenteredContent withNavbar={false}>
-                <Stack w={400} mt="4xl">
-                    <Box mx="auto" my="lg">
-                        <LightdashLogo />
-                    </Box>
-                    {withLegacyCard ? (
-                        <Card
-                            id={cardId}
-                            p="xl"
-                            radius="xs"
-                            withBorder
-                            shadow="xs"
-                        >
-                            {legacyTitle && (
-                                <Title order={3} ta="center" mb="md">
-                                    {legacyTitle}
-                                </Title>
-                            )}
-                            {children}
-                        </Card>
-                    ) : (
-                        children
-                    )}
-                    {footer}
-                </Stack>
-            </Page>
+            <Box bg={backgroundColor}>
+                <Page title={pageTitle} withCenteredContent withNavbar={false}>
+                    <Stack w={400} mt="4xl">
+                        <Box mx="auto" my="lg">
+                            <LightdashLogo />
+                        </Box>
+                        {withLegacyCard ? (
+                            <Card
+                                id={cardId}
+                                p="xl"
+                                radius="xs"
+                                withBorder
+                                shadow="xs"
+                            >
+                                {legacyTitle && (
+                                    <Title order={3} ta="center" mb="md">
+                                        {legacyTitle}
+                                    </Title>
+                                )}
+                                {children}
+                            </Card>
+                        ) : (
+                            children
+                        )}
+                        {footer}
+                    </Stack>
+                </Page>
+            </Box>
         );
     }
 
@@ -82,8 +98,8 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
         <>
             <DocumentTitle title={pageTitle} />
 
-            <Box className={classes.root}>
-                <Box className={classes.brandPanel}>
+            <Box className={classes.root} bg={backgroundColor}>
+                <Box className={classes.brandPanel} bg={backgroundColor}>
                     <Box className={classes.decorationTop} aria-hidden />
                     <Box className={classes.decorationBottom} aria-hidden />
 
@@ -128,7 +144,7 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
                     </Stack>
                 </Box>
 
-                <Box className={classes.formPanel}>
+                <Box className={classes.formPanel} bg={backgroundColor}>
                     <Stack id={cardId} className={classes.formContent} gap="xl">
                         <Group
                             gap="sm"

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -8,23 +8,25 @@ import LoginLanding from '../features/users/components/LoginLanding';
 const Login: FC<{ minimal?: boolean }> = ({ minimal = false }) => {
     if (minimal) {
         return (
-            <Stack m="xl">
-                <Box mx="auto" my="lg">
-                    <LightdashLogo />
-                </Box>
-                <Card
-                    id={LOGIN_PAGE_ID}
-                    p="xl"
-                    radius="xs"
-                    withBorder
-                    shadow="xs"
-                >
-                    <Title order={3} ta="center" mb="md">
-                        Sign in
-                    </Title>
-                    <LoginLanding />
-                </Card>
-            </Stack>
+            <Box bg="pink" mih="100vh" p="xl">
+                <Stack>
+                    <Box mx="auto" my="lg">
+                        <LightdashLogo />
+                    </Box>
+                    <Card
+                        id={LOGIN_PAGE_ID}
+                        p="xl"
+                        radius="xs"
+                        withBorder
+                        shadow="xs"
+                    >
+                        <Title order={3} ta="center" mb="md">
+                            Sign in
+                        </Title>
+                        <LoginLanding />
+                    </Card>
+                </Stack>
+            </Box>
         );
     }
 
@@ -35,6 +37,7 @@ const Login: FC<{ minimal?: boolean }> = ({ minimal = false }) => {
             subtitle="Welcome back — pick up where you left off."
             legacyTitle="Sign in"
             cardId={LOGIN_PAGE_ID}
+            backgroundColor="pink"
         >
             <LoginLanding />
         </AuthLayout>


### PR DESCRIPTION
## What changed

## Summary
- Makes the login page background pink across the split, legacy, loading, and mobile layouts.
- Keeps other authentication pages on their existing backgrounds.

### Validation
- `pnpm -F 'frontend' exec oxfmt 'src/components/common/AuthLayout/index.tsx' 'src/pages/Login.tsx'` — passed
- `pnpm -F 'frontend' run --if-present lint` — passed
- `pnpm -F 'frontend' run --if-present typecheck` — passed
- `pnpm -F 'frontend' run --if-present test` — passed

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10657-c80aff4e6a8c.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10657

