### PR TITLE
feat(sql-charts): add direct access administration

### DIFF
--- a/packages/backend/src/models/SavedSqlAccessModel.integration.test.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.integration.test.ts
@@ -1,0 +1,448 @@
+import {
+    DirectAccessOrigin,
+    OrganizationMemberRole,
+    ProjectMemberRole,
+    SEED_ORG_1_ADMIN,
+    SEED_PROJECT,
+    SpaceMemberRole,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { randomUUID } from 'node:crypto';
+import { DashboardsTableName } from '../database/entities/dashboards';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
+import { ProjectTableName } from '../database/entities/projects';
+import { SavedSqlTableName } from '../database/entities/savedSql';
+import {
+    SavedSqlGroupAccessTableName,
+    SavedSqlUserAccessTableName,
+} from '../database/entities/savedSqlAccess';
+import { SpaceTableName } from '../database/entities/spaces';
+import { UserTableName } from '../database/entities/users';
+import { getTestContext } from '../vitest.setup.integration';
+import { SavedSqlAccessModel } from './SavedSqlAccessModel';
+
+describe('saved SQL direct access model PostgreSQL integration', () => {
+    let database: Knex;
+    let transaction: Knex.Transaction;
+    let model: SavedSqlAccessModel;
+    let savedSqlUuid: string;
+    let spaceUuid: string;
+    let spaceId: number;
+    let groupUuid: string;
+    let userId: number;
+    let organizationId: number;
+    let organizationUuid: string;
+    let projectId: number;
+    let projectUuid: string;
+
+    const mutationExpectation = () => ({
+        organizationUuid,
+        projectUuid,
+        spaceUuid,
+        dashboardUuid: null,
+    });
+
+    beforeAll(() => {
+        database = getTestContext().db;
+    });
+
+    beforeEach(async () => {
+        transaction = await database.transaction();
+        model = new SavedSqlAccessModel(transaction);
+
+        const projectSpace = await transaction(SpaceTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(
+                `${ProjectTableName}.project_uuid`,
+                SEED_PROJECT.project_uuid,
+            )
+            .select(
+                `${SpaceTableName}.space_id`,
+                `${SpaceTableName}.space_uuid`,
+                `${ProjectTableName}.project_id`,
+                `${ProjectTableName}.project_uuid`,
+                `${ProjectTableName}.organization_id`,
+                `${OrganizationTableName}.organization_uuid`,
+            )
+            .first();
+        if (!projectSpace) {
+            throw new Error('Seed project space not found');
+        }
+        spaceId = projectSpace.space_id;
+        spaceUuid = projectSpace.space_uuid;
+        organizationId = projectSpace.organization_id;
+        organizationUuid = projectSpace.organization_uuid;
+        projectId = projectSpace.project_id;
+        projectUuid = projectSpace.project_uuid;
+
+        const user = await transaction(UserTableName)
+            .where('user_uuid', SEED_ORG_1_ADMIN.user_uuid)
+            .select('user_id')
+            .first();
+        if (!user) {
+            throw new Error('Seed user not found');
+        }
+        userId = user.user_id;
+
+        const [savedSql] = await transaction(SavedSqlTableName)
+            .insert({
+                project_uuid: projectUuid,
+                space_uuid: spaceUuid,
+                dashboard_uuid: null,
+                name: `Direct access SQL chart ${randomUUID()}`,
+                description: null,
+                slug: `direct-access-sql-${randomUUID()}`,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })
+            .returning('saved_sql_uuid');
+        savedSqlUuid = savedSql.saved_sql_uuid;
+
+        const [group] = await transaction(GroupTableName)
+            .insert({
+                organization_id: organizationId,
+                name: `Direct access SQL group ${randomUUID()}`,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                updated_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })
+            .returning('group_uuid');
+        groupUuid = group.group_uuid;
+        await transaction(GroupMembershipTableName).insert({
+            organization_id: organizationId,
+            group_uuid: groupUuid,
+            user_id: userId,
+        });
+        await transaction(ProjectGroupAccessTableName).insert({
+            project_uuid: projectUuid,
+            group_uuid: groupUuid,
+            role: ProjectMemberRole.VIEWER,
+        });
+    });
+
+    afterEach(async () => {
+        if (!transaction.isCompleted()) {
+            await transaction.rollback();
+        }
+    });
+
+    it('upserts, lists, resolves, revokes, and resets user and group grants', async () => {
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: savedSqlUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.VIEWER,
+                ...mutationExpectation(),
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).resolves.toMatchObject({
+            beforeRole: null,
+            afterRole: SpaceMemberRole.VIEWER,
+            organizationUuid,
+            projectUuid,
+        });
+        await model.upsertGroupAccess({
+            resourceUuid: savedSqlUuid,
+            groupUuid,
+            role: SpaceMemberRole.ADMIN,
+            ...mutationExpectation(),
+            grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+
+        await expect(
+            model.getUserAccess([savedSqlUuid], SEED_ORG_1_ADMIN.user_uuid, {
+                organizationUuid,
+            }),
+        ).resolves.toEqual({
+            [savedSqlUuid]: {
+                organizationUuid,
+                projectUuid,
+                spaceUuid,
+                userRole: SpaceMemberRole.VIEWER,
+                groupRoles: [SpaceMemberRole.ADMIN],
+            },
+        });
+        await expect(
+            model.getGroupRolesForUsers(
+                savedSqlUuid,
+                [SEED_ORG_1_ADMIN.user_uuid],
+                organizationUuid,
+            ),
+        ).resolves.toEqual({
+            [SEED_ORG_1_ADMIN.user_uuid]: [SpaceMemberRole.ADMIN],
+        });
+
+        const list = await model.getDirectAccessList(
+            savedSqlUuid,
+            organizationUuid,
+            {
+                paginateArgs: { page: 1, pageSize: 1 },
+                searchQuery: 'David',
+            },
+        );
+        expect(list.data).toHaveLength(1);
+        expect(list.data[0]).toMatchObject({
+            origin: DirectAccessOrigin.USER,
+            principalUuid: SEED_ORG_1_ADMIN.user_uuid,
+            directRole: SpaceMemberRole.VIEWER,
+        });
+        expect(list.pagination?.totalResults).toBe(1);
+
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: savedSqlUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.EDITOR,
+                ...mutationExpectation(),
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).resolves.toMatchObject({
+            beforeRole: SpaceMemberRole.VIEWER,
+            afterRole: SpaceMemberRole.EDITOR,
+        });
+        await expect(
+            model.revokeUserAccess({
+                resourceUuid: savedSqlUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                ...mutationExpectation(),
+            }),
+        ).resolves.toMatchObject({
+            beforeRole: SpaceMemberRole.EDITOR,
+            afterRole: null,
+        });
+        await expect(
+            model.resetAccess({
+                resourceUuid: savedSqlUuid,
+                ...mutationExpectation(),
+            }),
+        ).resolves.toMatchObject({ revokedUsers: 0, revokedGroups: 1 });
+    });
+
+    it('stops resolving grants when current project access is removed', async () => {
+        const principalUuid = randomUUID();
+        const [principal] = await transaction(UserTableName)
+            .insert({
+                user_uuid: principalUuid,
+                first_name: 'Direct',
+                last_name: 'Principal',
+                is_marketing_opted_in: false,
+                is_tracking_anonymized: false,
+                is_setup_complete: true,
+                is_active: true,
+            })
+            .returning('user_id');
+        await transaction(OrganizationMembershipsTableName).insert({
+            organization_id: organizationId,
+            user_id: principal.user_id,
+            role: OrganizationMemberRole.MEMBER,
+        });
+        await transaction(ProjectMembershipsTableName).insert({
+            project_id: projectId,
+            user_id: principal.user_id,
+            role: ProjectMemberRole.VIEWER,
+        });
+        await transaction(GroupMembershipTableName).insert({
+            organization_id: organizationId,
+            group_uuid: groupUuid,
+            user_id: principal.user_id,
+        });
+        await model.upsertUserAccess({
+            resourceUuid: savedSqlUuid,
+            userUuid: principalUuid,
+            role: SpaceMemberRole.VIEWER,
+            ...mutationExpectation(),
+            grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+        await model.upsertGroupAccess({
+            resourceUuid: savedSqlUuid,
+            groupUuid,
+            role: SpaceMemberRole.ADMIN,
+            ...mutationExpectation(),
+            grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+
+        await expect(
+            model.getUserAccess([savedSqlUuid], principalUuid, {
+                organizationUuid,
+            }),
+        ).resolves.toMatchObject({
+            [savedSqlUuid]: {
+                userRole: SpaceMemberRole.VIEWER,
+                groupRoles: [SpaceMemberRole.ADMIN],
+            },
+        });
+
+        await transaction(GroupMembershipTableName)
+            .where({ group_uuid: groupUuid, user_id: principal.user_id })
+            .delete();
+        await expect(
+            model.getUserAccess([savedSqlUuid], principalUuid, {
+                organizationUuid,
+            }),
+        ).resolves.toHaveProperty(`${savedSqlUuid}.groupRoles`, []);
+
+        await transaction(GroupMembershipTableName).insert({
+            organization_id: organizationId,
+            group_uuid: groupUuid,
+            user_id: principal.user_id,
+        });
+        await transaction(ProjectGroupAccessTableName)
+            .where({ project_uuid: projectUuid, group_uuid: groupUuid })
+            .delete();
+        await expect(
+            model.getUserAccess([savedSqlUuid], principalUuid, {
+                organizationUuid,
+            }),
+        ).resolves.toHaveProperty(`${savedSqlUuid}.groupRoles`, []);
+
+        await transaction(ProjectMembershipsTableName)
+            .where({ project_id: projectId, user_id: principal.user_id })
+            .delete();
+        await expect(
+            model.getUserAccess([savedSqlUuid], principalUuid, {
+                organizationUuid,
+            }),
+        ).resolves.toEqual({});
+    });
+
+    it('scopes mutations to the organization and active project principals', async () => {
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: savedSqlUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.VIEWER,
+                organizationUuid: randomUUID(),
+                projectUuid,
+                spaceUuid,
+                dashboardUuid: null,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).rejects.toMatchObject({
+            name: 'NotFoundError',
+            message: 'Direct access target not found',
+        });
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: savedSqlUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.VIEWER,
+                ...mutationExpectation(),
+                spaceUuid: randomUUID(),
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).rejects.toMatchObject({
+            name: 'NotFoundError',
+            message: 'Direct access target not found',
+        });
+        await expect(
+            model.upsertGroupAccess({
+                resourceUuid: savedSqlUuid,
+                groupUuid: randomUUID(),
+                role: SpaceMemberRole.VIEWER,
+                ...mutationExpectation(),
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).rejects.toMatchObject({ name: 'NotFoundError' });
+    });
+
+    it('rejects grants to dashboard-owned SQL charts', async () => {
+        const [dashboard] = await transaction(DashboardsTableName)
+            .insert({
+                project_uuid: projectUuid,
+                name: `SQL owner ${randomUUID()}`,
+                description: undefined,
+                space_id: spaceId,
+                slug: `sql-owner-${randomUUID()}`,
+            })
+            .returning('dashboard_uuid');
+        const [dashboardSql] = await transaction(SavedSqlTableName)
+            .insert({
+                project_uuid: projectUuid,
+                space_uuid: null,
+                dashboard_uuid: dashboard.dashboard_uuid,
+                name: `Owned SQL chart ${randomUUID()}`,
+                description: null,
+                slug: `owned-sql-${randomUUID()}`,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })
+            .returning('saved_sql_uuid');
+
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: dashboardSql.saved_sql_uuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.VIEWER,
+                organizationUuid,
+                projectUuid,
+                spaceUuid: null,
+                dashboardUuid: dashboard.dashboard_uuid,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            }),
+        ).rejects.toMatchObject({ name: 'ParameterError' });
+    });
+
+    it('preserves grants through soft delete and restore and cascades permanent deletion', async () => {
+        await model.upsertUserAccess({
+            resourceUuid: savedSqlUuid,
+            userUuid: SEED_ORG_1_ADMIN.user_uuid,
+            role: SpaceMemberRole.VIEWER,
+            ...mutationExpectation(),
+            grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+        });
+
+        await transaction(SavedSqlTableName)
+            .where('saved_sql_uuid', savedSqlUuid)
+            .update({ deleted_at: new Date() });
+        await expect(
+            model.getUserAccess([savedSqlUuid], SEED_ORG_1_ADMIN.user_uuid, {
+                organizationUuid,
+            }),
+        ).resolves.toEqual({});
+        await expect(
+            transaction(SavedSqlUserAccessTableName)
+                .where('saved_sql_uuid', savedSqlUuid)
+                .count('* as count')
+                .first(),
+        ).resolves.toMatchObject({ count: 1n });
+
+        await transaction(SavedSqlTableName)
+            .where('saved_sql_uuid', savedSqlUuid)
+            .update({ deleted_at: null });
+        await expect(
+            model.getUserAccess([savedSqlUuid], SEED_ORG_1_ADMIN.user_uuid, {
+                organizationUuid,
+            }),
+        ).resolves.toHaveProperty(
+            `${savedSqlUuid}.userRole`,
+            SpaceMemberRole.VIEWER,
+        );
+
+        await transaction(SavedSqlTableName)
+            .where('saved_sql_uuid', savedSqlUuid)
+            .delete();
+        const [userGrantCount, groupGrantCount] = await Promise.all([
+            transaction(SavedSqlUserAccessTableName)
+                .where('saved_sql_uuid', savedSqlUuid)
+                .count<{ count: bigint }>('* as count')
+                .first(),
+            transaction(SavedSqlGroupAccessTableName)
+                .where('saved_sql_uuid', savedSqlUuid)
+                .count<{ count: bigint }>('* as count')
+                .first(),
+        ]);
+        expect(userGrantCount?.count).toBe(0n);
+        expect(groupGrantCount?.count).toBe(0n);
+    });
+});

--- a/packages/backend/src/models/SavedSqlAccessModel.test.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.test.ts
@@ -1,0 +1,27 @@
+import { canReceiveSavedSqlDirectAccess } from './SavedSqlAccessModel';
+
+describe('canReceiveSavedSqlDirectAccess', () => {
+    it.each([
+        {
+            ownership: { spaceUuid: 'space-uuid', dashboardUuid: null },
+            expected: true,
+        },
+        {
+            ownership: { spaceUuid: null, dashboardUuid: 'dashboard-uuid' },
+            expected: false,
+        },
+        {
+            ownership: { spaceUuid: null, dashboardUuid: null },
+            expected: false,
+        },
+        {
+            ownership: {
+                spaceUuid: 'space-uuid',
+                dashboardUuid: 'dashboard-uuid',
+            },
+            expected: false,
+        },
+    ])('returns $expected for $ownership', ({ ownership, expected }) => {
+        expect(canReceiveSavedSqlDirectAccess(ownership)).toBe(expected);
+    });
+});

--- a/packages/backend/src/models/SavedSqlAccessModel.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.ts
@@ -1,5 +1,16 @@
+import {
+    DirectAccessOrigin,
+    NotFoundError,
+    ParameterError,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
+    type SpaceMemberRole,
+} from '@lightdash/common';
 import { type Knex } from 'knex';
+import { DashboardsTableName } from '../database/entities/dashboards';
+import { EmailTableName } from '../database/entities/emails';
 import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { GroupTableName } from '../database/entities/groups';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectTableName } from '../database/entities/projects';
@@ -10,18 +21,743 @@ import {
 } from '../database/entities/savedSqlAccess';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
+import KnexPaginate from '../database/pagination';
 import {
     getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
+    validateDirectAccessGroup,
+    validateDirectAccessUser,
     type DirectAccess,
+    type DirectAccessMutationContext,
+    type DirectAccessMutationResult,
+    type DirectAccessResetResult,
     type DirectAccessRow,
 } from './directAccessModelUtils';
+import { getColumnMatchRegexQuery } from './SearchModel/utils/search';
 
 export type SavedSqlDirectAccess = DirectAccess;
 
+export type SavedSqlDirectAccessListRow =
+    | {
+          origin: DirectAccessOrigin.USER;
+          principalUuid: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+          isInternal: boolean;
+          name: null;
+          directRole: SpaceMemberRole;
+      }
+    | {
+          origin: DirectAccessOrigin.GROUP;
+          principalUuid: string;
+          firstName: null;
+          lastName: null;
+          email: null;
+          isInternal: null;
+          name: string;
+          directRole: SpaceMemberRole;
+      };
+
+type SavedSqlOwnership = {
+    spaceUuid: string | null;
+    dashboardUuid: string | null;
+};
+
+type SavedSqlMutationTarget = {
+    context: DirectAccessMutationContext;
+    ownership: SavedSqlOwnership;
+};
+
+export type SavedSqlMutationExpectation = SavedSqlOwnership & {
+    organizationUuid: string;
+    projectUuid: string;
+};
+
+export const canReceiveSavedSqlDirectAccess = ({
+    spaceUuid,
+    dashboardUuid,
+}: SavedSqlOwnership): boolean => spaceUuid !== null && dashboardUuid === null;
+
 export class SavedSqlAccessModel {
     constructor(private readonly database: Knex) {}
+
+    private static async getMutationTarget(
+        trx: Knex,
+        resourceUuid: string,
+        expected: SavedSqlMutationExpectation,
+    ): Promise<SavedSqlMutationTarget> {
+        // Discover optimistically, then lock parents before children to match
+        // FK cascade order. The final SQL-chart re-read rejects ownership races.
+        const candidateChart = await trx(SavedSqlTableName)
+            .where(`${SavedSqlTableName}.saved_sql_uuid`, resourceUuid)
+            .where(`${SavedSqlTableName}.project_uuid`, expected.projectUuid)
+            .whereNull(`${SavedSqlTableName}.deleted_at`)
+            .select<
+                SavedSqlOwnership & {
+                    storedProjectUuid: string;
+                }
+            >({
+                spaceUuid: `${SavedSqlTableName}.space_uuid`,
+                dashboardUuid: `${SavedSqlTableName}.dashboard_uuid`,
+                storedProjectUuid: `${SavedSqlTableName}.project_uuid`,
+            })
+            .first();
+
+        if (candidateChart === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        let ownerSpaceId: number;
+        if (candidateChart.spaceUuid !== null) {
+            const candidateSpace = await trx(SpaceTableName)
+                .where('space_uuid', candidateChart.spaceUuid)
+                .whereNull('deleted_at')
+                .select<{ spaceId: number }>({ spaceId: 'space_id' })
+                .first();
+            if (candidateSpace === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            ownerSpaceId = candidateSpace.spaceId;
+        } else {
+            if (candidateChart.dashboardUuid === null) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const candidateDashboard = await trx(DashboardsTableName)
+                .where('dashboard_uuid', candidateChart.dashboardUuid)
+                .whereNull('deleted_at')
+                .select<{ spaceId: number }>({ spaceId: 'space_id' })
+                .first();
+            if (candidateDashboard === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            ownerSpaceId = candidateDashboard.spaceId;
+        }
+
+        const candidateOwner = await trx(SpaceTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(`${SpaceTableName}.space_id`, ownerSpaceId)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                expected.organizationUuid,
+            )
+            .where(`${ProjectTableName}.project_uuid`, expected.projectUuid)
+            .select<DirectAccessMutationContext>({
+                organizationId: `${OrganizationTableName}.organization_id`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectId: `${ProjectTableName}.project_id`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+            })
+            .first();
+        if (candidateOwner === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        const organization = await trx(OrganizationTableName)
+            .where('organization_id', candidateOwner.organizationId)
+            .where('organization_uuid', expected.organizationUuid)
+            .select<{ organizationId: number; organizationUuid: string }>({
+                organizationId: 'organization_id',
+                organizationUuid: 'organization_uuid',
+            })
+            .forNoKeyUpdate(OrganizationTableName)
+            .first();
+        if (organization === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        const project = await trx(ProjectTableName)
+            .where('project_id', candidateOwner.projectId)
+            .where('organization_id', organization.organizationId)
+            .select<{ projectId: number; projectUuid: string }>({
+                projectId: 'project_id',
+                projectUuid: 'project_uuid',
+            })
+            .forNoKeyUpdate(ProjectTableName)
+            .first();
+        if (project === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        const space = await trx(SpaceTableName)
+            .where('space_id', ownerSpaceId)
+            .where('project_id', project.projectId)
+            .whereNull('deleted_at')
+            .select<{ spaceUuid: string }>({ spaceUuid: 'space_uuid' })
+            .forNoKeyUpdate(SpaceTableName)
+            .first();
+        if (space === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        if (candidateChart.dashboardUuid !== null) {
+            const dashboard = await trx(DashboardsTableName)
+                .where('dashboard_uuid', candidateChart.dashboardUuid)
+                .where('space_id', ownerSpaceId)
+                .where('project_uuid', project.projectUuid)
+                .whereNull('deleted_at')
+                .select('dashboard_uuid')
+                .forNoKeyUpdate(DashboardsTableName)
+                .first();
+            if (dashboard === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
+        }
+
+        const chart = await trx(SavedSqlTableName)
+            .where('saved_sql_uuid', resourceUuid)
+            .whereNull('deleted_at')
+            .select<
+                SavedSqlOwnership & {
+                    storedProjectUuid: string;
+                }
+            >({
+                spaceUuid: 'space_uuid',
+                dashboardUuid: 'dashboard_uuid',
+                storedProjectUuid: 'project_uuid',
+            })
+            .forUpdate(SavedSqlTableName)
+            .first();
+        if (
+            chart === undefined ||
+            chart.spaceUuid !== expected.spaceUuid ||
+            chart.dashboardUuid !== expected.dashboardUuid ||
+            chart.spaceUuid !== candidateChart.spaceUuid ||
+            chart.dashboardUuid !== candidateChart.dashboardUuid ||
+            chart.storedProjectUuid !== project.projectUuid ||
+            (chart.spaceUuid !== null && chart.spaceUuid !== space.spaceUuid)
+        ) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        return {
+            context: {
+                organizationId: organization.organizationId,
+                organizationUuid: organization.organizationUuid,
+                projectId: project.projectId,
+                projectUuid: project.projectUuid,
+            },
+            ownership: {
+                spaceUuid: chart.spaceUuid,
+                dashboardUuid: chart.dashboardUuid,
+            },
+        };
+    }
+
+    async upsertUserAccess({
+        resourceUuid,
+        userUuid,
+        role,
+        organizationUuid,
+        projectUuid,
+        spaceUuid,
+        dashboardUuid,
+        grantedByUserUuid,
+    }: {
+        resourceUuid: string;
+        userUuid: string;
+        role: SpaceMemberRole;
+        grantedByUserUuid: string;
+    } & SavedSqlMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const { context, ownership } =
+                await SavedSqlAccessModel.getMutationTarget(trx, resourceUuid, {
+                    organizationUuid,
+                    projectUuid,
+                    spaceUuid,
+                    dashboardUuid,
+                });
+            if (!canReceiveSavedSqlDirectAccess(ownership)) {
+                throw new ParameterError(
+                    'Cannot grant direct access to a dashboard-owned SQL chart; grant access to its dashboard instead',
+                );
+            }
+            if (!(await validateDirectAccessUser(trx, context, userUuid))) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(SavedSqlUserAccessTableName)
+                .where({ saved_sql_uuid: resourceUuid, user_uuid: userUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            await trx(SavedSqlUserAccessTableName)
+                .insert({
+                    saved_sql_uuid: resourceUuid,
+                    user_uuid: userUuid,
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                })
+                .onConflict(['saved_sql_uuid', 'user_uuid'])
+                .merge({
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: role,
+            };
+        });
+    }
+
+    async upsertGroupAccess({
+        resourceUuid,
+        groupUuid,
+        role,
+        organizationUuid,
+        projectUuid,
+        spaceUuid,
+        dashboardUuid,
+        grantedByUserUuid,
+    }: {
+        resourceUuid: string;
+        groupUuid: string;
+        role: SpaceMemberRole;
+        grantedByUserUuid: string;
+    } & SavedSqlMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const { context, ownership } =
+                await SavedSqlAccessModel.getMutationTarget(trx, resourceUuid, {
+                    organizationUuid,
+                    projectUuid,
+                    spaceUuid,
+                    dashboardUuid,
+                });
+            if (!canReceiveSavedSqlDirectAccess(ownership)) {
+                throw new ParameterError(
+                    'Cannot grant direct access to a dashboard-owned SQL chart; grant access to its dashboard instead',
+                );
+            }
+            if (!(await validateDirectAccessGroup(trx, context, groupUuid))) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(SavedSqlGroupAccessTableName)
+                .where({
+                    saved_sql_uuid: resourceUuid,
+                    group_uuid: groupUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            await trx(SavedSqlGroupAccessTableName)
+                .insert({
+                    saved_sql_uuid: resourceUuid,
+                    group_uuid: groupUuid,
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                })
+                .onConflict(['saved_sql_uuid', 'group_uuid'])
+                .merge({
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: role,
+            };
+        });
+    }
+
+    async revokeUserAccess({
+        resourceUuid,
+        userUuid,
+        organizationUuid,
+        projectUuid,
+        spaceUuid,
+        dashboardUuid,
+    }: {
+        resourceUuid: string;
+        userUuid: string;
+    } & SavedSqlMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const { context } = await SavedSqlAccessModel.getMutationTarget(
+                trx,
+                resourceUuid,
+                {
+                    organizationUuid,
+                    projectUuid,
+                    spaceUuid,
+                    dashboardUuid,
+                },
+            );
+            const existing = await trx(SavedSqlUserAccessTableName)
+                .where({ saved_sql_uuid: resourceUuid, user_uuid: userUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            if (existing === undefined) {
+                return { ...context, beforeRole: null, afterRole: null };
+            }
+            await trx(SavedSqlUserAccessTableName)
+                .where({ saved_sql_uuid: resourceUuid, user_uuid: userUuid })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing.space_role,
+                afterRole: null,
+            };
+        });
+    }
+
+    async revokeGroupAccess({
+        resourceUuid,
+        groupUuid,
+        organizationUuid,
+        projectUuid,
+        spaceUuid,
+        dashboardUuid,
+    }: {
+        resourceUuid: string;
+        groupUuid: string;
+    } & SavedSqlMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const { context } = await SavedSqlAccessModel.getMutationTarget(
+                trx,
+                resourceUuid,
+                {
+                    organizationUuid,
+                    projectUuid,
+                    spaceUuid,
+                    dashboardUuid,
+                },
+            );
+            const existing = await trx(SavedSqlGroupAccessTableName)
+                .where({
+                    saved_sql_uuid: resourceUuid,
+                    group_uuid: groupUuid,
+                })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            if (existing === undefined) {
+                return { ...context, beforeRole: null, afterRole: null };
+            }
+            await trx(SavedSqlGroupAccessTableName)
+                .where({
+                    saved_sql_uuid: resourceUuid,
+                    group_uuid: groupUuid,
+                })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing.space_role,
+                afterRole: null,
+            };
+        });
+    }
+
+    async resetAccess({
+        resourceUuid,
+        organizationUuid,
+        projectUuid,
+        spaceUuid,
+        dashboardUuid,
+    }: {
+        resourceUuid: string;
+    } & SavedSqlMutationExpectation): Promise<DirectAccessResetResult> {
+        return this.database.transaction(async (trx) => {
+            const { context } = await SavedSqlAccessModel.getMutationTarget(
+                trx,
+                resourceUuid,
+                {
+                    organizationUuid,
+                    projectUuid,
+                    spaceUuid,
+                    dashboardUuid,
+                },
+            );
+            const [revokedUsers, revokedGroups] = await Promise.all([
+                trx(SavedSqlUserAccessTableName)
+                    .where('saved_sql_uuid', resourceUuid)
+                    .delete(),
+                trx(SavedSqlGroupAccessTableName)
+                    .where('saved_sql_uuid', resourceUuid)
+                    .delete(),
+            ]);
+            return { ...context, revokedUsers, revokedGroups };
+        });
+    }
+
+    async getDirectAccessList(
+        savedSqlUuid: string,
+        organizationUuid: string,
+        {
+            paginateArgs,
+            searchQuery,
+            principal,
+        }: {
+            paginateArgs?: KnexPaginateArgs;
+            searchQuery?: string;
+            principal?: {
+                origin: DirectAccessOrigin;
+                uuid: string;
+            };
+        } = {},
+    ): Promise<KnexPaginatedData<SavedSqlDirectAccessListRow[]>> {
+        const users = this.database(SavedSqlUserAccessTableName)
+            .innerJoin(
+                SavedSqlTableName,
+                `${SavedSqlTableName}.saved_sql_uuid`,
+                `${SavedSqlUserAccessTableName}.saved_sql_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_uuid`,
+                `${SavedSqlTableName}.space_uuid`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${SavedSqlUserAccessTableName}.user_uuid`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                function joinCurrentOrganizationMembership() {
+                    this.on(
+                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOn(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    );
+                },
+            )
+            .leftJoin(EmailTableName, function joinPrimaryEmail() {
+                this.on(
+                    `${EmailTableName}.user_id`,
+                    `${UserTableName}.user_id`,
+                ).andOnVal(`${EmailTableName}.is_primary`, true);
+            })
+            .where(
+                `${SavedSqlUserAccessTableName}.saved_sql_uuid`,
+                savedSqlUuid,
+            )
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(
+                `${SavedSqlTableName}.project_uuid`,
+                this.database.ref(`${ProjectTableName}.project_uuid`),
+            )
+            .whereNull(`${SavedSqlTableName}.dashboard_uuid`)
+            .whereNull(`${SavedSqlTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .where(getActiveProjectMemberPredicate(this.database))
+            .select({
+                origin: this.database.raw('?', [DirectAccessOrigin.USER]),
+                principalUuid: `${SavedSqlUserAccessTableName}.user_uuid`,
+                firstName: `${UserTableName}.first_name`,
+                lastName: `${UserTableName}.last_name`,
+                email: this.database.raw('COALESCE(??, ?)', [
+                    `${EmailTableName}.email`,
+                    '',
+                ]),
+                isInternal: `${UserTableName}.is_internal`,
+                name: this.database.raw('NULL::text'),
+                directRole: `${SavedSqlUserAccessTableName}.space_role`,
+            });
+
+        const groups = this.database(SavedSqlGroupAccessTableName)
+            .innerJoin(
+                SavedSqlTableName,
+                `${SavedSqlTableName}.saved_sql_uuid`,
+                `${SavedSqlGroupAccessTableName}.saved_sql_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_uuid`,
+                `${SavedSqlTableName}.space_uuid`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .innerJoin(GroupTableName, function joinSourceOrganizationGroup() {
+                this.on(
+                    `${GroupTableName}.group_uuid`,
+                    `${SavedSqlGroupAccessTableName}.group_uuid`,
+                ).andOn(
+                    `${GroupTableName}.organization_id`,
+                    `${ProjectTableName}.organization_id`,
+                );
+            })
+            .where(
+                `${SavedSqlGroupAccessTableName}.saved_sql_uuid`,
+                savedSqlUuid,
+            )
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(
+                `${SavedSqlTableName}.project_uuid`,
+                this.database.ref(`${ProjectTableName}.project_uuid`),
+            )
+            .whereNull(`${SavedSqlTableName}.dashboard_uuid`)
+            .whereNull(`${SavedSqlTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .where(
+                getActiveGrantedGroupPredicate(
+                    this.database,
+                    SavedSqlGroupAccessTableName,
+                ),
+            )
+            .select({
+                origin: this.database.raw('?', [DirectAccessOrigin.GROUP]),
+                principalUuid: `${SavedSqlGroupAccessTableName}.group_uuid`,
+                firstName: this.database.raw('NULL::text'),
+                lastName: this.database.raw('NULL::text'),
+                email: this.database.raw('NULL::text'),
+                isInternal: this.database.raw('NULL::boolean'),
+                name: `${GroupTableName}.name`,
+                directRole: `${SavedSqlGroupAccessTableName}.space_role`,
+            });
+
+        let query = this.database
+            .select<SavedSqlDirectAccessListRow[]>('*')
+            .from(users.unionAll(groups).as('saved_sql_direct_access'));
+
+        if (searchQuery) {
+            query = getColumnMatchRegexQuery(query, searchQuery, [
+                'firstName',
+                'lastName',
+                'email',
+                'name',
+            ]);
+        }
+        if (principal) {
+            void query
+                .where('origin', principal.origin)
+                .where('principalUuid', principal.uuid);
+        }
+        void query
+            .orderByRaw('LOWER(COALESCE(??, ??, ?))', ['name', 'firstName', ''])
+            .orderBy('origin')
+            .orderBy('principalUuid');
+
+        return KnexPaginate.paginate(query, paginateArgs);
+    }
+
+    async getGroupRolesForUsers(
+        savedSqlUuid: string,
+        userUuids: string[],
+        organizationUuid: string,
+    ): Promise<Record<string, SpaceMemberRole[]>> {
+        if (userUuids.length === 0) {
+            return {};
+        }
+
+        const rows = await this.database(SavedSqlGroupAccessTableName)
+            .innerJoin(
+                SavedSqlTableName,
+                `${SavedSqlTableName}.saved_sql_uuid`,
+                `${SavedSqlGroupAccessTableName}.saved_sql_uuid`,
+            )
+            .innerJoin(
+                SpaceTableName,
+                `${SpaceTableName}.space_uuid`,
+                `${SavedSqlTableName}.space_uuid`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .innerJoin(
+                GroupMembershipTableName,
+                `${GroupMembershipTableName}.group_uuid`,
+                `${SavedSqlGroupAccessTableName}.group_uuid`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_id`,
+                `${GroupMembershipTableName}.user_id`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                function joinCurrentOrganizationMembership() {
+                    this.on(
+                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOn(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    );
+                },
+            )
+            .where(
+                `${SavedSqlGroupAccessTableName}.saved_sql_uuid`,
+                savedSqlUuid,
+            )
+            .whereIn(`${UserTableName}.user_uuid`, userUuids)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(
+                `${GroupMembershipTableName}.organization_id`,
+                this.database.ref(`${ProjectTableName}.organization_id`),
+            )
+            .where(
+                `${SavedSqlTableName}.project_uuid`,
+                this.database.ref(`${ProjectTableName}.project_uuid`),
+            )
+            .where(getActiveProjectMemberPredicate(this.database))
+            .where(
+                getActiveGrantedGroupPredicate(
+                    this.database,
+                    SavedSqlGroupAccessTableName,
+                ),
+            )
+            .whereNull(`${SavedSqlTableName}.dashboard_uuid`)
+            .whereNull(`${SavedSqlTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .select<{ userUuid: string; role: SpaceMemberRole }[]>(
+                `${UserTableName}.user_uuid as userUuid`,
+                `${SavedSqlGroupAccessTableName}.space_role as role`,
+            );
+
+        const rolesByUserUuid: Record<string, SpaceMemberRole[]> = {};
+        for (const { userUuid, role } of rows) {
+            rolesByUserUuid[userUuid] = [
+                ...(rolesByUserUuid[userUuid] ?? []),
+                role,
+            ];
+        }
+        return rolesByUserUuid;
+    }
 
     async getUserAccess(
         savedSqlUuids: string[],

--- a/packages/backend/src/services/DirectAccess/ResourceAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/ResourceAccessHandler.ts
@@ -1,0 +1,47 @@
+import {
+    type DirectAccessGrant,
+    type DirectAccessList,
+    type DirectAccessListFilters,
+    type KnexPaginateArgs,
+    type SessionUser,
+    type SpaceMemberRole,
+} from '@lightdash/common';
+
+type ResourceAccessInput = {
+    user: SessionUser;
+    projectUuid: string;
+    resourceUuid: string;
+};
+
+/**
+ * Concrete artifact contract consumed by the shared direct-access controller.
+ * Revokes are idempotent: a missing grant succeeds without an audit event,
+ * while an unknown or inaccessible resource still fails closed.
+ */
+export type ResourceAccessHandler = {
+    listAccess(
+        input: ResourceAccessInput & {
+            paginateArgs?: KnexPaginateArgs;
+            filters?: DirectAccessListFilters;
+        },
+    ): Promise<DirectAccessList>;
+    replaceUserRole(
+        input: ResourceAccessInput & {
+            userUuid: string;
+            role: SpaceMemberRole;
+        },
+    ): Promise<DirectAccessGrant>;
+    replaceGroupRole(
+        input: ResourceAccessInput & {
+            groupUuid: string;
+            role: SpaceMemberRole;
+        },
+    ): Promise<DirectAccessGrant>;
+    revokeUser(
+        input: ResourceAccessInput & { userUuid: string },
+    ): Promise<void>;
+    revokeGroup(
+        input: ResourceAccessInput & { groupUuid: string },
+    ): Promise<void>;
+    reset(input: ResourceAccessInput): Promise<void>;
+};

--- a/packages/backend/src/services/DirectAccess/SavedSqlAccessHandler.test.ts
+++ b/packages/backend/src/services/DirectAccess/SavedSqlAccessHandler.test.ts
@@ -1,0 +1,470 @@
+import { Ability } from '@casl/ability';
+import {
+    DirectAccessOrigin,
+    ForbiddenError,
+    OrganizationMemberRole,
+    SpaceMemberRole,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import type { SavedSqlAccessModel } from '../../models/SavedSqlAccessModel';
+import type { SavedSqlModel } from '../../models/SavedSqlModel';
+import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import type { DirectAccessFeatureGate } from './DirectAccessFeatureGate';
+import { SavedSqlAccessHandler } from './SavedSqlAccessHandler';
+
+const organizationUuid = '8d4ee021-2dc9-4955-b349-711cc36125be';
+const projectUuid = 'b6735fb8-e57a-44af-a7d6-768bb9d3f87b';
+const savedSqlUuid = '154f3622-cb7d-4af7-9b48-c278aa2d5f95';
+const spaceUuid = '59acec01-47a5-44d2-a62b-fb9a4c2dbd8b';
+const adminUserUuid = 'e43891ac-dc01-4fcf-aad7-9e9eca697364';
+const principalUserUuid = '77904c19-ddf4-4c4c-b477-b72325a8a7de';
+const groupUuid = 'c81355f2-3cfe-4d89-8d65-acd8dc105210';
+
+const makeUser = (
+    abilityRules: ConstructorParameters<typeof Ability<PossibleAbilities>>[0],
+    userUuid = adminUserUuid,
+): SessionUser =>
+    ({
+        userUuid,
+        email: 'admin@example.com',
+        firstName: 'Direct',
+        lastName: 'Admin',
+        organizationUuid,
+        organizationName: 'Test org',
+        organizationCreatedAt: new Date(),
+        role: OrganizationMemberRole.MEMBER,
+        ability: new Ability<PossibleAbilities>(abilityRules),
+        abilityRules: [],
+        isActive: true,
+        userId: 1,
+        avatarUrl: null,
+        isTrackingAnonymized: false,
+        isMarketingOptedIn: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    }) as unknown as SessionUser;
+
+const adminUser = makeUser([
+    { subject: 'SavedChart', action: ['view', 'manage'] },
+]);
+const viewerUser = makeUser(
+    [{ subject: 'SavedChart', action: 'view' }],
+    principalUserUuid,
+);
+
+const savedSql = {
+    savedSqlUuid,
+    dashboard: null,
+    space: { uuid: spaceUuid, name: 'Private' },
+    project: { projectUuid },
+    organization: { organizationUuid },
+};
+const mutationExpectation = {
+    organizationUuid,
+    projectUuid,
+    spaceUuid,
+    dashboardUuid: null,
+};
+
+const adminAccessContext = {
+    organizationUuid,
+    projectUuid,
+    inheritsFromOrgOrProject: false,
+    access: [
+        {
+            userUuid: adminUserUuid,
+            role: SpaceMemberRole.ADMIN,
+            hasDirectAccess: true,
+            projectRole: undefined,
+            inheritedRole: undefined,
+            inheritedFrom: undefined,
+            grantedVia: 'sql_chart' as const,
+        },
+    ],
+    admins: [],
+    directOnly: true,
+};
+
+const userRow = {
+    origin: DirectAccessOrigin.USER as const,
+    principalUuid: principalUserUuid,
+    firstName: 'Grant',
+    lastName: 'Recipient',
+    email: 'recipient@example.com',
+    isInternal: false,
+    name: null,
+    directRole: SpaceMemberRole.VIEWER,
+};
+const groupRow = {
+    origin: DirectAccessOrigin.GROUP as const,
+    principalUuid: groupUuid,
+    firstName: null,
+    lastName: null,
+    email: null,
+    isInternal: null,
+    name: 'Analysts',
+    directRole: SpaceMemberRole.EDITOR,
+};
+
+const mutationResult = {
+    organizationId: 1,
+    organizationUuid,
+    projectId: 2,
+    projectUuid,
+    beforeRole: null,
+    afterRole: SpaceMemberRole.VIEWER,
+};
+
+describe('SavedSqlAccessHandler', () => {
+    const featureGate = {
+        isEnabledForUser: vi.fn(async () => true),
+    };
+    const savedSqlModel = {
+        getByUuid: vi.fn(async () => savedSql),
+    };
+    const savedSqlAccessModel = {
+        getDirectAccessList: vi.fn(
+            async (
+                _resourceUuid: string,
+                _organizationUuid: string,
+                options?: {
+                    principal?: {
+                        origin: DirectAccessOrigin;
+                        uuid: string;
+                    };
+                },
+            ) => ({
+                data: options?.principal
+                    ? [userRow, groupRow].filter(
+                          (row) =>
+                              row.origin === options.principal?.origin &&
+                              row.principalUuid === options.principal.uuid,
+                      )
+                    : [userRow, groupRow],
+                pagination: {
+                    page: 1,
+                    pageSize: 100,
+                    totalPageCount: 1,
+                    totalResults: 2,
+                },
+            }),
+        ),
+        getGroupRolesForUsers: vi.fn(async () => ({
+            [principalUserUuid]: [SpaceMemberRole.EDITOR],
+        })),
+        upsertUserAccess: vi.fn(async () => mutationResult),
+        upsertGroupAccess: vi.fn(async () => ({
+            ...mutationResult,
+            afterRole: SpaceMemberRole.EDITOR,
+        })),
+        revokeUserAccess: vi.fn(async () => ({
+            ...mutationResult,
+            beforeRole: SpaceMemberRole.VIEWER,
+            afterRole: null,
+        })),
+        revokeGroupAccess: vi.fn(async () => ({
+            ...mutationResult,
+            beforeRole: SpaceMemberRole.EDITOR,
+            afterRole: null,
+        })),
+        resetAccess: vi.fn(async () => ({
+            organizationId: 1,
+            organizationUuid,
+            projectId: 2,
+            projectUuid,
+            revokedUsers: 1,
+            revokedGroups: 1,
+        })),
+    };
+    const spacePermissionService = {
+        resolveAccess: vi.fn(async () => adminAccessContext),
+        getSpaceAccessContextForUsers: vi.fn(async () => ({
+            ...adminAccessContext,
+            access: [],
+        })),
+        mergeAdminAccess: vi.fn(
+            (context: { access: typeof adminAccessContext.access }) =>
+                context.access,
+        ),
+    };
+    const auditLogger = vi.fn();
+
+    const handler = new SavedSqlAccessHandler({
+        savedSqlAccessModel:
+            savedSqlAccessModel as unknown as SavedSqlAccessModel,
+        savedSqlModel: savedSqlModel as unknown as SavedSqlModel,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+        featureGate: featureGate as unknown as DirectAccessFeatureGate,
+        auditLogger,
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        featureGate.isEnabledForUser.mockResolvedValue(true);
+        savedSqlModel.getByUuid.mockResolvedValue(savedSql);
+        spacePermissionService.resolveAccess.mockResolvedValue(
+            adminAccessContext,
+        );
+    });
+
+    it('lists direct and effective roles with bounded pagination', async () => {
+        await expect(
+            handler.listAccess({
+                user: adminUser,
+                projectUuid,
+                resourceUuid: savedSqlUuid,
+                filters: { searchQuery: 'grant' },
+            }),
+        ).resolves.toMatchObject({
+            data: [
+                {
+                    principal: {
+                        type: DirectAccessOrigin.USER,
+                        uuid: principalUserUuid,
+                    },
+                    directRole: SpaceMemberRole.VIEWER,
+                    effectiveRole: SpaceMemberRole.EDITOR,
+                },
+                {
+                    principal: {
+                        type: DirectAccessOrigin.GROUP,
+                        uuid: groupUuid,
+                    },
+                    directRole: SpaceMemberRole.EDITOR,
+                },
+            ],
+        });
+        expect(savedSqlAccessModel.getDirectAccessList).toHaveBeenCalledWith(
+            savedSqlUuid,
+            organizationUuid,
+            {
+                paginateArgs: { page: 1, pageSize: 100 },
+                searchQuery: 'grant',
+            },
+        );
+        expect(
+            spacePermissionService.getSpaceAccessContextForUsers,
+        ).toHaveBeenCalledWith([principalUserUuid], spaceUuid);
+    });
+
+    it('reports admin as the effective role when a lower access row exists', async () => {
+        spacePermissionService.getSpaceAccessContextForUsers.mockResolvedValueOnce(
+            {
+                ...adminAccessContext,
+                access: [
+                    {
+                        ...adminAccessContext.access[0],
+                        userUuid: principalUserUuid,
+                        role: SpaceMemberRole.VIEWER,
+                    },
+                ],
+                admins: [{ userUuid: principalUserUuid }],
+            } as never,
+        );
+
+        await expect(
+            handler.listAccess({
+                user: adminUser,
+                projectUuid,
+                resourceUuid: savedSqlUuid,
+            }),
+        ).resolves.toMatchObject({
+            data: [
+                {
+                    principal: { uuid: principalUserUuid },
+                    effectiveRole: SpaceMemberRole.ADMIN,
+                },
+                expect.anything(),
+            ],
+        });
+    });
+
+    it('replaces a user role and emits a grant audit event', async () => {
+        await expect(
+            handler.replaceUserRole({
+                user: adminUser,
+                projectUuid,
+                resourceUuid: savedSqlUuid,
+                userUuid: principalUserUuid,
+                role: SpaceMemberRole.VIEWER,
+            }),
+        ).resolves.toMatchObject({
+            principal: { uuid: principalUserUuid },
+            directRole: SpaceMemberRole.VIEWER,
+        });
+        expect(savedSqlAccessModel.upsertUserAccess).toHaveBeenCalledWith({
+            resourceUuid: savedSqlUuid,
+            userUuid: principalUserUuid,
+            role: SpaceMemberRole.VIEWER,
+            grantedByUserUuid: adminUserUuid,
+            ...mutationExpectation,
+        });
+        expect(auditLogger).toHaveBeenCalledWith(
+            expect.objectContaining({ action: 'direct_access.grant' }),
+        );
+    });
+
+    it('replaces a group role and returns the group grant', async () => {
+        await expect(
+            handler.replaceGroupRole({
+                user: adminUser,
+                projectUuid,
+                resourceUuid: savedSqlUuid,
+                groupUuid,
+                role: SpaceMemberRole.EDITOR,
+            }),
+        ).resolves.toMatchObject({
+            principal: { type: DirectAccessOrigin.GROUP, uuid: groupUuid },
+            directRole: SpaceMemberRole.EDITOR,
+        });
+        expect(savedSqlAccessModel.upsertGroupAccess).toHaveBeenCalledWith({
+            resourceUuid: savedSqlUuid,
+            groupUuid,
+            role: SpaceMemberRole.EDITOR,
+            grantedByUserUuid: adminUserUuid,
+            ...mutationExpectation,
+        });
+    });
+
+    it('allows a viewer to revoke their own grant', async () => {
+        spacePermissionService.resolveAccess.mockResolvedValue({
+            ...adminAccessContext,
+            access: [
+                {
+                    ...adminAccessContext.access[0],
+                    userUuid: principalUserUuid,
+                    role: SpaceMemberRole.VIEWER,
+                },
+            ],
+        });
+
+        await expect(
+            handler.revokeUser({
+                user: viewerUser,
+                projectUuid,
+                resourceUuid: savedSqlUuid,
+                userUuid: principalUserUuid,
+            }),
+        ).resolves.toBeUndefined();
+        expect(savedSqlAccessModel.revokeUserAccess).toHaveBeenCalled();
+    });
+
+    it('requires effective admin role to mutate another principal', async () => {
+        spacePermissionService.resolveAccess.mockResolvedValue({
+            ...adminAccessContext,
+            access: [
+                {
+                    ...adminAccessContext.access[0],
+                    role: SpaceMemberRole.EDITOR,
+                },
+            ],
+        });
+
+        await expect(
+            handler.revokeUser({
+                user: adminUser,
+                projectUuid,
+                resourceUuid: savedSqlUuid,
+                userUuid: principalUserUuid,
+            }),
+        ).rejects.toThrow('Admin access is required');
+        expect(savedSqlAccessModel.revokeUserAccess).not.toHaveBeenCalled();
+    });
+
+    it('requires the current SavedChart capability for an admin grant', async () => {
+        const roleOnlyAdmin = makeUser([
+            { subject: 'SavedChart', action: 'view' },
+        ]);
+
+        await expect(
+            handler.reset({
+                user: roleOnlyAdmin,
+                projectUuid,
+                resourceUuid: savedSqlUuid,
+            }),
+        ).rejects.toThrow('Admin access is required');
+        expect(savedSqlAccessModel.resetAccess).not.toHaveBeenCalled();
+    });
+
+    it('revokes group access and resets all grants as an admin', async () => {
+        await handler.revokeGroup({
+            user: adminUser,
+            projectUuid,
+            resourceUuid: savedSqlUuid,
+            groupUuid,
+        });
+        await handler.reset({
+            user: adminUser,
+            projectUuid,
+            resourceUuid: savedSqlUuid,
+        });
+
+        expect(savedSqlAccessModel.revokeGroupAccess).toHaveBeenCalled();
+        expect(savedSqlAccessModel.resetAccess).toHaveBeenCalled();
+        expect(auditLogger).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps a missing-grant revoke idempotent without a phantom audit', async () => {
+        savedSqlAccessModel.revokeUserAccess.mockResolvedValueOnce({
+            ...mutationResult,
+            beforeRole: null,
+            afterRole: null,
+        } as never);
+
+        await handler.revokeUser({
+            user: adminUser,
+            projectUuid,
+            resourceUuid: savedSqlUuid,
+            userUuid: principalUserUuid,
+        });
+
+        expect(savedSqlAccessModel.revokeUserAccess).toHaveBeenCalled();
+        expect(auditLogger).not.toHaveBeenCalled();
+    });
+
+    it('fails closed before target lookup when the feature is disabled', async () => {
+        featureGate.isEnabledForUser.mockResolvedValue(false);
+
+        await expect(
+            handler.listAccess({
+                user: adminUser,
+                projectUuid,
+                resourceUuid: savedSqlUuid,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+        expect(savedSqlModel.getByUuid).not.toHaveBeenCalled();
+    });
+
+    it('normalizes malformed, inaccessible, and dashboard-owned targets', async () => {
+        await expect(
+            handler.listAccess({
+                user: adminUser,
+                projectUuid,
+                resourceUuid: 'not-a-uuid',
+            }),
+        ).rejects.toThrow('Access target not found');
+
+        savedSqlModel.getByUuid.mockRejectedValueOnce(new ForbiddenError());
+        await expect(
+            handler.listAccess({
+                user: adminUser,
+                projectUuid,
+                resourceUuid: savedSqlUuid,
+            }),
+        ).rejects.toThrow('Access target not found');
+
+        savedSqlModel.getByUuid.mockResolvedValueOnce({
+            ...savedSql,
+            dashboard: { uuid: 'dashboard-uuid', name: 'Dashboard' },
+        } as never);
+        await expect(
+            handler.listAccess({
+                user: adminUser,
+                projectUuid,
+                resourceUuid: savedSqlUuid,
+            }),
+        ).rejects.toThrow('Access target not found');
+    });
+});

--- a/packages/backend/src/services/DirectAccess/SavedSqlAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/SavedSqlAccessHandler.ts
@@ -1,0 +1,456 @@
+import { subject } from '@casl/ability';
+import {
+    DirectAccessOrigin,
+    ForbiddenError,
+    getHighestSpaceRole,
+    NotFoundError,
+    ParameterError,
+    SpaceMemberRole,
+    type DirectAccessGrant,
+    type DirectAccessList,
+    type DirectAccessListFilters,
+    type KnexPaginateArgs,
+    type SessionUser,
+} from '@lightdash/common';
+import { validate as isValidUuid } from 'uuid';
+import { createActorFromUser } from '../../logging/caslAuditWrapper';
+import type {
+    SavedSqlAccessModel,
+    SavedSqlDirectAccessListRow,
+    SavedSqlMutationExpectation,
+} from '../../models/SavedSqlAccessModel';
+import type { SavedSqlModel } from '../../models/SavedSqlModel';
+import { BaseService } from '../BaseService';
+import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import {
+    auditDirectAccessMutation,
+    auditDirectAccessReset,
+    type DirectAccessAuditLogger,
+} from './directAccessAudit';
+import type { DirectAccessFeatureGate } from './DirectAccessFeatureGate';
+import { type ResourceAccessHandler } from './ResourceAccessHandler';
+
+type SavedSqlAccessInput = {
+    user: SessionUser;
+    projectUuid: string;
+    resourceUuid: string;
+};
+
+type SavedSqlTarget = Awaited<ReturnType<SavedSqlModel['getByUuid']>>;
+
+const DEFAULT_ACCESS_LIST_PAGE: KnexPaginateArgs = {
+    page: 1,
+    pageSize: 100,
+};
+
+export class SavedSqlAccessHandler
+    extends BaseService
+    implements ResourceAccessHandler
+{
+    private readonly savedSqlAccessModel: SavedSqlAccessModel;
+
+    private readonly savedSqlModel: SavedSqlModel;
+
+    private readonly spacePermissionService: SpacePermissionService;
+
+    private readonly featureGate: DirectAccessFeatureGate;
+
+    private readonly auditLogger?: DirectAccessAuditLogger;
+
+    constructor({
+        savedSqlAccessModel,
+        savedSqlModel,
+        spacePermissionService,
+        featureGate,
+        auditLogger,
+    }: {
+        savedSqlAccessModel: SavedSqlAccessModel;
+        savedSqlModel: SavedSqlModel;
+        spacePermissionService: SpacePermissionService;
+        featureGate: DirectAccessFeatureGate;
+        auditLogger?: DirectAccessAuditLogger;
+    }) {
+        super();
+        this.savedSqlAccessModel = savedSqlAccessModel;
+        this.savedSqlModel = savedSqlModel;
+        this.spacePermissionService = spacePermissionService;
+        this.featureGate = featureGate;
+        this.auditLogger = auditLogger;
+    }
+
+    private async assertEnabled(user: SessionUser): Promise<void> {
+        if (
+            !(await this.featureGate.isEnabledForUser({
+                userUuid: user.userUuid,
+                organizationUuid: user.organizationUuid,
+            }))
+        ) {
+            throw new ForbiddenError('Direct access is not available');
+        }
+    }
+
+    private async resolveSavedSql(input: SavedSqlAccessInput): Promise<{
+        savedSql: SavedSqlTarget;
+        accessContext: Awaited<
+            ReturnType<SpacePermissionService['resolveAccess']>
+        >;
+    }> {
+        await this.assertEnabled(input.user);
+        if (!isValidUuid(input.resourceUuid)) {
+            throw new NotFoundError('Access target not found');
+        }
+
+        try {
+            const savedSql = await this.savedSqlModel.getByUuid(
+                input.resourceUuid,
+                { projectUuid: input.projectUuid },
+            );
+            if (savedSql.dashboard !== null) {
+                throw new NotFoundError('Access target not found');
+            }
+            const accessContext =
+                await this.spacePermissionService.resolveAccess(
+                    input.user.userUuid,
+                    {
+                        type: 'sqlChart',
+                        savedSqlUuid: savedSql.savedSqlUuid,
+                        spaceUuid: savedSql.space.uuid,
+                    },
+                );
+            const auditedAbility = this.createAuditedAbility(input.user);
+            if (
+                auditedAbility.cannot(
+                    'view',
+                    subject('SavedChart', {
+                        ...accessContext,
+                        metadata: { savedSqlUuid: savedSql.savedSqlUuid },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
+            return { savedSql, accessContext };
+        } catch (error) {
+            if (
+                error instanceof NotFoundError ||
+                error instanceof ForbiddenError ||
+                error instanceof ParameterError
+            ) {
+                throw new NotFoundError('Access target not found');
+            }
+            throw error;
+        }
+    }
+
+    private async assertAdmin(input: SavedSqlAccessInput): Promise<{
+        savedSql: SavedSqlTarget;
+        accessContext: Awaited<
+            ReturnType<SpacePermissionService['resolveAccess']>
+        >;
+    }> {
+        const resolved = await this.resolveSavedSql(input);
+        const { accessContext, savedSql } = resolved;
+        const hasAdminRole =
+            accessContext.admins.some(
+                ({ userUuid }) => userUuid === input.user.userUuid,
+            ) ||
+            accessContext.access.some(
+                ({ userUuid, role }) =>
+                    userUuid === input.user.userUuid &&
+                    role === SpaceMemberRole.ADMIN,
+            );
+        const auditedAbility = this.createAuditedAbility(input.user);
+        const hasManageCapability = auditedAbility.can(
+            'manage',
+            subject('SavedChart', {
+                ...accessContext,
+                metadata: { savedSqlUuid: savedSql.savedSqlUuid },
+            }),
+        );
+        if (!hasAdminRole || !hasManageCapability) {
+            throw new ForbiddenError('Admin access is required');
+        }
+        return resolved;
+    }
+
+    private async resolveGrants(
+        savedSql: SavedSqlTarget,
+        rows: SavedSqlDirectAccessListRow[],
+    ): Promise<DirectAccessGrant[]> {
+        const userUuids = rows.flatMap((row) =>
+            row.origin === DirectAccessOrigin.USER ? [row.principalUuid] : [],
+        );
+        if (userUuids.length === 0) {
+            return rows.map((row) => {
+                if (row.origin !== DirectAccessOrigin.GROUP) {
+                    throw new Error('Unexpected direct access principal');
+                }
+                return {
+                    principal: {
+                        type: DirectAccessOrigin.GROUP,
+                        uuid: row.principalUuid,
+                        name: row.name,
+                    },
+                    directRole: row.directRole,
+                };
+            });
+        }
+
+        const [groupRolesByUserUuid, spaceContext] = await Promise.all([
+            this.savedSqlAccessModel.getGroupRolesForUsers(
+                savedSql.savedSqlUuid,
+                userUuids,
+                savedSql.organization.organizationUuid,
+            ),
+            this.spacePermissionService.getSpaceAccessContextForUsers(
+                userUuids,
+                savedSql.space.uuid,
+            ),
+        ]);
+        const logicalRolesByUserUuid = new Map<string, SpaceMemberRole[]>();
+        for (const access of this.spacePermissionService.mergeAdminAccess(
+            spaceContext,
+        )) {
+            const roles = logicalRolesByUserUuid.get(access.userUuid) ?? [];
+            roles.push(access.role);
+            logicalRolesByUserUuid.set(access.userUuid, roles);
+        }
+        for (const { userUuid } of spaceContext.admins) {
+            const roles = logicalRolesByUserUuid.get(userUuid) ?? [];
+            roles.push(SpaceMemberRole.ADMIN);
+            logicalRolesByUserUuid.set(userUuid, roles);
+        }
+
+        return rows.map((row) => {
+            if (row.origin === DirectAccessOrigin.GROUP) {
+                return {
+                    principal: {
+                        type: DirectAccessOrigin.GROUP,
+                        uuid: row.principalUuid,
+                        name: row.name,
+                    },
+                    directRole: row.directRole,
+                };
+            }
+            return {
+                principal: {
+                    type: DirectAccessOrigin.USER,
+                    uuid: row.principalUuid,
+                    firstName: row.firstName,
+                    lastName: row.lastName,
+                    email: row.email,
+                    isInternal: row.isInternal,
+                },
+                directRole: row.directRole,
+                effectiveRole:
+                    getHighestSpaceRole([
+                        row.directRole,
+                        ...(groupRolesByUserUuid[row.principalUuid] ?? []),
+                        ...(logicalRolesByUserUuid.get(row.principalUuid) ??
+                            []),
+                    ]) ?? row.directRole,
+            };
+        });
+    }
+
+    private static getMutationExpectation(
+        savedSql: SavedSqlTarget,
+    ): SavedSqlMutationExpectation {
+        return {
+            organizationUuid: savedSql.organization.organizationUuid,
+            projectUuid: savedSql.project.projectUuid,
+            spaceUuid: savedSql.space.uuid,
+            dashboardUuid: savedSql.dashboard?.uuid ?? null,
+        };
+    }
+
+    private async getGrant(
+        savedSql: SavedSqlTarget,
+        principal: { origin: DirectAccessOrigin; uuid: string },
+    ): Promise<DirectAccessGrant> {
+        const { data } = await this.savedSqlAccessModel.getDirectAccessList(
+            savedSql.savedSqlUuid,
+            savedSql.organization.organizationUuid,
+            { principal },
+        );
+        const [grant] = await this.resolveGrants(savedSql, data);
+        if (!grant) {
+            throw new NotFoundError('Direct access grant not found');
+        }
+        return grant;
+    }
+
+    async listAccess({
+        user,
+        projectUuid,
+        resourceUuid,
+        paginateArgs,
+        filters,
+    }: SavedSqlAccessInput & {
+        paginateArgs?: KnexPaginateArgs;
+        filters?: DirectAccessListFilters;
+    }): Promise<DirectAccessList> {
+        const { savedSql } = await this.assertAdmin({
+            user,
+            projectUuid,
+            resourceUuid,
+        });
+        const { data, pagination } =
+            await this.savedSqlAccessModel.getDirectAccessList(
+                savedSql.savedSqlUuid,
+                savedSql.organization.organizationUuid,
+                {
+                    paginateArgs: paginateArgs ?? DEFAULT_ACCESS_LIST_PAGE,
+                    searchQuery: filters?.searchQuery,
+                },
+            );
+        return {
+            data: await this.resolveGrants(savedSql, data),
+            ...(pagination ? { pagination } : {}),
+        };
+    }
+
+    async replaceUserRole({
+        user,
+        projectUuid,
+        resourceUuid,
+        userUuid,
+        role,
+    }: SavedSqlAccessInput & {
+        userUuid: string;
+        role: SpaceMemberRole;
+    }): Promise<DirectAccessGrant> {
+        const { savedSql } = await this.assertAdmin({
+            user,
+            projectUuid,
+            resourceUuid,
+        });
+        const result = await this.savedSqlAccessModel.upsertUserAccess({
+            resourceUuid: savedSql.savedSqlUuid,
+            userUuid,
+            role,
+            grantedByUserUuid: user.userUuid,
+            ...SavedSqlAccessHandler.getMutationExpectation(savedSql),
+        });
+        auditDirectAccessMutation({
+            actor: createActorFromUser(user),
+            context: user.requestContext ?? {},
+            resourceType: 'SavedSql',
+            resourceUuid: savedSql.savedSqlUuid,
+            principal: { type: 'user', uuid: userUuid },
+            result,
+            auditLogger: this.auditLogger,
+        });
+        return this.getGrant(savedSql, {
+            origin: DirectAccessOrigin.USER,
+            uuid: userUuid,
+        });
+    }
+
+    async replaceGroupRole({
+        user,
+        projectUuid,
+        resourceUuid,
+        groupUuid,
+        role,
+    }: SavedSqlAccessInput & {
+        groupUuid: string;
+        role: SpaceMemberRole;
+    }): Promise<DirectAccessGrant> {
+        const { savedSql } = await this.assertAdmin({
+            user,
+            projectUuid,
+            resourceUuid,
+        });
+        const result = await this.savedSqlAccessModel.upsertGroupAccess({
+            resourceUuid: savedSql.savedSqlUuid,
+            groupUuid,
+            role,
+            grantedByUserUuid: user.userUuid,
+            ...SavedSqlAccessHandler.getMutationExpectation(savedSql),
+        });
+        auditDirectAccessMutation({
+            actor: createActorFromUser(user),
+            context: user.requestContext ?? {},
+            resourceType: 'SavedSql',
+            resourceUuid: savedSql.savedSqlUuid,
+            principal: { type: 'group', uuid: groupUuid },
+            result,
+            auditLogger: this.auditLogger,
+        });
+        return this.getGrant(savedSql, {
+            origin: DirectAccessOrigin.GROUP,
+            uuid: groupUuid,
+        });
+    }
+
+    async revokeUser({
+        user,
+        projectUuid,
+        resourceUuid,
+        userUuid,
+    }: SavedSqlAccessInput & { userUuid: string }): Promise<void> {
+        const input = { user, projectUuid, resourceUuid };
+        const { savedSql } =
+            userUuid === user.userUuid
+                ? await this.resolveSavedSql(input)
+                : await this.assertAdmin(input);
+        const result = await this.savedSqlAccessModel.revokeUserAccess({
+            resourceUuid: savedSql.savedSqlUuid,
+            userUuid,
+            ...SavedSqlAccessHandler.getMutationExpectation(savedSql),
+        });
+        auditDirectAccessMutation({
+            actor: createActorFromUser(user),
+            context: user.requestContext ?? {},
+            resourceType: 'SavedSql',
+            resourceUuid: savedSql.savedSqlUuid,
+            principal: { type: 'user', uuid: userUuid },
+            result,
+            auditLogger: this.auditLogger,
+        });
+    }
+
+    async revokeGroup({
+        user,
+        projectUuid,
+        resourceUuid,
+        groupUuid,
+    }: SavedSqlAccessInput & { groupUuid: string }): Promise<void> {
+        const { savedSql } = await this.assertAdmin({
+            user,
+            projectUuid,
+            resourceUuid,
+        });
+        const result = await this.savedSqlAccessModel.revokeGroupAccess({
+            resourceUuid: savedSql.savedSqlUuid,
+            groupUuid,
+            ...SavedSqlAccessHandler.getMutationExpectation(savedSql),
+        });
+        auditDirectAccessMutation({
+            actor: createActorFromUser(user),
+            context: user.requestContext ?? {},
+            resourceType: 'SavedSql',
+            resourceUuid: savedSql.savedSqlUuid,
+            principal: { type: 'group', uuid: groupUuid },
+            result,
+            auditLogger: this.auditLogger,
+        });
+    }
+
+    async reset(input: SavedSqlAccessInput): Promise<void> {
+        const { savedSql } = await this.assertAdmin(input);
+        const result = await this.savedSqlAccessModel.resetAccess({
+            resourceUuid: savedSql.savedSqlUuid,
+            ...SavedSqlAccessHandler.getMutationExpectation(savedSql),
+        });
+        auditDirectAccessReset({
+            actor: createActorFromUser(input.user),
+            context: input.user.requestContext ?? {},
+            resourceType: 'SavedSql',
+            resourceUuid: savedSql.savedSqlUuid,
+            result,
+            auditLogger: this.auditLogger,
+        });
+    }
+}

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -545,6 +545,22 @@ export class SpacePermissionService extends BaseService {
         return ctx;
     }
 
+    async getSpaceAccessContextForUsers(
+        userUuids: string[],
+        spaceUuid: string,
+    ): Promise<SpaceAccessContextForCasl> {
+        const accessContext = await this.getSpacesCaslContext([spaceUuid], {
+            userUuids,
+        });
+        const ctx = accessContext[spaceUuid];
+        if (!ctx) {
+            throw new NotFoundError(
+                `Couldn't find access context for space ${spaceUuid}`,
+            );
+        }
+        return ctx;
+    }
+
     mergeAdminAccess(ctx: SpaceAccessContextForCasl): SpaceAccess[] {
         const existingAccessUuids = new Set(
             ctx.access.map((access) => access.userUuid),

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -122,6 +122,7 @@ export * from './types/content';
 export * from './types/contentSlug';
 export * from './types/contentVerification';
 export * from './types/dashboard';
+export * from './types/directAccess';
 export * from './types/emailWhitelabel';
 export * from './types/dataTimezonePreview';
 export * from './types/fieldImpact';

--- a/packages/common/src/types/directAccess.ts
+++ b/packages/common/src/types/directAccess.ts
@@ -1,0 +1,40 @@
+import { type KnexPaginatedData } from './knex-paginate';
+import { type SpaceMemberRole } from './space';
+
+export enum DirectAccessOrigin {
+    USER = 'user',
+    GROUP = 'group',
+}
+
+export type DirectAccessUserPrincipal = {
+    type: DirectAccessOrigin.USER;
+    uuid: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    isInternal: boolean;
+};
+
+export type DirectAccessGroupPrincipal = {
+    type: DirectAccessOrigin.GROUP;
+    uuid: string;
+    name: string;
+};
+
+export type DirectAccessGrant =
+    | {
+          principal: DirectAccessUserPrincipal;
+          directRole: SpaceMemberRole;
+          /** Highest additive role before capability scopes are applied. */
+          effectiveRole: SpaceMemberRole;
+      }
+    | {
+          principal: DirectAccessGroupPrincipal;
+          directRole: SpaceMemberRole;
+      };
+
+export type DirectAccessListFilters = {
+    searchQuery?: string;
+};
+
+export type DirectAccessList = KnexPaginatedData<DirectAccessGrant[]>;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1469/stack-3b-apply-direct-access-to-saved-sql-charts

## Summary

PR 3 of 3 for [SPK-1469](https://linear.app/lightdash/issue/SPK-1469/stack-3b-apply-direct-access-to-saved-sql-charts). Adds the tenant-safe saved SQL grant administration model and concrete handler behind the shared direct-access controller contract.

Stacks on top of PR 2 ([#28214](https://github.com/lightdash/lightdash/pull/28214)), which applies direct access to lifecycle and asynchronous execution.

## Changes

- Lists, grants, updates, revokes, and resets user/group access.
- Revalidates the authorized organization, project, space, ownership, and principal under transaction locks.
- Computes effective roles from current direct and group access while preserving admin standing.
- Records direct-access audit events and supports self-revoke.
- Keeps dashboard-owned saved SQL charts ineligible for grants.

## Mutation flow

```text
request ──> feature + delegation checks ──> lock target + principal
                                                   │
                                                   └──> mutate + audit
```

## Notes

The HTTP route remains in Stack 5's shared controller. This PR provides the saved SQL handler for that contract and does not extend legacy SQL Runner routes.

## Test plan

- [x] Saved SQL access model and handler tests
- [x] PostgreSQL integration: 5 tests
- [x] Verifies immediate loss after group membership, project-group access, or direct project membership removal
- [x] Backend typecheck, lint, and format checks