### PR TITLE
fix(upgrade-automation): close superseded bump pull requests

### DIFF
--- a/examples/upgrade-automation/README.md
+++ b/examples/upgrade-automation/README.md
@@ -13,7 +13,7 @@ The loop is:
 2. Read the current image tag and the public release-safety index.
 3. Run `lightdash upgrade-check` against candidate public versions and select the newest green-reachable target. A required stop becomes the next target. Any next hop that is not green opens a held pull request: a genuinely red hop, and equally one whose safety data is unknown or incomplete. Both hold; neither merges. The held pull request states which of the two it is.
 4. Optionally require the mapped image tag to exist in an OCI registry.
-5. Open a pin pull request containing the complete nine-key verdict JSON.
+5. Open or reuse one pin pull request for the configured branch prefix, containing the complete nine-key verdict JSON. Pull requests for versions already pinned on the default branch close automatically. When a replacement target opens or is reused, older pull requests with the same prefix close automatically. A newer open target remains authoritative if an older planning run finishes later. Pull requests with another prefix are untouched.
 6. Enable auto-merge when configured and green, or send an `[upgrade-hold]` Slack message for a hop that is red or unknown. The escalation is sent once, when the held pull request is opened, not on every subsequent planning run.
 7. After the consumer's deployment workflow finishes, poll `/api/v1/readyz` every 20 seconds and compare the `Lightdash-Version` response header from `/` with the pinned public version. Three consecutive ready and version-matched polls are required.
 8. On failure, open a freeze issue and send an `[upgrade-verify-failed]` Slack message. The automation never rolls back.

--- a/examples/upgrade-automation/scripts/plan.sh
+++ b/examples/upgrade-automation/scripts/plan.sh
@@ -63,6 +63,105 @@ create_commit() {
         }' | gh api graphql --input -
 }
 
+load_open_upgrade_prs() {
+    local number
+    local url
+    local head
+    local mapped
+    local version
+    local closed_url
+    local already_closed
+
+    open_upgrade_pr_numbers=()
+    open_upgrade_pr_urls=()
+    open_upgrade_pr_heads=()
+    open_upgrade_pr_mapped_versions=()
+    open_upgrade_pr_versions=()
+
+    while IFS=$'\t' read -r number url head; do
+        if [[ -z "$number" || -z "$url" || "$head" != "$branch_prefix-"* ]]; then
+            continue
+        fi
+        mapped=${head#"$branch_prefix-"}
+        if ! version=$(public_version "$mapped" "${TAG_SUFFIX:-}" 2>/dev/null); then
+            continue
+        fi
+        already_closed=false
+        for closed_url in "${closed_upgrade_pr_urls[@]}"; do
+            if [[ "$url" == "$closed_url" ]]; then
+                already_closed=true
+                break
+            fi
+        done
+        if [[ "$already_closed" == "true" ]]; then
+            continue
+        fi
+        open_upgrade_pr_numbers+=("$number")
+        open_upgrade_pr_urls+=("$url")
+        open_upgrade_pr_heads+=("$head")
+        open_upgrade_pr_mapped_versions+=("$mapped")
+        open_upgrade_pr_versions+=("$version")
+    done < <(
+        gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --limit 1000 \
+            --json number,url,headRefName \
+            --jq '.[] | [.number, .url, .headRefName] | @tsv'
+    )
+}
+
+select_authoritative_open_upgrade_pr() {
+    local index
+
+    authoritative_open_pr_number=
+    authoritative_open_pr_url=
+    authoritative_open_pr_head=
+    authoritative_open_pr_mapped_version=
+    authoritative_open_pr_version=
+
+    for ((index = 0; index < ${#open_upgrade_pr_versions[@]}; index++)); do
+        if [[ -z "$authoritative_open_pr_version" ]] \
+            || version_gt "${open_upgrade_pr_versions[$index]}" "$authoritative_open_pr_version"; then
+            authoritative_open_pr_number=${open_upgrade_pr_numbers[$index]}
+            authoritative_open_pr_url=${open_upgrade_pr_urls[$index]}
+            authoritative_open_pr_head=${open_upgrade_pr_heads[$index]}
+            authoritative_open_pr_mapped_version=${open_upgrade_pr_mapped_versions[$index]}
+            authoritative_open_pr_version=${open_upgrade_pr_versions[$index]}
+        fi
+    done
+}
+
+close_deployed_upgrade_prs() {
+    local deployed_public=$1
+    local deployed_mapped=$2
+    local index
+
+    load_open_upgrade_prs
+    for ((index = 0; index < ${#open_upgrade_pr_versions[@]}; index++)); do
+        if version_gte "$deployed_public" "${open_upgrade_pr_versions[$index]}"; then
+            gh pr close "${open_upgrade_pr_urls[$index]}" \
+                --comment "$default_branch already pins deployed Lightdash version $deployed_mapped."
+            closed_upgrade_pr_urls+=("${open_upgrade_pr_urls[$index]}")
+        fi
+    done
+}
+
+close_superseded_upgrade_prs() {
+    local replacement_head=$1
+    local replacement_url=$2
+    local replacement_mapped=$3
+    local index
+
+    for ((index = 0; index < ${#open_upgrade_pr_versions[@]}; index++)); do
+        if [[ "${open_upgrade_pr_heads[$index]}" != "$replacement_head" ]]; then
+            gh pr close "${open_upgrade_pr_urls[$index]}" \
+                --comment "Superseded by $replacement_url, which targets Lightdash version $replacement_mapped."
+            closed_upgrade_pr_urls+=("${open_upgrade_pr_urls[$index]}")
+        fi
+    done
+}
+
 write_output branch ''
 write_output pr_number ''
 write_output pr_url ''
@@ -89,6 +188,7 @@ fi
 
 current_mapped=$(read_bump_value)
 current_public=$(public_version "$current_mapped" "${TAG_SUFFIX:-}")
+default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch')
 index_file=$(mktemp)
 gate_error=$(mktemp)
 merge_error=$(mktemp)
@@ -98,6 +198,7 @@ fresh_file=$(mktemp ./plan-fresh.XXXXXX)
 head_file=$(mktemp ./plan-head.XXXXXX)
 scratch_ref_created=false
 scratch_expected_sha=
+closed_upgrade_pr_urls=()
 
 delete_scratch_ref() {
     if [[ "$scratch_ref_created" == "true" ]]; then
@@ -136,6 +237,15 @@ mapfile -t candidates < <(
         reverse[]
     ' "$index_file"
 )
+
+close_deployed_upgrade_prs "$current_public" "$current_mapped"
+select_authoritative_open_upgrade_pr
+if [[ -n "$authoritative_open_pr_version" ]]; then
+    close_superseded_upgrade_prs \
+        "$authoritative_open_pr_head" \
+        "$authoritative_open_pr_url" \
+        "$authoritative_open_pr_mapped_version"
+fi
 
 if [[ ${#candidates[@]} -eq 0 ]]; then
     echo "no release newer than $current_public in the index; already up to date"
@@ -283,12 +393,24 @@ if [[ -n "${REGISTRY_CHECK:-}" ]]; then
     fi
 fi
 
-default_branch=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch')
 upgrade_branch="${branch_prefix}-$(safe_branch_version "$mapped_version")"
 if [[ -z "$upgrade_branch" || "$upgrade_branch" == "$branch_prefix-" ]] \
     || ! git check-ref-format "refs/heads/$upgrade_branch" >/dev/null; then
     echo "upgrade branch is not a valid non-empty branch name" >&2
     exit 1
+fi
+load_open_upgrade_prs
+select_authoritative_open_upgrade_pr
+if [[ -n "$authoritative_open_pr_version" ]] && version_gt "$authoritative_open_pr_version" "$selected_version"; then
+    close_superseded_upgrade_prs \
+        "$authoritative_open_pr_head" \
+        "$authoritative_open_pr_url" \
+        "$authoritative_open_pr_mapped_version"
+    echo "newer upgrade target $authoritative_open_pr_mapped_version is already open at $authoritative_open_pr_url; not replacing it with $mapped_version"
+    write_output branch "$authoritative_open_pr_head"
+    write_output pr_number "$authoritative_open_pr_number"
+    write_output pr_url "$authoritative_open_pr_url"
+    exit 0
 fi
 bump_file=${BUMP_TARGET%%#*}
 bump_path=${BUMP_TARGET#*#}
@@ -325,11 +447,14 @@ for attempt in 1 2 3; do
         | base64 --decode >"$fresh_file"
 
     fresh_mapped=$(python3 "$ACTION_ROOT/scripts/bump-target.py" read "$fresh_file#$bump_path")
+    fresh_public=$(public_version "$fresh_mapped" "${TAG_SUFFIX:-}")
+    if [[ "$fresh_mapped" != "$current_mapped" ]]; then
+        close_deployed_upgrade_prs "$fresh_public" "$fresh_mapped"
+    fi
     if [[ "$fresh_mapped" == "$mapped_version" ]]; then
         echo "$bump_file already pins $mapped_version at $base_sha; nothing to commit"
         exit 0
     fi
-    fresh_public=$(public_version "$fresh_mapped" "${TAG_SUFFIX:-}")
     if version_gt "$fresh_public" "$selected_version"; then
         echo "$bump_file already pins newer version $fresh_mapped at $base_sha; not lowering it to $mapped_version"
         exit 0
@@ -458,6 +583,20 @@ else
 fi
 pr_number=$(jq -r '.number' <<<"$pr_json")
 pr_url=$(jq -r '.url' <<<"$pr_json")
+load_open_upgrade_prs
+select_authoritative_open_upgrade_pr
+if [[ -n "$authoritative_open_pr_version" ]] && version_gt "$authoritative_open_pr_version" "$selected_version"; then
+    close_superseded_upgrade_prs \
+        "$authoritative_open_pr_head" \
+        "$authoritative_open_pr_url" \
+        "$authoritative_open_pr_mapped_version"
+    echo "newer upgrade target $authoritative_open_pr_mapped_version is already open at $authoritative_open_pr_url; not replacing it with $mapped_version"
+    write_output branch "$authoritative_open_pr_head"
+    write_output pr_number "$authoritative_open_pr_number"
+    write_output pr_url "$authoritative_open_pr_url"
+    exit 0
+fi
+close_superseded_upgrade_prs "$upgrade_branch" "$pr_url" "$mapped_version"
 write_output branch "$upgrade_branch"
 write_output pr_number "$pr_number"
 write_output pr_url "$pr_url"

--- a/examples/upgrade-automation/scripts/plan.test.sh
+++ b/examples/upgrade-automation/scripts/plan.test.sh
@@ -397,6 +397,10 @@ unrelated:
   tag: old
 EOF
     fi
+    if [[ "$scenario" == "up_to_date_cleanup" ]]; then
+        sed 's/tag: 1.0.0/tag: 1.0.2/' "$scenario_dir/$bump_filename" >"$scenario_dir/up-to-date.yml"
+        mv "$scenario_dir/up-to-date.yml" "$scenario_dir/$bump_filename"
+    fi
     cp "$scenario_dir/$bump_filename" "$scenario_dir/fresh-1.$fresh_suffix"
     cp "$scenario_dir/$bump_filename" "$scenario_dir/fresh-2.$fresh_suffix"
     sed 's/tag: 1.0.0/tag: 1.0.2/' "$scenario_dir/$bump_filename" >"$scenario_dir/head-pinned.$fresh_suffix"
@@ -424,7 +428,7 @@ EOF
         nothing_changed)
             safety_gate=true
             ;;
-        main_moved | first_run_creation | scratch_collision | unexpected_commit_parent | freeze_mid_run | retry_exhaustion)
+        main_moved | first_run_creation | scratch_collision | unexpected_commit_parent | freeze_mid_run | retry_exhaustion | superseded_prs | up_to_date_cleanup | newer_target)
             ;;
         *)
             printf 'unknown transaction test scenario: %s\n' "$scenario" >&2
@@ -536,7 +540,7 @@ if [[ "$*" == *"contents/$GH_BUMP_FILE?ref="* ]]; then
 fi
 
 if [[ "$*" == *'git/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'* ]]; then
-    if [[ "$GH_SCENARIO" == "nothing_changed" ]]; then
+    if [[ "$GH_SCENARIO" == "nothing_changed" || "$GH_SCENARIO" == "superseded_prs" ]]; then
         printf '1111111111111111111111111111111111111111\n'
     else
         printf '0000000000000000000000000000000000000000\n'
@@ -599,7 +603,30 @@ if [[ "$*" == *graphql* ]]; then
 fi
 
 if [[ "$*" == "pr list"* ]]; then
-    if [[ "$GH_SCENARIO" == "nothing_changed" || "$GH_SCENARIO" == "main_moved" ]]; then
+    if [[ "$*" == *'--json number,url,headRefName'* ]]; then
+        case "$GH_SCENARIO" in
+            superseded_prs)
+                printf '10\thttps://example.test/pr/10\tlightdash-upgrade-1.0.0\n'
+                printf '11\thttps://example.test/pr/11\tlightdash-upgrade-1.0.1\n'
+                printf '12\thttps://example.test/pr/12\tproduction-upgrade-1.0.1\n'
+                printf '13\thttps://example.test/pr/13\tlightdash-upgrade-1.0.2\n'
+                ;;
+            up_to_date_cleanup)
+                printf '20\thttps://example.test/pr/20\tlightdash-upgrade-1.0.0\n'
+                printf '21\thttps://example.test/pr/21\tlightdash-upgrade-1.0.2\n'
+                printf '22\thttps://example.test/pr/22\tproduction-upgrade-1.0.1\n'
+                printf '23\thttps://example.test/pr/23\tlightdash-upgrade-1.0.3\n'
+                printf '24\thttps://example.test/pr/24\tlightdash-upgrade-1.0.4\n'
+                ;;
+            newer_target)
+                printf '30\thttps://example.test/pr/30\tlightdash-upgrade-1.0.1\n'
+                printf '31\thttps://example.test/pr/31\tlightdash-upgrade-1.0.3\n'
+                printf '32\thttps://example.test/pr/32\tproduction-upgrade-1.0.1\n'
+                ;;
+        esac
+    elif [[ "$GH_SCENARIO" == "superseded_prs" ]]; then
+        printf '{"number":13,"url":"https://example.test/pr/13","headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}\n'
+    elif [[ "$GH_SCENARIO" == "nothing_changed" || "$GH_SCENARIO" == "main_moved" ]]; then
         printf '{"number":1,"url":"https://example.test/pr/1","headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}\n'
     fi
     exit 0
@@ -620,6 +647,10 @@ if [[ "$*" == "pr comment"* ]]; then
 fi
 
 if [[ "$*" == "pr edit"* ]]; then
+    exit 0
+fi
+
+if [[ "$*" == "pr close"* ]]; then
     exit 0
 fi
 
@@ -787,6 +818,41 @@ EOF
                 exit 1
             fi
             ;;
+        superseded_prs)
+            if ! grep -Fq 'pr close https://example.test/pr/10 --comment main already pins deployed Lightdash version 1.0.0.' "$scenario_dir/gh.log" \
+                || ! grep -Fq 'pr close https://example.test/pr/11 --comment Superseded by https://example.test/pr/13, which targets Lightdash version 1.0.2.' "$scenario_dir/gh.log" \
+                || grep -Fq 'pr close https://example.test/pr/12' "$scenario_dir/gh.log" \
+                || grep -Fq 'pr close https://example.test/pr/13' "$scenario_dir/gh.log" \
+                || grep -q '^pr create' "$scenario_dir/gh.log"; then
+                printf 'expected the exact target pull request to be reused and older same-prefix pull requests to close, gh calls were:\n%s\n' "$(cat "$scenario_dir/gh.log")" >&2
+                rm -rf "$scenario_dir"
+                exit 1
+            fi
+            ;;
+        up_to_date_cleanup)
+            if [[ "$output" != *'already up to date'* ]] \
+                || ! grep -Fq 'pr close https://example.test/pr/20 --comment main already pins deployed Lightdash version 1.0.2.' "$scenario_dir/gh.log" \
+                || ! grep -Fq 'pr close https://example.test/pr/21 --comment main already pins deployed Lightdash version 1.0.2.' "$scenario_dir/gh.log" \
+                || ! grep -Fq 'pr close https://example.test/pr/23 --comment Superseded by https://example.test/pr/24, which targets Lightdash version 1.0.4.' "$scenario_dir/gh.log" \
+                || grep -Fq 'pr close https://example.test/pr/22' "$scenario_dir/gh.log" \
+                || grep -Fq 'pr close https://example.test/pr/24' "$scenario_dir/gh.log" \
+                || grep -Eq -- 'api graphql|pr create' "$scenario_dir/gh.log"; then
+                printf 'expected the no-candidate path to close deployed and superseded same-prefix pull requests only, got:\n%s\ngh calls were:\n%s\n' "$output" "$(cat "$scenario_dir/gh.log")" >&2
+                rm -rf "$scenario_dir"
+                exit 1
+            fi
+            ;;
+        newer_target)
+            if [[ "$output" != *'newer upgrade target 1.0.3 is already open'* ]] \
+                || ! grep -Fq 'pr close https://example.test/pr/30 --comment Superseded by https://example.test/pr/31, which targets Lightdash version 1.0.3.' "$scenario_dir/gh.log" \
+                || grep -Fq 'pr close https://example.test/pr/31' "$scenario_dir/gh.log" \
+                || grep -Fq 'pr close https://example.test/pr/32' "$scenario_dir/gh.log" \
+                || grep -Eq -- '--method (POST|PATCH) repos/example/upgrade-test/git/refs|api graphql|pr create' "$scenario_dir/gh.log"; then
+                printf 'expected a stale run to preserve the newer target and close only its older same-prefix predecessor, got:\n%s\ngh calls were:\n%s\n' "$output" "$(cat "$scenario_dir/gh.log")" >&2
+                rm -rf "$scenario_dir"
+                exit 1
+            fi
+            ;;
     esac
 
     rm -rf "$scenario_dir"
@@ -806,6 +872,9 @@ run_transaction_test main_moved 'plan moved-main pull request reuse' 0
 run_transaction_test first_run_creation 'plan first-run pull request creation' 0
 run_transaction_test scratch_collision 'plan scratch ref collision' 1
 run_transaction_test unexpected_commit_parent 'plan unexpected commit parent' 1
+run_transaction_test superseded_prs 'plan superseded pull request cleanup' 0
+run_transaction_test up_to_date_cleanup 'plan up-to-date pull request cleanup' 0
+run_transaction_test newer_target 'plan newer target authority' 0
 
 run_auto_merge_test() {
     local test_name=$1


### PR DESCRIPTION
## What changes

- Close upgrade pull requests whose version is already on the default branch.
- Keep only the highest open target for each configured branch prefix.
- Re-check after pull request creation so overlapping runs converge on one target.
- Leave pull requests for other deployment prefixes untouched.

## Why

The planner only looked for an exact target branch. Older automated upgrade pull requests stayed open after a newer target appeared or deployed.

## Tests

- `common.test.sh`
- `verify.test.sh`
- `plan.test.sh`
- Bash syntax check
- ShellCheck at warning severity

Stacked on #27840.

Linear: SPK-1498