### PR TITLE
fix: write Google Sheets dates as native values

### DIFF
--- a/packages/backend/src/clients/Google/GoogleDriveClient.test.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.test.ts
@@ -2,6 +2,8 @@ import {
     DimensionType,
     FieldType,
     GoogleSheetsQuotaError,
+    TimeFrames,
+    type Dimension,
 } from '@lightdash/common';
 import { google } from 'googleapis';
 import { GoogleDriveClient } from './GoogleDriveClient';
@@ -172,6 +174,7 @@ describe('GoogleDriveClient', () => {
                 'file-id',
                 [['Total revenue'], [120]],
                 undefined,
+                [],
             );
         });
 
@@ -227,6 +230,7 @@ describe('GoogleDriveClient', () => {
                     [120],
                 ],
                 undefined,
+                [],
             );
         });
 
@@ -265,7 +269,141 @@ describe('GoogleDriveClient', () => {
                 'file-id',
                 [['Active filters'], ['No active filters applied'], [], []],
                 undefined,
+                [],
             );
+        });
+
+        test('should write supported date dimensions as native Google Sheets values', async () => {
+            vi.mocked(google.auth.fromJSON).mockReturnValue({} as never);
+            vi.mocked(google.auth.GoogleAuth).mockImplementation(
+                function MockGoogleAuth(this: object) {
+                    return this;
+                } as never,
+            );
+            const get = vi.fn().mockResolvedValue({
+                data: {
+                    sheets: [{ properties: { sheetId: 123, title: 'Sheet1' } }],
+                },
+            });
+            const clear = vi.fn().mockResolvedValue({});
+            const update = vi.fn().mockResolvedValue({});
+            const batchUpdate = vi.fn().mockResolvedValue({});
+            vi.mocked(google.sheets).mockReturnValue({
+                spreadsheets: {
+                    get,
+                    batchUpdate,
+                    values: { clear, update },
+                },
+            } as never);
+
+            const client = new GoogleDriveClient({
+                lightdashConfig: {
+                    auth: {
+                        google: {
+                            oauth2ClientId: 'client-id',
+                            oauth2ClientSecret: 'client-secret',
+                        },
+                    },
+                },
+            } as never);
+
+            await client.appendToSheet(
+                'refresh-token',
+                'file-id',
+                [
+                    {
+                        orders_order_date: '2023-03-15',
+                        orders_order_quarter: '2023-01-01',
+                        orders_total_revenue: 120,
+                    },
+                    {
+                        orders_order_date: null,
+                        orders_order_quarter: '2023-04-01',
+                        orders_total_revenue: 80,
+                    },
+                ],
+                {
+                    orders_order_date: {
+                        name: 'order_date',
+                        label: 'Order date',
+                        type: DimensionType.DATE,
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        fieldType: FieldType.DIMENSION,
+                        timeInterval: TimeFrames.DAY,
+                        sql: '${TABLE}.order_date',
+                        hidden: false,
+                    } as Dimension,
+                    orders_order_quarter: {
+                        name: 'order_quarter',
+                        label: 'Order quarter',
+                        type: DimensionType.DATE,
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        fieldType: FieldType.DIMENSION,
+                        timeInterval: TimeFrames.QUARTER,
+                        sql: '${TABLE}.order_date',
+                        hidden: false,
+                    } as Dimension,
+                    orders_total_revenue: {
+                        name: 'total_revenue',
+                        label: 'Total revenue',
+                        type: DimensionType.NUMBER,
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        fieldType: FieldType.DIMENSION,
+                        sql: '${TABLE}.total_revenue',
+                        hidden: false,
+                    },
+                },
+                false,
+                undefined,
+                [
+                    'orders_order_date',
+                    'orders_order_quarter',
+                    'orders_total_revenue',
+                ],
+            );
+
+            expect(update).toHaveBeenCalledWith({
+                spreadsheetId: 'file-id',
+                range: 'A1',
+                valueInputOption: 'RAW',
+                requestBody: {
+                    values: [
+                        ['Order date', 'Order quarter', 'Total revenue'],
+                        [45000, '2023-Q1', 120],
+                        ['NaT', '2023-Q2', 80],
+                    ],
+                },
+            });
+            expect(batchUpdate).toHaveBeenCalledWith({
+                spreadsheetId: 'file-id',
+                requestBody: {
+                    requests: [
+                        {
+                            repeatCell: {
+                                range: {
+                                    sheetId: 123,
+                                    startRowIndex: 1,
+                                    endRowIndex: 3,
+                                    startColumnIndex: 0,
+                                    endColumnIndex: 1,
+                                },
+                                cell: {
+                                    userEnteredFormat: {
+                                        numberFormat: {
+                                            type: 'DATE',
+                                            pattern: 'yyyy-mm-dd',
+                                        },
+                                    },
+                                },
+                                fields: 'userEnteredFormat.numberFormat',
+                            },
+                        },
+                    ],
+                },
+            });
         });
     });
 

--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -17,10 +17,14 @@ import {
     NotFoundError,
     shouldShiftItemTimezone,
     TableCalculation,
+    TimeFrames,
+    timeIntervalToExcelNumFmt,
+    toExcelWallClockDate,
     toIsoWithProjectOffset,
     UnexpectedGoogleSheetsError,
 } from '@lightdash/common';
 import { google, sheets_v4 } from 'googleapis';
+import moment from 'moment';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { processFieldsForExport } from '../../utils/FileDownloadUtils/FileDownloadUtils';
@@ -29,10 +33,29 @@ type GoogleDriveClientArguments = {
     lightdashConfig: LightdashConfig;
 };
 
+type NativeDateColumn = {
+    columnIndex: number;
+    numberFormat: {
+        type: 'DATE' | 'DATE_TIME';
+        pattern: string;
+    };
+    rowCount: number;
+    startRow: number;
+};
+
 // Google Sheets has a 50,000 character limit per cell
 const GOOGLE_SHEETS_CELL_CHAR_LIMIT = 50000;
 const TRUNCATION_SUFFIX = '... [TRUNCATED]';
 const TRUNCATE_INDEX = GOOGLE_SHEETS_CELL_CHAR_LIMIT - TRUNCATION_SUFFIX.length;
+const GOOGLE_SHEETS_EPOCH_MS = Date.UTC(1899, 11, 30);
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const DATE_TIME_FRAMES = new Set<TimeFrames>([
+    TimeFrames.HOUR,
+    TimeFrames.MINUTE,
+    TimeFrames.SECOND,
+    TimeFrames.MILLISECOND,
+]);
 
 const columnNumberToA1 = (columnCount: number): string => {
     let value = columnCount;
@@ -43,6 +66,26 @@ const columnNumberToA1 = (columnCount: number): string => {
         value = Math.floor(value / 26);
     }
     return result || 'A';
+};
+
+const toGoogleSheetsDateSerial = (
+    value: unknown,
+    shouldShift: boolean,
+    timezone?: string,
+): number | undefined => {
+    if (value === null || value === undefined || value === '') {
+        return undefined;
+    }
+
+    const date =
+        shouldShift && timezone && timezone !== 'UTC'
+            ? toExcelWallClockDate(value, timezone)
+            : moment.utc(value).toDate();
+    if (Number.isNaN(date.getTime())) {
+        return undefined;
+    }
+
+    return (date.getTime() - GOOGLE_SHEETS_EPOCH_MS) / MILLISECONDS_PER_DAY;
 };
 
 export class GoogleDriveClient {
@@ -419,6 +462,32 @@ export class GoogleDriveClient {
         }
     }
 
+    private static async getSheetId(
+        sheets: sheets_v4.Sheets,
+        fileId: string,
+        tabName?: string,
+    ): Promise<number> {
+        const spreadsheet = await GoogleDriveClient.catchApiError(
+            sheets.spreadsheets.get({
+                spreadsheetId: fileId,
+                fields: 'sheets(properties(sheetId,title))',
+            }),
+        );
+        const sheet = tabName
+            ? spreadsheet.data.sheets?.find(
+                  ({ properties }) => properties?.title === tabName,
+              )
+            : spreadsheet.data.sheets?.[0];
+        const sheetId = sheet?.properties?.sheetId;
+        if (sheetId === null || sheetId === undefined) {
+            throw new UnexpectedGoogleSheetsError(
+                `Unable to find Google Sheet tab${tabName ? `: ${tabName}` : ''}`,
+            );
+        }
+
+        return sheetId;
+    }
+
     static formatCell(
         value: AnyType,
         item?: Field | TableCalculation | CustomDimension | Metric,
@@ -539,20 +608,75 @@ export class GoogleDriveClient {
             },
         );
 
+        const nativeDateFormats = new Map<
+            number,
+            NativeDateColumn['numberFormat']
+        >();
+        sortedFieldIds.forEach((fieldId, columnIndex) => {
+            const item = itemMap[fieldId];
+            if (
+                !isField(item) ||
+                !isDimension(item) ||
+                item.type !== DimensionType.DATE
+            ) {
+                return;
+            }
+
+            const pattern = timeIntervalToExcelNumFmt(
+                item.timeInterval,
+                item.type,
+            );
+            if (!pattern) return;
+
+            nativeDateFormats.set(columnIndex, {
+                type:
+                    item.timeInterval && DATE_TIME_FRAMES.has(item.timeInterval)
+                        ? 'DATE_TIME'
+                        : 'DATE',
+                pattern,
+            });
+        });
+
         const values = csvContent.map((row) =>
-            sortedFieldIds.map((fieldId) => {
+            sortedFieldIds.map((fieldId, columnIndex) => {
                 const item = itemMap[fieldId];
+                const numberFormat = nativeDateFormats.get(columnIndex);
+                if (numberFormat && isField(item)) {
+                    const serialValue = toGoogleSheetsDateSerial(
+                        row[fieldId],
+                        shouldShiftItemTimezone(item),
+                        timezone,
+                    );
+                    if (serialValue !== undefined) return serialValue;
+                }
+
                 // Google sheet doesn't like arrays as values, so we need to convert them to strings
-                const value = row[fieldId];
-                return GoogleDriveClient.formatCell(value, item, timezone);
+                return GoogleDriveClient.formatCell(
+                    row[fieldId],
+                    item,
+                    timezone,
+                );
             }),
         );
+
+        const nativeDateColumns: NativeDateColumn[] =
+            csvContent.length === 0
+                ? []
+                : [...nativeDateFormats.entries()].map(
+                      ([columnIndex, numberFormat]) => ({
+                          columnIndex,
+                          numberFormat,
+                          rowCount: csvContent.length,
+                          startRow: headerRows.length + 2,
+                      }),
+                  );
 
         await this.appendCsvToSheet(
             refreshToken,
             fileId,
             [...headerRows, csvHeader, ...values],
             tabName,
+            nativeDateColumns,
         );
     }
 
@@ -560,8 +684,9 @@ export class GoogleDriveClient {
         refreshToken: string,
         fileId: string,
 
-        results: string[][],
+        results: AnyType[][],
         tabName?: string,
+        nativeDateColumns: NativeDateColumn[] = [],
     ) {
         if (!this.isEnabled) {
             throw new MissingConfigError('Google Drive is not enabled');
@@ -604,5 +729,42 @@ export class GoogleDriveClient {
                 },
             }),
         );
+
+        if (nativeDateColumns.length > 0) {
+            const sheetId = await GoogleDriveClient.getSheetId(
+                sheets,
+                fileId,
+                sanitizedTabName,
+            );
+            const requests = nativeDateColumns.map(
+                ({ columnIndex, numberFormat, rowCount, startRow }) => ({
+                    repeatCell: {
+                        range: {
+                            sheetId,
+                            startRowIndex: startRow - 1,
+                            endRowIndex: startRow - 1 + rowCount,
+                            startColumnIndex: columnIndex,
+                            endColumnIndex: columnIndex + 1,
+                        },
+                        cell: {
+                            userEnteredFormat: { numberFormat },
+                        },
+                        fields: 'userEnteredFormat.numberFormat',
+                    },
+                }),
+            );
+
+            // The full-table RAW write above already contains explicit date
+            // serials. Apply one compact format per date column so behavior is
+            // independent of Sheet locale without repeating format data per cell.
+            await GoogleDriveClient.catchApiError(
+                sheets.spreadsheets.batchUpdate({
+                    spreadsheetId: fileId,
+                    requestBody: {
+                        requests,
+                    },
+                }),
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-10638/google-sheets-sync-writes-date-dimension-column-as-text-instead-of-a

### Description:

- write supported date dimensions as native Google Sheets serial values in the existing `RAW` data upload
- apply explicit `DATE` or `DATE_TIME` formats with one compact `repeatCell` request per date column
- preserve unsupported granularities such as quarter and week as text, without changing non-date columns

### Validation:

- `pnpm -F backend exec vitest run src/clients/Google/GoogleDriveClient.test.ts --config vitest.config.ts`
- `pnpm -F backend typecheck`
- focused `oxlint` and `oxfmt --check`
- `git diff --check origin/main...HEAD`
- reproduced on localhost before the fix with a leading apostrophe in the date cell
- reran the scheduled Google Sheets sync after the fix and confirmed `=ISNUMBER(A2)` returns `TRUE`

### Risk assessment:

- [ ] This is a high-risk change
