### PR TITLE
feat(table-calculations): add difference from previous quick calculation

### DIFF
--- a/packages/backend/src/tableCalculationTemplateQueryCompiler.test.ts
+++ b/packages/backend/src/tableCalculationTemplateQueryCompiler.test.ts
@@ -579,6 +579,27 @@ describe('compileTableCalculationFromTemplate - Frame Clauses', () => {
         });
     });
 
+    describe('DIFFERENCE_FROM_PREVIOUS', () => {
+        it('subtracts the previous row value using orderBy and partitionBy', () => {
+            const template: TableCalculationTemplate = {
+                type: TableCalculationTemplateType.DIFFERENCE_FROM_PREVIOUS,
+                fieldId: 'table_revenue',
+                orderBy: [{ fieldId: 'table_date', order: 'asc' }],
+                partitionBy: ['table_category'],
+            };
+
+            const result = compileTableCalculationFromTemplate(
+                template,
+                warehouseClientMock,
+                [],
+            );
+
+            expect(result).toBe(
+                '"table_revenue" - LAG("table_revenue") OVER(PARTITION BY "table_category" ORDER BY "table_date" ASC )',
+            );
+        });
+    });
+
     describe('PERCENT_CHANGE_FROM_PREVIOUS partitionBy', () => {
         it('Should compile without partitionBy (backward compatibility)', () => {
             const template: TableCalculationTemplate = {

--- a/packages/backend/src/tableCalculationTemplateQueryCompiler.ts
+++ b/packages/backend/src/tableCalculationTemplateQueryCompiler.ts
@@ -228,6 +228,9 @@ export const compileTableCalculationFromTemplate = (
             );
         }
 
+        case TableCalculationTemplateType.DIFFERENCE_FROM_PREVIOUS:
+            return `${quotedFieldId} - LAG(${quotedFieldId}) OVER(${partitionByClause}${orderByClause})`;
+
         case TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE: {
             return (
                 `(CAST(${quotedFieldId} AS ${floatType}) / ` +

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -3146,6 +3146,44 @@
                             "type": "array"
                         },
                         "partitionBy": {
+                            "description": "Fields to partition by",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "$ref": "#/$defs/TableCalculationTemplateType.DIFFERENCE_FROM_PREVIOUS",
+                            "description": "Type of template calculation"
+                        }
+                    },
+                    "required": ["partitionBy", "orderBy", "fieldId", "type"],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "fieldId": {
+                            "description": "Field ID to apply the template to",
+                            "type": "string"
+                        },
+                        "orderBy": {
+                            "description": "Fields to order by for window functions",
+                            "items": {
+                                "properties": {
+                                    "fieldId": {
+                                        "type": "string"
+                                    },
+                                    "order": {
+                                        "enum": ["asc", "desc", null],
+                                        "type": ["string", "null"]
+                                    }
+                                },
+                                "required": ["order", "fieldId"],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "partitionBy": {
                             "items": {
                                 "type": "string"
                             },
@@ -3278,6 +3316,10 @@
                     "type": "object"
                 }
             ]
+        },
+        "TableCalculationTemplateType.DIFFERENCE_FROM_PREVIOUS": {
+            "enum": ["difference_from_previous"],
+            "type": "string"
         },
         "TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS": {
             "enum": ["percent_change_from_previous"],

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -441,6 +441,7 @@ export type FrameClause = {
 
 export enum TableCalculationTemplateType {
     PERCENT_CHANGE_FROM_PREVIOUS = 'percent_change_from_previous',
+    DIFFERENCE_FROM_PREVIOUS = 'difference_from_previous',
     PERCENT_OF_PREVIOUS_VALUE = 'percent_of_previous_value',
     PERCENT_OF_COLUMN_TOTAL = 'percent_of_column_total',
     RANK_IN_COLUMN = 'rank_in_column',
@@ -460,6 +461,19 @@ export type TableCalculationTemplate =
               order: 'asc' | 'desc' | null;
           }[];
           partitionBy?: string[];
+      }
+    | {
+          /** Type of template calculation */
+          type: TableCalculationTemplateType.DIFFERENCE_FROM_PREVIOUS;
+          /** Field ID to apply the template to */
+          fieldId: string;
+          /** Fields to order by for window functions */
+          orderBy: {
+              fieldId: string;
+              order: 'asc' | 'desc' | null;
+          }[];
+          /** Fields to partition by */
+          partitionBy: string[];
       }
     | {
           /** Type of template calculation */

--- a/packages/frontend/src/components/Explorer/ResultsCard/QuickCalculations.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/QuickCalculations.tsx
@@ -42,6 +42,7 @@ const getFormatForQuickCalculation = (
             };
         case TableCalculationTemplateType.RANK_IN_COLUMN:
             return undefined;
+        case TableCalculationTemplateType.DIFFERENCE_FROM_PREVIOUS:
         case TableCalculationTemplateType.RUNNING_TOTAL:
             return {
                 type: CustomFormatType.NUMBER,
@@ -76,6 +77,7 @@ const isCalculationAvailable = (
     ];
     switch (templateType) {
         case TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS:
+        case TableCalculationTemplateType.DIFFERENCE_FROM_PREVIOUS:
         case TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE:
         case TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL:
         case TableCalculationTemplateType.RUNNING_TOTAL:

--- a/packages/frontend/src/components/Explorer/ResultsCard/tableCalculationTemplateGenerator.ts
+++ b/packages/frontend/src/components/Explorer/ResultsCard/tableCalculationTemplateGenerator.ts
@@ -43,6 +43,14 @@ export function generateTableCalculationTemplate(
                 partitionBy: [],
             };
 
+        case TableCalculationTemplateType.DIFFERENCE_FROM_PREVIOUS:
+            return {
+                type: TableCalculationTemplateType.DIFFERENCE_FROM_PREVIOUS,
+                fieldId,
+                orderBy: mapSortsToOrderBy(currentSorts),
+                partitionBy: [],
+            };
+
         case TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE:
             return {
                 type: TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE,

--- a/packages/frontend/src/features/tableCalculation/utils/templateFormatting.ts
+++ b/packages/frontend/src/features/tableCalculation/utils/templateFormatting.ts
@@ -7,6 +7,8 @@ export const TemplateTypeLabels: Record<TableCalculationTemplateType, string> =
     {
         [TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS]:
             'Percent change from previous',
+        [TableCalculationTemplateType.DIFFERENCE_FROM_PREVIOUS]:
+            'Difference from previous',
         [TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE]:
             'Percent of previous value',
         [TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL]:
@@ -28,6 +30,8 @@ export const getTemplateDescription = (
     switch (type) {
         case TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS:
             return 'Calculates the percentage change from the previous row value.';
+        case TableCalculationTemplateType.DIFFERENCE_FROM_PREVIOUS:
+            return 'Calculates the difference from the previous row value.';
         case TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE:
             return 'Shows the current value as a percentage of the previous row value.';
         case TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL:


### PR DESCRIPTION
## Validation blocked — not ready to merge

This draft was published only for human inspection. Deterministic validation did not converge within the bounded repair workflow; do not merge it until every command below passes.

Terminal reason: `final_retry_exhausted`

## Validation diagnostics

### Failing command 1 — backend test

```sh
pnpm -F 'backend' run --if-present test
```

Bounded output excerpt:

```text
r[2m | src/ee/services/SupportService/SupportService.test.ts[2m > [22m[2mSupportService project URL parsing[2m > [22m[2mkeeps project UUID URLs on the existing path
[22m[39mUnknown lightdash page [90mundefined[39m


[31m⎯⎯⎯⎯⎯⎯⎯[39m[1m[41m Failed Tests 1 [49m[22m[31m⎯⎯⎯⎯⎯⎯⎯[39m

[41m[1m FAIL [22m[49m [30m[42m backend-unit-tests [49m[39m src/ee/postgresWire/pgCatalog/catalogQuery.test.ts[2m > [22mlarge projects[2m > [22manswers pgjdbc wildcard getColumns over 45k columns within resource budgets
[31m[1mPgWireServerError[22m: canceling statement due to statement timeout[39m
[36m [2m❯[22m spend src/ee/postgresWire/pgCatalog/catalogEvaluator.ts:[2m354:19[22m[39m
    [90m352|[39m         [35mconst[39m cpuUsage [33m=[39m budget[33m.[39m[34mthreadCpuUsage[39m(budget[33m.[39mcpuStartedAt)[33m;[39m
    [90m353|[39m         if (cpuUsage.user + cpuUsage.system > MAX_STATEMENT_CPU_MS * 1…
    [90m354|[39m             [35mthrow[39m [35mnew[39m [33mPgWireServerError[39m(
    [90m   |[39m                   [31m^[39m
    [90m355|[39m                 [32m'canceling statement due to statement timeout'[39m[33m,[39m
    [90m356|[39m                 [32m'57014'[39m[33m,[39m
[90m [2m❯[22m joinTuples src/ee/postgresWire/pgCatalog/catalogEvaluator.ts:[2m1269:9[22m[39m
[90m [2m❯[22m src/ee/postgresWire/pgCatalog/catalogEvaluator.ts:[2m1352:20[22m[39m
[90m [2m❯[22m resolveFrom src/ee/postgresWire/pgCatalog/catalogEvaluator.ts:[2m1340:17[22m[39m
[90m [2m❯[22m evaluateSelect src/ee/postgresWire/pgCatalog/catalogEvaluator.ts:[2m1704:19[22m[39m
[90m [2m❯[22m evaluateCatalogSelect src/ee/postgresWire/pgCatalog/catalogEvaluator.ts:[2m1828:16[22m[39m
[90m [2m❯[22m tryHandleCatalogQuery src/ee/postgresWire/pgCatalog/catalogQuery.ts:[2m164:20[22m[39m
[90m [2m❯[22m src/ee/postgresWire/pgCatalog/catalogQuery.test.ts:[2m439:24[22m[39m

[31m[2m⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯[22m[39m
```

## What changed

## Summary
- Add a **Difference from previous** quick table calculation for numeric metrics.
- Compile the template as the current value minus `LAG(current)` using the established previous-row ordering and optional partition behavior.
- Format quick-calculation results as numbers and expose the new type through the generated chart-as-code schema.

### Validation
- `pnpm -F backend test src/tableCalculationTemplateQueryCompiler.test.ts` — passed (28 tests).
- `pnpm generate-api` — completed; generated backend routes/Swagger were restored per repository policy, while the chart-as-code schema update was retained.
- Targeted validation — passed backend, common, and frontend formatting, lint, typecheck, and related tests.
- `pnpm -F backend test src/ee/postgresWire/pgCatalog/catalogEvaluator.test.ts src/ee/postgresWire/pgCatalog/catalogQuery.test.ts` — passed (58 tests) during failure diagnosis.
- `pnpm -F frontend test src/ee/pages/AiAgents/DeepResearchReportPage.test.tsx` — passed (6 tests) during failure diagnosis.
- Full final validation — terminal failure: `pnpm -F backend test` hit the unrelated PostgreSQL catalog query resource-budget timeout on the permitted rerun.

## References

Closes: PROD-10533

