### PR TITLE
fix(ai): scope filter field suggestions

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.test.ts
@@ -1,5 +1,6 @@
 import {
     MergeJoinType,
+    MetricType,
     TimeFrames,
     type AiWebAppPrompt,
     type SlackPrompt,
@@ -613,6 +614,73 @@ describe('getRunQuery', () => {
         });
         expect(output.result).toContain('Problem:');
         expect(output.result).toContain('How to fix:');
+        expect(runAsyncQuery).not.toHaveBeenCalled();
+        expect(createOrUpdateArtifact).not.toHaveBeenCalled();
+        expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it('returns custom metric category failures without execution or Sentry capture', async () => {
+        vi.mocked(Sentry.captureException).mockClear();
+        const runAsyncQuery = vi.fn<RunAsyncQueryFn>();
+        const createOrUpdateArtifact = vi.fn().mockResolvedValue(undefined);
+        const queryTool = getRunQuery({
+            updateProgress: vi.fn().mockResolvedValue(undefined),
+            runAsyncQuery,
+            runAsyncMergeQuery: vi.fn<RunAsyncMergeQueryFn>(),
+            enableMergeQueries: false,
+            enableFilterExpressions: true,
+            projectParameterDefinitions: {},
+            getPrompt: vi.fn().mockResolvedValue(makePrompt()),
+            sendFile: vi.fn().mockResolvedValue(undefined),
+            createOrUpdateArtifact,
+            maxLimit: 500,
+            maxContextRows: Number.POSITIVE_INFINITY,
+            exposeQueryUuid: false,
+            enableDataAccess: true,
+            resolveCustomChartType: vi.fn().mockResolvedValue(null),
+            exportCustomChartTypeImage: vi.fn<ExportCustomChartTypeImageFn>(),
+        });
+
+        if (!queryTool.execute) {
+            throw new Error('Expected run query to be executable');
+        }
+        const output = await queryTool.execute(
+            {
+                ...toolInput,
+                queryConfig: {
+                    ...toolInput.queryConfig,
+                    customMetrics: [
+                        {
+                            kind: 'aggregation',
+                            name: 'conditional_count',
+                            label: 'Conditional count',
+                            description: 'Count with an internal filter',
+                            baseDimensionName: 'a_dim1',
+                            table: 'a',
+                            type: MetricType.COUNT,
+                            filters: 'a_met1 equals=one',
+                        },
+                    ],
+                },
+            },
+            {
+                messages: [],
+                toolCallId: 'tool-call-1',
+                experimental_context: new AgentContext([validExplore]),
+            },
+        );
+        if (Symbol.asyncIterator in output) {
+            throw new Error('Expected a non-streaming tool result');
+        }
+
+        expect(output).toMatchObject({
+            result: expect.stringContaining(
+                '[FILTER_EXPRESSION_CUSTOM_METRIC_WRONG_CATEGORY]',
+            ),
+            metadata: { status: 'error' },
+        });
+        expect(output.result).toContain('dimension field ID');
+        expect(output.result).not.toContain('parserMessage');
         expect(runAsyncQuery).not.toHaveBeenCalled();
         expect(createOrUpdateArtifact).not.toHaveBeenCalled();
         expect(Sentry.captureException).not.toHaveBeenCalled();

--- a/packages/backend/src/ee/services/ai/utils/filterExpressions/errors.ts
+++ b/packages/backend/src/ee/services/ai/utils/filterExpressions/errors.ts
@@ -11,28 +11,48 @@ export type QueryFilterExpressionCategory =
     | 'metrics'
     | 'tableCalculations';
 
-export type FilterExpressionSource =
-    | {
-          kind: 'queryFilter';
-          exploreName: string;
-          category: QueryFilterExpressionCategory;
-      }
-    | {
-          kind: 'customMetricFilter';
-          exploreName: string;
-          category: 'customMetric';
-          customMetricName: string;
-      };
+export type FilterExpressionFieldSuggestion = {
+    fieldId: string;
+    category: QueryFilterExpressionCategory;
+    filterType: FilterType;
+};
 
-type FilterExpressionErrorBase = {
-    source: FilterExpressionSource;
+export type QueryFilterExpressionSource = {
+    kind: 'queryFilter';
+    exploreName: string;
+    category: QueryFilterExpressionCategory;
+};
+
+export type CustomMetricFilterExpressionSource = {
+    kind: 'customMetricFilter';
+    exploreName: string;
+    category: 'customMetric';
+    customMetricName: string;
+};
+
+export type FilterExpressionSource =
+    | QueryFilterExpressionSource
+    | CustomMetricFilterExpressionSource;
+
+type FilterExpressionErrorBase<
+    TSource extends FilterExpressionSource = FilterExpressionSource,
+> = {
+    source: TSource;
     span: FilterExpressionSpan;
     problem: string;
     guidance: string;
 };
 
-type FilterExpressionErrorWithExample = FilterExpressionErrorBase & {
+type FilterExpressionErrorWithExample<
+    TSource extends FilterExpressionSource = FilterExpressionSource,
+> = FilterExpressionErrorBase<TSource> & {
     example: string;
+};
+
+type FilterExpressionErrorWithNullableExample<
+    TSource extends FilterExpressionSource = FilterExpressionSource,
+> = FilterExpressionErrorBase<TSource> & {
+    example: string | null;
 };
 
 export type FilterExpressionResolutionError =
@@ -52,18 +72,24 @@ export type FilterExpressionResolutionError =
           maximum: number;
           actual: number;
       })
-    | (FilterExpressionErrorBase & {
+    | (FilterExpressionErrorWithNullableExample & {
           code: 'FILTER_EXPRESSION_UNKNOWN_FIELD';
-          example: string | null;
           fieldId: string;
           reason: 'notFound' | 'ambiguous';
           suggestions: string[];
+          suggestedFields: FilterExpressionFieldSuggestion[];
       })
-    | (FilterExpressionErrorWithExample & {
+    | (FilterExpressionErrorWithExample<QueryFilterExpressionSource> & {
           code: 'FILTER_EXPRESSION_WRONG_CATEGORY';
           fieldId: string;
           expectedCategory: QueryFilterExpressionCategory;
           actualCategory: QueryFilterExpressionCategory;
+      })
+    | (FilterExpressionErrorWithNullableExample<CustomMetricFilterExpressionSource> & {
+          code: 'FILTER_EXPRESSION_CUSTOM_METRIC_WRONG_CATEGORY';
+          fieldId: string;
+          allowedCategory: 'dimensions';
+          fieldCategory: Exclude<QueryFilterExpressionCategory, 'dimensions'>;
       })
     | (FilterExpressionErrorBase & {
           code: 'FILTER_EXPRESSION_INVALID_VALUE';

--- a/packages/backend/src/ee/services/ai/utils/filterExpressions/index.ts
+++ b/packages/backend/src/ee/services/ai/utils/filterExpressions/index.ts
@@ -1,7 +1,10 @@
 export type {
+    CustomMetricFilterExpressionSource,
+    FilterExpressionFieldSuggestion,
     FilterExpressionResolutionError,
     FilterExpressionSource,
     QueryFilterExpressionCategory,
+    QueryFilterExpressionSource,
 } from './errors';
 export { formatFilterExpressionError } from './renderFilterExpressionError';
 export {

--- a/packages/backend/src/ee/services/ai/utils/filterExpressions/renderFilterExpressionError.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/filterExpressions/renderFilterExpressionError.test.ts
@@ -79,6 +79,13 @@ const errorsByCode: Record<
         fieldId: 'orders_statu',
         reason: 'notFound',
         suggestions: ['orders_status'],
+        suggestedFields: [
+            {
+                fieldId: 'orders_status',
+                category: 'dimensions',
+                filterType: FilterType.STRING,
+            },
+        ],
     },
     FILTER_EXPRESSION_WRONG_CATEGORY: {
         ...details,
@@ -87,6 +94,15 @@ const errorsByCode: Record<
         fieldId: 'orders_total_revenue',
         expectedCategory: 'metrics',
         actualCategory: 'dimensions',
+    },
+    FILTER_EXPRESSION_CUSTOM_METRIC_WRONG_CATEGORY: {
+        ...details,
+        code: 'FILTER_EXPRESSION_CUSTOM_METRIC_WRONG_CATEGORY',
+        source: customMetricSource,
+        fieldId: 'orders_total_revenue',
+        allowedCategory: 'dimensions',
+        fieldCategory: 'metrics',
+        example: null,
     },
     FILTER_EXPRESSION_INVALID_VALUE: {
         ...details,
@@ -148,6 +164,12 @@ Location: line 2, column 3
 Problem: The expression is invalid.
 How to fix: Correct the expression.
 Example: field equals=value`,
+    FILTER_EXPRESSION_CUSTOM_METRIC_WRONG_CATEGORY: `[FILTER_EXPRESSION_CUSTOM_METRIC_WRONG_CATEGORY]
+Invalid custom metric "completed_revenue" filter expression for field "orders_total_revenue".
+
+Location: line 2, column 3
+Problem: The expression is invalid.
+How to fix: Correct the expression.`,
     FILTER_EXPRESSION_INVALID_VALUE: `[FILTER_EXPRESSION_INVALID_VALUE]
 Invalid metric filter expression for field "orders_total_revenue".
 

--- a/packages/backend/src/ee/services/ai/utils/filterExpressions/renderFilterExpressionError.ts
+++ b/packages/backend/src/ee/services/ai/utils/filterExpressions/renderFilterExpressionError.ts
@@ -50,6 +50,7 @@ const getFieldId = (
     switch (error.code) {
         case 'FILTER_EXPRESSION_UNKNOWN_FIELD':
         case 'FILTER_EXPRESSION_WRONG_CATEGORY':
+        case 'FILTER_EXPRESSION_CUSTOM_METRIC_WRONG_CATEGORY':
         case 'FILTER_EXPRESSION_INVALID_VALUE':
         case 'FILTER_EXPRESSION_WRONG_ARITY':
             return error.fieldId;

--- a/packages/backend/src/ee/services/ai/utils/filterExpressions/resolveFilterExpressionArgs.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/filterExpressions/resolveFilterExpressionArgs.test.ts
@@ -971,7 +971,7 @@ describe('resolveFilterExpressionArgs', () => {
         expectParseableExample(error.example);
     });
 
-    it('reports unknown fields with suggestions and a stable located message', async () => {
+    it('reports unknown fields with typed suggestions and a stable located message', async () => {
         const error = await expectResolutionError(
             expressionArgs({
                 filters: {
@@ -987,17 +987,25 @@ describe('resolveFilterExpressionArgs', () => {
             fieldId: 'orders_customer_nam',
             reason: 'notFound',
             suggestions: ['orders_customer_name'],
+            suggestedFields: [
+                {
+                    fieldId: 'orders_customer_name',
+                    category: 'dimensions',
+                    filterType: FilterType.STRING,
+                },
+            ],
             span: {
                 start: { offset: 0, line: 1, column: 1 },
                 end: { offset: 19, line: 1, column: 20 },
             },
+            example: 'orders_customer_name equals=Acme',
         });
         expect(formatFilterExpressionError(error)).toMatchInlineSnapshot(`
           "[FILTER_EXPRESSION_UNKNOWN_FIELD]
           Invalid dimension filter expression for field "orders_customer_nam".
 
           Location: line 1, column 1
-          Problem: The field does not exist in explore "test_explore". Did you mean: orders_customer_name?
+          Problem: The field does not exist in explore "test_explore". Did you mean: orders_customer_name (dimension, string)?
           How to fix: Replace it with an existing dimension field ID, or use field discovery to find the field.
           Example: orders_customer_name equals=Acme"
         `);
@@ -1084,6 +1092,291 @@ describe('resolveFilterExpressionArgs', () => {
                 'orders_customer_name equals="Acme, Inc." AND orders_product_category equals=Hardware',
         });
     });
+    it.each([
+        {
+            category: 'dimensions',
+            expression: 'orders_customer_segment startsWith=Acme',
+            expectedFieldId: 'orders_customer_name',
+            expectedCategory: 'dimensions',
+            expectedFilterType: FilterType.STRING,
+            expectedExample: 'orders_customer_name startsWith=Acme',
+        },
+        {
+            category: 'metrics',
+            expression: 'gross_revenue greaterThan=100',
+            expectedFieldId: 'orders_total_revenue',
+            expectedCategory: 'metrics',
+            expectedFilterType: FilterType.NUMBER,
+            expectedExample: 'orders_total_revenue greaterThan=100',
+        },
+        {
+            category: 'tableCalculations',
+            expression: 'margin_percent lessThan=0.2',
+            expectedFieldId: 'profit_margin',
+            expectedCategory: 'tableCalculations',
+            expectedFilterType: FilterType.NUMBER,
+            expectedExample: 'profit_margin lessThan=0.2',
+        },
+    ] as const)(
+        'keeps $category suggestions in their category',
+        async ({
+            category,
+            expression,
+            expectedFieldId,
+            expectedCategory,
+            expectedFilterType,
+            expectedExample,
+        }) => {
+            const error = await expectResolutionError(
+                expressionArgs({
+                    tableCalculations: [numericFormula],
+                    filters: {
+                        dimensions: null,
+                        metrics: null,
+                        tableCalculations: null,
+                        [category]: expression,
+                    },
+                }),
+            );
+
+            expect(error).toMatchObject({
+                code: 'FILTER_EXPRESSION_UNKNOWN_FIELD',
+                suggestions: [expectedFieldId],
+                suggestedFields: [
+                    {
+                        fieldId: expectedFieldId,
+                        category: expectedCategory,
+                        filterType: expectedFilterType,
+                    },
+                ],
+                example: expectedExample,
+            });
+            const categoryLabel =
+                expectedCategory === 'tableCalculations'
+                    ? 'table calculation'
+                    : expectedCategory.slice(0, -1);
+            expect(formatFilterExpressionError(error)).toContain(
+                `Did you mean: ${expectedFieldId} (${categoryLabel}, ${expectedFilterType})?`,
+            );
+        },
+    );
+
+    it.each([
+        {
+            operatorScope: 'date-only',
+            expression:
+                'orders_customer_nam inThePast=30{completed:false,unit:days}',
+            expectedFieldId: 'orders_order_date',
+            expectedFilterType: FilterType.DATE,
+        },
+        {
+            operatorScope: 'string-only',
+            expression: 'orders_order_dat startsWith=2025',
+            expectedFieldId: 'orders_customer_name',
+            expectedFilterType: FilterType.STRING,
+        },
+    ] as const)(
+        'derives $operatorScope suggestion types from operator definitions',
+        async ({ expression, expectedFieldId, expectedFilterType }) => {
+            const error = await expectResolutionError(
+                expressionArgs({
+                    filters: {
+                        dimensions: expression,
+                        metrics: null,
+                        tableCalculations: null,
+                    },
+                }),
+            );
+
+            expect(error).toMatchObject({
+                code: 'FILTER_EXPRESSION_UNKNOWN_FIELD',
+                suggestions: [expectedFieldId],
+                suggestedFields: [
+                    {
+                        fieldId: expectedFieldId,
+                        category: 'dimensions',
+                        filterType: expectedFilterType,
+                    },
+                ],
+            });
+        },
+    );
+
+    it('preserves the full expression when a field replacement is valid', async () => {
+        const expression = String.raw`orders_customer_name equals="Acme, Inc. \"HQ\""   AND
+orders_order_dat inThePast=30{completed:false,unit:days} AND orders_product_category notEquals='A\\B, {x}=y'`;
+        const expectedExample = expression.replace(
+            'orders_order_dat',
+            'orders_order_date',
+        );
+        const error = await expectResolutionError(
+            expressionArgs({
+                filters: {
+                    dimensions: expression,
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            }),
+        );
+
+        expect(error).toMatchObject({
+            code: 'FILTER_EXPRESSION_UNKNOWN_FIELD',
+            suggestions: ['orders_order_date'],
+            example: expectedExample,
+        });
+        expect(error.example).not.toContain('example value');
+        if (error.example === null) {
+            throw new Error('Expected a semantically valid repair example');
+        }
+
+        const data = await expectResolved(
+            expressionArgs({
+                filters: {
+                    dimensions: error.example,
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            }),
+        );
+        expect(
+            data.persistedArgs.queryConfig.filters?.dimensions,
+        ).toMatchObject([
+            { values: ['Acme, Inc. "HQ"'] },
+            {
+                fieldId: 'orders_order_date',
+                values: [30],
+                settings: { completed: false, unitOfTime: 'days' },
+            },
+            { values: ['A\\B, {x}=y'] },
+        ]);
+    });
+
+    it('does not recursively repair a second unknown field', async () => {
+        const error = await expectResolutionError(
+            expressionArgs({
+                filters: {
+                    dimensions:
+                        'orders_customer_nam equals=Acme AND orders_product_categor equals=Hardware',
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            }),
+        );
+
+        expect(error).toMatchObject({
+            code: 'FILTER_EXPRESSION_UNKNOWN_FIELD',
+            fieldId: 'orders_customer_nam',
+            suggestions: ['orders_customer_name'],
+            example: null,
+        });
+    });
+
+    it('keeps a typed suggestion but omits an invalid scalar repair', async () => {
+        const error = await expectResolutionError(
+            expressionArgs({
+                filters: {
+                    dimensions: 'orders_amount_typo equals=nonnumeric',
+                    metrics: null,
+                    tableCalculations: null,
+                },
+            }),
+        );
+
+        expect(error).toMatchObject({
+            code: 'FILTER_EXPRESSION_UNKNOWN_FIELD',
+            suggestions: ['orders_amount'],
+            suggestedFields: [
+                {
+                    fieldId: 'orders_amount',
+                    category: 'dimensions',
+                    filterType: FilterType.NUMBER,
+                },
+            ],
+            example: null,
+        });
+        const formatted = formatFilterExpressionError(error);
+        expect(formatted).toContain(
+            'Did you mean: orders_amount (dimension, number)?',
+        );
+        expect(formatted).not.toContain('Example:');
+    });
+
+    it('excludes metrics from custom metric filter suggestions', async () => {
+        const error = await expectResolutionError(
+            expressionArgs({
+                customMetrics: [
+                    {
+                        ...aggregationCustomMetric,
+                        filters: 'orders_total_revenue_typo greaterThan=10',
+                    },
+                ],
+            }),
+        );
+
+        expect(error).toMatchObject({
+            code: 'FILTER_EXPRESSION_UNKNOWN_FIELD',
+            suggestions: ['orders_amount'],
+            suggestedFields: [
+                {
+                    fieldId: 'orders_amount',
+                    category: 'dimensions',
+                    filterType: FilterType.NUMBER,
+                },
+            ],
+            guidance: expect.stringContaining('dimension field ID'),
+            example: 'orders_amount greaterThan=10',
+        });
+        if (error.code !== 'FILTER_EXPRESSION_UNKNOWN_FIELD') {
+            throw new Error('Expected an unknown field error');
+        }
+        expect(error.suggestions).not.toContain('orders_total_revenue');
+        expect(formatFilterExpressionError(error)).not.toContain(
+            'explore field ID',
+        );
+    });
+
+    it.each([
+        {
+            fieldKind: 'metric',
+            expression: 'orders_total_revenue greaterThan=100',
+            fieldCategory: 'metrics',
+        },
+        {
+            fieldKind: 'table calculation',
+            expression: 'profit_margin greaterThan=0.2',
+            fieldCategory: 'tableCalculations',
+        },
+    ] as const)(
+        'rejects an exact $fieldKind in a custom metric filter at resolution',
+        async ({ expression, fieldCategory }) => {
+            const error = await expectResolutionError(
+                expressionArgs({
+                    customMetrics: [
+                        { ...aggregationCustomMetric, filters: expression },
+                    ],
+                    tableCalculations: [numericFormula],
+                }),
+            );
+
+            expect(error).toMatchObject({
+                code: 'FILTER_EXPRESSION_CUSTOM_METRIC_WRONG_CATEGORY',
+                source: {
+                    kind: 'customMetricFilter',
+                    customMetricName: 'completed_revenue',
+                },
+                allowedCategory: 'dimensions',
+                fieldCategory,
+                span: {
+                    start: { offset: 0, line: 1, column: 1 },
+                },
+                example: null,
+            });
+            const formatted = formatFilterExpressionError(error);
+            expect(formatted).toContain('only accept dimension fields');
+            expect(formatted).not.toContain('Example:');
+            expect(formatted).not.toContain('parserMessage');
+        },
+    );
 
     it.each([
         ['dimensions', 'orders_total_revenue greaterThan=10', 'metrics'],
@@ -1164,9 +1457,10 @@ describe('resolveFilterExpressionArgs', () => {
             fieldId: 'orders_total_revenue',
             reason: 'ambiguous',
             suggestions: [],
+            suggestedFields: [],
             example: null,
         });
-        expect(formatFilterExpressionError(error)).not.toContain('\nExample:');
+        expect(formatFilterExpressionError(error)).not.toContain('Example:');
     });
 
     it('resolves aggregation custom metrics as metric filter fields', async () => {
@@ -1209,33 +1503,6 @@ describe('resolveFilterExpressionArgs', () => {
             expect(error).toMatchObject({
                 code: 'FILTER_EXPRESSION_INVALID_VALUE',
                 source: { kind: 'queryFilter', category: 'metrics' },
-                fieldId: postCalculationMetricId,
-                filterType: FilterType.NUMBER,
-                problem: `Metric type "${metricType}" is not supported by AI filters.`,
-                guidance:
-                    'Use another metric whose type is supported by AI filters, or remove this filter rule.',
-            });
-        },
-    );
-
-    it.each(unsupportedAiFilterMetricTypes)(
-        'rejects unsupported AI custom metric filter type %s before persistence',
-        async (metricType) => {
-            const error = await expectResolutionError(
-                expressionArgs({
-                    customMetrics: [
-                        {
-                            ...aggregationCustomMetric,
-                            filters: `${postCalculationMetricId} greaterThan=100`,
-                        },
-                    ],
-                }),
-                () => exploreWithPostCalculationMetric(metricType),
-            );
-
-            expect(error).toMatchObject({
-                code: 'FILTER_EXPRESSION_INVALID_VALUE',
-                source: { kind: 'customMetricFilter' },
                 fieldId: postCalculationMetricId,
                 filterType: FilterType.NUMBER,
                 problem: `Metric type "${metricType}" is not supported by AI filters.`,

--- a/packages/backend/src/ee/services/ai/utils/filterExpressions/resolveFilterExpressionArgs.ts
+++ b/packages/backend/src/ee/services/ai/utils/filterExpressions/resolveFilterExpressionArgs.ts
@@ -33,6 +33,7 @@ import { z } from 'zod';
 import { populateCustomMetricsSQL } from '../populateCustomMetricsSQL';
 import { suggestClosestFieldIds } from '../suggestClosestFieldIds';
 import type {
+    FilterExpressionFieldSuggestion,
     FilterExpressionResolutionError,
     FilterExpressionSource,
     QueryFilterExpressionCategory,
@@ -136,6 +137,25 @@ const getCategoryLabel = (category: QueryFilterExpressionCategory): string => {
     }
 };
 
+const getOperatorDefinition = (operator: FilterOperator) => {
+    const definition = filterExpressionOperatorDefinitions.find(
+        (candidate) => candidate.operator === operator,
+    );
+    if (!definition) {
+        throw new Error(
+            `Missing filter expression operator definition for ${operator}`,
+        );
+    }
+    return definition;
+};
+
+const operatorSupportsFilterType = (
+    operator: FilterOperator,
+    filterType: FilterType,
+): boolean =>
+    getOperatorDefinition(operator).argumentCountByFilterType[filterType] !==
+    null;
+
 const formatFieldId = (fieldId: string): string => {
     if (
         /^[A-Za-z0-9_.-]+$/.test(fieldId) &&
@@ -199,16 +219,6 @@ const exampleArguments = (
     return illustrativeValue(filterType);
 };
 
-const isOperatorAvailableForFilterType = (
-    operator: FilterOperator,
-    filterType: FilterType,
-): boolean =>
-    filterExpressionOperatorDefinitions.some(
-        ({ operator: candidate, argumentCountByFilterType }) =>
-            candidate === operator &&
-            argumentCountByFilterType[filterType] !== null,
-    );
-
 const supportedOperatorsForFilterType = (filterType: FilterType): string =>
     filterExpressionOperatorDefinitions
         .filter(
@@ -243,6 +253,23 @@ const makeExploreFields = (
         category: isDimension(field) ? 'dimensions' : 'metrics',
     }));
 
+const makeTableCalculationFields = (
+    tableCalculations: ExpressionQueryConfig['tableCalculations'],
+): ResolvedField[] =>
+    convertAiTableCalcsSchemaToTableCalcs(tableCalculations ?? null).map(
+        (tableCalculation): ResolvedField => {
+            const fieldType =
+                tableCalculation.type ?? TableCalculationType.NUMBER;
+            return {
+                id: tableCalculation.name,
+                table: null,
+                fieldType,
+                filterType: getFilterTypeFromItemType(fieldType),
+                category: 'tableCalculations',
+            };
+        },
+    );
+
 const makeQueryFields = ({
     explore,
     transformedCustomMetrics,
@@ -272,23 +299,10 @@ const makeQueryFields = ({
         ];
     });
 
-    const tableCalculationFields = convertAiTableCalcsSchemaToTableCalcs(
-        tableCalculations ?? null,
-    ).map((tableCalculation): ResolvedField => {
-        const fieldType = tableCalculation.type ?? TableCalculationType.NUMBER;
-        return {
-            id: tableCalculation.name,
-            table: null,
-            fieldType,
-            filterType: getFilterTypeFromItemType(fieldType),
-            category: 'tableCalculations',
-        };
-    });
-
     return [
         ...makeExploreFields(explore),
         ...customMetricFields,
-        ...tableCalculationFields,
+        ...makeTableCalculationFields(tableCalculations),
     ];
 };
 
@@ -310,55 +324,83 @@ const isSupportedAiFilterField = (field: ResolvedField): boolean =>
         operator: FilterOperator.NULL,
     }).success;
 
+const isFieldInSourceCategory = (
+    field: ResolvedField,
+    source: FilterExpressionSource,
+): boolean => {
+    switch (source.kind) {
+        case 'queryFilter':
+            return field.category === source.category;
+        case 'customMetricFilter':
+            return field.category === 'dimensions';
+        default:
+            return assertUnreachable(source, 'Unknown expression source');
+    }
+};
+
+const getAllowedFieldLabel = (source: FilterExpressionSource): string => {
+    switch (source.kind) {
+        case 'queryFilter':
+            return getCategoryLabel(source.category);
+        case 'customMetricFilter':
+            return 'dimension';
+        default:
+            return assertUnreachable(source, 'Unknown expression source');
+    }
+};
+
+const getSuggestionFields = ({
+    fields,
+    rule,
+    source,
+}: {
+    fields: ResolvedField[];
+    rule: FilterExpressionRule;
+    source: FilterExpressionSource;
+}): ResolvedField[] =>
+    fields.filter(
+        (field) =>
+            getFieldMatches(fields, field.id).length === 1 &&
+            isFieldInSourceCategory(field, source) &&
+            (field.category !== 'tableCalculations' ||
+                field.filterType === FilterType.NUMBER) &&
+            operatorSupportsFilterType(rule.operator.value, field.filterType),
+    );
+
+const toFieldSuggestion = (
+    field: ResolvedField,
+): FilterExpressionFieldSuggestion => ({
+    fieldId: field.id,
+    category: field.category,
+    filterType: field.filterType,
+});
+
+const formatFieldSuggestion = ({
+    fieldId,
+    category,
+    filterType,
+}: FilterExpressionFieldSuggestion): string =>
+    `${formatFieldId(fieldId)} (${getCategoryLabel(category)}, ${filterType})`;
+
 const compareFieldIds = (left: ResolvedField, right: ResolvedField): number => {
     if (left.id < right.id) return -1;
     if (left.id > right.id) return 1;
     return 0;
 };
 
-const suggestedFieldRepairExample = ({
-    expressionInput,
-    rule,
-    suggestedField,
-}: {
-    expressionInput: string;
-    rule: FilterExpressionRule;
-    suggestedField: ResolvedField;
-}): string | null => {
-    const candidate = `${expressionInput.slice(0, rule.field.span.start.offset)}${formatFieldId(suggestedField.id)}${expressionInput.slice(rule.field.span.end.offset)}`;
-    return parseFilterExpression(candidate).success ? candidate : null;
-};
-
 const scopedExample = (
     source: FilterExpressionSource,
     fields: ResolvedField[],
 ): string => {
-    const uniqueFields = fields.filter(
-        ({ id }) => getFieldMatches(fields, id).length === 1,
-    );
-    const matchingFields = (() => {
-        switch (source.kind) {
-            case 'customMetricFilter': {
-                const dimensions = uniqueFields
-                    .filter(({ category }) => category === 'dimensions')
-                    .sort(compareFieldIds);
-                return dimensions.length > 0
-                    ? dimensions
-                    : uniqueFields.sort(compareFieldIds);
-            }
-            case 'queryFilter':
-                return uniqueFields
-                    .filter(
-                        ({ category, filterType }) =>
-                            category === source.category &&
-                            (category !== 'tableCalculations' ||
-                                filterType === FilterType.NUMBER),
-                    )
-                    .sort(compareFieldIds);
-            default:
-                return assertUnreachable(source, 'Unknown expression source');
-        }
-    })();
+    const matchingFields = fields
+        .filter(
+            (field) =>
+                getFieldMatches(fields, field.id).length === 1 &&
+                isFieldInSourceCategory(field, source) &&
+                (field.category !== 'tableCalculations' ||
+                    field.filterType === FilterType.NUMBER),
+        )
+        .sort(compareFieldIds);
     const field = matchingFields[0];
     return field
         ? expressionExample(field.id, FilterOperator.EQUALS, field.filterType)
@@ -406,42 +448,27 @@ const resolveField = ({
 }): ResolutionResult<ResolvedField> => {
     const matches = getFieldMatches(fields, rule.field.value);
     if (matches.length !== 1) {
-        const suggestionFields =
-            source.kind === 'queryFilter'
-                ? fields.filter(({ category }) => category === source.category)
-                : fields;
-        const compatibleSuggestionFields = suggestionFields.filter(
-            ({ filterType }) =>
-                isOperatorAvailableForFilterType(
-                    rule.operator.value,
-                    filterType,
-                ),
-        );
-        const suggestions =
+        const suggestionFields = getSuggestionFields({ fields, rule, source });
+        const suggestionIds =
             matches.length === 0
                 ? suggestClosestFieldIds(
                       rule.field.value,
-                      compatibleSuggestionFields.map(({ id }) => id),
+                      suggestionFields.map(({ id }) => id),
                       1,
                   )
                 : [];
-        const suggestedField = suggestions[0]
-            ? compatibleSuggestionFields.find(
-                  ({ id }) =>
-                      id === suggestions[0] &&
-                      getFieldMatches(fields, id).length === 1,
-              )
+        const suggestedField = suggestionIds[0]
+            ? suggestionFields.find(({ id }) => id === suggestionIds[0])
             : undefined;
-        const example = suggestedField
-            ? suggestedFieldRepairExample({
-                  expressionInput,
-                  rule,
-                  suggestedField,
-              })
-            : null;
+        const suggestedFields = suggestedField
+            ? [toFieldSuggestion(suggestedField)]
+            : [];
+        const suggestions = suggestedFields.map(({ fieldId }) => fieldId);
         const reason = matches.length === 0 ? 'notFound' : 'ambiguous';
-        const suggestionText = suggestions.length
-            ? ` Did you mean: ${suggestions.join(', ')}?`
+        const suggestionText = suggestedFields.length
+            ? ` Did you mean: ${suggestedFields
+                  .map(formatFieldSuggestion)
+                  .join(', ')}?`
             : '';
         return failure({
             code: 'FILTER_EXPRESSION_UNKNOWN_FIELD',
@@ -450,48 +477,76 @@ const resolveField = ({
             fieldId: rule.field.value,
             reason,
             suggestions,
+            suggestedFields,
             problem:
                 reason === 'notFound'
                     ? `The field does not exist in explore "${source.exploreName}".${suggestionText}`
                     : `The field ID matches multiple fields in explore "${source.exploreName}" and cannot be resolved safely.`,
             guidance:
                 reason === 'notFound'
-                    ? `Replace it with an existing ${source.kind === 'queryFilter' ? getCategoryLabel(source.category) : 'explore'} field ID, or use field discovery to find the field.`
+                    ? `Replace it with an existing ${getAllowedFieldLabel(source)} field ID, or use field discovery to find the field.`
                     : 'Rename or remove the colliding custom metric or table calculation, then use an unambiguous field ID.',
-            example,
+            example: null,
         });
     }
 
     const field = matches[0];
-    if (source.kind === 'queryFilter' && field.category !== source.category) {
-        const operatorIsAvailable = isOperatorAvailableForFilterType(
-            rule.operator.value,
-            field.filterType,
-        );
-        const originalRule = expressionInput.slice(
-            rule.span.start.offset,
-            rule.span.end.offset,
-        );
-        return failure({
-            code: 'FILTER_EXPRESSION_WRONG_CATEGORY',
-            source,
-            span: rule.field.span,
-            fieldId: field.id,
-            expectedCategory: field.category,
-            actualCategory: source.category,
-            problem: `The field is a ${getCategoryLabel(field.category)}, not a ${getCategoryLabel(source.category)}.`,
-            guidance: `Move this rule from the ${getCategoryLabel(source.category)} filters to the ${getCategoryLabel(field.category)} filters.`,
-            example: operatorIsAvailable
-                ? originalRule
-                : expressionExample(
-                      field.id,
-                      FilterOperator.EQUALS,
-                      field.filterType,
-                  ),
-        });
+    switch (source.kind) {
+        case 'queryFilter': {
+            if (field.category === source.category) return success(field);
+            const operatorIsAvailable = operatorSupportsFilterType(
+                rule.operator.value,
+                field.filterType,
+            );
+            const originalRule = expressionInput.slice(
+                rule.span.start.offset,
+                rule.span.end.offset,
+            );
+            return failure({
+                code: 'FILTER_EXPRESSION_WRONG_CATEGORY',
+                source,
+                span: rule.field.span,
+                fieldId: field.id,
+                expectedCategory: field.category,
+                actualCategory: source.category,
+                problem: `The field is a ${getCategoryLabel(field.category)}, not a ${getCategoryLabel(source.category)}.`,
+                guidance: `Move this rule from the ${getCategoryLabel(source.category)} filters to the ${getCategoryLabel(field.category)} filters.`,
+                example: operatorIsAvailable
+                    ? originalRule
+                    : expressionExample(
+                          field.id,
+                          FilterOperator.EQUALS,
+                          field.filterType,
+                      ),
+            });
+        }
+        case 'customMetricFilter':
+            switch (field.category) {
+                case 'dimensions':
+                    return success(field);
+                case 'metrics':
+                case 'tableCalculations':
+                    return failure({
+                        code: 'FILTER_EXPRESSION_CUSTOM_METRIC_WRONG_CATEGORY',
+                        source,
+                        span: rule.field.span,
+                        fieldId: field.id,
+                        allowedCategory: 'dimensions',
+                        fieldCategory: field.category,
+                        problem: `The field is a ${getCategoryLabel(field.category)}, but custom metric filters only accept dimension fields.`,
+                        guidance:
+                            'Replace it with an existing dimension field ID, or use field discovery to find one.',
+                        example: null,
+                    });
+                default:
+                    return assertUnreachable(
+                        field.category,
+                        'Unknown resolved field category',
+                    );
+            }
+        default:
+            return assertUnreachable(source, 'Unknown expression source');
     }
-
-    return success(field);
 };
 
 const strictNumber = (scalar: FilterExpressionScalar): number | null => {
@@ -992,14 +1047,7 @@ const resolveRule = ({
         );
     }
 
-    const definition = filterExpressionOperatorDefinitions.find(
-        ({ operator }) => operator === rule.operator.value,
-    );
-    if (!definition) {
-        throw new Error(
-            `Missing filter expression operator definition for ${rule.operator.value}`,
-        );
-    }
+    const definition = getOperatorDefinition(rule.operator.value);
     const expectedArity =
         definition.argumentCountByFilterType[field.filterType];
     if (expectedArity === null) {
@@ -1169,6 +1217,57 @@ const validateRepairCandidate = ({
         : null;
 };
 
+const replaceRuleField = ({
+    input,
+    rule,
+    fieldId,
+}: {
+    input: string;
+    rule: FilterExpressionRule;
+    fieldId: string;
+}): string =>
+    `${input.slice(0, rule.field.span.start.offset)}${formatFieldId(fieldId)}${input.slice(rule.field.span.end.offset)}`;
+
+const resolveRuleWithRepair = ({
+    rule,
+    fields,
+    source,
+    input,
+}: {
+    rule: FilterExpressionRule;
+    fields: ResolvedField[];
+    source: FilterExpressionSource;
+    input: string;
+}): ResolutionResult<RawFilterRule> => {
+    const result = resolveRule({
+        expressionInput: input,
+        rule,
+        fields,
+        source,
+    });
+    if (
+        result.success ||
+        result.error.code !== 'FILTER_EXPRESSION_UNKNOWN_FIELD'
+    ) {
+        return result;
+    }
+
+    const suggestedField = result.error.suggestedFields[0];
+    if (!suggestedField) return result;
+
+    const candidate = replaceRuleField({
+        input,
+        rule,
+        fieldId: suggestedField.fieldId,
+    });
+    return failure({
+        ...result.error,
+        example: validateRepairCandidate({ candidate, fields, source })
+            ? candidate
+            : null,
+    });
+};
+
 const getRuleField = ({
     rule,
     fields,
@@ -1181,10 +1280,7 @@ const getRuleField = ({
     const matches = getFieldMatches(fields, rule.field.value);
     if (matches.length !== 1) return null;
     const field = matches[0];
-    if (!field) return null;
-    if (source.kind === 'queryFilter' && field.category !== source.category) {
-        return null;
-    }
+    if (!field || !isFieldInSourceCategory(field, source)) return null;
     if (
         field.category === 'tableCalculations' &&
         field.filterType !== FilterType.NUMBER
@@ -1640,9 +1736,11 @@ const parseExpression = (
 
 const resolveCustomMetrics = ({
     customMetrics,
+    tableCalculations,
     explore,
 }: {
     customMetrics: ExpressionQueryConfig['customMetrics'];
+    tableCalculations: ExpressionQueryConfig['tableCalculations'];
     explore: Parameters<typeof getFields>[0];
 }): ResolutionResult<{
     raw: unknown;
@@ -1652,7 +1750,10 @@ const resolveCustomMetrics = ({
         return success({ raw: null, transformed: null });
     }
 
-    const exploreFields = makeExploreFields(explore);
+    const fields = [
+        ...makeExploreFields(explore),
+        ...makeTableCalculationFields(tableCalculations),
+    ];
     const rawCustomMetrics: unknown[] = [];
     for (const customMetric of customMetrics) {
         if (
@@ -1668,7 +1769,7 @@ const resolveCustomMetrics = ({
             const parsedResult = parseExpression(
                 customMetric.filters,
                 source,
-                exploreFields,
+                fields,
             );
             if (!parsedResult.success) return parsedResult;
             const expression = parsedResult.data;
@@ -1687,16 +1788,16 @@ const resolveCustomMetrics = ({
 
             const filters: { table: string; filter: RawFilterRule }[] = [];
             for (const rule of expression.rules) {
-                const ruleResult = resolveRule({
-                    expressionInput: customMetric.filters,
+                const ruleResult = resolveRuleWithRepair({
                     rule,
-                    fields: exploreFields,
+                    fields,
                     source,
+                    input: customMetric.filters,
                 });
                 if (!ruleResult.success) return ruleResult;
                 const fieldResult = resolveField({
                     expressionInput: customMetric.filters,
-                    fields: exploreFields,
+                    fields,
                     rule,
                     source,
                 });
@@ -1771,11 +1872,11 @@ const resolveQueryFilters = ({
 
             const categoryRules: RawFilterRule[] = [];
             for (const rule of expression.rules) {
-                const ruleResult = resolveRule({
-                    expressionInput,
+                const ruleResult = resolveRuleWithRepair({
                     rule,
                     fields,
                     source,
+                    input: expressionInput,
                 });
                 if (!ruleResult.success) return ruleResult;
                 categoryRules.push(ruleResult.data);
@@ -1831,6 +1932,7 @@ const resolveQueryConfig = ({
 }): ResolutionResult<ResolvedQueryConfigParts> => {
     const customMetricsResult = resolveCustomMetrics({
         customMetrics: queryConfig.customMetrics,
+        tableCalculations: queryConfig.tableCalculations,
         explore,
     });
     if (!customMetricsResult.success) return customMetricsResult;


### PR DESCRIPTION
Related: ZAP-963
Related: ZAP-920
Related: #28262

Scopes filter field resolution and suggestions by category and operator-compatible type. Validates field-only repair examples before returning them and rejects non-dimension custom metric filters at resolution.

Risk: high — protects the query boundary; human peer review required.
