### PR TITLE
feat(maps): add tile usage and fallback analytics events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -51,6 +51,10 @@ import {
     type DataAppCodingAgentModel,
     type DataAppCreationExperience,
     type DataAppTemplate,
+    type FunnelChartDataInput,
+    type MapChartLocation,
+    type MapChartType,
+    type MapTileBackground,
     type PersistentDownloadFileAccessMode,
     type PlaygroundProjectTrigger,
     type PullRequestProvider,
@@ -814,6 +818,27 @@ export type CreateSavedChartVersionEvent = BaseTrack & {
         pie?: {
             isDonut: boolean;
         };
+        funnel?: {
+            dataInput: FunnelChartDataInput | undefined;
+        };
+        treemap?: {
+            visibleMin: number | undefined;
+            leafDepth: number | undefined;
+            dimensionCount: number;
+            startColor: string | undefined;
+            endColor: string | undefined;
+            useDynamicColors: boolean | undefined;
+            startColorThreshold: number | undefined;
+            endColorThreshold: number | undefined;
+        };
+        map?: {
+            mapType: MapChartLocation | undefined;
+            locationType: MapChartType | undefined;
+            hasCustomGeoJson: boolean;
+            tileBackground: MapTileBackground | null;
+            darkModeTileBackground: MapTileBackground | null;
+            savesMapExtent: boolean;
+        };
         table?: {
             conditionalFormattingRulesCount: number;
             hasMetricsAsRows: boolean;
@@ -1348,6 +1373,7 @@ type SavedChartView = BaseTrack & {
         projectId: string;
         organizationId: string;
         parametersCount: number;
+        chartType: ChartType;
     };
 };
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -338,6 +338,25 @@ export class SavedChartService
                           dataInput: savedChart.chartConfig?.config?.dataInput,
                       }
                     : undefined,
+            map:
+                savedChart.chartConfig.type === ChartType.MAP
+                    ? {
+                          mapType: savedChart.chartConfig.config?.mapType,
+                          locationType:
+                              savedChart.chartConfig.config?.locationType,
+                          hasCustomGeoJson:
+                              !!savedChart.chartConfig.config?.customGeoJsonUrl,
+                          tileBackground:
+                              savedChart.chartConfig.config?.tileBackground ??
+                              null,
+                          darkModeTileBackground:
+                              savedChart.chartConfig.config
+                                  ?.darkModeTileBackground ?? null,
+                          savesMapExtent:
+                              savedChart.chartConfig.config?.saveMapExtent ??
+                              false,
+                      }
+                    : undefined,
             table:
                 savedChart.chartConfig.type === ChartType.TABLE
                     ? {
@@ -1572,6 +1591,7 @@ export class SavedChartService
                 projectId: savedChart.projectUuid,
                 parametersCount: Object.keys(savedChart.parameters || {})
                     .length,
+                chartType: savedChart.chartConfig.type,
             },
         });
 

--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -31,6 +31,7 @@ import {
 } from 'react-leaflet';
 import * as topojson from 'topojson-client';
 import type { Topology } from 'topojson-specification';
+import useEmbed from '../../ee/providers/Embed/useEmbed';
 import {
     explorerActions,
     useExplorerDispatch,
@@ -39,8 +40,14 @@ import useLeafletMapConfig, {
     type ScatterPoint,
     type TooltipFieldInfo,
 } from '../../hooks/leaflet/useLeafletMapConfig';
+import { useMapTileTelemetry } from '../../hooks/leaflet/useMapTileTelemetry';
 import { useTileFallback } from '../../hooks/leaflet/useTileFallback';
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
+import { useProjectUuid } from '../../hooks/useProjectUuid';
+import { useAccount } from '../../hooks/user/useAccount';
+import { type MapUsageContext } from '../../providers/Tracking/types';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
 import { createMultiColorScale } from '../../utils/colorUtils';
 import { resolveRequestUrl } from '../../utils/request';
 import Callout from '../common/Callout';
@@ -329,6 +336,25 @@ const MapRefUpdater: FC<{ mapRef: RefObject<L.Map | null> }> = ({ mapRef }) => {
 
 // Component to track map extent and dispatch to Redux
 // This does NOT cause re-renders because nothing subscribes to mapExtent during render
+const MapInteractionTracker: FC<{
+    onInteraction: (type: 'zoom' | 'pan', zoomLevel: number) => void;
+}> = ({ onInteraction }) => {
+    const map = useMap();
+
+    useEffect(() => {
+        const handleZoom = () => onInteraction('zoom', map.getZoom());
+        const handlePan = () => onInteraction('pan', map.getZoom());
+        map.on('zoomend', handleZoom);
+        map.on('dragend', handlePan);
+        return () => {
+            map.off('zoomend', handleZoom);
+            map.off('dragend', handlePan);
+        };
+    }, [map, onInteraction]);
+
+    return null;
+};
+
 const MapExtentTracker: FC = () => {
     const map = useMap();
     const dispatch = useExplorerDispatch();
@@ -494,31 +520,93 @@ const SimpleMap: FC<SimpleMapProps> = memo(
             leafletMapRef,
             minimal,
             colorPalette,
+            savedChartUuid,
         } = useVisualizationContext();
         const mapConfig = useLeafletMapConfig({
             isInDashboard: props.isInDashboard,
         });
-        const { activeTile, tileLayerEventHandlers } = useTileFallback(
+        const tracking = useTracking({ failSilently: true });
+        const { data: account } = useAccount();
+        const projectUuid = useProjectUuid();
+        const { embedToken } = useEmbed();
+        const usageContext: MapUsageContext = embedToken
+            ? 'embed'
+            : minimal
+              ? 'minimal'
+              : props.isInDashboard
+                ? 'dashboard'
+                : 'explore';
+        const {
+            activeTile,
+            activeBackground,
+            hasFallenBack,
+            tileLayerEventHandlers,
+        } = useTileFallback(
             mapConfig?.tile ?? { url: null, attribution: '' },
             mapConfig?.tileBackground ?? MapTileBackground.OPENSTREETMAP,
-            useCallback((event) => {
-                captureException(
-                    new Error(
-                        `Map tile provider fallback: ${event.from} → ${event.to}`,
-                    ),
-                    {
-                        tags: {
-                            component: 'SimpleMap',
-                            tileProviderFrom: event.from,
-                            tileProviderTo: event.to,
+            useCallback(
+                (event) => {
+                    captureException(
+                        new Error(
+                            `Map tile provider fallback: ${event.from} → ${event.to}`,
+                        ),
+                        {
+                            tags: {
+                                component: 'SimpleMap',
+                                tileProviderFrom: event.from,
+                                tileProviderTo: event.to,
+                            },
+                            extra: {
+                                errorCount: event.errorCount,
+                                successCount: event.successCount,
+                            },
                         },
-                        extra: {
+                    );
+                    tracking?.track({
+                        name: EventName.MAP_TILE_FALLBACK,
+                        properties: {
+                            userId: account?.user?.id ?? null,
+                            organizationId:
+                                account?.organization?.organizationUuid ?? null,
+                            projectId: projectUuid ?? null,
+                            chartId: savedChartUuid ?? null,
+                            context: usageContext,
+                            fromTileBackground: event.from,
+                            toTileBackground: event.to,
                             errorCount: event.errorCount,
                             successCount: event.successCount,
                         },
-                    },
-                );
-            }, []),
+                    });
+                },
+                [tracking, account, projectUuid, savedChartUuid, usageContext],
+            ),
+        );
+        const {
+            tileLayerEventHandlers: telemetryTileEventHandlers,
+            recordInteraction,
+        } = useMapTileTelemetry({
+            chartId: savedChartUuid ?? null,
+            projectId: projectUuid ?? null,
+            organizationId: account?.organization?.organizationUuid ?? null,
+            userId: account?.user?.id ?? null,
+            context: usageContext,
+            tileBackground:
+                mapConfig?.tileBackground ?? MapTileBackground.OPENSTREETMAP,
+            activeTileBackground: activeBackground,
+            didFallback: hasFallenBack,
+        });
+        const combinedTileLayerEventHandlers = useMemo(
+            () => ({
+                tileerror: () => {
+                    tileLayerEventHandlers.tileerror();
+                    telemetryTileEventHandlers.tileerror();
+                },
+                tileload: () => {
+                    tileLayerEventHandlers.tileload();
+                    telemetryTileEventHandlers.tileload();
+                },
+            }),
+            [tileLayerEventHandlers, telemetryTileEventHandlers],
         );
         const { shouldShowMenu } = useContextMenuPermissions({ minimal });
 
@@ -1048,6 +1136,9 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                         maxBoundsViscosity={1.0}
                     >
                         <MapRefUpdater mapRef={leafletMapRef} />
+                        <MapInteractionTracker
+                            onInteraction={recordInteraction}
+                        />
                         {/* Only track extent changes in explorer, not on dashboards */}
                         {!props.isInDashboard && <MapExtentTracker />}
                         <MapBoundsFitter
@@ -1062,7 +1153,7 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                                 key={activeTile.url}
                                 attribution={activeTile.attribution}
                                 url={activeTile.url}
-                                eventHandlers={tileLayerEventHandlers}
+                                eventHandlers={combinedTileLayerEventHandlers}
                             />
                         )}
                         {isHexbin ? (
@@ -1250,6 +1341,9 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                         maxBoundsViscosity={1.0}
                     >
                         <MapRefUpdater mapRef={leafletMapRef} />
+                        <MapInteractionTracker
+                            onInteraction={recordInteraction}
+                        />
                         {/* Only track extent changes in explorer, not on dashboards */}
                         {!props.isInDashboard && <MapExtentTracker />}
                         <MapBoundsFitter
@@ -1264,7 +1358,7 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                                 key={activeTile.url}
                                 attribution={activeTile.attribution}
                                 url={activeTile.url}
-                                eventHandlers={tileLayerEventHandlers}
+                                eventHandlers={combinedTileLayerEventHandlers}
                             />
                         )}
                         {geoJsonData?.features &&

--- a/packages/frontend/src/hooks/leaflet/useMapTileTelemetry.ts
+++ b/packages/frontend/src/hooks/leaflet/useMapTileTelemetry.ts
@@ -1,0 +1,143 @@
+import { type MapTileBackground } from '@lightdash/common';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { type MapUsageContext } from '../../providers/Tracking/types';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
+
+type MapTileTelemetryArgs = {
+    chartId: string | null;
+    projectId: string | null;
+    organizationId: string | null;
+    userId: string | null;
+    context: MapUsageContext;
+    /** Background configured on the chart (after light/dark resolution). */
+    tileBackground: MapTileBackground;
+    /** Background actually serving tiles (differs after a provider fallback). */
+    activeTileBackground: MapTileBackground;
+    didFallback: boolean;
+};
+
+type MapTileTelemetryResult = {
+    tileLayerEventHandlers: {
+        tileerror: () => void;
+        tileload: () => void;
+    };
+    recordInteraction: (type: 'zoom' | 'pan', zoomLevel: number) => void;
+};
+
+type Counters = {
+    tilesLoaded: number;
+    tileErrors: number;
+    zoomCount: number;
+    panCount: number;
+    minZoom: number | null;
+    maxZoom: number | null;
+    startedAt: number;
+};
+
+const freshCounters = (): Counters => ({
+    tilesLoaded: 0,
+    tileErrors: 0,
+    zoomCount: 0,
+    panCount: 0,
+    minZoom: null,
+    maxZoom: null,
+    startedAt: Date.now(),
+});
+
+/**
+ * Accumulates tile-load volume and map interactions for a mounted map chart
+ * and flushes a single summary event when the map unmounts or the tab is
+ * hidden. Tiles are fetched browser-side from third-party providers, so this
+ * is the only place their volume can be measured.
+ */
+export const useMapTileTelemetry = (
+    args: MapTileTelemetryArgs,
+): MapTileTelemetryResult => {
+    const tracking = useTracking({ failSilently: true });
+
+    const counters = useRef<Counters>(freshCounters());
+    // Latest identity/track values, so flush callbacks never go stale
+    const argsRef = useRef(args);
+    argsRef.current = args;
+    const trackRef = useRef(tracking?.track);
+    trackRef.current = tracking?.track;
+
+    const flush = useCallback(() => {
+        const current = counters.current;
+        if (current.tilesLoaded === 0 && current.tileErrors === 0) return;
+        counters.current = freshCounters();
+        trackRef.current?.({
+            name: EventName.MAP_TILE_USAGE,
+            properties: {
+                userId: argsRef.current.userId,
+                organizationId: argsRef.current.organizationId,
+                projectId: argsRef.current.projectId,
+                chartId: argsRef.current.chartId,
+                context: argsRef.current.context,
+                tileBackground: argsRef.current.tileBackground,
+                activeTileBackground: argsRef.current.activeTileBackground,
+                didFallback: argsRef.current.didFallback,
+                tilesLoaded: current.tilesLoaded,
+                tileErrors: current.tileErrors,
+                zoomCount: current.zoomCount,
+                panCount: current.panCount,
+                minZoom: current.minZoom,
+                maxZoom: current.maxZoom,
+                durationMs: Date.now() - current.startedAt,
+            },
+        });
+    }, []);
+
+    useEffect(() => {
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'hidden') flush();
+        };
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        return () => {
+            document.removeEventListener(
+                'visibilitychange',
+                handleVisibilityChange,
+            );
+            flush();
+        };
+    }, [flush]);
+
+    const handleTileLoad = useCallback(() => {
+        counters.current.tilesLoaded += 1;
+    }, []);
+
+    const handleTileError = useCallback(() => {
+        counters.current.tileErrors += 1;
+    }, []);
+
+    const recordInteraction = useCallback(
+        (type: 'zoom' | 'pan', zoomLevel: number) => {
+            const current = counters.current;
+            if (type === 'zoom') current.zoomCount += 1;
+            else current.panCount += 1;
+            current.minZoom =
+                current.minZoom === null
+                    ? zoomLevel
+                    : Math.min(current.minZoom, zoomLevel);
+            current.maxZoom =
+                current.maxZoom === null
+                    ? zoomLevel
+                    : Math.max(current.maxZoom, zoomLevel);
+        },
+        [],
+    );
+
+    const tileLayerEventHandlers = useMemo(
+        () => ({
+            tileerror: handleTileError,
+            tileload: handleTileLoad,
+        }),
+        [handleTileError, handleTileLoad],
+    );
+
+    return {
+        tileLayerEventHandlers,
+        recordInteraction,
+    };
+};

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -4,6 +4,7 @@ import {
     type CustomFormatType,
     type DataAppTemplate,
     type HomepageRecommendedActionKey,
+    type MapTileBackground,
     type SearchItemType,
     type TableCalculationType,
     type TimeFrames,
@@ -878,8 +879,47 @@ type AgentOnboardingCompletionToastClickedEvent = {
     properties: AgentOnboardingCompletionToastProperties;
 };
 
+/** Where a map chart was rendered when tile telemetry was captured. */
+export type MapUsageContext = 'explore' | 'dashboard' | 'embed' | 'minimal';
+
+type MapTelemetryBaseProperties = {
+    userId: string | null;
+    organizationId: string | null;
+    projectId: string | null;
+    chartId: string | null;
+    context: MapUsageContext;
+};
+
+type MapTileUsageEvent = {
+    name: EventName.MAP_TILE_USAGE;
+    properties: MapTelemetryBaseProperties & {
+        tileBackground: MapTileBackground;
+        activeTileBackground: MapTileBackground;
+        didFallback: boolean;
+        tilesLoaded: number;
+        tileErrors: number;
+        zoomCount: number;
+        panCount: number;
+        minZoom: number | null;
+        maxZoom: number | null;
+        durationMs: number;
+    };
+};
+
+type MapTileFallbackEvent = {
+    name: EventName.MAP_TILE_FALLBACK;
+    properties: MapTelemetryBaseProperties & {
+        fromTileBackground: MapTileBackground;
+        toTileBackground: MapTileBackground;
+        errorCount: number;
+        successCount: number;
+    };
+};
+
 export type EventData =
     | GenericEvent
+    | MapTileUsageEvent
+    | MapTileFallbackEvent
     | AgentOnboardingDemoOfferShownEvent
     | AgentOnboardingDemoOfferAcceptedEvent
     | AgentOnboardingCompletionToastShownEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -184,6 +184,10 @@ export enum EventName {
 
     DASHBOARD_CHART_LOADED = 'dashboard_chart.loaded',
 
+    // Map charts
+    MAP_TILE_USAGE = 'map_chart.tile_usage',
+    MAP_TILE_FALLBACK = 'map_chart.tile_fallback',
+
     // Spaces
     SPACE_BREADCRUMB_CLICKED = 'space_breadcrumb.clicked',
 


### PR DESCRIPTION
Map charts load basemap tiles browser-side from public tile servers (OSM, CARTO, Esri), so we currently have no visibility into tile volume or provider throttling — the only signal is a Sentry exception when the client-side provider fallback triggers. This PR adds product analytics so we can quantify tile usage per chart/org and capture degradation events before deciding on a licensed/self-hosted tile provider.

## Changes

**Frontend (Rudderstack):**
- `map_chart.tile_usage` — one batched summary per mounted map, flushed on unmount/tab-hide (not per tile, to keep event volume sane): tiles loaded, tile errors, zoom/pan interaction counts, zoom range, configured vs active tile background, `didFallback`, duration, plus user/org/project/chart ids and render context (`explore` / `dashboard` / `embed` / `minimal`).
- `map_chart.tile_fallback` — fired alongside the existing Sentry capture when `useTileFallback` swaps providers after tile errors; carries from/to provider and error/success counts. This is the throttling signal.
- Embed pages mount the real `TrackingProvider`, so both events fire from embedded dashboards with `context: 'embed'`.

**Backend (`lightdash_server` events):**
- `saved_chart_version.created` / `saved_chart.created` now include a `map` config block (map type, location type, tile backgrounds, custom GeoJSON flag) so map-chart creation is self-describing; also declared the previously-emitted-but-undeclared `funnel`/`treemap` blocks on the event type.
- `saved_chart.view` now includes `chartType`, making views-by-chart-type queryable without a DB join.

## Known gaps
- `/minimal` headless screenshot routes disable tracking, so tiles loaded during scheduled-delivery renders are not counted.
- Leaflet's `tileerror` can't expose the HTTP status of a failed cross-origin `<img>` tile, so 429s aren't distinguishable from other failures; the fallback event is the aggregate proxy.

Closes: PROD-2501
Relates: PROD-2503

🤖 Generated with [Claude Code](https://claude.com/claude-code)
