### PR TITLE
fix: preserve metric formats in pivoted xlsx exports

### DIFF
--- a/packages/backend/src/services/ExcelService/ExcelService.test.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.test.ts
@@ -8,6 +8,7 @@ import {
     getItemId,
     ItemsMap,
     MetricType,
+    NumberSeparator,
     SortByDirection,
     TimeFrames,
     VizAggregationOptions,
@@ -879,6 +880,100 @@ describe('ExcelService', () => {
     // converted, even if values match ISO 8601 (e.g. "202811").
 
     describe('downloadPivotTableXlsx', () => {
+        it.each([false, true])(
+            'writes formatted pivoted metrics as numeric cells with Excel formats when improved dates is %s',
+            async (enableImprovedExcelDates) => {
+                const pivotDimension = 'orders_status';
+                const indexDimension = 'string_column';
+                const metric = 'number_with_usd_format';
+                const completedColumn = `${metric}_any_completed`;
+                const placedColumn = `${metric}_any_placed`;
+
+                const itemMap: ItemsMap = {
+                    ...mockItemMapWithFormats,
+                    [pivotDimension]: {
+                        ...mockItemMapWithFormats.string_column,
+                        name: 'orders_status',
+                        label: 'Status',
+                    },
+                    [metric]: {
+                        ...mockItemMapWithFormats.number_with_usd_format,
+                        round: 1,
+                        separator: NumberSeparator.PERIOD_COMMA,
+                    },
+                };
+                const valuesColumns = [
+                    ['completed', completedColumn],
+                    ['placed', placedColumn],
+                ].map(([value, pivotColumnName]) => ({
+                    aggregation: VizAggregationOptions.ANY,
+                    pivotValues: [
+                        {
+                            value,
+                            referenceField: pivotDimension,
+                        },
+                    ],
+                    referenceField: metric,
+                    pivotColumnName,
+                }));
+                const pivotDetails = {
+                    totalColumnCount: 2,
+                    valuesColumns,
+                    indexColumn: [
+                        {
+                            type: VizIndexType.CATEGORY,
+                            reference: indexDimension,
+                        },
+                    ],
+                    groupByColumns: [{ reference: pivotDimension }],
+                    sortBy: [
+                        {
+                            direction: SortByDirection.ASC,
+                            reference: indexDimension,
+                        },
+                    ],
+                    originalColumns: {},
+                };
+
+                const buffer = await ExcelService.downloadPivotTableXlsx({
+                    rows: [
+                        {
+                            [indexDimension]: '00123',
+                            [completedColumn]: 1234.56,
+                            [placedColumn]: 9876.54,
+                        },
+                    ],
+                    itemMap,
+                    pivotConfig: {
+                        pivotDimensions: [pivotDimension],
+                        metricsAsRows: false,
+                    },
+                    onlyRaw: false,
+                    customLabels: undefined,
+                    pivotDetails,
+                    enableImprovedExcelDates,
+                });
+
+                const workbook = new (await import('exceljs')).Workbook();
+                // @ts-ignore - Buffer type mismatch between exceljs and Node 20
+                await workbook.xlsx.load(buffer);
+                const worksheet = workbook.getWorksheet('Pivot Table');
+                expect(worksheet).toBeDefined();
+
+                const expectedFormat = getExcelFormatExpression(
+                    itemMap[metric],
+                );
+                const completedCell = worksheet!.getRow(3).getCell(2);
+                const placedCell = worksheet!.getRow(3).getCell(3);
+
+                expect(worksheet!.getRow(3).getCell(1).value).toBe('00123');
+                expect(completedCell.value).toBe(1234.56);
+                expect(placedCell.value).toBe(9876.54);
+                expect(completedCell.numFmt).toBe(expectedFormat);
+                expect(placedCell.numFmt).toBe(expectedFormat);
+            },
+        );
+
         it('should not convert metric values that look like YYYYMM to dates (PROD-6683)', async () => {
             const pivotDimension = 'payments_payment_method';
             const indexDimension = 'customers_created_month';
@@ -1022,23 +1117,13 @@ describe('ExcelService', () => {
             );
             expect(metricDateValues).toHaveLength(0);
 
-            // YYYYMM-like metric values should be preserved as strings
-            const stringValues = dataValues
-                .filter((v) => typeof v.value === 'string')
-                .map((v) => v.value as string);
-            const numericStrings = stringValues.filter((v) =>
-                [
-                    '202,811',
-                    '202811',
-                    '2,028',
-                    '2028',
-                    '20,281,101',
-                    '20281101',
-                    '141,312',
-                    '141312',
-                ].includes(v),
+            // YYYYMM-like metric values should be preserved as native numbers
+            const numericMetricValues = dataValues
+                .filter((v) => v.col > 1 && typeof v.value === 'number')
+                .map((v) => v.value);
+            expect(numericMetricValues).toEqual(
+                expect.arrayContaining([202811, 2028, 20281101, 141312]),
             );
-            expect(numericStrings.length).toBeGreaterThanOrEqual(4);
         });
 
         it('TC1: should convert both DATE and TIMESTAMP index dimensions to Date objects', async () => {

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -24,7 +24,6 @@ import {
     isNumericItem,
     ItemsMap,
     PivotConfig,
-    pivotResultsAsCsv,
     pivotResultsAsData,
     ResultRow,
     shouldShiftItemTimezone,
@@ -34,6 +33,7 @@ import {
     type ConditionalFormattingConfig,
     type ConditionalFormattingMinMaxMap,
     type ConditionalFormattingRowFields,
+    type PivotResultsDataCell,
     type PivotRowTotalsByIndex,
     type ReadyQueryResultsPage,
 } from '@lightdash/common';
@@ -158,6 +158,48 @@ export class ExcelService {
                 undefined,
                 timezone,
             );
+        });
+    }
+
+    private static convertPivotCellToExcel(
+        cell: PivotResultsDataCell,
+        itemMap: ItemsMap,
+        onlyRaw: boolean,
+    ): string | number {
+        const item = itemMap[cell.itemId ?? cell.fieldId];
+        if (
+            !onlyRaw &&
+            isNumericItem(item) &&
+            cell.raw !== null &&
+            cell.raw !== undefined &&
+            String(cell.raw).trim() !== '' &&
+            isNumber(cell.raw)
+        ) {
+            return Number(cell.raw);
+        }
+
+        return cell.formatted;
+    }
+
+    private static applyPivotNumberFormats(
+        excelRow: Excel.Row,
+        pivotRow: PivotResultsDataCell[],
+        itemMap: ItemsMap,
+        onlyRaw: boolean,
+    ) {
+        if (onlyRaw) return;
+
+        pivotRow.forEach((cell, colIndex) => {
+            const excelCell = excelRow.getCell(colIndex + 1);
+            if (typeof excelCell.value !== 'number') return;
+
+            const formatExpression = getExcelFormatExpression(
+                itemMap[cell.itemId ?? cell.fieldId],
+            );
+
+            if (formatExpression) {
+                excelCell.numFmt = formatExpression;
+            }
         });
     }
 
@@ -431,10 +473,16 @@ export class ExcelService {
             );
         }
 
+        const pivotValuesColumnsMap = Object.fromEntries(
+            pivotDetails.valuesColumns?.map((column) => [
+                column.pivotColumnName,
+                column,
+            ]) ?? [],
+        );
         const formattedRows = formatRows(
             rows,
             itemMap,
-            undefined,
+            pivotValuesColumnsMap,
             undefined,
             timezone,
         );
@@ -520,7 +568,7 @@ export class ExcelService {
             }
         });
 
-        // Add data rows — use raw values for date columns, formatted for everything else
+        // Add data rows with native date/number values and Excel formats.
         pivotData.dataRows.forEach((row) => {
             const excelRow = row.map((cell, colIndex) => {
                 const dateFmt = dateColumnFormats.get(colIndex);
@@ -537,9 +585,15 @@ export class ExcelService {
                             : m.toDate();
                     }
                 }
-                return cell.formatted;
+                return ExcelService.convertPivotCellToExcel(
+                    cell,
+                    itemMap,
+                    onlyRaw,
+                );
             });
             const wsRow = worksheet.addRow(excelRow);
+
+            ExcelService.applyPivotNumberFormats(wsRow, row, itemMap, onlyRaw);
 
             // Apply numFmt to date cells in this row
             dateColumnFormats.forEach(({ numFmt }, colIndex) => {
@@ -598,7 +652,7 @@ export class ExcelService {
         warehouseGrandTotals?: Record<string, number>;
         timezone?: string;
     }): Promise<Excel.Buffer> {
-        const csvResults = pivotResultsAsCsv({
+        const pivotData = pivotResultsAsData({
             pivotConfig,
             rows: formattedRows,
             itemMap,
@@ -609,15 +663,41 @@ export class ExcelService {
             warehouseColumnTotals,
             warehouseGrandTotals,
         });
+        const csvResults = [
+            ...pivotData.headers,
+            ...pivotData.dataRows.map((row) =>
+                row.map((cell) => cell.formatted),
+            ),
+        ];
 
         const workbook = new Excel.Workbook();
         const worksheet = workbook.addWorksheet('Pivot Table');
 
         csvResults.forEach((row, index) => {
-            const excelRow = row.map((value) =>
+            const pivotRow =
+                pivotData.dataRows[index - pivotData.headers.length];
+            const rowValues = pivotRow
+                ? pivotRow.map((cell) =>
+                      ExcelService.convertPivotCellToExcel(
+                          cell,
+                          itemMap,
+                          onlyRaw,
+                      ),
+                  )
+                : row;
+            const excelRow = rowValues.map((value) =>
                 ExcelService.convertToExcelDate(value, timezone),
             );
-            worksheet.addRow(excelRow);
+            const wsRow = worksheet.addRow(excelRow);
+
+            if (pivotRow) {
+                ExcelService.applyPivotNumberFormats(
+                    wsRow,
+                    pivotRow,
+                    itemMap,
+                    onlyRaw,
+                );
+            }
 
             if (index === 0) {
                 const headerRow = worksheet.getRow(1);

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1430,6 +1430,7 @@ export type PivotResultsDataCell = {
     raw: unknown;
     formatted: string;
     fieldId: string;
+    itemId?: string;
 };
 
 export type PivotResultsData = {
@@ -1589,23 +1590,43 @@ export const pivotResultsAsData = ({
     // and the "hide" semantic includes exports. Filtered here so every
     // downstream consumer of pivotResultsAsData (CSV, XLSX, etc.) inherits
     // the exclusion.
-    const fieldIds = Object.values(pivotedResults.retrofitData.pivotColumnInfo)
-        .filter((field) => field.columnType !== 'passthrough')
-        .map((field) => field.fieldId);
+    const pivotColumns = Object.values(
+        pivotedResults.retrofitData.pivotColumnInfo,
+    ).filter((field) => field.columnType !== 'passthrough');
+    const fieldIds = pivotColumns.map((field) => field.fieldId);
 
     const hasIndex = pivotedResults.indexValues.length > 0;
-    const dataRows = pivotedResults.retrofitData.allCombinedData.map((row) => {
-        const noIndexPrefix: PivotResultsDataCell[] = hasIndex
-            ? []
-            : [{ raw: '', formatted: '', fieldId: '' }];
-        const cells: PivotResultsDataCell[] = fieldIds.map((fieldId) => ({
-            raw: row[fieldId]?.value?.raw ?? '',
-            formatted:
-                pickValue(row[fieldId]?.value, fieldId) || undefinedCharacter,
-            fieldId,
-        }));
-        return [...noIndexPrefix, ...cells];
-    });
+    const dataRows = pivotedResults.retrofitData.allCombinedData.map(
+        (row, rowIndex) => {
+            const metricLabel = last(pivotedResults.indexValues[rowIndex]);
+            const metricAsRowItemId =
+                pivotConfig.metricsAsRows && metricLabel?.type === 'label'
+                    ? metricLabel.fieldId
+                    : undefined;
+            const noIndexPrefix: PivotResultsDataCell[] = hasIndex
+                ? []
+                : [{ raw: '', formatted: '', fieldId: '', itemId: '' }];
+            const cells: PivotResultsDataCell[] = pivotColumns.map((column) => {
+                const itemId =
+                    metricAsRowItemId &&
+                    (column.columnType === undefined ||
+                        column.columnType === 'rowTotal')
+                        ? metricAsRowItemId
+                        : (column.underlyingId ??
+                          column.baseId ??
+                          column.fieldId);
+                return {
+                    raw: row[column.fieldId]?.value?.raw ?? '',
+                    formatted:
+                        pickValue(row[column.fieldId]?.value, itemId) ||
+                        undefinedCharacter,
+                    fieldId: column.fieldId,
+                    itemId,
+                };
+            });
+            return [...noIndexPrefix, ...cells];
+        },
+    );
 
     // Column totals render as footer row(s) below the data — mirroring the
     // pivot table UI. Each row is [index labels, per-column totals, blank row
@@ -1628,7 +1649,12 @@ export const pivotResultsAsData = ({
                               : ''
                       }`
                     : '';
-                return { raw: label, formatted: label, fieldId: '' };
+                return {
+                    raw: label,
+                    formatted: label,
+                    fieldId: '',
+                    itemId: '',
+                };
             },
         );
 
@@ -1639,6 +1665,7 @@ export const pivotResultsAsData = ({
                         raw: '',
                         formatted: undefinedCharacter,
                         fieldId: '',
+                        itemId: '',
                     };
                 }
                 // The total's metric is the per-row metric (metricsAsRows) or
@@ -1654,7 +1681,12 @@ export const pivotResultsAsData = ({
                 const formatted = onlyRaw
                     ? String(total)
                     : formatItemValue(field, total, false);
-                return { raw: total, formatted, fieldId: fieldId ?? '' };
+                return {
+                    raw: total,
+                    formatted,
+                    fieldId: fieldId ?? '',
+                    itemId: fieldId ?? '',
+                };
             },
         );
 
@@ -1675,7 +1707,12 @@ export const pivotResultsAsData = ({
                           grandTotal === undefined ||
                           !fieldId
                       ) {
-                          return { raw: '', formatted: '', fieldId: '' };
+                          return {
+                              raw: '',
+                              formatted: '',
+                              fieldId: '',
+                              itemId: '',
+                          };
                       }
                       const field = itemMap[fieldId];
                       const formatted = onlyRaw
@@ -1685,6 +1722,7 @@ export const pivotResultsAsData = ({
                           raw: grandTotal,
                           formatted,
                           fieldId,
+                          itemId: fieldId,
                       };
                   })
                 : [];


### PR DESCRIPTION
Closes: [PROD-10640](https://linear.app/lightdash/issue/PROD-10640/pivoted-xlsx-export-preserves-metric-formats-in-grouped-layout)

### Description:

- Pass SQL pivot-column metadata into row formatting so grouped pivot exports retain their source metric formatting.
- Write formatted pivot metrics as native numeric XLSX cells and apply their Excel number formats in both legacy and improved-date export paths.
- Carry optional source-field metadata through pivot result cells for metrics-as-columns, metrics-as-rows, and total cells.
- Preserve numeric-looking string dimensions such as `00123` instead of coercing them to numbers.

Before the fix, the grouped XLSX export wrote pivot metric cells as shared strings. After the fix, the same browser export writes native numeric cells with the configured currency number format.

### Validation:

- Browser reproduction and post-fix export on `localhost:3000`
- `pnpm -F backend test` — 8,117 passed, 1 skipped
- `pnpm -F common test` — 3,776 passed, 1 skipped
- `pnpm -F backend test src/services/ExcelService/ExcelService.test.ts`
- `pnpm -F common test src/pivot/pivotQueryResults.test.ts src/pivot/pivotResultsAsCsv.test.ts`
- `pnpm -F backend typecheck`
- `pnpm -F common typecheck`
- Package lint and formatting checks
- `git diff --check`

### Risk assessment:

- [ ] This is a high-risk change