### PR TITLE
fix(permissions): cap the personal access token scope by deployment config

### DIFF
--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -599,3 +599,108 @@ describe('getUserAbilityBuilder — role sets (extra custom roles)', () => {
         expect(builder.rules.some((r) => r.inverted)).toBe(false);
     });
 });
+
+describe('getUserAbilityBuilder — personal access tokens', () => {
+    const PAT_ROLE_UUID = '33333333-3333-4333-a333-333333333333';
+    const PAT_SCOPE = 'manage:PersonalAccessToken';
+
+    const patAllowed = {
+        pat: {
+            enabled: true,
+            allowedOrgRoles: Object.values(OrganizationMemberRole),
+        },
+    };
+
+    // Mirrors PersonalAccessTokenService, which checks `create` on the subject
+    // carrying the caller's organization.
+    const canCreatePat = (builder: AbilityBuilder<MemberAbility>) =>
+        builder
+            .build()
+            .can(
+                'create',
+                subject('PersonalAccessToken', { organizationUuid: ORG_UUID }),
+            );
+
+    const buildWithOrgCustomRole = (
+        scopes: string[],
+        permissionsConfig: {
+            pat: {
+                enabled: boolean;
+                allowedOrgRoles: OrganizationMemberRole[];
+            };
+        },
+    ) =>
+        getUserAbilityBuilder({
+            user: {
+                role: OrganizationMemberRole.MEMBER,
+                organizationUuid: ORG_UUID,
+                userUuid: USER_UUID,
+                roleUuid: PAT_ROLE_UUID,
+            },
+            projectProfiles: [],
+            permissionsConfig,
+            customRoleScopes: { [PAT_ROLE_UUID]: scopes },
+            customRolesEnabled: true,
+            isEnterprise: true,
+        }).builder;
+
+    describe('deployment config caps a listed scope', () => {
+        it('grants when the deployment allows tokens', () => {
+            expect(
+                canCreatePat(buildWithOrgCustomRole([PAT_SCOPE], patAllowed)),
+            ).toBe(true);
+        });
+
+        it('denies when the deployment disabled tokens', () => {
+            expect(
+                canCreatePat(
+                    buildWithOrgCustomRole([PAT_SCOPE], {
+                        pat: { enabled: false, allowedOrgRoles: [] },
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('denies when the org role is outside allowedOrgRoles', () => {
+            expect(
+                canCreatePat(
+                    buildWithOrgCustomRole([PAT_SCOPE], {
+                        pat: {
+                            enabled: true,
+                            allowedOrgRoles: [OrganizationMemberRole.ADMIN],
+                        },
+                    }),
+                ),
+            ).toBe(false);
+        });
+    });
+
+    it('still inherits tokens when a role omits the scope', () => {
+        // The config fallback stays on for every scope set until the
+        // organization-role backfill has landed everywhere.
+        expect(
+            canCreatePat(
+                buildWithOrgCustomRole(['view:Dashboard'], patAllowed),
+            ),
+        ).toBe(true);
+    });
+
+    it.each([OrganizationMemberRole.MEMBER, OrganizationMemberRole.ADMIN])(
+        'system role %s keeps the deployment default',
+        (role) => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: undefined,
+                },
+                projectProfiles: [],
+                permissionsConfig: patAllowed,
+                customRolesEnabled: true,
+                isEnterprise: true,
+            });
+            expect(canCreatePat(builder)).toBe(true);
+        },
+    );
+});

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -197,17 +197,10 @@ const BASE_ROLE_SCOPES = {
         'view:Roadmap',
         'impersonate:User',
 
-        // PAT management. Granted dynamically at runtime via
-        // `applyOrganizationMemberDynamicAbilities` based on the
-        // deployment-wide `PAT_ALLOWED_ORG_ROLES` env var — that path
-        // remains the source of truth for system roles. Listing it
-        // here lets admin-clone custom roles surface the toggle in the
-        // role builder. **Caveat:** toggling it in a custom role
-        // *bypasses* the dynamic gate, since CASL is additive (the
-        // static scope-built rule wins regardless of deployment
-        // config). Operators who clone admin into a lower-privilege
-        // role should untick it manually if their deployment intends
-        // to restrict PAT to specific tiers.
+        // System roles take token access from the deployment config; listing
+        // it here surfaces the toggle in the role builder. Deployment config
+        // caps the scope, so a role can never grant tokens on a deployment
+        // that disabled them or excluded the role's tier.
         'manage:PersonalAccessToken',
     ],
 } as const;

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -45,6 +45,19 @@ const addAccessCondition = (context: ScopeContext, role?: SpaceMemberRole) => ({
 const addDefaultUuidCondition = flow(addUuidCondition, Array.of);
 
 /**
+ * Deployment config caps token access: a listed scope can be switched off by
+ * config, but never switched on for a deployment that disabled tokens or
+ * excluded the role's tier. An absent organization role cannot be checked
+ * against the allowlist, so it denies rather than assuming allowed.
+ */
+const personalAccessTokenConditions = (context: ScopeContext) => {
+    const { pat } = context.permissionsConfig ?? {};
+    if (!pat?.enabled || !context.organizationRole) return null;
+    if (!pat.allowedOrgRoles.includes(context.organizationRole)) return null;
+    return addDefaultUuidCondition(context);
+};
+
+/**
  * True only inside a preview the current user created. Shared by the @self
  * preview scopes; returns false for org-level assignments (no project context).
  */
@@ -1034,7 +1047,7 @@ const scopes: Scope[] = [
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
         dependencies: [],
         level: 'organization',
-        getConditions: addDefaultUuidCondition,
+        getConditions: personalAccessTokenConditions,
     },
     {
         name: 'impersonate:User',


### PR DESCRIPTION
Release 1 of 2. Expand half of an expand/contract rollout for restricting personal access tokens through custom roles. Ships on its own with no behaviour change; #28200 stacks the contract half on top.

## Problem

`manage:PersonalAccessToken` granted tokens **unconditionally** when a custom role listed it. `applyScopeAbilities` emitted the rule from the scope alone, so a role could hand out tokens on a deployment that had set `DISABLE_PAT` or excluded that tier from `PAT_ALLOWED_ORG_ROLES`. The comment in `roleToScopeMapping.ts` documented this as a known bypass.

## Change

`personalAccessTokenConditions` returns `null` — the existing "this scope emits no rule in this context" signal — when the deployment disallows tokens. Net semantics: **config can switch tokens off, never on.**

An absent `organizationRole` cannot be checked against the allowlist, so it denies rather than assuming allowed.

The config fallback (`handlePatConfigApplication`) stays on for every scope set, so a role that *omits* the scope keeps inheriting tokens exactly as before.

## Why this ships separately

The follow-up backfills the scope onto existing organization-level roles. Old code treats a listed scope as an unconditional grant, so writing those rows while any older version is still serving would hand tokens back to deployments that had disabled them — during a rolling upgrade, and durably if the app is rolled back without the migration.

Landing this first means the oldest version present during that rollout already reads the migrated rows safely. This is the redesign `packages/backend/src/database/migrations/CLAUDE.md` asks for before considering a breaking declaration.

## Testing

`common/src/authorization` passes, including new cases for a listed scope under `DISABLE_PAT`, under an excluding `PAT_ALLOWED_ORG_ROLES`, and under a permissive config — plus one pinning that a role omitting the scope still inherits tokens, which is what the follow-up flips.

Relates: #25543
