### PR TITLE
fix(ai): clarify field value searches

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -5743,13 +5743,15 @@ Response shape (MCP CallToolResult):
       "description": "Tool: search_field_values
 
 Purpose:
-Search for unique values of a specific field in a table. Returns all unique values by default, or use the query parameter to narrow down results. This is useful for finding suggestions for field values when building filters or exploring data.
+Validate or discover concrete values for a specific dimension before building a filter. Returns up to 100 unique values matching the query.
 
 Usage Tips:
-- Specify the table and field you want to search values for
-- Query parameter: use it to narrow down the search to matching values
-- Optionally add filters to further restrict the results
-- Results are returned as a list of unique field values (limited to 100)
+- Specify the table and field ID whose values you want to search
+- Prefer a non-empty query containing candidate text, such as "complete" for a status
+- Do not omit query or use an empty query to enumerate a warehouse column. A query without candidate text can return curated values defined in field metadata; otherwise it may be rejected to prevent an unbounded distinct-value scan
+- If the user or field metadata already provides the exact value, use it directly instead of searching
+- Omit filters when the search does not need additional filters
+- When a filters object is provided, include type, dimensions, metrics, and tableCalculations. Use null or [] for every unused category; never omit a category
 ",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -5766,7 +5768,7 @@ Usage Tips:
           },
           "filters": {
             "additionalProperties": false,
-            "description": "Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics., ",
+            "description": "Optional filters to scope the value search. If supplied, always include type, dimensions, metrics, and tableCalculations; use null or [] for every unused category. Never construct a partial filter group. Filtered fields must exist in the selected explore or be referenced from custom metrics., ",
             "properties": {
               "dimensions": {
                 "description": ", ",
@@ -7699,7 +7701,7 @@ Usage Tips:
             "type": "string",
           },
           "query": {
-            "description": "Query string to filter field values, Query string to filter field values",
+            "description": "Candidate text to match within field values. Prefer a non-empty value. Without candidate text, only curated field metadata values can be returned reliably; an empty warehouse-backed search may be rejected., Candidate text to match within field values. Prefer a non-empty value. Without candidate text, only curated field metadata values can be returned reliably; an empty warehouse-backed search may be rejected.",
             "type": "string",
           },
           "table": {

--- a/packages/backend/src/ee/services/ai/prompts/noResultsRetry.ts
+++ b/packages/backend/src/ee/services/ai/prompts/noResultsRetry.ts
@@ -1,2 +1,2 @@
 export const NO_RESULTS_RETRY_PROMPT = `No results were returned for your query.
-This may be due to the use of filter values. If you're filtering by specific values and aren't sure they exist in the data, use the "searchFieldValues`;
+This may be due to filter values. Preserve the requested filter semantics while checking filters one at a time. If you are unsure whether a specific dimension value exists, use searchFieldValues with that candidate as a non-empty query. Set filters to null unless the value search itself must be scoped. Do not request every value from a field.`;

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -47,7 +47,7 @@ The user sees BOTH your final response AND your internal reasoning ("thinking").
    - **No match**: no explore covers the request. Explain back to the user and offer alternatives if appropriate.
    Call it again when the user pivots mid-thread to a different topic. Don't re-call on follow-ups that iterate on the same data (different filter, different breakdown, follow-up with the same fields). For questions about existing dashboards, charts, or Data Apps use findContent, and don't re-discover on follow-ups about content already found.
 3. **generateVisualization** to build the chart. The tool's parameter docs describe every chart-config option — read those rather than guessing. Key conventions: \`dimensions[0]\` drives the x-axis; put extra grouping dimensions in \`chartConfig.groupBy\` (never the x-axis dim) for multi-series, leave \`null\` for single-series; always set \`xAxisLabel\` and \`yAxisLabel\`.
-4. **searchFieldValues** when you need to validate or discover concrete dimension values (e.g., specific product names, region names).
+4. **searchFieldValues** only when you need to validate or disambiguate a specific candidate dimension value (e.g., a product name or status). If the user or field metadata already provides the exact value, use it directly. Otherwise pass a non-empty candidate in \`query\`; never use a null or empty query to enumerate a warehouse column. Empty searches can return curated metadata values, but warehouse-backed scans are rejected. Set \`filters\` to null when no additional scope is needed. If \`filters\` is non-null, include \`type\`, \`dimensions\`, \`metrics\`, and \`tableCalculations\`, using null or [] for every unused category.
 
 ## Verified content
 

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -7271,13 +7271,15 @@ Returns the terminal node's result columns and a CSV preview of its rows, plus p
     "description": "Tool: searchFieldValues
 
 Purpose:
-Search for unique values of a specific field in a table. Returns all unique values by default, or use the query parameter to narrow down results. This is useful for finding suggestions for field values when building filters or exploring data.
+Validate or discover concrete values for a specific dimension before building a filter. Returns up to 100 unique values matching the query.
 
 Usage Tips:
-- Specify the table and field you want to search values for
-- Query parameter: use it to narrow down the search to matching values
-- Optionally add filters to further restrict the results
-- Results are returned as a list of unique field values (limited to 100)
+- Specify the table and field ID whose values you want to search
+- Prefer a non-empty query containing candidate text, such as "complete" for a status
+- Do not use a null or empty query to enumerate a warehouse column. A query without candidate text can return curated values defined in field metadata; otherwise it may be rejected to prevent an unbounded distinct-value scan
+- If the user or field metadata already provides the exact value, use it directly instead of searching
+- Set filters to null when the search does not need additional filters
+- When a filters object is provided, include type, dimensions, metrics, and tableCalculations. Use null or [] for every unused category; never omit a category
 ",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -8075,10 +8077,10 @@ Usage Tips:
               "type": "null",
             },
           ],
-          "description": "Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics.",
+          "description": "Optional filters to scope the value search. If supplied, always include type, dimensions, metrics, and tableCalculations; use null or [] for every unused category. Never construct a partial filter group. Filtered fields must exist in the selected explore or be referenced from custom metrics.",
         },
         "query": {
-          "description": "Query string to filter field values",
+          "description": "Candidate text to match within field values. Prefer a non-empty value. Without candidate text, only curated field metadata values can be returned reliably; an empty warehouse-backed search may be rejected.",
           "type": [
             "string",
             "null",

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolSearchFieldValuesArgs.ts
@@ -5,18 +5,31 @@ import { filtersSchemaTransformed, filtersSchemaV2 } from '../filters';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { createToolSchema } from '../toolSchemaBuilder';
 
+const boundedQueryInstructionByRuntime = {
+    agent: 'Do not use a null or empty query to enumerate a warehouse column',
+    mcp: 'Do not omit query or use an empty query to enumerate a warehouse column',
+} satisfies Record<ToolDescriptionContext['runtime'], string>;
+
+const emptyFiltersInstructionByRuntime = {
+    agent: 'Set filters to null when the search does not need additional filters',
+    mcp: 'Omit filters when the search does not need additional filters',
+} satisfies Record<ToolDescriptionContext['runtime'], string>;
+
 export const TOOL_SEARCH_FIELD_VALUES_DESCRIPTION = ({
+    runtime,
     toolName,
 }: ToolDescriptionContext): string => `Tool: ${toolName}
 
 Purpose:
-Search for unique values of a specific field in a table. Returns all unique values by default, or use the query parameter to narrow down results. This is useful for finding suggestions for field values when building filters or exploring data.
+Validate or discover concrete values for a specific dimension before building a filter. Returns up to 100 unique values matching the query.
 
 Usage Tips:
-- Specify the table and field you want to search values for
-- Query parameter: use it to narrow down the search to matching values
-- Optionally add filters to further restrict the results
-- Results are returned as a list of unique field values (limited to 100)
+- Specify the table and field ID whose values you want to search
+- Prefer a non-empty query containing candidate text, such as "complete" for a status
+- ${boundedQueryInstructionByRuntime[runtime]}. A query without candidate text can return curated values defined in field metadata; otherwise it may be rejected to prevent an unbounded distinct-value scan
+- If the user or field metadata already provides the exact value, use it directly instead of searching
+- ${emptyFiltersInstructionByRuntime[runtime]}
+- When a filters object is provided, include type, dimensions, metrics, and tableCalculations. Use null or [] for every unused category; never omit a category
 `;
 
 export const toolSearchFieldValuesArgsSchema = createToolSchema()
@@ -27,12 +40,14 @@ export const toolSearchFieldValuesArgsSchema = createToolSchema()
         }),
         query: z
             .string()
-            .describe('Query string to filter field values')
+            .describe(
+                'Candidate text to match within field values. Prefer a non-empty value. Without candidate text, only curated field metadata values can be returned reliably; an empty warehouse-backed search may be rejected.',
+            )
             .nullable(),
         filters: filtersSchemaV2
             .nullable()
             .describe(
-                'Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics.',
+                'Optional filters to scope the value search. If supplied, always include type, dimensions, metrics, and tableCalculations; use null or [] for every unused category. Never construct a partial filter group. Filtered fields must exist in the selected explore or be referenced from custom metrics.',
             ),
     })
     .build();

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -5762,7 +5762,7 @@
                 "openWorldHint": false,
                 "readOnlyHint": true
             },
-            "description": "Tool: search_field_values\n\nPurpose:\nSearch for unique values of a specific field in a table. Returns all unique values by default, or use the query parameter to narrow down results. This is useful for finding suggestions for field values when building filters or exploring data.\n\nUsage Tips:\n- Specify the table and field you want to search values for\n- Query parameter: use it to narrow down the search to matching values\n- Optionally add filters to further restrict the results\n- Results are returned as a list of unique field values (limited to 100)\n",
+            "description": "Tool: search_field_values\n\nPurpose:\nValidate or discover concrete values for a specific dimension before building a filter. Returns up to 100 unique values matching the query.\n\nUsage Tips:\n- Specify the table and field ID whose values you want to search\n- Prefer a non-empty query containing candidate text, such as \"complete\" for a status\n- Do not omit query or use an empty query to enumerate a warehouse column. A query without candidate text can return curated values defined in field metadata; otherwise it may be rejected to prevent an unbounded distinct-value scan\n- If the user or field metadata already provides the exact value, use it directly instead of searching\n- Omit filters when the search does not need additional filters\n- When a filters object is provided, include type, dimensions, metrics, and tableCalculations. Use null or [] for every unused category; never omit a category\n",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "additionalProperties": false,
@@ -5773,7 +5773,7 @@
                     },
                     "filters": {
                         "additionalProperties": false,
-                        "description": "Filters to apply to the query. Filtered fields must exist in the selected explore or should be referenced from the custom metrics., ",
+                        "description": "Optional filters to scope the value search. If supplied, always include type, dimensions, metrics, and tableCalculations; use null or [] for every unused category. Never construct a partial filter group. Filtered fields must exist in the selected explore or be referenced from custom metrics., ",
                         "properties": {
                             "dimensions": {
                                 "description": ", ",
@@ -7481,7 +7481,7 @@
                         "type": "object"
                     },
                     "query": {
-                        "description": "Query string to filter field values, Query string to filter field values",
+                        "description": "Candidate text to match within field values. Prefer a non-empty value. Without candidate text, only curated field metadata values can be returned reliably; an empty warehouse-backed search may be rejected., Candidate text to match within field values. Prefer a non-empty value. Without candidate text, only curated field metadata values can be returned reliably; an empty warehouse-backed search may be rejected.",
                         "type": "string"
                     },
                     "table": {


### PR DESCRIPTION
Related: ZAP-963
Related: ZAP-920
Related: #28262

Clarifies field-value search guidance so agents use bounded candidate queries, avoid partial filter groups, and preserve requested filter semantics after empty results. Updates the committed agent and MCP contract snapshots.

The input schema shape and query execution behavior are unchanged.

Risk: low — prompt and schema-description changes only; deterministic and reversible.
