### PR TITLE
fix: preserve additional dbt source identity in AI writeback

### DIFF
--- a/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.test.ts
@@ -58,6 +58,50 @@ describe('CommercialSchedulerClient.aiDeepResearch', () => {
     });
 });
 
+describe('CommercialSchedulerClient.aiAgentReviewWriteback', () => {
+    it('keeps the initial key stable and gives a continuation a run-specific key', async () => {
+        const addJob = vi
+            .fn()
+            .mockResolvedValueOnce({ id: 'job-1' })
+            .mockResolvedValueOnce({ id: 'job-2' });
+        const client = Object.create(
+            CommercialSchedulerClient.prototype,
+        ) as CommercialSchedulerClient;
+        client.graphileUtils = Promise.resolve({ addJob } as AnyType);
+        const payload = {
+            fingerprint: 'fingerprint-1',
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            userUuid: 'user-1',
+            remediationUuid: 'remediation-1',
+        };
+        const initialRunAt = new Date('2026-08-27T12:00:00.000Z');
+        const continuationRunAt = new Date('2026-08-27T12:00:05.000Z');
+
+        await client.aiAgentReviewWriteback(payload, initialRunAt);
+        await client.aiAgentReviewWriteback(payload, continuationRunAt, true);
+
+        expect(addJob).toHaveBeenNthCalledWith(
+            1,
+            EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK,
+            payload,
+            expect.objectContaining({
+                runAt: initialRunAt,
+                jobKey: 'ai-agent-review-writeback:fingerprint-1',
+            }),
+        );
+        expect(addJob).toHaveBeenNthCalledWith(
+            2,
+            EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK,
+            payload,
+            expect.objectContaining({
+                runAt: continuationRunAt,
+                jobKey: 'ai-agent-review-writeback:fingerprint-1:continuation:1787832005000',
+            }),
+        );
+    });
+});
+
 describe('CommercialSchedulerClient.ingestExternalSourceAttachment', () => {
     it('uses an attachment-only task that old workers cannot claim', async () => {
         const addJob = vi.fn().mockResolvedValue({ id: 'job-1' });

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -171,15 +171,21 @@ export class CommercialSchedulerClient extends SchedulerClient {
         return { jobId };
     }
 
-    async aiAgentReviewWriteback(payload: AiAgentReviewWritebackJobPayload) {
+    async aiAgentReviewWriteback(
+        payload: AiAgentReviewWritebackJobPayload,
+        runAt: Date = new Date(),
+        continuation: boolean = false,
+    ) {
         const graphileClient = await this.graphileUtils;
         const { id: jobId } = await graphileClient.addJob(
             EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK,
             payload,
             {
-                runAt: new Date(),
+                runAt,
                 maxAttempts: 1,
-                jobKey: `ai-agent-review-writeback:${payload.fingerprint}`,
+                jobKey: continuation
+                    ? `ai-agent-review-writeback:${payload.fingerprint}:continuation:${runAt.getTime()}`
+                    : `ai-agent-review-writeback:${payload.fingerprint}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -297,6 +297,22 @@ const makeService = ({
                 promptUuid: 'prompt-uuid-1',
             }),
             updateThreadTitle: vi.fn().mockResolvedValue(undefined),
+            getThreadMessages: vi.fn().mockResolvedValue([
+                {
+                    ai_prompt_uuid: 'prompt-uuid-1',
+                    created_at: new Date(),
+                },
+            ]),
+            getToolResultsForPrompt: vi
+                .fn()
+                .mockResolvedValueOnce([])
+                .mockResolvedValue([
+                    {
+                        toolName: 'editDbtProject',
+                        result: 'Opened a pull request.',
+                        metadata: { status: 'success', prUrl: PR_URL },
+                    },
+                ]),
             ...aiAgentModel,
         },
         aiAgentMemoryModel: {
@@ -2487,6 +2503,215 @@ describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
                     eventType: 'pr_opened',
                     payload: { prUrl: PR_URL, prNumber: 42 },
                 },
+            }),
+        );
+    });
+
+    it('waits for a pending dbt writeback to finish and uses its pull request', async () => {
+        const setReviewItemPrLink = vi.fn().mockResolvedValue(undefined);
+        const aiAgentReviewWriteback = vi.fn().mockResolvedValue({
+            jobId: 'continuation-job-1',
+        });
+        const service = makeService({
+            aiAgentModel: {
+                getToolResultsForPrompt: vi
+                    .fn()
+                    .mockResolvedValueOnce([])
+                    .mockResolvedValueOnce([
+                        {
+                            toolName: 'editDbtProject',
+                            result: 'Writeback is running.',
+                            metadata: {
+                                status: 'pending',
+                                aiWritebackRunUuid: 'writeback-run-1',
+                            },
+                        },
+                    ])
+                    .mockResolvedValue([
+                        {
+                            toolName: 'editDbtProject',
+                            result: 'Opened a pull request.',
+                            metadata: {
+                                status: 'success',
+                                prUrl: PR_URL,
+                            },
+                        },
+                    ]),
+            },
+            aiAgentReviewClassifierModel: {
+                setReviewItemPrLink,
+                getThreadWritebackPullRequests: vi
+                    .fn()
+                    .mockResolvedValue(new Map([[WORK_THREAD_UUID, []]])),
+            },
+            schedulerClient: { aiAgentReviewWriteback },
+        });
+
+        await expect(
+            service.runReviewItemWritebackJob(payload),
+        ).resolves.toBeUndefined();
+        expect(setReviewItemPrLink).not.toHaveBeenCalled();
+        expect(aiAgentReviewWriteback).toHaveBeenCalledWith(
+            payload,
+            expect.any(Date),
+            true,
+        );
+
+        await expect(
+            service.runReviewItemWritebackJob(payload),
+        ).resolves.toBeUndefined();
+        expect(setReviewItemPrLink).toHaveBeenCalledWith(
+            expect.objectContaining({ linkedPrUrl: PR_URL, prState: 'open' }),
+        );
+    });
+
+    it('fails actionably when a pending dbt writeback exceeds its deadline', async () => {
+        const aiAgentReviewWriteback = vi.fn();
+        const service = makeService({
+            aiAgentModel: {
+                getThreadMessages: vi.fn().mockResolvedValue([
+                    {
+                        ai_prompt_uuid: 'prompt-uuid-1',
+                        created_at: new Date(Date.now() - 61 * 60 * 1000),
+                    },
+                ]),
+                getToolResultsForPrompt: vi.fn().mockResolvedValue([
+                    {
+                        toolName: 'editDbtProject',
+                        result: 'Writeback is running.',
+                        metadata: {
+                            status: 'pending',
+                            aiWritebackRunUuid: 'writeback-run-1',
+                        },
+                    },
+                ]),
+            },
+            schedulerClient: { aiAgentReviewWriteback },
+        });
+
+        await expect(
+            service.runReviewItemWritebackJob(payload),
+        ).rejects.toThrow(
+            'Writeback did not finish within 60 minutes. Try again.',
+        );
+        expect(aiAgentReviewWriteback).not.toHaveBeenCalled();
+    });
+
+    it('keeps remediation open when dbt source selection prevents a pull request', async () => {
+        const updateReviewRemediationStatus = vi
+            .fn()
+            .mockResolvedValue(undefined);
+        const setReviewItemWritebackStatus = vi
+            .fn()
+            .mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentModel: {
+                getToolResultsForPrompt: vi.fn().mockResolvedValue([
+                    {
+                        toolName: 'editDbtProject',
+                        result: 'Select a dbt source and try again.',
+                        metadata: {
+                            status: 'success',
+                            prUrl: null,
+                            needsDbtSourceSelection: true,
+                            dbtSourceOptions: [
+                                {
+                                    projectDbtSourceUuid: 'source-1',
+                                    name: 'primary',
+                                    isPrimary: true,
+                                    repository: 'acme/analytics',
+                                    branch: 'main',
+                                    projectSubPath: '.',
+                                },
+                            ],
+                        },
+                    },
+                ]),
+            },
+            aiAgentReviewClassifierModel: {
+                updateReviewRemediationStatus,
+                setReviewItemWritebackStatus,
+                getThreadWritebackPullRequests: vi
+                    .fn()
+                    .mockResolvedValue(new Map([[WORK_THREAD_UUID, []]])),
+            },
+            aiAgentService: {
+                generateAgentThreadResponse: vi
+                    .fn()
+                    .mockResolvedValue('I need a source selection.'),
+            },
+        });
+
+        await expect(
+            service.runReviewItemWritebackJob(payload),
+        ).rejects.toThrow('Select a dbt source and try again');
+        expect(updateReviewRemediationStatus).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                remediationUuid: REMEDIATION_UUID,
+                status: 'failed',
+                errorMessage: expect.stringContaining(
+                    'Select a dbt source and try again',
+                ),
+            }),
+        );
+        expect(setReviewItemWritebackStatus).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: 'failed' }),
+        );
+        expect(updateReviewRemediationStatus).not.toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'resolved' }),
+        );
+    });
+
+    it('resolves remediation when writeback confirms no changes are needed', async () => {
+        const updateReviewRemediationStatus = vi
+            .fn()
+            .mockResolvedValue(undefined);
+        const setReviewItemWritebackStatus = vi
+            .fn()
+            .mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentModel: {
+                getToolResultsForPrompt: vi.fn().mockResolvedValue([
+                    {
+                        toolName: 'editDbtProject',
+                        result: 'No file changes were needed.',
+                        metadata: {
+                            status: 'success',
+                            prUrl: null,
+                            needsDbtSourceSelection: false,
+                        },
+                    },
+                ]),
+            },
+            aiAgentReviewClassifierModel: {
+                updateReviewRemediationStatus,
+                setReviewItemWritebackStatus,
+                getThreadWritebackPullRequests: vi
+                    .fn()
+                    .mockResolvedValue(new Map([[WORK_THREAD_UUID, []]])),
+            },
+            aiAgentService: {
+                generateAgentThreadResponse: vi
+                    .fn()
+                    .mockResolvedValue(
+                        'The existing semantic layer already contains the requested hint. No changes are needed.',
+                    ),
+            },
+        });
+
+        await expect(
+            service.runReviewItemWritebackJob(payload),
+        ).resolves.toBeUndefined();
+        expect(updateReviewRemediationStatus).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                remediationUuid: REMEDIATION_UUID,
+                status: 'resolved',
+            }),
+        );
+        expect(setReviewItemWritebackStatus).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                status: 'completed',
+                message: 'Writeback ran — no changes were needed',
             }),
         );
     });

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -54,6 +54,7 @@ import {
     PullRequestSource,
     RequestMethod,
     RETENTION_WINDOW_HOURS_ERROR,
+    toolEditDbtProjectOutputSchema,
     UpdateAiAgentReviewItemPriority,
     UpdateAiAgentReviewItemStatus,
     UpdateAiReviewNotificationSettings,
@@ -344,6 +345,15 @@ export const getAiAgentReviewItemWritebackEligibility = (args: {
         provider: projectAccess.provider,
     };
 };
+
+const REVIEW_WRITEBACK_TERMINAL_TIMEOUT_MS = 60 * 60 * 1000;
+const REVIEW_WRITEBACK_RETRY_DELAY_MS = 5 * 1000;
+
+type ReviewWritebackOutcome =
+    | { type: 'not_started' }
+    | { type: 'pending' }
+    | { type: 'action_required'; message: string }
+    | { type: 'success'; prUrl: string | null };
 
 export class AiAgentAdminService extends BaseService {
     private readonly analytics: LightdashAnalytics;
@@ -2181,6 +2191,75 @@ export class AiAgentAdminService extends BaseService {
      * the job, streaming phase messages onto the review item so the admin UI
      * can poll for progress.
      */
+    private async getReviewWritebackOutcome(
+        organizationUuid: string,
+        projectUuid: string,
+        workThreadUuid: string,
+    ): Promise<ReviewWritebackOutcome> {
+        const messages = await this.aiAgentModel.getThreadMessages(
+            organizationUuid,
+            projectUuid,
+            workThreadUuid,
+        );
+        const latestPrompt = messages.at(-1);
+        if (!latestPrompt) {
+            return {
+                type: 'action_required',
+                message: 'Writeback did not produce a prompt result',
+            };
+        }
+        const toolResults = await this.aiAgentModel.getToolResultsForPrompt(
+            latestPrompt.ai_prompt_uuid,
+        );
+        const latestWritebackResult = toolResults
+            .filter((result) => result.toolName === 'editDbtProject')
+            .at(-1);
+        if (!latestWritebackResult) {
+            return { type: 'not_started' };
+        }
+        const parsed = toolEditDbtProjectOutputSchema.safeParse({
+            result: latestWritebackResult.result,
+            metadata: latestWritebackResult.metadata,
+        });
+        if (!parsed.success) {
+            return {
+                type: 'action_required',
+                message: 'Writeback did not produce a terminal edit result',
+            };
+        }
+        if (parsed.data.metadata.status === 'pending') {
+            const promptCreatedAt = new Date(latestPrompt.created_at).getTime();
+            if (
+                !Number.isFinite(promptCreatedAt) ||
+                Date.now() - promptCreatedAt >=
+                    REVIEW_WRITEBACK_TERMINAL_TIMEOUT_MS
+            ) {
+                return {
+                    type: 'action_required',
+                    message:
+                        'Writeback did not finish within 60 minutes. Try again.',
+                };
+            }
+            return { type: 'pending' };
+        }
+        if (parsed.data.metadata.status === 'error') {
+            return {
+                type: 'action_required',
+                message: parsed.data.result,
+            };
+        }
+        if (parsed.data.metadata.needsDbtSourceSelection) {
+            return {
+                type: 'action_required',
+                message: parsed.data.result,
+            };
+        }
+        return {
+            type: 'success',
+            prUrl: parsed.data.metadata.prUrl,
+        };
+    }
+
     async runReviewItemWritebackJob(
         payload: AiAgentReviewWritebackJobPayload,
     ): Promise<void> {
@@ -2315,21 +2394,52 @@ export class AiAgentAdminService extends BaseService {
                         'Build-fix thread was not created for this remediation',
                     );
                 }
-                await this.aiAgentService.generateAgentThreadResponse(user, {
-                    agentUuid,
-                    threadUuid: workThreadUuid,
-                    autoApproveSql: true,
-                    // Force the writeback tool on the opening turn so the run
-                    // always opens a PR rather than just discussing the fix.
-                    toolHints: ['editDbtProject'],
-                    forceToolHints: true,
-                    // The review flow owns preview + verification (below), so the
-                    // tool must not also create its own preview project.
-                    suppressWritebackPreview: true,
-                    onStepProgress: (message) => {
-                        void setProgress(message);
-                    },
-                });
+                let writebackOutcome = await this.getReviewWritebackOutcome(
+                    organizationUuid,
+                    projectUuid,
+                    workThreadUuid,
+                );
+                if (writebackOutcome.type === 'not_started') {
+                    await this.aiAgentService.generateAgentThreadResponse(
+                        user,
+                        {
+                            agentUuid,
+                            threadUuid: workThreadUuid,
+                            autoApproveSql: true,
+                            dbtSourceUuid: plan.dbtSourceUuid ?? undefined,
+                            toolHints: ['editDbtProject'],
+                            forceToolHints: true,
+                            suppressWritebackPreview: true,
+                            onStepProgress: (message) => {
+                                void setProgress(message);
+                            },
+                        },
+                    );
+                    writebackOutcome = await this.getReviewWritebackOutcome(
+                        organizationUuid,
+                        projectUuid,
+                        workThreadUuid,
+                    );
+                }
+                if (writebackOutcome.type === 'pending') {
+                    const runAt = new Date(
+                        Date.now() + REVIEW_WRITEBACK_RETRY_DELAY_MS,
+                    );
+                    await this.schedulerClient.aiAgentReviewWriteback(
+                        payload,
+                        runAt,
+                        true,
+                    );
+                    return;
+                }
+                if (writebackOutcome.type === 'not_started') {
+                    throw new ParameterError(
+                        'Writeback did not produce an edit result',
+                    );
+                }
+                if (writebackOutcome.type === 'action_required') {
+                    throw new ParameterError(writebackOutcome.message);
+                }
                 const writebackPrs =
                     await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
                         [workThreadUuid],
@@ -2341,7 +2451,10 @@ export class AiAgentAdminService extends BaseService {
                 // tool (multi-repo, multiple PRs per turn), this selection
                 // would silently drop all but the newest PR — handle every
                 // entry instead of taking `[0]`.
-                prUrl = writebackPrs.get(workThreadUuid)?.[0]?.prUrl ?? null;
+                prUrl =
+                    writebackOutcome.prUrl ??
+                    writebackPrs.get(workThreadUuid)?.[0]?.prUrl ??
+                    null;
                 pullRequest = prUrl
                     ? await this.pullRequestsModel.findByProjectAndUrl(
                           projectUuid,
@@ -2445,9 +2558,6 @@ export class AiAgentAdminService extends BaseService {
                 await setTerminal('completed', terminalMessage);
             } else {
                 if (remediationUuid) {
-                    // No PR means nothing was wrong to fix — a legitimate
-                    // no-op, not a failure; close the remediation to match the
-                    // item's completed status.
                     await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
                         {
                             remediationUuid,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6608,6 +6608,7 @@ export class AiAgentService extends BaseService {
             forceToolHints,
             onStepProgress,
             suppressWritebackPreview,
+            dbtSourceUuid,
             isReviewRemediationWorkThread,
             execution = { mode: 'standard' },
         }: {
@@ -6624,6 +6625,7 @@ export class AiAgentService extends BaseService {
                 progressStatus?: 'in_progress' | 'complete' | 'error',
             ) => void | Promise<void>;
             suppressWritebackPreview?: boolean;
+            dbtSourceUuid?: string;
             // Enables the work-thread-only editProjectContext tool so the agent
             // can open/change the project_context PR from this thread.
             isReviewRemediationWorkThread?: boolean;
@@ -6676,6 +6678,7 @@ export class AiAgentService extends BaseService {
                     forceToolHints,
                     onSlackStepProgress: onStepProgress,
                     suppressWritebackPreview,
+                    dbtSourceUuid,
                     isReviewRemediationWorkThread,
                     execution,
                 },
@@ -8912,6 +8915,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             promptUuid,
             toolCallId,
             writebackPrompt,
+            dbtSourceUuid,
             source,
             prUrl,
             startNewPullRequest,
@@ -8947,6 +8951,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         user,
                         projectUuid,
                         prompt: writebackPrompt,
+                        dbtSourceUuid,
                         prUrl,
                         startNewPullRequest: startNewPullRequest ?? false,
                         aiThreadUuid: prompt.threadUuid,
@@ -9274,6 +9279,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             ) => void | Promise<void>;
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
             suppressWritebackPreview?: boolean;
+            dbtSourceUuid?: string;
             onWarehouseQuery?: () => void | Promise<void>;
         },
     ) {
@@ -9562,6 +9568,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 isSlackPrompt: isSlackPrompt(prompt),
                 toolCallId: args.progressId,
                 writebackPrompt,
+                dbtSourceUuid: args.dbtSourceUuid ?? options?.dbtSourceUuid,
                 source,
                 prUrl: args.prUrl,
                 startNewPullRequest: args.startNewPullRequest ?? null,
@@ -9943,6 +9950,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             const writeback = await this.projectContextService.writebackEntry({
                 user,
                 projectUuid,
+                dbtSourceUuid: entry.dbtSourceUuid ?? options?.dbtSourceUuid,
                 entry,
                 branchTimestamp: Date.now(),
                 sourceThread,
@@ -10080,6 +10088,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             // and verification itself — the editDbtProject tool must not also
             // spin up its own preview project.
             suppressWritebackPreview?: boolean;
+            dbtSourceUuid?: string;
             // Forces the first tool hint on the opening step instead of merely
             // suggesting it (review Build-fix guarantees editDbtProject runs).
             forceToolHints?: boolean;
@@ -10126,6 +10135,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableSqlMode?: boolean;
             autoApproveSql?: boolean;
             suppressWritebackPreview?: boolean;
+            dbtSourceUuid?: string;
             forceToolHints?: boolean;
             isReviewRemediationWorkThread?: boolean;
             toolHints?: string[];
@@ -10257,6 +10267,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     : undefined),
             runtimeOptions: options.runtimeOptions,
             suppressWritebackPreview: options.suppressWritebackPreview,
+            dbtSourceUuid: options.dbtSourceUuid,
             onWarehouseQuery:
                 responseExecution.mode === 'deep_research'
                     ? responseExecution.onWarehouseQuery

--- a/packages/backend/src/ee/services/AiAgentService/runEditDbtProjectPipeline.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/runEditDbtProjectPipeline.test.ts
@@ -214,6 +214,42 @@ describe('AiAgentService.runEditDbtProjectPipeline', () => {
         );
     });
 
+    it('keeps the selected additional dbt source through the worker pipeline', async () => {
+        const primaryResult = {
+            ...WRITEBACK_RESULT,
+            repository: 'acme/primary-analytics',
+            output: 'Updated models/orders.yml with primary orders.',
+            dbtSourceUuid: '00000000-0000-0000-0000-000000000001',
+        };
+        const additionalResult = {
+            ...WRITEBACK_RESULT,
+            repository: 'acme/additional-analytics',
+            output: 'Updated models/orders.yml with additional orders.',
+            dbtSourceUuid: '00000000-0000-0000-0000-000000000002',
+        };
+        const run = vi
+            .fn()
+            .mockImplementation(async (args) =>
+                args.dbtSourceUuid === additionalResult.dbtSourceUuid
+                    ? additionalResult
+                    : primaryResult,
+            );
+        const { service, updateToolResult } = buildService({ run });
+
+        await service.runEditDbtProjectPipeline({
+            ...PAYLOAD,
+            dbtSourceUuid: additionalResult.dbtSourceUuid,
+        });
+
+        expect(updateToolResult).toHaveBeenCalledWith(
+            'prompt-1',
+            'tool-call-1',
+            expect.objectContaining({
+                result: expect.stringContaining('acme/additional-analytics'),
+            }),
+        );
+    });
+
     it('waits for the tool-result row to exist before updating it', async () => {
         const { service, hasToolResult, updateToolResult } = buildService({});
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -1675,6 +1675,96 @@ describe('AiWritebackService repo read access', () => {
             ]);
         });
 
+        it('authorizes primary and configured additional source repositories without exposing unrelated installation repositories', async () => {
+            const sharedModelIdentity = {
+                modelName: 'orders',
+                ymlPath: 'models/orders.yml',
+            };
+            const project = {
+                ...githubProject(),
+                dbtSourceUuid: PRIMARY_SOURCE_UUID,
+                sourceFixture: {
+                    ...sharedModelIdentity,
+                    observableValue: 'primary orders',
+                },
+            };
+            const additionalSource = {
+                projectDbtSourceUuid: 'additional-source-uuid',
+                projectUuid: 'p1',
+                name: 'Additional source',
+                isPrimary: false,
+                precedence: 1,
+                dbtConnection: {
+                    type: DbtProjectType.GITHUB,
+                    authorization_method: 'installation_id',
+                    repository: 'acme/additional-analytics',
+                    branch: 'additional-main',
+                    project_sub_path: 'transform/dbt',
+                },
+                sourceFixture: {
+                    ...sharedModelIdentity,
+                    observableValue: 'additional orders',
+                },
+                createdAt: new Date('2026-08-27T00:00:00.000Z'),
+                updatedAt: new Date('2026-08-27T00:00:00.000Z'),
+            };
+            const { service } = buildWithInstallation(project);
+            (service as AnyType).projectDbtSourcesModel = {
+                getSources: vi.fn().mockResolvedValue([additionalSource]),
+            };
+            (
+                listReposAccessibleToInstallation as import('vitest').Mock
+            ).mockResolvedValue([
+                {
+                    owner: 'acme',
+                    repo: 'analytics',
+                    defaultBranch: 'main',
+                    private: true,
+                },
+                {
+                    owner: 'acme',
+                    repo: 'additional-analytics',
+                    defaultBranch: 'additional-main',
+                    private: true,
+                },
+                {
+                    owner: 'acme',
+                    repo: 'secret-infrastructure',
+                    defaultBranch: 'main',
+                    private: true,
+                },
+            ]);
+
+            const access = await service.getInstallationRepoReadAccess({
+                user: userWithOrg(true),
+                projectUuid: 'p1',
+            });
+
+            await expect(access.listRepos()).resolves.toEqual([
+                {
+                    owner: 'acme',
+                    repo: 'analytics',
+                    defaultBranch: 'main',
+                    private: true,
+                },
+                {
+                    owner: 'acme',
+                    repo: 'additional-analytics',
+                    defaultBranch: 'additional-main',
+                    private: true,
+                },
+            ]);
+            await expect(
+                access.resolveRepoAccess('acme', 'additional-analytics'),
+            ).resolves.toEqual({
+                branch: 'additional-main',
+                token: 'install-token',
+            });
+            await expect(
+                access.resolveRepoAccess('acme', 'secret-infrastructure'),
+            ).rejects.toThrow(ForbiddenError);
+        });
+
         it('unions the linked user repos with the org repos (org wins on collision)', async () => {
             const project = githubProject();
             project.dbtConnection.repository = 'acme/shared';
@@ -2164,7 +2254,7 @@ describe('mergeSourceCodeRepoAccess', () => {
             undefined,
             [u('acme', 'analytics'), u('acme', 'secret-infrastructure')],
             'inst-token',
-            'acme/analytics',
+            ['acme/analytics'],
         );
         expect([...map.keys()]).toEqual(['acme/analytics']);
         expect(map.get('acme/analytics')?.token).toBe('inst-token');
@@ -2176,7 +2266,7 @@ describe('mergeSourceCodeRepoAccess', () => {
             'user-token',
             [u('acme', 'shared'), u('acme', 'data')],
             'inst-token',
-            'acme/shared',
+            ['acme/shared'],
         );
         expect([...map.keys()].sort()).toEqual(['acme/shared', 'me/personal']);
         expect(map.get('me/personal')?.token).toBe('user-token');
@@ -2189,7 +2279,7 @@ describe('mergeSourceCodeRepoAccess', () => {
             'user-token',
             [u('Acme', 'Analytics')],
             'inst-token',
-            'acme/analytics',
+            ['acme/analytics'],
         );
 
         expect([...map.values()]).toEqual([
@@ -2235,7 +2325,7 @@ describe('computeWritableRepoKeys', () => {
             [r('acme', 'a'), r('acme', 'b')],
             [],
             false,
-            'acme/a',
+            ['acme/a'],
         );
         expect([...keys]).toEqual(['acme/a']);
     });
@@ -2245,7 +2335,7 @@ describe('computeWritableRepoKeys', () => {
             [r('acme', 'a'), r('acme', 'b'), r('acme', 'c')],
             [r('acme', 'b'), r('acme', 'c'), r('me', 'x')],
             true,
-            'acme/a',
+            ['acme/a'],
         );
         expect([...keys].sort()).toEqual(['acme/a', 'acme/b', 'acme/c']);
     });
@@ -2255,7 +2345,7 @@ describe('computeWritableRepoKeys', () => {
             [r('lightdash', 'lightdash'), r('acme', 'a')],
             [],
             false,
-            'acme/a',
+            ['acme/a'],
         );
         expect(keys.has('lightdash/lightdash')).toBe(false);
         expect(keys.has('acme/a')).toBe(true);
@@ -2266,7 +2356,7 @@ describe('computeWritableRepoKeys', () => {
             [r('Lightdash', 'Lightdash')],
             [],
             false,
-            'Lightdash/Lightdash',
+            ['Lightdash/Lightdash'],
         );
         expect(keys.size).toBe(0);
     });
@@ -2276,7 +2366,7 @@ describe('computeWritableRepoKeys', () => {
             [r('Acme', 'Web-App')],
             [r('acme', 'web-app')],
             true,
-            null,
+            [],
         );
         // The slug differs only by case across the two listings — it must still
         // intersect (L1), and the output keeps the installation's casing.

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -297,7 +297,7 @@ export const mergeSourceCodeRepoAccess = (
     userToken: string | undefined,
     installationRepos: RepoListing[],
     installationToken: string,
-    projectRepoKey: string | null,
+    projectRepoKeys: Iterable<string>,
 ): Map<string, SourceCodeRepoAccess> => {
     const map = new Map<string, SourceCodeRepoAccess>();
     if (userToken) {
@@ -311,11 +311,13 @@ export const mergeSourceCodeRepoAccess = (
             });
         }
     }
-    const normalizedProjectRepoKey = projectRepoKey?.toLowerCase();
-    const projectRepos = installationRepos.filter(
-        (repo) =>
-            `${repo.owner}/${repo.repo}`.toLowerCase() ===
-            normalizedProjectRepoKey,
+    const normalizedProjectRepoKeys = new Set(
+        [...projectRepoKeys].map((key) => key.toLowerCase()),
+    );
+    const projectRepos = installationRepos.filter((repo) =>
+        normalizedProjectRepoKeys.has(
+            `${repo.owner}/${repo.repo}`.toLowerCase(),
+        ),
     );
     for (const r of projectRepos) {
         map.set(`${r.owner}/${r.repo}`.toLowerCase(), {
@@ -362,7 +364,7 @@ export const computeWritableRepoKeys = (
     installationRepos: { owner: string; repo: string }[],
     userRepos: { owner: string; repo: string }[],
     intersectWithUser: boolean,
-    projectRepoKey: string | null,
+    projectRepoKeys: Iterable<string>,
 ): Set<string> => {
     // GitHub/GitLab repo slugs are case-insensitive, and the installation vs
     // user listings can disagree on case — compare lowercased so the
@@ -371,14 +373,16 @@ export const computeWritableRepoKeys = (
     const userKeys = new Set(
         userRepos.map((r) => `${r.owner}/${r.repo}`.toLowerCase()),
     );
-    const normalizedProjectRepoKey = projectRepoKey?.toLowerCase();
+    const normalizedProjectRepoKeys = new Set(
+        [...projectRepoKeys].map((key) => key.toLowerCase()),
+    );
     return new Set(
         installationRepos
             .map((r) => `${r.owner}/${r.repo}`)
             .filter((key) => !DENYLISTED_WRITE_REPOS.has(key.toLowerCase()))
             .filter(
                 (key) =>
-                    key.toLowerCase() === normalizedProjectRepoKey ||
+                    normalizedProjectRepoKeys.has(key.toLowerCase()) ||
                     (intersectWithUser && userKeys.has(key.toLowerCase())),
             ),
     );
@@ -988,7 +992,11 @@ export class AiWritebackService extends BaseService {
             token: installationToken,
             project,
         } = await this.resolveSourceCodeInstallation({ user, projectUuid });
-        const projectRepoKey = getProjectRepositoryKey(project.dbtConnection);
+        const projectRepoKeys = await this.getConfiguredRepositoryKeys(
+            projectUuid,
+            project,
+            DbtProjectType.GITHUB,
+        );
 
         // The linked user's own GitHub token, if any, authorizes additional
         // repositories independently of the organization installation.
@@ -1030,7 +1038,7 @@ export class AiWritebackService extends BaseService {
                         userToken,
                         orgRepos,
                         installationToken,
-                        projectRepoKey,
+                        projectRepoKeys,
                     );
                 })();
             }
@@ -1115,7 +1123,11 @@ export class AiWritebackService extends BaseService {
         // the connection's host_domain so gitlab.com and self-hosted both work.
         const bareHost = hostDomain.replace(/^https?:\/\//, '');
         const instanceUrl = `https://${bareHost}`;
-        const projectRepoKey = getProjectRepositoryKey(project.dbtConnection);
+        const projectRepoKeys = await this.getConfiguredRepositoryKeys(
+            projectUuid,
+            project,
+            DbtProjectType.GITLAB,
+        );
 
         // Build the repo map once and memoise it — listRepos and
         // resolveRepoAccess share it, so the GitLab listing happens at most once.
@@ -1143,8 +1155,9 @@ export class AiWritebackService extends BaseService {
                                 return;
                             const [owner, repo] = segments;
                             if (
-                                `${owner}/${repo}`.toLowerCase() !==
-                                projectRepoKey?.toLowerCase()
+                                !projectRepoKeys.has(
+                                    `${owner}/${repo}`.toLowerCase(),
+                                )
                             ) {
                                 return;
                             }
@@ -1246,7 +1259,13 @@ export class AiWritebackService extends BaseService {
             user,
             projectUuid,
         });
-        const projectRepoKey = getProjectRepositoryKey(project.dbtConnection);
+        const projectRepoKeys = await this.getConfiguredRepositoryKeys(
+            projectUuid,
+            project,
+            project.dbtConnection.type === DbtProjectType.GITLAB
+                ? DbtProjectType.GITLAB
+                : DbtProjectType.GITHUB,
+        );
 
         if (project.dbtConnection.type === DbtProjectType.GITLAB) {
             const access = await this.getGitlabInstallationRepoReadAccess({
@@ -1259,7 +1278,7 @@ export class AiWritebackService extends BaseService {
                 [],
                 // GitLab: single install identity, no user-intersection.
                 false,
-                projectRepoKey,
+                projectRepoKeys,
             );
             return repos.map(({ owner, repo, defaultBranch }) => ({
                 name: repo,
@@ -1312,7 +1331,7 @@ export class AiWritebackService extends BaseService {
             installationRepos,
             userRepos,
             intersectWithUser,
-            projectRepoKey,
+            projectRepoKeys,
         );
 
         const readableRepos = mergeSourceCodeRepoAccess(
@@ -1320,7 +1339,7 @@ export class AiWritebackService extends BaseService {
             userToken,
             installationRepos,
             installationToken,
-            projectRepoKey,
+            projectRepoKeys,
         );
         const normalizedWritableKeys = new Set(
             [...writableKeys].map((key) => key.toLowerCase()),
@@ -2823,6 +2842,26 @@ export class AiWritebackService extends BaseService {
         return primary ? [primary, ...extra] : extra;
     }
 
+    private async getConfiguredRepositoryKeys(
+        projectUuid: string,
+        project: { projectUuid: string; dbtConnection: DbtProjectConfig },
+        provider: DbtProjectType.GITHUB | DbtProjectType.GITLAB,
+    ): Promise<Set<string>> {
+        const candidates = await this.listDbtTargetCandidates(
+            projectUuid,
+            project,
+        );
+        return new Set(
+            candidates
+                .filter((candidate) => candidate.connection.type === provider)
+                .map((candidate) =>
+                    getProjectRepositoryKey(candidate.connection),
+                )
+                .filter((key): key is string => key !== null)
+                .map((key) => key.toLowerCase()),
+        );
+    }
+
     /**
      * Decide which dbt source a turn targets. Precedence:
      * 1. a resumed thread stays bound to its original source (never re-infer, or
@@ -3148,7 +3187,11 @@ export class AiWritebackService extends BaseService {
             installationRepos,
             userRepos,
             intersectWithUser,
-            getProjectRepositoryKey(project.dbtConnection),
+            await this.getConfiguredRepositoryKeys(
+                project.projectUuid,
+                project,
+                DbtProjectType.GITHUB,
+            ),
         );
         // Case-insensitive membership: `key` is user-supplied (repoTarget) and
         // may differ in case from the canonical installation listing (L1).
@@ -3230,7 +3273,11 @@ export class AiWritebackService extends BaseService {
             [],
             // GitLab: single install identity, no user-intersection.
             false,
-            getProjectRepositoryKey(project.dbtConnection),
+            await this.getConfiguredRepositoryKeys(
+                project.projectUuid,
+                project,
+                DbtProjectType.GITLAB,
+            ),
         );
         // Case-insensitive membership: `key` is user-supplied (L1).
         const writableLower = new Set(

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
@@ -115,6 +115,10 @@ const makeService = (overrides: {
     let cachedEntries = overrides.initialEntries ?? existingEntries();
     const projectModel = {
         get: vi.fn().mockResolvedValue(overrides.project ?? githubProject),
+        getDbtSourceIdentity: vi.fn().mockResolvedValue({
+            dbtSourceUuid: PROJECT_UUID,
+            dbtSourceName: 'primary',
+        }),
         getSummary: vi.fn().mockResolvedValue(
             overrides.projectSummary ?? {
                 organizationUuid: ORG_UUID,
@@ -446,6 +450,25 @@ describe('ProjectContextService.writebackEntry', () => {
                 sourceThread: null,
             }),
         ).rejects.toThrow(NotFoundError);
+    });
+
+    test('returns a clear limitation for an explicitly selected additional dbt source', async () => {
+        const { service } = makeService({});
+
+        await expect(
+            service.writebackEntry({
+                user: userWithProjectContextAccess(),
+                projectUuid: PROJECT_UUID,
+                dbtSourceUuid: '00000000-0000-0000-0000-000000000099',
+                entry: judgeEntry,
+                branchTimestamp: 1,
+                sourceThread: null,
+            }),
+        ).rejects.toThrow(
+            'Project context writeback currently supports only the primary dbt source',
+        );
+        expect(mockGetInstallationToken).not.toHaveBeenCalled();
+        expect(mockCreateBranch).not.toHaveBeenCalled();
     });
 
     test('links the originating agent thread in the PR body', async () => {

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
@@ -5,6 +5,7 @@ import {
     ForbiddenError,
     loadProjectContextFile,
     NotFoundError,
+    ParameterError,
     ParseError,
     persistedAiAgentJudgeProjectContextEntrySchema,
     type AiAgentJudgeProjectContextEntry,
@@ -291,6 +292,7 @@ export class ProjectContextService extends BaseService {
     async writebackEntry(args: {
         user: SessionUser;
         projectUuid: string;
+        dbtSourceUuid?: string;
         entry: AiAgentJudgeProjectContextEntry;
         branchTimestamp: number;
         // The agent thread that motivated this entry, linked from the PR body
@@ -302,6 +304,16 @@ export class ProjectContextService extends BaseService {
         } | null;
     }): Promise<ProjectContextWritebackResult> {
         const entry = parseWritebackEntry(args.entry);
+        if (args.dbtSourceUuid) {
+            const identity = await this.projectModel.getDbtSourceIdentity(
+                args.projectUuid,
+            );
+            if (args.dbtSourceUuid !== identity.dbtSourceUuid) {
+                throw new ParameterError(
+                    'Project context writeback currently supports only the primary dbt source',
+                );
+            }
+        }
         const access = await this.resolveGithubAccess(
             args.user,
             args.projectUuid,

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -3,6 +3,7 @@ import {
     type AiAgentReviewItemSummary,
 } from '@lightdash/common';
 import {
+    buildYmlPathByModel,
     planReviewWriteback,
     PROJECT_CONTEXT_WORK_THREAD_INSTRUCTION,
 } from './buildReviewWritebackPrompt';
@@ -97,7 +98,15 @@ describe('planReviewWriteback', () => {
         const plan = expectPromptPlan(
             planReviewWriteback(
                 baseItem(),
-                new Map([['orders', 'models/orders.yml']]),
+                new Map([
+                    [
+                        'orders',
+                        {
+                            ymlPath: 'models/orders.yml',
+                            dbtSourceUuid: null,
+                        },
+                    ],
+                ]),
             ),
         );
 
@@ -125,6 +134,54 @@ describe('planReviewWriteback', () => {
 
         expect(plan.promptText).toContain('metric "orders.average_order_size"');
         expect(plan.promptText).not.toContain('(yaml:');
+    });
+
+    it('keeps the additional source identity when two sources contain the same model and yaml path', () => {
+        const targets = buildYmlPathByModel([
+            {
+                name: 'primary__orders',
+                tables: {
+                    primary__orders: {
+                        name: 'orders',
+                        ymlPath: 'models/orders.yml',
+                        dbtSourceUuid: '00000000-0000-0000-0000-000000000001',
+                    },
+                },
+            },
+            {
+                name: 'additional__orders',
+                tables: {
+                    additional__orders: {
+                        name: 'orders',
+                        ymlPath: 'models/orders.yml',
+                        dbtSourceUuid: '00000000-0000-0000-0000-000000000002',
+                    },
+                },
+            },
+        ] as never);
+        const item = baseItem();
+        if (item.latestFinding) {
+            item.latestFinding.targetRefs = [
+                {
+                    type: 'metric',
+                    modelName: 'additional__orders',
+                    metricName: 'average_order_size',
+                },
+            ];
+        }
+
+        const plan = expectPromptPlan(planReviewWriteback(item, targets));
+
+        expect(targets.get('additional__orders')).toEqual({
+            ymlPath: 'models/orders.yml',
+            dbtSourceUuid: '00000000-0000-0000-0000-000000000002',
+        });
+        expect(plan).toMatchObject({
+            dbtSourceUuid: '00000000-0000-0000-0000-000000000002',
+        });
+        expect(plan.promptText).toContain(
+            'metric "additional__orders.average_order_size" (yaml: models/orders.yml)',
+        );
     });
 
     it('builds a prompt from a manual semantic-layer issue', () => {

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
@@ -23,6 +23,7 @@ export type ReviewWritebackPlan =
           strategy: 'prompt';
           promptText: string;
           aggregationKey: string | null;
+          dbtSourceUuid: string | null;
       }
     | {
           strategy: 'project_context';
@@ -32,15 +33,21 @@ export type ReviewWritebackPlan =
 // Resolves each model's dbt YAML path from compiled explores so the writeback agent edits the right file (the judge only gives names).
 export const buildYmlPathByModel = (
     explores: (Explore | ExploreError)[],
-): Map<string, string> => {
-    const map = new Map<string, string>();
+): Map<string, { ymlPath: string; dbtSourceUuid: string | null }> => {
+    const map = new Map<
+        string,
+        { ymlPath: string; dbtSourceUuid: string | null }
+    >();
     explores.forEach((explore) => {
         if (isExploreError(explore)) {
             return;
         }
         Object.entries(explore.tables).forEach(([tableName, table]) => {
             if (table.ymlPath) {
-                map.set(tableName, table.ymlPath);
+                map.set(tableName, {
+                    ymlPath: table.ymlPath,
+                    dbtSourceUuid: table.dbtSourceUuid ?? null,
+                });
             }
         });
     });
@@ -49,9 +56,12 @@ export const buildYmlPathByModel = (
 
 const formatSemanticTargetRef = (
     ref: AiAgentSemanticTargetRef,
-    ymlPathByModel: Map<string, string>,
+    ymlPathByModel: Map<
+        string,
+        { ymlPath: string; dbtSourceUuid: string | null }
+    >,
 ): string => {
-    const ymlPath = ymlPathByModel.get(ref.modelName);
+    const ymlPath = ymlPathByModel.get(ref.modelName)?.ymlPath;
     const yaml = ymlPath ? ` (yaml: ${ymlPath})` : '';
     switch (ref.type) {
         case 'model':
@@ -85,9 +95,26 @@ const isSemanticTargetRef = (
 
 const buildSemanticLayerWritebackPrompt = (
     item: AiAgentReviewItemSummary,
-    ymlPathByModel: Map<string, string>,
+    ymlPathByModel: Map<
+        string,
+        { ymlPath: string; dbtSourceUuid: string | null }
+    >,
 ): ReviewWritebackPlan => {
     const finding = item.latestFinding;
+    const targetRefs =
+        item.source === 'manual'
+            ? item.targetRefs
+            : (finding?.targetRefs ?? []);
+    const sourceUuids = new Set(
+        targetRefs
+            .filter(isSemanticTargetRef)
+            .map(
+                (ref) =>
+                    ymlPathByModel.get(ref.modelName)?.dbtSourceUuid ?? null,
+            )
+            .filter((uuid): uuid is string => uuid !== null),
+    );
+    const dbtSourceUuid = sourceUuids.size === 1 ? [...sourceUuids][0] : null;
     if (item.source === 'manual') {
         const manualTargetLines = item.targetRefs
             .filter(isSemanticTargetRef)
@@ -107,6 +134,7 @@ const buildSemanticLayerWritebackPrompt = (
             strategy: 'prompt',
             promptText: sections.join('\n\n'),
             aggregationKey: null,
+            dbtSourceUuid,
         };
     }
     const targetLines = (finding?.targetRefs ?? [])
@@ -130,6 +158,7 @@ const buildSemanticLayerWritebackPrompt = (
         strategy: 'prompt',
         promptText: sections.join('\n\n'),
         aggregationKey: null,
+        dbtSourceUuid,
     };
 };
 
@@ -149,7 +178,10 @@ export const PROJECT_CONTEXT_WORK_THREAD_INSTRUCTION =
  */
 export const planReviewWriteback = (
     item: AiAgentReviewItemSummary,
-    ymlPathByModel: Map<string, string> = new Map(),
+    ymlPathByModel: Map<
+        string,
+        { ymlPath: string; dbtSourceUuid: string | null }
+    > = new Map(),
 ): ReviewWritebackPlan => {
     if (item.primaryRootCause === 'semantic_layer') {
         return buildSemanticLayerWritebackPrompt(item, ymlPathByModel);

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -3863,6 +3863,11 @@ Parameters:
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {
+        "dbtSourceUuid": {
+          "description": "The project dbt source UUID to edit. Use the projectDbtSourceUuid returned by a prior source-selection result. Omit it only when the project has one dbt source.",
+          "format": "uuid",
+          "type": "string",
+        },
         "prUrl": {
           "description": "To UPDATE a specific existing pull request instead of opening a new one, put its full URL here (e.g. 'https://github.com/owner/repo/pull/123'). The PR must belong to this project's own dbt repository. Use this both for a PR the user pasted AND to target one of several pull requests this conversation has already opened (get the URL from listWorkstreams or a previous editDbtProject result). Otherwise pass null.",
           "type": [
@@ -4113,6 +4118,11 @@ Parameters:
       "properties": {
         "content": {
           "description": "A single self-contained sentence stating the fact (e.g. '"HR" = the high-risk diabetes cohort, not human resources.').",
+          "type": "string",
+        },
+        "dbtSourceUuid": {
+          "description": "The project dbt source UUID that owns the project context file. Omit it for the primary dbt source.",
+          "format": "uuid",
           "type": "string",
         },
         "id": {

--- a/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
+++ b/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
@@ -14,11 +14,12 @@ export const getEditDbtProject = ({ editDbtProject }: Dependencies) =>
     tool({
         ...toolDefinition,
         execute: async (
-            { prompt, prUrl: pastedPrUrl, startNewPullRequest },
+            { dbtSourceUuid, prompt, prUrl: pastedPrUrl, startNewPullRequest },
             { toolCallId },
         ) => {
             try {
                 const { aiWritebackRunUuid } = await editDbtProject({
+                    dbtSourceUuid,
                     prompt,
                     prUrl: pastedPrUrl,
                     startNewPullRequest,

--- a/packages/backend/src/ee/services/ai/tools/editProjectContext.ts
+++ b/packages/backend/src/ee/services/ai/tools/editProjectContext.ts
@@ -36,9 +36,18 @@ const toolDefinition = editProjectContextToolDefinition.for('agent');
 export const getEditProjectContext = ({ editProjectContext }: Dependencies) =>
     tool({
         ...toolDefinition,
-        execute: async ({ op, id, kind, content, terms, objects }) => {
+        execute: async ({
+            dbtSourceUuid,
+            op,
+            id,
+            kind,
+            content,
+            terms,
+            objects,
+        }) => {
             try {
                 const { prUrl, prAction } = await editProjectContext({
+                    dbtSourceUuid,
                     op,
                     id,
                     kind,

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -628,6 +628,7 @@ export type LoadAgentSkillFn = (
 ) => Promise<AiAgentSkill | undefined>;
 
 export type EditDbtProjectFn = (args: {
+    dbtSourceUuid?: string;
     prompt: string;
     prUrl: string | null;
     /** Open a new PR instead of continuing the thread's existing one. */
@@ -640,7 +641,7 @@ export type EditDbtProjectFn = (args: {
 // Applies a structured project-context entry to lightdash.project_context.yml
 // via the deterministic GitHub-API merge (no sandbox) and opens/updates a PR.
 export type EditProjectContextFn = (
-    entry: AiAgentJudgeProjectContextEntry,
+    entry: AiAgentJudgeProjectContextEntry & { dbtSourceUuid?: string },
 ) => Promise<{ prUrl: string; prAction: 'opened' | 'updated' }>;
 
 /**

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4792,10 +4792,27 @@ export class ProjectService extends BaseService {
             primary.adapter.getDbtManifest(),
             this.projectModel.getDbtSourceIdentity(projectUuid),
         ]);
-        const primaryManifest = manifestWithCompilationSelection(
+        const selectedPrimaryManifest = manifestWithCompilationSelection(
             rawPrimaryManifest,
             primarySelectedModelIds,
         );
+        const primaryManifest = {
+            ...selectedPrimaryManifest,
+            nodes: Object.fromEntries(
+                Object.entries(selectedPrimaryManifest.nodes).map(
+                    ([uniqueId, node]) => [
+                        uniqueId,
+                        node.resource_type === 'model' ||
+                        node.resource_type === 'seed'
+                            ? {
+                                  ...node,
+                                  lightdash_source_uuid: identity.dbtSourceUuid,
+                              }
+                            : node,
+                    ],
+                ),
+            ),
+        };
 
         // A credential error fails the whole deploy by name, matching every
         // other per-source failure below (broken clone, broken manifest) — a
@@ -4858,13 +4875,32 @@ export class ProjectService extends BaseService {
                         manifest,
                         selectedModelIds: sourceSelectedModelIds,
                     } = await sourceAdapter.getDbtManifest();
+                    const selectedManifest = manifestWithCompilationSelection(
+                        manifest,
+                        sourceSelectedModelIds,
+                    );
+                    const sourceManifest = {
+                        ...selectedManifest,
+                        nodes: Object.fromEntries(
+                            Object.entries(selectedManifest.nodes).map(
+                                ([uniqueId, node]) => [
+                                    uniqueId,
+                                    node.resource_type === 'model' ||
+                                    node.resource_type === 'seed'
+                                        ? {
+                                              ...node,
+                                              lightdash_source_uuid:
+                                                  source.projectDbtSourceUuid,
+                                          }
+                                        : node,
+                                ],
+                            ),
+                        ),
+                    };
                     return {
                         name: source.name,
                         precedence: source.precedence,
-                        manifest: manifestWithCompilationSelection(
-                            manifest,
-                            sourceSelectedModelIds,
-                        ),
+                        manifest: sourceManifest,
                         selectedModelIds: sourceSelectedModelIds,
                     };
                 } catch (e) {

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1095,6 +1095,9 @@ export const convertTable = (
         ...(meta.sets ? { sets: meta.sets } : {}),
         ...(tableWarnings.length > 0 ? { warnings: tableWarnings } : {}),
         ...(model.package_name ? { dbtPackageName: model.package_name } : {}),
+        ...(model.lightdash_source_uuid
+            ? { dbtSourceUuid: model.lightdash_source_uuid }
+            : {}),
         ...(model.patch_path
             ? { ymlPath: patchPathParts(model.patch_path).path }
             : {}),

--- a/packages/common/src/dbt/projectMergedManifest.ts
+++ b/packages/common/src/dbt/projectMergedManifest.ts
@@ -26,6 +26,7 @@ const MODEL_FIELDS = [
     'language',
     'depends_on',
     'lightdash_source_name',
+    'lightdash_source_uuid',
 ] as const;
 
 const COLUMN_FIELDS = [

--- a/packages/common/src/dbt/validation.ts
+++ b/packages/common/src/dbt/validation.ts
@@ -140,6 +140,7 @@ export class ManifestValidator {
         );
         const modelToValidate = { ...model };
         delete modelToValidate.lightdash_source_name;
+        delete modelToValidate.lightdash_source_uuid;
         return ManifestValidator.isValid(validator, modelToValidate, {
             modelName: model.name,
             sourceName: model.lightdash_source_name,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.test.ts
@@ -1,0 +1,16 @@
+import { toolEditDbtProjectArgsSchema } from './toolEditDbtProjectArgs';
+
+describe('toolEditDbtProjectArgsSchema', () => {
+    it('preserves an explicit dbt source identity', () => {
+        const dbtSourceUuid = '00000000-0000-0000-0000-000000000002';
+
+        expect(
+            toolEditDbtProjectArgsSchema.parse({
+                prompt: 'Update models/orders.yml',
+                prUrl: null,
+                startNewPullRequest: null,
+                dbtSourceUuid,
+            }),
+        ).toMatchObject({ dbtSourceUuid });
+    });
+});

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
@@ -11,6 +11,13 @@ export const TOOL_EDIT_DBT_PROJECT_DESCRIPTION = [
 ].join(' ');
 
 export const toolEditDbtProjectArgsSchema = z.object({
+    dbtSourceUuid: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+            'The project dbt source UUID to edit. Use the projectDbtSourceUuid returned by a prior source-selection result. Omit it only when the project has one dbt source.',
+        ),
     prompt: z
         .string()
         .describe(

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditProjectContextArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditProjectContextArgs.ts
@@ -11,6 +11,13 @@ export const TOOL_EDIT_PROJECT_CONTEXT_DESCRIPTION = [
 // Mirrors AiAgentJudgeProjectContextEntry — the structured entry the
 // deterministic ProjectContextService.writebackEntry applies to the YAML.
 export const toolEditProjectContextArgsSchema = z.object({
+    dbtSourceUuid: z
+        .string()
+        .uuid()
+        .optional()
+        .describe(
+            'The project dbt source UUID that owns the project context file. Omit it for the primary dbt source.',
+        ),
     op: z
         .enum(['create', 'update'])
         .describe(

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -57,6 +57,7 @@ export type DbtNode = {
     resource_type: string;
     config?: DbtNodeConfig;
     lightdash_source_name?: string;
+    lightdash_source_uuid?: string;
 };
 export type DbtRawModelNode = Omit<
     CompiledModelNode,
@@ -69,6 +70,7 @@ export type DbtRawModelNode = Omit<
     config?: CompiledModelNode['config'] & { meta?: DbtModelMetadata };
     meta: DbtModelMetadata;
     lightdash_source_name?: string;
+    lightdash_source_uuid?: string;
 };
 export type DbtModelNode = DbtRawModelNode & {
     database: string;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -133,6 +133,7 @@ export type AiAgentEditDbtProjectPipelineJobPayload = TraceTaskBase & {
     isSlackPrompt: boolean;
     toolCallId: string;
     writebackPrompt: string;
+    dbtSourceUuid?: string;
     source: AiWritebackSource;
     prUrl: string | null;
     startNewPullRequest: boolean | null;

--- a/packages/common/src/types/table.ts
+++ b/packages/common/src/types/table.ts
@@ -49,6 +49,7 @@ export type TableBase = {
     aiHint?: string | string[];
     warnings?: InlineError[];
     dbtPackageName?: string;
+    dbtSourceUuid?: string;
     ymlPath?: string;
     sqlPath?: string;
 };


### PR DESCRIPTION
## Summary

- Authorize every configured GitHub or GitLab dbt source repository while rejecting unrelated installation repositories.
- Carry the selected dbt source UUID through compilation, Ask AI, scheduled writeback, and Issues remediation.
- Keep pending remediation open, resume it without creating duplicate agent turns, and surface source-selection or writeback failures.
- Return a clear error when project-context writeback targets a non-primary dbt source.

## Reproduction

Before the fix, the focused repository-access test returned only the primary repository even though the additional repository was configured and visible to the installation. The test also includes an unrelated installation repository and confirms that it remains inaccessible.

## Tests

- Common suite: 3,777 passed, 1 skipped.
- Backend suite: 8,105 passed, 1 skipped.
- Post-rebase common build and backend typecheck passed on Node 24.
- Post-rebase focused contracts: 271 passed across repository access, source propagation, scheduler continuation, remediation outcomes, project context, and tool schemas.
- Touched-path backend and common lint passed.
- git diff --check passed.

Fixes #28174
Linear: PROD-10676