### PR TITLE
fix: support wildcard origins for embed events

### DIFF
--- a/packages/frontend/src/ee/features/embed/events/LightdashUiEvent.test.ts
+++ b/packages/frontend/src/ee/features/embed/events/LightdashUiEvent.test.ts
@@ -23,7 +23,7 @@ describe('LightdashUiEvent', () => {
     let dispatchEventSpy: any;
     let postMessageSpy: any;
     let eventSystem: LightdashUiEvent;
-    let mockConfig: HealthState['embedding']['events'];
+    let mockConfig: NonNullable<HealthState['embedding']['events']>;
 
     beforeEach(() => {
         dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
@@ -160,6 +160,50 @@ describe('LightdashUiEvent', () => {
                 LightdashEventType.FilterChanged,
                 payload,
             );
+
+            expect(postMessageSpy).not.toHaveBeenCalled();
+        });
+
+        it('should allow postMessage for wildcard subdomain origins', () => {
+            const wildcardConfig = {
+                ...mockConfig,
+                allowedOrigins: ['https://*.lightdash.dev'],
+            };
+            const wildcardEventSystem = new LightdashUiEvent(
+                wildcardConfig,
+                'https://javi.preview.lightdash.dev',
+            );
+
+            wildcardEventSystem.dispatch(LightdashEventType.FilterChanged, {
+                hasFilters: false,
+                filterCount: 0,
+            });
+
+            expect(postMessageSpy).toHaveBeenCalledTimes(1);
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                expect.any(Object),
+                'https://javi.preview.lightdash.dev',
+            );
+        });
+
+        it.each([
+            'https://lightdash.dev',
+            'http://javi.lightdash.dev',
+            'https://javi.lightdash.dev.example.com',
+        ])('should reject non-matching wildcard origin %s', (targetOrigin) => {
+            const wildcardConfig = {
+                ...mockConfig,
+                allowedOrigins: ['https://*.lightdash.dev'],
+            };
+            const wildcardEventSystem = new LightdashUiEvent(
+                wildcardConfig,
+                targetOrigin,
+            );
+
+            wildcardEventSystem.dispatch(LightdashEventType.FilterChanged, {
+                hasFilters: false,
+                filterCount: 0,
+            });
 
             expect(postMessageSpy).not.toHaveBeenCalled();
         });

--- a/packages/frontend/src/ee/features/embed/events/LightdashUiEvent.ts
+++ b/packages/frontend/src/ee/features/embed/events/LightdashUiEvent.ts
@@ -1,4 +1,7 @@
-import type { HealthState } from '@lightdash/common';
+import {
+    getCorsWildcardOriginRegexSource,
+    type HealthState,
+} from '@lightdash/common';
 import { addBreadcrumb, captureException } from '@sentry/react';
 import { type Exact } from 'type-fest';
 import {
@@ -6,6 +9,22 @@ import {
     type LightdashEventPayload,
     type LightdashEventType,
 } from './types';
+
+const isAllowedTargetOrigin = (
+    targetOrigin: string,
+    allowedOrigins: string[],
+): boolean =>
+    allowedOrigins.some((allowedOrigin) => {
+        if (allowedOrigin === targetOrigin) {
+            return true;
+        }
+
+        const wildcardRegexSource =
+            getCorsWildcardOriginRegexSource(allowedOrigin);
+        return wildcardRegexSource
+            ? new RegExp(wildcardRegexSource).test(targetOrigin)
+            : false;
+    });
 
 /**
  * LightdashUiEvent class for dispatching secure events in embedded dashboards.
@@ -41,7 +60,7 @@ export class LightdashUiEvent {
 
         // Validate targetOrigin against allowedOrigins if provided
         if (targetOrigin) {
-            if (!config.allowedOrigins.includes(targetOrigin)) {
+            if (!isAllowedTargetOrigin(targetOrigin, config.allowedOrigins)) {
                 addBreadcrumb({
                     category: 'embed.validation',
                     message: 'Target origin not in allowed list',


### PR DESCRIPTION
## Summary
- match wildcard subdomain entries in the embed event origin allowlist
- reuse the shared strict CORS wildcard compiler
- preserve exact-origin matching and reject apex, protocol, and lookalike mismatches

This enables `https://*.lightdash.dev` for iframe postMessage events.

Cloud configuration: lightdash/lightdash-cloud#3478

## Validation
- focused Vitest suite: 29 passed
- oxlint: clean
- oxfmt: clean
- full frontend typecheck has unrelated existing cross-package declaration errors; changed files report no errors