### PR TITLE
fix: support Athena personal warehouse credentials

### DIFF
--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.test.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.test.ts
@@ -188,6 +188,44 @@ describe('UserWarehouseCredentialsModel', () => {
         });
     });
 
+    describe('mergeCredentialsForUpdate', () => {
+        const existingCredentials = {
+            type: WarehouseTypes.ATHENA,
+            accessKeyId: 'existing-access-key',
+            secretAccessKey: 'existing-secret-key',
+        } as const;
+
+        test('preserves the Athena secret when the access key ID is unchanged', () => {
+            expect(
+                UserWarehouseCredentialsModel.mergeCredentialsForUpdate(
+                    {
+                        name: 'Renamed',
+                        credentials: {
+                            type: WarehouseTypes.ATHENA,
+                            accessKeyId: 'existing-access-key',
+                        },
+                    },
+                    existingCredentials,
+                ).credentials,
+            ).toEqual(existingCredentials);
+        });
+
+        test('requires the Athena secret when the access key ID changes', () => {
+            expect(() =>
+                UserWarehouseCredentialsModel.mergeCredentialsForUpdate(
+                    {
+                        name: 'Renamed',
+                        credentials: {
+                            type: WarehouseTypes.ATHENA,
+                            accessKeyId: 'new-access-key',
+                        },
+                    },
+                    existingCredentials,
+                ),
+            ).toThrow(ParameterError);
+        });
+    });
+
     describe('findForProjectWithSecrets', () => {
         test('returns the preferred credential when it is valid', async () => {
             const model = createModel({

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -117,10 +117,15 @@ export class UserWarehouseCredentialsModel {
                     break;
                 case WarehouseTypes.BIGQUERY:
                 case WarehouseTypes.DATABRICKS:
-                case WarehouseTypes.ATHENA:
                 case WarehouseTypes.DUCKDB:
                     credentials = {
                         type: credentialsWithSecrets.type,
+                    };
+                    break;
+                case WarehouseTypes.ATHENA:
+                    credentials = {
+                        type: credentialsWithSecrets.type,
+                        accessKeyId: credentialsWithSecrets.accessKeyId,
                     };
                     break;
                 default:
@@ -583,6 +588,43 @@ export class UserWarehouseCredentialsModel {
         return data;
     }
 
+    static mergeCredentialsForUpdate(
+        data: UpsertUserWarehouseCredentials,
+        existingCredentials: UserWarehouseCredentialsWithSecrets['credentials'],
+    ): UpsertUserWarehouseCredentials {
+        if (
+            data.credentials.type !== WarehouseTypes.ATHENA ||
+            data.credentials.secretAccessKey
+        ) {
+            return data;
+        }
+
+        if (existingCredentials.type !== WarehouseTypes.ATHENA) {
+            throw new ParameterError(
+                'Athena credentials require an AWS secret access key.',
+            );
+        }
+
+        const submittedAccessKeyId = data.credentials.accessKeyId?.trim();
+        if (
+            submittedAccessKeyId &&
+            submittedAccessKeyId !== existingCredentials.accessKeyId
+        ) {
+            throw new ParameterError(
+                'Enter the AWS secret access key when changing the access key ID.',
+            );
+        }
+
+        return {
+            ...data,
+            credentials: {
+                ...data.credentials,
+                accessKeyId: existingCredentials.accessKeyId,
+                secretAccessKey: existingCredentials.secretAccessKey,
+            },
+        };
+    }
+
     async create(
         userUuid: string,
         data: UpsertUserWarehouseCredentials,
@@ -621,9 +663,37 @@ export class UserWarehouseCredentialsModel {
         userWarehouseCredentialsUuid: string,
         data: UpsertUserWarehouseCredentials,
     ): Promise<string> {
+        let dataToPersist = data;
+        if (
+            data.credentials.type === WarehouseTypes.ATHENA &&
+            !data.credentials.secretAccessKey
+        ) {
+            const existingRow = await this.database(
+                UserWarehouseCredentialsTableName,
+            )
+                .where(
+                    'user_warehouse_credentials_uuid',
+                    userWarehouseCredentialsUuid,
+                )
+                .andWhere('user_uuid', userUuid)
+                .first();
+
+            if (!existingRow) {
+                throw new UnexpectedServerError('Could not save credentials.');
+            }
+
+            dataToPersist =
+                UserWarehouseCredentialsModel.mergeCredentialsForUpdate(
+                    data,
+                    this.convertToUserWarehouseCredentialsWithSecrets(
+                        existingRow,
+                    ).credentials,
+                );
+        }
+
         const normalized =
             UserWarehouseCredentialsModel.normalizeCredentialsForPersistence(
-                data,
+                dataToPersist,
             );
         let encryptedCredentials: Buffer;
         try {

--- a/packages/common/src/types/userWarehouseCredentials.ts
+++ b/packages/common/src/types/userWarehouseCredentials.ts
@@ -46,7 +46,7 @@ export type UserWarehouseCredentials = {
           >
         | Pick<CreateBigqueryCredentials, 'type'>
         | Pick<CreateDatabricksCredentials, 'type'>
-        | Pick<CreateAthenaCredentials, 'type'>
+        | Pick<CreateAthenaCredentials, 'type' | 'accessKeyId'>
         | Pick<CreateDuckdbCredentials, 'type'>;
     project: UserWarehouseCredentialsProject | null;
 };

--- a/packages/e2e/cypress/e2e/app/settings/warehouseConnections.cy.ts
+++ b/packages/e2e/cypress/e2e/app/settings/warehouseConnections.cy.ts
@@ -1,0 +1,139 @@
+const CREDENTIALS_NAME = 'Athena test';
+const UPDATED_CREDENTIALS_NAME = `${CREDENTIALS_NAME} updated`;
+
+type WarehouseCredentialsResponse = {
+    status: 'ok';
+    results: {
+        uuid: string;
+        name: string;
+        credentials: {
+            type: string;
+            accessKeyId?: string;
+            secretAccessKey?: string;
+        };
+    }[];
+};
+
+const openCredentialsMenu = (name: string) =>
+    cy
+        .findByRole('row', {
+            name: `${name} Athena All projects`,
+        })
+        .should('be.visible')
+        .within(() => cy.findByRole('button').click());
+
+const cleanupTestCredentials = () =>
+    cy
+        .request<WarehouseCredentialsResponse>(
+            'GET',
+            'api/v1/user/warehouseCredentials',
+        )
+        .then(({ body }) => {
+            const testCredentials = body.results.filter(({ name }) =>
+                [CREDENTIALS_NAME, UPDATED_CREDENTIALS_NAME].includes(name),
+            );
+
+            cy.wrap(testCredentials).each(({ uuid }) =>
+                cy.request(
+                    'DELETE',
+                    `api/v1/user/warehouseCredentials/${uuid}`,
+                ),
+            );
+        });
+
+describe('Settings - Warehouse connections', () => {
+    beforeEach(() => {
+        cy.login();
+        cleanupTestCredentials();
+    });
+
+    afterEach(() => {
+        cleanupTestCredentials();
+    });
+
+    it('creates and edits Athena personal credentials', () => {
+        cy.visit('/generalSettings/myWarehouseConnections');
+        cy.findByRole('button', { name: 'Add credentials' }).click();
+
+        cy.findByRole('dialog').within(() => {
+            cy.findByRole('textbox', { name: 'Name' }).type(CREDENTIALS_NAME);
+            cy.findByRole('textbox', { name: 'Warehouse' }).click();
+        });
+        cy.findByRole('option', { name: 'Athena' }).click();
+
+        cy.findByRole('dialog').within(() => {
+            cy.findByRole('textbox', { name: 'AWS access key ID' })
+                .should('be.visible')
+                .type('dummy-athena-access-key');
+            cy.findByLabelText(/AWS secret access key/)
+                .should('be.visible')
+                .type('dummy-athena-secret-key');
+            cy.findByRole('button', { name: 'Save' }).click();
+        });
+
+        cy.findByText('Success! Warehouse connection was created.').should(
+            'be.visible',
+        );
+        openCredentialsMenu(CREDENTIALS_NAME);
+
+        cy.findByRole('menuitem', { name: 'Edit' }).click();
+        cy.findByRole('dialog').within(() => {
+            cy.findByRole('textbox', { name: 'Name' })
+                .should('have.value', CREDENTIALS_NAME)
+                .clear()
+                .type(UPDATED_CREDENTIALS_NAME);
+            cy.findByRole('textbox', { name: 'AWS access key ID' }).should(
+                'have.value',
+                'dummy-athena-access-key',
+            );
+            cy.findByLabelText(/AWS secret access key/).should(
+                'have.value',
+                '',
+            );
+            cy.findByText(
+                'Leave blank to keep the current secret access key.',
+            ).should('be.visible');
+            cy.findByRole('button', { name: 'Save' }).click();
+        });
+
+        cy.findByText('Success! Warehouse connection was updated.').should(
+            'be.visible',
+        );
+        cy.findByRole('row', {
+            name: `${UPDATED_CREDENTIALS_NAME} Athena All projects`,
+        }).should('be.visible');
+
+        openCredentialsMenu(UPDATED_CREDENTIALS_NAME);
+        cy.findByRole('menuitem', { name: 'Edit' }).click();
+        cy.findByRole('dialog').within(() => {
+            cy.findByRole('textbox', { name: 'AWS access key ID' })
+                .should('have.value', 'dummy-athena-access-key')
+                .clear()
+                .type('updated-dummy-athena-access-key');
+            cy.findByRole('button', { name: 'Save' }).click();
+            cy.findByText(
+                'Enter the AWS secret access key for this access key ID.',
+            ).should('be.visible');
+            cy.findByLabelText(/AWS secret access key/).type(
+                'updated-dummy-athena-secret-key',
+            );
+            cy.findByRole('button', { name: 'Save' }).click();
+        });
+
+        cy.findByText('Success! Warehouse connection was updated.').should(
+            'be.visible',
+        );
+        cy.request<WarehouseCredentialsResponse>(
+            'GET',
+            'api/v1/user/warehouseCredentials',
+        ).then(({ body }) => {
+            const updated = body.results.find(
+                ({ name }) => name === UPDATED_CREDENTIALS_NAME,
+            );
+            expect(updated?.credentials).to.deep.equal({
+                type: 'athena',
+                accessKeyId: 'updated-dummy-athena-access-key',
+            });
+        });
+    });
+});

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
@@ -82,7 +82,6 @@ const getCredentialsWithPlaceholders = (
         case WarehouseTypes.ATHENA:
             return {
                 ...credentials,
-                accessKeyId: '',
                 secretAccessKey: '',
             };
         case WarehouseTypes.DUCKDB:
@@ -116,7 +115,11 @@ export const EditCredentialsModal: FC<
                 isDatabricksSsoEnabled,
             ),
         },
-        validate: validateUserWarehouseCredentials,
+        validate: (values) =>
+            validateUserWarehouseCredentials(
+                values,
+                userCredentials.credentials,
+            ),
     });
 
     // SSO-based credentials are only ever set through their OAuth popup. They
@@ -152,7 +155,16 @@ export const EditCredentialsModal: FC<
             <form
                 id={FORM_ID}
                 onSubmit={form.onSubmit(async (formData) => {
-                    await mutateAsync(formData);
+                    if (
+                        formData.credentials.type === WarehouseTypes.ATHENA &&
+                        !formData.credentials.secretAccessKey
+                    ) {
+                        const { secretAccessKey: _, ...credentials } =
+                            formData.credentials;
+                        await mutateAsync({ ...formData, credentials });
+                    } else {
+                        await mutateAsync(formData);
+                    }
                     onClose();
                 })}
             >
@@ -169,6 +181,12 @@ export const EditCredentialsModal: FC<
                         onClose={onClose}
                         form={form}
                         disabled={isSaving}
+                        existingAthenaAccessKeyId={
+                            userCredentials.credentials.type ===
+                            WarehouseTypes.ATHENA
+                                ? userCredentials.credentials.accessKeyId
+                                : undefined
+                        }
                     />
                 </Stack>
             </form>

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -520,6 +520,7 @@ export const WarehouseFormInputs: FC<{
     projectUuid?: string;
     projectName?: string;
     databricksCredentialsName?: string;
+    existingAthenaAccessKeyId?: string;
 }> = ({
     form,
     disabled,
@@ -528,6 +529,7 @@ export const WarehouseFormInputs: FC<{
     projectUuid,
     projectName,
     databricksCredentialsName,
+    existingAthenaAccessKeyId,
 }) => {
     const { data: project } = useProject(projectUuid, {
         enabled:
@@ -679,6 +681,34 @@ export const WarehouseFormInputs: FC<{
                     projectName={projectName}
                     credentialsName={databricksCredentialsName}
                 />
+            );
+        case WarehouseTypes.ATHENA:
+            const accessKeyId = form.values.credentials.accessKeyId?.trim();
+            const isSecretAccessKeyRequired =
+                !existingAthenaAccessKeyId ||
+                accessKeyId !== existingAthenaAccessKeyId;
+            return (
+                <>
+                    <TextInput
+                        required
+                        size="xs"
+                        label="AWS access key ID"
+                        disabled={disabled}
+                        {...form.getInputProps('credentials.accessKeyId')}
+                    />
+                    <PasswordInput
+                        withAsterisk={isSecretAccessKeyRequired}
+                        size="xs"
+                        label="AWS secret access key"
+                        description={
+                            isSecretAccessKeyRequired
+                                ? undefined
+                                : 'Leave blank to keep the current secret access key.'
+                        }
+                        disabled={disabled}
+                        {...form.getInputProps('credentials.secretAccessKey')}
+                    />
+                </>
             );
         case WarehouseTypes.DUCKDB:
             return (

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/utils.ts
@@ -3,6 +3,7 @@ import {
     SnowflakeAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
+    type UserWarehouseCredentials,
 } from '@lightdash/common';
 import { type FormErrors } from '@mantine/form';
 
@@ -10,6 +11,8 @@ import { type FormErrors } from '@mantine/form';
 export const PRIVATE_KEY_FIELD_PATH = 'credentials.privateKey';
 const USER_FIELD_PATH = 'credentials.user';
 const PASSWORD_FIELD_PATH = 'credentials.password';
+const ACCESS_KEY_ID_FIELD_PATH = 'credentials.accessKeyId';
+const SECRET_ACCESS_KEY_FIELD_PATH = 'credentials.secretAccessKey';
 
 /**
  * "Sign in with Databricks" (OAuth U2M) is enterprise-only, so instances
@@ -59,8 +62,30 @@ export const getDefaultSnowflakeAuthenticationType = (
  */
 export const validateUserWarehouseCredentials = (
     values: UpsertUserWarehouseCredentials,
+    existingCredentials?: UserWarehouseCredentials['credentials'],
 ): FormErrors => {
     const { credentials } = values;
+    if (credentials.type === WarehouseTypes.ATHENA) {
+        const errors: FormErrors = {};
+        const accessKeyId = credentials.accessKeyId?.trim();
+        if (!accessKeyId) {
+            errors[ACCESS_KEY_ID_FIELD_PATH] = 'Enter your AWS access key ID.';
+        }
+
+        const existingAccessKeyId =
+            existingCredentials?.type === WarehouseTypes.ATHENA
+                ? existingCredentials.accessKeyId
+                : undefined;
+        if (
+            (!existingAccessKeyId || accessKeyId !== existingAccessKeyId) &&
+            !credentials.secretAccessKey
+        ) {
+            errors[SECRET_ACCESS_KEY_FIELD_PATH] =
+                'Enter the AWS secret access key for this access key ID.';
+        }
+        return errors;
+    }
+
     if (credentials.type !== WarehouseTypes.SNOWFLAKE) return {};
 
     const { authenticationType } = credentials;


### PR DESCRIPTION
Closes #20968

### Description:

- render AWS access key ID and secret access key inputs for Athena personal credentials
- prefill the saved access key ID while keeping the secret redacted and preserving it during metadata-only edits
- require a new secret when replacing the access key ID
- cover create, rename, credential replacement, and response redaction in one Cypress flow

### Verification:

- pnpm -F common typecheck
- pnpm -F backend typecheck
- pnpm -F frontend typecheck
- pnpm -F backend exec vitest run --config vitest.config.ts src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.test.ts
- package lint and formatting checks for common, backend, frontend, and e2e
- pnpm generate-api
- Chrome Cypress spec: warehouseConnections.cy.ts, 1 passing
- manually verified the existing Athena edit form on localhost:3000

An actual Athena/Lake Formation query was not run because this local environment has no live Athena project; the E2E covers the credential UI, API, persistence path, and secret redaction.

### Risk assessment:

Low risk and limited to Athena personal credential CRUD. The authenticated response now includes the access key ID so it can be edited, but never returns the secret access key. The blank-secret preservation path is Athena-only.

- [ ] This is a high-risk change