### PR TITLE
fix(dev): validate shared PM2 process names

### DIFF
--- a/packages/backend/src/devHarnessConfig.test.ts
+++ b/packages/backend/src/devHarnessConfig.test.ts
@@ -75,11 +75,15 @@ describe('development PM2 harness', () => {
             path.join(repoRoot, 'scripts/dev-fast-start.sh'),
             'utf8',
         );
+        const instanceLib = fs.readFileSync(
+            path.join(repoRoot, 'scripts/dev-instance-lib.sh'),
+            'utf8',
+        );
 
         expect(backendPackage.scripts['generate-api-dev']).toMatch(
             /^pnpm run generate-api:build && chokidar /,
         );
-        expect(fastStart).toMatch(
+        expect(instanceLib).toMatch(
             /for suffix in api api-routes-watch scheduler/,
         );
         expect(fastStart).toContain('API_RELOAD_READY');


### PR DESCRIPTION
## What changed
- Read the PM2 suffix loop from `scripts/dev-instance-lib.sh`, where #28176 moved it
- Keep the existing fast-start route reload assertions

## Why
`main` currently fails `devHarnessConfig.test.ts` because the test still expects the loop in `dev-fast-start.sh`.

## Validation
- `git diff --check`
- Full backend unit suite exposed this exact stale assertion on #28007