### PR TITLE
fix(content-as-code): isolate write-back PRs by draft

### DIFF
--- a/packages/backend/src/database/entities/contentAsCodeWritebacks.ts
+++ b/packages/backend/src/database/entities/contentAsCodeWritebacks.ts
@@ -27,6 +27,7 @@ export type DbContentAsCodeWriteback = {
     project_uuid: string;
     content_type: string;
     slug: string;
+    content_draft_uuid: string | null;
     branch: string;
     pr_number: number | null;
     pr_url: string | null;
@@ -42,6 +43,7 @@ export type CreateDbContentAsCodeWriteback = Pick<
     | 'project_uuid'
     | 'content_type'
     | 'slug'
+    | 'content_draft_uuid'
     | 'branch'
     | 'status'
     | 'created_by_user_uuid'

--- a/packages/backend/src/database/migrations/20260827130000_add_content_draft_writeback_ownership.ts
+++ b/packages/backend/src/database/migrations/20260827130000_add_content_draft_writeback_ownership.ts
@@ -1,0 +1,32 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds nullable draft ownership metadata without rewriting existing write-backs',
+} as const;
+
+const WRITEBACKS_TABLE = 'content_as_code_writebacks';
+const DRAFTS_TABLE = 'content_drafts';
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(WRITEBACKS_TABLE, (table) => {
+        table
+            .uuid('content_draft_uuid')
+            .nullable()
+            .references('content_draft_uuid')
+            .inTable(DRAFTS_TABLE)
+            .onDelete('RESTRICT')
+            .index();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+
+    await knex.schema.alterTable(WRITEBACKS_TABLE, (table) => {
+        table.dropColumn('content_draft_uuid');
+    });
+}

--- a/packages/backend/src/models/ContentAsCodeWritebackModel.ts
+++ b/packages/backend/src/models/ContentAsCodeWritebackModel.ts
@@ -10,6 +10,7 @@ export type ContentAsCodeWriteback = {
     projectUuid: string;
     contentType: string;
     slug: string;
+    contentDraftUuid: string | null;
     branch: string;
     prNumber: number | null;
     prUrl: string | null;
@@ -32,6 +33,7 @@ const parseRow = (row: DbContentAsCodeWriteback): ContentAsCodeWriteback => ({
     projectUuid: row.project_uuid,
     contentType: row.content_type,
     slug: row.slug,
+    contentDraftUuid: row.content_draft_uuid,
     branch: row.branch,
     prNumber: row.pr_number,
     prUrl: row.pr_url,
@@ -100,6 +102,7 @@ export class ContentAsCodeWritebackModel {
         projectUuid: string;
         contentType: string;
         slug: string;
+        contentDraftUuid: string | null;
         branch: string;
         createdByUserUuid: string | null;
     }): Promise<ContentAsCodeWriteback> {
@@ -108,6 +111,7 @@ export class ContentAsCodeWritebackModel {
                 project_uuid: args.projectUuid,
                 content_type: args.contentType,
                 slug: args.slug,
+                content_draft_uuid: args.contentDraftUuid,
                 branch: args.branch,
                 status: 'pending',
                 created_by_user_uuid: args.createdByUserUuid,

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -1,5 +1,6 @@
 import { Ability } from '@casl/ability';
 import {
+    ConflictError,
     DbtProjectType,
     PossibleAbilities,
     PullRequestSource,
@@ -29,7 +30,10 @@ type Overrides = {
     settings?: object | undefined;
     snapshot?: object | undefined;
     liveRow?: object | undefined;
+    liveRows?: (object | undefined)[];
     existingFile?: object | 'missing';
+    draft?: object | undefined;
+    createError?: Error;
 };
 
 const buildService = (overrides: Overrides = {}) => {
@@ -74,6 +78,11 @@ const buildService = (overrides: Overrides = {}) => {
         getCurrentContentVersionBySlug: vi
             .fn()
             .mockResolvedValue({ contentUuid: 'chart-uuid' }),
+        getDashboardAsCodeWithOverlay: vi.fn().mockResolvedValue({
+            name: 'Weekly KPIs draft',
+            slug: 'weekly-kpis',
+            tiles: [],
+        }),
     };
     const contentAsCodeProjectSettingsModel = {
         get: vi
@@ -94,19 +103,43 @@ const buildService = (overrides: Overrides = {}) => {
             ),
     };
     const contentAsCodeWritebackModel = {
-        findLive: vi
-            .fn()
-            .mockResolvedValue(
-                'liveRow' in overrides ? overrides.liveRow : undefined,
-            ),
+        findLive: vi.fn(
+            overrides.liveRows
+                ? async () => overrides.liveRows!.shift()
+                : async () =>
+                      'liveRow' in overrides ? overrides.liveRow : undefined,
+        ),
         findLatestForBranch: vi.fn().mockResolvedValue(undefined),
-        create: vi.fn().mockResolvedValue({
-            uuid: 'row-uuid',
-            branch: 'lightdash/write-back/app.lightdash.dev/monthly-revenue',
-            prUrl: null,
-            status: 'pending',
+        create: vi.fn().mockImplementation(async (args) => {
+            if (overrides.createError) throw overrides.createError;
+            return {
+                uuid: 'row-uuid',
+                branch: args.branch,
+                contentDraftUuid: args.contentDraftUuid ?? null,
+                prUrl: null,
+                status: 'pending',
+            };
         }),
         update: vi.fn().mockResolvedValue(undefined),
+    };
+    const contentDraftModel = {
+        get: vi.fn().mockResolvedValue(
+            'draft' in overrides
+                ? overrides.draft
+                : {
+                      uuid: 'draft-uuid',
+                      projectUuid: 'project-uuid',
+                      contentType: 'dashboard',
+                      contentUuid: 'dashboard-uuid',
+                      slug: 'weekly-kpis',
+                      authorUserUuid: 'author-uuid',
+                      draft: { name: 'Weekly KPIs draft' },
+                      status: 'open',
+                      prUrl: null,
+                  },
+        ),
+        listByProject: vi.fn(),
+        update: vi.fn(),
     };
     const service = new ContentAsCodeWritebackService({
         lightdashConfig: { siteUrl: 'https://app.lightdash.dev' } as never,
@@ -125,17 +158,14 @@ const buildService = (overrides: Overrides = {}) => {
             contentAsCodeProjectSettingsModel as never,
         contentAsCodeSnapshotModel: contentAsCodeSnapshotModel as never,
         contentAsCodeWritebackModel: contentAsCodeWritebackModel as never,
-        contentDraftModel: {
-            get: vi.fn(),
-            listByProject: vi.fn(),
-            update: vi.fn(),
-        } as never,
+        contentDraftModel: contentDraftModel as never,
     });
     return {
         service,
         gitIntegrationService,
         coderService,
         contentAsCodeWritebackModel,
+        contentDraftModel,
     };
 };
 
@@ -203,6 +233,7 @@ describe('ContentAsCodeWritebackService', () => {
         const { service, gitIntegrationService } = buildService({
             liveRow: {
                 uuid: 'row-uuid',
+                contentDraftUuid: null,
                 branch: 'lightdash/write-back/app.lightdash.dev/monthly-revenue',
                 prUrl: 'https://github.com/acme/analytics/pull/42',
                 status: 'open',
@@ -235,6 +266,7 @@ describe('ContentAsCodeWritebackService', () => {
         const { service, gitIntegrationService } = buildService({
             liveRow: {
                 uuid: 'row-uuid',
+                contentDraftUuid: null,
                 branch: 'lightdash/write-back/app.lightdash.dev/monthly-revenue',
                 prUrl: 'https://github.com/acme/analytics/pull/42',
                 status: 'open',
@@ -279,5 +311,218 @@ describe('ContentAsCodeWritebackService', () => {
             'row-uuid',
             { status: 'error', error: 'github says no' },
         );
+    });
+
+    it('gives a draft a stable branch and write-back owner', async () => {
+        const { service, gitIntegrationService, contentAsCodeWritebackModel } =
+            buildService();
+
+        await service.writeBackDraft(user, 'project-uuid', 'draft-uuid');
+
+        expect(contentAsCodeWritebackModel.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contentDraftUuid: 'draft-uuid',
+                branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
+            }),
+        );
+        expect(
+            gitIntegrationService.createBranchFromSource,
+        ).toHaveBeenCalledWith(
+            user,
+            'project-uuid',
+            'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
+            'main',
+        );
+    });
+
+    it('reuses the branch and PR owned by the same draft', async () => {
+        const { service, gitIntegrationService, contentAsCodeWritebackModel } =
+            buildService({
+                liveRow: {
+                    uuid: 'row-uuid',
+                    contentType: 'dashboard',
+                    slug: 'weekly-kpis',
+                    contentDraftUuid: 'draft-uuid',
+                    branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
+                    prNumber: 42,
+                    prUrl: 'https://github.com/acme/analytics/pull/42',
+                    status: 'open',
+                },
+                existingFile: {
+                    type: 'file',
+                    content: 'stale: "content"\n',
+                    sha: 'old-sha',
+                    path: 'lightdash/dashboards/weekly-kpis.yml',
+                },
+            });
+
+        await service.writeBackDraft(user, 'project-uuid', 'draft-uuid');
+
+        expect(contentAsCodeWritebackModel.create).not.toHaveBeenCalled();
+        expect(
+            gitIntegrationService.createPullRequestFromBranch,
+        ).not.toHaveBeenCalled();
+        expect(gitIntegrationService.saveFile).toHaveBeenCalledWith(
+            user,
+            'project-uuid',
+            'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
+            'lightdash/dashboards/weekly-kpis.yml',
+            expect.any(String),
+            'old-sha',
+            expect.any(String),
+        );
+    });
+
+    it('opens the pending PR when a retry finds the draft content already committed', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+        const identical = require('js-yaml').dump(
+            {
+                name: 'Weekly KPIs draft',
+                slug: 'weekly-kpis',
+                tiles: [],
+            },
+            { quotingType: '"', sortKeys: true },
+        );
+        const { service, gitIntegrationService } = buildService({
+            liveRow: {
+                uuid: 'row-uuid',
+                contentType: 'dashboard',
+                slug: 'weekly-kpis',
+                contentDraftUuid: 'draft-uuid',
+                branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
+                prNumber: null,
+                prUrl: null,
+                status: 'pending',
+            },
+            existingFile: {
+                type: 'file',
+                content: identical,
+                sha: 'old-sha',
+                path: 'lightdash/dashboards/weekly-kpis.yml',
+            },
+        });
+
+        await service.writeBackDraft(user, 'project-uuid', 'draft-uuid');
+
+        expect(gitIntegrationService.saveFile).not.toHaveBeenCalled();
+        expect(
+            gitIntegrationService.createPullRequestFromBranch,
+        ).toHaveBeenCalledTimes(1);
+    });
+
+    it('refuses a competing draft before touching the existing branch', async () => {
+        const { service, gitIntegrationService, contentDraftModel } =
+            buildService({
+                liveRow: {
+                    uuid: 'row-uuid',
+                    contentType: 'dashboard',
+                    slug: 'weekly-kpis',
+                    contentDraftUuid: 'other-draft-uuid',
+                    branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-other-draft-uuid',
+                    prNumber: null,
+                    prUrl: null,
+                    status: 'pending',
+                },
+            });
+
+        await expect(
+            service.writeBackDraft(user, 'project-uuid', 'draft-uuid'),
+        ).rejects.toBeInstanceOf(ConflictError);
+
+        expect(gitIntegrationService.getProjectRepo).not.toHaveBeenCalled();
+        expect(
+            gitIntegrationService.createBranchFromSource,
+        ).not.toHaveBeenCalled();
+        expect(gitIntegrationService.saveFile).not.toHaveBeenCalled();
+        expect(contentDraftModel.update).not.toHaveBeenCalled();
+    });
+
+    it('refuses the losing draft when another owner wins the database race', async () => {
+        const competingRow = {
+            uuid: 'other-row-uuid',
+            contentType: 'dashboard',
+            slug: 'weekly-kpis',
+            contentDraftUuid: 'other-draft-uuid',
+            branch: 'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-other-draft-uuid',
+            prNumber: null,
+            prUrl: null,
+            status: 'pending',
+        };
+        const { service, gitIntegrationService } = buildService({
+            liveRows: [undefined, competingRow],
+            createError: new Error('unique constraint'),
+        });
+
+        await expect(
+            service.writeBackDraft(user, 'project-uuid', 'draft-uuid'),
+        ).rejects.toBeInstanceOf(ConflictError);
+
+        expect(
+            gitIntegrationService.createBranchFromSource,
+        ).not.toHaveBeenCalled();
+        expect(gitIntegrationService.saveFile).not.toHaveBeenCalled();
+    });
+
+    it('lets exactly one of two concurrent drafts create git state', async () => {
+        const {
+            service,
+            gitIntegrationService,
+            contentAsCodeWritebackModel,
+            contentDraftModel,
+        } = buildService();
+        let owner: string | null = null;
+        let liveRow: object | undefined;
+        contentDraftModel.get.mockImplementation(async (draftUuid: string) => ({
+            uuid: draftUuid,
+            projectUuid: 'project-uuid',
+            contentType: 'dashboard',
+            contentUuid: 'dashboard-uuid',
+            slug: 'weekly-kpis',
+            authorUserUuid: `${draftUuid}-author`,
+            draft: { name: `${draftUuid} changes` },
+            status: 'open',
+            prUrl: null,
+        }));
+        contentAsCodeWritebackModel.findLive.mockImplementation(
+            async () => liveRow,
+        );
+        contentAsCodeWritebackModel.create.mockImplementation(async (args) => {
+            if (liveRow) throw new Error('unique constraint');
+            owner = args.contentDraftUuid;
+            liveRow = {
+                uuid: 'row-uuid',
+                contentType: args.contentType,
+                slug: args.slug,
+                contentDraftUuid: args.contentDraftUuid,
+                branch: args.branch,
+                prNumber: null,
+                prUrl: null,
+                status: 'pending',
+            };
+            return liveRow;
+        });
+
+        const results = await Promise.allSettled([
+            service.writeBackDraft(user, 'project-uuid', 'alice-draft'),
+            service.writeBackDraft(user, 'project-uuid', 'bob-draft'),
+        ]);
+
+        expect(
+            results.filter((result) => result.status === 'fulfilled'),
+        ).toHaveLength(1);
+        const [rejected] = results.filter(
+            (result): result is PromiseRejectedResult =>
+                result.status === 'rejected',
+        );
+        expect(rejected.reason).toBeInstanceOf(ConflictError);
+        expect(owner).toMatch(/^(alice|bob)-draft$/);
+        expect(
+            gitIntegrationService.createBranchFromSource,
+        ).toHaveBeenCalledTimes(1);
+        expect(gitIntegrationService.saveFile).toHaveBeenCalledTimes(1);
+        expect(
+            gitIntegrationService.createPullRequestFromBranch,
+        ).toHaveBeenCalledTimes(1);
+        expect(contentDraftModel.update).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    ConflictError,
     ContentAsCodeType,
     DbtProjectType,
     ForbiddenError,
@@ -173,6 +174,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             contentType,
             contentUuid,
             slug,
+            contentDraftUuid: null,
         });
     }
 
@@ -275,6 +277,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             contentType: 'dashboard',
             contentUuid: draft.contentUuid,
             slug: draft.slug,
+            contentDraftUuid: draft.uuid,
             documentOverride: draftDoc,
         });
         await this.contentDraftModel.update(draft.uuid, {
@@ -364,6 +367,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             contentType: WritebackContentType;
             contentUuid: string;
             slug: string;
+            contentDraftUuid: string | null;
             documentOverride?: ChartAsCode | DashboardAsCode;
         },
     ): Promise<ContentAsCodeWriteback> {
@@ -392,13 +396,20 @@ export class ContentAsCodeWritebackService extends BaseService {
                 slug,
             );
         }
+        if (row !== undefined) {
+            this.assertWritebackOwner(row, target.contentDraftUuid);
+        }
         if (row === undefined) {
-            const branch = `lightdash/write-back/${this.getInstanceSlug()}/${slug}`;
+            const baseBranch = `lightdash/write-back/${this.getInstanceSlug()}/${slug}`;
+            const branch = target.contentDraftUuid
+                ? `${baseBranch}/draft-${target.contentDraftUuid}`
+                : baseBranch;
             try {
                 row = await this.contentAsCodeWritebackModel.create({
                     projectUuid,
                     contentType: snapshotType,
                     slug,
+                    contentDraftUuid: target.contentDraftUuid,
                     branch,
                     createdByUserUuid: user.userUuid,
                 });
@@ -411,6 +422,7 @@ export class ContentAsCodeWritebackService extends BaseService {
                     slug,
                 );
                 if (raced === undefined) throw error;
+                this.assertWritebackOwner(raced, target.contentDraftUuid);
                 row = raced;
             }
         }
@@ -436,6 +448,24 @@ export class ContentAsCodeWritebackService extends BaseService {
         return updated ?? row;
     }
 
+    private assertWritebackOwner(
+        row: ContentAsCodeWriteback,
+        requestedDraftUuid: string | null,
+    ): void {
+        if (row.contentDraftUuid === requestedDraftUuid) return;
+
+        throw new ConflictError(
+            `Content "${row.slug}" already has an active write-back proposal. Merge or close it before writing back another draft.`,
+            {
+                contentType: row.contentType,
+                slug: row.slug,
+                existingDraftUuid: row.contentDraftUuid,
+                requestedDraftUuid,
+                prUrl: row.prUrl,
+            },
+        );
+    }
+
     // For dashboards, the dashboard YAML plus its dashboard-owned tile
     // charts land on the same branch/PR; charts with their own open
     // write-back PR keep it and are only noted in the PR body.
@@ -446,6 +476,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             contentType: WritebackContentType;
             contentUuid: string;
             slug: string;
+            contentDraftUuid: string | null;
             documentOverride?: ChartAsCode | DashboardAsCode;
         },
         row: ContentAsCodeWriteback,
@@ -526,7 +557,7 @@ export class ContentAsCodeWritebackService extends BaseService {
             this.logger.debug(
                 `Content-as-code write-back for ${slug}: branch already has this content`,
             );
-            return;
+            if (row.prUrl !== null && row.status === 'open') return;
         }
 
         if (row.prUrl !== null && row.status === 'open') {


### PR DESCRIPTION
Closes #28186

## Summary
- persist the owning content draft on live write-back rows
- give draft proposals stable per-draft branches and reject competing owners before git mutation
- recover pending retries by opening the PR when content is already committed

## Tests
- backend focused suite: 13 passed
- backend changed suite: 16 passed
- backend typecheck
- backend lint
- migration up/down transaction validation
- SQL migration safety lint: non-breaking