### PR TITLE
fix(sdk): include @mantine/dates styles in the SDK bundle

### DIFF
--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -1,5 +1,6 @@
 import '@mantine/core/styles.css';
 import '@mantine/code-highlight/styles.css';
+import '@mantine/dates/styles.css';
 import '@mantine/tiptap/styles.css';
 import '../src/styles/global.css';
 import {


### PR DESCRIPTION
## Problem

In `@lightdash/sdk` embeds, the calendar popup of date filters (DatePicker / DateTimePicker) renders completely unstyled — oversized chevrons and a plain-text month grid. The SDK entry point imports `@mantine/core`, `@mantine/code-highlight`, and `@mantine/tiptap` styles, but not `@mantine/dates/styles.css`, so the dates components ship in the JS bundle without their CSS. The main app entry imports it, which is why the same popup looks correct in the regular UI.

## Fix

Add the missing `@mantine/dates/styles.css` import to the SDK entry so rollup's postcss (inject mode) bundles it like the other Mantine stylesheets.

Reproducible on the embedded-analytics showcase: open a date filter's calendar popup in the "Edit a chart" demo.

Closes: #28169
