### PR TITLE
feat: persist project chart type version pins

### DIFF
--- a/packages/backend/src/controllers/savedChartController.openapi.test.ts
+++ b/packages/backend/src/controllers/savedChartController.openapi.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import swagger from '../generated/swagger.json';
+
+describe('saved chart OpenAPI contract', () => {
+    it('validates project chart type versions as positive integers', () => {
+        const { dataAppVizVersion } = (
+            swagger.components.schemas.DataAppVizChart as {
+                properties: Record<string, unknown>;
+            }
+        ).properties;
+
+        expect(dataAppVizVersion).toMatchObject({
+            type: 'integer',
+            format: 'int32',
+            minimum: 1,
+        });
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7589,24 +7589,36 @@ export class AppGenerateService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         appUuids: string[],
-    ): Promise<{ sourceAppUuid: string; upstreamAppUuid: string }[]> {
+    ): Promise<
+        {
+            sourceAppUuid: string;
+            upstreamAppUuid: string;
+            upstreamAppVersion: number;
+        }[]
+    > {
         if (appUuids.length === 0) {
             return [];
         }
         await this.assertDataAppsEnabled(user);
 
-        const results: { sourceAppUuid: string; upstreamAppUuid: string }[] =
-            [];
+        const results: {
+            sourceAppUuid: string;
+            upstreamAppUuid: string;
+            upstreamAppVersion: number;
+        }[] = [];
         /* eslint-disable no-await-in-loop */
         for (const appUuid of appUuids) {
             const sourceApp = await this.appModel.findApp(appUuid, projectUuid);
             if (sourceApp) {
-                const { appUuid: upstreamAppUuid } = await this.promoteApp(
-                    user,
-                    projectUuid,
-                    appUuid,
-                );
-                results.push({ sourceAppUuid: appUuid, upstreamAppUuid });
+                const {
+                    appUuid: upstreamAppUuid,
+                    version: upstreamAppVersion,
+                } = await this.promoteApp(user, projectUuid, appUuid);
+                results.push({
+                    sourceAppUuid: appUuid,
+                    upstreamAppUuid,
+                    upstreamAppVersion,
+                });
             }
         }
         /* eslint-enable no-await-in-loop */
@@ -7868,12 +7880,15 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        const mappings: { sourceAppUuid: string; previewAppUuid: string }[] =
-            [];
+        const mappings: {
+            sourceAppUuid: string;
+            previewAppUuid: string;
+            previewAppVersion: number;
+        }[] = [];
 
         /* eslint-disable no-await-in-loop */
         for (const sourceApp of sourceApps) {
-            const previewAppUuid = await this.copyAppForPreview(
+            const previewApp = await this.copyAppForPreview(
                 sourceApp,
                 sourceProjectUuid,
                 previewProjectUuid,
@@ -7883,10 +7898,11 @@ export class AppGenerateService extends BaseService {
                 s3Client,
                 bucket,
             );
-            if (previewAppUuid) {
+            if (previewApp) {
                 mappings.push({
                     sourceAppUuid: sourceApp.app_id,
-                    previewAppUuid,
+                    previewAppUuid: previewApp.appUuid,
+                    previewAppVersion: previewApp.version,
                 });
             }
         }
@@ -7926,7 +7942,7 @@ export class AppGenerateService extends BaseService {
         connectionUuidMap: Map<string, string>,
         s3Client: S3Client,
         bucket: string,
-    ): Promise<string | null> {
+    ): Promise<{ appUuid: string; version: number } | null> {
         const sourceVersion = await this.appModel.getLatestReadyVersion(
             sourceApp.app_id,
         );
@@ -8062,7 +8078,7 @@ export class AppGenerateService extends BaseService {
             return null;
         }
 
-        return newAppUuid;
+        return { appUuid: newAppUuid, version: newVersion };
     }
 
     async cancelVersion(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -411,5 +411,17 @@ describe('version metadata propagation on app copy paths', () => {
             undefined, // no declared dependencies
             VIZ_SCHEMA,
         );
+        const previewAppUuid =
+            appModel.createWithVersion.mock.calls[0][0].app_id;
+        expect(appModel.remapPreviewChartVizBindings).toHaveBeenCalledWith(
+            PREVIEW_PROJECT_UUID,
+            [
+                {
+                    sourceAppUuid: SOURCE_APP_UUID,
+                    previewAppUuid,
+                    previewAppVersion: 1,
+                },
+            ],
+        );
     });
 });

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1207,7 +1207,11 @@ export class AppModel {
      */
     async remapPreviewChartVizBindings(
         previewProjectUuid: string,
-        mappings: { sourceAppUuid: string; previewAppUuid: string }[],
+        mappings: {
+            sourceAppUuid: string;
+            previewAppUuid: string;
+            previewAppVersion: number;
+        }[],
     ): Promise<void> {
         if (mappings.length === 0) {
             return;
@@ -1247,7 +1251,11 @@ export class AppModel {
             .select(`${SavedChartsTableName}.saved_query_id`);
 
         /* eslint-disable no-await-in-loop */
-        for (const { sourceAppUuid, previewAppUuid } of mappings) {
+        for (const {
+            sourceAppUuid,
+            previewAppUuid,
+            previewAppVersion,
+        } of mappings) {
             await this.database(SavedChartVersionsTableName)
                 .where('chart_type', ChartType.DATA_APP_VIZ)
                 .whereRaw(`chart_config->>'dataAppVizUuid' = ?`, [
@@ -1260,8 +1268,13 @@ export class AppModel {
                 })
                 .update({
                     chart_config: this.database.raw(
-                        `jsonb_set(chart_config, '{dataAppVizUuid}', to_jsonb(?::text))`,
-                        [previewAppUuid],
+                        `jsonb_set(
+                            jsonb_set(chart_config, '{dataAppVizUuid}', to_jsonb(?::text)),
+                            '{dataAppVizVersion}',
+                            to_jsonb(?::integer),
+                            true
+                        )`,
+                        [previewAppUuid, previewAppVersion],
                     ) as unknown as ChartConfig['config'],
                 });
         }

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -1840,6 +1840,7 @@ describe('CoderService', () => {
                         type: ChartType.DATA_APP_VIZ,
                         config: {
                             dataAppVizUuid: 'viz-uuid',
+                            dataAppVizVersion: 4,
                             fieldMapping: {},
                         },
                     },
@@ -1882,13 +1883,21 @@ describe('CoderService', () => {
         const buildResolver = ({
             findAppsBySlugs = vi.fn().mockResolvedValue([]),
             findAppsByUuids = vi.fn().mockResolvedValue([]),
+            getLatestRenderableDataAppVizVersion = vi
+                .fn()
+                .mockResolvedValue({ version: 9 }),
         }: {
             findAppsBySlugs?: ReturnType<typeof vi.fn>;
             findAppsByUuids?: ReturnType<typeof vi.fn>;
+            getLatestRenderableDataAppVizVersion?: ReturnType<typeof vi.fn>;
         } = {}) => {
             const warn = vi.fn();
             const service = {
-                appModel: { findAppsBySlugs, findAppsByUuids },
+                appModel: {
+                    findAppsBySlugs,
+                    findAppsByUuids,
+                    getLatestRenderableDataAppVizVersion,
+                },
                 logger: { warn },
                 resolveDataAppVizBinding: (CoderService.prototype as AnyType)
                     .resolveDataAppVizBinding,
@@ -1920,6 +1929,7 @@ describe('CoderService', () => {
             });
             expect(result.config).toEqual({
                 dataAppVizUuid: 'target-viz-uuid',
+                dataAppVizVersion: 9,
                 fieldMapping: { x: 'field_x' },
             });
             expect(service.appModel.findAppsBySlugs).toHaveBeenCalledWith(
@@ -1947,6 +1957,7 @@ describe('CoderService', () => {
             });
             expect(result.config).toEqual({
                 dataAppVizUuid: 'source-viz-uuid',
+                dataAppVizVersion: 9,
                 fieldMapping: {},
             });
             expect(service.appModel.findAppsByUuids).toHaveBeenCalledWith(
@@ -2008,7 +2019,13 @@ describe('CoderService', () => {
             };
             expect(
                 await service.resolveDataAppVizBinding('proj', legacyViz),
-            ).toEqual(legacyViz);
+            ).toEqual({
+                ...legacyViz,
+                config: {
+                    ...legacyViz.config,
+                    dataAppVizVersion: 9,
+                },
+            });
             expect(findAppsBySlugs).not.toHaveBeenCalled();
             expect(service.appModel.findAppsByUuids).toHaveBeenCalledWith(
                 'proj',

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -163,6 +163,10 @@ import {
     getScheduledDeliveryTargetsAsCode,
 } from './scheduledContent';
 
+type RuntimeChartAsCode = Omit<ChartAsCode, 'chartConfig'> & {
+    chartConfig: ChartConfig;
+};
+
 type ContentAsCodeSpaceContentMetadata = {
     savedChartUuid?: string;
     dashboardUuid?: string;
@@ -1426,7 +1430,7 @@ export class CoderService extends BaseService {
         spaceSummary: Pick<SpaceSummaryBase, 'uuid' | 'name' | 'path'>[],
         dashboardSlugs: Record<string, string>,
         verificationMap: Map<string, ContentVerificationInfo>,
-    ): ChartAsCode {
+    ): RuntimeChartAsCode {
         const contentSpace = spaceSummary.find(
             (space) => space.uuid === chart.spaceUuid,
         );
@@ -2171,7 +2175,7 @@ export class CoderService extends BaseService {
      * within its source project.
      */
     private static withDataAppVizSlugs(
-        charts: ChartAsCode[],
+        charts: RuntimeChartAsCode[],
         dataAppVizSlugByUuid: ReadonlyMap<string, string>,
     ): ChartAsCode[] {
         return charts.map((chart) => {
@@ -2181,15 +2185,11 @@ export class CoderService extends BaseService {
             ) {
                 return chart;
             }
-            const runtimeConfig = chart.chartConfig
-                .config as typeof chart.chartConfig.config & {
-                dataAppVizVersion?: number;
-            };
             const {
                 dataAppVizUuid,
                 dataAppVizVersion: _dataAppVizVersion,
                 ...portableConfig
-            } = runtimeConfig;
+            } = chart.chartConfig.config;
             const dataAppVizSlug =
                 dataAppVizUuid !== undefined
                     ? dataAppVizSlugByUuid.get(dataAppVizUuid)
@@ -2848,7 +2848,9 @@ export class CoderService extends BaseService {
 
     // The instance content in its canonical as-code form — the same document
     // an upload of the current state would have applied.
-    async getCurrentChartAsCode(chartUuid: string): Promise<ChartAsCode> {
+    async getCurrentChartAsCode(
+        chartUuid: string,
+    ): Promise<RuntimeChartAsCode> {
         const chart = await this.savedChartModel.get(chartUuid);
         const spaces = await this.spaceModel.find({
             spaceUuids: chart.spaceUuid ? [chart.spaceUuid] : [],
@@ -2881,7 +2883,7 @@ export class CoderService extends BaseService {
 
     private async makeChartAsCodePortable(
         projectUuid: string,
-        chartAsCode: ChartAsCode,
+        chartAsCode: RuntimeChartAsCode,
     ): Promise<ChartAsCode> {
         const dataAppVizUuid =
             chartAsCode.chartConfig.type === ChartType.DATA_APP_VIZ

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -2181,20 +2181,36 @@ export class CoderService extends BaseService {
             ) {
                 return chart;
             }
-            const { dataAppVizUuid, ...configWithoutUuid } =
-                chart.chartConfig.config;
+            const runtimeConfig = chart.chartConfig
+                .config as typeof chart.chartConfig.config & {
+                dataAppVizVersion?: number;
+            };
+            const {
+                dataAppVizUuid,
+                dataAppVizVersion: _dataAppVizVersion,
+                ...portableConfig
+            } = runtimeConfig;
             const dataAppVizSlug =
                 dataAppVizUuid !== undefined
                     ? dataAppVizSlugByUuid.get(dataAppVizUuid)
                     : undefined;
             if (dataAppVizSlug === undefined) {
-                return chart;
+                if (_dataAppVizVersion === undefined) {
+                    return chart;
+                }
+                return {
+                    ...chart,
+                    chartConfig: {
+                        ...chart.chartConfig,
+                        config: { ...portableConfig, dataAppVizUuid },
+                    },
+                };
             }
             return {
                 ...chart,
                 chartConfig: {
                     ...chart.chartConfig,
-                    config: { ...configWithoutUuid, dataAppVizSlug },
+                    config: { ...portableConfig, dataAppVizSlug },
                 },
             };
         });
@@ -2222,6 +2238,27 @@ export class CoderService extends BaseService {
         }
         const { dataAppVizSlug, dataAppVizUuid, ...configRest } =
             chartConfig.config;
+        const withTargetVersion = async (
+            targetDataAppVizUuid: string,
+        ): Promise<ChartConfig> => {
+            const targetVersion =
+                await this.appModel.getLatestRenderableDataAppVizVersion(
+                    targetDataAppVizUuid,
+                );
+            if (targetVersion === null) {
+                throw new NotFoundError(
+                    `Custom chart type ${targetDataAppVizUuid} has no renderable version`,
+                );
+            }
+            return {
+                type: ChartType.DATA_APP_VIZ,
+                config: {
+                    ...configRest,
+                    dataAppVizUuid: targetDataAppVizUuid,
+                    dataAppVizVersion: targetVersion.version,
+                },
+            };
+        };
         // The 'only' filter also rejects uuids pointing at regular data apps.
         const uuidResolvesInTargetProject = async (): Promise<boolean> =>
             dataAppVizUuid !== undefined &&
@@ -2239,10 +2276,7 @@ export class CoderService extends BaseService {
                 { dataAppVizsFilter: 'only' },
             );
             if (vizRow !== undefined) {
-                return {
-                    ...chartConfig,
-                    config: { ...configRest, dataAppVizUuid: vizRow.app_id },
-                };
+                return withTargetVersion(vizRow.app_id);
             }
             // Interim files carry both identities — fall back to the uuid,
             // but only when it names a chart type in this project.
@@ -2253,10 +2287,7 @@ export class CoderService extends BaseService {
                 this.logger.warn(
                     `Chart type "${dataAppVizSlug}" was not found in project ${projectUuid}; keeping the chart's existing dataAppVizUuid reference.`,
                 );
-                return {
-                    ...chartConfig,
-                    config: { ...configRest, dataAppVizUuid },
-                };
+                return withTargetVersion(dataAppVizUuid);
             }
             throw new NotFoundError(
                 `Custom chart type "${dataAppVizSlug}" was not found in this project. Upload it first (lightdash upload --chart-types ${dataAppVizSlug}), then re-upload this chart.`,
@@ -2264,10 +2295,7 @@ export class CoderService extends BaseService {
         }
         if (dataAppVizUuid !== undefined) {
             if (await uuidResolvesInTargetProject()) {
-                return {
-                    ...chartConfig,
-                    config: { ...configRest, dataAppVizUuid },
-                };
+                return withTargetVersion(dataAppVizUuid);
             }
             throw new ParameterError(
                 `Custom chart type ${dataAppVizUuid} was not found in this project. Chart type uuids are project-specific: re-download the chart with a current CLI to get a portable dataAppVizSlug, upload the chart type into this project, then re-upload this chart.`,

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -65,6 +65,7 @@ const buildService = (overrides: Overrides = {}) => {
             ...chartAsCode,
             name: 'Monthly revenue draft',
         }),
+        getCurrentChartAsCode: vi.fn().mockResolvedValue(chartAsCode),
         getCurrentDashboardAsCode: vi.fn().mockResolvedValue({
             name: 'Weekly KPIs',
             slug: 'weekly-kpis',
@@ -367,6 +368,45 @@ describe('ContentAsCodeWritebackService', () => {
             gitIntegrationService.createPullRequestFromBranch.mock.calls[0][5];
         expect(prSource).toBe(PullRequestSource.CONTENT_AS_CODE);
         expect(gitIntegrationService.recordPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('writes dashboard-owned charts with portable chart type bindings', async () => {
+        const { service, gitIntegrationService, coderService } = buildService();
+        coderService.getCurrentChartAsCode.mockResolvedValue({
+            ...chartAsCode,
+            dashboardSlug: 'weekly-kpis',
+            chartConfig: {
+                type: 'data_app_viz',
+                config: {
+                    dataAppVizUuid: 'source-viz-uuid',
+                    dataAppVizVersion: 7,
+                    fieldMapping: {},
+                },
+            },
+        });
+        coderService.getPortableChartAsCode.mockResolvedValue({
+            ...chartAsCode,
+            dashboardSlug: 'weekly-kpis',
+            chartConfig: {
+                type: 'data_app_viz',
+                config: {
+                    dataAppVizSlug: 'revenue-chart-type',
+                    fieldMapping: {},
+                },
+            },
+        });
+
+        await service.propose(user, 'project-uuid', 'dashboard', 'weekly-kpis');
+
+        const chartFileCall = gitIntegrationService.saveFile.mock.calls.find(
+            (call) => call[3] === 'lightdash/charts/monthly-revenue.yml',
+        );
+        expect(chartFileCall?.[4]).toContain(
+            'dataAppVizSlug: revenue-chart-type',
+        );
+        expect(chartFileCall?.[4]).not.toContain('dataAppVizUuid');
+        expect(chartFileCall?.[4]).not.toContain('dataAppVizVersion');
+        expect(coderService.getCurrentChartAsCode).not.toHaveBeenCalled();
     });
 
     it('every commit names the acting user and instance', async () => {

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -785,7 +785,8 @@ export class ContentAsCodeWritebackService extends BaseService {
                                 chartSlug,
                             );
                         const chartAsCode =
-                            await this.coderService.getCurrentChartAsCode(
+                            await this.coderService.getPortableChartAsCode(
+                                projectUuid,
                                 contentUuid,
                             );
                         // Only charts saved within this dashboard travel with

--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -1867,7 +1867,11 @@ describe('PromoteService permission checks', () => {
 describe('PromoteService data app promotion', () => {
     const appGenerateService = {
         promoteAppsForDashboard: vi.fn(async () => [
-            { sourceAppUuid: promotedAppUuid, upstreamAppUuid },
+            {
+                sourceAppUuid: promotedAppUuid,
+                upstreamAppUuid,
+                upstreamAppVersion: 12,
+            },
         ]),
     };
 
@@ -2010,6 +2014,7 @@ describe('PromoteService data app promotion', () => {
                         type: ChartType.DATA_APP_VIZ,
                         config: {
                             dataAppVizUuid: promotedAppUuid,
+                            dataAppVizVersion: 3,
                             fieldMapping: {},
                         },
                     },
@@ -2037,6 +2042,11 @@ describe('PromoteService data app promotion', () => {
                 ? chartConfig.config?.dataAppVizUuid
                 : undefined,
         ).toBe(upstreamAppUuid);
+        expect(
+            chartConfig.type === ChartType.DATA_APP_VIZ
+                ? chartConfig.config?.dataAppVizVersion
+                : undefined,
+        ).toBe(12);
     });
 
     test('keeps the chart binding when the referenced viz was skipped (soft-deleted)', async () => {
@@ -2054,5 +2064,10 @@ describe('PromoteService data app promotion', () => {
                 ? chartConfig.config?.dataAppVizUuid
                 : undefined,
         ).toBe(promotedAppUuid);
+        expect(
+            chartConfig.type === ChartType.DATA_APP_VIZ
+                ? chartConfig.config?.dataAppVizVersion
+                : undefined,
+        ).toBeUndefined();
     });
 });

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -1271,9 +1271,8 @@ export class PromoteService extends BaseService {
             const upstreamAppVersion = appVersionMap.get(
                 chartConfig.config.dataAppVizUuid,
             );
-            // No mapping → the viz was soft-deleted and skipped; keep the
-            // original reference (renders the viz-not-found state upstream),
-            // but never carry its project-local version number across.
+            // Keep a skipped viz's original reference, but never carry its
+            // project-local version number across.
             if (!upstreamAppUuid || upstreamAppVersion === undefined) {
                 const {
                     dataAppVizVersion: _dataAppVizVersion,

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -1216,6 +1216,12 @@ export class PromoteService extends BaseService {
                 upstreamAppUuid,
             ]),
         );
+        const appVersionMap = new Map(
+            promotedApps.map(({ sourceAppUuid, upstreamAppVersion }) => [
+                sourceAppUuid,
+                upstreamAppVersion,
+            ]),
+        );
 
         const updatedDashboards = promotionChanges.dashboards.map(
             (dashboardChange) => ({
@@ -1262,10 +1268,27 @@ export class PromoteService extends BaseService {
             const upstreamAppUuid = appUuidMap.get(
                 chartConfig.config.dataAppVizUuid,
             );
+            const upstreamAppVersion = appVersionMap.get(
+                chartConfig.config.dataAppVizUuid,
+            );
             // No mapping → the viz was soft-deleted and skipped; keep the
-            // original reference (renders the viz-not-found state upstream).
-            if (!upstreamAppUuid) {
-                return chartChange;
+            // original reference (renders the viz-not-found state upstream),
+            // but never carry its project-local version number across.
+            if (!upstreamAppUuid || upstreamAppVersion === undefined) {
+                const {
+                    dataAppVizVersion: _dataAppVizVersion,
+                    ...configWithoutVersion
+                } = chartConfig.config;
+                return {
+                    ...chartChange,
+                    data: {
+                        ...chartChange.data,
+                        chartConfig: {
+                            ...chartConfig,
+                            config: configWithoutVersion,
+                        },
+                    },
+                };
             }
             return {
                 ...chartChange,
@@ -1276,6 +1299,7 @@ export class PromoteService extends BaseService {
                         config: {
                             ...chartConfig.config,
                             dataAppVizUuid: upstreamAppUuid,
+                            dataAppVizVersion: upstreamAppVersion,
                         },
                     },
                 },

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -1197,7 +1197,7 @@
         "DataAppVizChartAsCode": {
             "allOf": [
                 {
-                    "$ref": "#/$defs/Omit_DataAppVizChart.dataAppVizUuid_"
+                    "$ref": "#/$defs/Omit_DataAppVizChart.dataAppVizUuid-or-dataAppVizVersion_"
                 },
                 {
                     "properties": {
@@ -2446,8 +2446,8 @@
             ],
             "type": "string"
         },
-        "Omit_DataAppVizChart.dataAppVizUuid_": {
-            "$ref": "#/$defs/Pick_DataAppVizChart.Exclude_keyofDataAppVizChart.dataAppVizUuid__",
+        "Omit_DataAppVizChart.dataAppVizUuid-or-dataAppVizVersion_": {
+            "$ref": "#/$defs/Pick_DataAppVizChart.Exclude_keyofDataAppVizChart.dataAppVizUuid-or-dataAppVizVersion__",
             "description": "Construct a type with the properties of T except for those in type K."
         },
         "Omit_FilterRule.id_": {
@@ -2679,7 +2679,7 @@
             "properties": {},
             "type": "object"
         },
-        "Pick_DataAppVizChart.Exclude_keyofDataAppVizChart.dataAppVizUuid__": {
+        "Pick_DataAppVizChart.Exclude_keyofDataAppVizChart.dataAppVizUuid-or-dataAppVizVersion__": {
             "description": "From T, pick a set of properties whose keys are in the union K",
             "properties": {
                 "fieldMapping": {

--- a/packages/common/src/types/contentAsCode/charts.ts
+++ b/packages/common/src/types/contentAsCode/charts.ts
@@ -30,7 +30,10 @@ import type { SpaceAsCode } from './spaces';
  * only in legacy files that predate slugs (accepted on upload, never
  * emitted).
  */
-export type DataAppVizChartAsCode = Omit<DataAppVizChart, 'dataAppVizUuid'> & {
+export type DataAppVizChartAsCode = Omit<
+    DataAppVizChart,
+    'dataAppVizUuid' | 'dataAppVizVersion'
+> & {
     dataAppVizSlug?: string;
     dataAppVizUuid?: string;
 };

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -799,6 +799,11 @@ export type DataAppVizChart = {
      * see DataAppVizChartAsCode.
      */
     dataAppVizUuid: string;
+    /**
+     * The version of the project chart type this saved chart renders.
+     * @minimum 1
+     */
+    dataAppVizVersion?: number;
     fieldMapping: DataAppVizFieldMapping;
     /**
      * Only options the user explicitly changed — declared defaults are never

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -801,6 +801,7 @@ export type DataAppVizChart = {
     dataAppVizUuid: string;
     /**
      * The version of the project chart type this saved chart renders.
+     * @isInt
      * @minimum 1
      */
     dataAppVizVersion?: number;

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -46,6 +46,8 @@ const mocks = vi.hoisted(() => ({
     },
     embedToken: { current: undefined as string | undefined },
     dataAppVizUuid: { current: 'viz-uuid' as string | null },
+    dataAppVizVersion: { current: 7 as number | undefined },
+    setDataAppVizVersion: vi.fn(),
     iframePreview: vi.fn(() => null),
     renderMetadataHook: vi.fn(),
     previewTokenHook: vi.fn(),
@@ -124,9 +126,12 @@ vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
                         ? null
                         : {
                               dataAppVizUuid: mocks.dataAppVizUuid.current,
+                              dataAppVizVersion:
+                                  mocks.dataAppVizVersion.current,
                               fieldMapping: { category: 'orders.category' },
                               optionValues: { title: 12 },
                           },
+                setDataAppVizVersion: mocks.setDataAppVizVersion,
             },
         },
         savedChartUuid: 'saved-chart-uuid',
@@ -187,6 +192,8 @@ describe('DataAppVizRenderer', () => {
         mocks.tokenError.current = undefined;
         mocks.embedToken.current = undefined;
         mocks.dataAppVizUuid.current = 'viz-uuid';
+        mocks.dataAppVizVersion.current = 7;
+        mocks.setDataAppVizVersion.mockClear();
         mocks.iframePreview.mockClear();
         mocks.renderMetadataHook.mockClear();
         mocks.previewTokenHook.mockClear();
@@ -341,6 +348,50 @@ describe('DataAppVizRenderer', () => {
             }),
             undefined,
         );
+    });
+
+    it('pins an unsaved project chart type to the version it previews', () => {
+        mocks.dataAppVizVersion.current = undefined;
+        mocks.vizContextOverrides.current = {
+            savedChartUuid: undefined,
+            isEditMode: true,
+        };
+
+        renderRenderer();
+
+        expect(mocks.setDataAppVizVersion).toHaveBeenCalledWith(7);
+    });
+
+    it('keeps an unchanged edited chart on its persisted project chart type version', () => {
+        mocks.metadata.current = { ...readyMetadata(), version: 3 };
+        mocks.dataAppVizVersion.current = 3;
+        mocks.vizContextOverrides.current = {
+            savedChartUuid: undefined,
+            isEditMode: true,
+            savedChartReference: {
+                uuid: 'saved-chart-uuid',
+                chartConfig: {
+                    type: 'data_app_viz',
+                    config: {
+                        dataAppVizUuid: 'viz-uuid',
+                        dataAppVizVersion: 3,
+                        fieldMapping: { category: 'orders.category' },
+                    },
+                },
+            },
+        };
+
+        renderRenderer();
+
+        expect(mocks.renderMetadataHook).toHaveBeenCalledWith(
+            'project-uuid',
+            'viz-uuid',
+            {
+                isEmbedded: false,
+                savedChartUuid: 'saved-chart-uuid',
+            },
+        );
+        expect(mocks.setDataAppVizVersion).not.toHaveBeenCalled();
     });
 
     it('renders the last good version while a newer build is running', () => {

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -1,4 +1,5 @@
 import {
+    ChartType,
     getEffectiveOptionValues,
     hasCustomBinDimension,
     type ApiError,
@@ -75,10 +76,12 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         colorPalette,
         itemsMap,
         savedChartUuid,
+        savedChartReference,
         minimal,
         parameters,
         dateZoom,
         resolvedTimezone,
+        isEditMode,
     } = useVisualizationContext();
     const { embedToken } = useEmbed();
     const { canViewUnderlyingData, canDrillInto } = useContextMenuPermissions();
@@ -115,9 +118,12 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         resultsData?.setFetchAll(true);
     }, [resultsData]);
 
-    const config = isDataAppVizVisualizationConfig(visualizationConfig)
-        ? visualizationConfig.chartConfig.validConfig
+    const dataAppVizChartConfig = isDataAppVizVisualizationConfig(
+        visualizationConfig,
+    )
+        ? visualizationConfig.chartConfig
         : null;
+    const config = dataAppVizChartConfig?.validConfig ?? null;
     const dataAppVizUuid = config?.dataAppVizUuid ?? null;
     const fieldMapping = config?.fieldMapping;
     const optionValues = config?.optionValues;
@@ -125,14 +131,51 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     const pivotDetails = resultsData?.pivotDetails ?? null;
 
     const chartVersionUuid = useChartVersionPreview();
+    const savedDataAppVizConfig =
+        savedChartReference?.chartConfig.type === ChartType.DATA_APP_VIZ
+            ? savedChartReference.chartConfig.config
+            : undefined;
+    const matchesSavedBinding =
+        config?.dataAppVizUuid === savedDataAppVizConfig?.dataAppVizUuid &&
+        config?.dataAppVizVersion === savedDataAppVizConfig?.dataAppVizVersion;
+    const renderSavedChartUuid = chartVersionUuid
+        ? (savedChartReference?.uuid ?? savedChartUuid)
+        : (savedChartUuid ??
+          (isEditMode && matchesSavedBinding
+              ? savedChartReference?.uuid
+              : undefined));
     const renderTarget = useMemo(
-        () => ({ isEmbedded: !!embedToken, savedChartUuid, chartVersionUuid }),
-        [embedToken, savedChartUuid, chartVersionUuid],
+        () => ({
+            isEmbedded: !!embedToken,
+            savedChartUuid: renderSavedChartUuid,
+            chartVersionUuid,
+        }),
+        [embedToken, renderSavedChartUuid, chartVersionUuid],
     );
     const { data: renderMetadata, error: renderMetadataError } =
         useDataAppVizRenderMetadata(projectUuid, dataAppVizUuid, renderTarget);
     const readyMetadata =
         renderMetadata?.state === 'ready' ? renderMetadata : undefined;
+    useEffect(() => {
+        if (
+            !isEditMode ||
+            !readyMetadata ||
+            !dataAppVizChartConfig ||
+            !config ||
+            (config.dataAppVizVersion !== undefined &&
+                renderSavedChartUuid !== undefined) ||
+            config.dataAppVizVersion === readyMetadata.version
+        ) {
+            return;
+        }
+        dataAppVizChartConfig.setDataAppVizVersion(readyMetadata.version);
+    }, [
+        config,
+        isEditMode,
+        readyMetadata,
+        renderSavedChartUuid,
+        dataAppVizChartConfig,
+    ]);
     const { data: token, error: previewTokenError } = useDataAppVizPreviewToken(
         projectUuid,
         dataAppVizUuid,

--- a/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
+++ b/packages/frontend/src/components/Explorer/SaveChartButton/index.tsx
@@ -15,6 +15,7 @@ import {
     selectHasPaletteChanges,
     selectHasUnsavedChanges,
     selectHasVersionChanges,
+    selectIsDataAppVizVersionReadyForSave,
     selectIsValidQuery,
     selectSavedChart,
     selectUnsavedChartVersion,
@@ -69,6 +70,9 @@ const SaveChartButton: FC<{
 
     // Read isValidQuery from Redux
     const isValidQuery = useExplorerSelector(selectIsValidQuery);
+    const isDataAppVizVersionReadyForSave = useExplorerSelector(
+        selectIsDataAppVizVersionReadyForSave,
+    );
     const spaceUuid = useSearchParams('fromSpace');
 
     // For new charts, button is enabled when query is valid
@@ -178,6 +182,7 @@ const SaveChartButton: FC<{
         disabled ||
         !unsavedChartVersion.tableName ||
         !hasUnsavedChanges ||
+        !isDataAppVizVersionReadyForSave ||
         foundCustomMetricWithDuplicateId ||
         !isMergeValid ||
         !!missingRequiredParameters?.length;
@@ -205,6 +210,7 @@ const SaveChartButton: FC<{
         // Embeds may duplicate a chart as-is (there is no other way to copy
         // one there); the main app keeps requiring changes
         (!hasUnsavedChanges && !isEmbedded) ||
+        !isDataAppVizVersionReadyForSave ||
         foundCustomMetricWithDuplicateId ||
         !isMergeValid ||
         !!missingRequiredParameters?.length;

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -314,6 +314,14 @@ const VisualizationCard: FC<Props> = memo((props) => {
                 columnOrder={visualizationColumnOrder}
                 onSeriesContextMenu={onSeriesContextMenu}
                 savedChartUuid={isEditMode ? undefined : savedChart?.uuid}
+                savedChartReference={
+                    savedChart
+                        ? {
+                              uuid: savedChart.uuid,
+                              chartConfig: savedChart.chartConfig,
+                          }
+                        : undefined
+                }
                 onChartConfigChange={handleSetChartConfig}
                 onChartTypeChange={handleSetChartType}
                 onPivotDimensionsChange={handleSetPivotFields}

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -39,7 +39,10 @@ import { type InfiniteQueryResults } from '../../hooks/useQueryResults';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { type EChartsReact } from '../EChartsReactWrapper';
 import { type EchartsSeriesClickEvent } from '../SimpleChart';
-import Context, { type EmbeddedDashboardInteractivity } from './context';
+import Context, {
+    type EmbeddedDashboardInteractivity,
+    type SavedChartReference,
+} from './context';
 import { type useVisualizationContext } from './useVisualizationContext';
 import VisualizationBigNumberConfig from './VisualizationBigNumberConfig';
 import VisualizationCartesianConfig from './VisualizationConfigCartesian';
@@ -76,6 +79,7 @@ export type VisualizationProviderProps = {
     onPivotDimensionsChange?: (value: string[] | undefined) => void;
     onPivotRowsChange?: (value: string[] | undefined) => void;
     savedChartUuid?: string;
+    savedChartReference?: SavedChartReference;
     dashboardFilters?: DashboardFilters;
     invalidateCache?: boolean;
     colorPalette: string[];
@@ -109,6 +113,7 @@ const VisualizationProvider: FC<
     onPivotRowsChange,
     children,
     savedChartUuid,
+    savedChartReference,
     dashboardFilters,
     invalidateCache,
     colorPalette,
@@ -364,6 +369,7 @@ const VisualizationProvider: FC<
         getSeriesColor,
         chartConfig,
         savedChartUuid,
+        savedChartReference,
         parameters,
         containerWidth,
         containerHeight,

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -23,6 +23,11 @@ export type EmbeddedDashboardInteractivity = {
     canCrossFilter: boolean;
 };
 
+export type SavedChartReference = {
+    uuid: string;
+    chartConfig: ChartConfig;
+};
+
 type VisualizationContext = {
     minimal: boolean;
     chartRef: RefObject<EChartsReact | null>;
@@ -55,6 +60,7 @@ type VisualizationContext = {
     colorPalette: string[];
     chartConfig: ChartConfig;
     savedChartUuid?: string;
+    savedChartReference?: SavedChartReference;
     apiErrorDetail?: ApiErrorDetail | null;
     parameters?: ParametersValuesMap;
     // Container dimensions for responsive visualizations

--- a/packages/frontend/src/features/explorer/store/selectors.test.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.test.ts
@@ -1,9 +1,10 @@
-import { type SavedChart } from '@lightdash/common';
+import { ChartType, type SavedChart } from '@lightdash/common';
 import { explorerActions, explorerReducer } from './explorerSlice';
 import {
     selectChartSidebarStep,
     selectHasPaletteChanges,
     selectIsChartTypeAuthoring,
+    selectIsDataAppVizVersionReadyForSave,
 } from './selectors';
 
 const PALETTE_UUID = '55555555-5555-4555-8555-555555555555';
@@ -79,5 +80,24 @@ describe('chart type authoring selectors', () => {
                 ),
             }),
         ).toBe(true);
+    });
+});
+
+describe('selectIsDataAppVizVersionReadyForSave', () => {
+    it('waits for an unsaved project chart type to capture its previewed version', () => {
+        const explorer = explorerReducer(
+            undefined,
+            explorerActions.setChartConfig({
+                chartConfig: {
+                    type: ChartType.DATA_APP_VIZ,
+                    config: {
+                        dataAppVizUuid: 'viz-1',
+                        fieldMapping: {},
+                    },
+                },
+            }),
+        );
+
+        expect(selectIsDataAppVizVersionReadyForSave({ explorer })).toBe(false);
     });
 });

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -39,6 +39,16 @@ export const selectUnsavedChartVersion = createSelector(
     (explorer) => explorer.unsavedChartVersion,
 );
 
+export const selectIsDataAppVizVersionReadyForSave = createSelector(
+    [selectUnsavedChartVersion],
+    ({ chartConfig }) =>
+        chartConfig.type !== ChartType.DATA_APP_VIZ ||
+        chartConfig.config?.dataAppVizUuid === undefined ||
+        (Number.isInteger(chartConfig.config.dataAppVizVersion) &&
+            chartConfig.config.dataAppVizVersion !== undefined &&
+            chartConfig.config.dataAppVizVersion > 0),
+);
+
 export const selectUnsavedColorPaletteUuid = createSelector(
     [selectExplorerState],
     (explorer) => explorer.unsavedColorPaletteUuid,

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
@@ -24,6 +24,43 @@ describe('useDataAppVizVisualizationConfig', () => {
         });
     });
 
+    it('preserves the saved project chart type version through config edits', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(
+                { ...initialConfig, dataAppVizVersion: 7 },
+                onConfigChange,
+            ),
+        );
+
+        act(() => result.current.setField('value', 'orders_count'));
+
+        expect(onConfigChange).toHaveBeenLastCalledWith({
+            dataAppVizUuid: 'viz-1',
+            dataAppVizVersion: 7,
+            fieldMapping: {
+                category: 'orders_status',
+                value: 'orders_count',
+            },
+            optionValues: { showLegend: false },
+        });
+    });
+
+    it('pins the selected project chart type to the rendered version', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(initialConfig, onConfigChange),
+        );
+
+        act(() => result.current.setDataAppVizVersion(8));
+
+        expect(result.current.validConfig?.dataAppVizVersion).toBe(8);
+        expect(onConfigChange).toHaveBeenLastCalledWith({
+            ...initialConfig,
+            dataAppVizVersion: 8,
+        });
+    });
+
     it('defaults to an empty option map when nothing is saved', () => {
         const { result } = renderHook(() =>
             useDataAppVizVisualizationConfig({
@@ -249,6 +286,24 @@ describe('useDataAppVizVisualizationConfig', () => {
             showLegend: false,
             barColor: '#ff0000',
         });
+    });
+
+    it('drops the pin when the same project chart type is re-selected', () => {
+        const { result, rerender } = renderHook(
+            ({ config }) => useDataAppVizVisualizationConfig(config),
+            {
+                initialProps: {
+                    config: {
+                        ...initialConfig,
+                        dataAppVizVersion: 3,
+                    } as DataAppVizChart,
+                },
+            },
+        );
+
+        rerender({ config: initialConfig });
+
+        expect(result.current.validConfig?.dataAppVizVersion).toBeUndefined();
     });
 
     it('points at no viz when the chart has no config', () => {

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
@@ -12,7 +12,7 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react';
  */
 export type SelectedDataAppViz = Pick<
     DataAppVizChart,
-    'dataAppVizUuid' | 'fieldMapping'
+    'dataAppVizUuid' | 'dataAppVizVersion' | 'fieldMapping'
 > &
     Required<Pick<DataAppVizChart, 'optionValues'>>;
 
@@ -28,6 +28,7 @@ export interface DataAppVizVisualizationConfigAndData {
         dataAppVizUuid: string,
         fieldMapping: DataAppVizFieldMapping,
     ) => void;
+    setDataAppVizVersion: (dataAppVizVersion: number) => void;
     /** Back to pointing at no viz; bindings and options go with it. */
     clearDataAppViz: () => void;
     setField: (fieldName: string, fieldId: string | null) => void;
@@ -55,6 +56,7 @@ const toSelected = (
     return chartConfig !== undefined && dataAppVizUuid !== null
         ? {
               dataAppVizUuid,
+              dataAppVizVersion: chartConfig.dataAppVizVersion,
               fieldMapping: chartConfig.fieldMapping,
               optionValues: chartConfig.optionValues ?? {},
           }
@@ -93,13 +95,20 @@ const useDataAppVizVisualizationConfig = (
     // A viz switched from outside this hook (the chart gallery goes through
     // the store) arrives as a new initial config while the hook stays mounted.
     const externalDataAppVizUuid = readDataAppVizUuid(initialChartConfig);
+    const externalDataAppVizVersion = initialChartConfig?.dataAppVizVersion;
     useLayoutEffect(() => {
         const currentUuid = configRef.current?.dataAppVizUuid ?? null;
-        if (externalDataAppVizUuid === currentUuid) return;
+        const currentVersion = configRef.current?.dataAppVizVersion;
+        if (
+            externalDataAppVizUuid === currentUuid &&
+            externalDataAppVizVersion === currentVersion
+        ) {
+            return;
+        }
         const next = toSelected(initialChartConfig);
         configRef.current = next;
         setConfigState(next);
-    }, [externalDataAppVizUuid, initialChartConfig]);
+    }, [externalDataAppVizUuid, externalDataAppVizVersion, initialChartConfig]);
 
     const commit = useCallback((next: SelectedDataAppViz | null) => {
         configRef.current = next;
@@ -122,6 +131,20 @@ const useDataAppVizVisualizationConfig = (
     );
 
     const clearDataAppViz = useCallback(() => commit(null), [commit]);
+
+    const setDataAppVizVersion = useCallback(
+        (dataAppVizVersion: number) => {
+            const selected = configRef.current;
+            if (
+                selected === null ||
+                selected.dataAppVizVersion === dataAppVizVersion
+            ) {
+                return;
+            }
+            commit({ ...selected, dataAppVizVersion });
+        },
+        [commit],
+    );
 
     const setField = useCallback(
         (fieldName: string, fieldId: string | null) => {
@@ -163,6 +186,7 @@ const useDataAppVizVisualizationConfig = (
         validConfig: config,
         dataAppVizUuid: config?.dataAppVizUuid ?? null,
         setDataAppVizUuid,
+        setDataAppVizVersion,
         clearDataAppViz,
         setField,
         setOption,


### PR DESCRIPTION
Linear: [GLITCH-698](https://linear.app/lightdash/issue/GLITCH-698/prevent-chart-type-edits-from-changing-existing-charts)

### Description

First layer of the GLITCH-698 stack:

- Persist the rendered project chart type's integer version in saved chart config.
- Preserve or replace the pin correctly while editing, re-selecting, promoting, or copying charts into preview projects.
- Keep content-as-code portable by stripping source-project UUID/version identities and resolving a fresh target-project version on upload.
- Prevent saving a selected project chart type until its render metadata has supplied a valid version.

### Verification

- 65 related frontend tests
- 103 related backend tests for persistence/transport paths
- frontend, backend, and common typechecks
- changed-file lint
- chart-as-code schema generation/check

### Risk assessment

- [ ] This is a high-risk change

The field is optional for compatibility with charts created before version pins shipped, and content-as-code does not transport environment-specific version numbers.
