### PR TITLE
feat(ai): readContent reads data apps without source

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -485,6 +485,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     builtInSkills: BuiltInSkills,
                     lightdashConfig: context.lightdashConfig,
                     appModel: models.getAppModel(),
+                    appGenerateService:
+                        repository.getAppGenerateService<AppGenerateService>(),
+                    schedulerService: repository.getSchedulerService(),
                     projectModel: models.getProjectModel(),
                     projectParametersModel: models.getProjectParametersModel(),
                     projectService: repository.getProjectService(),

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -108,6 +108,9 @@ const makeService = ({
     querySourceService = {},
     contentService = {},
     searchService = {},
+    appModel = {},
+    appGenerateService = {},
+    schedulerService = {},
 }: {
     explores?: Record<string, Explore>;
     userAttributes?: Record<string, string[]>;
@@ -131,6 +134,9 @@ const makeService = ({
     querySourceService?: Record<string, unknown>;
     contentService?: Record<string, unknown>;
     searchService?: Record<string, unknown>;
+    appModel?: Record<string, unknown>;
+    appGenerateService?: Record<string, unknown>;
+    schedulerService?: Record<string, unknown>;
 } = {}) =>
     new AiAgentToolsService({
         builtInSkills: {
@@ -200,6 +206,9 @@ const makeService = ({
         shareService: {},
         asyncQueryService,
         querySourceService,
+        appModel,
+        appGenerateService,
+        schedulerService,
     } as unknown as ConstructorParameters<typeof AiAgentToolsService>[0]);
 
 function makeRuntimeContext(
@@ -1502,6 +1511,241 @@ describe('AiAgentToolsService', () => {
             runtime.readContent({ slug: 'test-dashboard', type: 'dashboard' }),
         ).rejects.toThrow(NotFoundError);
         expect(dashboardService.getByIdOrSlug).not.toHaveBeenCalled();
+    });
+
+    describe('readContent data_app', () => {
+        const makeAppRow = (overrides: Record<string, unknown> = {}) => ({
+            app_id: 'app-uuid',
+            slug: 'revenue-app',
+            name: 'Revenue app',
+            template: 'dashboard',
+            space_uuid: 'allowed-space-uuid',
+            created_by_user_uuid: userUuid,
+            ...overrides,
+        });
+
+        const makeReadSource = (overrides: Record<string, unknown> = {}) => ({
+            app: {
+                uuid: 'app-uuid',
+                slug: 'revenue-app',
+                name: 'Revenue app',
+                description: 'Revenue by region',
+                template: 'dashboard',
+                space: { uuid: 'allowed-space-uuid', name: 'Finance' },
+                views: 3,
+                createdByUserUuid: userUuid,
+                upstreamAppUuid: null,
+            },
+            latestVersion: {
+                version: 1,
+                status: 'ready',
+                statusMessage: null,
+                error: null,
+            },
+            latestReadyVersion: {
+                version: 1,
+                resources: {
+                    images: [],
+                    charts: [],
+                    dashboardName: null,
+                    clarifications: [],
+                },
+            },
+            dataReferences: null,
+            externalConnections: [],
+            ...overrides,
+        });
+
+        const makeDataAppService = ({
+            app = makeAppRow(),
+            source = makeReadSource(),
+            getDataAppReadSource = vi.fn().mockResolvedValue(source),
+            getAppSchedulers = vi
+                .fn()
+                .mockResolvedValue([
+                    { schedulerUuid: 'sched-1', name: 'Weekly' },
+                ]),
+        }: {
+            app?: ReturnType<typeof makeAppRow> | null;
+            source?: ReturnType<typeof makeReadSource>;
+            getDataAppReadSource?: import('vitest').Mock;
+            getAppSchedulers?: import('vitest').Mock;
+        } = {}) => {
+            const service = makeService({
+                appModel: {
+                    findAppByUuidOrSlug: vi.fn().mockResolvedValue(app),
+                    listDashboardsContainingApp: vi.fn().mockResolvedValue([
+                        {
+                            uuid: 'dash-1',
+                            name: 'Finance overview',
+                            spaceUuid: 'allowed-space-uuid',
+                        },
+                        {
+                            uuid: 'dash-2',
+                            name: 'Hidden',
+                            spaceUuid: 'hidden-space-uuid',
+                        },
+                    ]),
+                },
+                appGenerateService: { getDataAppReadSource },
+                schedulerService: { getAppSchedulers },
+                projectSpaces: [
+                    { uuid: 'allowed-space-uuid', path: 'finance' },
+                ],
+            });
+            return { service, getDataAppReadSource };
+        };
+
+        it('reads a viewable data app with href and chip metadata', async () => {
+            const { service } = makeDataAppService();
+            const runtime = service.createRuntime(makeRuntimeContext());
+
+            const result = await runtime.readContent({
+                slug: 'revenue-app',
+                type: 'data_app',
+            });
+
+            expect(result.type).toBe('data_app');
+            if (result.type !== 'data_app') throw new Error('unreachable');
+            expect(result.href).toBe(
+                `/projects/${projectUuid}/apps/app-uuid/view`,
+            );
+            expect(result.content.identity).toMatchObject({
+                slug: 'revenue-app',
+                name: 'Revenue app',
+                href: result.href,
+            });
+            expect(result.content.status.latestReadyVersion).toBe(1);
+            expect(result.content.usage).toEqual({
+                dashboards: [
+                    {
+                        uuid: 'dash-1',
+                        name: 'Finance overview',
+                        href: `/projects/${projectUuid}/dashboards/dash-1/view#dashboard-link`,
+                    },
+                ],
+                schedulers: [{ uuid: 'sched-1', name: 'Weekly' }],
+                upstreamAppUuid: null,
+            });
+        });
+
+        it('reads without schedulers when the user cannot list deliveries', async () => {
+            const { service } = makeDataAppService({
+                getAppSchedulers: vi
+                    .fn()
+                    .mockRejectedValue(new ForbiddenError()),
+            });
+            const runtime = service.createRuntime(makeRuntimeContext());
+
+            const result = await runtime.readContent({
+                slug: 'revenue-app',
+                type: 'data_app',
+            });
+
+            if (result.type !== 'data_app') throw new Error('unreachable');
+            expect(result.content.usage.schedulers).toEqual([]);
+        });
+
+        it('does not read data apps outside the scoped agent spaces', async () => {
+            const { service, getDataAppReadSource } = makeDataAppService({
+                app: makeAppRow({ space_uuid: 'blocked-space-uuid' }),
+            });
+            const runtime = service.createRuntime(
+                makeRuntimeContext({ spaceAccess: ['allowed-space-uuid'] }),
+            );
+
+            await expect(
+                runtime.readContent({ slug: 'revenue-app', type: 'data_app' }),
+            ).rejects.toThrow(NotFoundError);
+            expect(getDataAppReadSource).not.toHaveBeenCalled();
+        });
+
+        it('does not read personal data apps through a space-scoped agent', async () => {
+            const { service, getDataAppReadSource } = makeDataAppService({
+                app: makeAppRow({ space_uuid: null }),
+            });
+            const runtime = service.createRuntime(
+                makeRuntimeContext({ spaceAccess: ['allowed-space-uuid'] }),
+            );
+
+            await expect(
+                runtime.readContent({ slug: 'revenue-app', type: 'data_app' }),
+            ).rejects.toThrow(NotFoundError);
+            expect(getDataAppReadSource).not.toHaveBeenCalled();
+        });
+
+        it("reads another user's personal data app as not found", async () => {
+            const { service } = makeDataAppService({
+                app: makeAppRow({
+                    space_uuid: null,
+                    created_by_user_uuid: 'someone-else',
+                }),
+                getDataAppReadSource: vi
+                    .fn()
+                    .mockRejectedValue(
+                        new NotFoundError('App not found: app-uuid'),
+                    ),
+            });
+            const runtime = service.createRuntime(makeRuntimeContext());
+
+            await expect(
+                runtime.readContent({ slug: 'revenue-app', type: 'data_app' }),
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('reads an app with no ready version as identity and status only', async () => {
+            const { service } = makeDataAppService({
+                source: makeReadSource({
+                    latestVersion: {
+                        version: 2,
+                        status: 'building',
+                        statusMessage: 'Compiling',
+                        error: null,
+                    },
+                    latestReadyVersion: null,
+                }),
+            });
+            const runtime = service.createRuntime(makeRuntimeContext());
+
+            const result = await runtime.readContent({
+                slug: 'revenue-app',
+                type: 'data_app',
+            });
+
+            if (result.type !== 'data_app') throw new Error('unreachable');
+            expect(result.content.status).toEqual({
+                latestVersion: {
+                    version: 2,
+                    status: 'building',
+                    statusMessage: 'Compiling',
+                    error: null,
+                },
+                latestReadyVersion: null,
+            });
+            expect(result.content.inputs).toBeNull();
+            expect(result.content.data).toBeNull();
+        });
+
+        it('does not read data app vizzes as data apps', async () => {
+            const { service, getDataAppReadSource } = makeDataAppService({
+                app: makeAppRow({ template: 'data_app_viz' }),
+            });
+            const runtime = service.createRuntime(makeRuntimeContext());
+
+            await expect(
+                runtime.readContent({ slug: 'revenue-app', type: 'data_app' }),
+            ).rejects.toThrow(NotFoundError);
+            expect(getDataAppReadSource).not.toHaveBeenCalled();
+        });
+
+        it('reads an unknown slug as not found', async () => {
+            const { service } = makeDataAppService({ app: null });
+            const runtime = service.createRuntime(makeRuntimeContext());
+
+            await expect(
+                runtime.readContent({ slug: 'missing', type: 'data_app' }),
+            ).rejects.toThrow(NotFoundError);
+        });
     });
 
     it('does not fetch dashboard charts outside the scoped agent spaces', async () => {

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -3,9 +3,11 @@ import {
     Account,
     AnyType,
     assertUnreachable,
+    buildDataAppRead,
     CatalogFilter,
     CatalogType,
     ContentType,
+    DATA_APP_VIZ_TEMPLATE,
     dataAppVizSchema,
     DimensionType,
     Explore,
@@ -41,6 +43,8 @@ import {
     type ChartAsCode,
     type CustomChartType,
     type DashboardAsCode,
+    type DataAppRead,
+    type DataAppReadUsage,
     type DataAppVizSchema,
     type FieldValueSearchResult,
     type ParameterDefinitions,
@@ -70,6 +74,7 @@ import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagSer
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
 import { QuerySourceService } from '../../../services/QuerySourceService/QuerySourceService';
 import { SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
+import { SchedulerService } from '../../../services/SchedulerService/SchedulerService';
 import { SearchService } from '../../../services/SearchService/SearchService';
 import { ShareService } from '../../../services/ShareService/ShareService';
 import { SpaceService } from '../../../services/SpaceService/SpaceService';
@@ -112,6 +117,7 @@ import {
     ListProjectsFn,
     ListWarehouseTablesFn,
     LoadAgentSkillFn,
+    ReadContentAsCodeResult,
     ReadContentFn,
     ResolveCustomChartTypeFn,
     ResolveUrlFn,
@@ -140,13 +146,14 @@ import {
     formatSqlScopeError,
     formatWarehouseTableScopeError,
 } from '../ai/utils/sqlScope';
+import type { AppGenerateService } from '../AppGenerateService/AppGenerateService';
 import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewDeploySetupService';
 import type { SchedulerAiAugmentationService } from '../SchedulerAiAugmentationService/SchedulerAiAugmentationService';
 
 type AgentListContentResult = Awaited<ReturnType<ListContentFn>>;
 type AgentListContentItem = AgentListContentResult['items'][number];
 type ProjectSpace = Awaited<ReturnType<ProjectService['getSpaces']>>[number];
-type ContentAsCodeType = Parameters<ReadContentFn>[0]['type'];
+type ContentAsCodeType = ReadContentAsCodeResult['type'];
 type SearchContentResult = Awaited<
     ReturnType<SearchService['findContent']>
 >['content'][number];
@@ -283,6 +290,8 @@ type BuiltInSkillsClient = Pick<
 type AiAgentToolsServiceDependencies = {
     builtInSkills: BuiltInSkillsClient;
     appModel: AppModel;
+    appGenerateService: AppGenerateService;
+    schedulerService: SchedulerService;
     projectModel: ProjectModel;
     projectParametersModel: ProjectParametersModel;
     projectService: ProjectService;
@@ -321,6 +330,10 @@ type AiAgentToolsServiceDependencies = {
 
 export class AiAgentToolsService extends BaseService {
     private readonly appModel: AppModel;
+
+    private readonly appGenerateService: AppGenerateService;
+
+    private readonly schedulerService: SchedulerService;
 
     private readonly projectModel: ProjectModel;
 
@@ -414,6 +427,8 @@ export class AiAgentToolsService extends BaseService {
     constructor({
         builtInSkills,
         appModel,
+        appGenerateService,
+        schedulerService,
         projectModel,
         projectParametersModel,
         projectService,
@@ -446,6 +461,8 @@ export class AiAgentToolsService extends BaseService {
         super();
         this.builtInSkills = builtInSkills;
         this.appModel = appModel;
+        this.appGenerateService = appGenerateService;
+        this.schedulerService = schedulerService;
         this.projectModel = projectModel;
         this.projectParametersModel = projectParametersModel;
         this.projectService = projectService;
@@ -1583,77 +1600,180 @@ export class AiAgentToolsService extends BaseService {
             { slug, type },
             async () => {
                 switch (type) {
-                    case 'dashboard': {
-                        const { dashboards } =
-                            await this.coderService.getDashboards(
-                                context.user,
-                                context.projectUuid,
-                                [slug],
-                            );
-                        const dashboard = dashboards[0];
-                        if (!dashboard) {
-                            throw new NotFoundError(
-                                `Dashboard "${slug}" was not found`,
-                            );
-                        }
-                        await this.assertContentSpaceInScope(
-                            context,
-                            dashboard.spaceSlug,
-                            `Dashboard "${slug}" was not found`,
-                        );
-                        const savedDashboard =
-                            await this.dashboardService.getByIdOrSlug(
-                                context.user,
-                                dashboard.slug,
-                                { projectUuid: context.projectUuid },
-                            );
-                        return {
-                            type: 'dashboard',
-                            content: dashboard,
-                            href: AiAgentToolsService.getContentUrl(
-                                context,
-                                'dashboard',
-                                savedDashboard.uuid,
-                            ),
-                        };
-                    }
-                    case 'chart': {
-                        const { charts } = await this.coderService.getCharts(
-                            context.user,
-                            context.projectUuid,
-                            [slug],
-                        );
-                        const chart = charts[0];
-                        if (!chart) {
-                            throw new NotFoundError(
-                                `Chart "${slug}" was not found`,
-                            );
-                        }
-                        await this.assertContentSpaceInScope(
-                            context,
-                            chart.spaceSlug,
-                            `Chart "${slug}" was not found`,
-                        );
-                        const savedChart = await this.savedChartService.get(
-                            chart.slug,
-                            context.account,
-                            { projectUuid: context.projectUuid },
-                        );
-                        return {
-                            type: 'chart',
-                            content: chart,
-                            href: AiAgentToolsService.getContentUrl(
-                                context,
-                                'chart',
-                                savedChart.uuid,
-                            ),
-                        };
-                    }
+                    case 'dashboard':
+                    case 'chart':
+                        return this.readContentAsCode(context, { slug, type });
+                    case 'data_app':
+                        return this.readDataApp(context, slug);
                     default:
                         return assertUnreachable(type, 'Invalid content type');
                 }
             },
         );
+    }
+
+    private async readDataApp(
+        context: AiAgentToolsRuntimeContext,
+        appUuidOrSlug: string,
+    ): Promise<{ type: 'data_app'; content: DataAppRead; href: string }> {
+        const notFound = () =>
+            new NotFoundError(`Data app "${appUuidOrSlug}" was not found`);
+        const app = await this.appModel.findAppByUuidOrSlug(
+            context.projectUuid,
+            appUuidOrSlug,
+        );
+        // Data app vizzes are chart types with their own tools.
+        if (!app || app.template === DATA_APP_VIZ_TEMPLATE) {
+            throw notFound();
+        }
+        // Personal apps live outside every space, so a space-scoped agent
+        // never reads them — same policy as findContent.
+        if (
+            context.spaceAccess &&
+            context.spaceAccess.length > 0 &&
+            (app.space_uuid === null ||
+                !AiAgentToolsService.hasAgentSpaceAccess(
+                    context.spaceAccess,
+                    app.space_uuid,
+                ))
+        ) {
+            throw notFound();
+        }
+
+        const source = await this.appGenerateService.getDataAppReadSource(
+            context.user,
+            context.projectUuid,
+            app.app_id,
+        );
+        const href = AiAgentToolsService.getDataAppUrl(context, app.app_id);
+        const usage = await this.getDataAppUsage(context, app.app_id);
+        return {
+            type: 'data_app',
+            content: buildDataAppRead({ source, href, usage }),
+            href,
+        };
+    }
+
+    private async getDataAppUsage(
+        context: AiAgentToolsRuntimeContext,
+        appUuid: string,
+    ): Promise<Omit<DataAppReadUsage, 'upstreamAppUuid'>> {
+        const [dashboards, schedulers, spaces] = await Promise.all([
+            this.appModel.listDashboardsContainingApp(
+                appUuid,
+                context.projectUuid,
+            ),
+            // Listing deliveries needs create rights the reader may lack.
+            this.schedulerService
+                .getAppSchedulers(context.user, appUuid)
+                .catch((error: unknown) => {
+                    if (error instanceof ForbiddenError) return [];
+                    throw error;
+                }),
+            this.projectService.getSpaces(context.user, context.projectUuid),
+        ]);
+        const readableSpaceUuids = new Set(
+            spaces
+                .filter((space) =>
+                    AiAgentToolsService.hasAgentSpaceAccess(
+                        context.spaceAccess,
+                        space.uuid,
+                    ),
+                )
+                .map((space) => space.uuid),
+        );
+        return {
+            dashboards: dashboards
+                .filter((dashboard) =>
+                    readableSpaceUuids.has(dashboard.spaceUuid),
+                )
+                .map((dashboard) => ({
+                    uuid: dashboard.uuid,
+                    name: dashboard.name,
+                    href: AiAgentToolsService.getContentUrl(
+                        context,
+                        'dashboard',
+                        dashboard.uuid,
+                    ),
+                })),
+            schedulers: schedulers.map((scheduler) => ({
+                uuid: scheduler.schedulerUuid,
+                name: scheduler.name,
+            })),
+        };
+    }
+
+    private async readContentAsCode(
+        context: AiAgentToolsRuntimeContext,
+        { slug, type }: { slug: string; type: ContentAsCodeType },
+    ): Promise<ReadContentAsCodeResult> {
+        switch (type) {
+            case 'dashboard': {
+                const { dashboards } = await this.coderService.getDashboards(
+                    context.user,
+                    context.projectUuid,
+                    [slug],
+                );
+                const dashboard = dashboards[0];
+                if (!dashboard) {
+                    throw new NotFoundError(
+                        `Dashboard "${slug}" was not found`,
+                    );
+                }
+                await this.assertContentSpaceInScope(
+                    context,
+                    dashboard.spaceSlug,
+                    `Dashboard "${slug}" was not found`,
+                );
+                const savedDashboard =
+                    await this.dashboardService.getByIdOrSlug(
+                        context.user,
+                        dashboard.slug,
+                        { projectUuid: context.projectUuid },
+                    );
+                return {
+                    type: 'dashboard',
+                    content: dashboard,
+                    href: AiAgentToolsService.getContentUrl(
+                        context,
+                        'dashboard',
+                        savedDashboard.uuid,
+                    ),
+                };
+            }
+            case 'chart': {
+                const { charts } = await this.coderService.getCharts(
+                    context.user,
+                    context.projectUuid,
+                    [slug],
+                );
+                const chart = charts[0];
+                if (!chart) {
+                    throw new NotFoundError(`Chart "${slug}" was not found`);
+                }
+                await this.assertContentSpaceInScope(
+                    context,
+                    chart.spaceSlug,
+                    `Chart "${slug}" was not found`,
+                );
+                const savedChart = await this.savedChartService.get(
+                    chart.slug,
+                    context.account,
+                    { projectUuid: context.projectUuid },
+                );
+                return {
+                    type: 'chart',
+                    content: chart,
+                    href: AiAgentToolsService.getContentUrl(
+                        context,
+                        'chart',
+                        savedChart.uuid,
+                    ),
+                };
+            }
+            default:
+                return assertUnreachable(type, 'Invalid content type');
+        }
     }
 
     private resolveUrl(
@@ -1716,7 +1836,7 @@ export class AiAgentToolsService extends BaseService {
                 }
                 this.aiAgentContentValidation.validatePatch(type, patch);
 
-                const currentContent = await this.readContent(context, {
+                const currentContent = await this.readContentAsCode(context, {
                     slug,
                     type,
                 });
@@ -1798,7 +1918,7 @@ export class AiAgentToolsService extends BaseService {
                         return assertUnreachable(type, 'Invalid content type');
                 }
 
-                const editedContent = await this.readContent(context, {
+                const editedContent = await this.readContentAsCode(context, {
                     slug: patchedSlug,
                     type,
                 });
@@ -1867,10 +1987,13 @@ export class AiAgentToolsService extends BaseService {
                                 `Created dashboard "${finalSlug}" was not found`,
                             );
                         }
-                        const createdContent = await this.readContent(context, {
-                            slug: finalSlug,
-                            type,
-                        });
+                        const createdContent = await this.readContentAsCode(
+                            context,
+                            {
+                                slug: finalSlug,
+                                type,
+                            },
+                        );
                         return {
                             ...createdContent,
                             uuid,
@@ -1899,10 +2022,13 @@ export class AiAgentToolsService extends BaseService {
                                 `Created chart "${finalSlug}" was not found`,
                             );
                         }
-                        const createdContent = await this.readContent(context, {
-                            slug: finalSlug,
-                            type,
-                        });
+                        const createdContent = await this.readContentAsCode(
+                            context,
+                            {
+                                slug: finalSlug,
+                                type,
+                            },
+                        );
                         return {
                             ...createdContent,
                             uuid,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppRead.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppRead.test.ts
@@ -1,0 +1,197 @@
+import { NotFoundError } from '@lightdash/common';
+import { AppGenerateService } from './AppGenerateService';
+
+const USER = { userUuid: 'user-1', organizationUuid: 'org-1' } as never;
+const PROJECT_UUID = 'project-1';
+
+const makeApp = (overrides: Record<string, unknown> = {}) => ({
+    app_id: 'app-1',
+    slug: 'revenue-app',
+    name: 'Revenue app',
+    description: 'Revenue by region',
+    project_uuid: PROJECT_UUID,
+    organization_uuid: 'org-1',
+    space_uuid: null,
+    template: 'dashboard',
+    created_by_user_uuid: 'user-1',
+    upstream_app_uuid: 'upstream-1',
+    views_count: 4,
+    ...overrides,
+});
+
+const readyVersion = {
+    version: 2,
+    status: 'ready',
+    status_message: null,
+    error: null,
+    resources: {
+        images: [],
+        charts: [],
+        dashboardName: null,
+        clarifications: [],
+    },
+    data_references: {
+        extractorVersion: 4,
+        references: [],
+        parseErrors: [],
+        stats: {
+            callSites: 0,
+            fullyResolved: 0,
+            partiallyResolved: 0,
+            unresolved: 0,
+        },
+    },
+};
+
+const buildService = ({
+    app = makeApp(),
+    latestVersion = readyVersion,
+    latestReadyVersion = readyVersion,
+}: {
+    app?: ReturnType<typeof makeApp>;
+    latestVersion?: typeof readyVersion | null;
+    latestReadyVersion?: typeof readyVersion | null;
+} = {}) => {
+    const service = new AppGenerateService({
+        lightdashConfig: {} as never,
+        analytics: { track: vi.fn() } as never,
+        analyticsModel: {} as never,
+        catalogModel: {} as never,
+        appModel: {
+            getApp: vi.fn().mockResolvedValue(app),
+            getLatestVersion: vi.fn().mockResolvedValue(latestVersion),
+            getLatestReadyVersion: vi
+                .fn()
+                .mockResolvedValue(latestReadyVersion),
+            getVersion: vi.fn().mockResolvedValue(latestReadyVersion),
+        } as never,
+        featureFlagModel: {
+            get: vi.fn().mockResolvedValue({ enabled: true }),
+        } as never,
+        organizationDesignModel: {} as never,
+        pinnedListModel: {} as never,
+        projectModel: {
+            getSummary: vi.fn().mockResolvedValue({
+                organizationUuid: 'org-1',
+                projectUuid: PROJECT_UUID,
+                type: 'DEFAULT',
+                createdByUserUuid: null,
+                upstreamProjectUuid: null,
+            }),
+        } as never,
+        projectParametersModel: {} as never,
+        spaceModel: {
+            getSpaceSummary: vi
+                .fn()
+                .mockResolvedValue({ uuid: 'space-1', name: 'Finance' }),
+        } as never,
+        savedChartModel: {} as never,
+        schedulerClient: {} as never,
+        savedChartService: {} as never,
+        spacePermissionService: {
+            getSpaceAccessContext: vi.fn().mockResolvedValue({}),
+        } as never,
+        coderService: {} as never,
+        dashboardService: {} as never,
+        projectService: {} as never,
+        promoteService: {} as never,
+        externalConnectionModel: {
+            listAppLinks: vi.fn().mockResolvedValue([
+                {
+                    alias: 'weather',
+                    connection: { origin: 'https://api.weather.example' },
+                },
+            ]),
+        } as never,
+        sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {} as never,
+    });
+    // Personal-app rule only: the creator can view their own spaceless app.
+    (
+        service as unknown as { createAuditedAbility: () => unknown }
+    ).createAuditedAbility = () => ({
+        can: (
+            _action: string,
+            subject: { createdByUserUuid: string; spaceUuid?: string },
+        ) => subject.createdByUserUuid === 'user-1',
+        cannot: () => false,
+    });
+    return service;
+};
+
+describe('AppGenerateService.getDataAppReadSource', () => {
+    it('assembles the read source for a viewable app', async () => {
+        const service = buildService({
+            latestVersion: { ...readyVersion, version: 3, status: 'building' },
+        });
+
+        const source = await service.getDataAppReadSource(
+            USER,
+            PROJECT_UUID,
+            'app-1',
+        );
+
+        expect(source.app).toEqual({
+            uuid: 'app-1',
+            slug: 'revenue-app',
+            name: 'Revenue app',
+            description: 'Revenue by region',
+            template: 'dashboard',
+            space: null,
+            views: 4,
+            createdByUserUuid: 'user-1',
+            upstreamAppUuid: 'upstream-1',
+        });
+        expect(source.latestVersion).toEqual({
+            version: 3,
+            status: 'building',
+            statusMessage: null,
+            error: null,
+        });
+        expect(source.latestReadyVersion).toEqual({
+            version: 2,
+            resources: readyVersion.resources,
+        });
+        expect(source.dataReferences).toEqual(readyVersion.data_references);
+        expect(source.externalConnections).toEqual([
+            { alias: 'weather', origin: 'https://api.weather.example' },
+        ]);
+        expect(source).not.toHaveProperty('files');
+    });
+
+    it("reads another user's personal app as not found, never forbidden", async () => {
+        const service = buildService({
+            app: makeApp({ created_by_user_uuid: 'someone-else' }),
+        });
+
+        await expect(
+            service.getDataAppReadSource(USER, PROJECT_UUID, 'app-1'),
+        ).rejects.toThrow(NotFoundError);
+    });
+
+    it('reads a data app viz as not found', async () => {
+        const service = buildService({
+            app: makeApp({ template: 'data_app_viz' }),
+        });
+
+        await expect(
+            service.getDataAppReadSource(USER, PROJECT_UUID, 'app-1'),
+        ).rejects.toThrow(NotFoundError);
+    });
+
+    it('reads an app with no ready version without data references', async () => {
+        const service = buildService({
+            latestVersion: { ...readyVersion, version: 1, status: 'error' },
+            latestReadyVersion: null,
+        });
+
+        const source = await service.getDataAppReadSource(
+            USER,
+            PROJECT_UUID,
+            'app-1',
+        );
+
+        expect(source.latestReadyVersion).toBeNull();
+        expect(source.dataReferences).toBeNull();
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -91,6 +91,7 @@ import {
     type DataAppDependencies,
     type DataAppGenerationUsage,
     type DataAppManifestExternalConnection,
+    type DataAppReadSource,
     type DataAppTemplate,
     type DataAppViz,
     type DataAppVizRenderMetadata,
@@ -10005,6 +10006,78 @@ export class AppGenerateService extends BaseService {
             );
             return null;
         }
+    }
+
+    // Read for the AI analyst and external agents; unviewable data apps read
+    // as not found so reads never leak.
+    async getDataAppReadSource(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+    ): Promise<DataAppReadSource> {
+        await this.assertDataAppsEnabled(user);
+        const notFound = () => new NotFoundError(`App not found: ${appUuid}`);
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+        if (app.template === DATA_APP_VIZ_TEMPLATE) {
+            throw notFound();
+        }
+        try {
+            await this.assertCanViewApp(user, app);
+        } catch (error) {
+            if (error instanceof ForbiddenError) {
+                throw notFound();
+            }
+            throw error;
+        }
+
+        const [latestVersion, latestReadyVersion, appLinks, space] =
+            await Promise.all([
+                this.appModel.getLatestVersion(appUuid),
+                this.appModel.getLatestReadyVersion(appUuid),
+                this.externalConnectionModel.listAppLinks(appUuid),
+                app.space_uuid
+                    ? this.spaceModel.getSpaceSummary(app.space_uuid)
+                    : null,
+            ]);
+        const dataReferences = latestReadyVersion
+            ? await this.getVersionDataReferences(
+                  appUuid,
+                  latestReadyVersion.version,
+              )
+            : null;
+
+        return {
+            app: {
+                uuid: app.app_id,
+                slug: app.slug,
+                name: app.name,
+                description: app.description,
+                template: app.template,
+                space: space ? { uuid: space.uuid, name: space.name } : null,
+                views: app.views_count,
+                createdByUserUuid: app.created_by_user_uuid,
+                upstreamAppUuid: app.upstream_app_uuid,
+            },
+            latestVersion: latestVersion
+                ? {
+                      version: latestVersion.version,
+                      status: latestVersion.status,
+                      statusMessage: latestVersion.status_message,
+                      error: latestVersion.error,
+                  }
+                : null,
+            latestReadyVersion: latestReadyVersion
+                ? {
+                      version: latestReadyVersion.version,
+                      resources: latestReadyVersion.resources,
+                  }
+                : null,
+            dataReferences,
+            externalConnections: appLinks.map(({ alias, connection }) => ({
+                alias,
+                origin: connection.origin,
+            })),
+        };
     }
 
     async getVersionDataReferences(

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -1243,7 +1243,7 @@ Usage tips:
         "openWorldHint": false,
         "readOnlyHint": true,
       },
-      "description": "Read a dashboard or chart as JSON using its slug. Call this before editing.",
+      "description": "Read a dashboard or chart as JSON using its slug, or a data app as a structured summary (identity, status, generation inputs, data references, usage — never source code). Call this before editing a dashboard or chart.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -1259,7 +1259,7 @@ Usage tips:
             "type": "string",
           },
           "slug": {
-            "description": "Slug of the dashboard or chart to read.",
+            "description": "Slug of the dashboard, chart or data app to read.",
             "minLength": 1,
             "type": "string",
           },
@@ -1268,6 +1268,7 @@ Usage tips:
             "enum": [
               "dashboard",
               "chart",
+              "data_app",
             ],
             "type": "string",
           },

--- a/packages/backend/src/ee/services/ai/prompts/systemV2ContentTools.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2ContentTools.ts
@@ -5,4 +5,5 @@ export const CONTENT_TOOLS_SECTION = `
 - When the user's intent is to create or edit saved Lightdash content, use the content tools:
   - listContent, readContent, createContent, editContent, and runContentQuery.
   - Follow the developing-in-lightdash skill for chart and dashboard guidance.
-  - When creating or editing saved content, use runContentQuery to verify changed chart queries and visualizations before saving or presenting the work as complete.`;
+  - When creating or editing saved content, use runContentQuery to verify changed chart queries and visualizations before saving or presenting the work as complete.
+- readContent with type "data_app" reads a data app by slug: identity, build status, what it was generated from, the explores, fields, saved charts and external hosts it queries, and where it is used. It never returns source code. Read the data-apps-reference resource of the developing-in-lightdash skill before describing or comparing data apps.`;

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/SKILL.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/SKILL.md
@@ -21,6 +21,7 @@ This skill is shared with Lightdash's native agent, so its workflows use camelCa
 | Task                          | Tools/Action                                                    | References                            |
 | ----------------------------- | --------------------------------------------------------------- | ------------------------------------- |
 | Read dashboards and charts    | `readContent`                                                   | `dashboard-reference`, chart refs     |
+| Read data apps                | `readContent` with `type: "data_app"`                           | `data-apps-reference`                 |
 | Edit dashboards               | `editContent` with RFC6902 JSON Patch                           | `dashboard-reference`                 |
 | Edit charts and tiles         | `editContent`, then update referencing dashboards if needed     | Chart refs, `dashboard-reference`     |
 | Create charts                 | `grepFields`, `getMetadata`, `runContentQuery`, `createContent` | Chart refs                            |
@@ -202,3 +203,7 @@ For period comparisons, read `period-over-period-reference` in addition to the c
 
 - `dashboard-reference` - Dashboard structure, layout, tabs, tiles, and filters
 - `dashboard-best-practices` - Dashboard design guidance
+
+### Data apps
+
+- `data-apps-reference` - What a data app read returns and when to suggest generating one

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/data-apps-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/data-apps-reference.md
@@ -1,0 +1,44 @@
+---
+name: data-apps-reference
+description: What a data app is, what readContent returns for one, how to answer questions about it, and when to suggest generating a new one.
+---
+
+# Data Apps Reference
+
+A data app is an AI-generated interactive application built on the project's semantic layer. A user describes what they want, a coding agent writes a React app in an isolated sandbox, and Lightdash builds and serves it. A data app is source code, not a block model: it has no tiles, filters or chart configs you can patch. Every prompt adds a version; versions are append-only.
+
+Data apps are identified by a project-scoped slug in URLs and by uuid internally. `findContent` and `listContent` return both.
+
+## Reading a data app
+
+Call `readContent` with `type: "data_app"` and the data app's slug. The result is a structured read, never source code:
+
+| Section    | What it holds                                                                                                                                 |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `identity` | uuid, slug, name, description, template (`dashboard`, `slideshow`, `pdf`, or null for custom), space, href, view count, creator uuid          |
+| `status`   | `latestVersion` (`version`, `status`, `statusMessage`, `error`) and `latestReadyVersion` — the version viewers actually see, or null           |
+| `inputs`   | What the latest ready version was generated from: attached charts (with `linkLive`), source dashboard, clarifications, design name, external connections. Null when no version is ready |
+| `data`     | Statically extracted data references of the latest ready version: one `queries` entry per call site (explore, dimensions, metrics, filter fields, parameter keys, unresolved parts), `savedChartUuids` run live, `externalHosts` called, and resolution `stats`. Null when no version is ready |
+| `usage`    | Dashboards embedding the data app, scheduled deliveries targeting it, and the upstream data app uuid when this is a preview copy                        |
+
+Notes:
+
+- `status.latestVersion.status` is one of `pending`, `sandbox`, `catalog`, `generating`, `building`, `packaging`, `ready`, or `error`. If it is not `ready`, tell the user the data app is still building or failed (`error` has the message) and describe only `latestReadyVersion`.
+- `data.queries[].unresolved` lists the parts the extractor could not resolve statically (for example an explore chosen at runtime). Say so instead of guessing.
+- `data.stats` counts call sites by how fully they resolved; use it to qualify how complete the picture is.
+- Personal data apps (no space) are only readable by their creator. A data app you cannot read reads as not found.
+- The read never includes source files, dependencies or prompts. External agents download source with the CLI.
+
+## Answering common questions
+
+- "What does this data app show?" — `identity.description`, `inputs.charts`, `inputs.dashboard`, and the explores and metrics in `data.queries`.
+- "What does it depend on?" — group `data.queries` by `explore`; list dimensions, metrics and filter fields. Add `data.savedChartUuids` for charts it runs live.
+- "Does it call anything outside Lightdash?" — `data.externalHosts` and `inputs.externalConnections`.
+- "Where is it used?" — `usage.dashboards` and `usage.schedulers`.
+- "Compare two data apps" — read both and contrast inputs, explores and fields, external hosts, and usage.
+
+Link to the data app with `identity.href` so the user can open it from the thread.
+
+## When to suggest generating a data app
+
+Suggest a data app when the user wants something a dashboard cannot express: a narrative or slideshow, a PDF report, custom interaction, bespoke layout, or calls to an external service. Prefer charts and dashboards for standard analysis; they are editable with `editContent` and cheaper to maintain. Generating and iterating data apps from a thread is not available through these tools yet — point the user to the data apps page.

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -4783,13 +4783,13 @@ Parameters:
     },
   },
   {
-    "description": "Read a dashboard or chart as JSON using its slug. Call this before editing.",
+    "description": "Read a dashboard or chart as JSON using its slug, or a data app as a structured summary (identity, status, generation inputs, data references, usage — never source code). Call this before editing a dashboard or chart.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {
         "slug": {
-          "description": "Slug of the dashboard or chart to read.",
+          "description": "Slug of the dashboard, chart or data app to read.",
           "minLength": 1,
           "type": "string",
         },
@@ -4798,6 +4798,7 @@ Parameters:
           "enum": [
             "dashboard",
             "chart",
+            "data_app",
           ],
           "type": "string",
         },

--- a/packages/backend/src/ee/services/ai/tools/readContent.ts
+++ b/packages/backend/src/ee/services/ai/tools/readContent.ts
@@ -1,4 +1,9 @@
-import { readContentToolDefinition } from '@lightdash/common';
+import {
+    assertUnreachable,
+    READ_CONTENT_TYPE_LABELS,
+    readContentToolDefinition,
+    type ReadContentType,
+} from '@lightdash/common';
 import { tool } from 'ai';
 import type { ReadContentFn } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
@@ -17,8 +22,25 @@ const contentResult = ({
 }: {
     content: unknown;
     href: string;
-    type: 'dashboard' | 'chart';
+    type: ReadContentType;
 }) => `<${type} href="${href}" />\n---\n${JSON.stringify(content, null, 2)}`;
+
+const contentIdentity = (
+    result: Awaited<ReturnType<ReadContentFn>>,
+): { slug: string; name: string } => {
+    switch (result.type) {
+        case 'dashboard':
+        case 'chart':
+            return { slug: result.content.slug, name: result.content.name };
+        case 'data_app':
+            return {
+                slug: result.content.identity.slug,
+                name: result.content.identity.name,
+            };
+        default:
+            return assertUnreachable(result, 'Invalid content type');
+    }
+};
 
 export const getReadContent = ({ readContent }: Dependencies) =>
     tool({
@@ -28,8 +50,7 @@ export const getReadContent = ({ readContent }: Dependencies) =>
                 const result = await readContent({ slug, type });
                 const metadata = {
                     status: 'success' as const,
-                    slug: result.content.slug,
-                    name: result.content.name,
+                    ...contentIdentity(result),
                     href: result.href,
                 };
 
@@ -45,7 +66,7 @@ export const getReadContent = ({ readContent }: Dependencies) =>
                 return {
                     result: toolErrorHandler(
                         error,
-                        `Error reading ${type} "${slug}"`,
+                        `Error reading ${READ_CONTENT_TYPE_LABELS[type]} "${slug}"`,
                     ),
                     metadata: {
                         status: 'error' as const,

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -19,6 +19,7 @@ import {
     CustomChartTypeLibrary,
     DashboardAsCode,
     DashboardSearchResult,
+    DataAppRead,
     DataAppSearchResult,
     DataAppVizSchema,
     DbtProjectType,
@@ -33,6 +34,7 @@ import {
     ParametersValuesMap,
     PreviewDeploySetupResult,
     ProjectType,
+    ReadContentType,
     ResultColumns,
     SavedChart,
     SchedulerAndTargets,
@@ -297,10 +299,7 @@ export type GetDashboardChartsFn = (args: {
     };
 }>;
 
-export type ReadContentFn = (args: {
-    slug: string;
-    type: 'dashboard' | 'chart';
-}) => Promise<
+export type ReadContentAsCodeResult =
     | {
           type: 'dashboard';
           content: DashboardAsCode;
@@ -309,6 +308,17 @@ export type ReadContentFn = (args: {
     | {
           type: 'chart';
           content: ChartAsCode;
+          href: string;
+      };
+
+export type ReadContentFn = (args: {
+    slug: string;
+    type: ReadContentType;
+}) => Promise<
+    | ReadContentAsCodeResult
+    | {
+          type: 'data_app';
+          content: DataAppRead;
           href: string;
       }
 >;

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1691,13 +1691,43 @@ export class AppModel {
         dashboardUuids: string[],
     ): Promise<string[]> {
         if (dashboardUuids.length === 0) return [];
+        const rows = await this.dashboardsContainingAppQuery(
+            appUuid,
+            projectUuid,
+            dashboardUuids,
+        );
+        return rows.map((r) => r.dashboard_uuid);
+    }
 
+    async listDashboardsContainingApp(
+        appUuid: string,
+        projectUuid: string,
+    ): Promise<{ uuid: string; name: string; spaceUuid: string }[]> {
+        const rows = await this.dashboardsContainingAppQuery(
+            appUuid,
+            projectUuid,
+            null,
+        );
+        return rows.map((r) => ({
+            uuid: r.dashboard_uuid,
+            name: r.name,
+            spaceUuid: r.space_uuid,
+        }));
+    }
+
+    private dashboardsContainingAppQuery(
+        appUuid: string,
+        projectUuid: string,
+        dashboardUuids: string[] | null,
+    ) {
         const latestVersionsCte = 'latest_dashboard_versions';
-        const rows = await this.database
+        return this.database
             .with(latestVersionsCte, (qb) => {
                 void qb
                     .select({
                         dashboard_uuid: `${DashboardsTableName}.dashboard_uuid`,
+                        name: `${DashboardsTableName}.name`,
+                        space_uuid: `${SpaceTableName}.space_uuid`,
                         dashboard_version_id: this.database.raw(
                             `MAX(${DashboardVersionsTableName}.dashboard_version_id)`,
                         ),
@@ -1721,15 +1751,25 @@ export class AppModel {
                         `${DashboardVersionsTableName}.dashboard_id`,
                     )
                     .where(`${ProjectTableName}.project_uuid`, projectUuid)
-                    .whereIn(
+                    .whereNull(`${DashboardsTableName}.deleted_at`)
+                    .groupBy(
+                        `${DashboardsTableName}.dashboard_uuid`,
+                        `${DashboardsTableName}.name`,
+                        `${SpaceTableName}.space_uuid`,
+                    );
+                if (dashboardUuids !== null) {
+                    void qb.whereIn(
                         `${DashboardsTableName}.dashboard_uuid`,
                         dashboardUuids,
-                    )
-                    .whereNull(`${DashboardsTableName}.deleted_at`)
-                    .groupBy(`${DashboardsTableName}.dashboard_uuid`);
+                    );
+                }
             })
-            .select<{ dashboard_uuid: string }[]>(
+            .select<
+                { dashboard_uuid: string; name: string; space_uuid: string }[]
+            >(
                 `${latestVersionsCte}.dashboard_uuid`,
+                `${latestVersionsCte}.name`,
+                `${latestVersionsCte}.space_uuid`,
             )
             .distinct()
             .from(latestVersionsCte)
@@ -1750,8 +1790,6 @@ export class AppModel {
                 );
             })
             .where(`${DashboardTileDataAppsTableName}.app_uuid`, appUuid);
-
-        return rows.map((r) => r.dashboard_uuid);
     }
 
     /**

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolReadContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolReadContentArgs.ts
@@ -1,12 +1,25 @@
 import { z } from 'zod';
 
 export const TOOL_READ_CONTENT_DESCRIPTION =
-    'Read a dashboard or chart as JSON using its slug. Call this before editing.';
+    'Read a dashboard or chart as JSON using its slug, or a data app as a structured summary (identity, status, generation inputs, data references, usage — never source code). Call this before editing a dashboard or chart.';
+
+export const READ_CONTENT_TYPES = ['dashboard', 'chart', 'data_app'] as const;
+
+export type ReadContentType = (typeof READ_CONTENT_TYPES)[number];
+
+export const READ_CONTENT_TYPE_LABELS: Record<ReadContentType, string> = {
+    dashboard: 'dashboard',
+    chart: 'chart',
+    data_app: 'data app',
+};
 
 export const toolReadContentArgsSchema = z.object({
-    slug: z.string().min(1).describe('Slug of the dashboard or chart to read.'),
+    slug: z
+        .string()
+        .min(1)
+        .describe('Slug of the dashboard, chart or data app to read.'),
     type: z
-        .enum(['dashboard', 'chart'])
+        .enum(READ_CONTENT_TYPES)
         .describe('Type of Lightdash content to read.'),
 });
 

--- a/packages/common/src/ee/apps/dataAppRead.test.ts
+++ b/packages/common/src/ee/apps/dataAppRead.test.ts
@@ -1,0 +1,285 @@
+import { buildDataAppRead, type DataAppReadSource } from './dataAppRead';
+
+const location = { path: 'src/App.tsx', line: 1, column: 1 };
+
+const source: DataAppReadSource = {
+    app: {
+        uuid: 'app-uuid',
+        slug: 'revenue-app',
+        name: 'Revenue app',
+        description: 'Revenue by region',
+        template: 'dashboard',
+        space: { uuid: 'space-uuid', name: 'Finance' },
+        views: 12,
+        createdByUserUuid: 'user-uuid',
+        upstreamAppUuid: 'upstream-uuid',
+    },
+    latestVersion: {
+        version: 3,
+        status: 'building',
+        statusMessage: 'Compiling',
+        error: null,
+    },
+    latestReadyVersion: {
+        version: 2,
+        resources: {
+            images: [],
+            files: [
+                {
+                    fileId: 'f1',
+                    filename: 'notes.md',
+                    mimeType: 'text/markdown',
+                },
+            ],
+            charts: [
+                {
+                    chartUuid: 'chart-1',
+                    chartName: 'Revenue by month',
+                    chartKind: 'line',
+                    linkLive: true,
+                },
+                {
+                    chartUuid: 'chart-2',
+                    chartName: 'Orders',
+                    chartKind: null,
+                },
+            ],
+            externalConnections: [
+                {
+                    externalConnectionUuid: 'ec-1',
+                    name: 'Weather API',
+                    alias: 'weather',
+                },
+            ],
+            dashboardName: 'Finance overview',
+            dashboardUuid: 'dash-1',
+            clarifications: [{ question: 'Currency?', answer: 'USD' }],
+            design: { designUuid: 'd-1', name: 'Brand', fileCount: 2 },
+        },
+    },
+    dataReferences: {
+        references: [
+            {
+                kind: 'query',
+                explore: 'orders',
+                dimensions: ['orders_region'],
+                metrics: ['orders_total_revenue'],
+                dimensionFilterFields: ['orders_status'],
+                metricFilterFields: [],
+                sortFields: ['orders_total_revenue'],
+                parameterKeys: ['currency'],
+                localFields: [],
+                unresolved: [],
+                location,
+            },
+            {
+                kind: 'query',
+                explore: null,
+                dimensions: [],
+                metrics: [],
+                dimensionFilterFields: [],
+                metricFilterFields: [],
+                sortFields: [],
+                parameterKeys: [],
+                localFields: [],
+                unresolved: ['explore', 'dimensions'],
+                location,
+            },
+            {
+                kind: 'savedChart',
+                chartUuid: 'chart-1',
+                filterFields: [],
+                unresolved: [],
+                location,
+            },
+            {
+                kind: 'savedChart',
+                chartUuid: 'chart-1',
+                filterFields: [],
+                unresolved: [],
+                location,
+            },
+            {
+                kind: 'savedChart',
+                chartUuid: null,
+                filterFields: [],
+                unresolved: ['chartUuid'],
+                location,
+            },
+            {
+                kind: 'externalFetch',
+                alias: 'weather',
+                path: '/forecast',
+                unresolved: [],
+                location,
+            },
+        ],
+        parseErrors: [],
+        stats: {
+            callSites: 6,
+            fullyResolved: 4,
+            partiallyResolved: 0,
+            unresolved: 2,
+        },
+    },
+    externalConnections: [
+        { alias: 'weather', origin: 'https://api.weather.example' },
+        { alias: 'crm', origin: 'https://crm.example' },
+    ],
+};
+
+const usage = {
+    dashboards: [{ uuid: 'dash-1', name: 'Finance overview', href: '/d' }],
+    schedulers: [{ uuid: 'sched-1', name: 'Weekly revenue' }],
+};
+
+describe('buildDataAppRead', () => {
+    it('maps app rows, versions, data references and usage into a read', () => {
+        const read = buildDataAppRead({
+            source,
+            href: '/projects/p/apps/app-uuid/view',
+            usage,
+        });
+
+        expect(read.identity).toEqual({
+            uuid: 'app-uuid',
+            slug: 'revenue-app',
+            name: 'Revenue app',
+            description: 'Revenue by region',
+            template: 'dashboard',
+            space: { uuid: 'space-uuid', name: 'Finance' },
+            href: '/projects/p/apps/app-uuid/view',
+            views: 12,
+            createdByUserUuid: 'user-uuid',
+        });
+        expect(read.status).toEqual({
+            latestVersion: {
+                version: 3,
+                status: 'building',
+                statusMessage: 'Compiling',
+                error: null,
+            },
+            latestReadyVersion: 2,
+        });
+        expect(read.inputs).toEqual({
+            charts: [
+                {
+                    uuid: 'chart-1',
+                    name: 'Revenue by month',
+                    chartKind: 'line',
+                    linkLive: true,
+                },
+                {
+                    uuid: 'chart-2',
+                    name: 'Orders',
+                    chartKind: null,
+                    linkLive: false,
+                },
+            ],
+            dashboard: { uuid: 'dash-1', name: 'Finance overview' },
+            clarifications: [{ question: 'Currency?', answer: 'USD' }],
+            designName: 'Brand',
+            externalConnections: [{ name: 'Weather API', alias: 'weather' }],
+        });
+        expect(read.usage).toEqual({
+            ...usage,
+            upstreamAppUuid: 'upstream-uuid',
+        });
+    });
+
+    it('reports every linked host when an external fetch alias is unresolved', () => {
+        const read = buildDataAppRead({
+            source: {
+                ...source,
+                dataReferences: {
+                    references: [
+                        {
+                            kind: 'externalFetch',
+                            alias: null,
+                            path: null,
+                            unresolved: ['alias'],
+                            location,
+                        },
+                    ],
+                    parseErrors: [],
+                    stats: {
+                        callSites: 1,
+                        fullyResolved: 0,
+                        partiallyResolved: 0,
+                        unresolved: 1,
+                    },
+                },
+            },
+            href: '/x',
+            usage,
+        });
+
+        expect(read.data?.externalHosts).toEqual([
+            'https://api.weather.example',
+            'https://crm.example',
+        ]);
+    });
+
+    it('keeps one query per call site with unresolved parts, dedupes chart uuids and maps hosts from fetched aliases', () => {
+        const read = buildDataAppRead({ source, href: '/x', usage });
+
+        expect(read.data).toEqual({
+            queries: [
+                {
+                    explore: 'orders',
+                    dimensions: ['orders_region'],
+                    metrics: ['orders_total_revenue'],
+                    dimensionFilterFields: ['orders_status'],
+                    metricFilterFields: [],
+                    parameterKeys: ['currency'],
+                    unresolved: [],
+                },
+                {
+                    explore: null,
+                    dimensions: [],
+                    metrics: [],
+                    dimensionFilterFields: [],
+                    metricFilterFields: [],
+                    parameterKeys: [],
+                    unresolved: ['explore', 'dimensions'],
+                },
+            ],
+            savedChartUuids: ['chart-1'],
+            externalHosts: ['https://api.weather.example'],
+            stats: source.dataReferences?.stats,
+        });
+    });
+
+    it('reads an app with no ready version as identity and status only', () => {
+        const read = buildDataAppRead({
+            source: {
+                ...source,
+                latestVersion: {
+                    version: 1,
+                    status: 'error',
+                    statusMessage: null,
+                    error: 'Build failed',
+                },
+                latestReadyVersion: null,
+                dataReferences: null,
+            },
+            href: '/x',
+            usage: { dashboards: [], schedulers: [] },
+        });
+
+        expect(read.status.latestReadyVersion).toBeNull();
+        expect(read.status.latestVersion?.error).toBe('Build failed');
+        expect(read.inputs).toBeNull();
+        expect(read.data).toBeNull();
+    });
+
+    it('never carries source-shaped fields', () => {
+        const read = buildDataAppRead({ source, href: '/x', usage });
+        const json = JSON.stringify(read);
+
+        expect(json).not.toContain('"files"');
+        expect(json).not.toContain('"dependencies"');
+        expect(json).not.toContain('notes.md');
+        expect(json).not.toContain('"location"');
+    });
+});

--- a/packages/common/src/ee/apps/dataAppRead.ts
+++ b/packages/common/src/ee/apps/dataAppRead.ts
@@ -1,0 +1,192 @@
+import assertUnreachable from '../../utils/assertUnreachable';
+import type {
+    DataReferenceStats,
+    PersistedDataAppDataReferences,
+    QueryReferenceUnresolvedPart,
+} from './dataReferences';
+import type {
+    AppClarification,
+    AppVersionResources,
+    AppVersionStatus,
+    DataAppTemplate,
+} from './types';
+
+export type DataAppReadQuery = {
+    explore: string | null;
+    dimensions: string[];
+    metrics: string[];
+    dimensionFilterFields: string[];
+    metricFilterFields: string[];
+    parameterKeys: string[];
+    unresolved: QueryReferenceUnresolvedPart[];
+};
+
+export type DataAppReadVersionStatus = {
+    version: number;
+    status: AppVersionStatus;
+    statusMessage: string | null;
+    error: string | null;
+};
+
+export type DataAppReadInputs = {
+    charts: {
+        uuid: string;
+        name: string;
+        chartKind: string | null;
+        linkLive: boolean;
+    }[];
+    dashboard: { uuid: string | null; name: string } | null;
+    clarifications: AppClarification[];
+    designName: string | null;
+    externalConnections: { name: string; alias: string }[];
+};
+
+export type DataAppReadData = {
+    queries: DataAppReadQuery[];
+    savedChartUuids: string[];
+    externalHosts: string[];
+    stats: DataReferenceStats;
+};
+
+export type DataAppReadUsage = {
+    dashboards: { uuid: string; name: string; href: string }[];
+    schedulers: { uuid: string; name: string }[];
+    upstreamAppUuid: string | null;
+};
+
+export type DataAppReadIdentity = {
+    uuid: string;
+    slug: string;
+    name: string;
+    description: string;
+    template: DataAppTemplate | null;
+    space: { uuid: string; name: string } | null;
+    views: number;
+    createdByUserUuid: string;
+};
+
+/** What the AI analyst and external agents see of a data app. Never source. */
+export type DataAppRead = {
+    identity: DataAppReadIdentity & { href: string };
+    status: {
+        latestVersion: DataAppReadVersionStatus | null;
+        latestReadyVersion: number | null;
+    };
+    inputs: DataAppReadInputs | null;
+    data: DataAppReadData | null;
+    usage: DataAppReadUsage;
+};
+
+/** Rows the data app service resolves for a permission-checked read. */
+export type DataAppReadSource = {
+    app: DataAppReadIdentity & { upstreamAppUuid: string | null };
+    latestVersion: DataAppReadVersionStatus | null;
+    latestReadyVersion: {
+        version: number;
+        resources: AppVersionResources | null;
+    } | null;
+    dataReferences: PersistedDataAppDataReferences | null;
+    /** Live external connection links, keyed by the alias source code uses. */
+    externalConnections: { alias: string; origin: string }[];
+};
+
+const buildInputs = (
+    resources: AppVersionResources | null,
+): DataAppReadInputs | null => {
+    if (!resources) return null;
+    return {
+        charts: resources.charts.map((chart) => ({
+            uuid: chart.chartUuid,
+            name: chart.chartName,
+            chartKind: chart.chartKind,
+            linkLive: chart.linkLive ?? false,
+        })),
+        dashboard:
+            resources.dashboardName === null
+                ? null
+                : {
+                      uuid: resources.dashboardUuid ?? null,
+                      name: resources.dashboardName,
+                  },
+        clarifications: resources.clarifications,
+        designName: resources.design?.name ?? null,
+        externalConnections: (resources.externalConnections ?? []).map(
+            ({ name, alias }) => ({ name, alias }),
+        ),
+    };
+};
+
+const buildData = (
+    dataReferences: PersistedDataAppDataReferences | null,
+    externalConnections: DataAppReadSource['externalConnections'],
+): DataAppReadData | null => {
+    if (!dataReferences) return null;
+    const queries: DataAppReadQuery[] = [];
+    const savedChartUuids = new Set<string>();
+    const externalHosts = new Set<string>();
+    const originsByAlias = new Map(
+        externalConnections.map(({ alias, origin }) => [alias, origin]),
+    );
+    for (const reference of dataReferences.references) {
+        switch (reference.kind) {
+            case 'query':
+                queries.push({
+                    explore: reference.explore,
+                    dimensions: reference.dimensions,
+                    metrics: reference.metrics,
+                    dimensionFilterFields: reference.dimensionFilterFields,
+                    metricFilterFields: reference.metricFilterFields,
+                    parameterKeys: reference.parameterKeys,
+                    unresolved: reference.unresolved,
+                });
+                break;
+            case 'savedChart':
+                if (reference.chartUuid)
+                    savedChartUuids.add(reference.chartUuid);
+                break;
+            case 'externalFetch': {
+                // An unresolved alias may reach any linked connection.
+                const origins =
+                    reference.alias === null
+                        ? originsByAlias.values()
+                        : [originsByAlias.get(reference.alias)];
+                for (const origin of origins) {
+                    if (origin) externalHosts.add(origin);
+                }
+                break;
+            }
+            case 'globalFilter':
+                break;
+            default:
+                assertUnreachable(reference, 'Unknown data reference kind');
+        }
+    }
+    return {
+        queries,
+        savedChartUuids: [...savedChartUuids],
+        externalHosts: [...externalHosts],
+        stats: dataReferences.stats,
+    };
+};
+
+export const buildDataAppRead = ({
+    source,
+    href,
+    usage,
+}: {
+    source: DataAppReadSource;
+    href: string;
+    usage: Omit<DataAppReadUsage, 'upstreamAppUuid'>;
+}): DataAppRead => {
+    const { upstreamAppUuid, ...identity } = source.app;
+    return {
+        identity: { ...identity, href },
+        status: {
+            latestVersion: source.latestVersion,
+            latestReadyVersion: source.latestReadyVersion?.version ?? null,
+        },
+        inputs: buildInputs(source.latestReadyVersion?.resources ?? null),
+        data: buildData(source.dataReferences, source.externalConnections),
+        usage: { ...usage, upstreamAppUuid },
+    };
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -17,6 +17,7 @@ export * from './apps/types';
 export * from './apps/code';
 export * from './apps/dataReferenceChecker';
 export * from './apps/dataReferences';
+export * from './apps/dataAppRead';
 export * from './apps/sdkBridgeRoutes';
 export * from './ambientAi';
 export * from './commercialFeatureFlags';

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -1899,19 +1899,19 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "Read a dashboard or chart as JSON using its slug. Call this before editing.",
+            "description": "Read a dashboard or chart as JSON using its slug, or a data app as a structured summary (identity, status, generation inputs, data references, usage — never source code). Call this before editing a dashboard or chart.",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
                 "properties": {
                     "slug": {
-                        "description": "Slug of the dashboard or chart to read.",
+                        "description": "Slug of the dashboard, chart or data app to read.",
                         "minLength": 1,
                         "type": "string"
                     },
                     "type": {
                         "description": "Type of Lightdash content to read.",
-                        "enum": ["dashboard", "chart"],
+                        "enum": ["dashboard", "chart", "data_app"],
                         "type": "string"
                     }
                 },

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ContentEditorToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ContentEditorToolCallDescription.tsx
@@ -1,3 +1,7 @@
+import {
+    READ_CONTENT_TYPE_LABELS,
+    type ReadContentType,
+} from '@lightdash/common';
 import { rem, Text } from '@mantine/core';
 import type { FC } from 'react';
 import { ToolCallChip } from '../ToolCallChip';
@@ -5,7 +9,7 @@ import { ToolCallChip } from '../ToolCallChip';
 type Props = {
     action: 'read' | 'edit' | 'create';
     slug: string;
-    type: 'dashboard' | 'chart';
+    type: ReadContentType;
 };
 
 export const ContentEditorToolCallDescription: FC<Props> = ({
@@ -15,6 +19,7 @@ export const ContentEditorToolCallDescription: FC<Props> = ({
 }) => (
     <Text c="dimmed" size="xs">
         {action === 'read' ? 'Read' : action === 'edit' ? 'Edited' : 'Created'}{' '}
-        {type} <ToolCallChip mx={rem(2)}>{slug}</ToolCallChip>
+        {READ_CONTENT_TYPE_LABELS[type]}{' '}
+        <ToolCallChip mx={rem(2)}>{slug}</ToolCallChip>
     </Text>
 );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallDisplayMessage.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallDisplayMessage.ts
@@ -1,6 +1,8 @@
 import {
+    READ_CONTENT_TYPE_LABELS,
     TOOL_DISPLAY_MESSAGES,
     TOOL_DISPLAY_MESSAGES_AFTER_TOOL_CALL,
+    type ReadContentType,
     type ToolName,
 } from '@lightdash/common';
 import { type ToolCallGroupDisplay } from './toolCallGrouping';
@@ -9,7 +11,7 @@ import { type ToolCallSummary } from './types';
 export type ToolCallDisplayStatus = 'running' | 'done';
 
 type ContentToolArgs = {
-    type?: 'dashboard' | 'chart';
+    type?: ReadContentType;
 };
 
 const CONTENT_TOOL_LABELS: Partial<
@@ -46,7 +48,9 @@ const getContentToolDisplayMessage = (
     if (contentTypes.size !== 1) return null;
 
     const [contentType] = contentTypes;
-    return contentType ? labelForTool[status](contentType) : null;
+    return contentType
+        ? labelForTool[status](READ_CONTENT_TYPE_LABELS[contentType])
+        : null;
 };
 
 export const getToolCallDisplayMessage = ({


### PR DESCRIPTION
## Summary

`readContent` (and MCP `read_content`) learns a third content type, `data_app`. Given a slug, the AI analyst gets a structured read of a data app — identity, build status, the inputs its latest ready version was generated from, its data references (explores, fields, filters, live saved charts, external hosts) and where it's used (dashboards, scheduled deliveries, upstream app). Never its source code.

## Changes

- **common**: `DataAppRead` / `DataAppReadSource` types and a pure `buildDataAppRead` builder; `readContent` args enum gains `data_app`; `READ_CONTENT_TYPE_LABELS` for UI copy. MCP inherits through the shared definition (`mcp-tools-1.0.json` regenerated).
- **AppGenerateService.getDataAppReadSource**: feature-gated, permission-checked the way the app viewer resolves it. Unviewable apps (incl. other users' personal apps) and data app vizzes read as not found, never forbidden. Data references re-extract lazily when stale via the existing `getVersionDataReferences`.
- **AppModel.listDashboardsContainingApp** (shares the CTE with `findDashboardsContainingApp`).
- **AiAgentToolsService**: `readContent` dispatches to `readContentAsCode` (chart/dashboard, unchanged) or `readDataApp`. Agent space restrictions apply before any service fetch; personal apps are hidden under a space-scoped agent (same policy as `findContent`). Usage dashboards are filtered to spaces the user and agent can see; delivery listing degrades to `[]` when the user lacks delivery rights.
- **Tool result**: `<data_app href>` header + JSON payload; metadata carries `slug, name, href` so the existing data-app chip opens the preview panel.
- **Prompt/skill**: content-tools section mentions data apps; new `data-apps-reference` resource in `developing-in-lightdash`.
- **Frontend**: tool-call labels say "data app".

## Tests

- Pure builder tests in common (shape, per-call-site queries with unresolved parts, host mapping from fetch aliases, no source-shaped fields).
- Tools-service runtime tests: viewable read with href + chip metadata, out-of-scope / personal-under-scope / other user's personal / viz → not found with no service fetch, no-ready-version read, forbidden delivery listing tolerated.
- Service read tests: assembly, other user's personal app → not found, viz → not found.
- Agent + MCP contract snapshots updated.

Closes: ZAP-948
