### PR TITLE
fix(frontend): preserve xlsx conditional formatting

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -5,6 +5,7 @@ import {
     createDashboardFilterRuleFromField,
     DashboardTileTypes,
     getChartKind,
+    getConditionalFormattingsFromChartConfig,
     getCustomLabelsFromTableConfig,
     getDimensions,
     getFields,
@@ -1854,6 +1855,9 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                     customLabels={getCustomLabelsFromTableConfig(
                         chart.chartConfig.config,
                     )}
+                    conditionalFormattings={getConditionalFormattingsFromChartConfig(
+                        chart.chartConfig.config,
+                    )}
                     hiddenFields={getHiddenTableFields(chart.chartConfig)}
                     pivotConfig={downloadPivotConfig}
                     showColumnTotals={getShowColumnTotalsFromChartConfig(
@@ -2207,6 +2211,9 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMinimalProps> = (
                     chartName={title || chart.name}
                     columnOrder={chart.tableConfig.columnOrder}
                     customLabels={getCustomLabelsFromTableConfig(
+                        chart.chartConfig.config,
+                    )}
+                    conditionalFormattings={getConditionalFormattingsFromChartConfig(
                         chart.chartConfig.config,
                     )}
                     hiddenFields={getHiddenTableFields(chart.chartConfig)}

--- a/packages/frontend/src/components/ExportResults/index.test.tsx
+++ b/packages/frontend/src/components/ExportResults/index.test.tsx
@@ -1,0 +1,123 @@
+import { createConditionalFormattingConfigWithSingleColor } from '@lightdash/common';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+    type Mock,
+} from 'vitest';
+import ExportResults from '.';
+import { renderWithProviders } from '../../testing/testUtils';
+
+const PROJECT_UUID = 'project-uuid';
+const QUERY_UUID = 'query-uuid';
+const conditionalFormattings = [
+    createConditionalFormattingConfigWithSingleColor('#ff0000', {
+        fieldId: 'orders_count',
+    }),
+];
+
+const mockApiResponse = (results: unknown) =>
+    new Response(JSON.stringify({ status: 'ok', results }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+    });
+
+const getScheduledDownloadBody = async () =>
+    waitFor(() => {
+        const scheduleRequest = (fetch as Mock).mock.calls.find(([url]) =>
+            url.toString().includes('/schedule-download'),
+        );
+        if (!scheduleRequest) {
+            throw new Error('Expected a scheduled download request');
+        }
+        return JSON.parse(scheduleRequest[1].body);
+    });
+
+const renderExportResults = () =>
+    renderWithProviders(
+        <ExportResults
+            projectUuid={PROJECT_UUID}
+            totalResults={1}
+            getDownloadQueryUuid={vi.fn().mockResolvedValue(QUERY_UUID)}
+            conditionalFormattings={conditionalFormattings}
+            hideLimitSelection
+        />,
+    );
+
+describe('ExportResults', () => {
+    beforeEach(() => {
+        vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(
+            () => undefined,
+        );
+        vi.stubGlobal(
+            'fetch',
+            vi.fn((input: RequestInfo | URL) => {
+                const url = input.toString();
+                if (url.includes('/schedule-download')) {
+                    return Promise.resolve(
+                        mockApiResponse({ jobId: 'job-id' }),
+                    );
+                }
+                if (url.includes('/schedulers/job/job-id/status')) {
+                    return Promise.resolve(
+                        mockApiResponse({
+                            status: 'completed',
+                            details: { fileUrl: 'about:blank' },
+                        }),
+                    );
+                }
+                throw new Error(`Unexpected request: ${url}`);
+            }),
+        );
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it.each([
+        { valueLabel: 'Formatted', onlyRaw: false },
+        { valueLabel: 'Raw', onlyRaw: true },
+    ])(
+        'includes conditional formatting in a non-pivoted XLSX export with $valueLabel values',
+        async ({ valueLabel, onlyRaw }) => {
+            const user = userEvent.setup();
+            renderExportResults();
+
+            await user.click(screen.getByText('XLSX'));
+            if (valueLabel === 'Raw') {
+                await user.click(screen.getByText(valueLabel));
+            }
+            await user.click(screen.getByTestId('chart-export-results-button'));
+
+            await expect(getScheduledDownloadBody()).resolves.toMatchObject({
+                type: 'xlsx',
+                onlyRaw,
+                conditionalFormattings,
+            });
+            await waitFor(() =>
+                expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled(),
+            );
+        },
+    );
+
+    it('does not include conditional formatting in a CSV export', async () => {
+        const user = userEvent.setup();
+        renderExportResults();
+
+        await user.click(screen.getByTestId('chart-export-results-button'));
+
+        const body = await getScheduledDownloadBody();
+        expect(body).toMatchObject({ type: 'csv' });
+        expect(body).not.toHaveProperty('conditionalFormattings');
+        await waitFor(() =>
+            expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled(),
+        );
+    });
+});

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -130,9 +130,11 @@ const ExportResults: FC<ExportResultsProps> = memo(
                         attachmentDownloadName: chartName
                             ? `${chartName}_${formatDate(new Date())}`
                             : undefined,
-                        conditionalFormattings: exportPivotedData
-                            ? undefined
-                            : conditionalFormattings,
+                        conditionalFormattings:
+                            fileType === DownloadFileType.XLSX &&
+                            (!pivotConfig || !exportPivotedData)
+                                ? conditionalFormattings
+                                : undefined,
                         // Pivoted exports get their totals from `pivotConfig`
                         showColumnTotals:
                             exportPivotedData && pivotConfig


### PR DESCRIPTION
## Validation blocked — not ready to merge

This draft was published only for human inspection. Deterministic validation did not converge within the bounded repair workflow; do not merge it until every command below passes.

Terminal reason: `final_retry_exhausted`

## Validation diagnostics

### Failing command 1 — frontend test

```sh
pnpm -F 'frontend' run --if-present test
```

Bounded output excerpt:

```text
t be grouped under "orders_identifiers" because a field with that key already exists. Adding to current level instead.


[31m⎯⎯⎯⎯⎯⎯⎯[39m[1m[41m Failed Tests 2 [49m[22m[31m⎯⎯⎯⎯⎯⎯⎯[39m

[41m[1m FAIL [22m[49m src/components/ProjectConnection/CreateProjectconnection.test.tsx[2m > [22mCreateProjectConnection in-flight job recovery[2m > [22mresumes polling the job carried by a 409 instead of failing the submit
[31m[1mError[22m: Test timed out in 5000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".[39m
[36m [2m❯[22m src/components/ProjectConnection/CreateProjectconnection.test.tsx:[2m187:5[22m[39m
    [90m185|[39m     })[33m;[39m
    [90m186|[39m
    [90m187|[39m     it('resumes polling the job carried by a 409 instead of failing th…
    [90m   |[39m     [31m^[39m
    [90m188|[39m         [35mconst[39m calls [33m=[39m [34mrouteApi[39m({
    [90m189|[39m             activeJob[33m:[39m () [33m=>[39m [35mnull[39m[33m,[39m

[31m[2m⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯[22m[39m

[41m[1m FAIL [22m[49m src/components/ProjectConnection/CreateProjectconnection.test.tsx[2m > [22mCreateProjectConnection in-flight job recovery[2m > [22mshows an informational conflict without registering another active job
[31m[1mError[22m: Test timed out in 5000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".[39m
[36m [2m❯[22m src/components/ProjectConnection/CreateProjectconnection.test.tsx:[2m222:5[22m[39m
    [90m220|[39m     })[33m;[39m
    [90m221|[39m
    [90m222|[39m     it('shows an informational conflict without registering another ac…
    [90m   |[39m     [31m^[39m
    [90m223|[39m         [35mconst[39m message [33m=[39m
    [90m224|[39m             'A project creation is already in progress for the organiz…

[31m[2m⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯[22m[39m
```

## What changed

## Summary

- Preserve table-chart conditional formatting rules in non-pivoted XLSX download requests for both formatted and raw values.
- Forward saved table formatting rules through both standard and minimal dashboard tile export paths.
- Keep CSV and grouped-pivot exports unstyled while retaining flat-pivot XLSX behavior.

### Validation

- `pnpm -F @lightdash/frontend test --run src/components/ExportResults/index.test.tsx` — passed the focused red/green regression test after implementation.
- `pnpm -F 'frontend' exec oxfmt 'src/components/DashboardTiles/DashboardChartTile.tsx' 'src/components/ExportResults/index.test.tsx' 'src/components/ExportResults/index.tsx'` — passed in targeted validation.
- `pnpm -F 'frontend' run --if-present linter -- 'src/components/DashboardTiles/DashboardChartTile.tsx' 'src/components/ExportResults/index.test.tsx' 'src/components/ExportResults/index.tsx'` — passed in targeted validation.
- `pnpm -F 'frontend' run --if-present typecheck` — passed in targeted validation.
- `pnpm -F 'frontend' exec vitest related 'src/components/DashboardTiles/DashboardChartTile.tsx' 'src/components/ExportResults/index.test.tsx' 'src/components/ExportResults/index.tsx' --run` — passed in targeted validation.
- `pnpm -F 'frontend' run --if-present test` — terminal failure on the permitted final rerun due to two unrelated 5-second timeouts in `CreateProjectconnection.test.tsx`; the draft is blocked on this full-suite gate.

### Review notes

- The regression tests cover formatted/raw non-pivot XLSX request payloads and CSV exclusion at the shared export interface. An alternative is adding heavier dashboard-tile and grouped/flat pivot integration fixtures; reviewer input is useful on whether that extra setup is worthwhile for this localized request-routing fix.
- The test helper parses the app-generated request body directly. An alternative is wrapping this test-only `JSON.parse` in contextual error handling; reviewer input is useful on whether the repository’s production parsing guideline should also be enforced for controlled test fixtures.

## References

Closes: PROD-10662

