### PR TITLE
fix(previews): copy additional dbt sources

### DIFF
--- a/packages/backend/src/models/ProjectDbtSourcesModel.test.ts
+++ b/packages/backend/src/models/ProjectDbtSourcesModel.test.ts
@@ -1,0 +1,99 @@
+import { DbtProjectType } from '@lightdash/common';
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import {
+    ProjectDbtSourcesTableName,
+    type DbProjectDbtSource,
+} from '../database/entities/projectDbtSources';
+import { type EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
+import { ProjectDbtSourcesModel } from './ProjectDbtSourcesModel';
+
+describe('ProjectDbtSourcesModel', () => {
+    const upstreamProjectUuid = '11111111-1111-4111-8111-111111111111';
+    const previewProjectUuid = '22222222-2222-4222-8222-222222222222';
+    const githubCiphertext = Buffer.from('github-source-ciphertext');
+    const gitlabCiphertext = Buffer.from('gitlab-source-ciphertext');
+    const createdAt = new Date('2026-08-01T10:00:00.000Z');
+    const updatedAt = new Date('2026-08-02T11:00:00.000Z');
+    const sources: DbProjectDbtSource[] = [
+        {
+            project_dbt_source_uuid: '33333333-3333-4333-8333-333333333333',
+            project_uuid: upstreamProjectUuid,
+            name: 'finance_models',
+            is_primary: false,
+            precedence: 2,
+            dbt_connection_type: DbtProjectType.GITHUB,
+            dbt_connection: githubCiphertext,
+            warehouse_database: 'finance_database',
+            warehouse_schema: null,
+            created_at: createdAt,
+            updated_at: updatedAt,
+        },
+        {
+            project_dbt_source_uuid: '44444444-4444-4444-8444-444444444444',
+            project_uuid: upstreamProjectUuid,
+            name: 'marketing_models',
+            is_primary: false,
+            precedence: 5,
+            dbt_connection_type: DbtProjectType.GITLAB,
+            dbt_connection: gitlabCiphertext,
+            warehouse_database: null,
+            warehouse_schema: 'marketing_schema',
+            created_at: createdAt,
+            updated_at: updatedAt,
+        },
+    ];
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const encryptionUtil = {
+        encrypt: vi.fn(),
+        decrypt: vi.fn(),
+    } as unknown as EncryptionUtil;
+    const model = new ProjectDbtSourcesModel({
+        database: database as unknown as Knex,
+        encryptionUtil,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+        vi.clearAllMocks();
+    });
+
+    it('copies raw source configuration with new identities', async () => {
+        tracker.on.select(ProjectDbtSourcesTableName).responseOnce(sources);
+        tracker.on.insert(ProjectDbtSourcesTableName).responseOnce([]);
+
+        await model.copySources(upstreamProjectUuid, previewProjectUuid);
+
+        expect(tracker.history.select[0].bindings).toEqual([
+            upstreamProjectUuid,
+        ]);
+        expect(tracker.history.insert[0].bindings).toEqual([
+            githubCiphertext,
+            DbtProjectType.GITHUB,
+            false,
+            'finance_models',
+            2,
+            previewProjectUuid,
+            'finance_database',
+            null,
+            gitlabCiphertext,
+            DbtProjectType.GITLAB,
+            false,
+            'marketing_models',
+            5,
+            previewProjectUuid,
+            null,
+            'marketing_schema',
+        ]);
+        expect(tracker.history.insert[0].sql).not.toMatch(
+            /project_dbt_source_uuid|created_at|updated_at/,
+        );
+        expect(encryptionUtil.decrypt).not.toHaveBeenCalled();
+        expect(encryptionUtil.encrypt).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/models/ProjectDbtSourcesModel.ts
+++ b/packages/backend/src/models/ProjectDbtSourcesModel.ts
@@ -126,6 +126,40 @@ export class ProjectDbtSourcesModel {
         return row !== undefined;
     }
 
+    async copySources(
+        sourceProjectUuid: string,
+        targetProjectUuid: string,
+    ): Promise<void> {
+        const sources = await this.database(ProjectDbtSourcesTableName)
+            .select(
+                'name',
+                'is_primary',
+                'precedence',
+                'dbt_connection_type',
+                'dbt_connection',
+                'warehouse_database',
+                'warehouse_schema',
+            )
+            .where('project_uuid', sourceProjectUuid);
+
+        if (sources.length === 0) {
+            return;
+        }
+
+        await this.database(ProjectDbtSourcesTableName).insert(
+            sources.map((source) => ({
+                project_uuid: targetProjectUuid,
+                name: source.name,
+                is_primary: source.is_primary,
+                precedence: source.precedence,
+                dbt_connection_type: source.dbt_connection_type,
+                dbt_connection: source.dbt_connection,
+                warehouse_database: source.warehouse_database,
+                warehouse_schema: source.warehouse_schema,
+            })),
+        );
+    }
+
     async getSource(projectDbtSourceUuid: string): Promise<ProjectDbtSource> {
         const row = await this.database(ProjectDbtSourcesTableName)
             .where('project_dbt_source_uuid', projectDbtSourceUuid)

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -405,7 +405,9 @@ const getMockedProjectService = (
         projectModel: projectModel as unknown as ProjectModel,
         projectDbtSourcesModel:
             overrides.projectDbtSourcesModel ??
-            ({} as unknown as ProjectDbtSourcesModel),
+            ({
+                copySources: vi.fn(async () => undefined),
+            } as unknown as ProjectDbtSourcesModel),
         preAggregateModel: preAggregateModel as unknown as PreAggregateModel,
         onboardingModel: onboardingModel as unknown as OnboardingModel,
         savedChartModel: savedChartModel as unknown as SavedChartModel,
@@ -1365,6 +1367,107 @@ describe('ProjectService', () => {
         createWithoutCompileSpy.mockRestore();
         scheduleCompileProjectSpy.mockRestore();
     });
+
+    test.each([RequestMethod.WEB_APP, RequestMethod.CLI])(
+        'copies additional dbt sources when creating a preview through %s',
+        async (requestMethod) => {
+            const upstreamProjectUuid = 'upstream-project-uuid';
+            const previewProjectUuid = 'created-preview-project-uuid';
+            const primaryDbtConnection = {
+                type: DbtProjectType.GITHUB,
+                authorization_method: 'installation_id',
+                repository: 'lightdash/primary-models',
+                branch: 'preview-primary-branch',
+                project_sub_path: '/primary',
+                installation_id: 'primary-installation-id',
+            } as const;
+            const copySources = vi.fn(async () => undefined);
+            const previewService = getMockedProjectService(
+                lightdashConfigMock,
+                {
+                    projectDbtSourcesModel: {
+                        copySources,
+                    } as unknown as ProjectDbtSourcesModel,
+                },
+            );
+            const previewUser: SessionUser = {
+                ...user,
+                organizationUuid: projectWithSensitiveFields.organizationUuid,
+                organizationName: 'Test organization',
+                organizationCreatedAt: new Date(),
+                ability: new Ability<PossibleAbilities>([
+                    { subject: 'Project', action: 'create' },
+                ]),
+            };
+            const validateSpy = vi
+                .spyOn(
+                    previewService as unknown as {
+                        validateProjectCreationPermissions: () => Promise<true>;
+                    },
+                    'validateProjectCreationPermissions',
+                )
+                .mockResolvedValue(true);
+            const expirationSpy = vi
+                .spyOn(previewService, 'getPreviewExpiresAt')
+                .mockResolvedValue(null);
+            const copyAccessSpy = vi
+                .spyOn(previewService, 'copyUserAccessOnPreview')
+                .mockResolvedValue();
+            projectModel.createWithOptionalCredentials.mockResolvedValueOnce(
+                previewProjectUuid,
+            );
+            projectModel.get
+                .mockResolvedValueOnce({
+                    ...projectWithSensitiveFields,
+                    projectUuid: upstreamProjectUuid,
+                    dbtConnection: {
+                        ...primaryDbtConnection,
+                        branch: 'upstream-primary-branch',
+                    },
+                })
+                .mockResolvedValueOnce({
+                    ...projectWithSensitiveFields,
+                    projectUuid: previewProjectUuid,
+                    type: ProjectType.PREVIEW,
+                    dbtConnection: primaryDbtConnection,
+                });
+
+            try {
+                await previewService.createWithoutCompile(
+                    previewUser,
+                    {
+                        name: 'Preview with additional sources',
+                        type: ProjectType.PREVIEW,
+                        dbtConnection: primaryDbtConnection,
+                        upstreamProjectUuid,
+                        copyContent: false,
+                        dbtVersion: projectWithSensitiveFields.dbtVersion,
+                    },
+                    requestMethod,
+                );
+
+                expect(copySources).toHaveBeenCalledWith(
+                    upstreamProjectUuid,
+                    previewProjectUuid,
+                );
+                expect(
+                    projectModel.createWithOptionalCredentials,
+                ).toHaveBeenCalledWith(
+                    previewUser.userUuid,
+                    previewUser.organizationUuid,
+                    expect.objectContaining({
+                        dbtConnection: primaryDbtConnection,
+                    }),
+                    null,
+                    undefined,
+                );
+            } finally {
+                validateSpy.mockRestore();
+                expirationSpy.mockRestore();
+                copyAccessSpy.mockRestore();
+            }
+        },
+    );
 
     test('attempts content copying when preview access copying fails', async () => {
         const upstreamProjectUuid = 'upstream-project-uuid';

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2757,6 +2757,16 @@ export class ProjectService extends BaseService {
                 internalProvisioning?.source,
             );
 
+        if (
+            createProject.type === ProjectType.PREVIEW &&
+            createProject.upstreamProjectUuid
+        ) {
+            await this.projectDbtSourcesModel.copySources(
+                createProject.upstreamProjectUuid,
+                projectUuid,
+            );
+        }
+
         const onboardingFlow = await this.getOnboardingFlow(user);
         // Do not give this user admin permissions on this new project,
         // as it could be an interactive viewer creating a preview


### PR DESCRIPTION
## Summary

Preview projects now copy every additional dbt source from the parent project. The copy keeps each source name, precedence, connection type, stored configuration, and warehouse location. The database assigns preview-local identifiers and timestamps.

The app and CLI use the same backend project creation path. This change fixes that shared path.

## Tests

- Added a model regression that checks the exact source values and generated identity policy.
- Added shared service contract tests for app and CLI preview requests.
- pnpm -F backend typecheck
- pnpm -F backend test (8,099 passed, 1 skipped)
- Touched backend lint and format checks

Fixes #27433

Issue: https://github.com/lightdash/lightdash/issues/27433

Linear: PROD-10145