### PR TITLE
fix(ai-agent): keep composer enabled during background work

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/WorkspaceThreadPane.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/WorkspaceThreadPane.tsx
@@ -53,7 +53,7 @@ export const WorkspaceThreadPane: FC<Props> = ({
         refetch,
     } = useAiAgentThread(projectUuid, agentUuid, threadUuid);
 
-    const { isStreaming, isPending } = usePendingThreadRefetch(
+    const { isStreaming, isThreadPending } = usePendingThreadRefetch(
         thread,
         threadUuid,
         refetch,
@@ -129,7 +129,7 @@ export const WorkspaceThreadPane: FC<Props> = ({
         >
             {interactive ? (
                 <AgentChatInput
-                    loading={isCreating || isStreaming || isPending}
+                    loading={isCreating || isStreaming || isThreadPending}
                     onSubmit={handleSubmit}
                     placeholder={
                         placeholder ?? `Ask ${agentName} to refine the PR…`

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -478,7 +478,7 @@ const ExistingThreadPanel: FC<{
         refetch,
     } = useAiAgentThread(projectUuid, agent.uuid, threadId);
 
-    const { isStreaming, isPending } = usePendingThreadRefetch(
+    const { isStreaming, isThreadPending } = usePendingThreadRefetch(
         thread,
         threadId,
         refetch,
@@ -536,7 +536,7 @@ const ExistingThreadPanel: FC<{
     const isBusy = Boolean(
         isCreatingMessage ||
         isStreaming ||
-        isPending ||
+        isThreadPending ||
         startDeepResearch.isLoading,
     );
     const isInputDisabled =

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx
@@ -100,7 +100,30 @@ describe('usePendingThreadRefetch', () => {
             ),
         );
 
-        expect(result.current.isPending).toBe(false);
+        expect(result.current.isBackgroundWorkPending).toBe(false);
+    });
+
+    it('polls pending background work without marking the thread pending', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-11T12:00:00.000Z'));
+        const refetch = vi.fn().mockResolvedValue({ isError: false });
+
+        const { result } = renderHook(() =>
+            usePendingThreadRefetch(
+                pendingThread('2026-08-11T12:00:00.001Z'),
+                'thread-1',
+                refetch,
+            ),
+        );
+
+        expect(result.current.isThreadPending).toBe(false);
+        expect(result.current.isBackgroundWorkPending).toBe(true);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5_000);
+        });
+
+        expect(refetch).toHaveBeenCalledOnce();
     });
 
     it('polls a pending thread while recovering its connection', async () => {
@@ -109,7 +132,12 @@ describe('usePendingThreadRefetch', () => {
         const refetch = vi.fn().mockResolvedValue({ isError: false });
         const thread = threadWithAssistantStatus('pending');
 
-        renderHook(() => usePendingThreadRefetch(thread, 'thread-1', refetch));
+        const { result } = renderHook(() =>
+            usePendingThreadRefetch(thread, 'thread-1', refetch),
+        );
+
+        expect(result.current.isThreadPending).toBe(true);
+        expect(result.current.isBackgroundWorkPending).toBe(false);
 
         await act(async () => {
             await vi.advanceTimersByTimeAsync(5_000);
@@ -149,6 +177,24 @@ describe('usePendingThreadRefetch', () => {
         );
     });
 
+    it('does not keep recovery active for pending background work', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-11T12:00:00.000Z'));
+        streamState.recovering = true;
+
+        renderHook(() =>
+            usePendingThreadRefetch(
+                pendingThread('2026-08-11T12:00:00.001Z'),
+                'thread-1',
+                vi.fn(),
+            ),
+        );
+
+        expect(dispatchMock).toHaveBeenCalledWith(
+            stopStreaming({ threadUuid: 'thread-1' }),
+        );
+    });
+
     it('refetches once more before expiring an active writeback', async () => {
         vi.useFakeTimers();
         vi.setSystemTime(new Date('2026-08-11T12:00:00.000Z'));
@@ -162,12 +208,12 @@ describe('usePendingThreadRefetch', () => {
             ),
         );
 
-        expect(result.current.isPending).toBe(true);
+        expect(result.current.isBackgroundWorkPending).toBe(true);
 
         await act(async () => {
             await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
         });
-        expect(result.current.isPending).toBe(true);
+        expect(result.current.isBackgroundWorkPending).toBe(true);
         refetch.mockClear();
 
         await act(async () => {
@@ -175,6 +221,6 @@ describe('usePendingThreadRefetch', () => {
         });
 
         expect(refetch).toHaveBeenCalledTimes(1);
-        expect(result.current.isPending).toBe(false);
+        expect(result.current.isBackgroundWorkPending).toBe(false);
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.ts
@@ -57,14 +57,16 @@ export const usePendingThreadRefetch = (
     const isRecoveryActive = useAiAgentThreadRecoveryActive(threadUuid);
     const [expirationClock, setExpirationClock] = useState(0);
     const pendingWritebackExpiresAt = getPendingWritebackExpiresAt(thread);
-    const hasPendingWriteback =
+    const isBackgroundWorkPending =
         pendingWritebackExpiresAt !== null &&
         pendingWritebackExpiresAt > Math.max(Date.now(), expirationClock);
-    const isPending =
+    const isThreadPending = Boolean(
         thread?.messages?.some(
             (message) =>
                 message.role === 'assistant' && message.status === 'pending',
-        ) || hasPendingWriteback;
+        ),
+    );
+    const shouldPoll = isThreadPending || isBackgroundWorkPending;
 
     useEffect(() => {
         if (pendingWritebackExpiresAt === null) {
@@ -89,7 +91,7 @@ export const usePendingThreadRefetch = (
     }, [pendingWritebackExpiresAt, refetch]);
 
     useEffect(() => {
-        if (!isPending || isStreaming) return;
+        if (!shouldPoll || isStreaming) return;
 
         const pollThread = async () => {
             try {
@@ -107,18 +109,18 @@ export const usePendingThreadRefetch = (
         return () => clearInterval(interval);
     }, [
         dispatch,
-        isPending,
         isRecoveryActive,
         isStreaming,
         refetch,
+        shouldPoll,
         threadUuid,
     ]);
 
     useEffect(() => {
-        if (thread !== undefined && isRecoveryActive && !isPending) {
+        if (thread !== undefined && isRecoveryActive && !isThreadPending) {
             dispatch(stopStreaming({ threadUuid }));
         }
-    }, [dispatch, isPending, isRecoveryActive, thread, threadUuid]);
+    }, [dispatch, isRecoveryActive, isThreadPending, thread, threadUuid]);
 
-    return { isStreaming, isPending };
+    return { isStreaming, isThreadPending, isBackgroundWorkPending };
 };

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -161,7 +161,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         },
     );
 
-    const { isStreaming, isPending } = usePendingThreadRefetch(
+    const { isStreaming, isThreadPending } = usePendingThreadRefetch(
         thread,
         threadUuid!,
         refetch,
@@ -354,7 +354,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const isBusy = Boolean(
         isCreatingMessage ||
         isStreaming ||
-        isPending ||
+        isThreadPending ||
         startDeepResearch.isLoading,
     );
     const retryPrompt = reviewItem?.remediation?.retryPrompt ?? null;


### PR DESCRIPTION
## Summary

- separate thread-pending from background-work-pending
- keep background polling without disabling the composer
- end stream recovery once the thread turn finishes

## Tests

- pnpm -F frontend test src/ee/features/aiCopilot/hooks/usePendingThreadRefetch.test.tsx
- pnpm -F frontend typecheck

Closes: ZAP-960