### PR TITLE
feat(content-as-code): save Git-backed chart edits as drafts

### DIFF
--- a/packages/backend/src/contentAsCode/fieldCoverage/chart.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/chart.test.ts
@@ -11,9 +11,11 @@ describeContentAsCodeSchemaContract({
         'dashboardUuid',
         'deletedAt',
         'deletedBy',
-        // A chart's merge is not expressible as code yet; the saved shape is
-        // experimental alongside the endpoint.
-        'merge',
+        // Overlay flags for unpublished drafts; not part of the as-code document.
+        'dismissedDraftUuid',
+        'draftOverlayError',
+        'draftsAwaitingReview',
+        'hasUnpublishedChanges',
         'organizationUuid',
         'pinnedListOrder',
         'pinnedListUuid',

--- a/packages/backend/src/controllers/ProjectCoderController.ts
+++ b/packages/backend/src/controllers/ProjectCoderController.ts
@@ -260,7 +260,7 @@ export class ProjectCoderController extends BaseController {
     }
 
     /**
-     * Unpublished dashboard drafts awaiting review
+     * Unpublished content drafts awaiting review
      * @summary List content drafts
      */
     @Tags('Projects')

--- a/packages/backend/src/controllers/v2/ProjectSavedChartController.ts
+++ b/packages/backend/src/controllers/v2/ProjectSavedChartController.ts
@@ -10,6 +10,7 @@ import {
     Middlewares,
     OperationId,
     Path,
+    Query,
     Request,
     Response,
     Route,
@@ -41,13 +42,29 @@ export class ProjectSavedChartControllerV2 extends BaseController {
         @Path() projectUuid: string,
         @Path() chartUuidOrSlug: string,
         @Request() req: express.Request,
+        @Query() includeUnpublishedDraft?: boolean,
     ): Promise<ApiSavedChartResponse> {
         this.setStatus(200);
+        const savedChartService = this.services.getSavedChartService();
+        if (includeUnpublishedDraft === true) {
+            assertRegisteredAccount(req.account);
+            return {
+                status: 'ok',
+                results: await savedChartService.getForViewer(
+                    toSessionUser(req.account),
+                    chartUuidOrSlug,
+                    req.account,
+                    { projectUuid },
+                ),
+            };
+        }
         return {
             status: 'ok',
-            results: await this.services
-                .getSavedChartService()
-                .get(chartUuidOrSlug, req.account!, { projectUuid }),
+            results: await savedChartService.get(
+                chartUuidOrSlug,
+                req.account!,
+                { projectUuid },
+            ),
         };
     }
 

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1457,6 +1457,7 @@ export class CoderService extends BaseService {
             },
             chartConfig: chart.chartConfig,
             pivotConfig: chart.pivotConfig,
+            ...(chart.merge ? { merge: chart.merge } : {}),
             dashboardSlug: chart.dashboardUuid
                 ? dashboardSlugs[chart.dashboardUuid]
                 : undefined,
@@ -2847,6 +2848,13 @@ export class CoderService extends BaseService {
         chartUuid: string,
     ): Promise<ChartAsCode> {
         const chartAsCode = await this.getCurrentChartAsCode(chartUuid);
+        return this.makeChartAsCodePortable(projectUuid, chartAsCode);
+    }
+
+    private async makeChartAsCodePortable(
+        projectUuid: string,
+        chartAsCode: ChartAsCode,
+    ): Promise<ChartAsCode> {
         const dataAppVizUuid =
             chartAsCode.chartConfig.type === ChartType.DATA_APP_VIZ
                 ? chartAsCode.chartConfig.config?.dataAppVizUuid
@@ -2862,6 +2870,64 @@ export class CoderService extends BaseService {
             new Map(dataAppVizRows.map((row) => [row.app_id, row.slug])),
         );
         return transformed;
+    }
+
+    async getPortableChartAsCodeWithOverlay(
+        projectUuid: string,
+        chartUuid: string,
+        overlay: object,
+    ): Promise<ChartAsCode> {
+        const chart = await this.savedChartModel.get(chartUuid);
+        const fields = overlay as Partial<typeof chart> & {
+            verified?: boolean;
+        };
+        const merged = {
+            ...chart,
+            ...(fields.name !== undefined && { name: fields.name }),
+            ...(fields.description !== undefined && {
+                description: fields.description,
+            }),
+            ...(fields.tableName !== undefined && {
+                tableName: fields.tableName,
+            }),
+            ...(fields.metricQuery !== undefined && {
+                metricQuery: fields.metricQuery,
+            }),
+            ...(fields.chartConfig !== undefined && {
+                chartConfig: fields.chartConfig,
+            }),
+            ...(fields.tableConfig !== undefined && {
+                tableConfig: fields.tableConfig,
+            }),
+            ...(fields.pivotConfig !== undefined && {
+                pivotConfig: fields.pivotConfig,
+            }),
+            ...(fields.parameters !== undefined && {
+                parameters: fields.parameters,
+            }),
+            ...(fields.merge !== undefined && { merge: fields.merge }),
+        };
+        const spaces = await this.spaceModel.find({
+            spaceUuids: merged.spaceUuid ? [merged.spaceUuid] : [],
+        });
+        const dashboardSlugs = merged.dashboardUuid
+            ? await this.dashboardModel.getSlugsForUuids([merged.dashboardUuid])
+            : {};
+        const verificationMap =
+            await this.contentVerificationModel.getByContentUuids(
+                ContentType.CHART,
+                [merged.uuid],
+            );
+        const chartAsCode = CoderService.transformChart(
+            merged,
+            spaces,
+            dashboardSlugs,
+            verificationMap,
+        );
+        if (fields.verified !== undefined) {
+            chartAsCode.verified = fields.verified;
+        }
+        return this.makeChartAsCodePortable(projectUuid, chartAsCode);
     }
 
     async getCurrentDashboardAsCode(

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.test.ts
@@ -61,6 +61,10 @@ const buildService = (overrides: Overrides = {}) => {
     };
     const coderService = {
         getPortableChartAsCode: vi.fn().mockResolvedValue(chartAsCode),
+        getPortableChartAsCodeWithOverlay: vi.fn().mockResolvedValue({
+            ...chartAsCode,
+            name: 'Monthly revenue draft',
+        }),
         getCurrentDashboardAsCode: vi.fn().mockResolvedValue({
             name: 'Weekly KPIs',
             slug: 'weekly-kpis',
@@ -480,6 +484,45 @@ describe('ContentAsCodeWritebackService', () => {
             'project-uuid',
             'lightdash/write-back/app.lightdash.dev/weekly-kpis/draft-draft-uuid',
             'main',
+        );
+    });
+
+    it('reviews and writes a chart draft to the chart file', async () => {
+        const { service, coderService, gitIntegrationService } = buildService({
+            draft: {
+                uuid: 'chart-draft-uuid',
+                projectUuid: 'project-uuid',
+                contentType: 'chart',
+                contentUuid: 'chart-uuid',
+                slug: 'monthly-revenue',
+                authorUserUuid: 'author-uuid',
+                draft: { name: 'Monthly revenue draft' },
+                status: 'open',
+                prUrl: null,
+            },
+        });
+
+        const review = await service.getDraftReview(
+            user,
+            'project-uuid',
+            'chart-draft-uuid',
+        );
+        await service.writeBackDraft(user, 'project-uuid', 'chart-draft-uuid');
+
+        expect(review.draftYaml).toContain('Monthly revenue draft');
+        expect(
+            coderService.getPortableChartAsCodeWithOverlay,
+        ).toHaveBeenCalledWith('project-uuid', 'chart-uuid', {
+            name: 'Monthly revenue draft',
+        });
+        expect(gitIntegrationService.saveFile).toHaveBeenCalledWith(
+            user,
+            'project-uuid',
+            expect.stringContaining('/draft-chart-draft-uuid'),
+            'lightdash/charts/monthly-revenue.yml',
+            expect.stringContaining('Monthly revenue draft'),
+            undefined,
+            expect.any(String),
         );
     });
 

--- a/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
+++ b/packages/backend/src/services/ContentAsCodeWritebackService/ContentAsCodeWritebackService.ts
@@ -299,13 +299,32 @@ export class ContentAsCodeWritebackService extends BaseService {
         if (!draft || draft.projectUuid !== projectUuid) {
             throw new ParameterError('Draft not found');
         }
-        const published = await this.coderService.getCurrentDashboardAsCode(
-            draft.contentUuid,
-        );
-        const draftDoc = await this.coderService.getDashboardAsCodeWithOverlay(
-            draft.contentUuid,
-            draft.draft,
-        );
+        if (
+            draft.contentType !== 'chart' &&
+            draft.contentType !== 'dashboard'
+        ) {
+            throw new ParameterError('Unsupported draft content type');
+        }
+        const published =
+            draft.contentType === 'chart'
+                ? await this.coderService.getPortableChartAsCode(
+                      projectUuid,
+                      draft.contentUuid,
+                  )
+                : await this.coderService.getCurrentDashboardAsCode(
+                      draft.contentUuid,
+                  );
+        const draftDoc =
+            draft.contentType === 'chart'
+                ? await this.coderService.getPortableChartAsCodeWithOverlay(
+                      projectUuid,
+                      draft.contentUuid,
+                      draft.draft,
+                  )
+                : await this.coderService.getDashboardAsCodeWithOverlay(
+                      draft.contentUuid,
+                      draft.draft,
+                  );
         return {
             draft,
             publishedYaml: dumpContentAsCode(published),
@@ -325,13 +344,28 @@ export class ContentAsCodeWritebackService extends BaseService {
         if (!draft || draft.projectUuid !== projectUuid) {
             throw new ParameterError('Draft not found');
         }
-        const draftDoc = await this.coderService.getDashboardAsCodeWithOverlay(
-            draft.contentUuid,
-            draft.draft,
-        );
+        if (
+            draft.contentType !== 'chart' &&
+            draft.contentType !== 'dashboard'
+        ) {
+            throw new ParameterError('Unsupported draft content type');
+        }
+        const contentType =
+            draft.contentType === 'chart' ? 'chart' : 'dashboard';
+        const draftDoc =
+            contentType === 'chart'
+                ? await this.coderService.getPortableChartAsCodeWithOverlay(
+                      projectUuid,
+                      draft.contentUuid,
+                      draft.draft,
+                  )
+                : await this.coderService.getDashboardAsCodeWithOverlay(
+                      draft.contentUuid,
+                      draft.draft,
+                  );
         const row = await this.writeContentToWritebackPr(user, {
             projectUuid,
-            contentType: 'dashboard',
+            contentType,
             contentUuid: draft.contentUuid,
             slug: draft.slug,
             contentDraftUuid: draft.uuid,

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
@@ -176,6 +176,11 @@ describe('SavedChartService - Content Verification', () => {
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
         organizationModel: {} as unknown as OrganizationModel,
+        contentAsCodeProjectSettingsModel: {
+            get: vi.fn(async () => undefined),
+        } as never,
+        contentAsCodeSnapshotModel: {} as never,
+        contentDraftModel: {} as never,
     });
 
     afterEach(() => {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.drafts.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.drafts.test.ts
@@ -1,0 +1,289 @@
+import { Ability } from '@casl/ability';
+import {
+    ChartType,
+    PossibleAbilities,
+    type AnyType,
+    type SessionUser,
+} from '@lightdash/common';
+import { describe, expect, it, vi } from 'vitest';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { fromSession } from '../../auth/account';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { SavedChartService } from './SavedChartService';
+
+const chart = {
+    uuid: 'chart-uuid',
+    projectUuid: 'project-uuid',
+    organizationUuid: 'org-uuid',
+    slug: 'monthly-revenue',
+    name: 'Monthly revenue',
+    description: 'Published description',
+    tableName: 'orders',
+    metricQuery: {
+        metrics: ['orders_revenue'],
+        dimensions: [],
+        filters: { dimensions: {}, metrics: {}, tableCalculations: {} },
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+    },
+    chartConfig: { type: ChartType.CARTESIAN, config: {} },
+    tableConfig: { columnOrder: [] },
+    merge: null,
+    updatedAt: new Date(),
+    updatedByUser: undefined,
+    spaceUuid: 'space-uuid',
+    spaceName: 'Finance',
+    dashboardUuid: null,
+    dashboardName: null,
+    pinnedListUuid: null,
+    pinnedListOrder: null,
+    colorPalette: [],
+    colorPaletteUuid: null,
+    resolvedColorPalette: { colors: [] },
+    verification: null,
+};
+
+const editor = {
+    userUuid: 'editor-uuid',
+    ability: new Ability<PossibleAbilities>([
+        { action: ['view', 'update'], subject: 'SavedChart' },
+    ]),
+    abilityRules: [],
+} as unknown as SessionUser;
+
+const reviewer = {
+    userUuid: 'reviewer-uuid',
+    ability: new Ability<PossibleAbilities>([
+        { action: 'manage', subject: 'ContentAsCode' },
+    ]),
+} as unknown as SessionUser;
+
+const spaceContext = { inheritsFromOrgOrProject: true, access: [] };
+
+const buildService = (
+    overrides: {
+        settings?: object;
+        snapshot?: object;
+        draft?: object;
+    } = {},
+) => {
+    const settingsGet = vi
+        .fn()
+        .mockResolvedValue(
+            'settings' in overrides
+                ? overrides.settings
+                : { syncEnabled: true },
+        );
+    const snapshotGet = vi
+        .fn()
+        .mockResolvedValue(
+            'snapshot' in overrides
+                ? overrides.snapshot
+                : { snapshotHash: 'hash' },
+        );
+    const upsertOpenDraft = vi.fn(async (args: AnyType) => ({
+        uuid: 'draft-uuid',
+        draft: args.draft,
+    }));
+    const findOpenDraft = vi.fn().mockResolvedValue(overrides.draft);
+    const contentDraftModel = {
+        upsertOpenDraft,
+        findOpenDraft,
+        findLatestDismissedDraft: vi.fn().mockResolvedValue(undefined),
+        countOpenForContent: vi.fn().mockResolvedValue(0),
+    };
+    const savedChartModel = {
+        get: vi.fn().mockResolvedValue(chart),
+        getSummary: vi.fn().mockResolvedValue(chart),
+        createVersion: vi.fn(),
+        update: vi.fn(),
+    };
+    const service = new SavedChartService({
+        analytics: analyticsMock,
+        lightdashConfig: lightdashConfigMock,
+        projectModel: {
+            get: vi.fn().mockResolvedValue({
+                projectUuid: chart.projectUuid,
+                organizationUuid: chart.organizationUuid,
+            }),
+        },
+        savedChartModel,
+        spaceModel: {},
+        analyticsModel: {},
+        pinnedListModel: {},
+        schedulerModel: {},
+        schedulerService: {},
+        schedulerClient: {},
+        slackClient: {},
+        dashboardModel: {},
+        catalogModel: {},
+        permissionsService: {},
+        googleDriveClient: {},
+        userService: {},
+        spacePermissionService: {
+            resolveAccess: vi.fn().mockResolvedValue(spaceContext),
+        },
+        contentVerificationModel: {
+            getByContent: vi.fn().mockResolvedValue(undefined),
+        },
+        organizationModel: {},
+        contentAsCodeProjectSettingsModel: { get: settingsGet },
+        contentAsCodeSnapshotModel: { get: snapshotGet },
+        contentDraftModel,
+    } as AnyType);
+    return {
+        service,
+        settingsGet,
+        snapshotGet,
+        upsertOpenDraft,
+        findOpenDraft,
+        contentDraftModel,
+        savedChartModel,
+    };
+};
+
+describe('SavedChartService chart drafts', () => {
+    it('stores Git-backed editor changes without mutating published content', async () => {
+        const { service, upsertOpenDraft } = buildService();
+
+        const result = await service['maybeStoreDraft'](
+            editor,
+            chart as AnyType,
+            { name: 'Drafted revenue' },
+            null,
+            spaceContext,
+        );
+
+        expect(upsertOpenDraft).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contentType: 'chart',
+                contentUuid: chart.uuid,
+                authorUserUuid: editor.userUuid,
+            }),
+        );
+        expect(result).toMatchObject({
+            name: 'Drafted revenue',
+            hasUnpublishedChanges: true,
+        });
+        expect(chart.name).toBe('Monthly revenue');
+    });
+
+    it('turns a Git-backed chart version save into a draft', async () => {
+        const { service, savedChartModel, upsertOpenDraft } = buildService();
+
+        const result = await service.createVersion(
+            fromSession(editor as AnyType, 'session-cookie'),
+            chart.uuid,
+            {
+                tableName: chart.tableName,
+                metricQuery: chart.metricQuery,
+                chartConfig: {
+                    type: ChartType.CARTESIAN,
+                    config: { isStacked: true },
+                },
+                tableConfig: chart.tableConfig,
+                merge: null,
+            } as AnyType,
+        );
+
+        expect(result).toMatchObject({ hasUnpublishedChanges: true });
+        expect(upsertOpenDraft).toHaveBeenCalledWith(
+            expect.objectContaining({ contentType: 'chart' }),
+        );
+        expect(savedChartModel.createVersion).not.toHaveBeenCalled();
+    });
+
+    it('turns a Git-backed chart rename into the same draft workflow', async () => {
+        const { service, savedChartModel } = buildService();
+
+        const result = await service.update(editor, chart.uuid, {
+            name: 'Drafted chart name',
+        });
+
+        expect(result).toMatchObject({
+            name: 'Drafted chart name',
+            hasUnpublishedChanges: true,
+        });
+        expect(savedChartModel.update).not.toHaveBeenCalled();
+    });
+
+    it('publishes UI-only charts through the existing path', async () => {
+        const { service, upsertOpenDraft } = buildService({
+            snapshot: undefined,
+        });
+
+        const result = await service['maybeStoreDraft'](
+            editor,
+            chart as AnyType,
+            { name: 'Published rename' },
+            null,
+            spaceContext,
+        );
+
+        expect(result).toBeUndefined();
+        expect(upsertOpenDraft).not.toHaveBeenCalled();
+    });
+
+    it('lets content-as-code reviewers publish directly', async () => {
+        const { service, upsertOpenDraft } = buildService();
+
+        const result = await service['maybeStoreDraft'](
+            reviewer,
+            chart as AnyType,
+            { name: 'Reviewed rename' },
+            null,
+            spaceContext,
+        );
+
+        expect(result).toBeUndefined();
+        expect(upsertOpenDraft).not.toHaveBeenCalled();
+    });
+
+    it("overlays only the caller's draft", async () => {
+        const { service, findOpenDraft } = buildService({
+            draft: {
+                uuid: 'draft-uuid',
+                draft: { name: 'Author draft' },
+            },
+        });
+
+        const result = await service['applyOpenDraftOverlay'](editor, {
+            ...chart,
+            ...spaceContext,
+        } as AnyType);
+
+        expect(result).toMatchObject({
+            name: 'Author draft',
+            hasUnpublishedChanges: true,
+        });
+        expect(findOpenDraft).toHaveBeenCalledWith(
+            chart.projectUuid,
+            'chart',
+            chart.uuid,
+            editor.userUuid,
+        );
+    });
+
+    it('serves published content when a stored chart draft is invalid', async () => {
+        const { service } = buildService({
+            draft: {
+                uuid: 'draft-uuid',
+                draft: { metricQuery: 'invalid' },
+            },
+        });
+
+        const result = await service['applyOpenDraftOverlay'](editor, {
+            ...chart,
+            ...spaceContext,
+        } as AnyType);
+
+        expect(result).toMatchObject({
+            name: 'Monthly revenue',
+            draftOverlayError: {
+                code: 'invalid_chart_draft',
+                draftUuid: 'draft-uuid',
+            },
+        });
+    });
+});

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.grantWrites.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.grantWrites.test.ts
@@ -198,6 +198,11 @@ describe('SavedChartService direct-grant write parity', () => {
             unverify: vi.fn(async () => undefined),
         } as unknown as ContentVerificationModel,
         organizationModel: {} as unknown as OrganizationModel,
+        contentAsCodeProjectSettingsModel: {
+            get: vi.fn(async () => undefined),
+        },
+        contentAsCodeSnapshotModel: {},
+        contentDraftModel: {},
     } as never);
 
     afterEach(() => {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -9,6 +9,7 @@ import {
     ChartSummary,
     ChartType,
     ChartVersion,
+    ContentAsCodeType,
     ContentType,
     countCustomDimensionsInMetricQuery,
     countTotalFilterRules,
@@ -78,6 +79,9 @@ import { getSchedulerTargetType } from '../../database/entities/scheduler';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { getChartFieldUsageChanges } from '../../models/CatalogModel/utils';
+import { ContentAsCodeProjectSettingsModel } from '../../models/ContentAsCodeProjectSettingsModel';
+import { ContentAsCodeSnapshotModel } from '../../models/ContentAsCodeSnapshotModel';
+import { ContentDraftModel } from '../../models/ContentDraftModel';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
@@ -117,6 +121,57 @@ type SavedChartServiceArguments = {
     spacePermissionService: SpacePermissionService;
     contentVerificationModel: ContentVerificationModel;
     organizationModel: OrganizationModel;
+    contentAsCodeProjectSettingsModel: ContentAsCodeProjectSettingsModel;
+    contentAsCodeSnapshotModel: ContentAsCodeSnapshotModel;
+    contentDraftModel: ContentDraftModel;
+};
+
+type ChartDraftOverlay = Partial<
+    Pick<
+        SavedChartDAO,
+        | 'name'
+        | 'description'
+        | 'tableName'
+        | 'metricQuery'
+        | 'chartConfig'
+        | 'tableConfig'
+        | 'pivotConfig'
+        | 'parameters'
+        | 'merge'
+    >
+> & { verified?: boolean };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const assertChartDraftOverlay: (
+    draft: unknown,
+) => asserts draft is ChartDraftOverlay = (draft) => {
+    if (!isRecord(draft)) throw new Error('Chart draft must be an object');
+    const validators: Record<
+        keyof ChartDraftOverlay,
+        (value: unknown) => boolean
+    > = {
+        name: (value) => typeof value === 'string',
+        description: (value) => typeof value === 'string',
+        tableName: (value) => typeof value === 'string',
+        metricQuery: isRecord,
+        chartConfig: isRecord,
+        tableConfig: isRecord,
+        pivotConfig: isRecord,
+        parameters: isRecord,
+        merge: (value) => value === null || isRecord(value),
+        verified: (value) => typeof value === 'boolean',
+    };
+    for (const [field, validate] of Object.entries(validators)) {
+        if (
+            Object.prototype.hasOwnProperty.call(draft, field) &&
+            draft[field] !== undefined &&
+            !validate(draft[field])
+        ) {
+            throw new Error(`Invalid chart draft field: ${field}`);
+        }
+    }
 };
 
 type GoogleSheetValidationOptions = {
@@ -176,6 +231,12 @@ export class SavedChartService
 
     private readonly organizationModel: OrganizationModel;
 
+    private readonly contentAsCodeProjectSettingsModel: ContentAsCodeProjectSettingsModel;
+
+    private readonly contentAsCodeSnapshotModel: ContentAsCodeSnapshotModel;
+
+    private readonly contentDraftModel: ContentDraftModel;
+
     constructor(args: SavedChartServiceArguments) {
         super();
         this.analytics = args.analytics;
@@ -197,6 +258,10 @@ export class SavedChartService
         this.spacePermissionService = args.spacePermissionService;
         this.contentVerificationModel = args.contentVerificationModel;
         this.organizationModel = args.organizationModel;
+        this.contentAsCodeProjectSettingsModel =
+            args.contentAsCodeProjectSettingsModel;
+        this.contentAsCodeSnapshotModel = args.contentAsCodeSnapshotModel;
+        this.contentDraftModel = args.contentDraftModel;
     }
 
     private async checkUpdateAccess(
@@ -633,6 +698,189 @@ export class SavedChartService
         );
     }
 
+    private async canManageContentAsCode(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<boolean> {
+        const project = await this.projectModel.get(projectUuid);
+        return this.createAuditedAbility(user).can(
+            'manage',
+            subject('ContentAsCode', {
+                projectUuid: project.projectUuid,
+                organizationUuid: project.organizationUuid,
+                upstreamProjectUuid: project.upstreamProjectUuid,
+                type: project.type,
+                createdByUserUuid: project.createdByUserUuid,
+                metadata: { slug: '' },
+            }),
+        );
+    }
+
+    private static mergeDraftIntoChart<T extends SavedChartDAO>(
+        chart: T,
+        draft: unknown,
+    ): T {
+        assertChartDraftOverlay(draft);
+        return {
+            ...chart,
+            ...(draft.name !== undefined && { name: draft.name }),
+            ...(draft.description !== undefined && {
+                description: draft.description,
+            }),
+            ...(draft.tableName !== undefined && {
+                tableName: draft.tableName,
+            }),
+            ...(draft.metricQuery !== undefined && {
+                metricQuery: draft.metricQuery,
+            }),
+            ...(draft.chartConfig !== undefined && {
+                chartConfig: draft.chartConfig,
+            }),
+            ...(draft.tableConfig !== undefined && {
+                tableConfig: draft.tableConfig,
+            }),
+            ...(draft.pivotConfig !== undefined && {
+                pivotConfig: draft.pivotConfig,
+            }),
+            ...(draft.parameters !== undefined && {
+                parameters: draft.parameters,
+            }),
+            ...(draft.merge !== undefined && { merge: draft.merge }),
+        };
+    }
+
+    private async maybeStoreDraft(
+        user: SessionUser,
+        existingChart: SavedChartDAO | ChartSummary,
+        draftFields: ChartDraftOverlay,
+        verificationAfterUpdate: ContentVerificationInfo | null,
+        spaceContext: {
+            inheritsFromOrgOrProject: boolean;
+            access: SpaceAccess[];
+        },
+    ): Promise<SavedChart | undefined> {
+        if (Object.keys(draftFields).length === 0) return undefined;
+        const settings = await this.contentAsCodeProjectSettingsModel.get(
+            existingChart.projectUuid,
+        );
+        if (!settings?.syncEnabled) return undefined;
+        const snapshot = await this.contentAsCodeSnapshotModel.get(
+            existingChart.projectUuid,
+            ContentAsCodeType.CHART,
+            existingChart.slug,
+        );
+        if (snapshot === undefined) return undefined;
+        if (
+            await this.canManageContentAsCode(user, existingChart.projectUuid)
+        ) {
+            return undefined;
+        }
+        const stored = await this.contentDraftModel.upsertOpenDraft({
+            projectUuid: existingChart.projectUuid,
+            contentType: 'chart',
+            contentUuid: existingChart.uuid,
+            slug: existingChart.slug,
+            authorUserUuid: user.userUuid,
+            draft: draftFields,
+        });
+        const chartForOverlay =
+            'metricQuery' in existingChart
+                ? existingChart
+                : await this.savedChartModel.get(existingChart.uuid);
+        return {
+            ...SavedChartService.mergeDraftIntoChart(
+                chartForOverlay,
+                stored.draft,
+            ),
+            verification: verificationAfterUpdate,
+            ...spaceContext,
+            hasUnpublishedChanges: true,
+        };
+    }
+
+    private async applyOpenDraftOverlay(
+        user: SessionUser,
+        chart: SavedChart,
+    ): Promise<SavedChart> {
+        try {
+            const settings = await this.contentAsCodeProjectSettingsModel.get(
+                chart.projectUuid,
+            );
+            if (!settings?.syncEnabled) return chart;
+            const draft = await this.contentDraftModel.findOpenDraft(
+                chart.projectUuid,
+                'chart',
+                chart.uuid,
+                user.userUuid,
+            );
+            if (draft) {
+                try {
+                    assertChartDraftOverlay(draft.draft);
+                    return {
+                        ...SavedChartService.mergeDraftIntoChart(
+                            chart,
+                            draft.draft,
+                        ),
+                        verification:
+                            draft.draft.verified === false
+                                ? null
+                                : chart.verification,
+                        hasUnpublishedChanges: true,
+                    };
+                } catch (error) {
+                    this.logger.warn(
+                        'Chart draft overlay failed; serving published chart',
+                        {
+                            projectUuid: chart.projectUuid,
+                            chartUuid: chart.uuid,
+                            draftUuid: draft.uuid,
+                            error:
+                                error instanceof Error
+                                    ? error.message
+                                    : String(error),
+                        },
+                    );
+                    return {
+                        ...chart,
+                        draftOverlayError: {
+                            code: 'invalid_chart_draft',
+                            draftUuid: draft.uuid,
+                        },
+                    };
+                }
+            }
+            const dismissedDraft =
+                await this.contentDraftModel.findLatestDismissedDraft(
+                    chart.projectUuid,
+                    'chart',
+                    chart.uuid,
+                    user.userUuid,
+                );
+            const chartForViewer = dismissedDraft
+                ? { ...chart, dismissedDraftUuid: dismissedDraft.uuid }
+                : chart;
+            if (await this.canManageContentAsCode(user, chart.projectUuid)) {
+                const awaiting =
+                    await this.contentDraftModel.countOpenForContent(
+                        chart.projectUuid,
+                        'chart',
+                        chart.uuid,
+                        user.userUuid,
+                    );
+                if (awaiting > 0) {
+                    return {
+                        ...chartForViewer,
+                        draftsAwaitingReview: awaiting,
+                    };
+                }
+            }
+            return chartForViewer;
+        } catch (error) {
+            this.logger.warn('Chart draft overlay failed', error);
+            return chart;
+        }
+    }
+
     async createVersion(
         account: Account,
         savedChartUuid: string,
@@ -641,6 +889,7 @@ export class SavedChartService
         // Embed writes run as the write actor and only inside the write space
         const { user, embedWriteActions } = getAccountWriteContext(account);
         const { preserveVerification, ...chartVersion } = data;
+        const existingChart = await this.savedChartModel.get(savedChartUuid);
         const {
             organizationUuid,
             projectUuid,
@@ -652,7 +901,7 @@ export class SavedChartService
                 customDimensions: oldCustomDimensions,
                 tableCalculations: oldTableCalculations,
             },
-        } = await this.savedChartModel.get(savedChartUuid);
+        } = existingChart;
 
         if (embedWriteActions && spaceUuid !== embedWriteActions.spaceUuid) {
             throw new ForbiddenError(
@@ -770,6 +1019,26 @@ export class SavedChartService
                 preserveVerification,
             });
 
+        if (!embedWriteActions) {
+            const draftResult = await this.maybeStoreDraft(
+                user,
+                existingChart,
+                {
+                    tableName: chartVersion.tableName,
+                    metricQuery: chartVersion.metricQuery,
+                    chartConfig: chartVersion.chartConfig,
+                    tableConfig: chartVersion.tableConfig,
+                    pivotConfig: chartVersion.pivotConfig,
+                    parameters: chartVersion.parameters,
+                    merge: chartVersion.merge,
+                    verified: verificationAfterUpdate !== null,
+                },
+                verificationAfterUpdate,
+                { inheritsFromOrgOrProject, access },
+            );
+            if (draftResult) return draftResult;
+        }
+
         const savedChart = await this.savedChartModel.createVersion(
             savedChartUuid,
             chartVersion,
@@ -879,13 +1148,15 @@ export class SavedChartService
         data: UpdateSavedChart,
     ): Promise<SavedChart> {
         const { preserveVerification, ...chartUpdate } = data;
+        const existingChart =
+            await this.savedChartModel.getSummary(savedChartUuid);
         const {
             organizationUuid,
             projectUuid,
             spaceUuid,
             dashboardUuid,
             name,
-        } = await this.savedChartModel.getSummary(savedChartUuid);
+        } = existingChart;
 
         const { inheritsFromOrgOrProject, access, directOnly } =
             await this.spacePermissionService.resolveAccess(user.userUuid, {
@@ -970,6 +1241,25 @@ export class SavedChartService
                 organizationUuid,
                 preserveVerification,
             });
+
+        const chartDraftFields: ChartDraftOverlay = {
+            ...(chartUpdate.name !== undefined && { name: chartUpdate.name }),
+            ...(chartUpdate.description !== undefined && {
+                description: chartUpdate.description,
+            }),
+            ...(chartUpdate.name !== undefined ||
+            chartUpdate.description !== undefined
+                ? { verified: verificationAfterUpdate !== null }
+                : {}),
+        };
+        const draftResult = await this.maybeStoreDraft(
+            user,
+            existingChart,
+            chartDraftFields,
+            verificationAfterUpdate,
+            { inheritsFromOrgOrProject, access },
+        );
+        if (draftResult) return draftResult;
 
         const savedChart = await this.savedChartModel.update(
             savedChartUuid,
@@ -1592,6 +1882,18 @@ export class SavedChartService
             inheritsFromOrgOrProject,
             access,
         };
+    }
+
+    // Interactive chart pages opt into the caller's unpublished overlay.
+    // Other consumers keep using `get`, which is always published-only.
+    async getForViewer(
+        user: SessionUser,
+        savedChartUuidOrSlug: string,
+        account: Account,
+        options?: { projectUuid?: string },
+    ): Promise<SavedChart> {
+        const chart = await this.get(savedChartUuidOrSlug, account, options);
+        return this.applyOpenDraftOverlay(user, chart);
     }
 
     async verifyChart(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1047,6 +1047,11 @@ export class ServiceRepository
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
                     organizationModel: this.models.getOrganizationModel(),
+                    contentAsCodeProjectSettingsModel:
+                        this.models.getContentAsCodeProjectSettingsModel(),
+                    contentAsCodeSnapshotModel:
+                        this.models.getContentAsCodeSnapshotModel(),
+                    contentDraftModel: this.models.getContentDraftModel(),
                 }),
         );
     }

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -120,6 +120,23 @@
             "required": ["type", "sql", "table", "name"],
             "type": "object"
         },
+        "AndFilterGroup": {
+            "properties": {
+                "and": {
+                    "description": "Array of filters or nested groups combined with AND logic",
+                    "items": {
+                        "$ref": "#/$defs/FilterGroupItem"
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "description": "Unique identifier for the filter group",
+                    "type": "string"
+                }
+            },
+            "required": ["and", "id"],
+            "type": "object"
+        },
         "AndFilterGroupInput": {
             "properties": {
                 "and": {
@@ -1361,6 +1378,16 @@
             "required": ["fieldId"],
             "type": "object"
         },
+        "FilterGroup": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/OrFilterGroup"
+                },
+                {
+                    "$ref": "#/$defs/AndFilterGroup"
+                }
+            ]
+        },
         "FilterGroupInput": {
             "anyOf": [
                 {
@@ -1368,6 +1395,16 @@
                 },
                 {
                     "$ref": "#/$defs/AndFilterGroupInput"
+                }
+            ]
+        },
+        "FilterGroupItem": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/FilterGroup"
+                },
+                {
+                    "$ref": "#/$defs/FilterRule"
                 }
             ]
         },
@@ -1406,6 +1443,52 @@
             ],
             "type": "string"
         },
+        "FilterRule": {
+            "additionalProperties": true,
+            "properties": {
+                "caseSensitive": {
+                    "description": "Overrides the field/explore case-sensitivity for this rule only.\nUsed by internal features like autocomplete search that must always\nmatch case-insensitively regardless of the field's configured setting.",
+                    "type": "boolean"
+                },
+                "disabled": {
+                    "description": "Whether this filter is disabled",
+                    "type": "boolean"
+                },
+                "id": {
+                    "description": "Unique identifier for the filter",
+                    "type": "string"
+                },
+                "includeNull": {
+                    "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule.",
+                    "type": "boolean"
+                },
+                "operator": {
+                    "$ref": "#/$defs/FilterOperator",
+                    "description": "Filter operator"
+                },
+                "required": {
+                    "description": "Whether this filter is required",
+                    "type": "boolean"
+                },
+                "settings": {
+                    "$ref": "#/$defs/AnyType",
+                    "description": "Additional settings for date/time filters"
+                },
+                "target": {
+                    "$ref": "#/$defs/FieldTarget",
+                    "description": "Target field for the filter"
+                },
+                "values": {
+                    "description": "Values to filter by",
+                    "items": {
+                        "$ref": "#/$defs/AnyType"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["operator", "id", "target"],
+            "type": "object"
+        },
         "FilterRuleInput": {
             "allOf": [
                 {
@@ -1421,6 +1504,23 @@
                 }
             ],
             "description": "Permissive filter types for chart-as-code uploads where `id` may be omitted.\nFilter IDs are auto-generated during upsert if absent.\nAfter normalization these become the strict runtime types (FilterGroup, Filters)."
+        },
+        "Filters": {
+            "properties": {
+                "dimensions": {
+                    "$ref": "#/$defs/FilterGroup",
+                    "description": "Dimension filter group"
+                },
+                "metrics": {
+                    "$ref": "#/$defs/FilterGroup",
+                    "description": "Metric filter group"
+                },
+                "tableCalculations": {
+                    "$ref": "#/$defs/FilterGroup",
+                    "description": "Table calculation filter group"
+                }
+            },
+            "type": "object"
         },
         "FiltersInput": {
             "properties": {
@@ -2118,6 +2218,42 @@
             "required": ["uuid"],
             "type": "object"
         },
+        "MergeJoinKeyPart": {
+            "description": "One column of the join key. Sources name the same real-world key differently\n(`orders.order_date` vs `users.created_date`), so the mapping is explicit per\nsource rather than positional.",
+            "properties": {
+                "fieldIdBySourceId": {
+                    "$ref": "#/$defs/Record_string.FieldId_",
+                    "description": "The field each source joins on. Every source must have an entry."
+                },
+                "name": {
+                    "description": "Column name this key part takes in the merged result.",
+                    "type": "string"
+                }
+            },
+            "required": ["fieldIdBySourceId", "name"],
+            "type": "object"
+        },
+        "MergeJoinType": {
+            "description": "How unmatched keys survive the merge. Mirrors the SQL join it compiles to.",
+            "enum": ["full", "left", "inner"],
+            "type": "string"
+        },
+        "MergeTableCalculation": {
+            "description": "A calculation over the *merged* result, which is the only place a row-wise\ncalculation across two queries can correctly live. References name a source\nand one of its fields, `${sourceId.fieldId}`, because the merged statement\nrenames columns to keep two sources from colliding.",
+            "properties": {
+                "displayName": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "sql": {
+                    "type": "string"
+                }
+            },
+            "required": ["sql", "displayName", "name"],
+            "type": "object"
+        },
         "MetricFilterRule": {
             "additionalProperties": true,
             "description": "Filter rule for metrics, targeting fields by reference",
@@ -2179,6 +2315,103 @@
             "properties": {},
             "type": "object"
         },
+        "MetricQuery": {
+            "properties": {
+                "additionalMetrics": {
+                    "description": "Custom metrics defined inline (ad-hoc metrics not in the dbt model)",
+                    "items": {
+                        "$ref": "#/$defs/AdditionalMetric"
+                    },
+                    "type": "array"
+                },
+                "customDimensions": {
+                    "description": "Custom dimensions defined inline",
+                    "items": {
+                        "$ref": "#/$defs/CustomDimension"
+                    },
+                    "type": "array"
+                },
+                "dimensionOverrides": {
+                    "$ref": "#/$defs/DimensionOverrides",
+                    "description": "Override formatting options for existing dimensions"
+                },
+                "dimensions": {
+                    "description": "List of dimension field IDs to include",
+                    "items": {
+                        "$ref": "#/$defs/FieldId"
+                    },
+                    "type": "array"
+                },
+                "exploreName": {
+                    "description": "The name of the explore to query",
+                    "type": "string"
+                },
+                "filters": {
+                    "$ref": "#/$defs/Filters",
+                    "description": "Filter rules to apply to the query"
+                },
+                "limit": {
+                    "description": "Maximum number of rows to return",
+                    "format": "double",
+                    "type": "number"
+                },
+                "metadata": {
+                    "properties": {
+                        "hasADateDimension": {
+                            "$ref": "#/$defs/Pick_CompiledDimension.label-or-name-or-table_"
+                        }
+                    },
+                    "required": ["hasADateDimension"],
+                    "type": "object"
+                },
+                "metricOverrides": {
+                    "$ref": "#/$defs/MetricOverrides",
+                    "description": "Override formatting options for existing metrics"
+                },
+                "metrics": {
+                    "description": "List of metric field IDs to include",
+                    "items": {
+                        "$ref": "#/$defs/FieldId"
+                    },
+                    "type": "array"
+                },
+                "pivotDimensions": {
+                    "description": "Dimension field IDs used as pivot columns (from chart's pivotConfig.columns).\nUsed by row_total() to determine non-pivot dimensions for GROUP BY.",
+                    "items": {
+                        "$ref": "#/$defs/FieldId"
+                    },
+                    "type": "array"
+                },
+                "sorts": {
+                    "description": "Sort configuration for query results",
+                    "items": {
+                        "$ref": "#/$defs/SortField"
+                    },
+                    "type": "array"
+                },
+                "tableCalculations": {
+                    "description": "Custom calculations to perform on query results",
+                    "items": {
+                        "$ref": "#/$defs/TableCalculation"
+                    },
+                    "type": "array"
+                },
+                "timezone": {
+                    "description": "Timezone for date/time values (e.g., 'America/Los_Angeles', 'UTC')",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "tableCalculations",
+                "limit",
+                "sorts",
+                "filters",
+                "metrics",
+                "dimensions",
+                "exploreName"
+            ],
+            "type": "object"
+        },
         "MetricType": {
             "enum": [
                 "percentile",
@@ -2224,6 +2457,23 @@
         "Omit_MetricQuery.filters_": {
             "$ref": "#/$defs/Pick_MetricQuery.Exclude_keyofMetricQuery.filters__",
             "description": "Construct a type with the properties of T except for those in type K."
+        },
+        "OrFilterGroup": {
+            "properties": {
+                "id": {
+                    "description": "Unique identifier for the filter group",
+                    "type": "string"
+                },
+                "or": {
+                    "description": "Array of filters or nested groups combined with OR logic",
+                    "items": {
+                        "$ref": "#/$defs/FilterGroupItem"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["or", "id"],
+            "type": "object"
         },
         "OrFilterGroupInput": {
             "properties": {
@@ -2406,6 +2656,22 @@
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "Pick_CompiledDimension.label-or-name-or-table_": {
+            "description": "From T, pick a set of properties whose keys are in the union K",
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "table": {
+                    "type": "string"
+                }
+            },
+            "required": ["name", "label", "table"],
             "type": "object"
         },
         "Pick_CompiledDimension.name-or-label-or-table_": {
@@ -2752,6 +3018,14 @@
             "properties": {},
             "type": "object"
         },
+        "Record_string.FieldId_": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "description": "Construct a type with a set of properties K of type T",
+            "properties": {},
+            "type": "object"
+        },
         "Record_string.MapFieldConfig_": {
             "additionalProperties": {
                 "$ref": "#/$defs/MapFieldConfig"
@@ -2865,6 +3139,78 @@
             "description": "How nodes are laid out:\n- `multi-step`: depth-unrolled journeys (default)\n- `merged`: one node per label, journeys preserved (acyclic flows only)\n- `direct`: two-column source→target pairs, no chaining",
             "enum": ["multi-step", "merged", "direct"],
             "type": "string"
+        },
+        "SavedMergeQuery": {
+            "description": "Canonical, scalable representation of a merge stored on a chart version.",
+            "properties": {
+                "joinKey": {
+                    "items": {
+                        "$ref": "#/$defs/MergeJoinKeyPart"
+                    },
+                    "type": "array"
+                },
+                "joinType": {
+                    "$ref": "#/$defs/MergeJoinType"
+                },
+                "primarySourceId": {
+                    "description": "Source whose rows a LEFT merge preserves.",
+                    "type": "string"
+                },
+                "sources": {
+                    "items": {
+                        "$ref": "#/$defs/SavedMergeQuerySource"
+                    },
+                    "type": "array"
+                },
+                "tableCalculations": {
+                    "items": {
+                        "$ref": "#/$defs/MergeTableCalculation"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "tableCalculations",
+                "joinType",
+                "joinKey",
+                "sources",
+                "primarySourceId"
+            ],
+            "type": "object"
+        },
+        "SavedMergeQuerySource": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "kind": {
+                            "enum": ["chart"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["kind", "id"],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "kind": {
+                            "enum": ["query"],
+                            "type": "string"
+                        },
+                        "metricQuery": {
+                            "$ref": "#/$defs/MetricQuery"
+                        }
+                    },
+                    "required": ["metricQuery", "kind", "id"],
+                    "type": "object"
+                }
+            ],
+            "description": "A persisted merge source.\n\nThe chart source is a reference: its metric query already lives on the chart\nversion. Every additional source owns its query. This keeps one source of\ntruth while allowing more sources without adding `thirdQuery`, `fourthQuery`,\nand so on."
         },
         "Series": {
             "properties": {
@@ -3742,6 +4088,21 @@
             "description": "Timestamp when this chart was downloaded from Lightdash",
             "format": "date-time",
             "type": "string"
+        },
+        "merge": {
+            "anyOf": [
+                {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/SavedMergeQuery"
+                        }
+                    ],
+                    "description": "Second query this chart's query is merged with, when it has one. Absent\non the overwhelming majority of charts."
+                },
+                {
+                    "type": "null"
+                }
+            ]
         },
         "metricQuery": {
             "allOf": [

--- a/packages/common/src/types/contentAsCode/charts.ts
+++ b/packages/common/src/types/contentAsCode/charts.ts
@@ -71,6 +71,7 @@ export type ChartAsCode = Omit<
         | 'metricQuery'
         | 'chartConfig'
         | 'pivotConfig'
+        | 'merge'
         | 'slug'
         | 'parameters'
     >,

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -987,6 +987,17 @@ export type SavedChart = {
     /** Unique identifier slug for this chart */
     slug: string;
     verification: ContentVerificationInfo | null;
+    /** The caller's unpublished content-as-code draft is applied. */
+    hasUnpublishedChanges?: boolean;
+    /** Open drafts from other authors visible to content-as-code reviewers. */
+    draftsAwaitingReview?: number;
+    /** The caller's latest dismissed draft, available to reopen. */
+    dismissedDraftUuid?: string;
+    /** The caller's draft could not be safely applied. */
+    draftOverlayError?: {
+        code: 'invalid_chart_draft';
+        draftUuid: string;
+    };
     deletedAt?: Date;
     deletedBy?: {
         userUuid: string;

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -10,6 +10,7 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
+    Badge,
     Box,
     Button,
     Group,
@@ -54,9 +55,12 @@ import {
     useState,
     type FC,
 } from 'react';
-import { useBlocker, useLocation, useNavigate } from 'react-router';
+import { Link, useBlocker, useLocation, useNavigate } from 'react-router';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import ChartAsCodeModal from '../../../features/contentAsCode/components/ChartAsCodeModal';
+import DismissedDraftAlert from '../../../features/contentAsCode/components/DismissedDraftAlert';
+import DraftOverlayFailureAlert from '../../../features/contentAsCode/components/DraftOverlayFailureAlert';
+import { useReopenDraftMutation } from '../../../features/contentAsCode/hooks/useContentDrafts';
 import {
     explorerActions,
     selectHasUnsavedChanges,
@@ -171,6 +175,8 @@ const SavedChartsHeader: FC = () => {
     const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
 
     const savedChart = useExplorerSelector(selectSavedChart);
+    const { mutate: reopenDraft, isLoading: isReopeningDraft } =
+        useReopenDraftMutation(projectUuid);
     const dashboardIdentifier = savedChart?.dashboardSlug ?? dashboardUuid;
 
     const hasUnsavedChanges = useExplorerSelector(selectHasUnsavedChanges);
@@ -576,6 +582,45 @@ const SavedChartsHeader: FC = () => {
                                 >
                                     {savedChart.name}
                                 </Title>
+
+                                {savedChart.hasUnpublishedChanges && (
+                                    <Tooltip
+                                        label="Only you can see these changes. A reviewer can write them back to the repo from Content review."
+                                        multiline
+                                        maw={280}
+                                        withinPortal
+                                    >
+                                        <Badge
+                                            color="yellow"
+                                            variant="dot"
+                                            size="sm"
+                                            radius="sm"
+                                            tt="none"
+                                            fw={500}
+                                        >
+                                            Unpublished changes
+                                        </Badge>
+                                    </Tooltip>
+                                )}
+
+                                {!!savedChart.draftsAwaitingReview && (
+                                    <Badge
+                                        component={Link}
+                                        to={`/generalSettings/projectManagement/${savedChart.projectUuid}/contentReview`}
+                                        color="blue"
+                                        variant="dot"
+                                        size="sm"
+                                        radius="sm"
+                                        tt="none"
+                                        fw={500}
+                                    >
+                                        {savedChart.draftsAwaitingReview} draft
+                                        {savedChart.draftsAwaitingReview === 1
+                                            ? ''
+                                            : 's'}{' '}
+                                        to review
+                                    </Badge>
+                                )}
 
                                 {isChartVerified && (
                                     <Tooltip
@@ -1081,6 +1126,20 @@ const SavedChartsHeader: FC = () => {
                     )}
                 </Group>
             </PageHeader>
+
+            {savedChart?.draftOverlayError ? (
+                <DraftOverlayFailureAlert
+                    error={savedChart.draftOverlayError}
+                    contentType="chart"
+                />
+            ) : null}
+
+            {savedChart?.dismissedDraftUuid ? (
+                <DismissedDraftAlert
+                    isReopening={isReopeningDraft}
+                    onReopen={() => reopenDraft(savedChart.dismissedDraftUuid!)}
+                />
+            ) : null}
 
             {savedChart && isAddToDashboardModalOpen && projectUuid && (
                 <AddTilesToDashboardModal

--- a/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
@@ -197,9 +197,9 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                     </ThemeIcon>
                     <Text fw={600}>All clear</Text>
                     <Text size="sm" c="dimmed" ta="center" maw={360}>
-                        When editors save unpublished changes to managed
-                        dashboards, their drafts land here for you to review and
-                        write back to the repo.
+                        When editors save unpublished changes to managed charts
+                        or dashboards, their drafts land here for you to review
+                        and write back to the repo.
                     </Text>
                 </Stack>
             </Center>
@@ -273,13 +273,17 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                                     </Text>
                                     <Anchor
                                         component={Link}
-                                        to={`/projects/${projectUuid}/dashboards/${active.contentUuid}/view`}
+                                        to={
+                                            active.contentType === 'chart'
+                                                ? `/projects/${projectUuid}/saved/${active.contentUuid}/view`
+                                                : `/projects/${projectUuid}/dashboards/${active.contentUuid}/view`
+                                        }
                                         size="xs"
                                         c="dimmed"
                                         underline="always"
                                     >
                                         <Group gap={2} display="inline-flex">
-                                            Open dashboard
+                                            Open {active.contentType}
                                             <MantineIcon
                                                 icon={IconExternalLink}
                                                 size="sm"
@@ -353,7 +357,7 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                                             </Popover.Dropdown>
                                         </Popover>
                                         <Tooltip
-                                            label="Opens (or appends to) this dashboard's pull request with the draft's content"
+                                            label={`Opens this ${active.contentType}'s pull request with the draft's content`}
                                             withinPortal
                                         >
                                             <Button
@@ -391,11 +395,19 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                                 >
                                     <MultiFileDiff
                                         oldFile={{
-                                            name: `lightdash/dashboards/${active.slug}.yml`,
+                                            name: `lightdash/${
+                                                active.contentType === 'chart'
+                                                    ? 'charts'
+                                                    : 'dashboards'
+                                            }/${active.slug}.yml`,
                                             contents: review.publishedYaml,
                                         }}
                                         newFile={{
-                                            name: `lightdash/dashboards/${active.slug}.yml`,
+                                            name: `lightdash/${
+                                                active.contentType === 'chart'
+                                                    ? 'charts'
+                                                    : 'dashboards'
+                                            }/${active.slug}.yml`,
                                             contents: review.draftYaml,
                                         }}
                                         style={{ colorScheme }}

--- a/packages/frontend/src/features/contentAsCode/components/DraftOverlayFailureAlert.test.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/DraftOverlayFailureAlert.test.tsx
@@ -24,4 +24,20 @@ describe('DraftOverlayFailureAlert', () => {
             screen.getByText(/Ask a Content as Code admin/),
         ).toBeInTheDocument();
     });
+
+    it('identifies the published chart when a chart overlay fails', () => {
+        renderWithProviders(
+            <DraftOverlayFailureAlert
+                error={{
+                    code: 'invalid_chart_draft',
+                    draftUuid: 'chart-draft-uuid',
+                }}
+                contentType="chart"
+            />,
+        );
+
+        expect(
+            screen.getByText(/You're viewing the published chart/),
+        ).toBeInTheDocument();
+    });
 });

--- a/packages/frontend/src/features/contentAsCode/components/DraftOverlayFailureAlert.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/DraftOverlayFailureAlert.tsx
@@ -1,15 +1,16 @@
-import { type DashboardDraftOverlayError } from '@lightdash/common';
 import { Alert, Text } from '@mantine/core';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 
 type DraftOverlayFailureAlertProps = {
-    error: DashboardDraftOverlayError;
+    error: { code: string; draftUuid: string };
+    contentType?: 'dashboard' | 'chart';
 };
 
 const DraftOverlayFailureAlert: FC<DraftOverlayFailureAlertProps> = ({
     error,
+    contentType = 'dashboard',
 }) => (
     <Alert
         color="orange"
@@ -20,8 +21,9 @@ const DraftOverlayFailureAlert: FC<DraftOverlayFailureAlertProps> = ({
         data-draft-error={error.code}
     >
         <Text size="sm">
-            You're viewing the published dashboard. Your draft is still saved
-            for review. Ask a Content as Code admin to review or dismiss it.
+            You're viewing the published {contentType}. Your draft is still
+            saved for review. Ask a Content as Code admin to review or dismiss
+            it.
         </Text>
     </Alert>
 );

--- a/packages/frontend/src/features/contentAsCode/hooks/useContentDrafts.ts
+++ b/packages/frontend/src/features/contentAsCode/hooks/useContentDrafts.ts
@@ -122,6 +122,7 @@ export const useReopenDraftMutation = (projectUuid: string | undefined) => {
                         projectUuid,
                     ]),
                     queryClient.invalidateQueries(['saved_dashboard_query']),
+                    queryClient.invalidateQueries(['saved_query']),
                 ]);
                 showToastSuccess({ title: 'Draft reopened' });
             },

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -90,9 +90,12 @@ const updateSavedQuery = async (
 export const getSavedQuery = async (
     id: string,
     projectUuid: string,
+    includeUnpublishedDraft = false,
 ): Promise<SavedChart> =>
     lightdashApi<SavedChart>({
-        url: `/projects/${projectUuid}/saved/${id}`,
+        url: `/projects/${projectUuid}/saved/${id}${
+            includeUnpublishedDraft ? '?includeUnpublishedDraft=true' : ''
+        }`,
         version: 'v2',
         method: 'GET',
         body: undefined,
@@ -123,6 +126,7 @@ const addVersionSavedQuery = async ({
 interface Args {
     uuidOrSlug?: string;
     projectUuid?: string;
+    includeUnpublishedDraft?: boolean;
     useQueryOptions?: UseQueryOptions<SavedChart, ApiError>;
 }
 
@@ -130,12 +134,22 @@ export const useSavedQuery = ({
     uuidOrSlug,
     projectUuid,
     useQueryOptions,
+    includeUnpublishedDraft = false,
 }: Args) =>
     useQuery<SavedChart, ApiError>({
-        queryKey: ['saved_query', uuidOrSlug, projectUuid],
+        queryKey: [
+            'saved_query',
+            uuidOrSlug,
+            projectUuid,
+            includeUnpublishedDraft,
+        ],
         queryFn: async () => {
             if (!projectUuid) throw new Error('projectUuid is required');
-            return getSavedQuery(uuidOrSlug || '', projectUuid);
+            return getSavedQuery(
+                uuidOrSlug || '',
+                projectUuid,
+                includeUnpublishedDraft,
+            );
         },
         enabled: uuidOrSlug !== undefined && !!projectUuid,
         retry: false,
@@ -318,12 +332,20 @@ export const useUpdateMutation = (
                     'color-palette',
                 ]);
 
-                queryClient.setQueryData(
-                    ['saved_query', data.uuid, data.projectUuid],
+                queryClient.setQueriesData(
+                    {
+                        queryKey: ['saved_query', data.uuid, data.projectUuid],
+                    },
                     data,
                 );
-                queryClient.setQueryData(
-                    ['saved_query', params.savedQueryUuid, data.projectUuid],
+                queryClient.setQueriesData(
+                    {
+                        queryKey: [
+                            'saved_query',
+                            params.savedQueryUuid,
+                            data.projectUuid,
+                        ],
+                    },
                     data,
                 );
 
@@ -336,7 +358,9 @@ export const useUpdateMutation = (
                 });
 
                 showToastSuccess({
-                    title: `Success! Chart was saved.`,
+                    title: data.hasUnpublishedChanges
+                        ? 'Chart draft saved for review'
+                        : 'Success! Chart was saved.',
                     action: dashboardUuid
                         ? {
                               children: 'Open dashboard',
@@ -529,12 +553,20 @@ export const useAddVersionMutation = (options?: {
                 'color-palette',
             ]);
 
-            queryClient.setQueryData(
-                ['saved_query', data.uuid, data.projectUuid],
+            queryClient.setQueriesData(
+                {
+                    queryKey: ['saved_query', data.uuid, data.projectUuid],
+                },
                 data,
             );
-            queryClient.setQueryData(
-                ['saved_query', params.savedQueryUuid, data.projectUuid],
+            queryClient.setQueriesData(
+                {
+                    queryKey: [
+                        'saved_query',
+                        params.savedQueryUuid,
+                        data.projectUuid,
+                    ],
+                },
                 data,
             );
             await queryClient.resetQueries(['savedChartResults', data.uuid]);
@@ -556,7 +588,9 @@ export const useAddVersionMutation = (options?: {
 
             if (dashboardUuid)
                 showToastSuccess({
-                    title: `Success! Chart was updated.`,
+                    title: data.hasUnpublishedChanges
+                        ? 'Chart draft saved for review'
+                        : 'Success! Chart was updated.',
                     action: {
                         children: 'Open dashboard',
                         icon: IconArrowRight,
@@ -568,7 +602,9 @@ export const useAddVersionMutation = (options?: {
                 });
             else {
                 showToastSuccess({
-                    title: `Success! Chart was updated.`,
+                    title: data.hasUnpublishedChanges
+                        ? 'Chart draft saved for review'
+                        : 'Success! Chart was updated.',
                 });
                 if (redirectOnSuccess) {
                     void navigate(

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -74,6 +74,7 @@ const SavedExplorer = () => {
     const { data, isInitialLoading, error } = useSavedQuery({
         uuidOrSlug: savedQueryUuid,
         projectUuid,
+        includeUnpublishedDraft: true,
     });
     const [isChangeExploreModalOpen, changeExploreModalHandlers] =
         useDisclosure(false);


### PR DESCRIPTION
Closes #28190

## Summary
- route Git-backed chart version and metadata saves into unpublished author drafts when sync is enabled
- apply author-only chart overlays while keeping published reads unchanged for other consumers
- support chart review, canonical YAML diff, write-back, dismissal/reopen indicators, and reviewer entry points
- preserve the existing direct-save and Add to Git behavior for UI-only charts and Content as Code managers
- round-trip merged-query configuration through chart-as-code so reviewed drafts are complete

## Validation
- common/backend/frontend typechecks
- targeted backend draft, write-back, verification, permission, snapshot, and schema-contract tests
- targeted frontend draft alert/reopen tests
- targeted common/backend/frontend lint
- generated OpenAPI + chart-as-code schema check