### PR TITLE
refactor(permissions): unify access context resolution

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -184,7 +184,7 @@ function buildService(
     };
 
     const spacePermissionService = {
-        getSpaceAccessContext: vi.fn().mockResolvedValue({}),
+        resolveAccess: vi.fn().mockResolvedValue({}),
     };
 
     const lightdashConfig = {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -98,7 +98,7 @@ function buildService(
         schedulerClient: {} as never,
         savedChartService: (overrides.savedChartService ?? {}) as never,
         spacePermissionService: {
-            getSpaceAccessContext: vi.fn().mockResolvedValue({
+            resolveAccess: vi.fn().mockResolvedValue({
                 inheritsFromOrgOrProject: false,
                 access: [],
             }),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -204,7 +204,7 @@ function buildService(overrides: {
         get: vi.fn().mockResolvedValue({ enabled: true }),
     };
     const spacePermissionService = {
-        getSpaceAccessContext: vi.fn().mockResolvedValue({}),
+        resolveAccess: vi.fn().mockResolvedValue({}),
     };
 
     const svc = new AppGenerateService({

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -716,11 +716,11 @@ export class AppGenerateService extends BaseService {
         await assertUserCanViewApp(
             {
                 auditedAbility: this.createAuditedAbility(user),
-                getSpaceAccessContext: (userUuid, spaceUuid) =>
-                    this.spacePermissionService.getSpaceAccessContext(
-                        userUuid,
+                resolveAccess: (userUuid, spaceUuid) =>
+                    this.spacePermissionService.resolveAccess(userUuid, {
+                        type: 'space',
                         spaceUuid,
-                    ),
+                    }),
                 getProjectContext: (projectUuid) =>
                     this.getDataAppProjectContext(projectUuid),
             },
@@ -749,10 +749,10 @@ export class AppGenerateService extends BaseService {
         extraContext: Record<string, unknown> = {},
     ): Promise<DataAppProjectContext> {
         const spaceContext = app.space_uuid
-            ? await this.spacePermissionService.getSpaceAccessContext(
-                  user.userUuid,
-                  app.space_uuid,
-              )
+            ? await this.spacePermissionService.resolveAccess(user.userUuid, {
+                  type: 'space',
+                  spaceUuid: app.space_uuid,
+              })
             : {};
         return this.assertDataAppAbility(
             user,
@@ -1210,10 +1210,10 @@ export class AppGenerateService extends BaseService {
     ): Promise<boolean> {
         const [spaceContext, resolvedProjectContext] = await Promise.all([
             app.space_uuid
-                ? this.spacePermissionService.getSpaceAccessContext(
-                      user.userUuid,
-                      app.space_uuid,
-                  )
+                ? this.spacePermissionService.resolveAccess(user.userUuid, {
+                      type: 'space',
+                      spaceUuid: app.space_uuid,
+                  })
                 : Promise.resolve({}),
             projectContext ?? this.getDataAppProjectContext(app.project_uuid),
         ]);
@@ -1231,7 +1231,7 @@ export class AppGenerateService extends BaseService {
     /**
      * Bulk filter for callers that have a list of apps already loaded
      * (e.g. SearchService). Resolves space access contexts in parallel —
-     * one `getSpaceAccessContext` call per app with a space.
+     * one `resolveAccess` call per app with a space.
      */
     async filterAppsUserCanView<
         T extends {
@@ -6000,10 +6000,10 @@ export class AppGenerateService extends BaseService {
         // (or project admin) already pass through `manage:DataApp@space`.
         if (spaceUuid) {
             const spaceContext =
-                await this.spacePermissionService.getSpaceAccessContext(
-                    user.userUuid,
+                await this.spacePermissionService.resolveAccess(user.userUuid, {
+                    type: 'space',
                     spaceUuid,
-                );
+                });
             await this.assertDataAppAbility(
                 user,
                 'manage',
@@ -9103,10 +9103,10 @@ export class AppGenerateService extends BaseService {
             // …and manage on the target space, otherwise a user could move an
             // app into a space they don't own.
             const targetSpaceContext =
-                await this.spacePermissionService.getSpaceAccessContext(
-                    user.userUuid,
-                    targetSpaceUuid,
-                );
+                await this.spacePermissionService.resolveAccess(user.userUuid, {
+                    type: 'space',
+                    spaceUuid: targetSpaceUuid,
+                });
             await this.assertDataAppAbility(
                 user,
                 'manage',
@@ -10075,10 +10075,10 @@ export class AppGenerateService extends BaseService {
         if (!app || app.organization_uuid !== organizationUuid) return empty();
         const [spaceContext, projectContext] = await Promise.all([
             app.space_uuid
-                ? this.spacePermissionService.getSpaceAccessContext(
-                      account.user.id,
-                      app.space_uuid,
-                  )
+                ? this.spacePermissionService.resolveAccess(account.user.id, {
+                      type: 'space',
+                      spaceUuid: app.space_uuid,
+                  })
                 : Promise.resolve({}),
             this.getDataAppProjectContext(projectUuid),
         ]);
@@ -11018,9 +11018,9 @@ export class AppGenerateService extends BaseService {
                     manifestSpaceUuid !== existingApp.space_uuid
                 ) {
                     const spaceContext =
-                        await this.spacePermissionService.getSpaceAccessContext(
+                        await this.spacePermissionService.resolveAccess(
                             user.userUuid,
-                            manifestSpaceUuid,
+                            { type: 'space', spaceUuid: manifestSpaceUuid },
                         );
                     await this.assertDataAppAbility(
                         user,
@@ -11088,9 +11088,9 @@ export class AppGenerateService extends BaseService {
             }
             if (targetSpaceUuid) {
                 const spaceContext =
-                    await this.spacePermissionService.getSpaceAccessContext(
+                    await this.spacePermissionService.resolveAccess(
                         user.userUuid,
-                        targetSpaceUuid,
+                        { type: 'space', spaceUuid: targetSpaceUuid },
                     );
                 await this.assertDataAppAbility(
                     user,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -86,7 +86,7 @@ function buildService(
     };
 
     const spacePermissionService = {
-        getSpaceAccessContext: vi.fn().mockResolvedValue({}),
+        resolveAccess: vi.fn().mockResolvedValue({}),
     };
 
     const analytics = { track: vi.fn() };

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -155,7 +155,7 @@ function buildService() {
         schedulerClient: {} as never,
         savedChartService: {} as never,
         spacePermissionService: {
-            getSpaceAccessContext: vi.fn().mockResolvedValue({}),
+            resolveAccess: vi.fn().mockResolvedValue({}),
         } as never,
         coderService: {} as never,
         dashboardService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
@@ -25,7 +25,7 @@ export type DataAppProjectContext = {
 
 export type AppViewAuthzDeps = {
     auditedAbility: CaslAuditWrapper<Ability>;
-    getSpaceAccessContext: (
+    resolveAccess: (
         userUuid: string,
         spaceUuid: string,
     ) => Promise<Record<string, unknown>>;
@@ -39,7 +39,7 @@ async function userCanViewApp(
 ): Promise<boolean> {
     const [spaceContext, projectContext] = await Promise.all([
         app.space_uuid
-            ? deps.getSpaceAccessContext(user.userUuid, app.space_uuid)
+            ? deps.resolveAccess(user.userUuid, app.space_uuid)
             : Promise.resolve({}),
         deps.getProjectContext(app.project_uuid),
     ]);

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -396,7 +396,7 @@ describe('EmbedService', () => {
                     }),
                 },
                 spacePermissionService: {
-                    getSpaceAccessContext: vi
+                    resolveAccess: vi
                         .fn()
                         .mockResolvedValue(spaceAccessContext),
                 },

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -768,9 +768,9 @@ export class EmbedService extends BaseService {
                         chart.spaceUuid === writeSpaceUuid
                     ) {
                         const spaceAccessContext =
-                            await this.spacePermissionService.getSpaceAccessContext(
+                            await this.spacePermissionService.resolveAccess(
                                 embedWriteUser.userUuid,
-                                chart.spaceUuid,
+                                { type: 'space', spaceUuid: chart.spaceUuid },
                             );
                         const auditedAbility =
                             this.createAuditedAbility(embedWriteUser);
@@ -2719,9 +2719,9 @@ export class EmbedService extends BaseService {
 
         try {
             const spaceAccessContext =
-                await this.spacePermissionService.getSpaceAccessContext(
+                await this.spacePermissionService.resolveAccess(
                     embedWriteUser.userUuid,
-                    writeActions.spaceUuid,
+                    { type: 'space', spaceUuid: writeActions.spaceUuid },
                 );
 
             if (spaceAccessContext.projectUuid !== projectUuid) {

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -148,7 +148,7 @@ function buildService(opts: {
         getSummary: vi.fn().mockResolvedValue({ organizationUuid: 'org-1' }),
     };
     const spacePermissionService = {
-        getSpaceAccessContext: vi.fn().mockResolvedValue({}),
+        resolveAccess: vi.fn().mockResolvedValue({}),
     };
     const analytics = { track: vi.fn(), trackAccount: vi.fn() };
 

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -175,7 +175,7 @@ function buildService(opts: {
         externalConnectionModel: model as never,
         appModel: {} as never,
         spacePermissionService: {
-            getSpaceAccessContext: vi.fn().mockResolvedValue({}),
+            resolveAccess: vi.fn().mockResolvedValue({}),
         } as never,
         analytics: { track: vi.fn() } as never,
         googleTokenProvider: {

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -164,10 +164,10 @@ export class ExternalConnectionService extends BaseService {
         }
 
         const spaceContext = app.space_uuid
-            ? await this.spacePermissionService.getSpaceAccessContext(
-                  account.user.id,
-                  app.space_uuid,
-              )
+            ? await this.spacePermissionService.resolveAccess(account.user.id, {
+                  type: 'space',
+                  spaceUuid: app.space_uuid,
+              })
             : {};
         const projectContext = await this.getDataAppProjectContext(
             app.project_uuid,
@@ -623,11 +623,11 @@ export class ExternalConnectionService extends BaseService {
             await assertCanViewApp(
                 {
                     auditedAbility: this.createAuditedAbility(user),
-                    getSpaceAccessContext: (userUuid, spaceUuid) =>
-                        this.spacePermissionService.getSpaceAccessContext(
-                            userUuid,
+                    resolveAccess: (userUuid, spaceUuid) =>
+                        this.spacePermissionService.resolveAccess(userUuid, {
+                            type: 'space',
                             spaceUuid,
-                        ),
+                        }),
                     getProjectContext: (appProjectUuid) =>
                         this.getDataAppProjectContext(appProjectUuid),
                 },

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -710,7 +710,7 @@ export class ManagedAgentService extends BaseService {
         }
     }
 
-    private async getChartAccessContext(
+    private async resolveChartAccess(
         actor: SessionUser,
         chart: {
             spaceUuid: string;
@@ -720,10 +720,10 @@ export class ManagedAgentService extends BaseService {
         access: unknown[];
     }> {
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                actor.userUuid,
-                chart.spaceUuid,
-            );
+            await this.spacePermissionService.resolveAccess(actor.userUuid, {
+                type: 'space',
+                spaceUuid: chart.spaceUuid,
+            });
         return { inheritsFromOrgOrProject, access };
     }
 
@@ -738,7 +738,7 @@ export class ManagedAgentService extends BaseService {
         },
     ): Promise<boolean> {
         const { inheritsFromOrgOrProject, access } =
-            await this.getChartAccessContext(actor, chart);
+            await this.resolveChartAccess(actor, chart);
         const auditedAbility = this.createAuditedAbility(actor);
         return auditedAbility.can(
             'view',
@@ -766,7 +766,7 @@ export class ManagedAgentService extends BaseService {
         },
     ): Promise<void> {
         const { inheritsFromOrgOrProject, access } =
-            await this.getChartAccessContext(actor, chart);
+            await this.resolveChartAccess(actor, chart);
         const auditedAbility = this.createAuditedAbility(actor);
         if (
             auditedAbility.cannot(
@@ -800,7 +800,7 @@ export class ManagedAgentService extends BaseService {
         },
     ): Promise<void> {
         const { inheritsFromOrgOrProject, access } =
-            await this.getChartAccessContext(actor, chart);
+            await this.resolveChartAccess(actor, chart);
         const auditedAbility = this.createAuditedAbility(actor);
         if (
             auditedAbility.cannot(
@@ -889,10 +889,10 @@ export class ManagedAgentService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                actor.userUuid,
+            await this.spacePermissionService.resolveAccess(actor.userUuid, {
+                type: 'space',
                 spaceUuid,
-            );
+            });
         const auditedAbility = this.createAuditedAbility(actor);
         if (
             auditedAbility.cannot(
@@ -912,7 +912,7 @@ export class ManagedAgentService extends BaseService {
         }
     }
 
-    private async getDashboardAccessContext(
+    private async resolveDashboardAccess(
         actor: SessionUser,
         dashboard: {
             spaceUuid: string;
@@ -922,10 +922,10 @@ export class ManagedAgentService extends BaseService {
         access: unknown[];
     }> {
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                actor.userUuid,
-                dashboard.spaceUuid,
-            );
+            await this.spacePermissionService.resolveAccess(actor.userUuid, {
+                type: 'space',
+                spaceUuid: dashboard.spaceUuid,
+            });
         return { inheritsFromOrgOrProject, access };
     }
 
@@ -940,7 +940,7 @@ export class ManagedAgentService extends BaseService {
         },
     ): Promise<boolean> {
         const { inheritsFromOrgOrProject, access } =
-            await this.getDashboardAccessContext(actor, dashboard);
+            await this.resolveDashboardAccess(actor, dashboard);
         const auditedAbility = this.createAuditedAbility(actor);
         return auditedAbility.can(
             'view',
@@ -968,7 +968,7 @@ export class ManagedAgentService extends BaseService {
         },
     ): Promise<void> {
         const { inheritsFromOrgOrProject, access } =
-            await this.getDashboardAccessContext(actor, dashboard);
+            await this.resolveDashboardAccess(actor, dashboard);
         const auditedAbility = this.createAuditedAbility(actor);
         if (
             auditedAbility.cannot(

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -380,21 +380,7 @@ const getMockedAsyncQueryService = (
         projectCompileLogModel: {} as ProjectCompileLogModel,
         adminNotificationService: {} as AdminNotificationService,
         spacePermissionService: {
-            getSpaceAccessContext: vi.fn(async () => ({
-                organizationUuid: projectSummary.organizationUuid,
-                projectUuid,
-                inheritsFromOrgOrProject: true,
-                access: [],
-            })),
-            getDashboardAccessContext: vi.fn(async () => ({
-                organizationUuid: projectSummary.organizationUuid,
-                projectUuid,
-                inheritsFromOrgOrProject: true,
-                access: [],
-                admins: [],
-                directOnly: false,
-            })),
-            getChartAccessContext: vi.fn(async () => ({
+            resolveAccess: vi.fn(async () => ({
                 organizationUuid: projectSummary.organizationUuid,
                 projectUuid,
                 inheritsFromOrgOrProject: true,
@@ -4296,21 +4282,7 @@ describe('AsyncQueryService', () => {
                     }),
                 };
                 (service as AnyType).spacePermissionService = {
-                    getSpaceAccessContext: vi.fn().mockResolvedValue({
-                        organizationUuid: projectSummary.organizationUuid,
-                        projectUuid,
-                        inheritsFromOrgOrProject: true,
-                        access: [],
-                    }),
-                    getDashboardAccessContext: vi.fn().mockResolvedValue({
-                        organizationUuid: projectSummary.organizationUuid,
-                        projectUuid,
-                        inheritsFromOrgOrProject: true,
-                        access: [],
-                        admins: [],
-                        directOnly: false,
-                    }),
-                    getChartAccessContext: vi.fn().mockResolvedValue({
+                    resolveAccess: vi.fn().mockResolvedValue({
                         organizationUuid: projectSummary.organizationUuid,
                         projectUuid,
                         inheritsFromOrgOrProject: true,
@@ -5065,25 +5037,29 @@ describe('checkDashboardChartQueryPermissions', () => {
     const buildSpacePermissionService = (
         dashboardAccess: { userUuid: string }[],
     ) => ({
-        getChartAccessContext: vi.fn(async () => ({
-            organizationUuid: projectSummary.organizationUuid,
-            projectUuid: projectSummary.projectUuid,
-            inheritsFromOrgOrProject: false,
-            access: dashboardAccess.map(({ userUuid }) => ({
-                userUuid,
-                role: 'viewer',
-                hasDirectAccess: true,
-            })),
-            admins: [],
-            directOnly: true,
-        })),
-        getSpaceAccessContext: vi.fn(async () => ({
-            organizationUuid: projectSummary.organizationUuid,
-            projectUuid: projectSummary.projectUuid,
-            inheritsFromOrgOrProject: false,
-            access: [],
-            admins: [],
-        })),
+        resolveAccess: vi.fn(async (_userUuid, target) =>
+            target.type === 'space'
+                ? {
+                      organizationUuid: projectSummary.organizationUuid,
+                      projectUuid: projectSummary.projectUuid,
+                      inheritsFromOrgOrProject: false,
+                      access: [],
+                      admins: [],
+                      directOnly: false,
+                  }
+                : {
+                      organizationUuid: projectSummary.organizationUuid,
+                      projectUuid: projectSummary.projectUuid,
+                      inheritsFromOrgOrProject: false,
+                      access: dashboardAccess.map(({ userUuid }) => ({
+                          userUuid,
+                          role: 'viewer',
+                          hasDirectAccess: true,
+                      })),
+                      admins: [],
+                      directOnly: true,
+                  },
+        ),
     });
 
     it('authorizes a dashboard-owned chart through the dashboard grant', async () => {
@@ -5103,16 +5079,16 @@ describe('checkDashboardChartQueryPermissions', () => {
                 owningDashboardUuid,
             ),
         ).resolves.toBeUndefined();
-        expect(
-            spacePermissionService.getChartAccessContext,
-        ).toHaveBeenCalledWith(account.user.id, {
-            uuid: 'chart-uuid',
-            dashboardUuid: owningDashboardUuid,
-            spaceUuid: chartSpace.uuid,
-        });
-        expect(
-            spacePermissionService.getSpaceAccessContext,
-        ).not.toHaveBeenCalled();
+        expect(spacePermissionService.resolveAccess).toHaveBeenCalledWith(
+            account.user.id,
+            {
+                type: 'chart',
+                chartUuid: 'chart-uuid',
+                dashboardUuid: owningDashboardUuid,
+                spaceUuid: chartSpace.uuid,
+            },
+        );
+        expect(spacePermissionService.resolveAccess).toHaveBeenCalledTimes(1);
     });
 
     it('denies a dashboard-owned chart without a grant or space access', async () => {
@@ -5147,12 +5123,14 @@ describe('checkDashboardChartQueryPermissions', () => {
                 null,
             ),
         ).rejects.toThrow(ForbiddenError);
-        expect(
-            spacePermissionService.getChartAccessContext,
-        ).toHaveBeenCalledWith(account.user.id, {
-            uuid: 'chart-uuid',
-            dashboardUuid: null,
-            spaceUuid: chartSpace.uuid,
-        });
+        expect(spacePermissionService.resolveAccess).toHaveBeenCalledWith(
+            account.user.id,
+            {
+                type: 'chart',
+                chartUuid: 'chart-uuid',
+                dashboardUuid: null,
+                spaceUuid: chartSpace.uuid,
+            },
+        );
     });
 });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -739,9 +739,9 @@ export class AsyncQueryService extends ProjectService {
             space: Pick<SpaceSummaryBase, 'uuid'>;
         },
     ) {
-        const ctx = await this.spacePermissionService.getSpaceAccessContext(
+        const ctx = await this.spacePermissionService.resolveAccess(
             account.user.id,
-            savedChart.space.uuid,
+            { type: 'space', spaceUuid: savedChart.space.uuid },
         );
 
         const auditedAbility = this.createAuditedAbility(account);
@@ -773,9 +773,9 @@ export class AsyncQueryService extends ProjectService {
             savedSqlUuid?: string;
         },
     ) {
-        const ctx = await this.spacePermissionService.getSpaceAccessContext(
+        const ctx = await this.spacePermissionService.resolveAccess(
             user.userUuid,
-            savedChart.spaceUuid,
+            { type: 'space', spaceUuid: savedChart.spaceUuid },
         );
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -809,9 +809,9 @@ export class AsyncQueryService extends ProjectService {
             spaceUuid: string;
         },
     ) {
-        const ctx = await this.spacePermissionService.getSpaceAccessContext(
+        const ctx = await this.spacePermissionService.resolveAccess(
             user.userUuid,
-            dashboard.spaceUuid,
+            { type: 'space', spaceUuid: dashboard.spaceUuid },
         );
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -5698,10 +5698,11 @@ export class AsyncQueryService extends ProjectService {
                 );
             inheritsFromOrgOrProject = spaceCtx.inheritsFromOrgOrProject;
         } else {
-            const ctx = await this.spacePermissionService.getChartAccessContext(
+            const ctx = await this.spacePermissionService.resolveAccess(
                 account.user.id,
                 {
-                    uuid: savedChart.uuid,
+                    type: 'chart',
+                    chartUuid: savedChart.uuid,
                     dashboardUuid: savedChart.dashboardUuid,
                     spaceUuid: savedChartSpaceUuid,
                 },
@@ -6037,10 +6038,11 @@ export class AsyncQueryService extends ProjectService {
             );
         } else {
             const auditedAbility = this.createAuditedAbility(account);
-            const ctx = await this.spacePermissionService.getChartAccessContext(
+            const ctx = await this.spacePermissionService.resolveAccess(
                 account.user.id,
                 {
-                    uuid: savedChartUuid,
+                    type: 'chart',
+                    chartUuid: savedChartUuid,
                     dashboardUuid: owningDashboardUuid,
                     spaceUuid: space.uuid,
                 },
@@ -9586,15 +9588,15 @@ export class AsyncQueryService extends ProjectService {
               )
             : savedChart.metricQuery;
 
-        const spaceCtx =
-            await this.spacePermissionService.getChartAccessContext(
-                account.user.id,
-                {
-                    uuid: savedChart.uuid,
-                    dashboardUuid: savedChart.dashboardUuid,
-                    spaceUuid: savedChart.spaceUuid,
-                },
-            );
+        const spaceCtx = await this.spacePermissionService.resolveAccess(
+            account.user.id,
+            {
+                type: 'chart',
+                chartUuid: savedChart.uuid,
+                dashboardUuid: savedChart.dashboardUuid,
+                spaceUuid: savedChart.spaceUuid,
+            },
+        );
 
         const auditedAbility = this.createAuditedAbility(account);
         if (

--- a/packages/backend/src/services/CoderService/CoderService.spaces.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.spaces.test.ts
@@ -180,7 +180,7 @@ const buildService = ({
         getAccessibleSpaceUuids: vi.fn(async () => accessibleSpaceUuids),
         getRawDirectAccess: vi.fn(async () => rawAccess),
         can: vi.fn(async () => canResults?.shift() ?? canManage),
-        getSpaceAccessContext: vi.fn(async () => ({
+        resolveAccess: vi.fn(async () => ({
             organizationUuid: ORGANIZATION_UUID,
             projectUuid: PROJECT_UUID,
             inheritsFromOrgOrProject: false,

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -871,9 +871,9 @@ export class CoderService extends BaseService {
 
         if (access.inheritParentPermissions && parentSpaceUuid !== null) {
             const parentContext =
-                await this.spacePermissionService.getSpaceAccessContext(
+                await this.spacePermissionService.resolveAccess(
                     user.userUuid,
-                    parentSpaceUuid,
+                    { type: 'space', spaceUuid: parentSpaceUuid },
                     { trx },
                 );
             inheritsFromOrgOrProject = parentContext.inheritsFromOrgOrProject;
@@ -3250,9 +3250,9 @@ export class CoderService extends BaseService {
             // Fetched once, reused by the placeholder-dashboard check below
             const spaceAccessContexts = canUploadAnyContent
                 ? null
-                : await this.spacePermissionService.getSpacesAccessContext(
+                : await this.spacePermissionService.resolveAccessBatch(
                       user.userUuid,
-                      [space.uuid],
+                      [{ type: 'space', spaceUuid: space.uuid }],
                   );
             if (spaceAccessContexts !== null) {
                 await this.assertSpaceContentAccess({
@@ -3573,9 +3573,9 @@ export class CoderService extends BaseService {
                 });
                 if (!canUploadAnyContent) {
                     const { inheritsFromOrgOrProject, access } =
-                        await this.spacePermissionService.getSpaceAccessContext(
+                        await this.spacePermissionService.resolveAccess(
                             user.userUuid,
-                            chart.spaceUuid,
+                            { type: 'space', spaceUuid: chart.spaceUuid },
                         );
                     if (
                         auditedAbility.cannot(
@@ -3847,10 +3847,10 @@ export class CoderService extends BaseService {
         if (spaceUuid === null) return undefined;
 
         const accessContexts =
-            await this.spacePermissionService.getSpacesAccessContext(userUuid, [
-                spaceUuid,
+            await this.spacePermissionService.resolveAccessBatch(userUuid, [
+                { type: 'space', spaceUuid },
             ]);
-        return accessContexts[spaceUuid];
+        return accessContexts[0];
     }
 
     // Throws unless the caller can write content as code. `canUploadAnyContent`
@@ -3920,31 +3920,42 @@ export class CoderService extends BaseService {
         errorMessage: string;
         // Pre-fetched contexts to avoid refetching for the same spaces
         accessContexts?: Awaited<
-            ReturnType<SpacePermissionService['getSpacesAccessContext']>
+            ReturnType<SpacePermissionService['resolveAccessBatch']>
         >;
     }): Promise<void> {
         const uniqueSpaceUuids = [...new Set(spaceUuids)];
         if (uniqueSpaceUuids.length === 0) return;
         const spaceAccessContexts =
             accessContexts ??
-            (await this.spacePermissionService.getSpacesAccessContext(
+            (await this.spacePermissionService.resolveAccessBatch(
                 userUuid,
-                uniqueSpaceUuids,
+                uniqueSpaceUuids.map((spaceUuid) => ({
+                    type: 'space' as const,
+                    spaceUuid,
+                })),
             ));
-        const lacksAccess = auditedAbility
-            .canBulk(
-                action,
-                uniqueSpaceUuids.map((spaceUuid) =>
-                    subject(subjectType, {
-                        ...spaceAccessContexts[spaceUuid],
-                        metadata: {
-                            spaceUuid,
-                            ...(metadata ?? {}),
-                        },
-                    }),
-                ),
-            )
-            .some((allowed) => !allowed);
+        const contextsWithSpace = uniqueSpaceUuids.flatMap(
+            (spaceUuid, index) => {
+                const context = spaceAccessContexts[index];
+                return context ? [{ context, spaceUuid }] : [];
+            },
+        );
+        const lacksAccess =
+            contextsWithSpace.length !== uniqueSpaceUuids.length ||
+            auditedAbility
+                .canBulk(
+                    action,
+                    contextsWithSpace.map(({ context, spaceUuid }) =>
+                        subject(subjectType, {
+                            ...context,
+                            metadata: {
+                                spaceUuid,
+                                ...(metadata ?? {}),
+                            },
+                        }),
+                    ),
+                )
+                .some((allowed) => !allowed);
         if (lacksAccess) {
             throw new ForbiddenError(errorMessage);
         }
@@ -4042,22 +4053,47 @@ export class CoderService extends BaseService {
         ];
         if (referencedCharts.length === 0) return;
 
-        const spaceAccessContexts =
-            await this.spacePermissionService.getSpacesAccessContext(userUuid, [
-                ...new Set(referencedCharts.map((chart) => chart.spaceUuid)),
-            ]);
+        const uniqueSpaceUuids = [
+            ...new Set(referencedCharts.map((chart) => chart.spaceUuid)),
+        ];
+        const resolvedSpaceContexts =
+            await this.spacePermissionService.resolveAccessBatch(
+                userUuid,
+                uniqueSpaceUuids.map((spaceUuid) => ({
+                    type: 'space',
+                    spaceUuid,
+                })),
+            );
+        const spaceAccessContexts = Object.fromEntries(
+            uniqueSpaceUuids.map((spaceUuid, index) => [
+                spaceUuid,
+                resolvedSpaceContexts[index],
+            ]),
+        );
+        const chartsWithContext = referencedCharts.flatMap((chart) => {
+            const context = spaceAccessContexts[chart.spaceUuid];
+            return context ? [{ chart, context }] : [];
+        });
         const accessResults = auditedAbility.canBulk(
             'view',
-            referencedCharts.map((chart) =>
+            chartsWithContext.map(({ chart, context }) =>
                 subject('SavedChart', {
-                    ...spaceAccessContexts[chart.spaceUuid],
+                    ...context,
                     metadata: chart.metadata,
                 }),
             ),
         );
-        const inaccessibleChartSlugs = referencedCharts
-            .filter((_, index) => !accessResults[index])
-            .map((chart) => chart.slug);
+        const inaccessibleChartSlugs = [
+            ...referencedCharts
+                .filter(
+                    (chart) =>
+                        spaceAccessContexts[chart.spaceUuid] === undefined,
+                )
+                .map((chart) => chart.slug),
+            ...chartsWithContext
+                .filter((_, index) => !accessResults[index])
+                .map(({ chart }) => chart.slug),
+        ];
         if (inaccessibleChartSlugs.length > 0) {
             throw new ForbiddenError(
                 `You don't have access to chart(s) referenced by this dashboard: ${inaccessibleChartSlugs.join(

--- a/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
@@ -126,20 +126,17 @@ const buildService = () =>
         } as AnyType,
         spacePermissionService: {
             can: vi.fn(async () => true),
-            getSpacesAccessContext: vi.fn(async () => ({
-                [SPACE_UUID]: {
-                    organizationUuid: ORG_UUID,
-                    projectUuid: PROJECT_UUID,
-                    inheritsFromOrgOrProject: true,
-                    access: [],
-                },
-                [OTHER_SPACE_UUID]: {
-                    organizationUuid: ORG_UUID,
-                    projectUuid: PROJECT_UUID,
-                    inheritsFromOrgOrProject: true,
-                    access: [],
-                },
-            })),
+            resolveAccessBatch: vi.fn(
+                async (_userUuid: string, targets: { spaceUuid: string }[]) =>
+                    targets.map(({ spaceUuid }) => ({
+                        organizationUuid: ORG_UUID,
+                        projectUuid: PROJECT_UUID,
+                        inheritsFromOrgOrProject: true,
+                        access: [],
+                        admins: [],
+                        directOnly: false,
+                    })),
+            ),
         } as AnyType,
         contentAsCodeSnapshotModel: { upsert: vi.fn() } as AnyType,
         contentAsCodeProjectSettingsModel: { upsert: vi.fn() } as AnyType,
@@ -352,7 +349,7 @@ describe('CoderService content-as-code space permissions', () => {
             ),
         ).resolves.toMatchObject({ charts: [{ action: 'create' }] });
         expect(
-            service.spacePermissionService.getSpacesAccessContext,
+            service.spacePermissionService.resolveAccessBatch,
         ).not.toHaveBeenCalled();
     });
 
@@ -400,16 +397,17 @@ describe('CoderService content-as-code space permissions', () => {
             service.spaceModel.findClosestAncestorByPath,
         ).mockResolvedValue(PARENT_SPACE_UUID);
         vi.mocked(
-            service.spacePermissionService.getSpacesAccessContext,
-        ).mockResolvedValue({
-            [PARENT_SPACE_UUID]: {
+            service.spacePermissionService.resolveAccessBatch,
+        ).mockResolvedValue([
+            {
                 organizationUuid: ORG_UUID,
                 projectUuid: PROJECT_UUID,
                 inheritsFromOrgOrProject: false,
                 access: [],
                 admins: [],
+                directOnly: false,
             },
-        });
+        ]);
         const user = makeUser([
             { subject: 'ContentAsCode', action: 'create' },
             {
@@ -477,32 +475,28 @@ describe('CoderService content-as-code space permissions', () => {
             inheritParentPermissions: true,
         } as AnyType);
         vi.mocked(
-            service.spacePermissionService.getSpacesAccessContext,
-        ).mockImplementation(async (_userUuid, spaceUuids) =>
-            Object.fromEntries(
-                spaceUuids.map((spaceUuid) => [
-                    spaceUuid,
-                    {
-                        organizationUuid: ORG_UUID,
-                        projectUuid: PROJECT_UUID,
-                        inheritsFromOrgOrProject: false,
-                        access:
-                            spaceUuid === SPACE_UUID
-                                ? [
-                                      {
-                                          userUuid: 'user-uuid',
-                                          role: SpaceMemberRole.EDITOR,
-                                          hasDirectAccess: true,
-                                          projectRole: undefined,
-                                          inheritedRole: undefined,
-                                          inheritedFrom: undefined,
-                                      },
-                                  ]
-                                : [],
-                        admins: [],
-                    },
-                ]),
-            ),
+            service.spacePermissionService.resolveAccessBatch,
+        ).mockImplementation(async (_userUuid, targets) =>
+            targets.map(({ spaceUuid }) => ({
+                organizationUuid: ORG_UUID,
+                projectUuid: PROJECT_UUID,
+                inheritsFromOrgOrProject: false,
+                access:
+                    spaceUuid === SPACE_UUID
+                        ? [
+                              {
+                                  userUuid: 'user-uuid',
+                                  role: SpaceMemberRole.EDITOR,
+                                  hasDirectAccess: true,
+                                  projectRole: undefined,
+                                  inheritedRole: undefined,
+                                  inheritedFrom: undefined,
+                              },
+                          ]
+                        : [],
+                admins: [],
+                directOnly: false,
+            })),
         );
         const user = makeUser([
             { subject: 'ContentAsCode', action: 'create' },
@@ -775,23 +769,19 @@ describe('CoderService content-as-code space permissions', () => {
             filters: { dimensions: [], metrics: [], tableCalculations: [] },
         } as AnyType);
         vi.mocked(
-            service.spacePermissionService.getSpacesAccessContext,
-        ).mockImplementation(async (_userUuid, spaceUuids) =>
-            Object.fromEntries(
-                spaceUuids.map((spaceUuid) => [
-                    spaceUuid,
-                    {
-                        organizationUuid: ORG_UUID,
-                        projectUuid:
-                            spaceUuid === OTHER_SPACE_UUID
-                                ? 'restricted-project'
-                                : PROJECT_UUID,
-                        inheritsFromOrgOrProject: true,
-                        access: [],
-                        admins: [],
-                    },
-                ]),
-            ),
+            service.spacePermissionService.resolveAccessBatch,
+        ).mockImplementation(async (_userUuid, targets) =>
+            targets.map(({ spaceUuid }) => ({
+                organizationUuid: ORG_UUID,
+                projectUuid:
+                    spaceUuid === OTHER_SPACE_UUID
+                        ? 'restricted-project'
+                        : PROJECT_UUID,
+                inheritsFromOrgOrProject: true,
+                access: [],
+                admins: [],
+                directOnly: false,
+            })),
         );
         const user = makeUser([
             { subject: 'ContentAsCode', action: 'create' },
@@ -836,23 +826,19 @@ describe('CoderService content-as-code space permissions', () => {
             filters: { dimensions: [], metrics: [], tableCalculations: [] },
         } as AnyType);
         vi.mocked(
-            service.spacePermissionService.getSpacesAccessContext,
-        ).mockImplementation(async (_userUuid, spaceUuids) =>
-            Object.fromEntries(
-                spaceUuids.map((spaceUuid) => [
-                    spaceUuid,
-                    {
-                        organizationUuid: ORG_UUID,
-                        projectUuid:
-                            spaceUuid === SPACE_UUID
-                                ? 'restricted-project'
-                                : PROJECT_UUID,
-                        inheritsFromOrgOrProject: true,
-                        access: [],
-                        admins: [],
-                    },
-                ]),
-            ),
+            service.spacePermissionService.resolveAccessBatch,
+        ).mockImplementation(async (_userUuid, targets) =>
+            targets.map(({ spaceUuid }) => ({
+                organizationUuid: ORG_UUID,
+                projectUuid:
+                    spaceUuid === SPACE_UUID
+                        ? 'restricted-project'
+                        : PROJECT_UUID,
+                inheritsFromOrgOrProject: true,
+                access: [],
+                admins: [],
+                directOnly: false,
+            })),
         );
         const user = makeUser([
             { subject: 'ContentAsCode', action: 'create' },
@@ -952,32 +938,28 @@ describe('CoderService content-as-code space permissions', () => {
             } as AnyType,
         ]);
         vi.mocked(
-            service.spacePermissionService.getSpacesAccessContext,
-        ).mockImplementation(async (_userUuid, spaceUuids) =>
-            Object.fromEntries(
-                spaceUuids.map((spaceUuid) => [
-                    spaceUuid,
-                    {
-                        organizationUuid: ORG_UUID,
-                        projectUuid: PROJECT_UUID,
-                        inheritsFromOrgOrProject: false,
-                        access:
-                            spaceUuid === SPACE_UUID
-                                ? [
-                                      {
-                                          userUuid: 'user-uuid',
-                                          role: SpaceMemberRole.EDITOR,
-                                          hasDirectAccess: true,
-                                          projectRole: undefined,
-                                          inheritedRole: undefined,
-                                          inheritedFrom: undefined,
-                                      },
-                                  ]
-                                : [],
-                        admins: [],
-                    },
-                ]),
-            ),
+            service.spacePermissionService.resolveAccessBatch,
+        ).mockImplementation(async (_userUuid, targets) =>
+            targets.map(({ spaceUuid }) => ({
+                organizationUuid: ORG_UUID,
+                projectUuid: PROJECT_UUID,
+                inheritsFromOrgOrProject: false,
+                access:
+                    spaceUuid === SPACE_UUID
+                        ? [
+                              {
+                                  userUuid: 'user-uuid',
+                                  role: SpaceMemberRole.EDITOR,
+                                  hasDirectAccess: true,
+                                  projectRole: undefined,
+                                  inheritedRole: undefined,
+                                  inheritedFrom: undefined,
+                              },
+                          ]
+                        : [],
+                admins: [],
+                directOnly: false,
+            })),
         );
         const user = makeUser([
             { subject: 'ContentAsCode', action: 'create' },
@@ -1097,32 +1079,28 @@ describe('CoderService content-as-code space permissions', () => {
             } as AnyType,
         ]);
         vi.mocked(
-            service.spacePermissionService.getSpacesAccessContext,
-        ).mockImplementation(async (_userUuid, spaceUuids) =>
-            Object.fromEntries(
-                spaceUuids.map((spaceUuid) => [
-                    spaceUuid,
-                    {
-                        organizationUuid: ORG_UUID,
-                        projectUuid: PROJECT_UUID,
-                        inheritsFromOrgOrProject: false,
-                        access:
-                            spaceUuid === SPACE_UUID
-                                ? [
-                                      {
-                                          userUuid: 'user-uuid',
-                                          role: SpaceMemberRole.EDITOR,
-                                          hasDirectAccess: true,
-                                          projectRole: undefined,
-                                          inheritedRole: undefined,
-                                          inheritedFrom: undefined,
-                                      },
-                                  ]
-                                : [],
-                        admins: [],
-                    },
-                ]),
-            ),
+            service.spacePermissionService.resolveAccessBatch,
+        ).mockImplementation(async (_userUuid, targets) =>
+            targets.map(({ spaceUuid }) => ({
+                organizationUuid: ORG_UUID,
+                projectUuid: PROJECT_UUID,
+                inheritsFromOrgOrProject: false,
+                access:
+                    spaceUuid === SPACE_UUID
+                        ? [
+                              {
+                                  userUuid: 'user-uuid',
+                                  role: SpaceMemberRole.EDITOR,
+                                  hasDirectAccess: true,
+                                  projectRole: undefined,
+                                  inheritedRole: undefined,
+                                  inheritedFrom: undefined,
+                              },
+                          ]
+                        : [],
+                admins: [],
+                directOnly: false,
+            })),
         );
         const user = makeUser([
             { subject: 'ContentAsCode', action: 'create' },
@@ -1193,32 +1171,28 @@ describe('CoderService content-as-code space permissions', () => {
             } as AnyType,
         ]);
         vi.mocked(
-            service.spacePermissionService.getSpacesAccessContext,
-        ).mockImplementation(async (_userUuid, spaceUuids) =>
-            Object.fromEntries(
-                spaceUuids.map((spaceUuid) => [
-                    spaceUuid,
-                    {
-                        organizationUuid: ORG_UUID,
-                        projectUuid: PROJECT_UUID,
-                        inheritsFromOrgOrProject: false,
-                        access:
-                            spaceUuid === SPACE_UUID
-                                ? [
-                                      {
-                                          userUuid: 'user-uuid',
-                                          role: SpaceMemberRole.EDITOR,
-                                          hasDirectAccess: true,
-                                          projectRole: undefined,
-                                          inheritedRole: undefined,
-                                          inheritedFrom: undefined,
-                                      },
-                                  ]
-                                : [],
-                        admins: [],
-                    },
-                ]),
-            ),
+            service.spacePermissionService.resolveAccessBatch,
+        ).mockImplementation(async (_userUuid, targets) =>
+            targets.map(({ spaceUuid }) => ({
+                organizationUuid: ORG_UUID,
+                projectUuid: PROJECT_UUID,
+                inheritsFromOrgOrProject: false,
+                access:
+                    spaceUuid === SPACE_UUID
+                        ? [
+                              {
+                                  userUuid: 'user-uuid',
+                                  role: SpaceMemberRole.EDITOR,
+                                  hasDirectAccess: true,
+                                  projectRole: undefined,
+                                  inheritedRole: undefined,
+                                  inheritedFrom: undefined,
+                              },
+                          ]
+                        : [],
+                admins: [],
+                directOnly: false,
+            })),
         );
         const user = makeUser([
             { subject: 'ContentAsCode', action: 'create' },
@@ -1355,7 +1329,7 @@ describe('CoderService content-as-code space permissions', () => {
         expect(service.dashboardModel.create).toHaveBeenCalled();
         expect(service.savedChartModel.create).toHaveBeenCalled();
         expect(
-            service.spacePermissionService.getSpacesAccessContext,
+            service.spacePermissionService.resolveAccessBatch,
         ).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
@@ -68,11 +68,11 @@ const accessContext = (projectUuid: string = PROJECT_UUID) => ({
 
 const buildService = (
     savedSqlModel: AnyType,
-    getSpacesAccessContext: AnyType = vi.fn(
-        async (_userUuid: string, spaceUuids: string[]) =>
-            Object.fromEntries(
-                spaceUuids.map((uuid) => [uuid, accessContext()]),
-            ),
+    resolveAccessBatch: AnyType = vi.fn(
+        async (
+            _userUuid: string,
+            targets: { type: 'space'; spaceUuid: string }[],
+        ) => targets.map(() => ({ ...accessContext(), directOnly: false })),
     ),
 ) =>
     new CoderService({
@@ -100,7 +100,7 @@ const buildService = (
         schedulerClient: {} as unknown as SchedulerClient,
         promoteService: {} as unknown as PromoteService,
         spacePermissionService: {
-            getSpacesAccessContext,
+            resolveAccessBatch,
             can: vi.fn(async () => true),
         } as unknown as SpacePermissionService,
         contentAsCodeSnapshotModel: {
@@ -201,16 +201,17 @@ describe('CoderService.upsertSqlChart - permissions', () => {
                 service.spaceModel.findClosestAncestorByPath,
             ).mockResolvedValue(PARENT_SPACE_UUID);
             vi.mocked(
-                service.spacePermissionService.getSpacesAccessContext,
-            ).mockResolvedValue({
-                [PARENT_SPACE_UUID]: {
+                service.spacePermissionService.resolveAccessBatch,
+            ).mockResolvedValue([
+                {
                     organizationUuid: ORG_UUID,
                     projectUuid: PROJECT_UUID,
                     inheritsFromOrgOrProject: false,
                     access: [],
                     admins: [],
+                    directOnly: false,
                 },
-            });
+            ]);
             const user = makeUser([
                 { subject: 'ContentAsCode', action: 'create' },
                 { subject: 'CustomSql', action: 'manage' },
@@ -298,18 +299,18 @@ describe('CoderService.upsertSqlChart - permissions', () => {
                 update: vi.fn(),
                 create: vi.fn(),
             };
-            const getSpacesAccessContext = vi.fn(
-                async (_userUuid: string, spaceUuids: string[]) =>
-                    Object.fromEntries(
-                        spaceUuids.map((uuid) => [
-                            uuid,
-                            uuid === SPACE_UUID
-                                ? accessContext(PROJECT_UUID)
-                                : accessContext('inaccessible-project'),
-                        ]),
+            const resolveAccessBatch = vi.fn(
+                async (
+                    _userUuid: string,
+                    targets: { type: 'space'; spaceUuid: string }[],
+                ) =>
+                    targets.map(({ spaceUuid }) =>
+                        spaceUuid === SPACE_UUID
+                            ? accessContext(PROJECT_UUID)
+                            : accessContext('inaccessible-project'),
                     ),
             );
-            const service = buildService(savedSqlModel, getSpacesAccessContext);
+            const service = buildService(savedSqlModel, resolveAccessBatch);
             stubSpace(service, SPACE_UUID);
             const user = makeUser([
                 { subject: 'ContentAsCode', action: 'create' },
@@ -326,9 +327,9 @@ describe('CoderService.upsertSqlChart - permissions', () => {
             );
             expect(savedSqlModel.update).not.toHaveBeenCalled();
             // both the target and the current space were checked
-            expect(getSpacesAccessContext).toHaveBeenCalledWith('user-uuid', [
-                SPACE_UUID,
-                OTHER_SPACE_UUID,
+            expect(resolveAccessBatch).toHaveBeenCalledWith('user-uuid', [
+                { type: 'space', spaceUuid: SPACE_UUID },
+                { type: 'space', spaceUuid: OTHER_SPACE_UUID },
             ]);
         });
     });

--- a/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
@@ -92,13 +92,10 @@ const buildService = (overrides: Overrides = {}) => {
         organizationModel: {} as AnyType,
         organizationMemberProfileModel: {} as AnyType,
         spacePermissionService: {
-            getSpaceAccessContext: vi.fn().mockResolvedValue({
+            resolveAccess: vi.fn().mockResolvedValue({
                 inheritsFromOrgOrProject: true,
                 access: [],
-            }),
-            getDashboardAccessContext: vi.fn().mockResolvedValue({
-                inheritsFromOrgOrProject: true,
-                access: [],
+                directOnly: false,
             }),
         } as AnyType,
         contentVerificationModel: {} as AnyType,

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -40,7 +40,10 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import type { SchedulerService } from '../SchedulerService/SchedulerService';
-import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import {
+    SpacePermissionService,
+    type AccessTarget,
+} from '../SpaceService/SpacePermissionService';
 import { DashboardService } from './DashboardService';
 import {
     chart,
@@ -187,20 +190,16 @@ const lookupSpaceContext = (spaceUuid: string) => {
 };
 
 const spacePermissionService = {
-    getSpaceAccessContext: vi.fn(async (_userUuid: string, spaceUuid: string) =>
-        lookupSpaceContext(spaceUuid),
-    ),
-    getDashboardAccessContext: vi.fn(
-        async (
-            _userUuid: string,
-            dashboardRef: { uuid: string | null; spaceUuid: string },
-        ) => ({
-            ...lookupSpaceContext(dashboardRef.spaceUuid),
-            directOnly: false,
-        }),
-    ),
-    getSpacesAccessContext: vi.fn(
-        async (_userUuid: string, spaceUuids: string[]) => spaceContexts,
+    resolveAccess: vi.fn(async (_userUuid: string, target: AccessTarget) => ({
+        ...lookupSpaceContext(target.spaceUuid),
+        directOnly: false,
+    })),
+    resolveAccessBatch: vi.fn(
+        async (_userUuid: string, targets: { spaceUuid: string }[]) =>
+            targets.map(({ spaceUuid }) => ({
+                ...lookupSpaceContext(spaceUuid),
+                directOnly: false,
+            })),
     ),
     getFirstViewableSpaceUuid: vi.fn(async () => publicSpace.uuid),
 };
@@ -314,12 +313,16 @@ describe('DashboardService', () => {
         });
         // The user holds a viewer grant on the chart's owning dashboard; the
         // grant must still not authorize copying it into another dashboard.
-        spacePermissionService.getDashboardAccessContext.mockImplementationOnce(
-            async (_userUuid: string, ref: { uuid: string | null }) =>
-                ({
+        spacePermissionService.resolveAccess.mockImplementationOnce(
+            async (_userUuid: string, target: AccessTarget) => {
+                const targetDashboardUuid =
+                    target.type === 'dashboard'
+                        ? target.dashboardUuid
+                        : undefined;
+                return {
                     ...spaceContexts[privateSpace.uuid],
                     access:
-                        ref.uuid === 'other-dashboard-uuid'
+                        targetDashboardUuid === 'other-dashboard-uuid'
                             ? [
                                   {
                                       userUuid: user.userUuid,
@@ -329,8 +332,9 @@ describe('DashboardService', () => {
                                   },
                               ]
                             : [],
-                    directOnly: ref.uuid === 'other-dashboard-uuid',
-                }) as never,
+                    directOnly: targetDashboardUuid === 'other-dashboard-uuid',
+                } as never;
+            },
         );
 
         await expect(
@@ -342,12 +346,13 @@ describe('DashboardService', () => {
                 user: grantOnlyUser,
             }),
         ).rejects.toThrow(ForbiddenError);
-        expect(
-            spacePermissionService.getDashboardAccessContext,
-        ).toHaveBeenCalledWith(user.userUuid, {
-            uuid: null,
-            spaceUuid: privateSpace.uuid,
-        });
+        expect(spacePermissionService.resolveAccess).toHaveBeenCalledWith(
+            user.userUuid,
+            {
+                type: 'space',
+                spaceUuid: privateSpace.uuid,
+            },
+        );
         expect(savedChartModel.create).not.toHaveBeenCalled();
     });
 
@@ -368,7 +373,7 @@ describe('DashboardService', () => {
             ...chart,
             spaceUuid: privateSpace.uuid,
         });
-        spacePermissionService.getDashboardAccessContext.mockResolvedValueOnce({
+        spacePermissionService.resolveAccess.mockResolvedValueOnce({
             ...spaceContexts[privateSpace.uuid],
             access: [
                 {
@@ -390,12 +395,14 @@ describe('DashboardService', () => {
                 user: grantOnlyUser,
             }),
         ).resolves.toBe('duplicated-chart-uuid');
-        expect(
-            spacePermissionService.getDashboardAccessContext,
-        ).toHaveBeenCalledWith(user.userUuid, {
-            uuid: dashboardUuid,
-            spaceUuid: privateSpace.uuid,
-        });
+        expect(spacePermissionService.resolveAccess).toHaveBeenCalledWith(
+            user.userUuid,
+            {
+                type: 'dashboard',
+                dashboardUuid,
+                spaceUuid: privateSpace.uuid,
+            },
+        );
     });
 
     test('should get dashboard by uuid', async () => {
@@ -433,7 +440,7 @@ describe('DashboardService', () => {
             spaceName: 'Private finance',
         };
         dashboardModel.getByIdOrSlug.mockResolvedValueOnce(privateDashboard);
-        spacePermissionService.getDashboardAccessContext.mockResolvedValueOnce({
+        spacePermissionService.resolveAccess.mockResolvedValueOnce({
             ...spaceContexts[privateSpace.uuid],
             access: [
                 {
@@ -465,12 +472,14 @@ describe('DashboardService', () => {
                 }),
             ],
         });
-        expect(
-            spacePermissionService.getDashboardAccessContext,
-        ).toHaveBeenCalledWith(user.userUuid, {
-            uuid: privateDashboard.uuid,
-            spaceUuid: privateSpace.uuid,
-        });
+        expect(spacePermissionService.resolveAccess).toHaveBeenCalledWith(
+            user.userUuid,
+            {
+                type: 'dashboard',
+                dashboardUuid: privateDashboard.uuid,
+                spaceUuid: privateSpace.uuid,
+            },
+        );
     });
 
     test('denies the same private dashboard without a direct grant', async () => {
@@ -492,7 +501,7 @@ describe('DashboardService', () => {
             ...dashboard,
             spaceUuid: privateSpace.uuid,
         });
-        spacePermissionService.getDashboardAccessContext.mockResolvedValueOnce({
+        spacePermissionService.resolveAccess.mockResolvedValueOnce({
             ...spaceContexts[privateSpace.uuid],
             directOnly: false,
         });
@@ -626,7 +635,7 @@ describe('DashboardService', () => {
     });
 
     test('keeps the space name in the update response for a grant-only editor', async () => {
-        spacePermissionService.getDashboardAccessContext
+        spacePermissionService.resolveAccess
             .mockResolvedValueOnce({
                 ...lookupSpaceContext(dashboard.spaceUuid),
                 directOnly: true,

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -209,9 +209,13 @@ export class DashboardService
             // real session, so it is not available to embed/JWT callers.
             assertRegisteredAccount(account);
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getDashboardAccessContext(
+                await this.spacePermissionService.resolveAccess(
                     account.user.userUuid,
-                    { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
+                    {
+                        type: 'dashboard',
+                        dashboardUuid: dashboard.uuid,
+                        spaceUuid: dashboard.spaceUuid,
+                    },
                 );
 
             if (
@@ -563,14 +567,19 @@ export class DashboardService
         // a grant must never move content beyond the dashboard it covers.
         const staysInOwningDashboard =
             chartToDuplicate.dashboardUuid === dashboardUuid;
-        const sourceContext =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                {
-                    uuid: staysInOwningDashboard ? dashboardUuid : null,
-                    spaceUuid: chartToDuplicate.spaceUuid,
-                },
-            );
+        const sourceContext = await this.spacePermissionService.resolveAccess(
+            user.userUuid,
+            staysInOwningDashboard
+                ? {
+                      type: 'dashboard',
+                      dashboardUuid,
+                      spaceUuid: chartToDuplicate.spaceUuid,
+                  }
+                : {
+                      type: 'space',
+                      spaceUuid: chartToDuplicate.spaceUuid,
+                  },
+        );
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
@@ -676,11 +685,20 @@ export class DashboardService
         const spaceUuids = [
             ...new Set(dashboards.map((dashboard) => dashboard.spaceUuid)),
         ];
-        const spaceContexts =
-            await this.spacePermissionService.getSpacesAccessContext(
+        const resolvedSpaceContexts =
+            await this.spacePermissionService.resolveAccessBatch(
                 user.userUuid,
-                spaceUuids,
+                spaceUuids.map((spaceUuid) => ({
+                    type: 'space' as const,
+                    spaceUuid,
+                })),
             );
+        const spaceContexts = Object.fromEntries(
+            spaceUuids.map((spaceUuid, index) => [
+                spaceUuid,
+                resolvedSpaceContexts[index],
+            ]),
+        );
 
         const dashboardsWithContext = dashboards.flatMap((dashboard) => {
             const spaceContext = spaceContexts[dashboard.spaceUuid];
@@ -720,10 +738,11 @@ export class DashboardService
         );
 
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'dashboard',
+                dashboardUuid: dashboardDao.uuid,
+                spaceUuid: dashboardDao.spaceUuid,
+            });
         const dashboard = {
             ...dashboardDao,
             inheritsFromOrgOrProject,
@@ -810,11 +829,14 @@ export class DashboardService
             dashboardUuidOrSlug,
             { projectUuid },
         );
-        const spaceContext =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
-            );
+        const spaceContext = await this.spacePermissionService.resolveAccess(
+            user.userUuid,
+            {
+                type: 'dashboard',
+                dashboardUuid: dashboard.uuid,
+                spaceUuid: dashboard.spaceUuid,
+            },
+        );
 
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -1048,9 +1070,9 @@ export class DashboardService
                 }
 
                 const spaceAccessContext =
-                    await this.spacePermissionService.getSpaceAccessContext(
+                    await this.spacePermissionService.resolveAccess(
                         user.userUuid,
-                        savedChart.spaceUuid,
+                        { type: 'space', spaceUuid: savedChart.spaceUuid },
                     );
                 const auditedAbility = this.createAuditedAbility(user);
                 if (
@@ -1104,9 +1126,9 @@ export class DashboardService
                 }
 
                 const spaceAccessContext =
-                    await this.spacePermissionService.getSpaceAccessContext(
+                    await this.spacePermissionService.resolveAccess(
                         user.userUuid,
-                        savedSqlChart.space.uuid,
+                        { type: 'space', spaceUuid: savedSqlChart.space.uuid },
                     );
                 const auditedAbility = this.createAuditedAbility(user);
                 if (
@@ -1215,10 +1237,10 @@ export class DashboardService
         }
 
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                space.uuid,
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'space',
+                spaceUuid: space.uuid,
+            });
 
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -1413,10 +1435,10 @@ export class DashboardService
             );
         }
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                dashboardDao.spaceUuid,
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'space',
+                spaceUuid: dashboardDao.spaceUuid,
+            });
         const dashboard = {
             ...dashboardDao,
             inheritsFromOrgOrProject,
@@ -1424,10 +1446,10 @@ export class DashboardService
         };
         const targetSpaceUuid = options?.targetSpaceUuid ?? dashboard.spaceUuid;
         const targetSpaceAccess =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                targetSpaceUuid,
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'space',
+                spaceUuid: targetSpaceUuid,
+            });
         if (targetSpaceAccess.projectUuid !== projectUuid) {
             throw new ForbiddenError(
                 'Target space does not belong to this project',
@@ -1812,14 +1834,14 @@ export class DashboardService
         );
         const { preserveVerification, ...dashboardFields } = dashboard;
 
-        const currentSpace =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                {
-                    uuid: existingDashboardDao.uuid,
-                    spaceUuid: existingDashboardDao.spaceUuid,
-                },
-            );
+        const currentSpace = await this.spacePermissionService.resolveAccess(
+            user.userUuid,
+            {
+                type: 'dashboard',
+                dashboardUuid: existingDashboardDao.uuid,
+                spaceUuid: existingDashboardDao.spaceUuid,
+            },
+        );
         const auditedAbility = this.createAuditedAbility(user);
         const canUpdateDashboardInCurrentSpace = auditedAbility.can(
             'update',
@@ -1861,9 +1883,9 @@ export class DashboardService
         if (isDashboardUnversionedFields(dashboardFields)) {
             if (dashboardFields.spaceUuid) {
                 const newSpace =
-                    await this.spacePermissionService.getSpaceAccessContext(
+                    await this.spacePermissionService.resolveAccess(
                         user.userUuid,
-                        dashboardFields.spaceUuid,
+                        { type: 'space', spaceUuid: dashboardFields.spaceUuid },
                     );
                 const canUpdateDashboardInNewSpace = auditedAbility.can(
                     'update',
@@ -2069,14 +2091,14 @@ export class DashboardService
         const updatedNewDashboard = await this.dashboardModel.getByIdOrSlug(
             existingDashboardDao.uuid,
         );
-        const updatedSpace =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                {
-                    uuid: updatedNewDashboard.uuid,
-                    spaceUuid: updatedNewDashboard.spaceUuid,
-                },
-            );
+        const updatedSpace = await this.spacePermissionService.resolveAccess(
+            user.userUuid,
+            {
+                type: 'dashboard',
+                dashboardUuid: updatedNewDashboard.uuid,
+                spaceUuid: updatedNewDashboard.spaceUuid,
+            },
+        );
 
         return {
             ...updatedNewDashboard,
@@ -2162,13 +2184,11 @@ export class DashboardService
         const existingDashboardDao =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                {
-                    uuid: existingDashboardDao.uuid,
-                    spaceUuid: existingDashboardDao.spaceUuid,
-                },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'dashboard',
+                dashboardUuid: existingDashboardDao.uuid,
+                spaceUuid: existingDashboardDao.spaceUuid,
+            });
         const existingDashboard = {
             ...existingDashboardDao,
             inheritsFromOrgOrProject,
@@ -2258,10 +2278,11 @@ export class DashboardService
                     dashboardToUpdate.uuid,
                 );
                 const currentSpaceContext =
-                    await this.spacePermissionService.getDashboardAccessContext(
+                    await this.spacePermissionService.resolveAccess(
                         user.userUuid,
                         {
-                            uuid: dashboard.uuid,
+                            type: 'dashboard',
+                            dashboardUuid: dashboard.uuid,
                             spaceUuid: dashboard.spaceUuid,
                         },
                     );
@@ -2273,9 +2294,12 @@ export class DashboardService
                     }),
                 );
                 const newSpaceContext =
-                    await this.spacePermissionService.getSpaceAccessContext(
+                    await this.spacePermissionService.resolveAccess(
                         user.userUuid,
-                        dashboardToUpdate.spaceUuid,
+                        {
+                            type: 'space',
+                            spaceUuid: dashboardToUpdate.spaceUuid,
+                        },
                     );
                 const canUpdateDashboardInNewSpace = auditedAbility.can(
                     'update',
@@ -2328,10 +2352,11 @@ export class DashboardService
         const updatedDashboardsWithSpacesAccess = updatedDashboards.map(
             async (dashboard) => {
                 const dashboardSpaceContext =
-                    await this.spacePermissionService.getDashboardAccessContext(
+                    await this.spacePermissionService.resolveAccess(
                         user.userUuid,
                         {
-                            uuid: dashboard.uuid,
+                            type: 'dashboard',
+                            dashboardUuid: dashboard.uuid,
                             spaceUuid: dashboard.spaceUuid,
                         },
                     );
@@ -2363,10 +2388,11 @@ export class DashboardService
 
         if (!options?.bypassPermissions) {
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getDashboardAccessContext(
-                    user.userUuid,
-                    { uuid: dashboardToDelete.uuid, spaceUuid },
-                );
+                await this.spacePermissionService.resolveAccess(user.userUuid, {
+                    type: 'dashboard',
+                    dashboardUuid: dashboardToDelete.uuid,
+                    spaceUuid,
+                });
             const auditedAbility = this.createAuditedAbility(user);
             if (
                 auditedAbility.cannot(
@@ -2479,10 +2505,11 @@ export class DashboardService
             });
         } else {
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getDashboardAccessContext(
-                    user.userUuid,
-                    { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
-                );
+                await this.spacePermissionService.resolveAccess(user.userUuid, {
+                    type: 'dashboard',
+                    dashboardUuid: dashboard.uuid,
+                    spaceUuid: dashboard.spaceUuid,
+                });
             const auditedAbility = this.createAuditedAbility(user);
             if (
                 auditedAbility.cannot(
@@ -2817,10 +2844,11 @@ export class DashboardService
         const dashboardDao =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'dashboard',
+                dashboardUuid: dashboardDao.uuid,
+                spaceUuid: dashboardDao.spaceUuid,
+            });
         const dashboard = {
             ...dashboardDao,
             inheritsFromOrgOrProject,
@@ -2882,9 +2910,13 @@ export class DashboardService
             throw new NotFoundError('Dashboard not found');
         }
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
+            await this.spacePermissionService.resolveAccess(
                 actor.user.userUuid,
-                { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
+                {
+                    type: 'dashboard',
+                    dashboardUuid: dashboard.uuid,
+                    spaceUuid: dashboard.spaceUuid,
+                },
             );
 
         const auditedAbility = this.createAuditedAbility(actor.user);
@@ -2906,11 +2938,10 @@ export class DashboardService
         }
 
         if (resource.spaceUuid && dashboard.spaceUuid !== resource.spaceUuid) {
-            const newSpace =
-                await this.spacePermissionService.getSpaceAccessContext(
-                    actor.user.userUuid,
-                    resource.spaceUuid,
-                );
+            const newSpace = await this.spacePermissionService.resolveAccess(
+                actor.user.userUuid,
+                { type: 'space', spaceUuid: resource.spaceUuid },
+            );
 
             const isActorAllowedToPerformActionInNewSpace = auditedAbility.can(
                 action,
@@ -2938,10 +2969,11 @@ export class DashboardService
         const dashboardDao =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'dashboard',
+                dashboardUuid: dashboardDao.uuid,
+                spaceUuid: dashboardDao.spaceUuid,
+            });
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
@@ -2987,10 +3019,11 @@ export class DashboardService
         const dashboardDao =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'dashboard',
+                dashboardUuid: dashboardDao.uuid,
+                spaceUuid: dashboardDao.spaceUuid,
+            });
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
@@ -3136,10 +3169,11 @@ export class DashboardService
         }
 
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                { uuid: dashboardDao.uuid, spaceUuid: dashboardDao.spaceUuid },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'dashboard',
+                dashboardUuid: dashboardDao.uuid,
+                spaceUuid: dashboardDao.spaceUuid,
+            });
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -1762,9 +1762,9 @@ export class DashboardService
             existingDashboardDao,
             dashboardFields,
         );
-        const space = await this.spacePermissionService.getSpaceAccessContext(
+        const space = await this.spacePermissionService.resolveAccess(
             user.userUuid,
-            existingDashboardDao.spaceUuid,
+            { type: 'space', spaceUuid: existingDashboardDao.spaceUuid },
         );
         return {
             ...overlaid,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -6217,25 +6217,22 @@ describe('assertCustomSqlAuthorizedForQuery', () => {
     } as unknown as ReturnType<typeof buildAccount>;
 
     const spacePermissionService = {
-        getSpaceAccessContext: vi.fn(async () => ({
+        resolveAccess: vi.fn(async () => ({
             organizationUuid,
             projectUuid,
             inheritsFromOrgOrProject: true,
             access: [],
         })),
-        getSpacesAccessContext: vi.fn(
-            async (_userUuid: string, spaceUuids: string[]) =>
-                Object.fromEntries(
-                    spaceUuids.map((s) => [
-                        s,
-                        {
-                            organizationUuid,
-                            projectUuid,
-                            inheritsFromOrgOrProject: true,
-                            access: [],
-                        },
-                    ]),
-                ),
+        resolveAccessBatch: vi.fn(
+            async (_userUuid: string, targets: { spaceUuid: string }[]) =>
+                targets.map(() => ({
+                    organizationUuid,
+                    projectUuid,
+                    inheritsFromOrgOrProject: true,
+                    access: [],
+                    admins: [],
+                    directOnly: false,
+                })),
         ),
     } as unknown as SpacePermissionService;
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5208,11 +5208,19 @@ export class ProjectService extends BaseService {
             ];
             const viewableSpaceUuids = new Set<string>();
             if (candidateSpaceUuids.length > 0) {
-                const spaceContexts = Object.entries(
-                    await this.spacePermissionService.getSpacesAccessContext(
+                const resolvedSpaceContexts =
+                    await this.spacePermissionService.resolveAccessBatch(
                         account.user.id,
-                        candidateSpaceUuids,
-                    ),
+                        candidateSpaceUuids.map((spaceUuid) => ({
+                            type: 'space',
+                            spaceUuid,
+                        })),
+                    );
+                const spaceContexts = candidateSpaceUuids.flatMap(
+                    (spaceUuid, index) => {
+                        const context = resolvedSpaceContexts[index];
+                        return context ? [[spaceUuid, context] as const] : [];
+                    },
                 );
                 const accessResults = auditedAbility.canBulk(
                     'view',
@@ -6636,8 +6644,9 @@ export class ProjectService extends BaseService {
         const { organizationUuid, projectUuid } = savedChart;
 
         const [spaceCtx, explore] = await Promise.all([
-            this.spacePermissionService.getChartAccessContext(account.user.id, {
-                uuid: savedChart.uuid,
+            this.spacePermissionService.resolveAccess(account.user.id, {
+                type: 'chart',
+                chartUuid: savedChart.uuid,
                 dashboardUuid: savedChart.dashboardUuid,
                 spaceUuid: savedChart.spaceUuid,
             }),
@@ -6737,8 +6746,9 @@ export class ProjectService extends BaseService {
         const { organizationUuid, projectUuid } = savedChart;
 
         const [spaceCtx, explore] = await Promise.all([
-            this.spacePermissionService.getChartAccessContext(account.user.id, {
-                uuid: savedChart.uuid,
+            this.spacePermissionService.resolveAccess(account.user.id, {
+                type: 'chart',
+                chartUuid: savedChart.uuid,
                 dashboardUuid: savedChart.dashboardUuid,
                 spaceUuid: savedChart.spaceUuid,
             }),
@@ -9762,10 +9772,11 @@ export class ProjectService extends BaseService {
                     ]);
 
                 const spaceCtx =
-                    await this.spacePermissionService.getChartAccessContext(
+                    await this.spacePermissionService.resolveAccess(
                         account.user.id,
                         {
-                            uuid: savedChart.uuid,
+                            type: 'chart',
+                            chartUuid: savedChart.uuid,
                             dashboardUuid: savedChart.dashboardUuid,
                             spaceUuid: savedChart.spaceUuid,
                         },
@@ -9836,10 +9847,11 @@ export class ProjectService extends BaseService {
                 }
 
                 const [chartContexts, exploresMap] = await Promise.all([
-                    this.spacePermissionService.getChartsAccessContext(
+                    this.spacePermissionService.resolveAccessBatch(
                         account.user.id,
                         savedCharts.map((chart) => ({
-                            uuid: chart.uuid,
+                            type: 'chart',
+                            chartUuid: chart.uuid,
                             dashboardUuid: chart.dashboardUuid,
                             spaceUuid: chart.spaceUuid,
                         })),
@@ -10604,16 +10616,19 @@ export class ProjectService extends BaseService {
 
         const spaces = await this.spaceModel.find({ projectUuid });
         const spaceUuids = spaces.map((s) => s.uuid);
-        const [userSpacesCtx, directAccessMap] = await Promise.all([
-            this.spacePermissionService.getSpacesAccessContext(
+        const [userSpaceContexts, directAccessMap] = await Promise.all([
+            this.spacePermissionService.resolveAccessBatch(
                 user.userUuid,
-                spaceUuids,
+                spaceUuids.map((spaceUuid) => ({
+                    type: 'space' as const,
+                    spaceUuid,
+                })),
             ),
             this.spacePermissionService.getDirectAccessUserUuids(spaceUuids),
         ]);
 
-        const spacesWithContext = spaces.flatMap((space) => {
-            const ctx = userSpacesCtx[space.uuid];
+        const spacesWithContext = spaces.flatMap((space, index) => {
+            const ctx = userSpaceContexts[index];
             return ctx ? [{ space, ctx }] : [];
         });
         const accessResults = auditedAbility.canBulk(

--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -86,7 +86,7 @@ const dashboardModel = {
     find: vi.fn(async () => []),
 };
 const spacePermissionService = {
-    getSpaceAccessContext: vi.fn(async () => ({
+    resolveAccess: vi.fn(async () => ({
         organizationUuid: 'org-uuid',
         projectUuid: 'project-uuid',
         inheritsFromOrgOrProject: true,

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -262,11 +262,10 @@ export class PromoteService extends BaseService {
         const upstreamSpace =
             upstreamSpaces.length === 1 ? upstreamSpaces[0] : undefined;
 
-        const promotedCtx =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                promotedSpace.uuid,
-            );
+        const promotedCtx = await this.spacePermissionService.resolveAccess(
+            user.userUuid,
+            { type: 'space', spaceUuid: promotedSpace.uuid },
+        );
         let upstreamCtx: SpaceAccessContextForCasl | undefined;
         if (upstreamSpace === undefined) {
             upstreamCtx = undefined;
@@ -275,11 +274,10 @@ export class PromoteService extends BaseService {
             // space, so the access context is identical — skip the re-query.
             upstreamCtx = promotedCtx;
         } else {
-            upstreamCtx =
-                await this.spacePermissionService.getSpaceAccessContext(
-                    user.userUuid,
-                    upstreamSpace.uuid,
-                );
+            upstreamCtx = await this.spacePermissionService.resolveAccess(
+                user.userUuid,
+                { type: 'space', spaceUuid: upstreamSpace.uuid },
+            );
         }
 
         return {
@@ -356,16 +354,15 @@ export class PromoteService extends BaseService {
         const upstreamSpace =
             upstreamSpaces.length === 1 ? upstreamSpaces[0] : undefined;
 
-        const promotedCtx =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                promotedSpace.uuid,
-            );
+        const promotedCtx = await this.spacePermissionService.resolveAccess(
+            user.userUuid,
+            { type: 'space', spaceUuid: promotedSpace.uuid },
+        );
         const upstreamCtx = upstreamSpace
-            ? await this.spacePermissionService.getSpaceAccessContext(
-                  user.userUuid,
-                  upstreamSpace.uuid,
-              )
+            ? await this.spacePermissionService.resolveAccess(user.userUuid, {
+                  type: 'space',
+                  spaceUuid: upstreamSpace.uuid,
+              })
             : undefined;
 
         return {
@@ -2515,11 +2512,10 @@ export class PromoteService extends BaseService {
             );
         }
 
-        const promotedCtx =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                promotedSpace.uuid,
-            );
+        const promotedCtx = await this.spacePermissionService.resolveAccess(
+            user.userUuid,
+            { type: 'space', spaceUuid: promotedSpace.uuid },
+        );
 
         const promotedDashboard: PromotedDashboard = {
             dashboard,
@@ -2532,10 +2528,10 @@ export class PromoteService extends BaseService {
             upstreamSpaces.length === 1 ? upstreamSpaces[0] : undefined;
 
         const upstreamCtx = upstreamSpace
-            ? await this.spacePermissionService.getSpaceAccessContext(
-                  user.userUuid,
-                  upstreamSpace.uuid,
-              )
+            ? await this.spacePermissionService.resolveAccess(user.userUuid, {
+                  type: 'space',
+                  spaceUuid: upstreamSpace.uuid,
+              })
             : undefined;
 
         const upstreamDashboard: UpstreamDashboard = {

--- a/packages/backend/src/services/RenameService/RenameService.test.ts
+++ b/packages/backend/src/services/RenameService/RenameService.test.ts
@@ -44,7 +44,7 @@ const projectModel = {
     getExploreFromCache: vi.fn(async () => ({})),
 };
 const spacePermissionService = {
-    getSpaceAccessContext: vi.fn(async () => ({
+    resolveAccess: vi.fn(async () => ({
         inheritsFromOrgOrProject: true,
         access: [],
     })),

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -185,10 +185,10 @@ export class RenameService extends BaseService {
             name: chartName,
         } = chart;
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'space',
                 spaceUuid,
-            );
+            });
 
         const auditedAbility = this.createAuditedAbility(user);
         if (

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
@@ -125,21 +125,7 @@ const contentVerificationModel = {
 };
 
 const spacePermissionService = {
-    getSpaceAccessContext: vi.fn(async () => ({
-        organizationUuid: 'org-uuid',
-        projectUuid: 'project-uuid',
-        inheritsFromOrgOrProject: true,
-        access: [],
-    })),
-    getDashboardAccessContext: vi.fn(async () => ({
-        organizationUuid: 'org-uuid',
-        projectUuid: 'project-uuid',
-        inheritsFromOrgOrProject: true,
-        access: [],
-        admins: [],
-        directOnly: false,
-    })),
-    getChartAccessContext: vi.fn(async () => ({
+    resolveAccess: vi.fn(async () => ({
         organizationUuid: 'org-uuid',
         projectUuid: 'project-uuid',
         inheritsFromOrgOrProject: true,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.grantWrites.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.grantWrites.test.ts
@@ -20,7 +20,10 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { SchedulerService } from '../SchedulerService/SchedulerService';
-import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import {
+    SpacePermissionService,
+    type AccessTarget,
+} from '../SpaceService/SpacePermissionService';
 import { SavedChartService } from './SavedChartService';
 
 const OWNING_DASHBOARD = 'owning-dashboard-uuid';
@@ -161,11 +164,14 @@ const projectModel = {
     })),
 };
 
-const spacePermissionService = {
-    getSpaceAccessContext: vi.fn(async () => spaceOnlyContext),
-    getDashboardAccessContext: vi.fn(async () => grantContext),
-    getChartAccessContext: vi.fn(async () => grantContext),
+const resolveAccess = async (_userUuid: string, target: AccessTarget) => {
+    if (target.type === 'space') return spaceOnlyContext;
+    return target.type === 'chart' && target.dashboardUuid === null
+        ? chartGrantContext
+        : grantContext;
 };
+
+const spacePermissionService = { resolveAccess: vi.fn(resolveAccess) };
 
 vi.spyOn(analyticsMock, 'track');
 
@@ -196,9 +202,7 @@ describe('SavedChartService direct-grant write parity', () => {
 
     afterEach(() => {
         vi.clearAllMocks();
-        spacePermissionService.getChartAccessContext.mockResolvedValue(
-            grantContext,
-        );
+        spacePermissionService.resolveAccess.mockImplementation(resolveAccess);
         savedChartModel.getSummary.mockResolvedValue(ownedChart);
         savedChartModel.get.mockResolvedValue(ownedChart);
     });
@@ -212,13 +216,15 @@ describe('SavedChartService direct-grant write parity', () => {
             } as never),
         ).resolves.toBeDefined();
         // The router resolves the OWNING dashboard's grants for an owned chart.
-        expect(
-            spacePermissionService.getChartAccessContext,
-        ).toHaveBeenCalledWith(grantOnlyEditor.userUuid, {
-            uuid: ownedChart.uuid,
-            dashboardUuid: OWNING_DASHBOARD,
-            spaceUuid: PRIVATE_SPACE,
-        });
+        expect(spacePermissionService.resolveAccess).toHaveBeenCalledWith(
+            grantOnlyEditor.userUuid,
+            {
+                type: 'chart',
+                chartUuid: ownedChart.uuid,
+                dashboardUuid: OWNING_DASHBOARD,
+                spaceUuid: PRIVATE_SPACE,
+            },
+        );
         // Audit records the grant provenance.
         expect(analyticsMock.track).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -242,13 +248,17 @@ describe('SavedChartService direct-grant write parity', () => {
                 spaceUuid: 'attacker-space-uuid',
             } as never),
         ).rejects.toThrow('move this chart out of its space');
-        expect(
-            spacePermissionService.getSpaceAccessContext,
-        ).toHaveBeenCalledWith(grantOnlyEditor.userUuid, PRIVATE_SPACE);
+        expect(spacePermissionService.resolveAccess).toHaveBeenCalledWith(
+            grantOnlyEditor.userUuid,
+            {
+                type: 'space',
+                spaceUuid: PRIVATE_SPACE,
+            },
+        );
     });
 
     it('denies the update when the context carries no grant (space-only)', async () => {
-        spacePermissionService.getChartAccessContext.mockResolvedValue(
+        spacePermissionService.resolveAccess.mockResolvedValue(
             spaceOnlyContext,
         );
         await expect(
@@ -275,7 +285,7 @@ describe('SavedChartService direct-grant write parity', () => {
     });
 
     it('denies the delete when the context carries no grant (space-only)', async () => {
-        spacePermissionService.getChartAccessContext.mockResolvedValue(
+        spacePermissionService.resolveAccess.mockResolvedValue(
             spaceOnlyContext,
         );
         await expect(
@@ -285,9 +295,6 @@ describe('SavedChartService direct-grant write parity', () => {
 
     it('lets a grant-only editor rename a space-saved chart via its own chart grant', async () => {
         savedChartModel.getSummary.mockResolvedValue(spaceChart as never);
-        spacePermissionService.getChartAccessContext.mockResolvedValue(
-            chartGrantContext,
-        );
         await expect(
             service.update(grantOnlyEditor, spaceChart.uuid, {
                 name: 'Renamed in space',
@@ -295,13 +302,15 @@ describe('SavedChartService direct-grant write parity', () => {
             } as never),
         ).resolves.toBeDefined();
         // The router resolves the chart's OWN grant for a space chart.
-        expect(
-            spacePermissionService.getChartAccessContext,
-        ).toHaveBeenCalledWith(grantOnlyEditor.userUuid, {
-            uuid: spaceChart.uuid,
-            dashboardUuid: null,
-            spaceUuid: PRIVATE_SPACE,
-        });
+        expect(spacePermissionService.resolveAccess).toHaveBeenCalledWith(
+            grantOnlyEditor.userUuid,
+            {
+                type: 'chart',
+                chartUuid: spaceChart.uuid,
+                dashboardUuid: null,
+                spaceUuid: PRIVATE_SPACE,
+            },
+        );
         // A saved_chart grant is grant-only but not a dashboard grant.
         expect(analyticsMock.track).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -316,9 +325,6 @@ describe('SavedChartService direct-grant write parity', () => {
 
     it('denies moving a space-saved chart to another space via its chart grant (boundary)', async () => {
         savedChartModel.getSummary.mockResolvedValue(spaceChart as never);
-        spacePermissionService.getChartAccessContext.mockResolvedValue(
-            chartGrantContext,
-        );
         // The chart grant authorizes the edit, but relocating requires space
         // access to the current space, which a grant-only editor lacks.
         await expect(
@@ -328,16 +334,17 @@ describe('SavedChartService direct-grant write parity', () => {
                 spaceUuid: 'attacker-space-uuid',
             } as never),
         ).rejects.toThrow('move this chart out of its space');
-        expect(
-            spacePermissionService.getSpaceAccessContext,
-        ).toHaveBeenCalledWith(grantOnlyEditor.userUuid, PRIVATE_SPACE);
+        expect(spacePermissionService.resolveAccess).toHaveBeenCalledWith(
+            grantOnlyEditor.userUuid,
+            {
+                type: 'space',
+                spaceUuid: PRIVATE_SPACE,
+            },
+        );
     });
 
     it('lets a grant-only editor delete a space-saved chart via its chart grant', async () => {
         savedChartModel.get.mockResolvedValue(spaceChart as never);
-        spacePermissionService.getChartAccessContext.mockResolvedValue(
-            chartGrantContext,
-        );
         await expect(
             service.delete(grantOnlyEditor, spaceChart.uuid),
         ).resolves.toBeUndefined();

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -209,14 +209,12 @@ export class SavedChartService
         const savedChart = await this.savedChartModel.getSummary(chartUuid);
         const { organizationUuid, projectUuid } = savedChart;
         const { access, inheritsFromOrgOrProject, directOnly } =
-            await this.spacePermissionService.getChartAccessContext(
-                user.userUuid,
-                {
-                    uuid: savedChart.uuid,
-                    dashboardUuid: savedChart.dashboardUuid,
-                    spaceUuid: savedChart.spaceUuid,
-                },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'chart',
+                chartUuid: savedChart.uuid,
+                dashboardUuid: savedChart.dashboardUuid,
+                spaceUuid: savedChart.spaceUuid,
+            });
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
@@ -666,13 +664,18 @@ export class SavedChartService
         // identities is a separate decision.
         const { inheritsFromOrgOrProject, access, directOnly } =
             embedWriteActions
-                ? await this.spacePermissionService.getDashboardAccessContext(
+                ? await this.spacePermissionService.resolveAccess(
                       user.userUuid,
-                      { uuid: null, spaceUuid },
+                      { type: 'space', spaceUuid },
                   )
-                : await this.spacePermissionService.getChartAccessContext(
+                : await this.spacePermissionService.resolveAccess(
                       user.userUuid,
-                      { uuid: savedChartUuid, dashboardUuid, spaceUuid },
+                      {
+                          type: 'chart',
+                          chartUuid: savedChartUuid,
+                          dashboardUuid,
+                          spaceUuid,
+                      },
                   );
 
         const auditedAbility = this.createAuditedAbility(user);
@@ -885,10 +888,12 @@ export class SavedChartService
         } = await this.savedChartModel.getSummary(savedChartUuid);
 
         const { inheritsFromOrgOrProject, access, directOnly } =
-            await this.spacePermissionService.getChartAccessContext(
-                user.userUuid,
-                { uuid: savedChartUuid, dashboardUuid, spaceUuid },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'chart',
+                chartUuid: savedChartUuid,
+                dashboardUuid,
+                spaceUuid,
+            });
 
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -912,13 +917,13 @@ export class SavedChartService
         // relocates it (SavedChartModel.update) — a boundary-crossing move that
         // a dashboard grant must never authorize. Require real space access to
         // the chart's current space; grant-only editors have none. See the
-        // boundary rule on getDashboardAccessContext.
+        // boundary rule on resolveAccess.
         if (chartUpdate.spaceUuid) {
             const currentSpaceCtx =
-                await this.spacePermissionService.getSpaceAccessContext(
-                    user.userUuid,
+                await this.spacePermissionService.resolveAccess(user.userUuid, {
+                    type: 'space',
                     spaceUuid,
-                );
+                });
             if (
                 auditedAbility.cannot(
                     'update',
@@ -1165,9 +1170,9 @@ export class SavedChartService
                     await this.savedChartModel.getSummary(chart.uuid);
                 const spaceContexts = await Promise.all(
                     [currentSpaceUuid, chart.spaceUuid].map((spaceUuid) =>
-                        this.spacePermissionService.getSpaceAccessContext(
+                        this.spacePermissionService.resolveAccess(
                             user.userUuid,
-                            spaceUuid,
+                            { type: 'space', spaceUuid },
                         ),
                     ),
                 );
@@ -1216,9 +1221,9 @@ export class SavedChartService
         const savedCharts = await Promise.all(
             savedChartsDaos.map(async (savedChart) => {
                 const { inheritsFromOrgOrProject, access } =
-                    await this.spacePermissionService.getSpaceAccessContext(
+                    await this.spacePermissionService.resolveAccess(
                         user.userUuid,
-                        savedChart.spaceUuid,
+                        { type: 'space', spaceUuid: savedChart.spaceUuid },
                     );
                 return {
                     ...savedChart,
@@ -1265,10 +1270,12 @@ export class SavedChartService
             });
         } else {
             const { inheritsFromOrgOrProject, access, directOnly } =
-                await this.spacePermissionService.getChartAccessContext(
-                    user.userUuid,
-                    { uuid: resolvedUuid, dashboardUuid, spaceUuid },
-                );
+                await this.spacePermissionService.resolveAccess(user.userUuid, {
+                    type: 'chart',
+                    chartUuid: resolvedUuid,
+                    dashboardUuid,
+                    spaceUuid,
+                });
             deleteAuditContext = {
                 viaDashboardGrant:
                     SavedChartService.hasDashboardGrantRow(access),
@@ -1357,14 +1364,12 @@ export class SavedChartService
         } else {
             const chart = await this.savedChartModel.get(savedChartUuid);
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getChartAccessContext(
-                    user.userUuid,
-                    {
-                        uuid: chart.uuid,
-                        dashboardUuid: chart.dashboardUuid,
-                        spaceUuid: chart.spaceUuid,
-                    },
-                );
+                await this.spacePermissionService.resolveAccess(user.userUuid, {
+                    type: 'chart',
+                    chartUuid: chart.uuid,
+                    dashboardUuid: chart.dashboardUuid,
+                    spaceUuid: chart.spaceUuid,
+                });
             const auditedAbility = this.createAuditedAbility(user);
             if (
                 auditedAbility.cannot(
@@ -1415,14 +1420,12 @@ export class SavedChartService
         const savedChart =
             await this.savedChartModel.getSummary(savedChartUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getChartAccessContext(
-                user.userUuid,
-                {
-                    uuid: savedChart.uuid,
-                    dashboardUuid: savedChart.dashboardUuid,
-                    spaceUuid: savedChart.spaceUuid,
-                },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'chart',
+                chartUuid: savedChart.uuid,
+                dashboardUuid: savedChart.dashboardUuid,
+                spaceUuid: savedChart.spaceUuid,
+            });
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
@@ -1463,9 +1466,9 @@ export class SavedChartService
             if (embedWriteUser && writeSpaceUuid === space.uuid) {
                 permissionActor = embedWriteUser;
                 const spaceCtx =
-                    await this.spacePermissionService.getSpaceAccessContext(
+                    await this.spacePermissionService.resolveAccess(
                         embedWriteUser.userUuid,
-                        space.uuid,
+                        { type: 'space', spaceUuid: space.uuid },
                     );
 
                 access = spaceCtx.access;
@@ -1489,10 +1492,11 @@ export class SavedChartService
                 inheritsFromOrgOrProject = spaceCtx.inheritsFromOrgOrProject;
             }
         } else {
-            const ctx = await this.spacePermissionService.getChartAccessContext(
+            const ctx = await this.spacePermissionService.resolveAccess(
                 account.user.userUuid,
                 {
-                    uuid: savedChart.uuid,
+                    type: 'chart',
+                    chartUuid: savedChart.uuid,
                     dashboardUuid: savedChart.dashboardUuid,
                     spaceUuid: savedChart.spaceUuid,
                 },
@@ -1726,10 +1730,10 @@ export class SavedChartService
         let createGrantOnly = false;
         if (resolvedSpaceUuid) {
             const spaceAccessContext =
-                await this.spacePermissionService.getSpaceAccessContext(
-                    user.userUuid,
-                    resolvedSpaceUuid,
-                );
+                await this.spacePermissionService.resolveAccess(user.userUuid, {
+                    type: 'space',
+                    spaceUuid: resolvedSpaceUuid,
+                });
             inheritsFromOrgOrProject =
                 spaceAccessContext.inheritsFromOrgOrProject;
             access = spaceAccessContext.access;
@@ -1741,12 +1745,18 @@ export class SavedChartService
             // embed write actors stay space-only (see createVersion).
             const { embedWriteActions } = getAccountWriteContext(account);
             const dashboardAccessContext =
-                await this.spacePermissionService.getDashboardAccessContext(
+                await this.spacePermissionService.resolveAccess(
                     user.userUuid,
-                    {
-                        uuid: embedWriteActions ? null : dashboard.uuid,
-                        spaceUuid: dashboard.spaceUuid,
-                    },
+                    embedWriteActions
+                        ? {
+                              type: 'space',
+                              spaceUuid: dashboard.spaceUuid,
+                          }
+                        : {
+                              type: 'dashboard',
+                              dashboardUuid: dashboard.uuid,
+                              spaceUuid: dashboard.spaceUuid,
+                          },
                 );
             inheritsFromOrgOrProject =
                 dashboardAccessContext.inheritsFromOrgOrProject;
@@ -1936,12 +1946,18 @@ export class SavedChartService
     ): Promise<SavedChart> {
         const chart = await this.savedChartModel.get(chartUuid);
         // Duplicating a dashboard-owned chart re-creates it inside the same
-        // owning dashboard, so its grants count; space charts resolve
-        // space-only through the null uuid.
+        // owning dashboard, so its grants count; space charts resolve through
+        // their space target.
         const { inheritsFromOrgOrProject, access, directOnly } =
-            await this.spacePermissionService.getDashboardAccessContext(
+            await this.spacePermissionService.resolveAccess(
                 user.userUuid,
-                { uuid: chart.dashboardUuid, spaceUuid: chart.spaceUuid },
+                chart.dashboardUuid
+                    ? {
+                          type: 'dashboard',
+                          dashboardUuid: chart.dashboardUuid,
+                          spaceUuid: chart.spaceUuid,
+                      }
+                    : { type: 'space', spaceUuid: chart.spaceUuid },
             );
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -2320,14 +2336,12 @@ export class SavedChartService
     ): Promise<ChartHistory> {
         const chart = await this.savedChartModel.getSummary(chartUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getChartAccessContext(
-                user.userUuid,
-                {
-                    uuid: chart.uuid,
-                    dashboardUuid: chart.dashboardUuid,
-                    spaceUuid: chart.spaceUuid,
-                },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'chart',
+                chartUuid: chart.uuid,
+                dashboardUuid: chart.dashboardUuid,
+                spaceUuid: chart.spaceUuid,
+            });
 
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -2371,14 +2385,12 @@ export class SavedChartService
     ): Promise<ChartVersion> {
         const chart = await this.savedChartModel.getSummary(chartUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getChartAccessContext(
-                user.userUuid,
-                {
-                    uuid: chart.uuid,
-                    dashboardUuid: chart.dashboardUuid,
-                    spaceUuid: chart.spaceUuid,
-                },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'chart',
+                chartUuid: chart.uuid,
+                dashboardUuid: chart.dashboardUuid,
+                spaceUuid: chart.spaceUuid,
+            });
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
@@ -2538,9 +2550,9 @@ export class SavedChartService
             access: spaceAccess,
             inheritsFromOrgOrProject,
             organizationUuid,
-        } = await this.spacePermissionService.getSpaceAccessContext(
+        } = await this.spacePermissionService.resolveAccess(
             actor.user.userUuid,
-            spaceUuid,
+            { type: 'space', spaceUuid },
         );
 
         const auditedAbility = this.createAuditedAbility(actor.user);
@@ -2569,9 +2581,9 @@ export class SavedChartService
                 inheritsFromOrgOrProject: newSpaceInheritsFromOrgOrProject,
                 access: newSpaceAccess,
                 organizationUuid: newSpaceOrganizationUuid,
-            } = await this.spacePermissionService.getSpaceAccessContext(
+            } = await this.spacePermissionService.resolveAccess(
                 actor.user.userUuid,
-                resource.spaceUuid,
+                { type: 'space', spaceUuid: resource.spaceUuid },
             );
 
             const hasPermissionInNewSpace = auditedAbility.can(

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -179,15 +179,22 @@ export class SavedSqlService
         const needsNewSpaceCheck =
             resource.spaceUuid && spaceUuid !== resource.spaceUuid;
 
-        const ctx = needsNewSpaceCheck
-            ? await this.spacePermissionService.getSpacesAccessContext(
-                  actor.user.userUuid,
-                  [spaceUuid, resource.spaceUuid!],
-              )
-            : await this.spacePermissionService.getSpacesAccessContext(
-                  actor.user.userUuid,
-                  [spaceUuid],
-              );
+        const targetSpaceUuids = needsNewSpaceCheck
+            ? [spaceUuid, resource.spaceUuid!]
+            : [spaceUuid];
+        const contexts = await this.spacePermissionService.resolveAccessBatch(
+            actor.user.userUuid,
+            targetSpaceUuids.map((targetSpaceUuid) => ({
+                type: 'space',
+                spaceUuid: targetSpaceUuid,
+            })),
+        );
+        const currentContext = contexts[0];
+        if (currentContext === undefined) {
+            throw new ForbiddenError(
+                `You don't have access to ${action} this Saved SQL chart`,
+            );
+        }
 
         const auditedAbility = this.createAuditedAbility(actor.user);
 
@@ -195,7 +202,7 @@ export class SavedSqlService
             auditedAbility.cannot(
                 action,
                 subject('SavedChart', {
-                    ...ctx[spaceUuid],
+                    ...currentContext,
                     metadata: { savedSqlUuid: resource.savedSqlUuid ?? '' },
                 }),
             )
@@ -206,11 +213,17 @@ export class SavedSqlService
         }
 
         if (needsNewSpaceCheck) {
+            const targetContext = contexts[1];
+            if (targetContext === undefined) {
+                throw new ForbiddenError(
+                    `You don't have access to ${action} this Saved SQL chart in the new space`,
+                );
+            }
             if (
                 auditedAbility.cannot(
                     action,
                     subject('SavedChart', {
-                        ...ctx[resource.spaceUuid!],
+                        ...targetContext,
                         metadata: { savedSqlUuid: resource.savedSqlUuid ?? '' },
                     }),
                 )
@@ -221,7 +234,7 @@ export class SavedSqlService
             }
         }
 
-        return ctx[spaceUuid];
+        return currentContext;
     }
 
     async getSqlChart(

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -130,18 +130,12 @@ const dashboardModel = {
 };
 
 const spacePermissionService = {
-    getSpaceAccessContext: vi.fn(async () => ({
+    resolveAccess: vi.fn(async () => ({
+        organizationUuid,
+        projectUuid,
         inheritsFromOrgOrProject: false,
         access: [],
-    })),
-    getDashboardAccessContext: vi.fn(async () => ({
-        inheritsFromOrgOrProject: false,
-        access: [],
-        directOnly: false,
-    })),
-    getChartAccessContext: vi.fn(async () => ({
-        inheritsFromOrgOrProject: false,
-        access: [],
+        admins: [],
         directOnly: false,
     })),
 };
@@ -544,7 +538,7 @@ describe('SchedulerService', () => {
                 dashboardUuid: 'owningDashboardUuid',
             } as never);
             // Grant-only user: no space access, only a viewer grant row.
-            spacePermissionService.getChartAccessContext.mockResolvedValueOnce({
+            spacePermissionService.resolveAccess.mockResolvedValueOnce({
                 inheritsFromOrgOrProject: false,
                 access: [
                     {
@@ -569,13 +563,15 @@ describe('SchedulerService', () => {
             await expect(
                 service.getScheduler(user, 'schedulerUuid'),
             ).resolves.toEqual(chartScheduler);
-            expect(
-                spacePermissionService.getChartAccessContext,
-            ).toHaveBeenCalledWith('userUuid', {
-                uuid: savedChartUuid,
-                dashboardUuid: 'owningDashboardUuid',
-                spaceUuid: privateSpaceUuid,
-            });
+            expect(spacePermissionService.resolveAccess).toHaveBeenCalledWith(
+                'userUuid',
+                {
+                    type: 'chart',
+                    chartUuid: savedChartUuid,
+                    dashboardUuid: 'owningDashboardUuid',
+                    spaceUuid: privateSpaceUuid,
+                },
+            );
         });
 
         test('denies a dashboard-owned chart scheduler without a grant', async () => {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -393,14 +393,12 @@ export class SchedulerService extends BaseService {
                 await this.savedChartModel.getSummary(scheduler.savedChartUuid);
 
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getChartAccessContext(
-                    user.userUuid,
-                    {
-                        uuid: scheduler.savedChartUuid,
-                        dashboardUuid,
-                        spaceUuid,
-                    },
-                );
+                await this.spacePermissionService.resolveAccess(user.userUuid, {
+                    type: 'chart',
+                    chartUuid: scheduler.savedChartUuid,
+                    dashboardUuid,
+                    spaceUuid,
+                });
             if (
                 auditedAbility.cannot(
                     'view',
@@ -426,10 +424,11 @@ export class SchedulerService extends BaseService {
                 scheduler.dashboardUuid,
             );
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getDashboardAccessContext(
-                    user.userUuid,
-                    { uuid: dashboardUuid, spaceUuid },
-                );
+                await this.spacePermissionService.resolveAccess(user.userUuid, {
+                    type: 'dashboard',
+                    dashboardUuid,
+                    spaceUuid,
+                });
 
             if (
                 auditedAbility.cannot(
@@ -456,10 +455,10 @@ export class SchedulerService extends BaseService {
             const spaceUuid = sqlChart.space.uuid;
 
             const { inheritsFromOrgOrProject, access } =
-                await this.spacePermissionService.getSpaceAccessContext(
-                    user.userUuid,
+                await this.spacePermissionService.resolveAccess(user.userUuid, {
+                    type: 'space',
                     spaceUuid,
-                );
+                });
             if (
                 auditedAbility.cannot(
                     'view',
@@ -481,9 +480,9 @@ export class SchedulerService extends BaseService {
                 throw new NotFoundError(`App not found: ${scheduler.appUuid}`);
             }
             const spaceContext = app.space_uuid
-                ? await this.spacePermissionService.getSpaceAccessContext(
+                ? await this.spacePermissionService.resolveAccess(
                       user.userUuid,
-                      app.space_uuid,
+                      { type: 'space', spaceUuid: app.space_uuid },
                   )
                 : {};
             if (
@@ -637,10 +636,10 @@ export class SchedulerService extends BaseService {
         }
         const auditedAbility = this.createAuditedAbility(user);
         const spaceContext = app.space_uuid
-            ? await this.spacePermissionService.getSpaceAccessContext(
-                  user.userUuid,
-                  app.space_uuid,
-              )
+            ? await this.spacePermissionService.resolveAccess(user.userUuid, {
+                  type: 'space',
+                  spaceUuid: app.space_uuid,
+              })
             : {};
         if (
             auditedAbility.cannot(

--- a/packages/backend/src/services/SearchService/SearchService.test.ts
+++ b/packages/backend/src/services/SearchService/SearchService.test.ts
@@ -60,7 +60,7 @@ const makeService = ({ dataAppsEnabled = true } = {}) => {
         spaceModel: {} as never,
         userAttributesModel: {} as never,
         spacePermissionService: {
-            getSpacesAccessContext: vi.fn().mockResolvedValue({}),
+            resolveAccessBatch: vi.fn().mockResolvedValue({}),
         } as never,
         appGenerateService: appGenerateService as never,
     });

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -141,10 +141,13 @@ export class SearchService extends BaseService {
         const spaceUuids = [
             ...new Set(allContent.map((content) => content.spaceUuid)),
         ];
-        const [spaceContexts, visibleDataApps] = await Promise.all([
-            this.spacePermissionService.getSpacesAccessContext(
+        const [resolvedSpaceContexts, visibleDataApps] = await Promise.all([
+            this.spacePermissionService.resolveAccessBatch(
                 user.userUuid,
-                spaceUuids,
+                spaceUuids.map((spaceUuid) => ({
+                    type: 'space' as const,
+                    spaceUuid,
+                })),
             ),
             this.appGenerateService && dataAppSearchResults.length > 0
                 ? this.appGenerateService.filterAppsUserCanView(
@@ -155,6 +158,12 @@ export class SearchService extends BaseService {
                   )
                 : Promise.resolve([]),
         ]);
+        const spaceContexts = Object.fromEntries(
+            spaceUuids.map((spaceUuid, index) => [
+                spaceUuid,
+                resolvedSpaceContexts[index],
+            ]),
+        );
 
         const contentWithContext = allContent.flatMap((content) => {
             const spaceContext = spaceContexts[content.spaceUuid];

--- a/packages/backend/src/services/SpaceService/CLAUDE.md
+++ b/packages/backend/src/services/SpaceService/CLAUDE.md
@@ -109,11 +109,12 @@ moving, or copying content **beyond** it needs real space access. This turns on
 one distinction: a chart **owned by** a dashboard (`saved_queries.dashboard_uuid`
 set, `space_id` null) inherits the dashboard's grants, while a chart that merely
 **lives in a space** does not. The single choke point is
-`getDashboardAccessContext(userUuid, { uuid, spaceUuid })` — its doc comment is
-the canonical explanation; pass `uuid: null` at every boundary-crossing call
-site so grants never count (the `expectNoGrantRows` test guards those). See the
-`/ld-permissions` skill for the full rule and the grant-aware-vs-space-only site
-list.
+`resolveAccess(userUuid, target)` — its doc comment is the canonical
+explanation. Pass a `dashboard` or ownership-aware `chart` target for operations
+that stay within the owning dashboard; pass a `space` target at every
+boundary-crossing call site so grants never count (the `expectNoGrantRows` test
+guards those). See the `/ld-permissions` skill for the full rule and the
+grant-aware-vs-space-only site list.
 
 </importantToKnow>
 

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -1773,7 +1773,26 @@ const expectNoGrantRows = (context: { access: SpaceAccess[] }) => {
     ).toEqual([]);
 };
 
-describe('getDashboardAccessContext', () => {
+type SpaceContextResolver = {
+    getSpacesCaslContext: (
+        spaceUuids: string[],
+        filters?: { userUuid?: string; userUuids?: string[] },
+        options?: { trx?: Knex },
+    ) => Promise<Record<string, SpaceAccessContextForCasl>>;
+};
+
+const mockSpaceContexts = (
+    service: SpacePermissionService,
+    contexts: Record<string, SpaceAccessContextForCasl>,
+) =>
+    vi
+        .spyOn(
+            service as unknown as SpaceContextResolver,
+            'getSpacesCaslContext',
+        )
+        .mockResolvedValue(contexts);
+
+describe('resolveAccess', () => {
     const spaceContext: SpaceAccessContextForCasl = {
         organizationUuid: 'organization-uuid',
         projectUuid: 'project-uuid',
@@ -1781,7 +1800,11 @@ describe('getDashboardAccessContext', () => {
         access: [],
         admins: [],
     };
-    const dashboardRef = { uuid: 'dashboard-uuid', spaceUuid: 'space-uuid' };
+    const dashboardTarget = {
+        type: 'dashboard' as const,
+        dashboardUuid: 'dashboard-uuid',
+        spaceUuid: 'space-uuid',
+    };
 
     const createService = ({
         enabled,
@@ -1809,7 +1832,7 @@ describe('getDashboardAccessContext', () => {
             directAccessFeatureGate:
                 directAccessFeatureGate as unknown as DirectAccessFeatureGate,
         });
-        vi.spyOn(service, 'getSpaceAccessContext').mockResolvedValue(context);
+        mockSpaceContexts(service, { 'space-uuid': context });
         return { service, dashboardAccessModel, directAccessFeatureGate };
     };
 
@@ -1819,7 +1842,7 @@ describe('getDashboardAccessContext', () => {
         });
 
         await expect(
-            service.getDashboardAccessContext('user-uuid', dashboardRef),
+            service.resolveAccess('user-uuid', dashboardTarget),
         ).resolves.toEqual({ ...spaceContext, directOnly: false });
         expect(dashboardAccessModel.getUserAccess).not.toHaveBeenCalled();
     });
@@ -1828,7 +1851,7 @@ describe('getDashboardAccessContext', () => {
         const { service } = createService({ enabled: true });
 
         await expect(
-            service.getDashboardAccessContext('user-uuid', dashboardRef),
+            service.resolveAccess('user-uuid', dashboardTarget),
         ).resolves.toEqual({ ...spaceContext, directOnly: false });
     });
 
@@ -1847,7 +1870,7 @@ describe('getDashboardAccessContext', () => {
         });
 
         await expect(
-            service.getDashboardAccessContext('user-uuid', dashboardRef),
+            service.resolveAccess('user-uuid', dashboardTarget),
         ).resolves.toEqual({
             ...spaceContext,
             access: [
@@ -1908,7 +1931,7 @@ describe('getDashboardAccessContext', () => {
         });
 
         await expect(
-            service.getDashboardAccessContext('user-uuid', dashboardRef),
+            service.resolveAccess('user-uuid', dashboardTarget),
         ).resolves.toMatchObject({ directOnly: false });
 
         const adminContext: SpaceAccessContextForCasl = {
@@ -1931,16 +1954,16 @@ describe('getDashboardAccessContext', () => {
             },
         });
         await expect(
-            adminService.getDashboardAccessContext('user-uuid', dashboardRef),
+            adminService.resolveAccess('user-uuid', dashboardTarget),
         ).resolves.toMatchObject({ directOnly: false });
     });
 
-    test('a null dashboard uuid returns the space-only context without any grant lookup', async () => {
+    test('a space target returns the space-only context without any grant lookup', async () => {
         const { service, dashboardAccessModel, directAccessFeatureGate } =
             createService({ enabled: true });
 
-        const result = await service.getDashboardAccessContext('user-uuid', {
-            uuid: null,
+        const result = await service.resolveAccess('user-uuid', {
+            type: 'space',
             spaceUuid: 'space-uuid',
         });
 
@@ -1965,12 +1988,12 @@ describe('getDashboardAccessContext', () => {
         });
 
         await expect(
-            service.getDashboardAccessContext('user-uuid', dashboardRef),
+            service.resolveAccess('user-uuid', dashboardTarget),
         ).rejects.toThrow(ParameterError);
     });
 });
 
-describe('getDashboardsAccessContext', () => {
+describe('resolveAccessBatch', () => {
     const baseContext: SpaceAccessContextForCasl = {
         organizationUuid: 'organization-uuid',
         projectUuid: 'project-uuid',
@@ -1982,14 +2005,25 @@ describe('getDashboardsAccessContext', () => {
     const createService = ({
         enabled,
         grants = {},
+        grantsByOrganization,
         contexts,
     }: {
         enabled: boolean;
         grants?: Record<string, unknown>;
+        grantsByOrganization?: Record<string, Record<string, unknown>>;
         contexts: Record<string, SpaceAccessContextForCasl>;
     }) => {
         const dashboardAccessModel = {
-            getUserAccess: vi.fn(async () => grants),
+            getUserAccess: vi.fn(
+                async (
+                    _resourceUuids: string[],
+                    _userUuid: string,
+                    { organizationUuid }: { organizationUuid: string },
+                ) => grantsByOrganization?.[organizationUuid] ?? grants,
+            ),
+        };
+        const savedChartAccessModel = {
+            getUserAccess: vi.fn(async () => ({})),
         };
         const directAccessFeatureGate = {
             isEnabledForUser: vi.fn(async () => enabled),
@@ -1999,26 +2033,41 @@ describe('getDashboardsAccessContext', () => {
             spacePermissionModel: {} as unknown as SpacePermissionModel,
             dashboardAccessModel:
                 dashboardAccessModel as unknown as DashboardAccessModel,
-            savedChartAccessModel: {
-                getUserAccess: vi.fn(async () => ({})),
-            } as never,
+            savedChartAccessModel: savedChartAccessModel as never,
             directAccessFeatureGate:
                 directAccessFeatureGate as unknown as DirectAccessFeatureGate,
         });
-        vi.spyOn(service, 'getSpacesAccessContext').mockResolvedValue(contexts);
-        return { service, dashboardAccessModel, directAccessFeatureGate };
+        const spaceContextResolver = mockSpaceContexts(service, contexts);
+        return {
+            service,
+            dashboardAccessModel,
+            savedChartAccessModel,
+            directAccessFeatureGate,
+            spaceContextResolver,
+        };
     };
 
-    test('null uuids return space-only contexts with no gate or grant lookup', async () => {
+    test('an empty batch performs no resolution work', async () => {
+        const { service, spaceContextResolver, directAccessFeatureGate } =
+            createService({ enabled: true, contexts: {} });
+
+        await expect(
+            service.resolveAccessBatch('user-uuid', []),
+        ).resolves.toEqual([]);
+        expect(spaceContextResolver).not.toHaveBeenCalled();
+        expect(directAccessFeatureGate.isEnabledForUser).not.toHaveBeenCalled();
+    });
+
+    test('space targets return space-only contexts with no gate or grant lookup', async () => {
         const { service, dashboardAccessModel, directAccessFeatureGate } =
             createService({
                 enabled: true,
                 contexts: { 'space-a': baseContext },
             });
 
-        const result = await service.getDashboardsAccessContext('user-uuid', [
-            { uuid: null, spaceUuid: 'space-a' },
-            { uuid: null, spaceUuid: 'space-a' },
+        const result = await service.resolveAccessBatch('user-uuid', [
+            { type: 'space', spaceUuid: 'space-a' },
+            { type: 'space', spaceUuid: 'space-a' },
         ]);
 
         expect(result).toEqual([
@@ -2033,26 +2082,142 @@ describe('getDashboardsAccessContext', () => {
     });
 
     test('feature off returns space-only for every ref without a grant lookup', async () => {
-        const { service, dashboardAccessModel } = createService({
+        const {
+            service,
+            dashboardAccessModel,
+            savedChartAccessModel,
+            directAccessFeatureGate,
+            spaceContextResolver,
+        } = createService({
             enabled: false,
             contexts: { 'space-a': baseContext },
-            grants: {
-                'dash-1': {
-                    organizationUuid: 'organization-uuid',
-                    projectUuid: 'project-uuid',
-                    spaceUuid: 'space-a',
-                    userRole: SpaceMemberRole.EDITOR,
-                    groupRoles: [],
-                },
-            },
         });
 
-        const result = await service.getDashboardsAccessContext('user-uuid', [
-            { uuid: 'dash-1', spaceUuid: 'space-a' },
+        const result = await service.resolveAccessBatch('user-uuid', [
+            { type: 'space', spaceUuid: 'space-a' },
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dash-1',
+                spaceUuid: 'space-a',
+            },
+            {
+                type: 'saved_chart',
+                savedChartUuid: 'chart-1',
+                spaceUuid: 'space-a',
+            },
         ]);
 
-        expect(result[0]).toEqual({ ...baseContext, directOnly: false });
+        expect(result).toEqual([
+            { ...baseContext, directOnly: false },
+            { ...baseContext, directOnly: false },
+            { ...baseContext, directOnly: false },
+        ]);
+        expect(spaceContextResolver).toHaveBeenCalledTimes(1);
+        expect(directAccessFeatureGate.isEnabledForUser).toHaveBeenCalledTimes(
+            1,
+        );
         expect(dashboardAccessModel.getUserAccess).not.toHaveBeenCalled();
+        expect(savedChartAccessModel.getUserAccess).not.toHaveBeenCalled();
+    });
+
+    test('partitions feature checks and grant lookups by organization', async () => {
+        const organizationBContext = {
+            ...baseContext,
+            organizationUuid: 'organization-b',
+            projectUuid: 'project-b',
+        };
+        const { service, dashboardAccessModel, directAccessFeatureGate } =
+            createService({
+                enabled: true,
+                contexts: {
+                    'space-a': baseContext,
+                    'space-b': organizationBContext,
+                },
+                grantsByOrganization: {
+                    'organization-uuid': {
+                        'dash-a': {
+                            organizationUuid: 'organization-uuid',
+                            projectUuid: 'project-uuid',
+                            spaceUuid: 'space-a',
+                            userRole: SpaceMemberRole.VIEWER,
+                            groupRoles: [],
+                        },
+                    },
+                    'organization-b': {
+                        'dash-b': {
+                            organizationUuid: 'organization-b',
+                            projectUuid: 'project-b',
+                            spaceUuid: 'space-b',
+                            userRole: SpaceMemberRole.EDITOR,
+                            groupRoles: [],
+                        },
+                    },
+                },
+            });
+
+        const result = await service.resolveAccessBatch('user-uuid', [
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dash-a',
+                spaceUuid: 'space-a',
+            },
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dash-b',
+                spaceUuid: 'space-b',
+            },
+        ]);
+
+        expect(result[0]?.access).toEqual([
+            expect.objectContaining({ role: SpaceMemberRole.VIEWER }),
+        ]);
+        expect(result[1]?.access).toEqual([
+            expect.objectContaining({ role: SpaceMemberRole.EDITOR }),
+        ]);
+        expect(directAccessFeatureGate.isEnabledForUser).toHaveBeenCalledTimes(
+            2,
+        );
+        expect(dashboardAccessModel.getUserAccess).toHaveBeenCalledTimes(2);
+        expect(dashboardAccessModel.getUserAccess).toHaveBeenCalledWith(
+            ['dash-a'],
+            'user-uuid',
+            { organizationUuid: 'organization-uuid' },
+        );
+        expect(dashboardAccessModel.getUserAccess).toHaveBeenCalledWith(
+            ['dash-b'],
+            'user-uuid',
+            { organizationUuid: 'organization-b' },
+        );
+    });
+
+    test('forwards a transaction to space and grant resolution', async () => {
+        const { service, dashboardAccessModel, spaceContextResolver } =
+            createService({
+                enabled: true,
+                contexts: { 'space-a': baseContext },
+            });
+        const trx = {} as Knex;
+
+        await service.resolveAccess(
+            'user-uuid',
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dash-a',
+                spaceUuid: 'space-a',
+            },
+            { trx },
+        );
+
+        expect(spaceContextResolver).toHaveBeenCalledWith(
+            ['space-a'],
+            { userUuid: 'user-uuid' },
+            { trx },
+        );
+        expect(dashboardAccessModel.getUserAccess).toHaveBeenCalledWith(
+            ['dash-a'],
+            'user-uuid',
+            { organizationUuid: 'organization-uuid', trx },
+        );
     });
 
     test('appends tagged grant rows per granted dashboard from one batched lookup, aligned with input order', async () => {
@@ -2070,9 +2235,17 @@ describe('getDashboardsAccessContext', () => {
             },
         });
 
-        const result = await service.getDashboardsAccessContext('user-uuid', [
-            { uuid: 'dash-2', spaceUuid: 'space-b' },
-            { uuid: 'dash-1', spaceUuid: 'space-a' },
+        const result = await service.resolveAccessBatch('user-uuid', [
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dash-2',
+                spaceUuid: 'space-b',
+            },
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dash-1',
+                spaceUuid: 'space-a',
+            },
         ]);
 
         // Order preserved: dash-2 (no grant) first, dash-1 (grant) second.
@@ -2108,8 +2281,12 @@ describe('getDashboardsAccessContext', () => {
             },
         });
 
-        const result = await service.getDashboardsAccessContext('user-uuid', [
-            { uuid: 'dash-1', spaceUuid: 'space-a' },
+        const result = await service.resolveAccessBatch('user-uuid', [
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dash-1',
+                spaceUuid: 'space-a',
+            },
         ]);
 
         expect(result[0]).toEqual({ ...baseContext, directOnly: false });
@@ -2119,15 +2296,19 @@ describe('getDashboardsAccessContext', () => {
     test('unresolvable spaces map to undefined', async () => {
         const { service } = createService({ enabled: true, contexts: {} });
 
-        const result = await service.getDashboardsAccessContext('user-uuid', [
-            { uuid: 'dash-1', spaceUuid: 'missing-space' },
+        const result = await service.resolveAccessBatch('user-uuid', [
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dash-1',
+                spaceUuid: 'missing-space',
+            },
         ]);
 
         expect(result).toEqual([undefined]);
     });
 });
 
-describe('getSavedChartAccessContext', () => {
+describe('resolveAccess saved chart target', () => {
     const spaceContext: SpaceAccessContextForCasl = {
         organizationUuid: 'organization-uuid',
         projectUuid: 'project-uuid',
@@ -2135,7 +2316,11 @@ describe('getSavedChartAccessContext', () => {
         access: [],
         admins: [],
     };
-    const chartRef = { uuid: 'chart-uuid', spaceUuid: 'space-uuid' };
+    const savedChartTarget = {
+        type: 'saved_chart' as const,
+        savedChartUuid: 'chart-uuid',
+        spaceUuid: 'space-uuid',
+    };
 
     const createService = ({
         enabled,
@@ -2158,18 +2343,16 @@ describe('getSavedChartAccessContext', () => {
                 isEnabledForUser: vi.fn(async () => enabled),
             } as unknown as DirectAccessFeatureGate,
         });
-        vi.spyOn(service, 'getSpaceAccessContext').mockResolvedValue(
-            spaceContext,
-        );
+        mockSpaceContexts(service, { 'space-uuid': spaceContext });
         return { service, savedChartAccessModel };
     };
 
-    test('null uuid returns the space-only context with no grant lookup', async () => {
+    test('space target returns the space-only context with no grant lookup', async () => {
         const { service, savedChartAccessModel } = createService({
             enabled: true,
         });
-        const result = await service.getSavedChartAccessContext('user-uuid', {
-            uuid: null,
+        const result = await service.resolveAccess('user-uuid', {
+            type: 'space',
             spaceUuid: 'space-uuid',
         });
         expect(result).toEqual({ ...spaceContext, directOnly: false });
@@ -2190,9 +2373,9 @@ describe('getSavedChartAccessContext', () => {
                 },
             },
         });
-        const result = await service.getSavedChartAccessContext(
+        const result = await service.resolveAccess(
             'user-uuid',
-            chartRef,
+            savedChartTarget,
         );
         expect(result.access).toEqual([
             expect.objectContaining({
@@ -2218,12 +2401,12 @@ describe('getSavedChartAccessContext', () => {
             },
         });
         await expect(
-            service.getSavedChartAccessContext('user-uuid', chartRef),
+            service.resolveAccess('user-uuid', savedChartTarget),
         ).rejects.toThrow(ParameterError);
     });
 });
 
-describe('getChartAccessContext (ownership routing)', () => {
+describe('resolveAccess chart ownership routing', () => {
     const baseContext: SpaceAccessContextForCasl = {
         organizationUuid: 'organization-uuid',
         projectUuid: 'project-uuid',
@@ -2264,11 +2447,13 @@ describe('getChartAccessContext (ownership routing)', () => {
                 isEnabledForUser: vi.fn(async () => true),
             } as unknown as DirectAccessFeatureGate,
         });
-        vi.spyOn(service, 'getSpaceAccessContext').mockImplementation(
-            async (_userUuid, spaceUuid) => contexts[spaceUuid],
-        );
-        vi.spyOn(service, 'getSpacesAccessContext').mockResolvedValue(contexts);
-        return { service, dashboardAccessModel, savedChartAccessModel };
+        const spaceContextResolver = mockSpaceContexts(service, contexts);
+        return {
+            service,
+            dashboardAccessModel,
+            savedChartAccessModel,
+            spaceContextResolver,
+        };
     };
 
     test('an owned chart resolves through its dashboard grant, never the chart grant', async () => {
@@ -2280,8 +2465,9 @@ describe('getChartAccessContext (ownership routing)', () => {
                 },
             });
 
-        const result = await service.getChartAccessContext('user-uuid', {
-            uuid: 'chart-uuid',
+        const result = await service.resolveAccess('user-uuid', {
+            type: 'chart',
+            chartUuid: 'chart-uuid',
             dashboardUuid: 'dashboard-uuid',
             spaceUuid: 'space-uuid',
         });
@@ -2304,8 +2490,9 @@ describe('getChartAccessContext (ownership routing)', () => {
                 chartGrants: { 'chart-uuid': editorGrant('space-uuid') },
             });
 
-        const result = await service.getChartAccessContext('user-uuid', {
-            uuid: 'chart-uuid',
+        const result = await service.resolveAccess('user-uuid', {
+            type: 'chart',
+            chartUuid: 'chart-uuid',
             dashboardUuid: null,
             spaceUuid: 'space-uuid',
         });
@@ -2322,19 +2509,30 @@ describe('getChartAccessContext (ownership routing)', () => {
     });
 
     test('batched routing stays aligned across a mixed owned/space set', async () => {
-        const { service } = createService({
+        const {
+            service,
+            dashboardAccessModel,
+            savedChartAccessModel,
+            spaceContextResolver,
+        } = createService({
             contexts: { 'space-a': baseContext, 'space-b': baseContext },
             dashboardGrants: { 'dashboard-uuid': editorGrant('space-a') },
             chartGrants: { 'chart-b': editorGrant('space-b') },
         });
 
-        const result = await service.getChartsAccessContext('user-uuid', [
+        const result = await service.resolveAccessBatch('user-uuid', [
             {
-                uuid: 'chart-a',
+                type: 'chart',
+                chartUuid: 'chart-a',
                 dashboardUuid: 'dashboard-uuid',
                 spaceUuid: 'space-a',
             },
-            { uuid: 'chart-b', dashboardUuid: null, spaceUuid: 'space-b' },
+            {
+                type: 'chart',
+                chartUuid: 'chart-b',
+                dashboardUuid: null,
+                spaceUuid: 'space-b',
+            },
         ]);
 
         expect(result[0]?.access).toEqual([
@@ -2343,5 +2541,8 @@ describe('getChartAccessContext (ownership routing)', () => {
         expect(result[1]?.access).toEqual([
             expect.objectContaining({ grantedVia: 'saved_chart' }),
         ]);
+        expect(spaceContextResolver).toHaveBeenCalledTimes(1);
+        expect(dashboardAccessModel.getUserAccess).toHaveBeenCalledTimes(1);
+        expect(savedChartAccessModel.getUserAccess).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -2101,8 +2101,9 @@ describe('resolveAccessBatch', () => {
                 spaceUuid: 'space-a',
             },
             {
-                type: 'saved_chart',
-                savedChartUuid: 'chart-1',
+                type: 'chart',
+                chartUuid: 'chart-1',
+                dashboardUuid: null,
                 spaceUuid: 'space-a',
             },
         ]);
@@ -2308,7 +2309,7 @@ describe('resolveAccessBatch', () => {
     });
 });
 
-describe('resolveAccess saved chart target', () => {
+describe('resolveAccess space-saved chart target', () => {
     const spaceContext: SpaceAccessContextForCasl = {
         organizationUuid: 'organization-uuid',
         projectUuid: 'project-uuid',
@@ -2317,8 +2318,9 @@ describe('resolveAccess saved chart target', () => {
         admins: [],
     };
     const savedChartTarget = {
-        type: 'saved_chart' as const,
-        savedChartUuid: 'chart-uuid',
+        type: 'chart' as const,
+        chartUuid: 'chart-uuid',
+        dashboardUuid: null,
         spaceUuid: 'space-uuid',
     };
 

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -54,7 +54,6 @@ export type SpaceAccessContextForCasl = {
 export type AccessTarget =
     | { type: 'space'; spaceUuid: string }
     | { type: 'dashboard'; dashboardUuid: string; spaceUuid: string }
-    | { type: 'saved_chart'; savedChartUuid: string; spaceUuid: string }
     | {
           type: 'chart';
           chartUuid: string;
@@ -272,13 +271,6 @@ export class SpacePermissionService extends BaseService {
                     source: 'dashboard',
                     resourceUuid: target.dashboardUuid,
                     resourceLabel: 'Dashboard',
-                    spaceUuid: target.spaceUuid,
-                };
-            case 'saved_chart':
-                return {
-                    source: 'saved_chart',
-                    resourceUuid: target.savedChartUuid,
-                    resourceLabel: 'Saved chart',
                     spaceUuid: target.spaceUuid,
                 };
             case 'chart':

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    assertUnreachable,
     getHighestSpaceRole,
     getOrganizationRoleForRoleSetSpaceAccess,
     getProjectRoleForRoleSetSpaceAccess,
@@ -50,14 +51,32 @@ export type SpaceAccessContextForCasl = {
     admins: SpaceAdmin[];
 };
 
+export type AccessTarget =
+    | { type: 'space'; spaceUuid: string }
+    | { type: 'dashboard'; dashboardUuid: string; spaceUuid: string }
+    | { type: 'saved_chart'; savedChartUuid: string; spaceUuid: string }
+    | {
+          type: 'chart';
+          chartUuid: string;
+          dashboardUuid: string | null;
+          spaceUuid: string;
+      };
+
 // A content type's direct-grant lookup (e.g. DashboardAccessModel.getUserAccess
 // or SavedChartAccessModel.getUserAccess), pre-bound to the requesting user.
 type GrantLookup = (
     resourceUuids: string[],
-    opts: { organizationUuid: string },
+    opts: { organizationUuid: string; trx?: Knex },
 ) => Promise<Record<string, DirectAccess>>;
 
-export type DashboardAccessContextForCasl = SpaceAccessContextForCasl & {
+type DirectGrantTarget = {
+    source: GrantSource;
+    resourceUuid: string;
+    resourceLabel: string;
+    spaceUuid: string;
+};
+
+export type AccessContextForCasl = SpaceAccessContextForCasl & {
     /**
      * True when the requester has no space-derived access path (membership,
      * inheritance, or admin standing) and reaches the content only through
@@ -180,34 +199,8 @@ export class SpacePermissionService extends BaseService {
     }
 
     /**
-     * Returns the CASL context for a space (organizationUuid, projectUuid, inheritsFromOrgOrProject, access)
-     * without performing any permission checks. Callers use this to build their own
-     * `subject(...)` checks when the resource type is not Space.
-     */
-    async getSpaceAccessContext(
-        userUuid: string,
-        spaceUuid: string,
-        { trx }: { trx?: Knex } = {},
-    ): Promise<SpaceAccessContextForCasl> {
-        const accessContext = await this.getSpacesCaslContext(
-            [spaceUuid],
-            {
-                userUuid,
-            },
-            { trx },
-        );
-        const ctx = accessContext[spaceUuid];
-        if (!ctx) {
-            throw new NotFoundError(
-                `Couldn't find access context for space ${spaceUuid}`,
-            );
-        }
-        return ctx;
-    }
-
-    /**
-     * The single choke point for authorizing a dashboard-owned chart through
-     * a direct dashboard grant. Read this before touching any grant call site.
+     * Resolves effective access to one supported target. Space permissions are
+     * always the baseline; direct content grants are added when applicable.
      *
      * THE BOUNDARY RULE. A direct grant on a dashboard authorizes operations
      * whose effect stays INSIDE that dashboard; anything that reads, moves, or
@@ -231,268 +224,251 @@ export class SpacePermissionService extends BaseService {
      * feature gate; with the flag off the result equals the plain space
      * context.
      *
-     * Pass `uuid: null` for a chart with no owning dashboard, AND at every
-     * boundary-crossing call site (copying or moving content out of the
-     * dashboard) where the grant must not count: the space-only context is
-     * returned and no grant lookup runs. The `expectNoGrantRows` test tripwire
-     * guards those sites. See also `ld-permissions` skill and this service's
-     * CLAUDE.md.
+     * Boundary-crossing operations pass a `space` target so content grants do
+     * not count. A `chart` target routes through its owning dashboard when it
+     * has one, otherwise through the saved chart's own direct grants.
      */
-    async getDashboardAccessContext(
+    async resolveAccess(
         userUuid: string,
-        dashboard: { uuid: string | null; spaceUuid: string },
-    ): Promise<DashboardAccessContextForCasl> {
-        return this.resolveGrantAccessContext(userUuid, dashboard, {
-            grantedVia: 'dashboard',
-            resourceLabel: 'Dashboard',
-            lookupGrants: (uuids, opts) =>
-                this.dashboardAccessModel.getUserAccess(uuids, userUuid, opts),
+        target: AccessTarget,
+        { trx }: { trx?: Knex } = {},
+    ): Promise<AccessContextForCasl> {
+        const [context] = await this.resolveAccessTargets(userUuid, [target], {
+            onMismatch: 'throw',
+            trx,
         });
-    }
-
-    /**
-     * Direct-grant access context for a saved (explore) chart. Same kernel and
-     * boundary rule as `getDashboardAccessContext` (read its doc); grants are
-     * tagged `grantedVia: 'saved_chart'`. Pass `uuid: null` for a chart with no
-     * direct policy, or at a boundary-crossing site where grants must not
-     * count.
-     */
-    async getSavedChartAccessContext(
-        userUuid: string,
-        chart: { uuid: string | null; spaceUuid: string },
-    ): Promise<DashboardAccessContextForCasl> {
-        return this.resolveGrantAccessContext(userUuid, chart, {
-            grantedVia: 'saved_chart',
-            resourceLabel: 'Saved chart',
-            lookupGrants: (uuids, opts) =>
-                this.savedChartAccessModel.getUserAccess(uuids, userUuid, opts),
-        });
-    }
-
-    /** Batched `getSavedChartAccessContext` for hot paths (listings, tiles). */
-    async getSavedChartsAccessContext(
-        userUuid: string,
-        charts: { uuid: string | null; spaceUuid: string }[],
-    ): Promise<(DashboardAccessContextForCasl | undefined)[]> {
-        return this.resolveGrantsAccessContext(userUuid, charts, {
-            grantedVia: 'saved_chart',
-            lookupGrants: (uuids, opts) =>
-                this.savedChartAccessModel.getUserAccess(uuids, userUuid, opts),
-        });
-    }
-
-    /**
-     * Access context for a chart, routed by ownership: a dashboard-owned chart
-     * (`dashboardUuid` set) resolves through the owning dashboard's grants; a
-     * space-saved chart resolves through its own grants. Callers pass the
-     * chart's own uuid, its dashboardUuid, and its space; this is the entry
-     * point every chart read/write path should use.
-     */
-    async getChartAccessContext(
-        userUuid: string,
-        chart: {
-            uuid: string;
-            dashboardUuid: string | null;
-            spaceUuid: string;
-        },
-    ): Promise<DashboardAccessContextForCasl> {
-        return chart.dashboardUuid
-            ? this.getDashboardAccessContext(userUuid, {
-                  uuid: chart.dashboardUuid,
-                  spaceUuid: chart.spaceUuid,
-              })
-            : this.getSavedChartAccessContext(userUuid, {
-                  uuid: chart.uuid,
-                  spaceUuid: chart.spaceUuid,
-              });
-    }
-
-    /**
-     * Batched `getChartAccessContext`, aligned with the input. Owned charts
-     * resolve in one dashboard-grant batch and space charts in one
-     * chart-grant batch (non-applicable entries take the no-lookup null path),
-     * so a mixed dashboard load costs two grant queries, never N+1.
-     */
-    async getChartsAccessContext(
-        userUuid: string,
-        charts: {
-            uuid: string;
-            dashboardUuid: string | null;
-            spaceUuid: string;
-        }[],
-    ): Promise<(DashboardAccessContextForCasl | undefined)[]> {
-        const [dashboardContexts, chartContexts] = await Promise.all([
-            this.getDashboardsAccessContext(
-                userUuid,
-                charts.map((chart) => ({
-                    uuid: chart.dashboardUuid,
-                    spaceUuid: chart.spaceUuid,
-                })),
-            ),
-            this.getSavedChartsAccessContext(
-                userUuid,
-                charts.map((chart) => ({
-                    uuid: chart.dashboardUuid ? null : chart.uuid,
-                    spaceUuid: chart.spaceUuid,
-                })),
-            ),
-        ]);
-        return charts.map((chart, index) =>
-            chart.dashboardUuid
-                ? dashboardContexts[index]
-                : chartContexts[index],
-        );
-    }
-
-    /**
-     * Batched `getDashboardAccessContext` for hot paths that resolve many
-     * (dashboard, space) refs at once. Returns contexts aligned with the input;
-     * undefined where the space context could not be resolved. Doubtful refs
-     * degrade to the space-only context — never to more access.
-     */
-    async getDashboardsAccessContext(
-        userUuid: string,
-        dashboards: { uuid: string | null; spaceUuid: string }[],
-    ): Promise<(DashboardAccessContextForCasl | undefined)[]> {
-        return this.resolveGrantsAccessContext(userUuid, dashboards, {
-            grantedVia: 'dashboard',
-            lookupGrants: (uuids, opts) =>
-                this.dashboardAccessModel.getUserAccess(uuids, userUuid, opts),
-        });
-    }
-
-    // The canonical single-ref grant kernel that every getXAccessContext
-    // delegates to. See the getDashboardAccessContext doc for the boundary
-    // rule. One space fetch, one gate check, one grant lookup; a space the
-    // resource does not belong to is a caller bug and throws.
-    private async resolveGrantAccessContext(
-        userUuid: string,
-        ref: { uuid: string | null; spaceUuid: string },
-        {
-            grantedVia,
-            resourceLabel,
-            lookupGrants,
-        }: {
-            grantedVia: GrantSource;
-            resourceLabel: string;
-            lookupGrants: GrantLookup;
-        },
-    ): Promise<DashboardAccessContextForCasl> {
-        const spaceContext = await this.getSpaceAccessContext(
-            userUuid,
-            ref.spaceUuid,
-        );
-        const spaceOnlyContext = { ...spaceContext, directOnly: false };
-        if (ref.uuid === null) {
-            return spaceOnlyContext;
-        }
-        if (
-            !(await this.directAccessFeatureGate.isEnabledForUser({
-                userUuid,
-                organizationUuid: spaceContext.organizationUuid,
-            }))
-        ) {
-            return spaceOnlyContext;
-        }
-        const grants = await lookupGrants([ref.uuid], {
-            organizationUuid: spaceContext.organizationUuid,
-        });
-        const grant = grants[ref.uuid];
-        if (grant === undefined) {
-            return spaceOnlyContext;
-        }
-        const grantRoles = [
-            ...(grant.userRole ? [grant.userRole] : []),
-            ...grant.groupRoles,
-        ];
-        if (grantRoles.length === 0) {
-            return spaceOnlyContext;
-        }
-        if (grant.spaceUuid !== ref.spaceUuid) {
-            throw new ParameterError(
-                `${resourceLabel} ${ref.uuid} does not belong to space ${ref.spaceUuid}`,
+        if (context === undefined) {
+            throw new NotFoundError(
+                `Couldn't find access context for space ${target.spaceUuid}`,
             );
         }
-        return SpacePermissionService.withGrantAccess(
-            spaceContext,
-            userUuid,
-            grantRoles,
-            grantedVia,
-        );
+        return context;
     }
 
-    // Batched sibling of resolveGrantAccessContext: one space batch, one gate
-    // check, one grant lookup. Doubtful refs degrade to space-only rather than
-    // throwing, so one bad ref never fails a whole hot-path request.
-    private async resolveGrantsAccessContext(
+    /**
+     * Batched access resolution aligned with the input. Missing spaces and
+     * mismatched resource refs degrade to `undefined` or space-only access so
+     * one doubtful target never fails an entire hot-path request.
+     */
+    async resolveAccessBatch(
         userUuid: string,
-        refs: { uuid: string | null; spaceUuid: string }[],
-        {
-            grantedVia,
-            lookupGrants,
-        }: { grantedVia: GrantSource; lookupGrants: GrantLookup },
-    ): Promise<(DashboardAccessContextForCasl | undefined)[]> {
-        const uniqueSpaceUuids = [...new Set(refs.map((ref) => ref.spaceUuid))];
-        const spaceContexts = await this.getSpacesAccessContext(
-            userUuid,
-            uniqueSpaceUuids,
-        );
-        const spaceOnly = (ref: {
-            spaceUuid: string;
-        }): DashboardAccessContextForCasl | undefined => {
-            const ctx = spaceContexts[ref.spaceUuid];
-            return ctx ? { ...ctx, directOnly: false } : undefined;
-        };
+        targets: AccessTarget[],
+        { trx }: { trx?: Knex } = {},
+    ): Promise<(AccessContextForCasl | undefined)[]> {
+        return this.resolveAccessTargets(userUuid, targets, {
+            onMismatch: 'fallback',
+            trx,
+        });
+    }
 
-        const resourceUuids = [
-            ...new Set(
-                refs.flatMap((ref) =>
-                    ref.uuid !== null && spaceContexts[ref.spaceUuid]
-                        ? [ref.uuid]
-                        : [],
-                ),
-            ),
-        ];
-        const organizationUuid = refs
-            .map((ref) => spaceContexts[ref.spaceUuid]?.organizationUuid)
-            .find((uuid) => uuid !== undefined);
-        if (
-            resourceUuids.length === 0 ||
-            organizationUuid === undefined ||
-            !(await this.directAccessFeatureGate.isEnabledForUser({
-                userUuid,
-                organizationUuid,
-            }))
-        ) {
-            return refs.map(spaceOnly);
+    private static getDirectGrantTarget(
+        target: AccessTarget,
+    ): DirectGrantTarget | undefined {
+        switch (target.type) {
+            case 'space':
+                return undefined;
+            case 'dashboard':
+                return {
+                    source: 'dashboard',
+                    resourceUuid: target.dashboardUuid,
+                    resourceLabel: 'Dashboard',
+                    spaceUuid: target.spaceUuid,
+                };
+            case 'saved_chart':
+                return {
+                    source: 'saved_chart',
+                    resourceUuid: target.savedChartUuid,
+                    resourceLabel: 'Saved chart',
+                    spaceUuid: target.spaceUuid,
+                };
+            case 'chart':
+                return target.dashboardUuid
+                    ? {
+                          source: 'dashboard',
+                          resourceUuid: target.dashboardUuid,
+                          resourceLabel: 'Dashboard',
+                          spaceUuid: target.spaceUuid,
+                      }
+                    : {
+                          source: 'saved_chart',
+                          resourceUuid: target.chartUuid,
+                          resourceLabel: 'Saved chart',
+                          spaceUuid: target.spaceUuid,
+                      };
+            default:
+                return assertUnreachable(
+                    target,
+                    'Unsupported access target type',
+                );
+        }
+    }
+
+    private getGrantLookup(userUuid: string, source: GrantSource): GrantLookup {
+        switch (source) {
+            case 'dashboard':
+                return (resourceUuids, opts) =>
+                    this.dashboardAccessModel.getUserAccess(
+                        resourceUuids,
+                        userUuid,
+                        opts,
+                    );
+            case 'saved_chart':
+                return (resourceUuids, opts) =>
+                    this.savedChartAccessModel.getUserAccess(
+                        resourceUuids,
+                        userUuid,
+                        opts,
+                    );
+            default:
+                return assertUnreachable(
+                    source,
+                    'Unsupported direct grant source',
+                );
+        }
+    }
+
+    private async resolveAccessTargets(
+        userUuid: string,
+        targets: AccessTarget[],
+        {
+            onMismatch,
+            trx,
+        }: {
+            onMismatch: 'throw' | 'fallback';
+            trx?: Knex;
+        },
+    ): Promise<(AccessContextForCasl | undefined)[]> {
+        if (targets.length === 0) {
+            return [];
         }
 
-        const grants = await lookupGrants(resourceUuids, { organizationUuid });
-        return refs.map((ref) => {
-            const spaceContext = spaceContexts[ref.spaceUuid];
-            if (spaceContext === undefined || ref.uuid === null) {
-                return spaceOnly(ref);
+        const uniqueSpaceUuids = [
+            ...new Set(targets.map((target) => target.spaceUuid)),
+        ];
+        const spaceContexts = await this.getSpacesCaslContext(
+            uniqueSpaceUuids,
+            { userUuid },
+            { trx },
+        );
+        const spaceOnly = (
+            target: AccessTarget,
+        ): AccessContextForCasl | undefined => {
+            const context = spaceContexts[target.spaceUuid];
+            return context ? { ...context, directOnly: false } : undefined;
+        };
+        const grantTargets = targets.flatMap((target) => {
+            const spaceContext = spaceContexts[target.spaceUuid];
+            const grantTarget =
+                SpacePermissionService.getDirectGrantTarget(target);
+            return grantTarget && spaceContext
+                ? [
+                      {
+                          ...grantTarget,
+                          organizationUuid: spaceContext.organizationUuid,
+                      },
+                  ]
+                : [];
+        });
+        if (grantTargets.length === 0) {
+            return targets.map(spaceOnly);
+        }
+
+        const organizationUuids = [
+            ...new Set(grantTargets.map((target) => target.organizationUuid)),
+        ];
+        const directAccessEnabledByOrganization = new Map(
+            await Promise.all(
+                organizationUuids.map(
+                    async (organizationUuid) =>
+                        [
+                            organizationUuid,
+                            await this.directAccessFeatureGate.isEnabledForUser(
+                                {
+                                    userUuid,
+                                    organizationUuid,
+                                },
+                            ),
+                        ] as const,
+                ),
+            ),
+        );
+
+        const grantBatches = new Map<string, Map<GrantSource, Set<string>>>();
+        grantTargets.forEach((target) => {
+            if (
+                !directAccessEnabledByOrganization.get(target.organizationUuid)
+            ) {
+                return;
             }
-            const grant = grants[ref.uuid];
+            const batchesBySource =
+                grantBatches.get(target.organizationUuid) ?? new Map();
+            const resourceUuids =
+                batchesBySource.get(target.source) ?? new Set();
+            resourceUuids.add(target.resourceUuid);
+            batchesBySource.set(target.source, resourceUuids);
+            grantBatches.set(target.organizationUuid, batchesBySource);
+        });
+        if (grantBatches.size === 0) {
+            return targets.map(spaceOnly);
+        }
+
+        const grantResults = await Promise.all(
+            [...grantBatches].flatMap(([organizationUuid, batchesBySource]) =>
+                [...batchesBySource].map(async ([source, resourceUuids]) => ({
+                    organizationUuid,
+                    source,
+                    grants: await this.getGrantLookup(userUuid, source)(
+                        [...resourceUuids],
+                        trx ? { organizationUuid, trx } : { organizationUuid },
+                    ),
+                })),
+            ),
+        );
+        const grantsByOrganization = new Map<
+            string,
+            Map<GrantSource, Record<string, DirectAccess>>
+        >();
+        grantResults.forEach(({ organizationUuid, source, grants }) => {
+            const grantsBySource =
+                grantsByOrganization.get(organizationUuid) ?? new Map();
+            grantsBySource.set(source, grants);
+            grantsByOrganization.set(organizationUuid, grantsBySource);
+        });
+
+        return targets.map((target) => {
+            const spaceContext = spaceContexts[target.spaceUuid];
+            const grantTarget =
+                SpacePermissionService.getDirectGrantTarget(target);
+            if (spaceContext === undefined || grantTarget === undefined) {
+                return spaceOnly(target);
+            }
+            const grant = grantsByOrganization
+                .get(spaceContext.organizationUuid)
+                ?.get(grantTarget.source)?.[grantTarget.resourceUuid];
             if (grant === undefined) {
-                return spaceOnly(ref);
+                return spaceOnly(target);
             }
             const grantRoles = [
                 ...(grant.userRole ? [grant.userRole] : []),
                 ...grant.groupRoles,
             ];
-            if (
-                grantRoles.length === 0 ||
-                grant.spaceUuid !== ref.spaceUuid ||
-                spaceContext.organizationUuid !== organizationUuid
-            ) {
-                return spaceOnly(ref);
+            if (grantRoles.length === 0) {
+                return spaceOnly(target);
+            }
+            const isMismatched = grant.spaceUuid !== target.spaceUuid;
+            if (isMismatched && onMismatch === 'throw') {
+                throw new ParameterError(
+                    `${grantTarget.resourceLabel} ${grantTarget.resourceUuid} does not belong to space ${target.spaceUuid}`,
+                );
+            }
+            if (isMismatched) {
+                return spaceOnly(target);
             }
             return SpacePermissionService.withGrantAccess(
                 spaceContext,
                 userUuid,
                 grantRoles,
-                grantedVia,
+                grantTarget.source,
             );
         });
     }
@@ -502,7 +478,7 @@ export class SpacePermissionService extends BaseService {
         userUuid: string,
         grantRoles: SpaceMemberRole[],
         grantedVia: GrantSource,
-    ): DashboardAccessContextForCasl {
+    ): AccessContextForCasl {
         const hasSpacePath =
             spaceContext.access.some(
                 (access) => access.userUuid === userUuid,
@@ -524,20 +500,6 @@ export class SpacePermissionService extends BaseService {
             ],
             directOnly: !hasSpacePath,
         };
-    }
-
-    /**
-     * Gets the access context for a list of space uuids
-     * @param userUuid - The user uuid to get the access context for
-     * @param spaceUuids - The space uuids to get the access context for
-     * @returns The access context for the given space uuids
-     */
-    async getSpacesAccessContext(
-        userUuid: string,
-        spaceUuids: string[],
-        { trx }: { trx?: Knex } = {},
-    ): Promise<Record<string, SpaceAccessContextForCasl>> {
-        return this.getSpacesCaslContext(spaceUuids, { userUuid }, { trx });
     }
 
     /**

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -45,7 +45,7 @@ describe('SpaceService', () => {
                 {} as OrganizationMemberProfileModel,
             pinnedListModel: {} as PinnedListModel,
             spacePermissionService: {
-                getSpaceAccessContext: mockGetSpaceAccessContext,
+                resolveAccess: mockGetSpaceAccessContext,
             } as unknown as SpacePermissionService,
             savedChartService: {} as SavedChartService,
             dashboardService: {} as DashboardService,
@@ -949,7 +949,7 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
     const mockSpacePermissionService = {
         can: vi.fn(),
         getAccessibleSpaceUuids: vi.fn(),
-        getSpaceAccessContext: vi.fn(),
+        resolveAccess: vi.fn(),
         getAllSpaceAccessContext: vi.fn(),
         mergeAdminAccess: vi.fn(),
         getPaginatedSpaceAccess: vi.fn(),
@@ -991,7 +991,7 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
                 Promise.resolve(uuids),
         );
         // Default: user has direct access (so auto-add doesn't fire)
-        mockSpacePermissionService.getSpaceAccessContext.mockResolvedValue({
+        mockSpacePermissionService.resolveAccess.mockResolvedValue({
             organizationUuid: 'org-uuid',
             projectUuid: 'project-uuid',
             inheritsFromOrgOrProject: true,
@@ -1339,7 +1339,7 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
         mockSpaceModel.isRootSpace.mockResolvedValue(true);
 
         // User has EDITOR access inherited from project (no direct access)
-        mockSpacePermissionService.getSpaceAccessContext.mockResolvedValue({
+        mockSpacePermissionService.resolveAccess.mockResolvedValue({
             organizationUuid: 'org-uuid',
             projectUuid: 'project-uuid',
             inheritsFromOrgOrProject: true,
@@ -1387,7 +1387,7 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
         mockSpaceModel.isRootSpace.mockResolvedValue(true);
 
         // User has EDITOR access inherited (not direct) on the target space
-        mockSpacePermissionService.getSpaceAccessContext.mockResolvedValue({
+        mockSpacePermissionService.resolveAccess.mockResolvedValue({
             organizationUuid: 'org-uuid',
             projectUuid: 'project-uuid',
             inheritsFromOrgOrProject: true,
@@ -1445,7 +1445,7 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
         mockSpaceModel.isRootSpace.mockResolvedValue(true);
 
         // User already has direct access
-        mockSpacePermissionService.getSpaceAccessContext.mockResolvedValue({
+        mockSpacePermissionService.resolveAccess.mockResolvedValue({
             organizationUuid: 'org-uuid',
             projectUuid: 'project-uuid',
             inheritsFromOrgOrProject: true,
@@ -1494,16 +1494,14 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
         );
 
         // turnInheritOff is false (going public), so no copy or auto-add
-        expect(
-            mockSpacePermissionService.getSpaceAccessContext,
-        ).toHaveBeenCalledOnce();
+        expect(mockSpacePermissionService.resolveAccess).toHaveBeenCalledOnce();
         expect(
             mockSpaceModel.updateWithCopiedPermissions,
         ).not.toHaveBeenCalled();
     });
 
     test('getSpace returns only the requesting org admin when the resolver omits them', async () => {
-        mockSpacePermissionService.getSpaceAccessContext.mockResolvedValue({
+        mockSpacePermissionService.resolveAccess.mockResolvedValue({
             organizationUuid: 'org-uuid',
             projectUuid: 'project-uuid',
             inheritsFromOrgOrProject: false,
@@ -1534,9 +1532,13 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
             'space-uuid',
         );
 
-        expect(
-            mockSpacePermissionService.getSpaceAccessContext,
-        ).toHaveBeenCalledWith(mockUser.userUuid, 'space-uuid');
+        expect(mockSpacePermissionService.resolveAccess).toHaveBeenCalledWith(
+            mockUser.userUuid,
+            {
+                type: 'space',
+                spaceUuid: 'space-uuid',
+            },
+        );
         expect(
             mockSpacePermissionService.getAllSpaceAccessContext,
         ).not.toHaveBeenCalled();
@@ -1561,7 +1563,7 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
             inheritedRole: undefined,
             inheritedFrom: undefined,
         };
-        mockSpacePermissionService.getSpaceAccessContext.mockResolvedValue({
+        mockSpacePermissionService.resolveAccess.mockResolvedValue({
             organizationUuid: 'org-uuid',
             projectUuid: 'project-uuid',
             inheritsFromOrgOrProject: false,
@@ -1604,7 +1606,7 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
             inheritedRole: OrganizationMemberRole.ADMIN,
             inheritedFrom: 'organization' as const,
         };
-        mockSpacePermissionService.getSpaceAccessContext.mockResolvedValue({
+        mockSpacePermissionService.resolveAccess.mockResolvedValue({
             organizationUuid: 'org-uuid',
             projectUuid: 'project-uuid',
             inheritsFromOrgOrProject: true,

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -128,11 +128,10 @@ export class SpaceService
         space: Pick<SpaceSummary, 'uuid'>,
         action: AbilityAction,
     ): Promise<boolean> {
-        const spaceCtx =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                space.uuid,
-            );
+        const spaceCtx = await this.spacePermissionService.resolveAccess(
+            user.userUuid,
+            { type: 'space', spaceUuid: space.uuid },
+        );
         // eslint-disable-next-line lightdash/no-direct-ability-check -- test-only method exercises raw CASL abilities
         return user.ability.can(action, subject(contentType, spaceCtx));
     }
@@ -147,10 +146,10 @@ export class SpaceService
     ): Promise<Space> {
         const space = await this.spaceModel.get(spaceUuid);
         const [ctx, groupsAccess, rawBreadcrumbs] = await Promise.all([
-            this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
+            this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'space',
                 spaceUuid,
-            ),
+            }),
             this.spacePermissionService.getGroupAccess(spaceUuid),
             this.spaceModel.getSpaceBreadcrumbs(spaceUuid, space.projectUuid),
         ]);
@@ -416,9 +415,9 @@ export class SpaceService
             inheritParentPermissions === false;
 
         if (turnInheritOff) {
-            const ctx = await this.spacePermissionService.getSpaceAccessContext(
+            const ctx = await this.spacePermissionService.resolveAccess(
                 user.userUuid,
-                spaceUuid,
+                { type: 'space', spaceUuid },
             );
             const userAccess = ctx.access.find(
                 (a) => a.userUuid === user.userUuid,

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -970,10 +970,11 @@ export class UnfurlService extends BaseService {
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'dashboard',
+                dashboardUuid: dashboard.uuid,
+                spaceUuid: dashboard.spaceUuid,
+            });
 
         validateSelectedTabs(selectedTabs, dashboard.tiles);
 
@@ -1069,14 +1070,12 @@ export class UnfurlService extends BaseService {
             projectUuid ? { projectUuid } : undefined,
         );
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getChartAccessContext(
-                user.userUuid,
-                {
-                    uuid: chart.uuid,
-                    dashboardUuid: chart.dashboardUuid,
-                    spaceUuid: chart.spaceUuid,
-                },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'chart',
+                chartUuid: chart.uuid,
+                dashboardUuid: chart.dashboardUuid,
+                spaceUuid: chart.spaceUuid,
+            });
 
         const auditedAbility = this.createAuditedAbility(user);
         if (

--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -103,16 +103,15 @@ const spaceModel = {
     find: vi.fn(async () => []),
 };
 const spacePermissionService = {
-    getSpaceAccessContext: vi.fn(async () => ({
+    resolveAccess: vi.fn(async () => ({
+        organizationUuid: 'orgUuid',
+        projectUuid: 'projectUuid',
         inheritsFromOrgOrProject: false,
         access: [],
-    })),
-    getDashboardAccessContext: vi.fn(async () => ({
-        inheritsFromOrgOrProject: false,
-        access: [],
+        admins: [],
         directOnly: false,
     })),
-    getSpacesAccessContext: vi.fn(async () => ({})),
+    resolveAccessBatch: vi.fn(async () => []),
     getAccessibleSpaceUuids: vi.fn(async () => []),
 };
 describe('validation', () => {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -1449,13 +1449,22 @@ export class ValidationService extends BaseService {
                 ),
             ),
         ];
-        const spaceAccessContexts =
+        const resolvedSpaceAccessContexts =
             appSpaceUuids.length > 0
-                ? await this.spacePermissionService.getSpacesAccessContext(
+                ? await this.spacePermissionService.resolveAccessBatch(
                       user.userUuid,
-                      appSpaceUuids,
+                      appSpaceUuids.map((spaceUuid) => ({
+                          type: 'space' as const,
+                          spaceUuid,
+                      })),
                   )
-                : {};
+                : [];
+        const spaceAccessContexts = Object.fromEntries(
+            appSpaceUuids.map((spaceUuid, index) => [
+                spaceUuid,
+                resolvedSpaceAccessContexts[index],
+            ]),
+        );
 
         return apps
             .filter((app) => {
@@ -2001,10 +2010,10 @@ export class ValidationService extends BaseService {
 
         // Check user permissions
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                chart.spaceUuid,
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'space',
+                spaceUuid: chart.spaceUuid,
+            });
 
         if (
             auditedAbility.cannot(
@@ -2096,10 +2105,11 @@ export class ValidationService extends BaseService {
 
         // Check user permissions
         const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getDashboardAccessContext(
-                user.userUuid,
-                { uuid: dashboard.uuid, spaceUuid: dashboard.spaceUuid },
-            );
+            await this.spacePermissionService.resolveAccess(user.userUuid, {
+                type: 'dashboard',
+                dashboardUuid: dashboard.uuid,
+                spaceUuid: dashboard.spaceUuid,
+            });
 
         if (
             auditedAbility.cannot(


### PR DESCRIPTION
## Summary

PR 4 of 5 for [SPK-1417](https://linear.app/lightdash/issue/SPK-1417). Consolidates user-scoped space, dashboard, and ownership-aware chart access-context construction behind `resolveAccess` and `resolveAccessBatch`.

Stacks on top of PR 3 ([#28145](https://github.com/lightdash/lightdash/pull/28145), open), which adds saved-chart grant management and hardens dashboard-owned chart mutations.

Closes: https://linear.app/lightdash/issue/SPK-1417

## Changes

**Backend**

- Replaces the eight singular/plural `get*AccessContext` methods with two public methods: `resolveAccess` and `resolveAccessBatch`.
- Adds an exhaustive `AccessTarget` union with resource-specific identifiers for `space`, `dashboard`, and ownership-aware `chart` targets.
- Keeps space permissions as the common baseline, then overlays the applicable dashboard or saved-chart direct grants into one `AccessContextForCasl`.
- Routes dashboard-owned charts only through their owning dashboard policy; space-saved charts route through their own policy.
- Keeps `saved_chart` as an internal grant source rather than exposing a second public target for charts.
- Makes boundary-crossing operations explicit by resolving a `space` target, so content grants cannot authorize moves or copies outside their scope.
- Partitions batches by organization and grant source, forwards transactions to every read, and short-circuits empty batches.
- Migrates all backend callers, mocks, and the local permission guide; no REST, database, or frontend changes.

## Resolver semantics

```text
AccessTarget
    │
    ▼
space permission baseline (one batched resolution)
    │
    ├── space ────────────────────────────────┐
    │                                         │
    └── content target                        │
            │                                 │
            ▼                                 │
        feature gate per organization         │
            │                                 │
            ▼                                 │
        direct grants per source              │
        (dashboard | saved_chart)              │
            │                                 │
            └──────────────┬──────────────────┘
                           ▼
                 AccessContextForCasl
```

- `space` → space baseline only.
- `dashboard` → space baseline plus that dashboard's grants.
- `chart` → owning dashboard grants when `dashboardUuid` is set; otherwise the chart's own saved-chart grants.

For the common single-organization batch, the resolver performs one space-context resolution, one feature check, and at most one grant query per represented source. With direct access disabled, it performs no grant queries; ordinary space targets skip the feature check too.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint`
- [x] Backend format check
- [x] `SpacePermissionService.test.ts` (46 passed)
- [x] Full backend suite (8,077 passed, 1 skipped)
- [x] Five-lens review: correctness, security/tenant boundaries, call-site regression, performance, and maintainability/test adequacy

🤖 Generated with Codex
