### PR TITLE
fix(data-apps): pass sandbox environments separately

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.sandboxOutputRedaction.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.sandboxOutputRedaction.test.ts
@@ -1,0 +1,200 @@
+import { SandboxCommandError } from '../SandboxRuntime';
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({ generateObject: vi.fn() }));
+
+type CommandOptions = {
+    onStdout?: (chunk: string) => void;
+    onStderr?: (chunk: string) => void;
+};
+
+type GenerationResult = {
+    responseText: string | null;
+};
+
+type PrivateAppGenerateService = {
+    logger: {
+        info: ReturnType<typeof vi.fn>;
+        warn: ReturnType<typeof vi.fn>;
+        debug: ReturnType<typeof vi.fn>;
+    };
+    runCodingAgentGeneration: (
+        sandbox: unknown,
+        appUuid: string,
+        version: number,
+        continueSession: boolean,
+        env: Record<string, string>,
+        model: 'sonnet',
+        effort: 'low',
+        structuredOutputSchema: string | null,
+    ) => Promise<GenerationResult>;
+};
+
+const line = (value: unknown): string => `${JSON.stringify(value)}\n`;
+
+const buildService = (codingAgent: 'claude' | 'codex') => {
+    const appModel = {
+        getVersionStatus: vi.fn().mockResolvedValue('generating'),
+        recordBuildNarration: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = new AppGenerateService({
+        lightdashConfig: {
+            appRuntime: { dataAppCodingAgent: codingAgent },
+        },
+        appModel,
+    } as never) as unknown as PrivateAppGenerateService;
+    service.logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+    };
+    return { service, appModel };
+};
+
+const emitAcrossSecretBoundary = (
+    onStdout: ((chunk: string) => void) | undefined,
+    output: string,
+    secret: string,
+): void => {
+    const splitAt = output.indexOf(secret) + Math.floor(secret.length / 2);
+    onStdout?.(output.slice(0, splitAt));
+    onStdout?.(output.slice(splitAt));
+};
+
+describe.each([
+    {
+        codingAgent: 'claude' as const,
+        secretKey: 'ANTHROPIC_API_KEY',
+        streamOutput: (secret: string) =>
+            line({
+                type: 'assistant',
+                message: {
+                    content: [
+                        {
+                            type: 'tool_use',
+                            name: 'Write',
+                            input: { file_path: `/app/src/${secret}.tsx` },
+                        },
+                    ],
+                },
+            }) +
+            line({
+                type: 'result',
+                subtype: 'success',
+                result: `finished with ${secret}`,
+            }),
+    },
+    {
+        codingAgent: 'codex' as const,
+        secretKey: 'CODEX_API_KEY',
+        streamOutput: (secret: string) =>
+            line({
+                type: 'item.completed',
+                item: {
+                    id: 'reasoning-1',
+                    type: 'reasoning',
+                    text: `checking ${secret}`,
+                },
+            }) +
+            line({
+                type: 'item.completed',
+                item: {
+                    id: 'message-1',
+                    type: 'agent_message',
+                    text: `finished with ${secret}`,
+                },
+            }),
+    },
+])(
+    '$codingAgent output handling',
+    ({ codingAgent, secretKey, streamOutput }) => {
+        test('redacts streamed status, logs, and returned text', async () => {
+            const secret = 'synthetic-provider-secret';
+            const output = streamOutput(secret);
+            const run = vi.fn(
+                async (_command: string, options?: CommandOptions) => {
+                    expect(options?.onStderr).toBeUndefined();
+                    emitAcrossSecretBoundary(options?.onStdout, output, secret);
+                    return { exitCode: 0, stdout: output, stderr: '' };
+                },
+            );
+            const { service, appModel } = buildService(codingAgent);
+
+            const result = await service.runCodingAgentGeneration(
+                { commands: { run } },
+                'app-1',
+                1,
+                false,
+                {
+                    [secretKey]: secret,
+                    DATA_APP_CODEX_MODEL: 'gpt-5.1-codex-mini',
+                },
+                'sonnet',
+                'low',
+                null,
+            );
+
+            expect(result.responseText).toBe('finished with [redacted]');
+            expect(
+                JSON.stringify(appModel.recordBuildNarration.mock.calls),
+            ).toContain('[redacted]');
+            expect(
+                JSON.stringify(appModel.recordBuildNarration.mock.calls),
+            ).not.toContain(secret);
+            expect(
+                JSON.stringify(service.logger.info.mock.calls),
+            ).not.toContain(secret);
+        });
+    },
+);
+
+describe.each([
+    { codingAgent: 'claude' as const, secretKey: 'ANTHROPIC_API_KEY' },
+    { codingAgent: 'codex' as const, secretKey: 'CODEX_API_KEY' },
+])('$codingAgent failure handling', ({ codingAgent, secretKey }) => {
+    test('redacts failed command output before logging and throwing', async () => {
+        vi.useFakeTimers();
+        const secret = 'synthetic-provider-secret';
+        const run = vi.fn(
+            async (_command: string, options?: CommandOptions) => {
+                expect(options?.onStderr).toBeUndefined();
+                throw new SandboxCommandError(
+                    1,
+                    `authentication_error for ${secret}`,
+                    `provider response included ${secret}`,
+                );
+            },
+        );
+        const { service } = buildService(codingAgent);
+
+        const generation = service.runCodingAgentGeneration(
+            { commands: { run } },
+            'app-1',
+            1,
+            false,
+            {
+                [secretKey]: secret,
+                DATA_APP_CODEX_MODEL: 'gpt-5.1-codex-mini',
+            },
+            'sonnet',
+            'low',
+            null,
+        );
+        void generation.catch(() => undefined);
+
+        await vi.runAllTimersAsync();
+        await expect(generation).rejects.toThrow(
+            'authentication_error for [redacted]',
+        );
+
+        const logs = JSON.stringify(service.logger.info.mock.calls);
+        expect(logs).toContain('[redacted]');
+        expect(logs).not.toContain(secret);
+        vi.useRealTimers();
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -225,11 +225,13 @@ import {
 } from './claudeCliFailure';
 import {
     buildClaudeCodeEnv,
+    CLAUDE_CODE_SECRET_ENV_KEYS,
     claudeCodeAllowedHosts,
     describeClaudeCodeEnv,
 } from './claudeCodeEnv';
 import {
     buildClaudeCodeOtelEnv,
+    CLAUDE_CODE_OTEL_SECRET_ENV_KEYS,
     claudeCodeOtelAllowedHosts,
 } from './claudeCodeOtelEnv';
 import {
@@ -249,6 +251,7 @@ import {
 import {
     buildCodexCodeEnv,
     buildCodexExecCommand,
+    CODEX_CODE_SECRET_ENV_KEYS,
     CODEX_PROJECT_INSTRUCTIONS,
     CODEX_PROJECT_INSTRUCTIONS_PATH,
     codexCodeAllowedHosts,
@@ -281,6 +284,7 @@ import {
 import { resolveOtelExportHeaders } from './gcpOtelAuth';
 import { readDesignForDownload } from './readDesignForDownload';
 import { readS3ObjectAsBuffer } from './s3Utils';
+import { redactSandboxEnvSecrets } from './sandboxOutputRedaction';
 import {
     buildTemplateBaseline,
     TEMPLATE_DEV_DEPENDENCIES,
@@ -3306,6 +3310,11 @@ export class AppGenerateService extends BaseService {
     ): Promise<CodingAgentGenerationResult> {
         const start = performance.now();
         let telemetry = ZERO_CLAUDE_GENERATION_TELEMETRY;
+        const redactOutput = (text: string): string =>
+            redactSandboxEnvSecrets(text, claudeCodeEnv, [
+                ...CLAUDE_CODE_SECRET_ENV_KEYS,
+                ...CLAUDE_CODE_OTEL_SECRET_ENV_KEYS,
+            ]);
 
         if (structuredOutputSchema) {
             // A resumed sandbox may still hold a root-owned
@@ -3397,19 +3406,22 @@ export class AppGenerateService extends BaseService {
                                         this.updateAppStatus(
                                             appUuid,
                                             version,
-                                            event.snippet,
+                                            redactOutput(event.snippet),
                                             'thinking',
                                         );
                                         break;
                                     case 'tool_use': {
+                                        const description = redactOutput(
+                                            event.description,
+                                        );
                                         this.logger.info(
-                                            `App ${appUuid}: claude tool #${event.index}: ${event.description}`,
+                                            `App ${appUuid}: claude tool #${event.index}: ${description}`,
                                         );
                                         // description can be comma-separated
                                         // (e.g. "Write foo.tsx, Read bar.tsx") —
                                         // use only the first tool for the status.
                                         const firstTool =
-                                            event.description.split(', ')[0];
+                                            description.split(', ')[0];
                                         const toolStatus =
                                             AppGenerateService.toolDescriptionToStatusMessage(
                                                 firstTool,
@@ -3427,7 +3439,9 @@ export class AppGenerateService extends BaseService {
                                     }
                                     case 'result':
                                         if (event.text) {
-                                            responseText = event.text;
+                                            responseText = redactOutput(
+                                                event.text,
+                                            );
                                         }
                                         structuredOutput =
                                             event.structuredOutput;
@@ -3439,11 +3453,6 @@ export class AppGenerateService extends BaseService {
                                         );
                                 }
                             }
-                        },
-                        onStderr: (chunk) => {
-                            this.logger.debug(
-                                `App ${appUuid}: claude stderr: ${chunk.trimEnd()}`,
-                            );
                         },
                     },
                 )
@@ -3461,7 +3470,12 @@ export class AppGenerateService extends BaseService {
                         stdout: err.stdout,
                         stderr: err.stderr,
                     };
-                });
+                })
+                .then((raw) => ({
+                    ...raw,
+                    stdout: redactOutput(raw.stdout),
+                    stderr: redactOutput(raw.stderr),
+                }));
             const toolCallCount = processor.totalToolCalls;
             const usage = processor.lastUsage;
             const { timeToFirstTokenMs, turnDurationsMs } = processor;
@@ -3583,6 +3597,8 @@ export class AppGenerateService extends BaseService {
     ): Promise<CodingAgentGenerationResult> {
         const start = performance.now();
         let telemetry = ZERO_CLAUDE_GENERATION_TELEMETRY;
+        const redactOutput = (text: string): string =>
+            redactSandboxEnvSecrets(text, codexEnv, CODEX_CODE_SECRET_ENV_KEYS);
 
         if (structuredOutputSchema) {
             await sandbox.commands.run(
@@ -3642,17 +3658,20 @@ export class AppGenerateService extends BaseService {
                                     this.updateAppStatus(
                                         appUuid,
                                         version,
-                                        event.snippet,
+                                        redactOutput(event.snippet),
                                         'thinking',
                                     );
                                     break;
                                 case 'tool_use': {
+                                    const description = redactOutput(
+                                        event.description,
+                                    );
                                     this.logger.info(
-                                        `App ${appUuid}: codex tool #${event.index}: ${event.description}`,
+                                        `App ${appUuid}: codex tool #${event.index}: ${description}`,
                                     );
                                     const toolStatus =
                                         AppGenerateService.toolDescriptionToStatusMessage(
-                                            event.description,
+                                            description,
                                         );
                                     this.updateAppStatus(
                                         appUuid,
@@ -3665,7 +3684,7 @@ export class AppGenerateService extends BaseService {
                                 }
                                 case 'result':
                                     if (event.text) {
-                                        responseText = event.text;
+                                        responseText = redactOutput(event.text);
                                     }
                                     break;
                                 default:
@@ -3676,20 +3695,22 @@ export class AppGenerateService extends BaseService {
                             }
                         }
                     },
-                    onStderr: (chunk) => {
-                        this.logger.debug(
-                            `App ${appUuid}: codex stderr: ${chunk.trimEnd()}`,
-                        );
-                    },
                 })
                 .catch((err: unknown) => {
-                    if (!(err instanceof SandboxCommandError)) throw err;
+                    if (!(err instanceof SandboxCommandError)) {
+                        throw err;
+                    }
                     return {
                         exitCode: err.exitCode,
                         stdout: err.stdout,
                         stderr: err.stderr,
                     };
-                });
+                })
+                .then((raw) => ({
+                    ...raw,
+                    stdout: redactOutput(raw.stdout),
+                    stderr: redactOutput(raw.stderr),
+                }));
 
             const usage = processor.lastUsage;
             const toolCallCount = processor.totalToolCalls;
@@ -6999,7 +7020,7 @@ export class AppGenerateService extends BaseService {
                 // sandbox hasn't generated anything before this restore).
                 // Best-effort: log and move on.
                 this.logger.warn(
-                    `App ${appUuid}: restore FYI to Claude failed (exit ${result.exitCode}): ${AppGenerateService.truncateEnd(result.stderr, 500)}`,
+                    `App ${appUuid}: restore FYI to Claude failed (exit ${result.exitCode}): ${AppGenerateService.truncateEnd(redactSandboxEnvSecrets(result.stderr, claudeCodeEnv, CLAUDE_CODE_SECRET_ENV_KEYS), 500)}`,
                 );
                 return;
             }

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts
@@ -44,6 +44,15 @@ export type ClaudeCodeProviderConfig = {
     };
 };
 
+export const CLAUDE_CODE_SECRET_ENV_KEYS = [
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_AUTH_TOKEN',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_BEARER_TOKEN_BEDROCK',
+] as const;
+
 export const buildAnthropicClaudeCodeEnv = (
     apiKey: string,
     baseUrl?: string | null,

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCodeOtelEnv.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCodeOtelEnv.ts
@@ -12,6 +12,10 @@ export type ClaudeCodeOtelExporterConfig = {
     exportIntervalMs: number;
 };
 
+export const CLAUDE_CODE_OTEL_SECRET_ENV_KEYS = [
+    'OTEL_EXPORTER_OTLP_HEADERS',
+] as const;
+
 /**
  * Serialise export headers into the `OTEL_EXPORTER_OTLP_HEADERS` format:
  * a comma-separated list of `key=value` pairs. Bearer tokens and project ids

--- a/packages/backend/src/ee/services/AppGenerateService/codexCodeEnv.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/codexCodeEnv.ts
@@ -22,6 +22,15 @@ export type CodexProviderConfig = {
     };
 };
 
+export const CODEX_CODE_SECRET_ENV_KEYS = [
+    'CODEX_API_KEY',
+    'BEDROCK_GATEWAY_API_KEY',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_BEARER_TOKEN_BEDROCK',
+] as const;
+
 const getOpenAiConfig = (copilot: CodexProviderConfig) => {
     const config = copilot.providers.openai;
     if (!config?.apiKey) {

--- a/packages/backend/src/ee/services/AppGenerateService/sandboxOutputRedaction.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/sandboxOutputRedaction.test.ts
@@ -1,0 +1,101 @@
+import { redactSandboxEnvSecrets } from './sandboxOutputRedaction';
+
+describe('redactSandboxEnvSecrets', () => {
+    const secretEnvKeys = [
+        'ANTHROPIC_API_KEY',
+        'ANTHROPIC_AUTH_TOKEN',
+        'AWS_ACCESS_KEY_ID',
+        'AWS_SECRET_ACCESS_KEY',
+        'AWS_SESSION_TOKEN',
+        'AWS_BEARER_TOKEN_BEDROCK',
+        'CODEX_API_KEY',
+        'OTEL_EXPORTER_OTLP_HEADERS',
+        'FIRST_API_KEY',
+        'SECOND_API_KEY',
+        'PROVIDER_API_KEY',
+    ];
+
+    test('redacts coding-agent credentials while preserving configuration', () => {
+        const text = [
+            'anthropic-key',
+            'gateway-token',
+            'AKIAEXAMPLE',
+            'aws-secret',
+            'aws-session',
+            'bedrock-token',
+            'codex-key',
+            'us-east-1',
+        ].join(' ');
+
+        expect(
+            redactSandboxEnvSecrets(
+                text,
+                {
+                    ANTHROPIC_API_KEY: 'anthropic-key',
+                    ANTHROPIC_AUTH_TOKEN: 'gateway-token',
+                    AWS_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+                    AWS_SECRET_ACCESS_KEY: 'aws-secret',
+                    AWS_SESSION_TOKEN: 'aws-session',
+                    AWS_BEARER_TOKEN_BEDROCK: 'bedrock-token',
+                    CODEX_API_KEY: 'codex-key',
+                    AWS_REGION: 'us-east-1',
+                },
+                secretEnvKeys,
+            ),
+        ).toBe(
+            '[redacted] [redacted] [redacted] [redacted] [redacted] [redacted] [redacted] us-east-1',
+        );
+    });
+
+    test('redacts the complete OTLP header value', () => {
+        const headers = 'Authorization=Bearer synthetic-token,x-project=test';
+
+        expect(
+            redactSandboxEnvSecrets(
+                `export headers: ${headers}`,
+                {
+                    OTEL_EXPORTER_OTLP_HEADERS: headers,
+                },
+                secretEnvKeys,
+            ),
+        ).toBe('export headers: [redacted]');
+    });
+
+    test('redacts longer overlapping values first', () => {
+        expect(
+            redactSandboxEnvSecrets(
+                'token-long token',
+                {
+                    FIRST_API_KEY: 'token',
+                    SECOND_API_KEY: 'token-long',
+                },
+                secretEnvKeys,
+            ),
+        ).toBe('[redacted] [redacted]');
+    });
+
+    test('matches secret values literally', () => {
+        expect(
+            redactSandboxEnvSecrets(
+                'failed for key.*[value]',
+                {
+                    PROVIDER_API_KEY: 'key.*[value]',
+                },
+                secretEnvKeys,
+            ),
+        ).toBe('failed for [redacted]');
+    });
+
+    test('ignores empty and non-secret environment values', () => {
+        expect(
+            redactSandboxEnvSecrets(
+                'region=us-east-1',
+                {
+                    PROVIDER_API_KEY: '',
+                    AWS_REGION: 'us-east-1',
+                },
+                secretEnvKeys,
+            ),
+        ).toBe('region=us-east-1');
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/sandboxOutputRedaction.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/sandboxOutputRedaction.ts
@@ -1,0 +1,18 @@
+export const redactSandboxEnvSecrets = (
+    text: string,
+    env: Record<string, string>,
+    secretEnvKeys: readonly string[],
+): string => {
+    const secretValues = [
+        ...new Set(
+            secretEnvKeys
+                .map((key) => env[key])
+                .filter((value): value is string => Boolean(value)),
+        ),
+    ].sort((left, right) => right.length - left.length);
+
+    return secretValues.reduce(
+        (redacted, value) => redacted.split(value).join('[redacted]'),
+        text,
+    );
+};

--- a/packages/backend/src/ee/services/SandboxRuntime/CloudRunExecChannel.test.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/CloudRunExecChannel.test.ts
@@ -1,0 +1,122 @@
+import {
+    CloudRunExecChannel,
+    CloudRunGatewayClient,
+} from './CloudRunExecChannel';
+
+const execJson = (payload: {
+    stdout?: string;
+    stderr?: string;
+    exitCode?: number;
+}) => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+        stdout: payload.stdout ?? '',
+        stderr: payload.stderr ?? '',
+        exitCode: payload.exitCode ?? 0,
+    }),
+    text: async () => '',
+});
+
+const b64 = (value: string): string => Buffer.from(value).toString('base64');
+
+const tickResponse = (status: string, stdout = '', stderr = '') =>
+    execJson({
+        stdout: `S${status}\nO${b64(stdout)}\nE${b64(stderr)}\n`,
+    });
+
+describe('CloudRunExecChannel', () => {
+    const originalFetch = global.fetch;
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn().mockResolvedValue(execJson({ stdout: 'ok' }));
+        global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    test('passes invocation env separately from the sandbox command', async () => {
+        const secret = 'synthetic-provider-secret';
+        const client = new CloudRunGatewayClient(
+            'https://gateway.example.test',
+            'gateway-secret',
+        );
+        const channel = new CloudRunExecChannel(client, 'sandbox-1');
+
+        await channel.commands.run('agent --run', {
+            cwd: '/app',
+            envs: { PROVIDER_API_KEY: secret },
+            timeoutMs: 1_000,
+        });
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        const body = JSON.parse(String(init.body)) as {
+            command: string;
+            cwd?: string;
+            env?: Record<string, string>;
+        };
+
+        expect(body.command).not.toContain(secret);
+        expect(body.command).toContain('agent --run');
+        expect(body.cwd).toBe('/app');
+        expect(body.env).toEqual({ PROVIDER_API_KEY: secret });
+    });
+
+    test('passes detached command env only on the start request', async () => {
+        const secret = 'synthetic-provider-secret';
+        fetchMock
+            .mockResolvedValueOnce(execJson({}))
+            .mockResolvedValueOnce(tickResponse('0', 'done'))
+            .mockResolvedValue(execJson({}));
+        const client = new CloudRunGatewayClient(
+            'https://gateway.example.test',
+            'gateway-secret',
+        );
+        const channel = new CloudRunExecChannel(client, 'sandbox-1', {
+            detachedThresholdMs: 1,
+            pollIntervalMs: 1,
+        });
+
+        await channel.commands.run('agent --run', {
+            cwd: '/app',
+            envs: { PROVIDER_API_KEY: secret },
+            timeoutMs: 1_000,
+        });
+
+        const bodies = fetchMock.mock.calls.map(
+            (call) =>
+                JSON.parse(String((call[1] as RequestInit).body)) as {
+                    command: string;
+                    cwd?: string;
+                    env?: Record<string, string>;
+                },
+        );
+
+        expect(bodies.every(({ command }) => !command.includes(secret))).toBe(
+            true,
+        );
+        expect(bodies[0].cwd).toBe('/app');
+        expect(bodies[0].env).toEqual({ PROVIDER_API_KEY: secret });
+        expect(bodies.slice(1).every(({ env }) => env === undefined)).toBe(
+            true,
+        );
+    });
+
+    test('rejects invalid invocation env names before calling the gateway', async () => {
+        const client = new CloudRunGatewayClient(
+            'https://gateway.example.test',
+            'gateway-secret',
+        );
+        const channel = new CloudRunExecChannel(client, 'sandbox-1');
+
+        await expect(
+            channel.commands.run('agent --run', {
+                envs: { 'INVALID-NAME': 'value' },
+            }),
+        ).rejects.toThrow('Invalid sandbox env var name');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/services/SandboxRuntime/CloudRunExecChannel.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/CloudRunExecChannel.ts
@@ -11,10 +11,6 @@ import {
 } from './types';
 
 /**
- * Fold `cwd`/`envs` into a single `/bin/sh -c` command line. The gateway exec
- * takes only a command (its own `--workdir`/`-e` flags exist but folding keeps
- * one wire shape for buffered and detached runs alike).
- *
  * `export PATH;` first: the sandbox exec shell has a PATH *variable* (with
  * /usr/local/bin) but does not export it, so child processes fall back to
  * glibc's `/bin:/usr/bin` default and `#!/usr/bin/env node` shebangs (pnpm,
@@ -28,28 +24,17 @@ import {
  * ~90s into a run, so they are disabled for every command in the sandbox —
  * they only affect the `claude` CLI and are harmless to other commands.
  */
-const buildCommandLine = (command: string, options?: RunOptions): string => {
-    const parts: string[] = [
-        'export PATH DISABLE_AUTOUPDATER=1 CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1;',
-    ];
-    if (options?.cwd) parts.push(`cd ${shQuote(options.cwd)} &&`);
-    if (options?.envs) {
-        const exports = Object.entries(options.envs)
-            .map(([key, value]) => {
-                // Keys are interpolated unquoted into the sh -c string — only
-                // POSIX identifiers are safe.
-                if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
-                    throw new Error(
-                        `Invalid sandbox env var name: ${JSON.stringify(key)}`,
-                    );
-                }
-                return `${key}=${shQuote(value)}`;
-            })
-            .join(' ');
-        if (exports) parts.push(`export ${exports};`);
+const buildCommandLine = (command: string): string =>
+    `export PATH DISABLE_AUTOUPDATER=1 CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1; ${command}`;
+
+const validateEnvKeys = (envs: Record<string, string> | undefined): void => {
+    for (const key of Object.keys(envs ?? {})) {
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+            throw new Error(
+                `Invalid sandbox env var name: ${JSON.stringify(key)}`,
+            );
+        }
     }
-    parts.push(command);
-    return parts.join(' ');
 };
 
 /**
@@ -304,6 +289,7 @@ export class CloudRunExecChannel {
         command: string,
         options?: RunOptions,
     ): Promise<CommandResult> {
+        validateEnvKeys(options?.envs);
         const controller = new AbortController();
         const timeoutMs =
             options?.timeoutMs && options.timeoutMs > 0
@@ -323,7 +309,9 @@ export class CloudRunExecChannel {
                 'exec',
                 {
                     sandboxId: this.sandboxId,
-                    command: buildCommandLine(command, options),
+                    command: buildCommandLine(command),
+                    cwd: options?.cwd,
+                    env: options?.envs,
                     timeout: serverTimeoutMs,
                 },
                 {
@@ -390,17 +378,18 @@ export class CloudRunExecChannel {
         options: RunOptions & { timeoutMs: number },
     ): Promise<CommandResult> {
         const runDir = `/tmp/.lightdash-exec/${randomUUID()}`;
-        // cwd/envs are folded into the inner command line; the subshell keeps
-        // compound inner commands (a && b) under one redirect.
-        const inner = buildCommandLine(command, options);
-        const wrapped = `( ${inner} ) > ${runDir}/out.log 2> ${runDir}/err.log; echo $? > ${runDir}/exit`;
+        const wrapped = `( ${command} ) > ${runDir}/out.log 2> ${runDir}/err.log; echo $? > ${runDir}/exit`;
         // setsid makes the wrapper the leader of a fresh process group whose
         // PGID equals the recorded PID, so a kill can target the whole command
         // tree (`kill -- -PID`) — signalling only the wrapper shell would
         // orphan its children (claude, pnpm, …).
         await this.runBuffered(
             `mkdir -p ${shQuote(runDir)}; nohup setsid /bin/sh -c ${shQuote(wrapped)} < /dev/null > /dev/null 2>&1 & echo $! > ${shQuote(`${runDir}/pid`)}`,
-            { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
+            {
+                cwd: options.cwd,
+                envs: options.envs,
+                timeoutMs: INTERNAL_EXEC_TIMEOUT_MS,
+            },
         );
 
         const startedAt = Date.now();


### PR DESCRIPTION
Closes: N/A — no tracking issue

## Summary

Keeps Data Apps Cloud Run execution options in dedicated gateway request fields. It also filters sensitive invocation values from coding-agent diagnostics before they reach statuses, logs, or returned errors.

## Root cause

The Cloud Run adapter serialized the working directory and environment into the shell command instead of using the gateway's native request fields. Coding-agent diagnostic output was then forwarded without a shared filtering boundary.

```ts
command: buildCommandLine(command, options)
```

## Fix

- Passes `cwd` and `env` separately for buffered and detached Cloud Run commands.
- Applies one explicit, shared filtering boundary to Claude and Codex output.
- Keeps credential-key declarations alongside the environment builders that own them.

## Before / after

Before:
  command → runtime options + application command
  output  → status / logs / errors

After:
  request → runtime options
  command → application command
  output  → filter → status / logs / errors

## Test plan

- [x] `pnpm -F backend lint`
- [x] `pnpm -F backend typecheck`
- [x] 70 focused backend tests covering Cloud Run transport, Claude/Codex output handling, environment builders, stream processors, and failure classification
- [x] Synthetic values only; no external credentials or cloud resources used
