### PR TITLE
feat(sql-charts): apply direct access to lifecycle

### DIFF
--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -56,6 +56,10 @@ const adminUser = {
     role: OrganizationMemberRole.ADMIN,
     ability: new Ability<PossibleAbilities>([
         {
+            subject: 'SavedChart',
+            action: 'view',
+        },
+        {
             subject: 'ScheduledDeliveries',
             action: 'manage',
             conditions: { organizationUuid },
@@ -68,6 +72,10 @@ const editorUser = {
     userUuid: 'editor-uuid',
     role: OrganizationMemberRole.EDITOR,
     ability: new Ability<PossibleAbilities>([
+        {
+            subject: 'SavedChart',
+            action: 'view',
+        },
         {
             subject: 'ScheduledDeliveries',
             action: 'create',
@@ -108,10 +116,23 @@ const createdScheduler = {
 const savedSqlModel = {
     getByUuid: vi.fn(async () => sqlChart),
     resolveColorPalette: vi.fn(async () => undefined),
+    update: vi.fn(async () => ({
+        savedSqlUuid,
+        savedSqlVersionUuid: null,
+    })),
+    softDelete: vi.fn(async () => undefined),
+    moveToSpace: vi.fn(async () => undefined),
 };
 const schedulerModel = {
     getSqlChartSchedulers: vi.fn(async () => []),
     createScheduler: vi.fn(async () => createdScheduler),
+};
+const schedulerClient = {
+    runSql: vi.fn(async () => 'job-uuid'),
+    runSqlPivotQuery: vi.fn(async () => 'job-uuid'),
+};
+const projectModel = {
+    getSummary: vi.fn(async () => ({ organizationUuid })),
 };
 const spacePermissionService = {
     can: vi.fn(async () => true),
@@ -149,9 +170,9 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
     const service = new SavedSqlService({
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
-        projectModel: {} as unknown as ProjectModel,
+        projectModel: projectModel as unknown as ProjectModel,
         savedSqlModel: savedSqlModel as unknown as SavedSqlModel,
-        schedulerClient: {} as unknown as SchedulerClient,
+        schedulerClient: schedulerClient as unknown as SchedulerClient,
         schedulerModel: schedulerModel as unknown as SchedulerModel,
         analyticsModel: {} as unknown as AnalyticsModel,
         spacePermissionService:
@@ -217,6 +238,117 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
         );
     });
 
+    describe('direct-grant write boundaries', () => {
+        const editor = {
+            ...baseUser,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'SavedChart', action: ['update', 'delete'] },
+                { subject: 'CustomSql', action: 'manage' },
+            ]),
+        };
+
+        test('updates a saved SQL chart through its resource access target', async () => {
+            await service.updateSqlChart(
+                editor,
+                projectUuid,
+                savedSqlUuid,
+                {} as never,
+            );
+
+            expect(
+                spacePermissionService.resolveAccessBatch,
+            ).toHaveBeenCalledWith(editor.userUuid, [
+                {
+                    type: 'sqlChart',
+                    savedSqlUuid,
+                    spaceUuid,
+                },
+            ]);
+        });
+
+        test('soft-deletes a saved SQL chart through its resource access target', async () => {
+            await service.softDelete(editor, savedSqlUuid);
+
+            expect(
+                spacePermissionService.resolveAccessBatch,
+            ).toHaveBeenCalledWith(editor.userUuid, [
+                {
+                    type: 'sqlChart',
+                    savedSqlUuid,
+                    spaceUuid,
+                },
+            ]);
+        });
+
+        test('requires real access to both spaces when moving a saved SQL chart', async () => {
+            const targetSpaceUuid = 'target-space-uuid';
+            const accessContext = {
+                organizationUuid,
+                projectUuid,
+                inheritsFromOrgOrProject: false,
+                access: [],
+                admins: [],
+                directOnly: false,
+            };
+            spacePermissionService.resolveAccessBatch.mockResolvedValueOnce([
+                {
+                    target: { spaceUuid },
+                    context: accessContext,
+                },
+                {
+                    target: { spaceUuid: targetSpaceUuid },
+                    context: accessContext,
+                },
+            ]);
+
+            await service.moveToSpace(editor, {
+                projectUuid,
+                itemUuid: savedSqlUuid,
+                targetSpaceUuid,
+            });
+
+            expect(
+                spacePermissionService.resolveAccessBatch,
+            ).toHaveBeenCalledWith(editor.userUuid, [
+                { type: 'space', spaceUuid },
+                { type: 'space', spaceUuid: targetSpaceUuid },
+            ]);
+        });
+    });
+
+    describe('deprecated Graphile execution boundaries', () => {
+        test('requires space access to execute a saved SQL pivot query', async () => {
+            spacePermissionService.can.mockResolvedValueOnce(false);
+
+            await expect(
+                service.getResultJobFromSqlPivotQuery(editorUser, projectUuid, {
+                    savedSqlUuid,
+                } as never),
+            ).rejects.toThrow(ForbiddenError);
+            expect(schedulerClient.runSqlPivotQuery).not.toHaveBeenCalled();
+            expect(
+                spacePermissionService.resolveAccessBatch,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('requires space access to execute a saved SQL chart query', async () => {
+            spacePermissionService.can.mockResolvedValueOnce(false);
+
+            await expect(
+                service.getSqlChartResultJob(
+                    editorUser,
+                    projectUuid,
+                    undefined,
+                    savedSqlUuid,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(schedulerClient.runSql).not.toHaveBeenCalled();
+            expect(
+                spacePermissionService.resolveAccessBatch,
+            ).not.toHaveBeenCalled();
+        });
+    });
+
     describe('getSchedulers', () => {
         it('admin lists all SQL chart schedulers', async () => {
             await expect(
@@ -245,12 +377,17 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             expect(schedulerModel.getSqlChartSchedulers).not.toHaveBeenCalled();
         });
 
-        it('user without space access is blocked', async () => {
-            spacePermissionService.can.mockResolvedValueOnce(false);
+        it('user without chart access is blocked', async () => {
+            spacePermissionService.resolveAccessBatch.mockResolvedValueOnce([
+                {
+                    target: { spaceUuid },
+                    context: undefined,
+                },
+            ] as never);
             await expect(
                 service.getSchedulers(editorUser, projectUuid, savedSqlUuid),
             ).rejects.toThrow(
-                "You don't have access to the space this chart belongs to",
+                "You don't have access to view this Saved SQL chart",
             );
             expect(schedulerModel.getSqlChartSchedulers).not.toHaveBeenCalled();
         });
@@ -291,8 +428,13 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
         });
 
-        it('user without space access is blocked from creating scheduler', async () => {
-            spacePermissionService.can.mockResolvedValueOnce(false);
+        it('user without chart access is blocked from creating scheduler', async () => {
+            spacePermissionService.resolveAccessBatch.mockResolvedValueOnce([
+                {
+                    target: { spaceUuid },
+                    context: undefined,
+                },
+            ] as never);
             await expect(
                 service.createScheduler(
                     editorUser,
@@ -301,7 +443,7 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
                     newSchedulerPayload,
                 ),
             ).rejects.toThrow(
-                "You don't have access to the space this chart belongs to",
+                "You don't have access to view this Saved SQL chart",
             );
             expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
         });

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -191,7 +191,7 @@ export class SavedSqlService
                 : [];
 
         const currentTarget: AccessTarget =
-            action === 'view' && resource.savedSqlUuid !== null
+            destinationTargets.length === 0 && resource.savedSqlUuid !== null
                 ? {
                       type: 'sqlChart',
                       savedSqlUuid: resource.savedSqlUuid,
@@ -256,6 +256,21 @@ export class SavedSqlService
         }
 
         return currentContext;
+    }
+
+    private async hasChartSpaceAccess(
+        user: SessionUser,
+        spaceUuid: string,
+    ): Promise<boolean> {
+        try {
+            return await this.spacePermissionService.can(
+                'view',
+                user,
+                spaceUuid,
+            );
+        } catch (e) {
+            return false;
+        }
     }
 
     async getSqlChart(
@@ -768,11 +783,11 @@ export class SavedSqlService
             if (!savedChart) {
                 throw new Error('Saved chart not found');
             }
-            await this.hasAccess(
-                'view',
-                { user, projectUuid },
-                { savedSqlUuid: savedChart.savedSqlUuid },
-            );
+            if (
+                !(await this.hasChartSpaceAccess(user, savedChart.space.uuid))
+            ) {
+                throw new ForbiddenError();
+            }
         } else {
             // If it's not a saved chart, check if the user has access to run a pivot query
             const auditedAbility = this.createAuditedAbility(user);
@@ -833,11 +848,9 @@ export class SavedSqlService
             throw new Error('Either chartUuid or slug must be provided');
         }
 
-        await this.hasAccess(
-            'view',
-            { user, projectUuid },
-            { savedSqlUuid: savedChart.savedSqlUuid },
-        );
+        if (!(await this.hasChartSpaceAccess(user, savedChart.space.uuid))) {
+            throw new ForbiddenError();
+        }
 
         const jobId = await this.schedulerClient.runSql({
             userUuid: user.userUuid,
@@ -921,21 +934,6 @@ export class SavedSqlService
         }
     }
 
-    private async hasChartSpaceAccess(
-        user: SessionUser,
-        spaceUuid: string,
-    ): Promise<boolean> {
-        try {
-            return await this.spacePermissionService.can(
-                'view',
-                user,
-                spaceUuid,
-            );
-        } catch (e) {
-            return false;
-        }
-    }
-
     private async checkCreateScheduledDeliveryAccess(
         user: SessionUser,
         projectUuid: string,
@@ -961,11 +959,7 @@ export class SavedSqlService
             throw new ForbiddenError();
         }
 
-        if (!(await this.hasChartSpaceAccess(user, spaceUuid))) {
-            throw new ForbiddenError(
-                "You don't have access to the space this chart belongs to",
-            );
-        }
+        await this.hasAccess('view', { user, projectUuid }, { savedSqlUuid });
 
         return { organizationUuid, spaceUuid };
     }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1469/stack-3b-apply-direct-access-to-saved-sql-charts

## Summary

PR 2 of 2 for [SPK-1469](https://linear.app/lightdash/issue/SPK-1469/stack-3b-apply-direct-access-to-saved-sql-charts). Applies direct access to saved SQL chart edits and scheduler administration while preserving space-only boundaries for moves and deprecated execution paths.

Stacks on top of PR 1 ([#28213](https://github.com/lightdash/lightdash/pull/28213)), which adds the saved SQL access read model, fresh-operation authorization, and the JWT/embed space-only boundary.

## Changes

- Applies direct access to in-place updates and soft deletion.
- Applies direct access to scheduled-delivery list and create operations.
- Requires real access to both the source and destination spaces when moving a chart.
- Keeps both deprecated Graphile SQL chart execution paths space-authorized.
- Leaves query history, queued workers, results, and derivatives on the existing snapshot and creator semantics used by dashboards and saved charts.

## Boundary flow

```text
in-place edit / scheduler admin → space or direct chart access
move chart                      → source space + destination space access
deprecated Graphile execution   → containing-space access
accepted async query            → existing creator + project + expiry checks
```

Grant administration is deferred to Stack 5, which owns the shared direct-access controller contract.

## Test plan

- [x] 19 saved SQL service tests, including embed isolation and both deprecated Graphile boundaries
- [x] 203 focused backend tests across the two-PR stack
- [x] 2 PostgreSQL access-model integration tests
- [x] Common and backend typecheck and lint
- [x] Full backend suite: 8,290 passed and 1 skipped

