### PR TITLE
feat(content-as-code): report open drafts during upload

### DIFF
--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -12,6 +12,7 @@ import {
     type ApiChartAsCodeUpsertResponse,
     type ApiContentAsCodeProposeResponse,
     type ApiContentAsCodeSettingsResponse,
+    type ApiContentAsCodeUploadAdvisoryResponse,
     type ApiContentAsCodeWritebacksResponse,
     type ApiContentDraftReviewResponse,
     type ApiContentDraftsResponse,
@@ -232,6 +233,28 @@ export class ProjectCoderController extends BaseController {
                     toSessionUser(req.account),
                     projectUuid,
                 ),
+        );
+    }
+
+    /**
+     * Advisory state shown by the CLI before an upload. It never gates upload.
+     * @summary Get content-as-code upload advisory
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_WRITE_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Get('/code/upload-advisory')
+    @OperationId('getContentAsCodeUploadAdvisory')
+    async getContentAsCodeUploadAdvisory(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiContentAsCodeUploadAdvisoryResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return codeSuccess(
+            await this.services
+                .getContentAsCodeWritebackService()
+                .getUploadAdvisory(toSessionUser(req.account), projectUuid),
         );
     }
 

--- a/packages/backend/src/models/ContentDraftModel.ts
+++ b/packages/backend/src/models/ContentDraftModel.ts
@@ -150,6 +150,16 @@ export class ContentDraftModel {
         return Number(row?.count ?? 0);
     }
 
+    async countOpenByProject(projectUuid: string): Promise<number> {
+        const [row] = await this.database(ContentDraftsTableName)
+            .where({
+                project_uuid: projectUuid,
+                status: 'open',
+            })
+            .count<{ count: string }[]>('* as count');
+        return Number(row?.count ?? 0);
+    }
+
     async get(uuid: string): Promise<ContentDraft | undefined> {
         const row = await this.database(ContentDraftsTableName)
             .leftJoin(

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -34,6 +34,7 @@ type Overrides = {
     existingFile?: object | 'missing';
     draft?: object | undefined;
     createError?: Error;
+    openDraftCount?: number;
 };
 
 const buildService = (overrides: Overrides = {}) => {
@@ -139,6 +140,9 @@ const buildService = (overrides: Overrides = {}) => {
                   },
         ),
         listByProject: vi.fn(),
+        countOpenByProject: vi
+            .fn()
+            .mockResolvedValue(overrides.openDraftCount ?? 0),
         update: vi.fn(),
     };
     const service = new ContentAsCodeWritebackService({
@@ -170,6 +174,37 @@ const buildService = (overrides: Overrides = {}) => {
 };
 
 describe('ContentAsCodeWritebackService', () => {
+    it.each([0, 3])(
+        'reports %i open drafts for upload without changing content',
+        async (openDraftCount) => {
+            const { service, gitIntegrationService } = buildService({
+                openDraftCount,
+            });
+
+            await expect(
+                service.getUploadAdvisory(user, 'project-uuid'),
+            ).resolves.toEqual({ openDraftCount });
+            expect(gitIntegrationService.saveFile).not.toHaveBeenCalled();
+            expect(
+                gitIntegrationService.createPullRequestFromBranch,
+            ).not.toHaveBeenCalled();
+        },
+    );
+
+    it('allows upload-only users to read the advisory', async () => {
+        const uploadOnlyUser = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                { action: 'create', subject: 'ContentAsCode' },
+            ]),
+        } as unknown as SessionUser;
+        const { service } = buildService({ openDraftCount: 2 });
+
+        await expect(
+            service.getUploadAdvisory(uploadOnlyUser, 'project-uuid'),
+        ).resolves.toEqual({ openDraftCount: 2 });
+    });
+
     it('first save creates the instance branch, commits the YAML, and opens one PR', async () => {
         const { service, gitIntegrationService, contentAsCodeWritebackModel } =
             buildService();

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -8,6 +8,7 @@ import {
     ParameterError,
     PullRequestSource,
     type ChartAsCode,
+    type ContentAsCodeUploadAdvisory,
     type DashboardAsCode,
     type SessionUser,
 } from '@lightdash/common';
@@ -201,6 +202,39 @@ export class ContentAsCodeWritebackService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
+    }
+
+    private async assertCanUploadContentAsCode(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        const project = await this.projectModel.get(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        const contentAsCode = subject('ContentAsCode', {
+            projectUuid: project.projectUuid,
+            organizationUuid: project.organizationUuid,
+            upstreamProjectUuid: project.upstreamProjectUuid,
+            type: project.type,
+            createdByUserUuid: project.createdByUserUuid,
+            metadata: { slug: '' },
+        });
+        if (
+            auditedAbility.cannot('create', contentAsCode) &&
+            auditedAbility.cannot('manage', contentAsCode)
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    async getUploadAdvisory(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ContentAsCodeUploadAdvisory> {
+        await this.assertCanUploadContentAsCode(user, projectUuid);
+        return {
+            openDraftCount:
+                await this.contentDraftModel.countOpenByProject(projectUuid),
+        };
     }
 
     async listWritebacks(

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -86,6 +86,7 @@ const {
     readAiAgentFiles,
     readSpaceFiles,
     readSpaceNames,
+    reportOpenDraftsForUpload,
     sanitizeChartForDownload,
     shouldFallBackToEmbeddedSpaces,
     shouldDownloadAiAgents,
@@ -97,6 +98,66 @@ const {
     validateSpaceIdentity,
     writeSpaceFiles,
 } = testHelpers;
+
+describe('reportOpenDraftsForUpload', () => {
+    beforeEach(() => {
+        vi.mocked(lightdashApi).mockReset();
+        vi.spyOn(GlobalState, 'log').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('stays quiet when the project has no open drafts', async () => {
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            openDraftCount: 0,
+        } as never);
+
+        await reportOpenDraftsForUpload('project-uuid');
+
+        expect(lightdashApi).toHaveBeenCalledWith({
+            method: 'GET',
+            url: '/api/v1/projects/project-uuid/code/upload-advisory',
+            body: undefined,
+        });
+        expect(GlobalState.log).not.toHaveBeenCalled();
+    });
+
+    it('warns without blocking when the project has multiple open drafts', async () => {
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            openDraftCount: 3,
+        } as never);
+
+        await expect(
+            reportOpenDraftsForUpload('project-uuid'),
+        ).resolves.toBeUndefined();
+
+        expect(GlobalState.log).toHaveBeenCalledWith(
+            expect.stringContaining('3 open content drafts'),
+        );
+        expect(GlobalState.log).toHaveBeenCalledWith(
+            expect.stringContaining('Upload will continue'),
+        );
+    });
+
+    it('warns without blocking when the draft count cannot be loaded', async () => {
+        vi.mocked(lightdashApi).mockRejectedValueOnce(
+            new Error('draft table unavailable'),
+        );
+
+        await expect(
+            reportOpenDraftsForUpload('project-uuid'),
+        ).resolves.toBeUndefined();
+
+        expect(GlobalState.log).toHaveBeenCalledWith(
+            expect.stringContaining('Could not check for open content drafts'),
+        );
+        expect(GlobalState.log).toHaveBeenCalledWith(
+            expect.stringContaining('Upload will continue'),
+        );
+    });
+});
 
 const makeDownloadHandlerOptions = (
     overrides: Partial<DownloadHandlerOptions> = {},

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -48,6 +48,7 @@ import {
     SqlChartAsCode,
     validateDataAppDependencies,
     VirtualViewAsCode,
+    type ContentAsCodeUploadAdvisory,
     type DashboardAsCodeUpsertResult,
     type DataAppCodeDownload,
     type SpaceAsCode,
@@ -3489,6 +3490,39 @@ const isFilteredWithNoDashboards = (
     dashboardSlugs: string[],
 ): boolean => hasFilters && dashboardSlugs.length === 0;
 
+const reportOpenDraftsForUpload = async (
+    projectUuid: string,
+): Promise<void> => {
+    try {
+        const { openDraftCount } =
+            await lightdashApi<ContentAsCodeUploadAdvisory>({
+                method: 'GET',
+                url: `/api/v1/projects/${projectUuid}/code/upload-advisory`,
+                body: undefined,
+            });
+        if (openDraftCount > 0) {
+            GlobalState.log(
+                styles.warning(
+                    `⚠ ${openDraftCount} open content draft${
+                        openDraftCount === 1 ? '' : 's'
+                    }. Upload will continue; Git content remains authoritative.`,
+                ),
+            );
+        }
+    } catch (error) {
+        GlobalState.log(
+            styles.warning(
+                '⚠ Could not check for open content drafts. Upload will continue.',
+            ),
+        );
+        GlobalState.debug(
+            `Could not load content-as-code upload advisory: ${getErrorMessage(
+                error,
+            )}`,
+        );
+    }
+};
+
 export const uploadHandler = async (
     options: DownloadHandlerOptions,
 ): Promise<void> => {
@@ -3607,6 +3641,8 @@ export const uploadHandler = async (
 
     // Log current project info
     logSelectedProject(projectSelection, config, 'Uploading to');
+
+    await reportOpenDraftsForUpload(projectId);
 
     // Persist repo-owned sync settings for the review/write-back workflow.
     let syncEnabled: boolean | undefined;
@@ -4708,6 +4744,7 @@ export const testHelpers = {
     readExternalConnectionFiles,
     readSpaceFiles,
     readSpaceNames,
+    reportOpenDraftsForUpload,
     sanitizeChartForDownload,
     selectVirtualViewCandidates,
     shouldFallBackToEmbeddedSpaces,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -144,6 +144,7 @@ import {
     type ApiChartAsCodeUpsertResponse,
     type ApiContentAsCodeProposeResponse,
     type ApiContentAsCodeSettingsResponse,
+    type ApiContentAsCodeUploadAdvisoryResponse,
     type ApiContentAsCodeWritebacksResponse,
     type ApiContentDraftReviewResponse,
     type ApiContentDraftsResponse,
@@ -1371,6 +1372,7 @@ type ApiResults =
     | ApiContentDraftWriteBackResponse['results']
     | ApiContentAsCodeProposeResponse['results']
     | ApiContentAsCodeSettingsResponse['results']
+    | ApiContentAsCodeUploadAdvisoryResponse['results']
     | ApiGetMetricsTree['results']
     | ApiGetMetricsTreeResponse['results']
     | ApiGetMetricsTreesResponse['results']

--- a/packages/common/src/types/contentAsCode/base.ts
+++ b/packages/common/src/types/contentAsCode/base.ts
@@ -108,6 +108,15 @@ export type ApiContentAsCodeSettingsResponse = {
     results: ContentAsCodeProjectSettings | null;
 };
 
+export type ContentAsCodeUploadAdvisory = {
+    openDraftCount: number;
+};
+
+export type ApiContentAsCodeUploadAdvisoryResponse = {
+    status: 'ok';
+    results: ContentAsCodeUploadAdvisory;
+};
+
 export type ContentDraftSummary = {
     uuid: string;
     contentType: string;


### PR DESCRIPTION
Closes #28187

## Summary
- add an upload advisory API returning the project open-draft count
- warn in the CLI when drafts exist, while keeping Git uploads authoritative
- warn and continue when advisory lookup fails
- allow both create and manage ContentAsCode users to read the advisory

## Tests
- backend advisory behavior: zero, multiple, upload-only permission
- CLI behavior: zero, multiple, lookup failure
- backend and CLI typechecks
- backend, CLI, and common lint/format

test-cli