### PR TITLE
fix(cli): restore --show-chart-configuration-warnings as deprecated alias

### DIFF
--- a/packages/cli/src/handlers/validate.test.ts
+++ b/packages/cli/src/handlers/validate.test.ts
@@ -6,7 +6,11 @@ import {
 } from '@lightdash/common';
 import { compile } from './compile';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
-import { validateHandler } from './validate';
+import {
+    resolveValidateSeverity,
+    SHOW_CHART_CONFIGURATION_WARNINGS_DEPRECATION,
+    validateHandler,
+} from './validate';
 
 vi.mock('../analytics/analytics');
 vi.mock('../config', () => ({
@@ -322,6 +326,37 @@ describe('validateHandler warehouse column validation', () => {
         expect(output).toContain('Chart configuration warning');
         expect(output).toContain('orders.unused_dim');
         expect(output).toContain('1 warning');
+    });
+
+    test('fails when deprecated --show-chart-configuration-warnings is set and warnings exist', async () => {
+        validationResults = [chartConfigurationWarning];
+        vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+        await validateHandler({
+            ...baseOptions,
+            showChartConfigurationWarnings: true,
+        });
+
+        expect(process.exit).toHaveBeenCalledWith(1);
+        const output = errorOutput.join('\n');
+        expect(output).toContain(SHOW_CHART_CONFIGURATION_WARNINGS_DEPRECATION);
+        expect(output).toContain('Chart configuration warning');
+        expect(output).toContain('orders.unused_dim');
+        expect(output).toContain('1 warning');
+    });
+
+    test('treats the deprecated flag as --severity warning even when severity defaults to error', async () => {
+        expect(
+            resolveValidateSeverity({
+                severity: 'error',
+                showChartConfigurationWarnings: true,
+            }),
+        ).toBe('warning');
+        expect(
+            resolveValidateSeverity({
+                severity: 'error',
+            }),
+        ).toBe('error');
     });
 
     test('fails on blocking errors even when warnings stay hidden', async () => {

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -93,6 +93,9 @@ const REFETCH_JOB_INTERVAL = 3000;
 export const VALIDATION_SEVERITIES = ['error', 'warning'] as const;
 export type ValidationSeverity = (typeof VALIDATION_SEVERITIES)[number];
 
+export const SHOW_CHART_CONFIGURATION_WARNINGS_DEPRECATION =
+    '`--show-chart-configuration-warnings` is deprecated. Use `--severity warning` instead.';
+
 type ValidateHandlerOptions = CompileHandlerOptions & {
     project?: string;
     verbose: boolean;
@@ -100,9 +103,22 @@ type ValidateHandlerOptions = CompileHandlerOptions & {
     only: ValidationTarget[];
     validateWarehouseColumns: boolean;
     severity?: ValidationSeverity;
+    showChartConfigurationWarnings?: boolean;
     includeSpaces?: string[];
     excludeSpaces?: string[];
 };
+
+export function resolveValidateSeverity(
+    options: Pick<
+        ValidateHandlerOptions,
+        'severity' | 'showChartConfigurationWarnings'
+    >,
+): ValidationSeverity {
+    if (options.showChartConfigurationWarnings) {
+        return 'warning';
+    }
+    return options.severity ?? 'error';
+}
 
 type WaitUntilFinishedOptions = {
     jobUuid: string;
@@ -133,6 +149,12 @@ export const validateHandler = async (
 ) => {
     const options = { ...originalOptions };
     GlobalState.setVerbose(options.verbose);
+    if (options.showChartConfigurationWarnings) {
+        console.error(
+            styles.warning(SHOW_CHART_CONFIGURATION_WARNINGS_DEPRECATION),
+        );
+    }
+    const severity = resolveValidateSeverity(options);
     await checkLightdashVersion();
 
     if (options.includeSpaces?.length && options.excludeSpaces?.length) {
@@ -226,8 +248,6 @@ export const validateHandler = async (
             ),
         );
     }
-
-    const severity = options.severity ?? 'error';
 
     await LightdashAnalytics.track({
         event: 'validate.started',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1478,6 +1478,12 @@ program
             .default('error'),
     )
     .addOption(
+        new Option(
+            '--show-chart-configuration-warnings',
+            '(deprecated) Alias for --severity warning. Shows chart configuration warnings and treats them as errors.',
+        ),
+    )
+    .addOption(
         new Option('--only <elems...>', 'Specify project elements to validate')
             .choices(Object.values(ValidationTarget))
             .default(Object.values(ValidationTarget)),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Relates: #28109

### Description:
`--show-chart-configuration-warnings` is restored as a deprecated alias for `lightdash validate --severity warning`.

#28109 replaced that flag with `--severity`. Anyone already passing the old flag in CI would hit an unknown-option error. The original flag already showed chart configuration warnings and failed when they were present, so this alias matches `--severity warning`.

- `--severity warning` remains the documented way to show and fail on those warnings
- `--show-chart-configuration-warnings` still works, maps to warning severity, and prints a deprecation notice

### Risk assessment:
- [ ] This is a high-risk change

Backwards-compatible. Default `--severity error` is unchanged.

### Testing:
- `pnpm -F cli test src/handlers/validate.test.ts` — 16 passed, including the restored alias
- `pnpm -F cli typecheck` — passed
- `lightdash validate --help` lists both `--severity` and the deprecated alias
- An unknown option still errors; `--show-chart-configuration-warnings` is accepted and prints the deprecation notice
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71b01706-4100-4290-a96b-28f018b4cb48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71b01706-4100-4290-a96b-28f018b4cb48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

