### PR TITLE
test(ai-agent): add pending writeback story

### DIFF
--- a/packages/frontend/src/stories/WritebackPrCard.stories.tsx
+++ b/packages/frontend/src/stories/WritebackPrCard.stories.tsx
@@ -7,16 +7,28 @@ import {
 import { Box, Button, Group, Paper, Stack, Text } from '@mantine/core';
 import '@mantine/core/styles.css';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { useState, type FC, type ReactNode } from 'react';
-import { PullRequestActionButtons } from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import {
+    AiEditDbtProjectToolCall,
+    PullRequestActionButtons,
+} from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall';
 import styles from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.module.css';
 import { PullRequestCiChecks } from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/PullRequestCiChecks';
+import { store } from '../ee/features/aiCopilot/store';
+import { AiAgentThreadStreamAbortControllerContextProvider } from '../ee/features/aiCopilot/streaming/AiAgentThreadStreamAbortControllerContextProvider';
 import MantineBaseProvider from '../providers/MantineBaseProvider';
+import { createQueryClient } from '../providers/ReactQuery/createQueryClient';
+import AppProviderMock from '../testing/__mocks__/providers/AppProvider.mock';
 
 const DEMO_PR_URL = 'https://github.com/charliedowler/jaffle/pull/1';
+const PROJECT_UUID = '3675b69e-8324-4110-bdca-059031aa8da3';
 
 const MERGE_LATENCY_MS = 1200;
 const CLOSE_LATENCY_MS = 1000;
+const storyQueryClient = createQueryClient();
 
 const makeCiChecks = (overrides: Partial<CiChecks>): CiChecks => ({
     provider: CiProviderType.GITHUB,
@@ -173,6 +185,32 @@ const meta: Meta = {
 export default meta;
 
 type Story = StoryObj;
+
+export const WorkingOnChange: Story = {
+    render: () => (
+        <QueryClientProvider client={storyQueryClient}>
+            <AppProviderMock>
+                <Provider store={store}>
+                    <AiAgentThreadStreamAbortControllerContextProvider>
+                        <MemoryRouter>
+                            <Stack w={560} p="md">
+                                <AiEditDbtProjectToolCall
+                                    metadata={{
+                                        status: 'pending',
+                                        aiWritebackRunUuid:
+                                            'story-writeback-run',
+                                    }}
+                                    projectUuid={PROJECT_UUID}
+                                    isPreviewDeploySetup={false}
+                                />
+                            </Stack>
+                        </MemoryRouter>
+                    </AiAgentThreadStreamAbortControllerContextProvider>
+                </Provider>
+            </AppProviderMock>
+        </QueryClientProvider>
+    ),
+};
 
 export const InteractiveMergeFlow: Story = {
     render: () => <InteractiveDemo />,


### PR DESCRIPTION
### Description

Adds Storybook coverage for the pending writeback state using the production `AiEditDbtProjectToolCall` and the standard agent chat provider stack.

### Verification

- `agent-browser`: story renders the pending card with no page errors
- frontend lint
- formatting check

### Risk assessment

- [ ] This is a high-risk change

Story-only change. No production behavior changed.

Relates: ZAP-950
