### PR TITLE
fix(content-as-code): surface draft overlay failures to authors

### DIFF
--- a/packages/backend/src/contentAsCode/fieldCoverage/dashboard.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/dashboard.test.ts
@@ -10,6 +10,7 @@ describeContentAsCodeSchemaContract({
         'deletedAt',
         'deletedBy',
         // Overlay flags for unpublished drafts; not part of the as-code document.
+        'draftOverlayError',
         'draftsAwaitingReview',
         'firstViewedAt',
         'hasUnpublishedChanges',

--- a/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
@@ -145,6 +145,17 @@ describe('DashboardService drafts gating (sync + git-backed only)', () => {
         });
     });
 
+    it('rejects an invalid draft before persisting it', async () => {
+        const { service, upsertOpenDraft } = buildService();
+
+        await expect(
+            service['maybeStoreDraft'](editorUser, dashboardDao, {
+                tiles: 'not-an-array',
+            }),
+        ).rejects.toThrow('Invalid dashboard draft field: tiles');
+        expect(upsertOpenDraft).not.toHaveBeenCalled();
+    });
+
     it('publishes normally when the repo never opted into sync', async () => {
         const { service, snapshotGet, upsertOpenDraft } = buildService({
             settings: undefined,
@@ -193,13 +204,30 @@ describe('DashboardService drafts gating (sync + git-backed only)', () => {
 describe('DashboardService draft overlay is opt-in', () => {
     afterEach(() => vi.clearAllMocks());
 
-    const buildReadService = () => {
-        const findOpenDraft = vi
-            .fn()
-            .mockResolvedValue({ draft: { name: 'Weekly KPIs (drafted)' } });
+    const buildReadService = (
+        draftFieldsForRead: object = { name: 'Weekly KPIs (drafted)' },
+    ) => {
+        const findOpenDraft = vi.fn(
+            async (
+                _projectUuid: string,
+                _contentType: string,
+                _contentUuid: string,
+                authorUserUuid: string,
+            ) =>
+                authorUserUuid === 'author-uuid'
+                    ? {
+                          uuid: 'draft-uuid',
+                          draft: draftFieldsForRead,
+                      }
+                    : undefined,
+        );
+        const updateDraft = vi.fn();
         const { service } = buildService();
         // Replace the collaborators the read path needs
-        (service as AnyType).contentDraftModel = { findOpenDraft };
+        (service as AnyType).contentDraftModel = {
+            findOpenDraft,
+            update: updateDraft,
+        };
         (service as AnyType).dashboardModel = {
             getByIdOrSlug: vi.fn().mockResolvedValue(dashboardDao),
         };
@@ -215,7 +243,7 @@ describe('DashboardService draft overlay is opt-in', () => {
                 { action: 'view', subject: 'Dashboard' },
             ]),
         } as unknown as SessionUser;
-        return { service, viewer, findOpenDraft };
+        return { service, viewer, findOpenDraft, updateDraft };
     };
 
     it('getByIdOrSlug returns the published dashboard and never reads drafts', async () => {
@@ -238,6 +266,55 @@ describe('DashboardService draft overlay is opt-in', () => {
 
         expect(dashboard.name).toBe('Weekly KPIs (drafted)');
         expect(dashboard.hasUnpublishedChanges).toBe(true);
+    });
+
+    it('returns published content with a typed failure when the author draft is corrupt', async () => {
+        const { service, viewer, updateDraft } = buildReadService({
+            tiles: 'not-an-array',
+        });
+
+        const dashboard = await service.getByIdOrSlugForViewer(
+            viewer,
+            'weekly-kpis',
+        );
+
+        expect(dashboard).toMatchObject({
+            name: 'Weekly KPIs',
+            tiles: [],
+            draftOverlayError: {
+                code: 'invalid_dashboard_draft',
+                draftUuid: 'draft-uuid',
+            },
+        });
+        expect(dashboard.hasUnpublishedChanges).toBeUndefined();
+        expect(updateDraft).not.toHaveBeenCalled();
+    });
+
+    it('does not expose another author corrupt draft or its failure', async () => {
+        const { service, viewer, findOpenDraft } = buildReadService({
+            tiles: 'not-an-array',
+        });
+        const otherViewer = {
+            ...viewer,
+            userUuid: 'other-viewer-uuid',
+        } as SessionUser;
+
+        const dashboard = await service.getByIdOrSlugForViewer(
+            otherViewer,
+            'weekly-kpis',
+        );
+
+        expect(dashboard).toMatchObject({
+            name: 'Weekly KPIs',
+            tiles: [],
+        });
+        expect(dashboard).not.toHaveProperty('draftOverlayError');
+        expect(findOpenDraft).toHaveBeenCalledWith(
+            PROJECT_UUID,
+            'dashboard',
+            'dashboard-uuid',
+            'other-viewer-uuid',
+        );
     });
 });
 

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -135,6 +135,44 @@ type DashboardServiceArguments = {
     contentVerificationModel: ContentVerificationModel;
 };
 
+type DashboardDraftOverlay = Partial<
+    Pick<
+        DashboardDAO,
+        'name' | 'description' | 'tiles' | 'filters' | 'tabs' | 'config'
+    >
+>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const assertDashboardDraftOverlay: (
+    draft: unknown,
+) => asserts draft is DashboardDraftOverlay = (draft) => {
+    if (!isRecord(draft)) {
+        throw new Error('Dashboard draft must be an object');
+    }
+    const validators: Record<
+        keyof DashboardDraftOverlay,
+        (value: unknown) => boolean
+    > = {
+        name: (value) => typeof value === 'string',
+        description: (value) => typeof value === 'string',
+        tiles: Array.isArray,
+        filters: isRecord,
+        tabs: Array.isArray,
+        config: isRecord,
+    };
+    for (const [field, validate] of Object.entries(validators)) {
+        if (
+            Object.prototype.hasOwnProperty.call(draft, field) &&
+            draft[field] !== undefined &&
+            !validate(draft[field])
+        ) {
+            throw new Error(`Invalid dashboard draft field: ${field}`);
+        }
+    }
+};
+
 export class DashboardService
     extends BaseService
     implements BulkActionable<Knex>, SoftDeletableService
@@ -1705,9 +1743,10 @@ export class DashboardService
 
     private static mergeDraftIntoDashboard<T extends DashboardDAO>(
         dashboard: T,
-        draft: object,
+        draft: unknown,
     ): T {
-        const fields = draft as Partial<DashboardDAO>;
+        assertDashboardDraftOverlay(draft);
+        const fields = draft;
         return {
             ...dashboard,
             ...(fields.name !== undefined && { name: fields.name }),
@@ -1750,6 +1789,10 @@ export class DashboardService
         ) {
             return undefined;
         }
+        const overlaid = DashboardService.mergeDraftIntoDashboard(
+            existingDashboardDao,
+            dashboardFields,
+        );
         await this.contentDraftModel.upsertOpenDraft({
             projectUuid: existingDashboardDao.projectUuid,
             contentType: 'dashboard',
@@ -1758,10 +1801,6 @@ export class DashboardService
             authorUserUuid: user.userUuid,
             draft: dashboardFields,
         });
-        const overlaid = DashboardService.mergeDraftIntoDashboard(
-            existingDashboardDao,
-            dashboardFields,
-        );
         const space = await this.spacePermissionService.resolveAccess(
             user.userUuid,
             { type: 'space', spaceUuid: existingDashboardDao.spaceUuid },
@@ -1790,13 +1829,35 @@ export class DashboardService
                 user.userUuid,
             );
             if (draft) {
-                return {
-                    ...DashboardService.mergeDraftIntoDashboard(
-                        dashboard,
-                        draft.draft,
-                    ),
-                    hasUnpublishedChanges: true,
-                };
+                try {
+                    return {
+                        ...DashboardService.mergeDraftIntoDashboard(
+                            dashboard,
+                            draft.draft,
+                        ),
+                        hasUnpublishedChanges: true,
+                    };
+                } catch (error) {
+                    this.logger.warn(
+                        'Draft overlay failed; serving published dashboard',
+                        {
+                            projectUuid: dashboard.projectUuid,
+                            dashboardUuid: dashboard.uuid,
+                            draftUuid: draft.uuid,
+                            error:
+                                error instanceof Error
+                                    ? error.message
+                                    : String(error),
+                        },
+                    );
+                    return {
+                        ...dashboard,
+                        draftOverlayError: {
+                            code: 'invalid_dashboard_draft',
+                            draftUuid: draft.uuid,
+                        },
+                    };
+                }
             }
             // Reviewers get an entry point when others have open drafts here
             if (

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -252,6 +252,11 @@ export type DashboardOwner = {
     email: string | null;
 };
 
+export type DashboardDraftOverlayError = {
+    code: 'invalid_dashboard_draft';
+    draftUuid: string;
+};
+
 export type Dashboard = {
     organizationUuid: string;
     projectUuid: string;
@@ -259,6 +264,8 @@ export type Dashboard = {
     hasUnpublishedChanges?: boolean;
     /** For reviewers: open drafts by other users awaiting review */
     draftsAwaitingReview?: number;
+    /** The author draft was preserved but could not be safely rendered */
+    draftOverlayError?: DashboardDraftOverlayError;
     dashboardVersionId: number;
     versionUuid: string;
     uuid: string;

--- a/packages/frontend/src/features/contentAsCode/components/DraftOverlayFailureAlert.test.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/DraftOverlayFailureAlert.test.tsx
@@ -1,0 +1,27 @@
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../testing/testUtils';
+import DraftOverlayFailureAlert from './DraftOverlayFailureAlert';
+
+describe('DraftOverlayFailureAlert', () => {
+    it('clearly tells the author that published content is shown and the draft is safe', () => {
+        renderWithProviders(
+            <DraftOverlayFailureAlert
+                error={{
+                    code: 'invalid_dashboard_draft',
+                    draftUuid: 'draft-uuid',
+                }}
+            />,
+        );
+
+        expect(
+            screen.getByText("Your unpublished draft couldn't be displayed"),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/You're viewing the published dashboard/),
+        ).toBeInTheDocument();
+        expect(screen.getByText(/draft is still saved/)).toBeInTheDocument();
+        expect(
+            screen.getByText(/Ask a Content as Code admin/),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/contentAsCode/components/DraftOverlayFailureAlert.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/DraftOverlayFailureAlert.tsx
@@ -1,0 +1,29 @@
+import { type DashboardDraftOverlayError } from '@lightdash/common';
+import { Alert, Text } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+
+type DraftOverlayFailureAlertProps = {
+    error: DashboardDraftOverlayError;
+};
+
+const DraftOverlayFailureAlert: FC<DraftOverlayFailureAlertProps> = ({
+    error,
+}) => (
+    <Alert
+        color="orange"
+        icon={<MantineIcon icon={IconAlertTriangle} />}
+        title="Your unpublished draft couldn't be displayed"
+        mx="md"
+        mt="md"
+        data-draft-error={error.code}
+    >
+        <Text size="sm">
+            You're viewing the published dashboard. Your draft is still saved
+            for review. Ask a Content as Code admin to review or dismiss it.
+        </Text>
+    </Alert>
+);
+
+export default DraftOverlayFailureAlert;

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -34,6 +34,7 @@ import { DashboardExportModal } from '../components/common/modal/DashboardExport
 import Page from '../components/common/Page/Page';
 import PageSpinner from '../components/PageSpinner';
 import { useDashboardCommentsCheck } from '../features/comments';
+import DraftOverlayFailureAlert from '../features/contentAsCode/components/DraftOverlayFailureAlert';
 import { FilterBarPopoversProvider } from '../features/dashboardFilters/FilterRequirements/FilterBarPopoversProvider';
 import DashboardTabs from '../features/dashboardTabs';
 import {
@@ -1012,6 +1013,12 @@ const Dashboard: FC = () => {
             >
                 <div>
                     <DashboardHeader {...dashboardHeaderProps} />
+
+                    {dashboard.draftOverlayError ? (
+                        <DraftOverlayFailureAlert
+                            error={dashboard.draftOverlayError}
+                        />
+                    ) : null}
 
                     {/* Coordinates filter chip / rules popovers across the dashboard */}
                     <FilterBarPopoversProvider>


### PR DESCRIPTION
Closes #28188

## Summary
- validate dashboard draft overlays before rendering or persistence
- return published content with an author-only typed failure marker
- show an actionable warning while preserving the draft
- prevent draft/error leakage to other viewers

## Tests
- `pnpm -F backend exec vitest run src/services/DashboardService/DashboardService.drafts.test.ts`
- `pnpm -F frontend exec vitest run src/features/contentAsCode/components/DraftOverlayFailureAlert.test.tsx`
- backend/frontend/common typechecks
- targeted lint and formatting

/test-backend