### PR TITLE
feat(sql-charts): apply direct access to reads

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -314,6 +314,12 @@ import {
     SavedSqlVersionsTableName,
 } from '../database/entities/savedSql';
 import {
+    SavedSqlGroupAccessTable,
+    SavedSqlGroupAccessTableName,
+    SavedSqlUserAccessTable,
+    SavedSqlUserAccessTableName,
+} from '../database/entities/savedSqlAccess';
+import {
     SchedulerEmailTargetTable,
     SchedulerEmailTargetTableName,
     SchedulerGoogleChatTargetTable,
@@ -616,6 +622,8 @@ declare module 'knex/types/tables' {
         [SavedChartAdditionalMetricTableName]: SavedChartAdditionalMetricTable;
         [SavedSqlTableName]: SavedSqlTable;
         [SavedSqlVersionsTableName]: SavedSqlVersionsTable;
+        [SavedSqlUserAccessTableName]: SavedSqlUserAccessTable;
+        [SavedSqlGroupAccessTableName]: SavedSqlGroupAccessTable;
         [SpaceTableName]: SpaceTable;
         [DashboardsTableName]: DashboardTable;
         [DashboardUserAccessTableName]: DashboardUserAccessTable;

--- a/packages/backend/src/database/entities/savedSqlAccess.ts
+++ b/packages/backend/src/database/entities/savedSqlAccess.ts
@@ -1,0 +1,41 @@
+import { type SpaceMemberRole } from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const SavedSqlUserAccessTableName = 'saved_sql_user_access';
+export const SavedSqlGroupAccessTableName = 'saved_sql_group_access';
+
+export type DbSavedSqlUserAccess = {
+    saved_sql_uuid: string;
+    user_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type SavedSqlUserAccessTable = Knex.CompositeTableType<
+    DbSavedSqlUserAccess,
+    Omit<DbSavedSqlUserAccess, 'created_at' | 'updated_at'>,
+    Pick<
+        DbSavedSqlUserAccess,
+        'space_role' | 'granted_by_user_uuid' | 'updated_at'
+    >
+>;
+
+export type DbSavedSqlGroupAccess = {
+    saved_sql_uuid: string;
+    group_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type SavedSqlGroupAccessTable = Knex.CompositeTableType<
+    DbSavedSqlGroupAccess,
+    Omit<DbSavedSqlGroupAccess, 'created_at' | 'updated_at'>,
+    Pick<
+        DbSavedSqlGroupAccess,
+        'space_role' | 'granted_by_user_uuid' | 'updated_at'
+    >
+>;

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -57,6 +57,7 @@ import { ResourceViewItemModel } from './ResourceViewItemModel';
 import { RolesModel } from './RolesModel';
 import { SavedChartAccessModel } from './SavedChartAccessModel';
 import { SavedChartModel } from './SavedChartModel';
+import { SavedSqlAccessModel } from './SavedSqlAccessModel';
 import { SavedSqlModel } from './SavedSqlModel';
 import { SchedulerModel } from './SchedulerModel';
 import { SearchModel } from './SearchModel';
@@ -92,6 +93,7 @@ export type ModelManifest = {
     dashboardModel: DashboardModel;
     dashboardAccessModel: DashboardAccessModel;
     savedChartAccessModel: SavedChartAccessModel;
+    savedSqlAccessModel: SavedSqlAccessModel;
     deploySessionModel: DeploySessionModel;
     downloadFileModel: DownloadFileModel;
     downloadAuditModel: DownloadAuditModel;
@@ -329,6 +331,13 @@ export class ModelRepository
         return this.getModel(
             'savedChartAccessModel',
             () => new SavedChartAccessModel(this.database),
+        );
+    }
+
+    public getSavedSqlAccessModel(): SavedSqlAccessModel {
+        return this.getModel(
+            'savedSqlAccessModel',
+            () => new SavedSqlAccessModel(this.database),
         );
     }
 

--- a/packages/backend/src/models/SavedSqlAccessModel.integration.test.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.integration.test.ts
@@ -1,0 +1,254 @@
+import {
+    OrganizationMemberRole,
+    ProjectMemberRole,
+    SEED_ORG_1_ADMIN,
+    SEED_PROJECT,
+    SpaceMemberRole,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { randomUUID } from 'node:crypto';
+import { DashboardsTableName } from '../database/entities/dashboards';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
+import { ProjectTableName } from '../database/entities/projects';
+import { SavedSqlTableName } from '../database/entities/savedSql';
+import {
+    SavedSqlGroupAccessTableName,
+    SavedSqlUserAccessTableName,
+} from '../database/entities/savedSqlAccess';
+import { SpaceTableName } from '../database/entities/spaces';
+import { UserTableName } from '../database/entities/users';
+import { getTestContext } from '../vitest.setup.integration';
+import { SavedSqlAccessModel } from './SavedSqlAccessModel';
+
+describe('SavedSqlAccessModel PostgreSQL integration', () => {
+    let database: Knex;
+    let transaction: Knex.Transaction;
+    let model: SavedSqlAccessModel;
+    let organizationId: number;
+    let organizationUuid: string;
+    let projectId: number;
+    let projectUuid: string;
+    let spaceId: number;
+    let spaceUuid: string;
+    let adminUserId: number;
+
+    beforeAll(() => {
+        database = getTestContext().db;
+    });
+
+    beforeEach(async () => {
+        transaction = await database.transaction();
+        model = new SavedSqlAccessModel(transaction);
+
+        const projectSpace = await transaction(SpaceTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(
+                `${ProjectTableName}.project_uuid`,
+                SEED_PROJECT.project_uuid,
+            )
+            .select(
+                `${OrganizationTableName}.organization_id`,
+                `${OrganizationTableName}.organization_uuid`,
+                `${ProjectTableName}.project_id`,
+                `${ProjectTableName}.project_uuid`,
+                `${SpaceTableName}.space_id`,
+                `${SpaceTableName}.space_uuid`,
+            )
+            .first();
+        if (!projectSpace) {
+            throw new Error('Seed project space not found');
+        }
+
+        organizationId = projectSpace.organization_id;
+        organizationUuid = projectSpace.organization_uuid;
+        projectId = projectSpace.project_id;
+        projectUuid = projectSpace.project_uuid;
+        spaceId = projectSpace.space_id;
+        spaceUuid = projectSpace.space_uuid;
+
+        const admin = await transaction(UserTableName)
+            .where('user_uuid', SEED_ORG_1_ADMIN.user_uuid)
+            .select('user_id')
+            .first();
+        if (!admin) {
+            throw new Error('Seed user not found');
+        }
+        adminUserId = admin.user_id;
+    });
+
+    afterEach(async () => {
+        if (!transaction.isCompleted()) {
+            await transaction.rollback();
+        }
+    });
+
+    const createSpaceChart = async () => {
+        const [chart] = await transaction(SavedSqlTableName)
+            .insert({
+                project_uuid: projectUuid,
+                space_uuid: spaceUuid,
+                dashboard_uuid: null,
+                name: `Direct access SQL chart ${randomUUID()}`,
+                description: null,
+                slug: `direct-access-sql-${randomUUID()}`,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })
+            .returning('saved_sql_uuid');
+        return chart.saved_sql_uuid;
+    };
+
+    it('resolves current user and group grants for active space charts only', async () => {
+        const activeChartUuid = await createSpaceChart();
+        const deletedChartUuid = await createSpaceChart();
+        await transaction(SavedSqlTableName)
+            .where('saved_sql_uuid', deletedChartUuid)
+            .update({ deleted_at: new Date() });
+
+        const [dashboard] = await transaction(DashboardsTableName)
+            .insert({
+                project_uuid: projectUuid,
+                name: `Direct access owner ${randomUUID()}`,
+                description: undefined,
+                space_id: spaceId,
+                slug: `direct-access-owner-${randomUUID()}`,
+            })
+            .returning('dashboard_uuid');
+        const [dashboardChart] = await transaction(SavedSqlTableName)
+            .insert({
+                project_uuid: projectUuid,
+                space_uuid: null,
+                dashboard_uuid: dashboard.dashboard_uuid,
+                name: `Dashboard SQL chart ${randomUUID()}`,
+                description: null,
+                slug: `dashboard-sql-${randomUUID()}`,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })
+            .returning('saved_sql_uuid');
+
+        const [group] = await transaction(GroupTableName)
+            .insert({
+                organization_id: organizationId,
+                name: `Direct access group ${randomUUID()}`,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                updated_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })
+            .returning('group_uuid');
+        await transaction(GroupMembershipTableName).insert({
+            organization_id: organizationId,
+            group_uuid: group.group_uuid,
+            user_id: adminUserId,
+        });
+        await transaction(ProjectGroupAccessTableName).insert({
+            project_uuid: projectUuid,
+            group_uuid: group.group_uuid,
+            role: ProjectMemberRole.VIEWER,
+        });
+        await transaction(SavedSqlUserAccessTableName).insert(
+            [
+                activeChartUuid,
+                deletedChartUuid,
+                dashboardChart.saved_sql_uuid,
+            ].map((savedSqlUuid) => ({
+                saved_sql_uuid: savedSqlUuid,
+                user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                space_role: SpaceMemberRole.VIEWER,
+                granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })),
+        );
+        await transaction(SavedSqlGroupAccessTableName).insert({
+            saved_sql_uuid: activeChartUuid,
+            group_uuid: group.group_uuid,
+            space_role: SpaceMemberRole.ADMIN,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+
+        await expect(
+            model.getUserAccess(
+                [
+                    activeChartUuid,
+                    deletedChartUuid,
+                    dashboardChart.saved_sql_uuid,
+                ],
+                SEED_ORG_1_ADMIN.user_uuid,
+                { organizationUuid },
+            ),
+        ).resolves.toEqual({
+            [activeChartUuid]: {
+                organizationUuid,
+                projectUuid,
+                spaceUuid,
+                userRole: SpaceMemberRole.VIEWER,
+                groupRoles: [SpaceMemberRole.ADMIN],
+            },
+        });
+        await expect(
+            model.getUserAccess([activeChartUuid], SEED_ORG_1_ADMIN.user_uuid, {
+                organizationUuid: randomUUID(),
+            }),
+        ).resolves.toEqual({});
+    });
+
+    it('stops resolving a user grant after project membership is removed', async () => {
+        const savedSqlUuid = await createSpaceChart();
+        const principalUuid = randomUUID();
+        const [principal] = await transaction(UserTableName)
+            .insert({
+                user_uuid: principalUuid,
+                first_name: 'Direct',
+                last_name: 'Principal',
+                is_marketing_opted_in: false,
+                is_tracking_anonymized: false,
+                is_setup_complete: true,
+                is_active: true,
+            })
+            .returning('user_id');
+        await transaction(OrganizationMembershipsTableName).insert({
+            organization_id: organizationId,
+            user_id: principal.user_id,
+            role: OrganizationMemberRole.MEMBER,
+        });
+        await transaction(ProjectMembershipsTableName).insert({
+            project_id: projectId,
+            user_id: principal.user_id,
+            role: ProjectMemberRole.VIEWER,
+        });
+        await transaction(SavedSqlUserAccessTableName).insert({
+            saved_sql_uuid: savedSqlUuid,
+            user_uuid: principalUuid,
+            space_role: SpaceMemberRole.EDITOR,
+            granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+
+        await expect(
+            model.getUserAccess([savedSqlUuid], principalUuid, {
+                organizationUuid,
+            }),
+        ).resolves.toHaveProperty(
+            `${savedSqlUuid}.userRole`,
+            SpaceMemberRole.EDITOR,
+        );
+
+        await transaction(ProjectMembershipsTableName)
+            .where({ project_id: projectId, user_id: principal.user_id })
+            .delete();
+        await expect(
+            model.getUserAccess([savedSqlUuid], principalUuid, {
+                organizationUuid,
+            }),
+        ).resolves.toEqual({});
+    });
+});

--- a/packages/backend/src/models/SavedSqlAccessModel.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.ts
@@ -1,0 +1,188 @@
+import { type Knex } from 'knex';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectTableName } from '../database/entities/projects';
+import { SavedSqlTableName } from '../database/entities/savedSql';
+import {
+    SavedSqlGroupAccessTableName,
+    SavedSqlUserAccessTableName,
+} from '../database/entities/savedSqlAccess';
+import { SpaceTableName } from '../database/entities/spaces';
+import { UserTableName } from '../database/entities/users';
+import {
+    getActiveGrantedGroupPredicate,
+    getActiveProjectMemberPredicate,
+    groupDirectAccessRows,
+    type DirectAccess,
+    type DirectAccessRow,
+} from './directAccessModelUtils';
+
+export type SavedSqlDirectAccess = DirectAccess;
+
+export class SavedSqlAccessModel {
+    constructor(private readonly database: Knex) {}
+
+    async getUserAccess(
+        savedSqlUuids: string[],
+        userUuid: string,
+        {
+            trx = this.database,
+            organizationUuid,
+        }: {
+            trx?: Knex;
+            organizationUuid: string;
+        },
+    ): Promise<Record<string, SavedSqlDirectAccess>> {
+        const uniqueUuids = [...new Set(savedSqlUuids)];
+        if (uniqueUuids.length === 0) {
+            return {};
+        }
+
+        const rows: DirectAccessRow[] = await trx(SavedSqlUserAccessTableName)
+            .select({
+                resourceUuid: `${SavedSqlUserAccessTableName}.saved_sql_uuid`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+                spaceUuid: `${SpaceTableName}.space_uuid`,
+                role: `${SavedSqlUserAccessTableName}.space_role`,
+                groupUuid: trx.raw('NULL'),
+            })
+            .innerJoin(
+                SavedSqlTableName,
+                `${SavedSqlTableName}.saved_sql_uuid`,
+                `${SavedSqlUserAccessTableName}.saved_sql_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_uuid`,
+                `${SavedSqlTableName}.space_uuid`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${SavedSqlUserAccessTableName}.user_uuid`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                function joinCurrentOrganizationMembership() {
+                    this.on(
+                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOn(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    );
+                },
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .whereIn(
+                `${SavedSqlUserAccessTableName}.saved_sql_uuid`,
+                uniqueUuids,
+            )
+            .where(`${SavedSqlUserAccessTableName}.user_uuid`, userUuid)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(getActiveProjectMemberPredicate(trx))
+            .where(
+                `${SavedSqlTableName}.project_uuid`,
+                trx.ref(`${ProjectTableName}.project_uuid`),
+            )
+            .whereNull(`${SavedSqlTableName}.dashboard_uuid`)
+            .whereNull(`${SavedSqlTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .unionAll(
+                trx(SavedSqlGroupAccessTableName)
+                    .select({
+                        resourceUuid: `${SavedSqlGroupAccessTableName}.saved_sql_uuid`,
+                        organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                        projectUuid: `${ProjectTableName}.project_uuid`,
+                        spaceUuid: `${SpaceTableName}.space_uuid`,
+                        role: `${SavedSqlGroupAccessTableName}.space_role`,
+                        groupUuid: `${SavedSqlGroupAccessTableName}.group_uuid`,
+                    })
+                    .innerJoin(
+                        SavedSqlTableName,
+                        `${SavedSqlTableName}.saved_sql_uuid`,
+                        `${SavedSqlGroupAccessTableName}.saved_sql_uuid`,
+                    )
+                    .innerJoin(
+                        SpaceTableName,
+                        `${SpaceTableName}.space_uuid`,
+                        `${SavedSqlTableName}.space_uuid`,
+                    )
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_id`,
+                        `${SpaceTableName}.project_id`,
+                    )
+                    .innerJoin(
+                        OrganizationTableName,
+                        `${OrganizationTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    )
+                    .innerJoin(
+                        GroupMembershipTableName,
+                        `${GroupMembershipTableName}.group_uuid`,
+                        `${SavedSqlGroupAccessTableName}.group_uuid`,
+                    )
+                    .innerJoin(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${GroupMembershipTableName}.user_id`,
+                    )
+                    .innerJoin(
+                        OrganizationMembershipsTableName,
+                        function joinCurrentOrganizationMembership() {
+                            this.on(
+                                `${OrganizationMembershipsTableName}.user_id`,
+                                `${UserTableName}.user_id`,
+                            ).andOn(
+                                `${OrganizationMembershipsTableName}.organization_id`,
+                                `${ProjectTableName}.organization_id`,
+                            );
+                        },
+                    )
+                    .whereIn(
+                        `${SavedSqlGroupAccessTableName}.saved_sql_uuid`,
+                        uniqueUuids,
+                    )
+                    .where(`${UserTableName}.user_uuid`, userUuid)
+                    .where(
+                        `${OrganizationTableName}.organization_uuid`,
+                        organizationUuid,
+                    )
+                    .where(getActiveProjectMemberPredicate(trx))
+                    .where(
+                        `${GroupMembershipTableName}.organization_id`,
+                        trx.ref(`${ProjectTableName}.organization_id`),
+                    )
+                    .where(
+                        getActiveGrantedGroupPredicate(
+                            trx,
+                            SavedSqlGroupAccessTableName,
+                        ),
+                    )
+                    .where(
+                        `${SavedSqlTableName}.project_uuid`,
+                        trx.ref(`${ProjectTableName}.project_uuid`),
+                    )
+                    .whereNull(`${SavedSqlTableName}.dashboard_uuid`)
+                    .whereNull(`${SavedSqlTableName}.deleted_at`)
+                    .whereNull(`${SpaceTableName}.deleted_at`),
+            );
+
+        return groupDirectAccessRows(rows);
+    }
+}

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -419,6 +419,92 @@ type JwtDashboardQueryContextTestService = {
 };
 
 describe('AsyncQueryService', () => {
+    describe('saved SQL chart access', () => {
+        test('resolves access through the saved SQL chart target', async () => {
+            const resolveAccess = vi.fn(async () => ({
+                organizationUuid: 'organizationUuid',
+                projectUuid,
+                inheritsFromOrgOrProject: false,
+                access: [
+                    {
+                        userUuid: 'userId',
+                        role: 'viewer',
+                        hasDirectAccess: true,
+                        grantedVia: 'sql_chart',
+                    },
+                ],
+                admins: [],
+                directOnly: true,
+            }));
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                spacePermissionService: {
+                    resolveAccess,
+                } as unknown as SpacePermissionService,
+            } as never);
+            const account = buildAccount() as AnyType;
+            account.user.ability = new Ability<PossibleAbilities>([
+                {
+                    subject: 'SavedChart',
+                    action: 'view',
+                    conditions: {
+                        access: { $elemMatch: { userUuid: 'userId' } },
+                    },
+                },
+            ]);
+
+            await (service as AnyType).assertSavedChartAccess(account, 'view', {
+                savedSqlUuid: 'savedSqlUuid',
+                organization: { organizationUuid: 'organizationUuid' },
+                project: { projectUuid },
+                space: { uuid: 'spaceUuid' },
+            });
+
+            expect(resolveAccess).toHaveBeenCalledWith('userId', {
+                type: 'sqlChart',
+                savedSqlUuid: 'savedSqlUuid',
+                spaceUuid: 'spaceUuid',
+            });
+        });
+
+        test('keeps JWT access scoped to the containing space', async () => {
+            const resolveAccess = vi.fn(async () => ({
+                organizationUuid: 'organizationUuid',
+                projectUuid,
+                inheritsFromOrgOrProject: true,
+                access: [],
+                admins: [],
+                directOnly: false,
+            }));
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                spacePermissionService: {
+                    resolveAccess,
+                } as unknown as SpacePermissionService,
+            } as never);
+            const account = buildAccount({
+                accountType: 'jwt',
+                userType: 'anonymous',
+            }) as AnyType;
+            account.user.ability = new Ability<PossibleAbilities>([
+                {
+                    subject: 'SavedChart',
+                    action: 'view',
+                },
+            ]);
+
+            await (service as AnyType).assertSavedChartAccess(account, 'view', {
+                savedSqlUuid: 'savedSqlUuid',
+                organization: { organizationUuid: 'organizationUuid' },
+                project: { projectUuid },
+                space: { uuid: 'spaceUuid' },
+            });
+
+            expect(resolveAccess).toHaveBeenCalledWith('userId', {
+                type: 'space',
+                spaceUuid: 'spaceUuid',
+            });
+        });
+    });
+
     describe('executeAsyncExternalSqlQuery', () => {
         const execute = (featureFlags: Record<string, boolean>) => {
             const service = getMockedAsyncQueryService(lightdashConfigMock, {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -734,14 +734,23 @@ export class AsyncQueryService extends ProjectService {
         account: Account,
         action: 'view' | 'create' | 'update' | 'delete' | 'manage',
         savedChart: {
+            savedSqlUuid: string;
             project: Pick<Project, 'projectUuid'>;
             organization: Pick<Organization, 'organizationUuid'>;
             space: Pick<SpaceSummaryBase, 'uuid'>;
         },
     ) {
+        // JWT/embed identities stay on their existing space-scoped contract.
+        // Direct user grants are only resolved for registered accounts.
         const ctx = await this.spacePermissionService.resolveAccess(
             account.user.id,
-            { type: 'space', spaceUuid: savedChart.space.uuid },
+            isJwtUser(account)
+                ? { type: 'space', spaceUuid: savedChart.space.uuid }
+                : {
+                      type: 'sqlChart',
+                      savedSqlUuid: savedChart.savedSqlUuid,
+                      spaceUuid: savedChart.space.uuid,
+                  },
         );
 
         const auditedAbility = this.createAuditedAbility(account);

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -107,6 +107,7 @@ const createdScheduler = {
 
 const savedSqlModel = {
     getByUuid: vi.fn(async () => sqlChart),
+    resolveColorPalette: vi.fn(async () => undefined),
 };
 const schedulerModel = {
     getSqlChartSchedulers: vi.fn(async () => []),
@@ -121,10 +122,10 @@ const spacePermissionService = {
                 context: {
                     organizationUuid,
                     projectUuid,
-                    inheritsFromOrgOrProject: true,
+                    inheritsFromOrgOrProject: false,
                     access: [],
                     admins: [],
-                    directOnly: false,
+                    directOnly: true,
                 },
             })),
     ),
@@ -158,6 +159,63 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
     });
 
     afterEach(() => vi.clearAllMocks());
+
+    test('loads a saved SQL chart through its resource access target', async () => {
+        const user = {
+            ...baseUser,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'SavedChart', action: 'view' },
+            ]),
+        };
+
+        await expect(
+            service.getSqlChart(user, projectUuid, savedSqlUuid),
+        ).resolves.toBeDefined();
+        expect(spacePermissionService.resolveAccessBatch).toHaveBeenCalledWith(
+            user.userUuid,
+            [
+                {
+                    type: 'sqlChart',
+                    savedSqlUuid,
+                    spaceUuid,
+                },
+            ],
+        );
+    });
+
+    test('keeps embed write actors scoped to their write space', async () => {
+        const embedWriteUser = {
+            ...baseUser,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'SavedChart', action: 'view' },
+            ]),
+        };
+
+        await expect(
+            service.getSqlChartFromAccount(
+                {
+                    authentication: {
+                        type: 'jwt',
+                        data: {
+                            content: {
+                                type: 'dashboard',
+                                dashboardUuid: 'dashboard-uuid',
+                            },
+                            writeActions: { spaceUuid },
+                        },
+                    },
+                    embedWriteUser,
+                    isJwtUser: () => true,
+                } as never,
+                projectUuid,
+                savedSqlUuid,
+            ),
+        ).resolves.toBeDefined();
+        expect(spacePermissionService.resolveAccessBatch).toHaveBeenCalledWith(
+            embedWriteUser.userUuid,
+            [{ type: 'space', spaceUuid }],
+        );
+    });
 
     describe('getSchedulers', () => {
         it('admin lists all SQL chart schedulers', async () => {

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -44,7 +44,10 @@ import type {
     SoftDeletableService,
     SoftDeleteOptions,
 } from '../SoftDeletableService';
-import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import {
+    SpacePermissionService,
+    type AccessTarget,
+} from '../SpaceService/SpacePermissionService';
 
 type SavedSqlServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -182,19 +185,30 @@ export class SavedSqlService
                 ? resource.spaceUuid
                 : null;
 
-        const targetSpaceUuids = newSpaceUuid
-            ? [spaceUuid, newSpaceUuid]
-            : [spaceUuid];
+        const destinationTargets: AccessTarget[] =
+            newSpaceUuid !== null
+                ? [{ type: 'space', spaceUuid: newSpaceUuid }]
+                : [];
+
+        const currentTarget: AccessTarget =
+            action === 'view' && resource.savedSqlUuid !== null
+                ? {
+                      type: 'sqlChart',
+                      savedSqlUuid: resource.savedSqlUuid,
+                      spaceUuid,
+                  }
+                : { type: 'space', spaceUuid };
+        const targets = [currentTarget, ...destinationTargets];
+        const accessResults =
+            await this.spacePermissionService.resolveAccessBatch(
+                actor.user.userUuid,
+                targets,
+            );
         const contextsBySpaceUuid = new Map(
-            (
-                await this.spacePermissionService.resolveAccessBatch(
-                    actor.user.userUuid,
-                    targetSpaceUuids.map((targetSpaceUuid) => ({
-                        type: 'space' as const,
-                        spaceUuid: targetSpaceUuid,
-                    })),
-                )
-            ).map(({ target, context }) => [target.spaceUuid, context]),
+            accessResults.map(({ target, context }) => [
+                target.spaceUuid,
+                context,
+            ]),
         );
         const currentContext = contextsBySpaceUuid.get(spaceUuid);
         if (currentContext === undefined) {
@@ -219,7 +233,7 @@ export class SavedSqlService
             );
         }
 
-        if (newSpaceUuid) {
+        if (newSpaceUuid !== null) {
             const targetContext = contextsBySpaceUuid.get(newSpaceUuid);
             if (targetContext === undefined) {
                 throw new ForbiddenError(
@@ -333,9 +347,12 @@ export class SavedSqlService
                 user,
                 projectUuid,
             },
-            {
-                savedSqlUuid: savedChart.savedSqlUuid,
-            },
+            embedWriteActions
+                ? {
+                      savedSqlUuid: null,
+                      spaceUuid: savedChart.space.uuid,
+                  }
+                : { savedSqlUuid: savedChart.savedSqlUuid },
         );
 
         this.analytics.track({

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -129,6 +129,15 @@ const dashboardModel = {
     getByIdOrSlug: vi.fn(async () => dashboardSummary),
 };
 
+const savedSqlModel = {
+    getByUuid: vi.fn(async () => ({
+        savedSqlUuid: 'savedSqlUuid',
+        organization: { organizationUuid },
+        project: { projectUuid },
+        space: { uuid: privateSpaceUuid },
+    })),
+};
+
 const spacePermissionService = {
     resolveAccess: vi.fn(async () => ({
         organizationUuid,
@@ -167,7 +176,7 @@ const buildService = () =>
         schedulerModel: schedulerModel as unknown as SchedulerModel,
         dashboardModel: dashboardModel as unknown as DashboardModel,
         savedChartModel: savedChartModel as unknown as SavedChartModel,
-        savedSqlModel: {} as SavedSqlModel,
+        savedSqlModel: savedSqlModel as unknown as SavedSqlModel,
         appModel: {} as AppModel,
         projectModel: {} as ProjectModel,
         schedulerClient: schedulerClient as unknown as SchedulerClient,
@@ -569,6 +578,50 @@ describe('SchedulerService', () => {
                     type: 'chart',
                     chartUuid: savedChartUuid,
                     dashboardUuid: 'owningDashboardUuid',
+                    spaceUuid: privateSpaceUuid,
+                },
+            );
+        });
+
+        test('views a saved SQL scheduler through the SQL chart grant', async () => {
+            const sqlScheduler = {
+                ...dashboardScheduler,
+                dashboardUuid: null,
+                savedSqlUuid: 'savedSqlUuid',
+            } as unknown as SchedulerAndTargets;
+            schedulerModel.getSchedulerAndTargets.mockResolvedValueOnce(
+                sqlScheduler,
+            );
+            spacePermissionService.resolveAccess.mockResolvedValueOnce({
+                inheritsFromOrgOrProject: false,
+                access: [
+                    {
+                        userUuid: 'userUuid',
+                        role: SpaceMemberRole.VIEWER,
+                        hasDirectAccess: true,
+                        grantedVia: 'sql_chart',
+                    },
+                ],
+                directOnly: true,
+            } as never);
+            const user = buildUser([
+                {
+                    subject: 'SavedChart',
+                    action: ['view'],
+                    conditions: {
+                        access: { $elemMatch: { userUuid: 'userUuid' } },
+                    },
+                },
+            ]);
+
+            await expect(
+                service.getScheduler(user, 'schedulerUuid'),
+            ).resolves.toEqual(sqlScheduler);
+            expect(spacePermissionService.resolveAccess).toHaveBeenCalledWith(
+                'userUuid',
+                {
+                    type: 'sqlChart',
+                    savedSqlUuid: 'savedSqlUuid',
                     spaceUuid: privateSpaceUuid,
                 },
             );

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -456,7 +456,8 @@ export class SchedulerService extends BaseService {
 
             const { inheritsFromOrgOrProject, access } =
                 await this.spacePermissionService.resolveAccess(user.userUuid, {
-                    type: 'space',
+                    type: 'sqlChart',
+                    savedSqlUuid: scheduler.savedSqlUuid,
                     spaceUuid,
                 });
             if (

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1146,6 +1146,7 @@ export class ServiceRepository
                     dashboardAccessModel: this.models.getDashboardAccessModel(),
                     savedChartAccessModel:
                         this.models.getSavedChartAccessModel(),
+                    savedSqlAccessModel: this.models.getSavedSqlAccessModel(),
                     directAccessFeatureGate: new DirectAccessFeatureGate(
                         this.models.getFeatureFlagModel(),
                         this.getLicenseService(),

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -105,6 +105,9 @@ describe('SpacePermissionService', () => {
         savedChartAccessModel: {
             getUserAccess: vi.fn(async () => ({})),
         } as never,
+        savedSqlAccessModel: {
+            getUserAccess: vi.fn(async () => ({})),
+        } as never,
         directAccessFeatureGate:
             directAccessFeatureGate as unknown as DirectAccessFeatureGate,
     });
@@ -1829,6 +1832,9 @@ describe('resolveAccess', () => {
             savedChartAccessModel: {
                 getUserAccess: vi.fn(async () => ({})),
             } as never,
+            savedSqlAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
             directAccessFeatureGate:
                 directAccessFeatureGate as unknown as DirectAccessFeatureGate,
         });
@@ -2026,6 +2032,9 @@ describe('resolveAccessBatch', () => {
             dashboardAccessModel:
                 dashboardAccessModel as unknown as DashboardAccessModel,
             savedChartAccessModel: savedChartAccessModel as never,
+            savedSqlAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
             directAccessFeatureGate:
                 directAccessFeatureGate as unknown as DirectAccessFeatureGate,
         });
@@ -2445,6 +2454,9 @@ describe('resolveAccess space-saved chart target', () => {
                 getUserAccess: vi.fn(async () => ({})),
             } as never,
             savedChartAccessModel: savedChartAccessModel as never,
+            savedSqlAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
             directAccessFeatureGate: {
                 isEnabledForUser: vi.fn(async () => enabled),
             } as unknown as DirectAccessFeatureGate,
@@ -2512,6 +2524,110 @@ describe('resolveAccess space-saved chart target', () => {
     });
 });
 
+describe('resolveAccess saved SQL chart target', () => {
+    const spaceContext: SpaceAccessContextForCasl = {
+        organizationUuid: 'organization-uuid',
+        projectUuid: 'project-uuid',
+        inheritsFromOrgOrProject: false,
+        access: [],
+        admins: [],
+    };
+    const sqlChartTarget = {
+        type: 'sqlChart' as const,
+        savedSqlUuid: 'saved-sql-uuid',
+        spaceUuid: 'space-uuid',
+    };
+
+    const createService = ({
+        enabled,
+        grants = {},
+    }: {
+        enabled: boolean;
+        grants?: Record<string, unknown>;
+    }) => {
+        const savedSqlAccessModel = {
+            getUserAccess: vi.fn(async () => grants),
+        };
+        const service = new SpacePermissionService({
+            spaceModel: {} as SpaceModel,
+            spacePermissionModel: {} as unknown as SpacePermissionModel,
+            dashboardAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
+            savedChartAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
+            savedSqlAccessModel: savedSqlAccessModel as never,
+            directAccessFeatureGate: {
+                isEnabledForUser: vi.fn(async () => enabled),
+            } as unknown as DirectAccessFeatureGate,
+        });
+        mockSpaceContexts(service, { 'space-uuid': spaceContext });
+        return { service, savedSqlAccessModel };
+    };
+
+    test('returns the plain space context while the feature is off', async () => {
+        const { service, savedSqlAccessModel } = createService({
+            enabled: false,
+        });
+
+        await expect(
+            service.resolveAccess('user-uuid', sqlChartTarget),
+        ).resolves.toEqual({ ...spaceContext, directOnly: false });
+        expect(savedSqlAccessModel.getUserAccess).not.toHaveBeenCalled();
+    });
+
+    test('appends a grant row tagged sql_chart and marks grant-only', async () => {
+        const { service, savedSqlAccessModel } = createService({
+            enabled: true,
+            grants: {
+                'saved-sql-uuid': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    spaceUuid: 'space-uuid',
+                    userRole: SpaceMemberRole.VIEWER,
+                    groupRoles: [],
+                },
+            },
+        });
+
+        const result = await service.resolveAccess('user-uuid', sqlChartTarget);
+
+        expect(result.access).toEqual([
+            expect.objectContaining({
+                userUuid: 'user-uuid',
+                role: SpaceMemberRole.VIEWER,
+                grantedVia: 'sql_chart',
+            }),
+        ]);
+        expect(result.directOnly).toBe(true);
+        expect(savedSqlAccessModel.getUserAccess).toHaveBeenCalledWith(
+            ['saved-sql-uuid'],
+            'user-uuid',
+            { organizationUuid: 'organization-uuid' },
+        );
+    });
+
+    test('throws when the grant does not belong to the given space', async () => {
+        const { service } = createService({
+            enabled: true,
+            grants: {
+                'saved-sql-uuid': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    spaceUuid: 'another-space',
+                    userRole: SpaceMemberRole.EDITOR,
+                    groupRoles: [],
+                },
+            },
+        });
+
+        await expect(
+            service.resolveAccess('user-uuid', sqlChartTarget),
+        ).rejects.toThrow(ParameterError);
+    });
+});
+
 describe('resolveAccess chart ownership routing', () => {
     const baseContext: SpaceAccessContextForCasl = {
         organizationUuid: 'organization-uuid',
@@ -2549,6 +2665,9 @@ describe('resolveAccess chart ownership routing', () => {
             spacePermissionModel: {} as unknown as SpacePermissionModel,
             dashboardAccessModel: dashboardAccessModel as never,
             savedChartAccessModel: savedChartAccessModel as never,
+            savedSqlAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
             directAccessFeatureGate: {
                 isEnabledForUser: vi.fn(async () => true),
             } as unknown as DirectAccessFeatureGate,

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -27,6 +27,7 @@ import { Knex } from 'knex';
 import { type DashboardAccessModel } from '../../models/DashboardAccessModel';
 import { type DirectAccess } from '../../models/directAccessModelUtils';
 import { type SavedChartAccessModel } from '../../models/SavedChartAccessModel';
+import { type SavedSqlAccessModel } from '../../models/SavedSqlAccessModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import {
     SpacePermissionModel,
@@ -59,7 +60,8 @@ export type AccessTarget =
           chartUuid: string;
           dashboardUuid: string | null;
           spaceUuid: string;
-      };
+      }
+    | { type: 'sqlChart'; savedSqlUuid: string; spaceUuid: string };
 
 // A content type's direct-grant lookup (e.g. DashboardAccessModel.getUserAccess
 // or SavedChartAccessModel.getUserAccess), pre-bound to the requesting user.
@@ -110,6 +112,8 @@ export class SpacePermissionService extends BaseService {
 
     private readonly savedChartAccessModel: SavedChartAccessModel;
 
+    private readonly savedSqlAccessModel: SavedSqlAccessModel;
+
     private readonly directAccessFeatureGate: DirectAccessFeatureGate;
 
     constructor({
@@ -117,12 +121,14 @@ export class SpacePermissionService extends BaseService {
         spacePermissionModel,
         dashboardAccessModel,
         savedChartAccessModel,
+        savedSqlAccessModel,
         directAccessFeatureGate,
     }: {
         spaceModel: SpaceModel;
         spacePermissionModel: SpacePermissionModel;
         dashboardAccessModel: DashboardAccessModel;
         savedChartAccessModel: SavedChartAccessModel;
+        savedSqlAccessModel: SavedSqlAccessModel;
         directAccessFeatureGate: DirectAccessFeatureGate;
     }) {
         super();
@@ -130,6 +136,7 @@ export class SpacePermissionService extends BaseService {
         this.spacePermissionModel = spacePermissionModel;
         this.dashboardAccessModel = dashboardAccessModel;
         this.savedChartAccessModel = savedChartAccessModel;
+        this.savedSqlAccessModel = savedSqlAccessModel;
         this.directAccessFeatureGate = directAccessFeatureGate;
     }
 
@@ -310,6 +317,13 @@ export class SpacePermissionService extends BaseService {
                           resourceLabel: 'Saved chart',
                           spaceUuid: target.spaceUuid,
                       };
+            case 'sqlChart':
+                return {
+                    source: 'sql_chart',
+                    resourceUuid: target.savedSqlUuid,
+                    resourceLabel: 'Saved SQL chart',
+                    spaceUuid: target.spaceUuid,
+                };
             default:
                 return assertUnreachable(
                     target,
@@ -330,6 +344,13 @@ export class SpacePermissionService extends BaseService {
             case 'saved_chart':
                 return (resourceUuids, opts) =>
                     this.savedChartAccessModel.getUserAccess(
+                        resourceUuids,
+                        userUuid,
+                        opts,
+                    );
+            case 'sql_chart':
+                return (resourceUuids, opts) =>
+                    this.savedSqlAccessModel.getUserAccess(
                         resourceUuids,
                         userUuid,
                         opts,

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -156,7 +156,7 @@ export type SpaceInheritanceChain = {
 
 // Which content type's direct grant synthesized an access row. Grows one
 // member per content type that ships direct grants.
-export type GrantSource = 'dashboard' | 'saved_chart';
+export type GrantSource = 'dashboard' | 'saved_chart' | 'sql_chart';
 
 // Access data for checking Space access permissions with CASL where only the role/access data matters.
 export type SpaceAccess = {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1469/stack-3b-apply-direct-access-to-saved-sql-charts

## Summary

PR 1 of 2 for [SPK-1469](https://linear.app/lightdash/issue/SPK-1469/stack-3b-apply-direct-access-to-saved-sql-charts). Adds the saved SQL direct-access read model and applies current access to chart reads, fresh execution, exports, and scheduled execution.

This is the base of the saved SQL chart stack.

## Changes

- Resolves user and group grants for active project members and independently space-saved SQL charts.
- Adds the `sqlChart` target to the shared batched access resolver and records `sql_chart` grant provenance.
- Applies the resolved context in `SavedSqlService`, `AsyncQueryService`, and `SchedulerService`.
- Keeps JWT and embed-write paths on their existing space-scoped authorization contract.
- Keeps access additive and capped by current organization, project, and custom-role capabilities.
- Does not grant SQL Runner, arbitrary SQL, schema, table, warehouse, or project access.

## Authorization flow

```text
registered account: space access + direct grant → capability ceiling → read / submit / export
JWT / embed:        containing-space access only → existing embed contract
scheduled run:      fresh chart access check → submit
accepted query:     existing creator + project + expiry checks
```

Already accepted async work and query history retain the existing snapshot semantics used by dashboards and saved charts. Grant changes apply to the next resource operation or scheduled execution.

## Test plan

- [x] 203 focused backend tests across saved SQL, async queries, schedulers, and access resolution
- [x] JWT and embed-write regression tests remain space-scoped
- [x] 2 PostgreSQL integration tests for user/group grants and project-membership removal
- [x] Common and backend typecheck and lint
- [x] Live API smoke: private chart returns 403 before grant, 200 after grant, and 403 after revoke
- [x] Full backend suite: 8,290 passed and 1 skipped

