### PR TITLE
fix: render saved charts with pinned chart types

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -678,6 +678,31 @@ describe('AppGenerateService data app vizs', () => {
             expect(appModel.getVersion).not.toHaveBeenCalled();
         });
 
+        it('rejects a historical preview token for an unpinned legacy chart', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getLatestRenderableDataAppVizVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion({ version: 4 })),
+                getVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion({ version: 2 })),
+            };
+            const service = buildService(appModel, chartDeps('data-app-viz-1'));
+
+            await expect(
+                service.getChartDataAppVizPreviewToken(
+                    USER,
+                    'project-1',
+                    'chart-1',
+                    'data-app-viz-1',
+                    2,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+        });
+
         it('propagates the chart denial and mints no token', async () => {
             const appModel = {
                 findVisualizationApp: vi

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -641,6 +641,43 @@ describe('AppGenerateService data app vizs', () => {
             expect(appModel.getLatestVersion).not.toHaveBeenCalled();
         });
 
+        it('rejects a preview token for a version other than the saved chart pin', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion({ version: 4 })),
+            };
+            const service = buildService(appModel, {
+                savedChartService: { hasAccess: vi.fn().mockResolvedValue([]) },
+                savedChartModel: {
+                    get: vi.fn().mockResolvedValue({
+                        uuid: 'chart-1',
+                        chartConfig: {
+                            type: ChartType.DATA_APP_VIZ,
+                            config: {
+                                dataAppVizUuid: 'data-app-viz-1',
+                                dataAppVizVersion: 2,
+                            },
+                        },
+                    }),
+                },
+            });
+
+            await expect(
+                service.getChartDataAppVizPreviewToken(
+                    USER,
+                    'project-1',
+                    'chart-1',
+                    'data-app-viz-1',
+                    4,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(appModel.getVersion).not.toHaveBeenCalled();
+        });
+
         it('propagates the chart denial and mints no token', async () => {
             const appModel = {
                 findVisualizationApp: vi

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -595,6 +595,52 @@ describe('AppGenerateService data app vizs', () => {
             );
         });
 
+        it('renders the project chart type version pinned by the saved chart', async () => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(makeDataAppVizRow()),
+                getVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion({ version: 2 })),
+                getLatestVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion({ version: 4 })),
+                getLatestRenderableDataAppVizVersion: vi
+                    .fn()
+                    .mockResolvedValue(makeVersion({ version: 4 })),
+            };
+            const service = buildService(appModel, {
+                savedChartService: { hasAccess: vi.fn().mockResolvedValue([]) },
+                savedChartModel: {
+                    get: vi.fn().mockResolvedValue({
+                        uuid: 'chart-1',
+                        chartConfig: {
+                            type: ChartType.DATA_APP_VIZ,
+                            config: {
+                                dataAppVizUuid: 'data-app-viz-1',
+                                dataAppVizVersion: 2,
+                            },
+                        },
+                    }),
+                },
+            });
+
+            await expect(
+                service.getChartDataAppVizRenderMetadata(
+                    USER,
+                    'project-1',
+                    'chart-1',
+                    'data-app-viz-1',
+                ),
+            ).resolves.toMatchObject({ state: 'ready', version: 2 });
+            expect(appModel.getVersion).toHaveBeenCalledWith(
+                'data-app-viz-1',
+                2,
+            );
+            expect(appModel.getLatestVersion).not.toHaveBeenCalled();
+        });
+
         it('propagates the chart denial and mints no token', async () => {
             const appModel = {
                 findVisualizationApp: vi
@@ -627,16 +673,18 @@ describe('AppGenerateService data app vizs', () => {
                 findVisualizationApp: vi
                     .fn()
                     .mockResolvedValue(makeDataAppVizRow()),
-                getLatestVersion: vi.fn().mockResolvedValue(makeVersion()),
-                getLatestRenderableDataAppVizVersion: vi
+                getVersion: vi
                     .fn()
-                    .mockResolvedValue(makeVersion()),
+                    .mockResolvedValue(makeVersion({ version: 2 })),
             };
             const get = vi.fn().mockResolvedValue({
                 uuid: 'chart-1',
                 chartConfig: {
                     type: ChartType.DATA_APP_VIZ,
-                    config: { dataAppVizUuid: 'data-app-viz-1' },
+                    config: {
+                        dataAppVizUuid: 'data-app-viz-1',
+                        dataAppVizVersion: 2,
+                    },
                 },
             });
             const service = buildService(appModel, {
@@ -652,10 +700,14 @@ describe('AppGenerateService data app vizs', () => {
                     'data-app-viz-1',
                     'chart-version-7',
                 ),
-            ).resolves.toMatchObject({ state: 'ready' });
+            ).resolves.toMatchObject({ state: 'ready', version: 2 });
             expect(get).toHaveBeenCalledWith('chart-1', 'chart-version-7', {
                 projectUuid: 'project-1',
             });
+            expect(appModel.getVersion).toHaveBeenCalledWith(
+                'data-app-viz-1',
+                2,
+            );
         });
 
         it('rejects a chart that does not reference the requested viz', async () => {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -148,7 +148,10 @@ import {
 } from '../../../database/entities/apps';
 import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
 import { AnalyticsModel } from '../../../models/AnalyticsModel';
-import { AppModel } from '../../../models/AppModel';
+import {
+    AppModel,
+    type PreviewChartVizBindingMapping,
+} from '../../../models/AppModel';
 import { CatalogModel } from '../../../models/CatalogModel/CatalogModel';
 import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { OrganizationDesignModel } from '../../../models/OrganizationDesignModel';
@@ -7880,11 +7883,7 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        const mappings: {
-            sourceAppUuid: string;
-            previewAppUuid: string;
-            previewAppVersion: number;
-        }[] = [];
+        const mappings: PreviewChartVizBindingMapping[] = [];
 
         /* eslint-disable no-await-in-loop */
         for (const sourceApp of sourceApps) {
@@ -8671,13 +8670,24 @@ export class AppGenerateService extends BaseService {
         version: number,
         chartVersionUuid?: string,
     ): Promise<string> {
-        const { dataAppViz } = await this.getAuthorizedDataAppVizForChart(
-            user,
-            projectUuid,
-            savedChartUuid,
-            dataAppVizUuid,
-            chartVersionUuid,
-        );
+        const { dataAppViz, chart } =
+            await this.getAuthorizedDataAppVizForChart(
+                user,
+                projectUuid,
+                savedChartUuid,
+                dataAppVizUuid,
+                chartVersionUuid,
+            );
+
+        const pinnedVersion =
+            chart.chartConfig.type === ChartType.DATA_APP_VIZ
+                ? chart.chartConfig.config?.dataAppVizVersion
+                : undefined;
+        if (pinnedVersion !== undefined && version !== pinnedVersion) {
+            throw new ForbiddenError(
+                'Not authorized to access this visualization version',
+            );
+        }
 
         await resolveRenderableDataAppVizVersion(
             this.appModel,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -277,6 +277,8 @@ import {
     describeDashboardBlueprint,
 } from './dashboardBlueprint';
 import {
+    assertDataAppVizPreviewVersionAllowed,
+    getDataAppVizVersionPin,
     resolveDataAppVisualizationForRender,
     resolveDataAppVizRenderMetadata,
     resolveRenderableDataAppVizVersion,
@@ -8655,10 +8657,7 @@ export class AppGenerateService extends BaseService {
                 dataAppVizUuid,
                 chartVersionUuid,
             );
-        const pinnedVersion =
-            chart.chartConfig.type === ChartType.DATA_APP_VIZ
-                ? chart.chartConfig.config?.dataAppVizVersion
-                : undefined;
+        const pinnedVersion = getDataAppVizVersionPin(chart.chartConfig);
         return this.resolveVizRenderMetadata(dataAppViz.app_id, pinnedVersion);
     }
 
@@ -8679,20 +8678,11 @@ export class AppGenerateService extends BaseService {
                 chartVersionUuid,
             );
 
-        const pinnedVersion =
-            chart.chartConfig.type === ChartType.DATA_APP_VIZ
-                ? chart.chartConfig.config?.dataAppVizVersion
-                : undefined;
-        if (pinnedVersion !== undefined && version !== pinnedVersion) {
-            throw new ForbiddenError(
-                'Not authorized to access this visualization version',
-            );
-        }
-
-        await resolveRenderableDataAppVizVersion(
+        await assertDataAppVizPreviewVersionAllowed(
             this.appModel,
             dataAppViz.app_id,
             version,
+            getDataAppVizVersionPin(chart.chartConfig),
         );
 
         return mintPreviewToken(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -8582,16 +8582,18 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        return dataAppViz;
+        return { dataAppViz, chart };
     }
 
     private resolveVizRenderMetadata(
         appUuid: string,
+        pinnedVersion?: number,
     ): Promise<DataAppVizRenderMetadata> {
         return resolveDataAppVizRenderMetadata(
             this.appModel,
             appUuid,
             getBundleServableChecker(this.lightdashConfig.appRuntime.s3),
+            pinnedVersion,
         );
     }
 
@@ -8646,14 +8648,19 @@ export class AppGenerateService extends BaseService {
         dataAppVizUuid: string,
         chartVersionUuid?: string,
     ): Promise<DataAppVizRenderMetadata> {
-        const dataAppViz = await this.getAuthorizedDataAppVizForChart(
-            user,
-            projectUuid,
-            savedChartUuid,
-            dataAppVizUuid,
-            chartVersionUuid,
-        );
-        return this.resolveVizRenderMetadata(dataAppViz.app_id);
+        const { dataAppViz, chart } =
+            await this.getAuthorizedDataAppVizForChart(
+                user,
+                projectUuid,
+                savedChartUuid,
+                dataAppVizUuid,
+                chartVersionUuid,
+            );
+        const pinnedVersion =
+            chart.chartConfig.type === ChartType.DATA_APP_VIZ
+                ? chart.chartConfig.config?.dataAppVizVersion
+                : undefined;
+        return this.resolveVizRenderMetadata(dataAppViz.app_id, pinnedVersion);
     }
 
     async getChartDataAppVizPreviewToken(
@@ -8664,7 +8671,7 @@ export class AppGenerateService extends BaseService {
         version: number,
         chartVersionUuid?: string,
     ): Promise<string> {
-        const dataAppViz = await this.getAuthorizedDataAppVizForChart(
+        const { dataAppViz } = await this.getAuthorizedDataAppVizForChart(
             user,
             projectUuid,
             savedChartUuid,

--- a/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.test.ts
@@ -30,6 +30,104 @@ const makeAppModel = (
     }) as unknown as AppModel;
 
 describe('resolveDataAppVizRenderMetadata', () => {
+    it('resolves a pinned version without consulting the latest version', async () => {
+        const appModel = makeAppModel(
+            makeVersion({ version: 4 }),
+            makeVersion({ version: 4 }),
+        ) as unknown as AppModel & {
+            getVersion: ReturnType<typeof vi.fn>;
+        };
+        appModel.getVersion = vi
+            .fn()
+            .mockResolvedValue(makeVersion({ version: 2 }));
+
+        await expect(
+            resolveDataAppVizRenderMetadata(
+                appModel,
+                APP_UUID,
+                vi.fn().mockResolvedValue(true),
+                2,
+            ),
+        ).resolves.toEqual({
+            state: 'ready',
+            version: 2,
+            schema: vizSchema,
+            latestBuildInProgress: false,
+        });
+        expect(appModel.getVersion).toHaveBeenCalledWith(APP_UUID, 2);
+        expect(appModel.getLatestVersion).not.toHaveBeenCalled();
+        expect(
+            appModel.getLatestRenderableDataAppVizVersion,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('reports a missing pinned version as unavailable', async () => {
+        const appModel = makeAppModel(null, null) as unknown as AppModel & {
+            getVersion: ReturnType<typeof vi.fn>;
+        };
+        appModel.getVersion = vi.fn().mockResolvedValue(null);
+        const isBundleServable = vi.fn();
+
+        await expect(
+            resolveDataAppVizRenderMetadata(
+                appModel,
+                APP_UUID,
+                isBundleServable,
+                2,
+            ),
+        ).resolves.toEqual({
+            state: 'unavailable',
+            latestBuildInProgress: false,
+        });
+        expect(isBundleServable).not.toHaveBeenCalled();
+    });
+
+    it.each([0, -1, 1.5])(
+        'reports an invalid pinned version (%s) as unavailable',
+        async (pinnedVersion) => {
+            const appModel = makeAppModel(null, null) as unknown as AppModel & {
+                getVersion: ReturnType<typeof vi.fn>;
+            };
+            appModel.getVersion = vi.fn().mockResolvedValue(null);
+            const isBundleServable = vi.fn();
+
+            await expect(
+                resolveDataAppVizRenderMetadata(
+                    appModel,
+                    APP_UUID,
+                    isBundleServable,
+                    pinnedVersion,
+                ),
+            ).resolves.toEqual({
+                state: 'unavailable',
+                latestBuildInProgress: false,
+            });
+            expect(appModel.getVersion).not.toHaveBeenCalled();
+            expect(isBundleServable).not.toHaveBeenCalled();
+        },
+    );
+
+    it('reports a pinned version with a missing bundle as unavailable', async () => {
+        const appModel = makeAppModel(null, null) as unknown as AppModel & {
+            getVersion: ReturnType<typeof vi.fn>;
+        };
+        appModel.getVersion = vi
+            .fn()
+            .mockResolvedValue(makeVersion({ version: 2 }));
+
+        await expect(
+            resolveDataAppVizRenderMetadata(
+                appModel,
+                APP_UUID,
+                vi.fn().mockResolvedValue(false),
+                2,
+            ),
+        ).resolves.toEqual({
+            state: 'unavailable',
+            latestBuildInProgress: false,
+        });
+    });
+
     it('reports ready when the version bundle is still in storage', async () => {
         const isBundleServable = vi.fn().mockResolvedValue(true);
 

--- a/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.test.ts
@@ -1,6 +1,8 @@
 import { type DataAppVizSchema } from '@lightdash/common';
-import { type AppModel } from '../../../models/AppModel';
-import { resolveDataAppVizRenderMetadata } from './dataAppVizRender';
+import {
+    resolveDataAppVizRenderMetadata,
+    type DataAppVizRenderModel,
+} from './dataAppVizRender';
 
 const APP_UUID = 'data-app-viz-1';
 
@@ -27,19 +29,16 @@ const makeAppModel = (
         getLatestRenderableDataAppVizVersion: vi
             .fn()
             .mockResolvedValue(latestRenderableVersion),
-    }) as unknown as AppModel;
+        getVersion: vi.fn(),
+    }) satisfies DataAppVizRenderModel;
 
 describe('resolveDataAppVizRenderMetadata', () => {
     it('resolves a pinned version without consulting the latest version', async () => {
         const appModel = makeAppModel(
             makeVersion({ version: 4 }),
             makeVersion({ version: 4 }),
-        ) as unknown as AppModel & {
-            getVersion: ReturnType<typeof vi.fn>;
-        };
-        appModel.getVersion = vi
-            .fn()
-            .mockResolvedValue(makeVersion({ version: 2 }));
+        );
+        appModel.getVersion.mockResolvedValue(makeVersion({ version: 2 }));
 
         await expect(
             resolveDataAppVizRenderMetadata(
@@ -62,10 +61,8 @@ describe('resolveDataAppVizRenderMetadata', () => {
     });
 
     it('reports a missing pinned version as unavailable', async () => {
-        const appModel = makeAppModel(null, null) as unknown as AppModel & {
-            getVersion: ReturnType<typeof vi.fn>;
-        };
-        appModel.getVersion = vi.fn().mockResolvedValue(null);
+        const appModel = makeAppModel(null, null);
+        appModel.getVersion.mockResolvedValue(null);
         const isBundleServable = vi.fn();
 
         await expect(
@@ -85,10 +82,8 @@ describe('resolveDataAppVizRenderMetadata', () => {
     it.each([0, -1, 1.5])(
         'reports an invalid pinned version (%s) as unavailable',
         async (pinnedVersion) => {
-            const appModel = makeAppModel(null, null) as unknown as AppModel & {
-                getVersion: ReturnType<typeof vi.fn>;
-            };
-            appModel.getVersion = vi.fn().mockResolvedValue(null);
+            const appModel = makeAppModel(null, null);
+            appModel.getVersion.mockResolvedValue(null);
             const isBundleServable = vi.fn();
 
             await expect(
@@ -108,12 +103,8 @@ describe('resolveDataAppVizRenderMetadata', () => {
     );
 
     it('reports a pinned version with a missing bundle as unavailable', async () => {
-        const appModel = makeAppModel(null, null) as unknown as AppModel & {
-            getVersion: ReturnType<typeof vi.fn>;
-        };
-        appModel.getVersion = vi
-            .fn()
-            .mockResolvedValue(makeVersion({ version: 2 }));
+        const appModel = makeAppModel(null, null);
+        appModel.getVersion.mockResolvedValue(makeVersion({ version: 2 }));
 
         await expect(
             resolveDataAppVizRenderMetadata(

--- a/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.ts
@@ -1,7 +1,10 @@
 import {
+    ChartType,
+    ForbiddenError,
     isAppVersionInProgress,
     NotFoundError,
     ParameterError,
+    type ChartConfig,
     type DataAppVizRenderMetadata,
 } from '@lightdash/common';
 import { type DbAppVersion } from '../../../database/entities/apps';
@@ -11,6 +14,18 @@ import { type BundleServableChecker } from './appBundleStorage';
 export type DataAppVisualizationForRender = NonNullable<
     Awaited<ReturnType<AppModel['findVisualizationApp']>>
 >;
+
+export type DataAppVizRenderModel = Pick<
+    AppModel,
+    'getVersion' | 'getLatestVersion' | 'getLatestRenderableDataAppVizVersion'
+>;
+
+export const getDataAppVizVersionPin = (
+    chartConfig: ChartConfig,
+): number | undefined =>
+    chartConfig.type === ChartType.DATA_APP_VIZ
+        ? chartConfig.config?.dataAppVizVersion
+        : undefined;
 
 export const resolveDataAppVisualizationForRender = async (
     appModel: AppModel,
@@ -28,7 +43,7 @@ export const resolveDataAppVisualizationForRender = async (
 };
 
 export async function resolveRenderableDataAppVizVersion(
-    appModel: AppModel,
+    appModel: Pick<AppModel, 'getVersion'>,
     appUuid: string,
     version: number,
 ): Promise<
@@ -51,8 +66,37 @@ export async function resolveRenderableDataAppVizVersion(
     return { ...appVersion, viz_schema: appVersion.viz_schema };
 }
 
+export async function assertDataAppVizPreviewVersionAllowed(
+    appModel: Pick<
+        AppModel,
+        'getVersion' | 'getLatestRenderableDataAppVizVersion'
+    >,
+    appUuid: string,
+    requestedVersion: number,
+    pinnedVersion?: number,
+): Promise<void> {
+    const allowedVersion =
+        pinnedVersion ??
+        (await appModel.getLatestRenderableDataAppVizVersion(appUuid))?.version;
+    if (allowedVersion === undefined) {
+        throw new NotFoundError(
+            'Renderable data app visualization version not found',
+        );
+    }
+    if (requestedVersion !== allowedVersion) {
+        throw new ForbiddenError(
+            'Not authorized to access this visualization version',
+        );
+    }
+    await resolveRenderableDataAppVizVersion(
+        appModel,
+        appUuid,
+        requestedVersion,
+    );
+}
+
 export const resolveDataAppVizRenderMetadata = async (
-    appModel: AppModel,
+    appModel: DataAppVizRenderModel,
     appUuid: string,
     isBundleServable: BundleServableChecker,
     pinnedVersion?: number,

--- a/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dataAppVizRender.ts
@@ -27,11 +27,74 @@ export const resolveDataAppVisualizationForRender = async (
     return dataAppViz;
 };
 
+export async function resolveRenderableDataAppVizVersion(
+    appModel: AppModel,
+    appUuid: string,
+    version: number,
+): Promise<
+    DbAppVersion & { viz_schema: NonNullable<DbAppVersion['viz_schema']> }
+> {
+    if (!Number.isInteger(version) || version < 1) {
+        throw new ParameterError('Version must be a positive integer');
+    }
+
+    const appVersion = await appModel.getVersion(appUuid, version);
+    if (
+        appVersion === null ||
+        appVersion.status !== 'ready' ||
+        appVersion.viz_schema === null
+    ) {
+        throw new NotFoundError(
+            'Renderable data app visualization version not found',
+        );
+    }
+    return { ...appVersion, viz_schema: appVersion.viz_schema };
+}
+
 export const resolveDataAppVizRenderMetadata = async (
     appModel: AppModel,
     appUuid: string,
     isBundleServable: BundleServableChecker,
+    pinnedVersion?: number,
 ): Promise<DataAppVizRenderMetadata> => {
+    if (pinnedVersion !== undefined) {
+        let appVersion: Awaited<
+            ReturnType<typeof resolveRenderableDataAppVizVersion>
+        >;
+        try {
+            appVersion = await resolveRenderableDataAppVizVersion(
+                appModel,
+                appUuid,
+                pinnedVersion,
+            );
+        } catch (error) {
+            if (
+                error instanceof NotFoundError ||
+                error instanceof ParameterError
+            ) {
+                return {
+                    state: 'unavailable',
+                    latestBuildInProgress: false,
+                };
+            }
+            throw error;
+        }
+
+        if (!(await isBundleServable(appUuid, appVersion.version))) {
+            return {
+                state: 'unavailable',
+                latestBuildInProgress: false,
+            };
+        }
+
+        return {
+            state: 'ready',
+            version: appVersion.version,
+            schema: appVersion.viz_schema,
+            latestBuildInProgress: false,
+        };
+    }
+
     const [latestVersion, latestRenderableVersion] = await Promise.all([
         appModel.getLatestVersion(appUuid),
         appModel.getLatestRenderableDataAppVizVersion(appUuid),
@@ -80,26 +143,4 @@ export const resolveDataAppVizRenderMetadata = async (
         state: 'failed',
         latestBuildInProgress: false,
     };
-};
-
-export const resolveRenderableDataAppVizVersion = async (
-    appModel: AppModel,
-    appUuid: string,
-    version: number,
-): Promise<DbAppVersion> => {
-    if (!Number.isInteger(version) || version < 1) {
-        throw new ParameterError('Version must be a positive integer');
-    }
-
-    const appVersion = await appModel.getVersion(appUuid, version);
-    if (
-        appVersion === null ||
-        appVersion.status !== 'ready' ||
-        appVersion.viz_schema === null
-    ) {
-        throw new NotFoundError(
-            'Renderable data app visualization version not found',
-        );
-    }
-    return appVersion;
 };

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
@@ -237,6 +237,43 @@ describe('EmbedService data app viz rendering', () => {
         expect(appModel.getLatestVersion).not.toHaveBeenCalled();
     });
 
+    it('rejects a preview token for a version other than the embedded chart pin', async () => {
+        const appModel = {
+            findVisualizationApp: vi
+                .fn()
+                .mockResolvedValue(makeDataAppVizRow()),
+            getVersion: vi.fn().mockResolvedValue(makeVersion({ version: 4 })),
+        };
+        const service = buildService({
+            appModel,
+            savedChartModel: {
+                get: vi.fn().mockResolvedValue(
+                    makeSavedChart({
+                        chartConfig: {
+                            type: ChartType.DATA_APP_VIZ,
+                            config: {
+                                dataAppVizUuid: DATA_APP_VIZ_UUID,
+                                dataAppVizVersion: 2,
+                                fieldMapping: {},
+                            },
+                        },
+                    }),
+                ),
+            },
+        });
+
+        await expect(
+            service.getEmbedDataAppVizPreviewToken(
+                chartAccount(),
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                DATA_APP_VIZ_UUID,
+                4,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+        expect(appModel.getVersion).not.toHaveBeenCalled();
+    });
+
     it('rejects a different chart than the standalone chart named by the JWT', async () => {
         const savedChartModel = { get: vi.fn() };
         const service = buildService({

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
@@ -194,6 +194,49 @@ describe('EmbedService data app viz rendering', () => {
         expect(savedChartModel.get).toHaveBeenCalledWith(SAVED_CHART_UUID);
     });
 
+    it('renders the project chart type version pinned by the embedded chart', async () => {
+        const appModel = {
+            findVisualizationApp: vi
+                .fn()
+                .mockResolvedValue(makeDataAppVizRow()),
+            getVersion: vi.fn().mockResolvedValue(makeVersion({ version: 2 })),
+            getLatestVersion: vi
+                .fn()
+                .mockResolvedValue(makeVersion({ version: 4 })),
+            getLatestRenderableDataAppVizVersion: vi
+                .fn()
+                .mockResolvedValue(makeVersion({ version: 4 })),
+        };
+        const service = buildService({
+            appModel,
+            savedChartModel: {
+                get: vi.fn().mockResolvedValue(
+                    makeSavedChart({
+                        chartConfig: {
+                            type: ChartType.DATA_APP_VIZ,
+                            config: {
+                                dataAppVizUuid: DATA_APP_VIZ_UUID,
+                                dataAppVizVersion: 2,
+                                fieldMapping: {},
+                            },
+                        },
+                    }),
+                ),
+            },
+        });
+
+        await expect(
+            service.getEmbedDataAppVizRenderMetadata(
+                chartAccount(),
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                DATA_APP_VIZ_UUID,
+            ),
+        ).resolves.toMatchObject({ state: 'ready', version: 2 });
+        expect(appModel.getVersion).toHaveBeenCalledWith(DATA_APP_VIZ_UUID, 2);
+        expect(appModel.getLatestVersion).not.toHaveBeenCalled();
+    });
+
     it('rejects a different chart than the standalone chart named by the JWT', async () => {
         const savedChartModel = { get: vi.fn() };
         const service = buildService({

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.dataAppVizRender.test.ts
@@ -274,6 +274,34 @@ describe('EmbedService data app viz rendering', () => {
         expect(appModel.getVersion).not.toHaveBeenCalled();
     });
 
+    it('rejects a historical preview token for an unpinned legacy chart', async () => {
+        const appModel = {
+            findVisualizationApp: vi
+                .fn()
+                .mockResolvedValue(makeDataAppVizRow()),
+            getLatestRenderableDataAppVizVersion: vi
+                .fn()
+                .mockResolvedValue(makeVersion({ version: 4 })),
+            getVersion: vi.fn().mockResolvedValue(makeVersion({ version: 2 })),
+        };
+        const service = buildService({
+            appModel,
+            savedChartModel: {
+                get: vi.fn().mockResolvedValue(makeSavedChart()),
+            },
+        });
+
+        await expect(
+            service.getEmbedDataAppVizPreviewToken(
+                chartAccount(),
+                PROJECT_UUID,
+                SAVED_CHART_UUID,
+                DATA_APP_VIZ_UUID,
+                2,
+            ),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
     it('rejects a different chart than the standalone chart named by the JWT', async () => {
         const savedChartModel = { get: vi.fn() };
         const service = buildService({
@@ -484,6 +512,9 @@ describe('EmbedService data app viz rendering', () => {
                 .fn()
                 .mockResolvedValue(makeDataAppVizRow()),
             getVersion: vi.fn().mockResolvedValue(makeVersion({ version: 2 })),
+            getLatestRenderableDataAppVizVersion: vi
+                .fn()
+                .mockResolvedValue(makeVersion({ version: 2 })),
         };
         const service = buildService({
             appModel,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1860,12 +1860,22 @@ export class EmbedService extends BaseService {
         dataAppVizUuid: string,
         version: number,
     ): Promise<string> {
-        const { dataAppViz } = await this.getAuthorizedDataAppVizForEmbed(
-            account,
-            projectUuid,
-            savedChartUuid,
-            dataAppVizUuid,
-        );
+        const { dataAppViz, chart } =
+            await this.getAuthorizedDataAppVizForEmbed(
+                account,
+                projectUuid,
+                savedChartUuid,
+                dataAppVizUuid,
+            );
+        const pinnedVersion =
+            chart.chartConfig.type === ChartType.DATA_APP_VIZ
+                ? chart.chartConfig.config?.dataAppVizVersion
+                : undefined;
+        if (pinnedVersion !== undefined && version !== pinnedVersion) {
+            throw new ForbiddenError(
+                'Not authorized to access this visualization version',
+            );
+        }
         await resolveRenderableDataAppVizVersion(
             this.appModel,
             dataAppViz.app_id,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -112,9 +112,10 @@ import { EmbedModel } from '../../models/EmbedModel';
 import { ExternalConnectionModel } from '../../models/ExternalConnectionModel';
 import { getBundleServableChecker } from '../AppGenerateService/appBundleStorage';
 import {
+    assertDataAppVizPreviewVersionAllowed,
+    getDataAppVizVersionPin,
     resolveDataAppVisualizationForRender,
     resolveDataAppVizRenderMetadata,
-    resolveRenderableDataAppVizVersion,
 } from '../AppGenerateService/dataAppVizRender';
 
 const escapeEmbedJwtUserAttributeValue = (value: string): string =>
@@ -1841,10 +1842,7 @@ export class EmbedService extends BaseService {
                 savedChartUuid,
                 dataAppVizUuid,
             );
-        const pinnedVersion =
-            chart.chartConfig.type === ChartType.DATA_APP_VIZ
-                ? chart.chartConfig.config?.dataAppVizVersion
-                : undefined;
+        const pinnedVersion = getDataAppVizVersionPin(chart.chartConfig);
         return resolveDataAppVizRenderMetadata(
             this.appModel,
             dataAppViz.app_id,
@@ -1867,19 +1865,11 @@ export class EmbedService extends BaseService {
                 savedChartUuid,
                 dataAppVizUuid,
             );
-        const pinnedVersion =
-            chart.chartConfig.type === ChartType.DATA_APP_VIZ
-                ? chart.chartConfig.config?.dataAppVizVersion
-                : undefined;
-        if (pinnedVersion !== undefined && version !== pinnedVersion) {
-            throw new ForbiddenError(
-                'Not authorized to access this visualization version',
-            );
-        }
-        await resolveRenderableDataAppVizVersion(
+        await assertDataAppVizPreviewVersionAllowed(
             this.appModel,
             dataAppViz.app_id,
             version,
+            getDataAppVizVersionPin(chart.chartConfig),
         );
         return mintPreviewToken(
             this.lightdashConfig.lightdashSecrets,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1825,7 +1825,7 @@ export class EmbedService extends BaseService {
             );
         }
 
-        return dataAppViz;
+        return { dataAppViz, chart };
     }
 
     async getEmbedDataAppVizRenderMetadata(
@@ -1834,16 +1834,22 @@ export class EmbedService extends BaseService {
         savedChartUuid: string,
         dataAppVizUuid: string,
     ): Promise<DataAppVizRenderMetadata> {
-        const dataAppViz = await this.getAuthorizedDataAppVizForEmbed(
-            account,
-            projectUuid,
-            savedChartUuid,
-            dataAppVizUuid,
-        );
+        const { dataAppViz, chart } =
+            await this.getAuthorizedDataAppVizForEmbed(
+                account,
+                projectUuid,
+                savedChartUuid,
+                dataAppVizUuid,
+            );
+        const pinnedVersion =
+            chart.chartConfig.type === ChartType.DATA_APP_VIZ
+                ? chart.chartConfig.config?.dataAppVizVersion
+                : undefined;
         return resolveDataAppVizRenderMetadata(
             this.appModel,
             dataAppViz.app_id,
             getBundleServableChecker(this.lightdashConfig.appRuntime.s3),
+            pinnedVersion,
         );
     }
 
@@ -1854,7 +1860,7 @@ export class EmbedService extends BaseService {
         dataAppVizUuid: string,
         version: number,
     ): Promise<string> {
-        const dataAppViz = await this.getAuthorizedDataAppVizForEmbed(
+        const { dataAppViz } = await this.getAuthorizedDataAppVizForEmbed(
             account,
             projectUuid,
             savedChartUuid,

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -58,6 +58,12 @@ type AppModelArguments = {
     database: Knex;
 };
 
+export type PreviewChartVizBindingMapping = {
+    sourceAppUuid: string;
+    previewAppUuid: string;
+    previewAppVersion: number;
+};
+
 const AppSlugSequence = 'apps_slug_sequence';
 
 type AppWithOrgAndPin = DbApp & {
@@ -1207,11 +1213,7 @@ export class AppModel {
      */
     async remapPreviewChartVizBindings(
         previewProjectUuid: string,
-        mappings: {
-            sourceAppUuid: string;
-            previewAppUuid: string;
-            previewAppVersion: number;
-        }[],
+        mappings: PreviewChartVizBindingMapping[],
     ): Promise<void> {
         if (mappings.length === 0) {
             return;

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -48,7 +48,11 @@ const mocks = vi.hoisted(() => ({
     dataAppVizUuid: { current: 'viz-uuid' as string | null },
     dataAppVizVersion: { current: 7 as number | undefined },
     setDataAppVizVersion: vi.fn(),
-    iframePreview: vi.fn(() => null),
+    iframePreview: vi.fn(
+        (_props: {
+            onScreenshotAvailabilityChange: (available: boolean) => void;
+        }) => null,
+    ),
     renderMetadataHook: vi.fn(),
     previewTokenHook: vi.fn(),
     setFetchAll: vi.fn(),
@@ -165,6 +169,12 @@ const renderRenderer = (props?: Parameters<typeof DataAppVizRenderer>[0]) =>
             <DataAppVizRenderer {...props} />
         </MantineProvider>,
     );
+
+const announceIframeAvailable = () => {
+    const iframeProps = mocks.iframePreview.mock.lastCall?.[0];
+    if (!iframeProps) throw new Error('Expected the iframe preview to render');
+    act(() => iframeProps.onScreenshotAvailabilityChange(true));
+};
 
 const readyMetadata = () => ({
     state: 'ready' as const,
@@ -366,7 +376,7 @@ describe('DataAppVizRenderer', () => {
         );
     });
 
-    it('pins an unsaved project chart type to the version it previews', () => {
+    it('pins an unsaved project chart type only after its iframe is available', () => {
         mocks.dataAppVizVersion.current = undefined;
         mocks.vizContextOverrides.current = {
             savedChartUuid: undefined,
@@ -374,6 +384,10 @@ describe('DataAppVizRenderer', () => {
         };
 
         renderRenderer();
+
+        expect(mocks.setDataAppVizVersion).not.toHaveBeenCalled();
+
+        announceIframeAvailable();
 
         expect(mocks.setDataAppVizVersion).toHaveBeenCalledWith(7);
     });
@@ -405,6 +419,10 @@ describe('DataAppVizRenderer', () => {
                 savedChartUuid: 'saved-chart-uuid',
             },
         );
+        expect(mocks.setDataAppVizVersion).not.toHaveBeenCalled();
+
+        announceIframeAvailable();
+
         expect(mocks.setDataAppVizVersion).toHaveBeenCalledWith(7);
     });
 
@@ -437,6 +455,9 @@ describe('DataAppVizRenderer', () => {
                 savedChartUuid: 'saved-chart-uuid',
             },
         );
+
+        announceIframeAvailable();
+
         expect(mocks.setDataAppVizVersion).not.toHaveBeenCalled();
     });
 

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -283,6 +283,20 @@ describe('DataAppVizRenderer', () => {
         ).not.toBeInTheDocument();
     });
 
+    it('keeps the generic unavailable state for a legacy unpinned saved chart', () => {
+        mocks.metadata.current = {
+            state: 'unavailable',
+            latestBuildInProgress: false,
+        };
+        mocks.dataAppVizVersion.current = undefined;
+
+        renderRenderer();
+
+        expect(
+            screen.getByText('Custom chart type preview is unavailable.'),
+        ).toBeInTheDocument();
+    });
+
     it('keeps the generic unavailable state for an unsaved preview', () => {
         mocks.metadata.current = {
             state: 'unavailable',

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -264,11 +264,27 @@ describe('DataAppVizRenderer', () => {
         renderRenderer();
 
         expect(
-            screen.getByText('Custom chart type preview is unavailable.'),
+            screen.getByText(
+                'The saved custom chart type version is unavailable.',
+            ),
         ).toBeInTheDocument();
         expect(
             screen.queryByText('Custom chart type failed to generate.'),
         ).not.toBeInTheDocument();
+    });
+
+    it('keeps the generic unavailable state for an unsaved preview', () => {
+        mocks.metadata.current = {
+            state: 'unavailable',
+            latestBuildInProgress: false,
+        };
+        mocks.vizContextOverrides.current = { savedChartUuid: undefined };
+
+        renderRenderer();
+
+        expect(
+            screen.getByText('Custom chart type preview is unavailable.'),
+        ).toBeInTheDocument();
     });
 
     it.each([
@@ -359,6 +375,36 @@ describe('DataAppVizRenderer', () => {
 
         renderRenderer();
 
+        expect(mocks.setDataAppVizVersion).toHaveBeenCalledWith(7);
+    });
+
+    it('lazily pins a legacy saved chart when it is next edited', () => {
+        mocks.dataAppVizVersion.current = undefined;
+        mocks.vizContextOverrides.current = {
+            savedChartUuid: undefined,
+            isEditMode: true,
+            savedChartReference: {
+                uuid: 'saved-chart-uuid',
+                chartConfig: {
+                    type: 'data_app_viz',
+                    config: {
+                        dataAppVizUuid: 'viz-uuid',
+                        fieldMapping: { category: 'orders.category' },
+                    },
+                },
+            },
+        };
+
+        renderRenderer();
+
+        expect(mocks.renderMetadataHook).toHaveBeenCalledWith(
+            'project-uuid',
+            'viz-uuid',
+            {
+                isEmbedded: false,
+                savedChartUuid: 'saved-chart-uuid',
+            },
+        );
         expect(mocks.setDataAppVizVersion).toHaveBeenCalledWith(7);
     });
 

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -376,7 +376,7 @@ describe('DataAppVizRenderer', () => {
         );
     });
 
-    it('pins an unsaved project chart type only after its iframe is available', () => {
+    it('pins an unsaved project chart type without requiring an SDK capability announcement', () => {
         mocks.dataAppVizVersion.current = undefined;
         mocks.vizContextOverrides.current = {
             savedChartUuid: undefined,
@@ -384,10 +384,6 @@ describe('DataAppVizRenderer', () => {
         };
 
         renderRenderer();
-
-        expect(mocks.setDataAppVizVersion).not.toHaveBeenCalled();
-
-        announceIframeAvailable();
 
         expect(mocks.setDataAppVizVersion).toHaveBeenCalledWith(7);
     });
@@ -419,10 +415,6 @@ describe('DataAppVizRenderer', () => {
                 savedChartUuid: 'saved-chart-uuid',
             },
         );
-        expect(mocks.setDataAppVizVersion).not.toHaveBeenCalled();
-
-        announceIframeAvailable();
-
         expect(mocks.setDataAppVizVersion).toHaveBeenCalledWith(7);
     });
 

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -105,6 +105,12 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     // The iframe SDK posts `lightdash:sdk:screenshot-available` at bundle
     // boot — proof the sandbox is alive, not that the viz painted.
     const [screenshotAnnounced, setScreenshotAnnounced] = useState(false);
+    const handleScreenshotAvailabilityChange = useCallback(
+        (available: boolean) => {
+            if (available) setScreenshotAnnounced(true);
+        },
+        [],
+    );
 
     // Fetch every page so the renderer gets all rows — surfaces that don't
     // auto-fetch (dashboard tiles) would otherwise push a partial result.
@@ -150,31 +156,26 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         useDataAppVizRenderMetadata(projectUuid, dataAppVizUuid, renderTarget);
     const readyMetadata =
         renderMetadata?.state === 'ready' ? renderMetadata : undefined;
-    const handleScreenshotAvailabilityChange = useCallback(
-        (available: boolean) => {
-            if (!available) return;
-            setScreenshotAnnounced(true);
-            if (
-                !isEditMode ||
-                !readyMetadata ||
-                !dataAppVizChartConfig ||
-                !config ||
-                (config.dataAppVizVersion !== undefined &&
-                    renderSavedChartUuid !== undefined) ||
-                config.dataAppVizVersion === readyMetadata.version
-            ) {
-                return;
-            }
-            dataAppVizChartConfig.setDataAppVizVersion(readyMetadata.version);
-        },
-        [
-            config,
-            isEditMode,
-            readyMetadata,
-            renderSavedChartUuid,
-            dataAppVizChartConfig,
-        ],
-    );
+    useEffect(() => {
+        if (
+            !isEditMode ||
+            !readyMetadata ||
+            !dataAppVizChartConfig ||
+            !config ||
+            (config.dataAppVizVersion !== undefined &&
+                renderSavedChartUuid !== undefined) ||
+            config.dataAppVizVersion === readyMetadata.version
+        ) {
+            return;
+        }
+        dataAppVizChartConfig.setDataAppVizVersion(readyMetadata.version);
+    }, [
+        config,
+        isEditMode,
+        readyMetadata,
+        renderSavedChartUuid,
+        dataAppVizChartConfig,
+    ]);
     const { data: token, error: previewTokenError } = useDataAppVizPreviewToken(
         projectUuid,
         dataAppVizUuid,

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -419,7 +419,8 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         return (
             <DataAppVizPlaceholder
                 message={
-                    renderSavedChartUuid
+                    renderSavedChartUuid &&
+                    config?.dataAppVizVersion !== undefined
                         ? 'The saved custom chart type version is unavailable.'
                         : 'Custom chart type preview is unavailable.'
                 }

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -417,7 +417,13 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
 
     if (renderMetadata.state === 'unavailable') {
         return (
-            <DataAppVizPlaceholder message="Custom chart type preview is unavailable." />
+            <DataAppVizPlaceholder
+                message={
+                    renderSavedChartUuid
+                        ? 'The saved custom chart type version is unavailable.'
+                        : 'Custom chart type preview is unavailable.'
+                }
+            />
         );
     }
 

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -105,12 +105,6 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
     // The iframe SDK posts `lightdash:sdk:screenshot-available` at bundle
     // boot — proof the sandbox is alive, not that the viz painted.
     const [screenshotAnnounced, setScreenshotAnnounced] = useState(false);
-    const handleScreenshotAvailabilityChange = useCallback(
-        (available: boolean) => {
-            if (available) setScreenshotAnnounced(true);
-        },
-        [],
-    );
 
     // Fetch every page so the renderer gets all rows — surfaces that don't
     // auto-fetch (dashboard tiles) would otherwise push a partial result.
@@ -156,26 +150,31 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         useDataAppVizRenderMetadata(projectUuid, dataAppVizUuid, renderTarget);
     const readyMetadata =
         renderMetadata?.state === 'ready' ? renderMetadata : undefined;
-    useEffect(() => {
-        if (
-            !isEditMode ||
-            !readyMetadata ||
-            !dataAppVizChartConfig ||
-            !config ||
-            (config.dataAppVizVersion !== undefined &&
-                renderSavedChartUuid !== undefined) ||
-            config.dataAppVizVersion === readyMetadata.version
-        ) {
-            return;
-        }
-        dataAppVizChartConfig.setDataAppVizVersion(readyMetadata.version);
-    }, [
-        config,
-        isEditMode,
-        readyMetadata,
-        renderSavedChartUuid,
-        dataAppVizChartConfig,
-    ]);
+    const handleScreenshotAvailabilityChange = useCallback(
+        (available: boolean) => {
+            if (!available) return;
+            setScreenshotAnnounced(true);
+            if (
+                !isEditMode ||
+                !readyMetadata ||
+                !dataAppVizChartConfig ||
+                !config ||
+                (config.dataAppVizVersion !== undefined &&
+                    renderSavedChartUuid !== undefined) ||
+                config.dataAppVizVersion === readyMetadata.version
+            ) {
+                return;
+            }
+            dataAppVizChartConfig.setDataAppVizVersion(readyMetadata.version);
+        },
+        [
+            config,
+            isEditMode,
+            readyMetadata,
+            renderSavedChartUuid,
+            dataAppVizChartConfig,
+        ],
+    );
     const { data: token, error: previewTokenError } = useDataAppVizPreviewToken(
         projectUuid,
         dataAppVizUuid,

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -259,6 +259,7 @@ describe('DataAppVizConfigTabs', () => {
         dataAppVizUuid: string | null = 'data-app-viz-uuid',
         optionValues: Record<string, boolean | number | string> = {},
         fieldMapping: Record<string, string> = {},
+        dataAppVizVersion?: number,
     ) =>
         vi.mocked(useVisualizationContext).mockReturnValue({
             itemsMap,
@@ -269,7 +270,12 @@ describe('DataAppVizConfigTabs', () => {
                     validConfig:
                         dataAppVizUuid === null
                             ? null
-                            : { dataAppVizUuid, fieldMapping, optionValues },
+                            : {
+                                  dataAppVizUuid,
+                                  dataAppVizVersion,
+                                  fieldMapping,
+                                  optionValues,
+                              },
                     dataAppVizUuid,
                     setDataAppVizUuid,
                     clearDataAppViz,
@@ -684,6 +690,18 @@ describe('DataAppVizConfigTabs', () => {
         } finally {
             authoringState.current = null;
         }
+    });
+
+    it('fetches the schema of the selected chart type version', () => {
+        mockContext(queryColumns, 'data-app-viz-uuid', {}, {}, 3);
+
+        renderWithProviders(<ConfigTabs />);
+
+        expect(useDataAppVisualization).toHaveBeenLastCalledWith(
+            'project-1',
+            'data-app-viz-uuid',
+            3,
+        );
     });
 
     it('stays on the latest schema when authoring a different type', () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -53,20 +53,24 @@ export const ConfigTabs: FC = memo(() => {
     const dataAppVizUuid = isDataAppViz
         ? visualizationConfig.chartConfig.dataAppVizUuid
         : null;
+    const selectedVersion = isDataAppViz
+        ? (visualizationConfig.chartConfig.validConfig?.dataAppVizVersion ??
+          null)
+        : null;
 
-    // A chart renders the viz's latest ready version, so its options come from
-    // that version's declaration — unless the builder is previewing an older
-    // version of this same viz, whose own declaration the panel then follows.
-    const authoringVersion =
+    // The panel follows the same version as the chart. The builder can
+    // temporarily preview a different version of this same viz; selecting a
+    // type again clears its pin, so that path still asks for latest.
+    const schemaVersion =
         authoring !== null &&
         dataAppVizUuid !== null &&
         authoring.dataAppVizUuid === dataAppVizUuid
             ? authoring.viewedVersion
-            : null;
+            : selectedVersion;
     const { data: dataAppViz } = useDataAppVisualization(
         projectUuid,
         dataAppVizUuid,
-        authoringVersion,
+        schemaVersion,
     );
 
     const configOptions = useMemo(

--- a/packages/frontend/src/hooks/useSavedQuery.test.tsx
+++ b/packages/frontend/src/hooks/useSavedQuery.test.tsx
@@ -1,0 +1,89 @@
+import {
+    type CreateSavedChartVersion,
+    type Project,
+    type SavedChart,
+} from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProjectRouteContext } from './useProjectRoute';
+
+const navigate = vi.fn();
+
+vi.mock('react-router', () => ({
+    useNavigate: () => navigate,
+    useParams: () => ({ savedQueryUuid: 'legacy-chart' }),
+}));
+
+vi.mock('../api', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+vi.mock('./toaster/useToaster', () => ({
+    default: () => ({
+        showToastSuccess: vi.fn(),
+        showToastError: vi.fn(),
+        showToastApiError: vi.fn(),
+    }),
+}));
+
+vi.mock('./useSearchParams', () => ({
+    default: () => undefined,
+}));
+
+import { lightdashApi } from '../api';
+import { useAddVersionMutation } from './useSavedQuery';
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            <ProjectRouteContext.Provider
+                value={{
+                    project: {} as Project,
+                    projectUuid: 'project-uuid',
+                    projectUrlIdentifier: 'jaffle-shop',
+                }}
+            >
+                {children}
+            </ProjectRouteContext.Provider>
+        </QueryClientProvider>
+    );
+};
+
+describe('useAddVersionMutation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(lightdashApi).mockResolvedValue({
+            uuid: 'chart-uuid',
+            slug: 'legacy-chart',
+            projectUuid: 'project-uuid',
+            hasUnpublishedChanges: false,
+        } as SavedChart);
+    });
+
+    it('preserves the project URL identifier when returning to chart view', async () => {
+        const { result } = renderHook(() => useAddVersionMutation(), {
+            wrapper: createWrapper(),
+        });
+
+        await act(() =>
+            result.current.mutateAsync({
+                uuid: 'chart-uuid',
+                payload: {
+                    metricQuery: { filters: {} },
+                } as CreateSavedChartVersion,
+            }),
+        );
+
+        expect(navigate).toHaveBeenCalledWith(
+            '/projects/jaffle-shop/saved/legacy-chart/view',
+        );
+    });
+});

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -22,6 +22,7 @@ import useApp from '../providers/App/useApp';
 import { convertDateFilters } from '../utils/dateFilter';
 import useToaster from './toaster/useToaster';
 import { invalidateContent } from './useContent';
+import { useOptionalProjectRoute } from './useProjectRoute';
 import { useProjectUuid } from './useProjectUuid';
 import useSearchParams from './useSearchParams';
 
@@ -532,6 +533,7 @@ export const useAddVersionMutation = (options?: {
     const queryClient = useQueryClient();
     const params = useParams();
     const dashboardUuid = useSearchParams('fromDashboard');
+    const projectRoute = useOptionalProjectRoute();
 
     const { showToastSuccess, showToastError, showToastApiError } =
         useToaster();
@@ -608,7 +610,7 @@ export const useAddVersionMutation = (options?: {
                 });
                 if (redirectOnSuccess) {
                     void navigate(
-                        `/projects/${data.projectUuid}/saved/${data.slug}/view`,
+                        `/projects/${projectRoute?.projectUrlIdentifier ?? data.projectUuid}/saved/${data.slug}/view`,
                     );
                 }
             }


### PR DESCRIPTION
Linear: [GLITCH-698](https://linear.app/lightdash/issue/GLITCH-698/prevent-chart-type-edits-from-changing-existing-charts)

### Description

Second layer of the GLITCH-698 stack (depends on #28219):

- Resolve the exact pinned project chart type version for registered charts, chart history, and embedded charts.
- Return a specific unavailable state when that saved version or bundle no longer exists instead of silently rendering a newer version.
- Keep legacy charts migration-free: an omitted version continues to use the latest renderable version, and the chart is pinned lazily on its next edit and save.
- Keep unsaved authoring previews on latest, and reliably pin or re-pin them when editing without depending on optional iframe SDK capability announcements.
- Restrict registered and embedded preview tokens to the saved pin, or to latest for legacy unpinned charts.

### Verification

- 63 focused backend rendering tests
- 39 focused frontend renderer tests
- backend and frontend typechecks
- changed-file lint and formatting
- release-safety test suite

### Risk assessment

- [ ] This is a high-risk change
