### PR TITLE
fix(dev): dev-ports.sh gc completes on macOS bash 3.2

### DIFF
--- a/scripts/dev-ports.sh
+++ b/scripts/dev-ports.sh
@@ -398,15 +398,20 @@ get_env_instance_id() {
 add_live_instance() {
     local instance_id="$1"
     local live_instance_id
-    for live_instance_id in "${LIVE_INSTANCE_IDS[@]}"; do
-        [ "$live_instance_id" = "$instance_id" ] && return
-    done
+    # bash 3.2 (macOS default) treats "${ARR[@]}" on an empty array as unbound
+    # under set -u, so guard every expansion with a length check.
+    if [ "${#LIVE_INSTANCE_IDS[@]}" -gt 0 ]; then
+        for live_instance_id in "${LIVE_INSTANCE_IDS[@]}"; do
+            [ "$live_instance_id" = "$instance_id" ] && return
+        done
+    fi
     LIVE_INSTANCE_IDS+=("$instance_id")
 }
 
 is_stale_instance() {
     local instance_id="$1"
     local stale_instance_id
+    [ "${#STALE_INSTANCE_IDS[@]}" -gt 0 ] || return 1
     for stale_instance_id in "${STALE_INSTANCE_IDS[@]}"; do
         [ "$stale_instance_id" = "$instance_id" ] && return 0
     done
@@ -457,6 +462,7 @@ collect_live_instances() {
 is_live_instance() {
     local instance_id="$1"
     local live_instance_id
+    [ "${#LIVE_INSTANCE_IDS[@]}" -gt 0 ] || return 1
     for live_instance_id in "${LIVE_INSTANCE_IDS[@]}"; do
         [ "$live_instance_id" = "$instance_id" ] && return 0
     done


### PR DESCRIPTION
## What

`./scripts/dev-ports.sh gc` died before its orphaned-volume sweep on stock macOS bash:

```
$ /bin/bash scripts/dev-ports.sh gc --dry-run
No stale instances found
scripts/dev-ports.sh: line 407: STALE_INSTANCE_IDS[@]: unbound variable
```

bash 3.2 treats `"${ARR[@]}"` on an empty array as an unbound variable under `set -u` (fixed in bash 4.4, which is why Linux never hits it). The gc instance-id arrays are legitimately empty in the common case — no stale instances — so the sweep that exists to prevent volume leaks never ran on Macs. Length guards now precede every expansion.

## Proof

Same command after the fix:

```
$ /bin/bash scripts/dev-ports.sh gc --dry-run
No stale instances found
No orphaned instance volumes found
```

Found by deliberately vague cross-model testing of the dev tooling ("anything to clean up?" to a fresh non-Claude agent).

Fixes SPK-1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)