### PR TITLE
fix(permissions): let an organization custom role deny personal access tokens

### DIFF
--- a/docs/authentication-and-roles.md
+++ b/docs/authentication-and-roles.md
@@ -229,6 +229,21 @@ This means the **same custom role** behaves differently:
 | Bound to `organization_memberships.role_uuid` (e.g. an SA token) | Can deploy any project + manage org members |
 | Bound to `project_memberships.role_uuid` for project A | Can deploy project A + content-as-code on project A; **silently cannot** manage org members |
 
+### Personal access tokens are the exception
+
+`manage:PersonalAccessToken` is the one scope where the organization
+primary slot has the final say. Every other scope set inherits token
+access from the deployment config (`DISABLE_PAT`, `PAT_ALLOWED_ORG_ROLES`)
+when it doesn't list the scope, so a project or extra role can never
+strip a permission the org layer granted. A custom role in
+`organization_memberships.role_uuid` replaces the system role outright,
+so it is read literally: omit the scope and its users cannot create
+tokens; list it and they can, still capped by the deployment config,
+which can deny but never grant.
+
+That makes an org-level custom role the supported way to deny tokens to
+a set of users. A project-level role cannot do it, by design.
+
 ### What `BASE_ROLE_SCOPES` returns when you duplicate "Admin"
 
 When an operator clicks **Duplicate role** on a system role, the new

--- a/packages/backend/src/database/migrations/20260826152304_grant_pat_scope_to_organization_roles.ts
+++ b/packages/backend/src/database/migrations/20260826152304_grant_pat_scope_to_organization_roles.ts
@@ -1,0 +1,78 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Inserts one existing scope name onto organization-level custom roles with ON CONFLICT DO NOTHING; adds no schema and modifies no existing row',
+} as const;
+
+const RolesTableName = 'roles';
+const ScopedRolesTableName = 'scoped_roles';
+const PAT_SCOPE = 'manage:PersonalAccessToken';
+
+/**
+ * `manage:PersonalAccessToken` used to be a no-op in a custom role: the ability
+ * builder granted token access from the deployment config regardless of the
+ * role's scopes. An organization-level role in the primary slot is now
+ * authoritative, so a role that omits the scope denies tokens. No existing role
+ * can list it — organization roles are seeded from the static system-role
+ * abilities, and token access was only ever added dynamically — so backfill it
+ * everywhere to keep current access intact. Deployments that restrict tokens
+ * through PAT_ALLOWED_ORG_ROLES or DISABLE_PAT still cap the scope at runtime.
+ *
+ * Project-level roles are untouched: the scope is organization-only, and their
+ * users keep taking token access from their organization layer.
+ *
+ * Depends on the previous release, which made a listed scope respect the
+ * deployment config. Older code treats a listed scope as an unconditional
+ * grant, so writing these rows before that shipped everywhere would hand
+ * tokens back to deployments that disabled them.
+ *
+ * Wrapped in try/catch because this is a backfill: failing it would block all
+ * later migrations, and the worst case (some roles miss the scope) is
+ * recoverable by re-running the SQL manually.
+ */
+export async function up(knex: Knex): Promise<void> {
+    try {
+        await knex.raw(
+            `
+            INSERT INTO ?? (role_uuid, scope_name, granted_by)
+            SELECT role_uuid, ?, created_by
+            FROM ??
+            WHERE level = 'organization'
+            ON CONFLICT DO NOTHING
+            `,
+            [ScopedRolesTableName, PAT_SCOPE, RolesTableName],
+        );
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[migration 20260826152304] Failed to backfill ${PAT_SCOPE} for organization-level custom roles. Affected roles will need to grant ${PAT_SCOPE} manually.`,
+            error,
+        );
+    }
+}
+
+/**
+ * Removes the scope from organization-level roles again. A role that was
+ * granted the scope deliberately after this migration ran is indistinguishable
+ * from a backfilled one, so it loses it too.
+ */
+export async function down(knex: Knex): Promise<void> {
+    try {
+        await knex(ScopedRolesTableName)
+            .where('scope_name', PAT_SCOPE)
+            .whereIn(
+                'role_uuid',
+                knex(RolesTableName)
+                    .select('role_uuid')
+                    .where('level', 'organization'),
+            )
+            .delete();
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[migration 20260826152304] Failed to remove ${PAT_SCOPE} rows during rollback.`,
+            error,
+        );
+    }
+}

--- a/packages/backend/src/database/migrations/20260826152304_grant_pat_scope_to_organization_roles.ts
+++ b/packages/backend/src/database/migrations/20260826152304_grant_pat_scope_to_organization_roles.ts
@@ -46,7 +46,7 @@ export async function up(knex: Knex): Promise<void> {
     } catch (error) {
         // eslint-disable-next-line no-console
         console.error(
-            `[migration 20260826152304] Failed to backfill ${PAT_SCOPE} for organization-level custom roles. Affected roles will need to grant ${PAT_SCOPE} manually.`,
+            `[migration 20260826152304] Failed to backfill ${PAT_SCOPE} for organization-level custom roles. Users on those roles lose token access, and their existing personal access tokens stop authenticating, until the scope is granted manually.`,
             error,
         );
     }

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -779,13 +779,7 @@ export class OrganizationService extends BaseService {
             await validateOrganizationScopesCanBeGranted({
                 user: authenticatedUser,
                 organizationUuid,
-                grantedScopes: getOrganizationSystemRoleScopes(data.role, {
-                    includePersonalAccessToken:
-                        this.lightdashConfig.auth?.pat?.enabled === true &&
-                        this.lightdashConfig.auth.pat.allowedOrgRoles.includes(
-                            data.role,
-                        ),
-                }),
+                grantedScopes: getOrganizationSystemRoleScopes(data.role),
                 rolesModel: this.rolesModel,
             });
             const organization =

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -1218,16 +1218,7 @@ export class RolesService extends BaseService {
         let ownerType: Role['ownerType'] = 'system';
         let roleScopes = isCustomRole
             ? []
-            : getOrganizationSystemRoleScopes(
-                  roleId as OrganizationMemberRole,
-                  {
-                      includePersonalAccessToken:
-                          this.lightdashConfig.auth?.pat?.enabled === true &&
-                          this.lightdashConfig.auth.pat.allowedOrgRoles.includes(
-                              roleId as OrganizationMemberRole,
-                          ),
-                  },
-              );
+            : getOrganizationSystemRoleScopes(roleId as OrganizationMemberRole);
 
         if (isCustomRole) {
             const role = await this.rolesModel.getRoleWithScopesByUuid(roleId);
@@ -1829,14 +1820,7 @@ export class RolesService extends BaseService {
             organizationUuid: orgUuid,
             grantedScopes: [
                 ...(roleSet.systemRole
-                    ? getOrganizationSystemRoleScopes(roleSet.systemRole, {
-                          includePersonalAccessToken:
-                              this.lightdashConfig.auth?.pat?.enabled ===
-                                  true &&
-                              this.lightdashConfig.auth.pat.allowedOrgRoles.includes(
-                                  roleSet.systemRole,
-                              ),
-                      })
+                    ? getOrganizationSystemRoleScopes(roleSet.systemRole)
                     : []),
                 ...customRoles.flatMap((role) => role.scopes),
             ],

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -782,13 +782,7 @@ export class UserService extends BaseService {
         await validateOrganizationScopesCanBeGranted({
             user,
             organizationUuid,
-            grantedScopes: getOrganizationSystemRoleScopes(userRole, {
-                includePersonalAccessToken:
-                    this.lightdashConfig.auth?.pat?.enabled === true &&
-                    this.lightdashConfig.auth.pat.allowedOrgRoles.includes(
-                        userRole,
-                    ),
-            }),
+            grantedScopes: getOrganizationSystemRoleScopes(userRole),
             rolesModel: this.rolesModel,
         });
 

--- a/packages/backend/src/utils/organizationRolePermissions.test.ts
+++ b/packages/backend/src/utils/organizationRolePermissions.test.ts
@@ -71,7 +71,6 @@ describe('validateOrganizationScopesCanBeGranted', () => {
                 organizationUuid: ORG,
                 grantedScopes: getOrganizationSystemRoleScopes(
                     OrganizationMemberRole.MEMBER,
-                    { includePersonalAccessToken: true },
                 ),
                 rolesModel: rolesModelWithScopes(managerScopes),
             }),
@@ -87,7 +86,6 @@ describe('validateOrganizationScopesCanBeGranted', () => {
                 organizationUuid: ORG,
                 grantedScopes: getOrganizationSystemRoleScopes(
                     OrganizationMemberRole.ADMIN,
-                    { includePersonalAccessToken: true },
                 ),
                 rolesModel: rolesModelWithScopes(managerScopes),
             }),
@@ -139,5 +137,22 @@ describe('validateOrganizationScopesCanBeGranted', () => {
                 rolesModel: rolesModelWithScopes(managerScopes),
             }),
         ).rejects.toThrow('Cannot grant permissions exceeding your own');
+    });
+
+    it('lets a token-restricted caller grant a system role', async () => {
+        // A system role takes token access from deployment config, not from the
+        // grant, so it must not block a caller whose own role denies tokens.
+        await expect(
+            validateOrganizationScopesCanBeGranted({
+                user: customRoleCaller({
+                    canManagePersonalAccessToken: false,
+                }),
+                organizationUuid: ORG,
+                grantedScopes: getOrganizationSystemRoleScopes(
+                    OrganizationMemberRole.MEMBER,
+                ),
+                rolesModel: rolesModelWithScopes(managerScopes),
+            }),
+        ).resolves.toBeUndefined();
     });
 });

--- a/packages/backend/src/utils/organizationRolePermissions.ts
+++ b/packages/backend/src/utils/organizationRolePermissions.ts
@@ -10,13 +10,7 @@ import { RolesModel } from '../models/RolesModel';
 
 export const getOrganizationSystemRoleScopes = (
     role: OrganizationMemberRole,
-    { includePersonalAccessToken = false } = {},
-): string[] => {
-    const permissions = getOrganizationMemberRolePermissions(role);
-    return includePersonalAccessToken
-        ? [...permissions, 'manage:PersonalAccessToken']
-        : permissions;
-};
+): string[] => getOrganizationMemberRolePermissions(role);
 
 const getCallerOrganizationScopes = async (
     user: SessionUser,
@@ -28,13 +22,6 @@ const getCallerOrganizationScopes = async (
     if (!user.role || user.organizationUuid !== organizationUuid) {
         throw new ForbiddenError('You do not have permission');
     }
-
-    // Custom roles never list this scope, but the ability builder still grants
-    // it from the PAT config, so it is part of the caller's real footprint.
-    const canManagePersonalAccessToken = user.ability.can(
-        'manage',
-        'PersonalAccessToken',
-    );
 
     // The caller's runtime ability is the union of the slot (system role or
     // custom role from the session) and any extra custom roles they hold.
@@ -59,11 +46,14 @@ const getCallerOrganizationScopes = async (
         throw new ForbiddenError('You do not have permission');
     }
 
+    // A system role takes token access from the deployment config, never from
+    // its scope list, so read it off the built ability instead. An org custom
+    // role lists the scope when it has it, and matches either way.
     const scopes = [
         ...(user.roleUuid ? [] : getOrganizationSystemRoleScopes(user.role)),
         ...customRoles.flatMap((role) => role.scopes),
     ];
-    return canManagePersonalAccessToken
+    return user.ability.can('manage', 'PersonalAccessToken')
         ? [...scopes, 'manage:PersonalAccessToken']
         : scopes;
 };

--- a/packages/common/src/authorization/AGENTS.md
+++ b/packages/common/src/authorization/AGENTS.md
@@ -48,6 +48,7 @@ Treat each scope in `scopes.ts` as a user-facing permission contract:
 - `roleToScopeMapping.ts` must stay aligned with system-role abilities so duplicated system roles and parity tests keep working.
 - A role's `level` (`'project' | 'organization'`) gates which scopes it may hold and where it can be assigned: org-level roles may only contain org-assignable scopes (`getOrgAssignableScopes` / `isScopeAssignableAtLevel`) and build org-level conditions with `{ organizationUuid }`; project-level roles build project-level conditions with `{ projectUuid }`. This applies to both human-user and service-account custom roles.
 - Org-level grants are deliberately hard to restrict with project-level custom roles because layers are additive.
+- `manage:PersonalAccessToken` is the one scope an organization primary-slot role fully owns: it emits no rule unless the role lists it (`applyPatConfigFallback: false` in `index.ts`), and the deployment config (`DISABLE_PAT`, `PAT_ALLOWED_ORG_ROLES`) still caps it. Every other scope set keeps inheriting token access from the config so a project or extra role never strips it. It is also excluded from the delegation ceiling — a token carries only its owner's own permissions, so it cannot escalate.
 
 ## Role Types
 

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -601,6 +601,7 @@ describe('getUserAbilityBuilder — role sets (extra custom roles)', () => {
 });
 
 describe('getUserAbilityBuilder — personal access tokens', () => {
+    const PROJECT_UUID = 'test-project-uuid';
     const PAT_ROLE_UUID = '33333333-3333-4333-a333-333333333333';
     const PAT_SCOPE = 'manage:PersonalAccessToken';
 
@@ -610,6 +611,7 @@ describe('getUserAbilityBuilder — personal access tokens', () => {
             allowedOrgRoles: Object.values(OrganizationMemberRole),
         },
     };
+    const patDisabled = { pat: { enabled: false, allowedOrgRoles: [] } };
 
     // Mirrors PersonalAccessTokenService, which checks `create` on the subject
     // carrying the caller's organization.
@@ -621,73 +623,88 @@ describe('getUserAbilityBuilder — personal access tokens', () => {
                 subject('PersonalAccessToken', { organizationUuid: ORG_UUID }),
             );
 
-    const buildWithOrgCustomRole = (
-        scopes: string[],
-        permissionsConfig: {
-            pat: {
-                enabled: boolean;
-                allowedOrgRoles: OrganizationMemberRole[];
-            };
-        },
-    ) =>
+    const buildFor = ({
+        roleUuid,
+        scopes,
+        permissionsConfig = patAllowed,
+        projectProfiles = [],
+    }: {
+        roleUuid?: string;
+        scopes?: string[];
+        permissionsConfig?: typeof patAllowed | typeof patDisabled;
+        projectProfiles?: Parameters<
+            typeof getUserAbilityBuilder
+        >[0]['projectProfiles'];
+    }) =>
         getUserAbilityBuilder({
             user: {
                 role: OrganizationMemberRole.MEMBER,
                 organizationUuid: ORG_UUID,
                 userUuid: USER_UUID,
-                roleUuid: PAT_ROLE_UUID,
+                roleUuid,
             },
-            projectProfiles: [],
+            projectProfiles,
             permissionsConfig,
-            customRoleScopes: { [PAT_ROLE_UUID]: scopes },
+            customRoleScopes: scopes ? { [PAT_ROLE_UUID]: scopes } : undefined,
             customRolesEnabled: true,
             isEnterprise: true,
         }).builder;
 
-    describe('deployment config caps a listed scope', () => {
-        it('grants when the deployment allows tokens', () => {
-            expect(
-                canCreatePat(buildWithOrgCustomRole([PAT_SCOPE], patAllowed)),
-            ).toBe(true);
+    describe('an org-level custom role in the primary slot is authoritative', () => {
+        it('denies PAT when the role omits the scope, even though the deployment allows it', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: ['view:Dashboard'],
+            });
+            expect(canCreatePat(builder)).toBe(false);
         });
 
-        it('denies when the deployment disabled tokens', () => {
-            expect(
-                canCreatePat(
-                    buildWithOrgCustomRole([PAT_SCOPE], {
-                        pat: { enabled: false, allowedOrgRoles: [] },
-                    }),
-                ),
-            ).toBe(false);
+        it('grants PAT when the role lists the scope', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: ['view:Dashboard', PAT_SCOPE],
+            });
+            expect(canCreatePat(builder)).toBe(true);
         });
 
-        it('denies when the org role is outside allowedOrgRoles', () => {
-            expect(
-                canCreatePat(
-                    buildWithOrgCustomRole([PAT_SCOPE], {
-                        pat: {
-                            enabled: true,
-                            allowedOrgRoles: [OrganizationMemberRole.ADMIN],
-                        },
-                    }),
-                ),
-            ).toBe(false);
+        it('still denies PAT when the role lists the scope but the deployment disabled PATs', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: [PAT_SCOPE],
+                permissionsConfig: patDisabled,
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        it('denies PAT when the role lists the scope but the org role is outside allowedOrgRoles', () => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: PAT_ROLE_UUID,
+                },
+                projectProfiles: [],
+                permissionsConfig: {
+                    pat: {
+                        enabled: true,
+                        allowedOrgRoles: [OrganizationMemberRole.ADMIN],
+                    },
+                },
+                customRoleScopes: { [PAT_ROLE_UUID]: [PAT_SCOPE] },
+                customRolesEnabled: true,
+                isEnterprise: true,
+            });
+            expect(canCreatePat(builder)).toBe(false);
         });
     });
 
-    it('still inherits tokens when a role omits the scope', () => {
-        // The config fallback stays on for every scope set until the
-        // organization-role backfill has landed everywhere.
-        expect(
-            canCreatePat(
-                buildWithOrgCustomRole(['view:Dashboard'], patAllowed),
-            ),
-        ).toBe(true);
-    });
-
-    it.each([OrganizationMemberRole.MEMBER, OrganizationMemberRole.ADMIN])(
-        'system role %s keeps the deployment default',
-        (role) => {
+    describe('system org roles are unchanged', () => {
+        it.each([
+            OrganizationMemberRole.MEMBER,
+            OrganizationMemberRole.VIEWER,
+            OrganizationMemberRole.ADMIN,
+        ])('%s keeps the deployment default', (role) => {
             const { builder } = getUserAbilityBuilder({
                 user: {
                     role,
@@ -701,6 +718,47 @@ describe('getUserAbilityBuilder — personal access tokens', () => {
                 isEnterprise: true,
             });
             expect(canCreatePat(builder)).toBe(true);
-        },
-    );
+        });
+
+        it('a project-level custom role cannot take PAT away from a system org role', () => {
+            const builder = buildFor({
+                scopes: ['view:Dashboard'],
+                projectProfiles: [
+                    {
+                        projectUuid: PROJECT_UUID,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: USER_UUID,
+                        roleUuid: PAT_ROLE_UUID,
+                    },
+                ],
+            });
+            expect(canCreatePat(builder)).toBe(true);
+        });
+
+        it('an extra org custom role cannot take PAT away from a system org role', () => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.VIEWER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: undefined,
+                },
+                orgExtraRoleUuids: [PAT_ROLE_UUID],
+                projectProfiles: [],
+                permissionsConfig: patAllowed,
+                customRoleScopes: { [PAT_ROLE_UUID]: ['view:Dashboard'] },
+                customRolesEnabled: true,
+                isEnterprise: true,
+            });
+            expect(canCreatePat(builder)).toBe(true);
+        });
+    });
+
+    it('emits no inverted rules (collapse stays sound)', () => {
+        const builder = buildFor({
+            roleUuid: PAT_ROLE_UUID,
+            scopes: ['view:Dashboard'],
+        });
+        expect(builder.rules.some((r) => r.inverted)).toBe(false);
+    });
 });

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -756,6 +756,27 @@ describe('getUserAbilityBuilder — personal access tokens', () => {
         });
     });
 
+    it('keeps inheriting tokens on an unlicensed deployment', () => {
+        // The scope is enterprise-only, so without a license it is absent from
+        // the vocabulary and no role could ever list it. Declining the fallback
+        // there would deny tokens unrecoverably.
+        const { builder, invalidScopes } = getUserAbilityBuilder({
+            user: {
+                role: OrganizationMemberRole.MEMBER,
+                organizationUuid: ORG_UUID,
+                userUuid: USER_UUID,
+                roleUuid: PAT_ROLE_UUID,
+            },
+            projectProfiles: [],
+            permissionsConfig: patAllowed,
+            customRoleScopes: { [PAT_ROLE_UUID]: [PAT_SCOPE] },
+            customRolesEnabled: true,
+            isEnterprise: false,
+        });
+        expect(invalidScopes).toContain(PAT_SCOPE);
+        expect(canCreatePat(builder)).toBe(true);
+    });
+
     describe('system org roles are unchanged', () => {
         it.each([
             OrganizationMemberRole.MEMBER,

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -603,6 +603,7 @@ describe('getUserAbilityBuilder — role sets (extra custom roles)', () => {
 describe('getUserAbilityBuilder — personal access tokens', () => {
     const PROJECT_UUID = 'test-project-uuid';
     const PAT_ROLE_UUID = '33333333-3333-4333-a333-333333333333';
+    const OTHER_ROLE_UUID = '44444444-4444-4444-a444-444444444444';
     const PAT_SCOPE = 'manage:PersonalAccessToken';
 
     const patAllowed = {
@@ -672,6 +673,62 @@ describe('getUserAbilityBuilder — personal access tokens', () => {
                 roleUuid: PAT_ROLE_UUID,
                 scopes: [PAT_SCOPE],
                 permissionsConfig: patDisabled,
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        // Regression: the config fallback used to still run for every other
+        // scope set, and its "no PAT rule yet" guard read the primary slot's
+        // deliberate refusal as an omission to repair.
+        it('stays denied when the user also holds a project custom role', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: ['view:Dashboard'],
+                projectProfiles: [
+                    {
+                        projectUuid: PROJECT_UUID,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: USER_UUID,
+                        roleUuid: OTHER_ROLE_UUID,
+                    },
+                ],
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        it('stays denied when the user also holds an extra org custom role', () => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: PAT_ROLE_UUID,
+                },
+                orgExtraRoleUuids: [OTHER_ROLE_UUID],
+                projectProfiles: [],
+                permissionsConfig: patAllowed,
+                customRoleScopes: {
+                    [PAT_ROLE_UUID]: ['view:Dashboard'],
+                    [OTHER_ROLE_UUID]: ['view:Dashboard'],
+                },
+                customRolesEnabled: true,
+                isEnterprise: true,
+            });
+            expect(canCreatePat(builder)).toBe(false);
+        });
+
+        it('stays denied when the user also holds a project system role', () => {
+            const builder = buildFor({
+                roleUuid: PAT_ROLE_UUID,
+                scopes: ['view:Dashboard'],
+                projectProfiles: [
+                    {
+                        projectUuid: PROJECT_UUID,
+                        role: ProjectMemberRole.VIEWER,
+                        userUuid: USER_UUID,
+                        roleUuid: undefined,
+                    },
+                ],
             });
             expect(canCreatePat(builder)).toBe(false);
         });

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -58,6 +58,11 @@ export const getUserAbilityBuilder = ({
 }: UserAbilityBuilderArgs): UserAbilityBuilderResult => {
     const builder = new AbilityBuilder<MemberAbility>(Ability);
     const invalidScopes: string[] = [];
+    // `manage:PersonalAccessToken` is an enterprise scope, so it is absent from
+    // the vocabulary without a license and a role could never list it. Declining
+    // the fallback there would deny tokens with no way to grant them back, so an
+    // unlicensed deployment keeps inheriting the deployment default.
+    const applyPatConfigFallback = !isEnterprise;
     // Extra custom roles are unioned on top of the slot; unknown uuids are
     // skipped (logged) rather than granting anything.
     const applyExtraRoles = (
@@ -100,12 +105,12 @@ export const getUserAbilityBuilder = ({
                         isEnterprise,
                         organizationRole: user.role,
                         permissionsConfig,
-                        // Every scope set a human user holds declines the
-                        // fallback: the organization layer alone decides token
-                        // access, so no later role can re-grant what the
-                        // primary slot withheld. Only the service-account path
-                        // in UserModel still inherits the deployment default.
-                        applyPatConfigFallback: false,
+                        // Every scope set a human user holds shares one answer:
+                        // the organization layer alone decides token access, so
+                        // no later role can re-grant what the primary slot
+                        // withheld. Only the service-account path in UserModel
+                        // always inherits the deployment default.
+                        applyPatConfigFallback,
                     },
                     builder,
                 ),
@@ -130,7 +135,7 @@ export const getUserAbilityBuilder = ({
                     isEnterprise,
                     organizationRole: user.role,
                     permissionsConfig,
-                    applyPatConfigFallback: false,
+                    applyPatConfigFallback,
                 },
                 builder,
             ),
@@ -165,7 +170,7 @@ export const getUserAbilityBuilder = ({
                             isEnterprise,
                             organizationRole: user.role,
                             permissionsConfig,
-                            applyPatConfigFallback: false,
+                            applyPatConfigFallback,
                         },
                         builder,
                     ),
@@ -188,7 +193,7 @@ export const getUserAbilityBuilder = ({
                         isEnterprise,
                         organizationRole: user.role,
                         permissionsConfig,
-                        applyPatConfigFallback: false,
+                        applyPatConfigFallback,
                     },
                     builder,
                 ),

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -100,9 +100,11 @@ export const getUserAbilityBuilder = ({
                         isEnterprise,
                         organizationRole: user.role,
                         permissionsConfig,
-                        // The primary slot replaces the system role outright,
-                        // so its scopes decide PAT access rather than
-                        // inheriting the deployment default.
+                        // Every scope set a human user holds declines the
+                        // fallback: the organization layer alone decides token
+                        // access, so no later role can re-grant what the
+                        // primary slot withheld. Only the service-account path
+                        // in UserModel still inherits the deployment default.
                         applyPatConfigFallback: false,
                     },
                     builder,
@@ -128,6 +130,7 @@ export const getUserAbilityBuilder = ({
                     isEnterprise,
                     organizationRole: user.role,
                     permissionsConfig,
+                    applyPatConfigFallback: false,
                 },
                 builder,
             ),
@@ -162,6 +165,7 @@ export const getUserAbilityBuilder = ({
                             isEnterprise,
                             organizationRole: user.role,
                             permissionsConfig,
+                            applyPatConfigFallback: false,
                         },
                         builder,
                     ),
@@ -184,6 +188,7 @@ export const getUserAbilityBuilder = ({
                         isEnterprise,
                         organizationRole: user.role,
                         permissionsConfig,
+                        applyPatConfigFallback: false,
                     },
                     builder,
                 ),

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -100,6 +100,10 @@ export const getUserAbilityBuilder = ({
                         isEnterprise,
                         organizationRole: user.role,
                         permissionsConfig,
+                        // The primary slot replaces the system role outright,
+                        // so its scopes decide PAT access rather than
+                        // inheriting the deployment default.
+                        applyPatConfigFallback: false,
                     },
                     builder,
                 ),

--- a/packages/common/src/authorization/scopeAbilityBuilder.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.ts
@@ -5,6 +5,12 @@ import { parseScope, parseScopes } from './parseScopes';
 import { getAllScopeMap } from './scopes';
 import { type MemberAbility } from './types';
 
+/**
+ * Compatibility grant for scope sets that were never able to express PAT
+ * access: without it, a project or extra custom role would strip the token
+ * permission its organization layer already granted. Skipped for the
+ * organization primary slot, where the role's scopes are authoritative.
+ */
 const handlePatConfigApplication = (
     context: ScopeContext,
     builder: AbilityBuilder<MemberAbility>,
@@ -34,6 +40,7 @@ const handlePatConfigApplication = (
 const applyScopeAbilities = (
     context: ScopeContext,
     builder: AbilityBuilder<MemberAbility>,
+    applyPatConfigFallback: boolean,
 ): void => {
     const scopeMap = getAllScopeMap({ isEnterprise: context.isEnterprise });
 
@@ -60,7 +67,9 @@ const applyScopeAbilities = (
         }
     });
 
-    handlePatConfigApplication(context, builder);
+    if (applyPatConfigFallback) {
+        handlePatConfigApplication(context, builder);
+    }
 };
 
 type OptionalIdContext =
@@ -88,6 +97,12 @@ type BuilderOptions = {
             allowedOrgRoles: string[];
         };
     };
+    /**
+     * Whether a scope set that omits `manage:PersonalAccessToken` still
+     * inherits it from the deployment config. False only for the organization
+     * primary slot, whose scopes fully define the user's organization layer.
+     */
+    applyPatConfigFallback?: boolean;
 } & OptionalIdContext;
 
 /**
@@ -101,18 +116,19 @@ export const buildAbilityFromScopes = (
     context: BuilderOptions,
     builder: AbilityBuilder<MemberAbility>,
 ): string[] => {
+    const { applyPatConfigFallback = true, ...scopeContext } = context;
     const isEnterprise = context.isEnterprise ?? false;
     const { valid, invalid } = parseScopes({
         scopes: context.scopes,
         isEnterprise,
     });
     const parsedContext = {
-        ...context,
+        ...scopeContext,
         scopes: valid,
         isEnterprise,
     };
 
-    applyScopeAbilities(parsedContext, builder);
+    applyScopeAbilities(parsedContext, builder, applyPatConfigFallback);
 
     return invalid;
 };

--- a/release-safety.overrides.json
+++ b/release-safety.overrides.json
@@ -29,6 +29,10 @@
         "1.112.0": {
             "minPreviousVersion": "1.111.0",
             "note": "Auto-recorded at release 1.112.0: a destructive migration here is safe to roll past only when upgrading from 1.111.0 or later."
+        },
+        "2.49.0": {
+            "requiredStop": true,
+            "note": "Introduces config-capped interpretation of manage:PersonalAccessToken and must be deployed before later releases backfill that scope into existing organization custom roles."
         }
     }
 }


### PR DESCRIPTION
Release 2 of 2, stacked on #28204. **Merge and release #28204 first** — this PR's migration is only safe once every running version interprets the scope as config-capped.

## Problem

`manage:PersonalAccessToken` is a no-op in a custom role. `handlePatConfigApplication` re-grants token access to any scope-built ability whenever the deployment config allows the org role, so unticking the scope in the role builder changes nothing. The comment in `roleToScopeMapping.ts` even told operators to "untick it manually" — advice that never worked.

No server-side gap to close: `PersonalAccessTokenService` already checks `create`/`view`/`delete` on the subject, all covered by `manage`. Once the rule is absent, the API is blocked, not just the settings panel hidden.

## Change

An organization custom role in the primary slot replaces the system role outright (see `authorization/CLAUDE.md`), so its scopes are now authoritative for tokens:

- `scopeAbilityBuilder.ts` gains `applyPatConfigFallback` (default `true`); the compatibility grant only runs when set.
- `index.ts` passes `false` for the organization primary slot.

Every other scope set keeps the fallback, so the additive layering holds — a project or extra custom role still cannot strip a permission its organization layer granted, and no `cannot` rules are emitted (`collapseAbilityRules` stays sound; asserted in a test).

### Why not from a project-level role

`authorization/CLAUDE.md` states that organization grants are deliberately hard to restrict from project roles because the layers are additive, and that a custom role in the organization slot is the only way to build a restrictive profile. Suppressing an organization grant from the project layer would make role composition non-monotonic — adding a role would remove a capability — which is a `cannot` in disguise and would break the premise `collapseAbilityRules.test.ts` guards.

## Blast radius

| Population | Effect |
|---|---|
| System organization role (the vast majority) | Unchanged — the org ability grants tokens first, the fallback short-circuits |
| Project custom roles, extra roles | Unchanged — their organization layer already decided |
| Organization custom role in the primary slot | Now honours its scope list — the intended change |
| Service accounts | Unchanged — they build abilities on a separate `UserModel` path, and `assertRegisteredAccount` blocks SA principals from token creation before CASL runs |

## Migration

`20260826152304_grant_pat_scope_to_organization_roles.ts` backfills the scope onto `roles.level = 'organization'`.

No existing organization role can list the scope: they are seeded from the static system-role abilities (`getOrganizationMemberRolePermissions`), and token access was only ever added by `applyOrganizationMemberDynamicAbilities`. Shipping without the backfill would silently strip tokens from every organization custom-role user on upgrade.

`granted_by` comes from `roles.created_by` (FK-safe, nullable on both sides). Wrapped in try/catch with a recoverable-error log, and classified `safe` for the SQL linter, per `20260722153938` and `migrations/CLAUDE.md`.

## Delegation ceiling

Removing the fallback made an organization custom-role caller's footprint honest, which broke invites: a caller whose role omits the scope could no longer invite a system-role user whose scopes include it.

Fixed by dropping `includePersonalAccessToken` from the four system-role call sites — token access on a system role comes from deployment config, not from the grant. The option is now dead and removed.

The ceiling still applies to **role** grants: creating or assigning a custom role that lists the scope requires the caller to hold it. Otherwise a token-restricted manager could mint a token-granting role, which defeats the point of the feature.

## Testing

- `common/src/authorization` — passes, including a block covering: role omits scope, role lists scope, `DISABLE_PAT`, `PAT_ALLOWED_ORG_ROLES` exclusion, system roles unchanged, project/extra roles cannot strip, no inverted rules.
- `organizationRolePermissions.test.ts` — existing ceiling invariants pass, plus a new case for a token-restricted caller granting a system role.
- `UserService` / `RolesService` / `OrganizationService` — pass.
- `common` and `backend` typecheck clean; `sql-migration-lint --enforce` clean.

The migration itself was not executed locally.

## Note

Alternative implementation of the same issue to #27897, which restricts tokens from the project role layer instead.

Closes: #25543
