### PR TITLE
fix(filters): preserve date values across operator changes

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.test.tsx
@@ -2,7 +2,9 @@ import {
     createFilterRuleFromField,
     DimensionType,
     FieldType,
+    FilterOperator,
     type FilterableDimension,
+    type FilterRule,
 } from '@lightdash/common';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -29,18 +31,33 @@ const visibleDimension: FilterableDimension = {
     hidden: false,
 };
 
-const renderFilterRuleForm = (dimension: FilterableDimension) =>
+const timestampDimension: FilterableDimension = {
+    ...visibleDimension,
+    type: DimensionType.TIMESTAMP,
+    name: 'created_at',
+    label: 'Created at',
+    sql: '${TABLE}.created_at',
+};
+
+const renderFilterRuleForm = (
+    dimension: FilterableDimension,
+    filterRule: FilterRule = createFilterRuleFromField(dimension),
+    onChange = vi.fn(),
+) => {
     renderWithProviders(
         <FiltersProvider itemsMap={{}}>
             <FilterRuleForm
-                fields={[visibleDimension, hiddenDimension]}
-                filterRule={createFilterRuleFromField(dimension)}
+                fields={[visibleDimension, hiddenDimension, timestampDimension]}
+                filterRule={filterRule}
                 isEditMode
-                onChange={vi.fn()}
+                onChange={onChange}
                 onDelete={vi.fn()}
             />
         </FiltersProvider>,
     );
+
+    return { onChange };
+};
 
 describe('FilterRuleForm', () => {
     beforeAll(() => {
@@ -82,5 +99,30 @@ describe('FilterRuleForm', () => {
         expect(
             screen.queryByRole('option', { name: hiddenDimension.label }),
         ).toBeNull();
+    });
+
+    it('preserves a timestamp value when changing to is between', async () => {
+        const user = userEvent.setup();
+        const timestampValue = '2024-11-01T10:00:00-05:00';
+        const filterRule = {
+            ...createFilterRuleFromField(timestampDimension),
+            values: [timestampValue],
+        };
+        const { onChange } = renderFilterRuleForm(
+            timestampDimension,
+            filterRule,
+        );
+
+        await user.click(screen.getByDisplayValue('is'));
+        await user.click(
+            await screen.findByRole('option', { name: 'is between' }),
+        );
+
+        expect(onChange).toHaveBeenCalledWith({
+            ...filterRule,
+            operator: FilterOperator.IN_BETWEEN,
+            values: [timestampValue],
+            settings: undefined,
+        });
     });
 });

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -7,6 +7,8 @@ import {
     getItemId,
     isDateItem,
     isField,
+    isRelativeDateFilterOperator,
+    isWithValueFilter,
     type FilterableField,
     type FilterRule,
 } from '@lightdash/common';
@@ -214,12 +216,35 @@ const FilterRuleForm: FC<Props> = memo(
                     }}
                     onChange={(value) => {
                         if (!value) return;
+
+                        const operator = value as FilterRule['operator'];
+                        // Absolute date values are already normalized. Running
+                        // them through the defaults again can shift timezones.
+                        const shouldPreserveValues =
+                            filterType === FilterType.DATE &&
+                            (filterRule.values?.length ?? 0) > 0 &&
+                            isWithValueFilter(filterRule.operator) &&
+                            isWithValueFilter(operator) &&
+                            !isRelativeDateFilterOperator(
+                                filterRule.operator,
+                            ) &&
+                            !isRelativeDateFilterOperator(operator);
+
+                        if (shouldPreserveValues) {
+                            onChange({
+                                ...filterRule,
+                                operator,
+                                settings: undefined,
+                            });
+                            return;
+                        }
+
                         onChange(
                             getFilterRuleFromFieldWithDefaultValue(
                                 activeField,
                                 {
                                     ...filterRule,
-                                    operator: value as FilterRule['operator'],
+                                    operator,
                                 },
                                 filterRule.values ?? [],
                             ),

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
@@ -2,6 +2,8 @@ import {
     FilterOperator,
     FilterType,
     getFilterRuleWithDefaultValue,
+    isRelativeDateFilterOperator,
+    isWithValueFilter,
     supportsSingleValue,
     type DashboardFilterableField,
     type DashboardFilterRule,
@@ -71,11 +73,27 @@ const FilterSettings: FC<FilterSettingsProps> = ({
     }, [filterLabel, filterRule.label, field?.label]);
 
     const handleChangeFilterOperator = (operator: FilterRule['operator']) => {
+        // Absolute date values are already normalized. Running them through
+        // the defaults again can shift timezones.
+        const shouldPreserveValues =
+            filterType === FilterType.DATE &&
+            (filterRule.values?.length ?? 0) > 0 &&
+            isWithValueFilter(filterRule.operator) &&
+            isWithValueFilter(operator) &&
+            !isRelativeDateFilterOperator(filterRule.operator) &&
+            !isRelativeDateFilterOperator(operator);
+
         onChangeFilterRule(
-            getFilterRuleWithDefaultValue(filterType, field, {
-                ...filterRule,
-                operator,
-            }),
+            shouldPreserveValues
+                ? {
+                      ...filterRule,
+                      operator,
+                      settings: undefined,
+                  }
+                : getFilterRuleWithDefaultValue(filterType, field, {
+                      ...filterRule,
+                      operator,
+                  }),
         );
     };
 

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
@@ -72,6 +72,16 @@ const mockField = {
     hidden: false,
 } as unknown as DashboardFilterableField;
 
+const mockTimestampField = {
+    ...mockField,
+    name: 'created_at',
+    type: DimensionType.TIMESTAMP,
+    table: 'orders',
+    tableLabel: 'Orders',
+    label: 'Created at',
+    sql: 'created_at',
+} as unknown as DashboardFilterableField;
+
 const anyValueRule: DashboardFilterRule = {
     id: 'filter-1',
     target: {
@@ -163,6 +173,49 @@ describe('FilterConfiguration', () => {
         expect(
             screen.getByRole('button', { name: 'Single value' }),
         ).toBeVisible();
+    });
+
+    it('preserves a timestamp value when changing to is between', async () => {
+        const user = userEvent.setup();
+        const onSave = vi.fn();
+        const timestampValue = '2024-11-01T10:00:00-05:00';
+        const timestampRule: DashboardFilterRule = {
+            ...anyValueRule,
+            target: {
+                fieldId: 'orders_created_at',
+                tableName: 'orders',
+            },
+            values: [timestampValue],
+            disabled: false,
+        };
+
+        renderWithProviders(
+            <FilterConfiguration
+                isEditMode={false}
+                isTemporary
+                tiles={[]}
+                tabs={[]}
+                availableTileFilters={{}}
+                field={mockTimestampField}
+                defaultFilterRule={timestampRule}
+                originalFilterRule={timestampRule}
+                onSave={onSave}
+            />,
+        );
+
+        await user.click(screen.getByDisplayValue('is'));
+        await user.click(
+            await screen.findByRole('option', { name: 'is between' }),
+        );
+        fireEvent.mouseDown(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+        expect(onSave).toHaveBeenCalledWith(
+            expect.objectContaining({
+                operator: FilterOperator.IN_BETWEEN,
+                values: [timestampValue],
+            }),
+        );
     });
 
     it('keeps the required toggle on and lists rule siblings for a rule member', () => {


### PR DESCRIPTION
Closes: #28149

### Description:

Fixes [PROD-10658](https://linear.app/lightdash/issue/PROD-10658/changing-a-date-filters-operator-to-is-between-shifts-the-value-into-a).

- Preserve existing absolute date and timestamp values when changing between value-bearing operators.
- Keep existing default generation for empty rules and relative date operators.
- Cover both the shared filter form and dashboard filter configuration paths with offset-bearing timestamp regression tests.

### Verification:

- `pnpm -F frontend test --run src/components/common/Filters/FilterRuleForm.test.tsx src/features/dashboardFilters/FilterConfiguration/index.test.tsx`
- `pnpm -F frontend typecheck`
- Focused Oxlint and Oxfmt checks
- `git diff --check`
- Browser reproduction and retest on `localhost:3000`: changing `2026-08-18T09:50:31+01:00` from `is` to `is between` preserved the stored value, displayed wall clock, and UTC subtext.

### Risk assessment:

- [ ] This is a high-risk change

The change is limited to date-filter operator transitions and retains the existing behavior for empty and relative filters.