### PR TITLE
fix(dev): resolve statusline instance from the LD_INSTANCE_ID pin

### DIFF
--- a/scripts/dev-statusline.sh
+++ b/scripts/dev-statusline.sh
@@ -4,7 +4,9 @@
 # Output (stdout): {"label":"🟢 http://localhost:<FE>"} when the frontend is up,
 # a muted variant when the instance is assigned but down, and NOTHING (exit 0)
 # when the cwd isn't a Lightdash worktree with an assigned slot — so it's silent
-# everywhere else. Designed to be fast (statusline budget): a single 0.3s TCP probe.
+# everywhere else. The instance is resolved from LD_INSTANCE_ID in .env.development.local with
+# basename fallback, matching dev-ports.sh. Designed to be fast (statusline budget): a
+# single 0.3s TCP probe.
 #
 # Wire it into claude-hud via `--extra-cmd` (see the /docker-dev "Statusline" note).
 # Run directly with `--plain` to just print the URL for humans.
@@ -12,7 +14,8 @@
 set -uo pipefail
 
 root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-id="$(basename "$root")"
+id="$(sed -n -E 's/^LD_INSTANCE_ID=(.*)$/\1/p' "$root/.env.development.local" 2>/dev/null | head -n 1 | sed -E "s/^['\"](.*)['\"]$/\1/")"
+[ -n "$id" ] || id="$(basename "$root")"
 inst="$HOME/.lightdash/dev-instances/${id}.json"
 [ -f "$inst" ] || exit 0
 


### PR DESCRIPTION
## What

`scripts/dev-statusline.sh` derived the dev instance from the git root's basename only, while `scripts/dev-ports.sh` deliberately prefers the `LD_INSTANCE_ID` pin in `.env.development.local` (same-basename checkouts collide on basename; a copied env file carries the donor's id). For those checkouts the statusline probed another instance's frontend port and showed the wrong URL.

The statusline now resolves identity the same way as `get_instance_id`: env pin first, basename fallback. The sed expressions mirror `get_env_instance_id` in `dev-ports.sh`.

## Proof

From a temp git dir with a random basename and `LD_INSTANCE_ID=lightdash-dev` pinned:

```
$ bash scripts/dev-statusline.sh --plain
http://localhost:3020        # lightdash-dev's slot — before the fix this printed nothing
```

A worktree with no pin and no registry file still exits 0 silently, and `bash -n`/`sh -n` pass.

Fixes SPK-1490

🤖 Generated with [Claude Code](https://claude.com/claude-code)