### PR TITLE
feat(embed): emit event when a chart is saved

### DIFF
--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -110,10 +110,19 @@ const SaveChartButton: FC<{
             preserveVerification === undefined ? {} : { preserveVerification };
 
         if (hasPaletteChanges) {
-            updateMetadata.mutate({
-                colorPaletteUuid: stagedColorPaletteUuid,
-                ...verificationUpdate,
-            });
+            updateMetadata.mutate(
+                {
+                    colorPaletteUuid: stagedColorPaletteUuid,
+                    ...verificationUpdate,
+                },
+                {
+                    onSuccess: (data) => {
+                        if (!hasVersionChanges && !hasMergeChanges) {
+                            embed.onChartSaved?.(data, 'updated');
+                        }
+                    },
+                },
+            );
         }
         if (hasVersionChanges || hasMergeChanges) {
             update.mutate(
@@ -128,7 +137,7 @@ const SaveChartButton: FC<{
                 {
                     // Lets the embed dashboard builder react to the update
                     // (e.g. close its chart editor modal)
-                    onSuccess: (data) => embed.onChartSaved?.(data),
+                    onSuccess: (data) => embed.onChartSaved?.(data, 'updated'),
                 },
             );
         }
@@ -289,7 +298,7 @@ const SaveChartButton: FC<{
                     onConfirm={(saved) => {
                         setIsQueryModalOpen(false);
                         setIsSaveAsModal(false);
-                        embed.onChartSaved?.(saved);
+                        embed.onChartSaved?.(saved, 'created');
                     }}
                     defaultSpaceUuid={spaceUuid ?? undefined}
                     chartMetadata={generatedMetadata ?? undefined}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartEditorModal.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartEditorModal.tsx
@@ -1,10 +1,11 @@
 import { type SavedChart } from '@lightdash/common';
 import { IconChartBar } from '@tabler/icons-react';
-import { useMemo, useState, type FC } from 'react';
+import { useCallback, useMemo, useState, type FC } from 'react';
 import MantineModal from '../../../../../components/common/MantineModal';
 import EmbedProviderContext from '../../../../providers/Embed/context';
 import useEmbed from '../../../../providers/Embed/useEmbed';
 import EmbedExplore from '../../EmbedExplore/components/EmbedExplore';
+import { type ChartSavedAction } from '../../events/types';
 
 type Props = {
     opened: boolean;
@@ -35,6 +36,13 @@ const EmbedDashboardChartEditorModal: FC<Props> = ({
         setPickedExploreId(undefined);
         onClose();
     };
+    const handleChartSaved = useCallback(
+        (chart: SavedChart, action: ChartSavedAction) => {
+            embedContext.onChartSaved?.(chart, action);
+            onChartSaved(chart);
+        },
+        [embedContext, onChartSaved],
+    );
 
     // The explorer renders over the dashboard, not instead of it: suppress the
     // header's "Back to Dashboard" button (closing the modal is the way back)
@@ -46,9 +54,9 @@ const EmbedDashboardChartEditorModal: FC<Props> = ({
             savedChart: undefined,
             customSqlProvenanceChartUuid: editChart?.uuid,
             savedQueryUuid: undefined,
-            onChartSaved,
+            onChartSaved: handleChartSaved,
         }),
-        [editChart?.uuid, embedContext, onChartSaved],
+        [editChart?.uuid, embedContext, handleChartSaved],
     );
 
     return (

--- a/packages/frontend/src/ee/features/embed/events/LightdashUiEvent.test.ts
+++ b/packages/frontend/src/ee/features/embed/events/LightdashUiEvent.test.ts
@@ -4,6 +4,7 @@ import { LightdashUiEvent } from './LightdashUiEvent';
 import {
     LightdashEventType,
     type AllTilesLoadedPayload,
+    type ChartSavedPayload,
     type FilterChangedPayload,
     type TabChangedPayload,
 } from './types';
@@ -350,6 +351,24 @@ describe('LightdashUiEvent', () => {
                         loadTimeMs: 1500,
                     },
                 }),
+            );
+        });
+
+        it('should dispatch ChartSaved event after a successful chart save', () => {
+            const payload: ChartSavedPayload = {
+                chartUuid: 'chart-uuid',
+                action: 'updated',
+            };
+
+            eventSystem.dispatch(LightdashEventType.ChartSaved, payload);
+
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                {
+                    type: 'lightdash:chartSaved',
+                    payload,
+                    timestamp: expect.any(Number),
+                },
+                'https://example.com',
             );
         });
     });

--- a/packages/frontend/src/ee/features/embed/events/types.ts
+++ b/packages/frontend/src/ee/features/embed/events/types.ts
@@ -7,6 +7,7 @@ export enum LightdashEventType {
     TabChanged = 'tabChanged',
     Error = 'error',
     AllTilesLoaded = 'allTilesLoaded',
+    ChartSaved = 'chartSaved',
 }
 
 /**
@@ -55,12 +56,24 @@ export type LocationChangedPayload = {
     href: string;
 };
 
+/**
+ * Payload for ChartSaved events.
+ * Contains the saved chart identifier and whether it was created or updated.
+ */
+export type ChartSavedAction = 'created' | 'updated';
+
+export type ChartSavedPayload = {
+    chartUuid: string;
+    action: ChartSavedAction;
+};
+
 export type LightdashEventPayload =
     | FilterChangedPayload
     | TabChangedPayload
     | ErrorPayload
     | AllTilesLoadedPayload
-    | LocationChangedPayload;
+    | LocationChangedPayload
+    | ChartSavedPayload;
 
 /**
  * Generic event structure for all Lightdash events

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -1,10 +1,11 @@
 import {
     type CreateEmbedJwt,
     type LanguageMap,
+    type SavedChart,
     type UUID,
 } from '@lightdash/common';
 import get from 'lodash/get';
-import { useEffect, useMemo, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useAccount } from '../../../hooks/user/useAccount';
 import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
@@ -13,7 +14,10 @@ import {
     setToInMemoryStorage,
 } from '../../../utils/inMemoryStorage';
 import { type SdkFilter } from '../../features/embed/EmbedDashboard/types';
-import { LightdashEventType } from '../../features/embed/events/types';
+import {
+    LightdashEventType,
+    type ChartSavedAction,
+} from '../../features/embed/events/types';
 import { useEmbedEventEmitter } from '../../features/embed/hooks/useEmbedEventEmitter';
 import EmbedProviderContext from './context';
 import { parseEmbedThemeParams } from './parseEmbedThemeParams';
@@ -35,6 +39,7 @@ type Props = {
     embedHeaders?: Record<string, string>;
     onExplore?: (options: EmbedExploreOptions) => void;
     onBackToDashboard?: () => void;
+    onChartSaved?: (chart: SavedChart, action: ChartSavedAction) => void;
     savedChart?: EmbedExploreChart;
     customSqlProvenanceChartUuid?: UUID;
     savedQueryUuid?: string;
@@ -73,6 +78,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     contentOverrides,
     onExplore,
     onBackToDashboard,
+    onChartSaved,
     savedChart,
     customSqlProvenanceChartUuid,
     savedQueryUuid,
@@ -106,6 +112,19 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     const embedJwtPayload = useMemo(
         () => decodeEmbedJwtPayload(tokenFromStorageOrProps),
         [tokenFromStorageOrProps],
+    );
+    const handleChartSaved = useCallback(
+        (chart: SavedChart, action: ChartSavedAction) => {
+            onChartSaved?.(chart, action);
+
+            if (mode === 'direct') {
+                dispatchEmbedEvent(LightdashEventType.ChartSaved, {
+                    chartUuid: chart.uuid,
+                    action,
+                });
+            }
+        },
+        [dispatchEmbedEvent, mode, onChartSaved],
     );
 
     // Remove the token from the URL.
@@ -162,6 +181,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
             paletteUuid,
             languageMap: contentOverrides,
             onExplore,
+            onChartSaved: handleChartSaved,
             savedChart,
             customSqlProvenanceChartUuid,
             savedQueryUuid,
@@ -183,6 +203,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
         paletteUuid,
         contentOverrides,
         onExplore,
+        handleChartSaved,
         savedChart,
         customSqlProvenanceChartUuid,
         savedQueryUuid,

--- a/packages/frontend/src/ee/providers/Embed/types.ts
+++ b/packages/frontend/src/ee/providers/Embed/types.ts
@@ -7,6 +7,7 @@ import {
     type UUID,
 } from '@lightdash/common';
 import { type SdkFilter } from '../../features/embed/EmbedDashboard/types';
+import { type ChartSavedAction } from '../../features/embed/events/types';
 
 export const EMBED_KEY = 'lightdash-embed';
 
@@ -49,9 +50,9 @@ export interface EmbedContext {
     t: (input: string) => string | undefined;
     // The function to call when the user clicks "Back to dashboard" from an Explore
     onBackToDashboard?: () => void;
-    // Called after a chart is created from an embedded Explore. The dashboard
-    // builder's "New chart" flow uses this to turn the chart into a tile.
-    onChartSaved?: (chart: SavedChart) => void;
+    // Called after a chart is created or updated from an embedded Explore. The
+    // dashboard builder uses this to update its chart editor state.
+    onChartSaved?: (chart: SavedChart, action: ChartSavedAction) => void;
     // The chart that the user is exploring
     savedChart?: EmbedExploreChart;
     // The saved chart whose persisted custom SQL seeded this Explore. This is


### PR DESCRIPTION
Closes: [PROD-10666](https://linear.app/lightdash/issue/PROD-10666/emit-embed-event-when-a-chart-is-saved)

### Description:

- emit `lightdash:chartSaved` to allowed iframe parent origins after successful chart saves
- include the chart UUID and whether the chart was created or updated
- cover chart creation, version updates, and palette-only updates without duplicate events
- preserve the embedded dashboard editor’s internal save callback

### Testing:

- `pnpm -F frontend test --run src/ee/features/embed/events/LightdashUiEvent.test.ts`
- `pnpm -F frontend typecheck`
- targeted frontend lint and formatting checks

### Risk assessment:

- [ ] This is a high-risk change