### PR TITLE
docs(agents): configure issue planning workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,20 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Agent skills
+
+### Issue tracker
+
+GitHub issues are canonical; Linear is a synchronized planning view. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the repository's mapped triage vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a multi-context repository rooted at `CONTEXT-MAP.md`. See `docs/agents/domain.md`.
+
 ## Opt-in Agent Okteto Development Environment
 
 This workflow is enabled only when

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,7 @@
+# Domain docs
+
+This is a multi-context repository.
+
+Before exploring, read `CONTEXT-MAP.md`, then each linked `CONTEXT.md` relevant to the work. Also read relevant system-wide ADRs under `docs/adr/` and context-scoped ADRs when present.
+
+Use the glossary's canonical vocabulary in issue titles, acceptance criteria, tests, code, and UI copy. If a proposal contradicts an ADR, surface the conflict explicitly instead of silently overriding it.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,16 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repository live in GitHub Issues. Use the `gh` CLI for all operations against `lightdash/lightdash`.
+
+Linear's GitHub Issues Sync mirrors GitHub issues into the configured Linear team. GitHub remains canonical; assign the synchronized Linear issue to the relevant Linear project for planning.
+
+## Conventions
+
+- Create issues with `gh issue create --repo lightdash/lightdash`.
+- Read issues and comments with `gh issue view <number> --repo lightdash/lightdash --comments`.
+- List issues with `gh issue list --repo lightdash/lightdash` and structured JSON output.
+- Apply or remove labels with `gh issue edit`.
+- Close issues with `gh issue close`.
+- Link pull requests with `Closes #<number>`.
+
+When a skill says to publish to the issue tracker, create a GitHub issue.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,11 @@
+# Triage labels
+
+| Canonical role | Repository label | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer needs to evaluate the issue |
+| `needs-info` | `needs-clarification` | Waiting for clarification |
+| `ready-for-agent` | `ai-ready` | Fully specified and ready for an AFK agent |
+| `ready-for-human` | `open-questions` | Needs human decisions before implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+Use the repository label whenever a skill mentions the canonical role.


### PR DESCRIPTION
## What changed
- Configure GitHub Issues as the canonical tracker
- Document Linear as the synchronized planning view
- Map triage labels to the repository vocabulary
- Register the existing multi-context domain docs layout