### PR TITLE
fix(warehouses): infer Trino decimals as numbers

### DIFF
--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { AnyType, QueryExecutionContext } from '@lightdash/common';
+import {
+    AnyType,
+    DimensionType,
+    QueryExecutionContext,
+} from '@lightdash/common';
 import { Columns, Iterator, QueryData, QueryResult, Trino } from 'trino-client';
 import {
     TrinoSqlBuilder,
@@ -82,6 +86,33 @@ describe('TrinoWarehouseClient', () => {
             warehouse.getCatalog(warehouseClient.config),
         ).resolves.toEqual(
             warehouseClient.expectedWarehouseSchemaWithNaiveTimestamp,
+        );
+    });
+
+    it('maps decimal precision and scale to a numeric dimension', async () => {
+        const warehouse = new TrinoWarehouseClient(credentials);
+        queryResultMock.mockReturnValue({
+            next: vi.fn().mockResolvedValue({
+                done: true,
+                value: {
+                    ...querySchemaResponse,
+                    data: [
+                        [
+                            'myDatabase',
+                            'mySchema',
+                            'myTable',
+                            'myDecimalColumn',
+                            'decimal(18,4)',
+                        ],
+                    ],
+                },
+            }),
+        });
+
+        const catalog = await warehouse.getCatalog(warehouseClient.config);
+
+        expect(catalog.myDatabase.mySchema.myTable.myDecimalColumn).toEqual(
+            DimensionType.NUMBER,
         );
     });
 

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -34,6 +34,9 @@ import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
 
 const TRINO_CLIENT_TAGS_HEADER = 'X-Trino-Client-Tags';
 
+const removeNumericTypeParameters = (type: string): string =>
+    type.replace(/\(\s*\d+(?:\s*,\s*\d+)?\s*\)/, '');
+
 // Trino splits the header on commas and Node rejects non-latin1 header values,
 // so tag keys/values are restricted to a safe charset
 const sanitizeClientTag = (tag: DriftedTagValue): string =>
@@ -103,7 +106,7 @@ const queryTableSchema = ({
 export const getTrinoTimestampDomain = (
     type: TrinoTypes | string,
 ): TimestampDomain | undefined => {
-    switch (type.replace(/\(\d+\)/, '')) {
+    switch (removeNumericTypeParameters(type)) {
         case TrinoTypes.TIMESTAMP:
             return 'naive';
         case TrinoTypes.TIMESTAMP_TZ:
@@ -116,8 +119,8 @@ export const getTrinoTimestampDomain = (
 const convertDataTypeToDimensionType = (
     type: TrinoTypes | string,
 ): DimensionType => {
-    const typeWithoutTimePrecision = type.replace(/\(\d+\)/, '');
-    switch (typeWithoutTimePrecision) {
+    const typeWithoutParameters = removeNumericTypeParameters(type);
+    switch (typeWithoutParameters) {
         case TrinoTypes.BOOLEAN:
             return DimensionType.BOOLEAN;
         case TrinoTypes.TINYINT:


### PR DESCRIPTION
Closes: #28057

### Description:

- normalize Trino numeric type parameters containing precision and scale
- generate numeric dimensions for `DECIMAL(p,s)` catalog columns
- cover the failing `decimal(18,4)` catalog path with a regression test

### Validation:

- `pnpm -F @lightdash/warehouses test`
- `pnpm -F @lightdash/warehouses typecheck`
- `pnpm -F @lightdash/warehouses lint`
- targeted Oxfmt check
- `git diff --check`

Live Trino was not available; the regression test exercises the public `getCatalog` path with a mocked Trino catalog response.

### Risk assessment:

- [ ] This is a high-risk change