### PR TITLE
feat(cli): publish linux x64 binary

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -14,6 +14,7 @@ preview_db_full:
   - "packages/backend/src/ee/database/seeds/**"
 
 cli:
+  - ".github/workflows/post-release.yml"
   - "packages/cli/**/*"
   - "packages/e2e/cypress/cli/**/*"
   - "packages/common/**/*"

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -367,6 +367,119 @@ jobs:
             security delete-keychain "$KEYCHAIN_PATH" || true
           fi
 
+  build-linux-binary:
+    name: Build Linux x64 CLI Binary
+    needs: check-cli-changes
+    if: needs.check-cli-changes.outputs.should_build == 'true'
+    runs-on: depot-ubuntu-24.04-4
+    permissions:
+      contents: write
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall-free
+
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+
+      - name: Read packageManager
+        id: package-manager
+        run: |
+          version=$(node -p 'JSON.parse(require("fs").readFileSync("package.json","utf8")).packageManager.split("+")[0]')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-node-modules-cli-binaries-v2-${{ steps.package-manager.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: pnpm install --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --prod=false --force --network-concurrency=16
+
+      - name: Cache common build
+        id: cache-common
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: packages/common/dist
+          key: ${{ runner.os }}-common-build-${{ hashFiles('packages/common/src/**', 'packages/common/tsconfig*.json') }}
+
+      - name: Build common package
+        if: steps.cache-common.outputs.cache-hit != 'true'
+        run: pnpm common-build
+
+      - name: Cache warehouses build
+        id: cache-warehouses
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: packages/warehouses/dist
+          key: ${{ runner.os }}-warehouses-build-${{ hashFiles('packages/warehouses/src/**', 'packages/warehouses/tsconfig*.json', 'packages/common/src/**') }}
+
+      - name: Build warehouses package
+        if: steps.cache-warehouses.outputs.cache-hit != 'true'
+        run: pnpm warehouses-build
+
+      - name: Build CLI package
+        working-directory: packages/cli
+        run: pnpm build
+
+      - name: Build Linux binary
+        working-directory: packages/cli
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          version=$(node -p "require('./package.json').version")
+          test "${tag#v}" = "$version"
+          ./scripts/build-binaries.sh --archive --linux-only
+          sha256sum --check checksums-linux-sha256.txt
+
+      - name: Upload binary to release
+        working-directory: packages/cli
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          gh release upload "$tag" \
+            "lightdash-cli-${tag}-linux-x64.tar.gz" \
+            checksums-linux-sha256.txt \
+            --clobber
+
+      - name: Test published binary without Node.js
+        working-directory: packages/cli
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          version=$(node -p "require('./package.json').version")
+          download_dir=$(mktemp -d)
+          trap 'rm -rf "$download_dir"' EXIT
+          gh release download "$tag" \
+            --pattern "lightdash-cli-${tag}-linux-x64.tar.gz" \
+            --pattern checksums-linux-sha256.txt \
+            --dir "$download_dir"
+          (cd "$download_dir" && sha256sum --check checksums-linux-sha256.txt)
+          ./scripts/smoke-test-linux-binary.sh \
+            "$download_dir/lightdash-cli-${tag}-linux-x64.tar.gz" \
+            "$version"
+
   update-homebrew-formula:
     name: Update Homebrew Formula
     needs: build-macos-binaries

--- a/packages/cli/pkg.config.json
+++ b/packages/cli/pkg.config.json
@@ -3,6 +3,7 @@
   "assets": [
     "bundle/**/*.node",
     "bundle/**/*.dylib",
+    "bundle/**/*.so",
     "bundle/ca-bundle-aws-redshift.crt",
     "bundle/ca-bundle-aws-rds-global.pem",
     "bundle/vendor/**/*"

--- a/packages/cli/scripts/build-binaries.sh
+++ b/packages/cli/scripts/build-binaries.sh
@@ -26,6 +26,10 @@ while [[ $# -gt 0 ]]; do
       TARGETS="node24-macos-x64,node24-macos-arm64"
       shift
       ;;
+    --linux-only)
+      TARGETS="node24-linux-x64"
+      shift
+      ;;
     --help)
       echo "Usage: $0 [OPTIONS]"
       echo ""
@@ -33,6 +37,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --sign        Sign and notarize macOS binaries (requires env vars)"
       echo "  --archive     Create tar.gz/zip archives and checksums for distribution"
       echo "  --mac-only    Build only macOS binaries"
+      echo "  --linux-only  Build only the Linux x64 binary"
       echo "  --help        Show this help message"
       echo ""
       echo "Required environment variables for signing:"

--- a/packages/cli/scripts/fixtures/day-ref.yml
+++ b/packages/cli/scripts/fixtures/day-ref.yml
@@ -1,0 +1,42 @@
+chartConfig:
+  config:
+    eChartsConfig:
+      series:
+        - encode:
+            xRef:
+              field: events_date_day
+            yRef:
+              field: events_count
+          type: bar
+          yAxisIndex: 0
+      showAxisTicks: false
+    layout:
+      xField: events_date_day
+      yField:
+        - events_count
+  type: cartesian
+contentType: chart
+description: Linux binary smoke test
+metricQuery:
+  additionalMetrics: []
+  customDimensions: []
+  dimensionOverrides: {}
+  dimensions:
+    - events_date_day
+  exploreName: events
+  filters: {}
+  limit: 1
+  metricOverrides: {}
+  metrics:
+    - events_count
+  sorts: []
+  tableCalculations: []
+name: Linux binary smoke test
+slug: linux-binary-smoke-test
+spaceSlug: smoke-test
+tableConfig:
+  columnOrder:
+    - events_date_day
+    - events_count
+tableName: events
+version: 1

--- a/packages/cli/scripts/smoke-test-linux-binary.sh
+++ b/packages/cli/scripts/smoke-test-linux-binary.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <archive> <expected-version>" >&2
+  exit 1
+fi
+
+ARCHIVE=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+EXPECTED_VERSION=$2
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+EXTRACT_DIR=$(mktemp -d)
+trap 'rm -rf "$EXTRACT_DIR"' EXIT
+
+tar -xzf "$ARCHIVE" -C "$EXTRACT_DIR"
+
+docker run --rm --platform linux/amd64 \
+  -e EXPECTED_VERSION="$EXPECTED_VERSION" \
+  -v "$EXTRACT_DIR:/cli:ro" \
+  -v "$SCRIPT_DIR/fixtures:/project:ro" \
+  ubuntu:20.04@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214 \
+  sh -euc '
+    ! command -v node
+    ! command -v npm
+    test "$(/cli/lightdash-linux-x64 --version)" = "$EXPECTED_VERSION"
+    /cli/lightdash-linux-x64 lint --path /project/day-ref.yml
+  '


### PR DESCRIPTION
## Summary

Publish a standalone Linux x64 CLI archive alongside macOS release assets. Linux CI can run Lightdash without installing Node.js or npm.

The CLI release workflow previously built only macOS binaries. The Linux package also needs its native DuckDB shared library included in the executable bundle.

This adds Linux release wiring, checksum verification, the required `.so` asset, and a post-upload Node-free Ubuntu smoke test covering `--version` and project-content linting.

## Tests

- built Linux x64 archive and verified SHA-256 checksum
- ran archive in Ubuntu 20.04 without Node.js/npm
- verified CLI version and lint command
- confirmed the same build and smoke test passed once in PR CI
- CLI typecheck
- CLI unit tests: 619 passed
- actionlint

Closes: PROD-10441
Closes: #27834
