### PR TITLE
feat(content-as-code): let authors reopen dismissed drafts

### DIFF
--- a/packages/backend/src/contentAsCode/fieldCoverage/dashboard.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/dashboard.test.ts
@@ -10,6 +10,7 @@ describeContentAsCodeSchemaContract({
         'deletedAt',
         'deletedBy',
         // Overlay flags for unpublished drafts; not part of the as-code document.
+        'dismissedDraftUuid',
         'draftOverlayError',
         'draftsAwaitingReview',
         'firstViewedAt',

--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -14,6 +14,7 @@ import {
     type ApiContentAsCodeSettingsResponse,
     type ApiContentAsCodeUploadAdvisoryResponse,
     type ApiContentAsCodeWritebacksResponse,
+    type ApiContentDraftReopenResponse,
     type ApiContentDraftReviewResponse,
     type ApiContentDraftsResponse,
     type ApiContentDraftWriteBackResponse,
@@ -347,6 +348,28 @@ export class ProjectCoderController extends BaseController {
             .getContentAsCodeWritebackService()
             .dismissDraft(toSessionUser(req.account), projectUuid, draftUuid);
         return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * Reopen the caller's dismissed draft without creating another record
+     * @summary Reopen content draft
+     */
+    @Tags('Projects')
+    @Middlewares(CODE_WRITE_MIDDLEWARES)
+    @SuccessResponse('200', 'Success')
+    @Post('/code/drafts/{draftUuid}/reopen')
+    @OperationId('reopenContentDraft')
+    async reopenContentDraft(
+        @Path() projectUuid: string,
+        @Path() draftUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiContentDraftReopenResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const draft = await this.services
+            .getContentAsCodeWritebackService()
+            .reopenDraft(toSessionUser(req.account), projectUuid, draftUuid);
+        return codeSuccess(toDraftSummary(draft));
     }
 
     /**

--- a/packages/backend/src/models/ContentDraftModel.ts
+++ b/packages/backend/src/models/ContentDraftModel.ts
@@ -116,6 +116,25 @@ export class ContentDraftModel {
         return row ? parseRow(row) : undefined;
     }
 
+    async findLatestDismissedDraft(
+        projectUuid: string,
+        contentType: string,
+        contentUuid: string,
+        authorUserUuid: string,
+    ): Promise<ContentDraft | undefined> {
+        const row = await this.database(ContentDraftsTableName)
+            .where({
+                project_uuid: projectUuid,
+                content_type: contentType,
+                content_uuid: contentUuid,
+                author_user_uuid: authorUserUuid,
+                status: 'dismissed',
+            })
+            .orderBy('updated_at', 'desc')
+            .first();
+        return row ? parseRow(row) : undefined;
+    }
+
     async listOpenForContent(
         projectUuid: string,
         contentType: string,

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -2,6 +2,7 @@ import { Ability } from '@casl/ability';
 import {
     ConflictError,
     DbtProjectType,
+    ForbiddenError,
     PossibleAbilities,
     PullRequestSource,
     type SessionUser,
@@ -143,6 +144,7 @@ const buildService = (overrides: Overrides = {}) => {
         countOpenByProject: vi
             .fn()
             .mockResolvedValue(overrides.openDraftCount ?? 0),
+        findOpenDraft: vi.fn().mockResolvedValue(undefined),
         update: vi.fn(),
     };
     const service = new ContentAsCodeWritebackService({
@@ -174,6 +176,25 @@ const buildService = (overrides: Overrides = {}) => {
 };
 
 describe('ContentAsCodeWritebackService', () => {
+    const dismissedDraft = {
+        uuid: 'draft-uuid',
+        projectUuid: 'project-uuid',
+        contentType: 'dashboard',
+        contentUuid: 'dashboard-uuid',
+        slug: 'weekly-kpis',
+        authorUserUuid: 'author-uuid',
+        draft: { name: 'Weekly KPIs draft' },
+        status: 'dismissed',
+        prUrl: null,
+    };
+    const author = {
+        ...user,
+        userUuid: 'author-uuid',
+        ability: new Ability<PossibleAbilities>([
+            { action: 'view', subject: 'ContentAsCode' },
+        ]),
+    } as SessionUser;
+
     it.each([0, 3])(
         'reports %i open drafts for upload without changing content',
         async (openDraftCount) => {
@@ -203,6 +224,98 @@ describe('ContentAsCodeWritebackService', () => {
         await expect(
             service.getUploadAdvisory(uploadOnlyUser, 'project-uuid'),
         ).resolves.toEqual({ openDraftCount: 2 });
+    });
+
+    it('dismisses an open draft without deleting it', async () => {
+        const { service, contentDraftModel } = buildService();
+
+        await service.dismissDraft(user, 'project-uuid', 'draft-uuid');
+
+        expect(contentDraftModel.update).toHaveBeenCalledWith('draft-uuid', {
+            status: 'dismissed',
+        });
+    });
+
+    it('lets the author reopen the same dismissed draft', async () => {
+        const { service, contentDraftModel } = buildService({
+            draft: dismissedDraft,
+        });
+
+        await expect(
+            service.reopenDraft(author, 'project-uuid', 'draft-uuid'),
+        ).resolves.toMatchObject({
+            uuid: 'draft-uuid',
+            status: 'open',
+        });
+        expect(contentDraftModel.update).toHaveBeenCalledWith('draft-uuid', {
+            status: 'open',
+        });
+    });
+
+    it('makes repeated reopen requests idempotent', async () => {
+        const { service, contentDraftModel } = buildService({
+            draft: { ...dismissedDraft, status: 'open' },
+        });
+
+        await expect(
+            service.reopenDraft(author, 'project-uuid', 'draft-uuid'),
+        ).resolves.toMatchObject({
+            uuid: 'draft-uuid',
+            status: 'open',
+        });
+        expect(contentDraftModel.update).not.toHaveBeenCalled();
+    });
+
+    it('does not let another user reopen an author draft', async () => {
+        const { service, contentDraftModel } = buildService({
+            draft: dismissedDraft,
+        });
+        const otherUser = {
+            ...author,
+            userUuid: 'other-user-uuid',
+        } as SessionUser;
+
+        await expect(
+            service.reopenDraft(otherUser, 'project-uuid', 'draft-uuid'),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(contentDraftModel.update).not.toHaveBeenCalled();
+    });
+
+    it('does not reopen history when the author already has an open draft', async () => {
+        const { service, contentDraftModel } = buildService({
+            draft: dismissedDraft,
+        });
+        contentDraftModel.findOpenDraft.mockResolvedValue({
+            ...dismissedDraft,
+            uuid: 'newer-open-draft-uuid',
+            status: 'open',
+        });
+
+        await expect(
+            service.reopenDraft(author, 'project-uuid', 'draft-uuid'),
+        ).rejects.toBeInstanceOf(ConflictError);
+        expect(contentDraftModel.update).not.toHaveBeenCalled();
+    });
+
+    it('shows the same reopened row in the review queue immediately', async () => {
+        const { service, contentDraftModel } = buildService({
+            draft: dismissedDraft,
+        });
+        let persistedDraft = { ...dismissedDraft };
+        contentDraftModel.get.mockImplementation(async () => persistedDraft);
+        contentDraftModel.update.mockImplementation(
+            async (_uuid: string, update: { status?: string }) => {
+                persistedDraft = { ...persistedDraft, ...update };
+            },
+        );
+        contentDraftModel.listByProject.mockImplementation(async () => [
+            persistedDraft,
+        ]);
+
+        await service.reopenDraft(author, 'project-uuid', 'draft-uuid');
+        await expect(service.listDrafts(user, 'project-uuid')).resolves.toEqual(
+            [expect.objectContaining({ uuid: 'draft-uuid', status: 'open' })],
+        );
     });
 
     it('first save creates the instance branch, commits the YAML, and opens one PR', async () => {

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -226,6 +226,29 @@ export class ContentAsCodeWritebackService extends BaseService {
         }
     }
 
+    private async assertCanViewContentAsCode(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        const project = await this.projectModel.get(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('ContentAsCode', {
+                    projectUuid: project.projectUuid,
+                    organizationUuid: project.organizationUuid,
+                    upstreamProjectUuid: project.upstreamProjectUuid,
+                    type: project.type,
+                    createdByUserUuid: project.createdByUserUuid,
+                    metadata: { slug: '' },
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
     async getUploadAdvisory(
         user: SessionUser,
         projectUuid: string,
@@ -334,6 +357,38 @@ export class ContentAsCodeWritebackService extends BaseService {
         await this.contentDraftModel.update(draft.uuid, {
             status: 'dismissed',
         });
+    }
+
+    async reopenDraft(
+        user: SessionUser,
+        projectUuid: string,
+        draftUuid: string,
+    ): Promise<ContentDraft> {
+        await this.assertCanViewContentAsCode(user, projectUuid);
+        const draft = await this.contentDraftModel.get(draftUuid);
+        if (!draft || draft.projectUuid !== projectUuid) {
+            throw new ParameterError('Draft not found');
+        }
+        if (draft.authorUserUuid !== user.userUuid) {
+            throw new ForbiddenError();
+        }
+        if (draft.status === 'open') return draft;
+        if (draft.status !== 'dismissed') {
+            throw new ConflictError('Only dismissed drafts can be reopened');
+        }
+        const existingOpen = await this.contentDraftModel.findOpenDraft(
+            projectUuid,
+            draft.contentType,
+            draft.contentUuid,
+            user.userUuid,
+        );
+        if (existingOpen && existingOpen.uuid !== draft.uuid) {
+            throw new ConflictError(
+                'This content already has a newer open draft',
+            );
+        }
+        await this.contentDraftModel.update(draft.uuid, { status: 'open' });
+        return { ...draft, status: 'open' };
     }
 
     // A merged-but-not-yet-deployed PR should read "merged, applies on the

--- a/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
@@ -221,11 +221,13 @@ describe('DashboardService draft overlay is opt-in', () => {
                       }
                     : undefined,
         );
+        const findLatestDismissedDraft = vi.fn().mockResolvedValue(undefined);
         const updateDraft = vi.fn();
         const { service } = buildService();
         // Replace the collaborators the read path needs
         (service as AnyType).contentDraftModel = {
             findOpenDraft,
+            findLatestDismissedDraft,
             update: updateDraft,
         };
         (service as AnyType).dashboardModel = {
@@ -243,7 +245,13 @@ describe('DashboardService draft overlay is opt-in', () => {
                 { action: 'view', subject: 'Dashboard' },
             ]),
         } as unknown as SessionUser;
-        return { service, viewer, findOpenDraft, updateDraft };
+        return {
+            service,
+            viewer,
+            findOpenDraft,
+            findLatestDismissedDraft,
+            updateDraft,
+        };
     };
 
     it('getByIdOrSlug returns the published dashboard and never reads drafts', async () => {
@@ -288,6 +296,60 @@ describe('DashboardService draft overlay is opt-in', () => {
         });
         expect(dashboard.hasUnpublishedChanges).toBeUndefined();
         expect(updateDraft).not.toHaveBeenCalled();
+    });
+
+    it('lets an author discover their dismissed draft from the published dashboard', async () => {
+        const { service, viewer, findOpenDraft, findLatestDismissedDraft } =
+            buildReadService();
+        findOpenDraft.mockResolvedValue(undefined);
+        findLatestDismissedDraft.mockResolvedValue({
+            uuid: 'dismissed-draft-uuid',
+            status: 'dismissed',
+        });
+
+        const dashboard = await service.getByIdOrSlugForViewer(
+            viewer,
+            'weekly-kpis',
+        );
+
+        expect(dashboard).toMatchObject({
+            name: 'Weekly KPIs',
+            dismissedDraftUuid: 'dismissed-draft-uuid',
+        });
+        expect(findLatestDismissedDraft).toHaveBeenCalledWith(
+            PROJECT_UUID,
+            'dashboard',
+            'dashboard-uuid',
+            'author-uuid',
+        );
+    });
+
+    it('does not expose another author dismissed draft', async () => {
+        const { service, viewer, findOpenDraft, findLatestDismissedDraft } =
+            buildReadService();
+        findOpenDraft.mockResolvedValue(undefined);
+        findLatestDismissedDraft.mockImplementation(
+            async (
+                _projectUuid: string,
+                _contentType: string,
+                _contentUuid: string,
+                authorUserUuid: string,
+            ) =>
+                authorUserUuid === 'author-uuid'
+                    ? { uuid: 'dismissed-draft-uuid', status: 'dismissed' }
+                    : undefined,
+        );
+        const otherViewer = {
+            ...viewer,
+            userUuid: 'other-viewer-uuid',
+        } as SessionUser;
+
+        const dashboard = await service.getByIdOrSlugForViewer(
+            otherViewer,
+            'weekly-kpis',
+        );
+
+        expect(dashboard).not.toHaveProperty('dismissedDraftUuid');
     });
 
     it('does not expose another author corrupt draft or its failure', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -1857,6 +1857,16 @@ export class DashboardService
                     };
                 }
             }
+            const dismissedDraft =
+                await this.contentDraftModel.findLatestDismissedDraft(
+                    dashboard.projectUuid,
+                    'dashboard',
+                    dashboard.uuid,
+                    user.userUuid,
+                );
+            const dashboardForViewer = dismissedDraft
+                ? { ...dashboard, dismissedDraftUuid: dismissedDraft.uuid }
+                : dashboard;
             // Reviewers get an entry point when others have open drafts here
             if (
                 await this.canManageContentAsCode(user, dashboard.projectUuid)
@@ -1869,10 +1879,13 @@ export class DashboardService
                         user.userUuid,
                     );
                 if (awaiting > 0) {
-                    return { ...dashboard, draftsAwaitingReview: awaiting };
+                    return {
+                        ...dashboardForViewer,
+                        draftsAwaitingReview: awaiting,
+                    };
                 }
             }
-            return dashboard;
+            return dashboardForViewer;
         } catch (error) {
             this.logger.warn('Draft overlay failed', error);
             return dashboard;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -146,6 +146,7 @@ import {
     type ApiContentAsCodeSettingsResponse,
     type ApiContentAsCodeUploadAdvisoryResponse,
     type ApiContentAsCodeWritebacksResponse,
+    type ApiContentDraftReopenResponse,
     type ApiContentDraftReviewResponse,
     type ApiContentDraftsResponse,
     type ApiContentDraftWriteBackResponse,
@@ -1369,6 +1370,7 @@ type ApiResults =
     | ApiContentAsCodeWritebacksResponse['results']
     | ApiContentDraftsResponse['results']
     | ApiContentDraftReviewResponse['results']
+    | ApiContentDraftReopenResponse['results']
     | ApiContentDraftWriteBackResponse['results']
     | ApiContentAsCodeProposeResponse['results']
     | ApiContentAsCodeSettingsResponse['results']

--- a/packages/common/src/types/contentAsCode/base.ts
+++ b/packages/common/src/types/contentAsCode/base.ts
@@ -150,3 +150,8 @@ export type ApiContentDraftWriteBackResponse = {
     status: 'ok';
     results: ContentDraftSummary;
 };
+
+export type ApiContentDraftReopenResponse = {
+    status: 'ok';
+    results: ContentDraftSummary;
+};

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -266,6 +266,8 @@ export type Dashboard = {
     draftsAwaitingReview?: number;
     /** The author draft was preserved but could not be safely rendered */
     draftOverlayError?: DashboardDraftOverlayError;
+    /** The viewer authored a dismissed draft that can be reopened */
+    dismissedDraftUuid?: string;
     dashboardVersionId: number;
     versionUuid: string;
     uuid: string;

--- a/packages/frontend/src/features/contentAsCode/components/DismissedDraftAlert.test.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/DismissedDraftAlert.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../testing/testUtils';
+import DismissedDraftAlert from './DismissedDraftAlert';
+
+describe('DismissedDraftAlert', () => {
+    it('lets the author reopen their preserved draft', () => {
+        const onReopen = vi.fn();
+
+        renderWithProviders(
+            <DismissedDraftAlert isReopening={false} onReopen={onReopen} />,
+        );
+
+        expect(
+            screen.getByText('Your dismissed draft is still available'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/Reopen it to continue editing/),
+        ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Reopen draft' }));
+        expect(onReopen).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/frontend/src/features/contentAsCode/components/DismissedDraftAlert.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/DismissedDraftAlert.tsx
@@ -1,0 +1,38 @@
+import { Alert, Button, Group, Text } from '@mantine/core';
+import { IconRestore } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+
+type DismissedDraftAlertProps = {
+    isReopening: boolean;
+    onReopen: () => void;
+};
+
+const DismissedDraftAlert: FC<DismissedDraftAlertProps> = ({
+    isReopening,
+    onReopen,
+}) => (
+    <Alert
+        color="blue"
+        icon={<MantineIcon icon={IconRestore} />}
+        title="Your dismissed draft is still available"
+        mx="md"
+        mt="md"
+    >
+        <Group justify="space-between" wrap="nowrap">
+            <Text size="sm">
+                Reopen it to continue editing and send it back for review.
+            </Text>
+            <Button
+                size="xs"
+                variant="light"
+                loading={isReopening}
+                onClick={onReopen}
+            >
+                Reopen draft
+            </Button>
+        </Group>
+    </Alert>
+);
+
+export default DismissedDraftAlert;

--- a/packages/frontend/src/features/contentAsCode/hooks/useContentDrafts.ts
+++ b/packages/frontend/src/features/contentAsCode/hooks/useContentDrafts.ts
@@ -103,3 +103,34 @@ export const useDismissDraftMutation = (projectUuid: string | undefined) => {
         },
     );
 };
+
+export const useReopenDraftMutation = (projectUuid: string | undefined) => {
+    const { showToastSuccess, showToastError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<ContentDraftSummary, ApiError, string>(
+        (draftUuid) =>
+            lightdashApi<ContentDraftSummary>({
+                url: `/projects/${projectUuid}/code/drafts/${draftUuid}/reopen`,
+                method: 'POST',
+                body: undefined,
+            }),
+        {
+            onSuccess: () => {
+                void Promise.all([
+                    queryClient.invalidateQueries([
+                        'content-drafts',
+                        projectUuid,
+                    ]),
+                    queryClient.invalidateQueries(['saved_dashboard_query']),
+                ]);
+                showToastSuccess({ title: 'Draft reopened' });
+            },
+            onError: (error) => {
+                showToastError({
+                    title: 'Failed to reopen draft',
+                    subtitle: error.error.message,
+                });
+            },
+        },
+    );
+};

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -34,7 +34,9 @@ import { DashboardExportModal } from '../components/common/modal/DashboardExport
 import Page from '../components/common/Page/Page';
 import PageSpinner from '../components/PageSpinner';
 import { useDashboardCommentsCheck } from '../features/comments';
+import DismissedDraftAlert from '../features/contentAsCode/components/DismissedDraftAlert';
 import DraftOverlayFailureAlert from '../features/contentAsCode/components/DraftOverlayFailureAlert';
+import { useReopenDraftMutation } from '../features/contentAsCode/hooks/useContentDrafts';
 import { FilterBarPopoversProvider } from '../features/dashboardFilters/FilterRequirements/FilterBarPopoversProvider';
 import DashboardTabs from '../features/dashboardTabs';
 import {
@@ -71,6 +73,8 @@ const Dashboard: FC = () => {
     const dashboard = useDashboardContext((c) => c.dashboard);
     const dashboardUuid = dashboard?.uuid;
     const dashboardIdentifier = dashboard?.slug ?? routeDashboardIdentifier;
+    const { mutate: reopenDraft, isLoading: isReopeningDraft } =
+        useReopenDraftMutation(projectUuid);
 
     const dashboardError = useDashboardContext((c) => c.dashboardError);
     const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
@@ -1017,6 +1021,15 @@ const Dashboard: FC = () => {
                     {dashboard.draftOverlayError ? (
                         <DraftOverlayFailureAlert
                             error={dashboard.draftOverlayError}
+                        />
+                    ) : null}
+
+                    {dashboard.dismissedDraftUuid ? (
+                        <DismissedDraftAlert
+                            isReopening={isReopeningDraft}
+                            onReopen={() =>
+                                reopenDraft(dashboard.dismissedDraftUuid!)
+                            }
                         />
                     ) : null}
 


### PR DESCRIPTION
Closes #28189

## Summary
- expose an author-only recovery marker on dashboards with dismissed drafts
- add an idempotent author-authorized reopen endpoint
- reopen the existing row and reject older history when a newer draft is open
- surface a dashboard action and refresh the draft/review state

## Tests
- dismiss, reopen, repeated reopen, authorization, existing-open conflict, and review queue behavior
- author-only dashboard discovery
- reopen alert interaction
- backend/frontend/common typechecks
- targeted lint and formatting

/test-backend