### PR TITLE
fix(scheduler): send plain-text emails without a cron

### DIFF
--- a/packages/backend/src/ee/services/SchedulerAiAugmentationService/SchedulerAiAugmentationService.ts
+++ b/packages/backend/src/ee/services/SchedulerAiAugmentationService/SchedulerAiAugmentationService.ts
@@ -2,7 +2,6 @@ import {
     AI_DEFAULT_MAX_QUERY_LIMIT,
     applyDimensionOverrides,
     assertUnreachable,
-    CreateSchedulerAndTargets,
     ForbiddenError,
     hasAiAgentAccessToSpace,
     hasSchedulerUuid,
@@ -14,6 +13,7 @@ import {
     QueryExecutionContext,
     SchedulerAiAugmentation,
     SchedulerAndTargets,
+    SendNowScheduler,
     SessionUser,
     type Account,
     type DashboardDAO,
@@ -215,7 +215,7 @@ export class SchedulerAiAugmentationService {
         createdBy,
         deliveryQueries,
     }: {
-        scheduler: SchedulerAndTargets | CreateSchedulerAndTargets;
+        scheduler: SchedulerAndTargets | SendNowScheduler;
         createdBy: string;
         deliveryQueries?: SchedulerDeliveryQuery[];
     }): Promise<string | null> {
@@ -283,7 +283,7 @@ export class SchedulerAiAugmentationService {
     // before the org lost copilot (or via an older client) must not keep
     // running the ambient model.
     private async runFastModelForDelivery(
-        scheduler: SchedulerAndTargets | CreateSchedulerAndTargets,
+        scheduler: SchedulerAndTargets | SendNowScheduler,
         createdBy: string,
         prompt: string,
         deliveryQueries: SchedulerDeliveryQuery[] | undefined,
@@ -332,7 +332,7 @@ export class SchedulerAiAugmentationService {
         account: Account;
         projectUuid: string;
         dashboard: DashboardDAO | null;
-        scheduler: SchedulerAndTargets | CreateSchedulerAndTargets;
+        scheduler: SchedulerAndTargets | SendNowScheduler;
         deliveryQueries: SchedulerDeliveryQuery[] | undefined;
     }): Promise<string> {
         if (deliveryQueries && deliveryQueries.length > 0) {
@@ -387,7 +387,7 @@ export class SchedulerAiAugmentationService {
     // summarises what the delivery renders (image/PDF formats).
     private async getChartDeliveryContent(
         account: Account,
-        scheduler: SchedulerAndTargets | CreateSchedulerAndTargets,
+        scheduler: SchedulerAndTargets | SendNowScheduler,
         projectUuid: string,
     ): Promise<string> {
         if (!scheduler.savedChartUuid) return '';
@@ -422,7 +422,7 @@ export class SchedulerAiAugmentationService {
     private async getDashboardDeliveryContent(
         account: Account,
         dashboard: DashboardDAO,
-        scheduler: SchedulerAndTargets | CreateSchedulerAndTargets,
+        scheduler: SchedulerAndTargets | SendNowScheduler,
     ): Promise<string> {
         const dashboardFilters = dashboard.filters;
         const schedulerFilters = isDashboardScheduler(scheduler)
@@ -441,7 +441,7 @@ export class SchedulerAiAugmentationService {
         };
 
         const selectedTabs = isDashboardScheduler(scheduler)
-            ? scheduler.selectedTabs
+            ? (scheduler.selectedTabs ?? null)
             : null;
         const chartTiles = dashboard.tiles
             .filter(isDashboardChartTileType)

--- a/packages/backend/src/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.test.ts
@@ -98,6 +98,9 @@ describe('SchedulerClient per-org delivery queue', () => {
             {
                 ...scheduler,
                 ...traceProperties,
+                savedChartUuid: null,
+                dashboardUuid: null,
+                savedSqlUuid: null,
                 appUuid: 'app-1',
             },
             scheduler.schedulerUuid,

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -2,7 +2,6 @@ import {
     AnyType,
     BackfillDefaultUserSpacesPayload,
     CompileProjectPayload,
-    CreateSchedulerAndTargets,
     CreateSchedulerTarget,
     EmailBatchNotificationPayload,
     EmailNotificationPayload,
@@ -42,6 +41,7 @@ import {
     SchedulerMsTeamsTarget,
     SchedulerSlackTarget,
     SchedulerTaskName,
+    SendNowScheduler,
     SlackBatchNotificationPayload,
     SlackNotificationPayload,
     SqlRunnerPayload,
@@ -564,7 +564,7 @@ export class SchedulerClient {
     private async addNotificationJob(
         date: Date,
         jobGroup: string,
-        scheduler: SchedulerAndTargets | CreateSchedulerAndTargets,
+        scheduler: SchedulerAndTargets | SendNowScheduler,
         target: CreateSchedulerTarget | undefined,
         targetUuid: string | undefined,
         page: NotificationPayloadBase['page'] | undefined,
@@ -996,7 +996,7 @@ export class SchedulerClient {
 
     async generateJobsForSchedulerTargets(
         scheduledTime: Date,
-        scheduler: SchedulerAndTargets | CreateSchedulerAndTargets,
+        scheduler: SchedulerAndTargets | SendNowScheduler,
         page: NotificationPayloadBase['page'] | undefined,
         parentJobId: string,
         traceProperties: TraceTaskBase,

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -23,11 +23,13 @@ import {
     type CapturedQuery,
     type CreateSchedulerAndTargets,
     type DeliveryCaptureManifest,
+    type EmailNotificationPayload,
     type MetricQuery,
     type NotificationPayloadBase,
     type ReadyQueryResultsPage,
     type ScheduledDeliveryPayload,
     type SchedulerAndTargets,
+    type SendNowScheduler,
     type UploadGsheetPayload,
 } from '@lightdash/common';
 import ExecutionContext from 'node-execution-context';
@@ -973,8 +975,17 @@ describe('uploadGsheetFromQuery', () => {
 
 type TaskDeps = ConstructorParameters<typeof SchedulerTask>[0];
 
+class TestSchedulerTask extends SchedulerTask {
+    public sendEmailNotificationForTest(
+        jobId: string,
+        notification: EmailNotificationPayload,
+    ) {
+        return this.sendEmailNotification(jobId, notification);
+    }
+}
+
 const makeTaskWithDeps = (overrides: Partial<TaskDeps> = {}) =>
-    new SchedulerTask({ ...({} as TaskDeps), ...overrides });
+    new TestSchedulerTask({ ...({} as TaskDeps), ...overrides });
 
 const asDep = <K extends keyof TaskDeps>(value: unknown): TaskDeps[K] =>
     value as TaskDeps[K];
@@ -3391,6 +3402,53 @@ describe('app delivery target senders', () => {
         expect(args[15]).toEqual(page.notices);
         // isApp — drives the app-aware headline in the template.
         expect(args[17]).toBe(true);
+    });
+
+    it('sends an inline plain-text dashboard email without a cron', async () => {
+        const sendDashboardCsvNotificationEmail = vi
+            .fn()
+            .mockResolvedValue(undefined);
+        const task = makeTaskWithDeps({
+            ...senderBaseDeps(),
+            emailClient: asDep<'emailClient'>({
+                sendDashboardCsvNotificationEmail,
+            }),
+            emailWhitelabelService: asDep<'emailWhitelabelService'>({
+                resolveSenderIdentity: vi.fn().mockResolvedValue(null),
+            }),
+        });
+        const scheduler: SendNowScheduler = {
+            ...appScheduler({
+                appUuid: null,
+                appName: null,
+                dashboardUuid: 'dashboard-1',
+                plainTextEmail: true,
+            }),
+            savedChartUuid: null,
+            dashboardUuid: 'dashboard-1',
+            savedSqlUuid: null,
+            appUuid: null,
+            cron: undefined,
+            selectedTabs: null,
+        };
+
+        const notification: EmailNotificationPayload = {
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            userUuid: 'user-1',
+            scheduledTime: new Date('2026-07-30T09:00:00Z'),
+            jobGroup: 'job-1',
+            scheduler,
+            page: senderPage(),
+            recipient: 'recipient@example.com',
+        };
+
+        await task.sendEmailNotificationForTest('job-1', notification);
+
+        expect(sendDashboardCsvNotificationEmail).toHaveBeenCalledTimes(1);
+        expect(sendDashboardCsvNotificationEmail.mock.calls[0][18]).toEqual({
+            cadence: undefined,
+        });
     });
 
     it('posts an app xlsx delivery to the MS Teams webhook', async () => {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -97,6 +97,7 @@ import {
     SchedulerJobStatus,
     SchedulerLog,
     SchedulerResourceType,
+    SendNowScheduler,
     SessionUser,
     SlackInstallationNotFoundError,
     SlackNotificationPayload,
@@ -220,7 +221,7 @@ export type SchedulerDeliveryQuery = {
 
 export interface SchedulerAiAugmentationRunner {
     runForDelivery(args: {
-        scheduler: SchedulerAndTargets | CreateSchedulerAndTargets;
+        scheduler: SchedulerAndTargets | SendNowScheduler;
         createdBy: string;
         deliveryQueries?: SchedulerDeliveryQuery[];
     }): Promise<string | null>;
@@ -620,7 +621,7 @@ export default class SchedulerTask {
     }
 
     private static getCsvOptions(
-        scheduler: SchedulerAndTargets | CreateSchedulerAndTargets,
+        scheduler: SchedulerAndTargets | SendNowScheduler,
     ) {
         return isSchedulerCsvOptions(scheduler.options)
             ? scheduler.options
@@ -715,7 +716,7 @@ export default class SchedulerTask {
     // Renders the app once in delivery capture mode and returns the manifest of
     // queries it ran. Must be called once per job, before the per-channel fan-out.
     protected async captureAppDeliveryQueries(
-        scheduler: CreateSchedulerAndTargets,
+        scheduler: SendNowScheduler,
         jobId: string,
     ): Promise<DeliveryCaptureManifest> {
         if (!isAppCreateScheduler(scheduler)) {
@@ -748,7 +749,7 @@ export default class SchedulerTask {
     }
 
     protected async getNotificationPageData(
-        scheduler: CreateSchedulerAndTargets,
+        scheduler: SendNowScheduler,
         jobId: string,
         isFinalAttempt: boolean,
         expirationSecondsOverride?: number,
@@ -809,7 +810,7 @@ export default class SchedulerTask {
                 : undefined);
 
         const selectedTabs = isDashboardScheduler(scheduler)
-            ? scheduler.selectedTabs
+            ? (scheduler.selectedTabs ?? null)
             : null;
 
         const context =
@@ -3576,7 +3577,11 @@ export default class SchedulerTask {
 
             // Email-only: strips the branded template in favour of a text body.
             const plainText = plainTextEmail
-                ? { cadence: getCronCadence(scheduler.cron) }
+                ? {
+                      cadence: scheduler.cron
+                          ? getCronCadence(scheduler.cron)
+                          : undefined,
+                  }
                 : undefined;
 
             await this.schedulerService.logSchedulerJob({
@@ -4890,7 +4895,7 @@ export default class SchedulerTask {
 
         const persistedOrInlineScheduler:
             | SchedulerAndTargets
-            | CreateSchedulerAndTargets = isInlineScheduler
+            | SendNowScheduler = isInlineScheduler
             ? schedulerPayload
             : await this.schedulerService.schedulerModel.getSchedulerAndTargets(
                   schedulerPayload.schedulerUuid,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.test.ts
@@ -10,7 +10,7 @@ import {
     SpaceMemberRole,
     UnexpectedGoogleSheetsError,
     type ChartScheduler,
-    type CreateSchedulerAndTargets,
+    type SendNowScheduler,
     type UpdateSchedulerAndTargetsWithoutId,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
@@ -248,7 +248,7 @@ describe('SchedulerService', () => {
             includeLinks: true,
             plainTextEmail: false,
             targets: [{ recipient: 'recipient@example.com' }],
-        } as unknown as CreateSchedulerAndTargets;
+        } as unknown as SendNowScheduler;
 
         const userWhoCanSend = buildUser([
             { subject: 'ScheduledDeliveries', action: ['create'] },
@@ -283,6 +283,10 @@ describe('SchedulerService', () => {
                     ...sendNowPayload,
                     savedChartUuid: null,
                     dashboardUuid: 'dashboardUuid',
+                    savedSqlUuid: null,
+                    appUuid: null,
+                    filters: undefined,
+                    selectedTabs: null,
                     sourceSchedulerUuid:
                         chartSchedulerInPrivateSpace.schedulerUuid,
                 }),
@@ -402,7 +406,7 @@ describe('SchedulerService', () => {
                     includeLinks: true,
                     plainTextEmail: false,
                     targets: [{ recipient: 'recipient@example.com' }],
-                }) as unknown as CreateSchedulerAndTargets;
+                }) as unknown as SendNowScheduler;
 
             test.each([SchedulerFormat.GSHEETS, SchedulerFormat.PDF])(
                 'rejects a %s send-now app payload',

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -46,6 +46,7 @@ import {
     SchedulerRunStatus,
     SchedulerTaskName,
     SchedulerWithLogs,
+    SendNowScheduler,
     SessionUser,
     UnexpectedGoogleSheetsError,
     UpdateSchedulerAndTargetsWithoutId,
@@ -186,7 +187,7 @@ export class SchedulerService extends BaseService {
     }
 
     public async getSchedulerProjectContext(
-        scheduler: Scheduler | CreateSchedulerAndTargets,
+        scheduler: Scheduler | CreateSchedulerAndTargets | SendNowScheduler,
     ): Promise<{
         projectUuid: string;
         organizationUuid: string;
@@ -1705,10 +1706,7 @@ export class SchedulerService extends BaseService {
         await this.schedulerModel.setJobStatus(jobId, status);
     }
 
-    async sendScheduler(
-        user: SessionUser,
-        scheduler: CreateSchedulerAndTargets,
-    ) {
+    async sendScheduler(user: SessionUser, scheduler: SendNowScheduler) {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -159,8 +159,8 @@ export type ChartScheduler = SchedulerBase & {
 };
 
 export const isDashboardScheduler = (
-    scheduler: Scheduler | CreateSchedulerAndTargets,
-): scheduler is DashboardScheduler =>
+    scheduler: Scheduler | CreateSchedulerAndTargets | SendNowScheduler,
+): scheduler is DashboardScheduler | InlineDashboardScheduler =>
     'dashboardUuid' in scheduler && !!scheduler.dashboardUuid;
 
 export type DashboardScheduler = SchedulerBase & {
@@ -212,12 +212,13 @@ export type AppScheduler = SchedulerBase & {
 };
 
 export const isAppScheduler = (
-    data: Scheduler | CreateSchedulerAndTargets,
-): data is AppScheduler => 'appUuid' in data && !!data.appUuid;
+    data: Scheduler | CreateSchedulerAndTargets | SendNowScheduler,
+): data is AppScheduler | InlineAppScheduler =>
+    'appUuid' in data && !!data.appUuid;
 
 export const isSqlChartScheduler = (
-    scheduler: Scheduler | CreateSchedulerAndTargets,
-): scheduler is SqlChartScheduler =>
+    scheduler: Scheduler | CreateSchedulerAndTargets | SendNowScheduler,
+): scheduler is SqlChartScheduler | InlineSqlChartScheduler =>
     'savedSqlUuid' in scheduler && !!scheduler.savedSqlUuid;
 
 export type Scheduler =
@@ -362,6 +363,61 @@ export type CreateSchedulerAndTargets = Omit<
     sourceSchedulerUuid?: string;
 };
 
+type InlineSchedulerBase = Omit<
+    CreateSchedulerAndTargets,
+    'cron' | 'savedChartUuid' | 'dashboardUuid' | 'savedSqlUuid' | 'appUuid'
+> & {
+    // Inline deliveries do not need a recurring schedule.
+    cron?: string;
+};
+
+type InlineChartScheduler = InlineSchedulerBase &
+    Pick<
+        ChartScheduler,
+        | 'savedChartUuid'
+        | 'dashboardUuid'
+        | 'savedSqlUuid'
+        | 'appUuid'
+        | 'filters'
+        | 'parameters'
+    >;
+
+type InlineDashboardScheduler = InlineSchedulerBase &
+    Pick<
+        DashboardScheduler,
+        | 'savedChartUuid'
+        | 'dashboardUuid'
+        | 'savedSqlUuid'
+        | 'appUuid'
+        | 'filters'
+        | 'parameters'
+        | 'customViewportWidth'
+    > & {
+        selectedTabs?: string[] | null;
+    };
+
+type InlineSqlChartScheduler = InlineSchedulerBase &
+    Pick<
+        SqlChartScheduler,
+        'savedChartUuid' | 'dashboardUuid' | 'savedSqlUuid' | 'appUuid'
+    >;
+
+type InlineAppScheduler = InlineSchedulerBase &
+    Pick<
+        AppScheduler,
+        | 'savedChartUuid'
+        | 'dashboardUuid'
+        | 'savedSqlUuid'
+        | 'appUuid'
+        | 'appState'
+    >;
+
+export type SendNowScheduler =
+    | InlineChartScheduler
+    | InlineDashboardScheduler
+    | InlineSqlChartScheduler
+    | InlineAppScheduler;
+
 export type CreateSchedulerAndTargetsWithoutIds = Omit<
     CreateSchedulerAndTargets,
     'savedChartUuid' | 'dashboardUuid' | 'savedSqlUuid' | 'createdBy'
@@ -425,11 +481,12 @@ export const isUpdateSchedulerEmailTarget = (
     'schedulerEmailTargetUuid' in data && !!data.schedulerEmailTargetUuid;
 
 export const isChartScheduler = (
-    data: Scheduler | CreateSchedulerAndTargets,
-): data is ChartScheduler => 'savedChartUuid' in data && !!data.savedChartUuid;
+    data: Scheduler | CreateSchedulerAndTargets | SendNowScheduler,
+): data is ChartScheduler | InlineChartScheduler =>
+    'savedChartUuid' in data && !!data.savedChartUuid;
 
 export const getSchedulerResourceTypeAndId = (
-    scheduler: Scheduler | CreateSchedulerAndTargets,
+    scheduler: Scheduler | CreateSchedulerAndTargets | SendNowScheduler,
 ): { resourceType: SchedulerResourceType; resourceId: string } => {
     if (isChartScheduler(scheduler)) {
         return {
@@ -459,19 +516,23 @@ export const getSchedulerResourceTypeAndId = (
 };
 
 export const isChartCreateScheduler = (
-    data: CreateSchedulerAndTargets,
-): data is ChartScheduler & { targets: CreateSchedulerTarget[] } =>
-    'savedChartUuid' in data && !!data.savedChartUuid;
+    data: CreateSchedulerAndTargets | SendNowScheduler,
+): data is
+    | (ChartScheduler & { targets: CreateSchedulerTarget[] })
+    | InlineChartScheduler => 'savedChartUuid' in data && !!data.savedChartUuid;
 
 export const isDashboardCreateScheduler = (
-    data: CreateSchedulerAndTargets,
-): data is DashboardScheduler & { targets: CreateSchedulerTarget[] } =>
+    data: CreateSchedulerAndTargets | SendNowScheduler,
+): data is
+    | (DashboardScheduler & { targets: CreateSchedulerTarget[] })
+    | InlineDashboardScheduler =>
     'dashboardUuid' in data && !!data.dashboardUuid;
 
 export const isAppCreateScheduler = (
-    data: CreateSchedulerAndTargets,
-): data is AppScheduler & { targets: CreateSchedulerTarget[] } =>
-    'appUuid' in data && !!data.appUuid;
+    data: CreateSchedulerAndTargets | SendNowScheduler,
+): data is
+    | (AppScheduler & { targets: CreateSchedulerTarget[] })
+    | InlineAppScheduler => 'appUuid' in data && !!data.appUuid;
 
 export const isSlackTarget = (
     target:
@@ -651,7 +712,7 @@ export type QueueTraceProperties = {
 // Scheduler task types
 export type ScheduledDeliveryPayload = TraceTaskBase &
     (
-        | CreateSchedulerAndTargets
+        | SendNowScheduler
         | (Pick<Scheduler, 'schedulerUuid'> & {
               executionUserUuid?: string;
           })
@@ -659,18 +720,24 @@ export type ScheduledDeliveryPayload = TraceTaskBase &
 
 export const isCreateScheduler = (
     data: ScheduledDeliveryPayload,
-): data is CreateSchedulerAndTargets & TraceTaskBase => 'targets' in data;
+): data is SendNowScheduler & TraceTaskBase => 'targets' in data;
 export const hasSchedulerUuid = (
-    data: SchedulerAndTargets | CreateSchedulerAndTargets,
+    data: SchedulerAndTargets | CreateSchedulerAndTargets | SendNowScheduler,
 ): data is SchedulerAndTargets => 'schedulerUuid' in data;
 
 export const getSchedulerUuid = (
-    data: CreateSchedulerAndTargets | Pick<Scheduler, 'schedulerUuid'>,
+    data:
+        | CreateSchedulerAndTargets
+        | SendNowScheduler
+        | Pick<Scheduler, 'schedulerUuid'>,
 ): string | undefined =>
     'schedulerUuid' in data ? data.schedulerUuid : undefined;
 
 export const getSourceSchedulerUuid = (
-    data: CreateSchedulerAndTargets | Pick<Scheduler, 'schedulerUuid'>,
+    data:
+        | CreateSchedulerAndTargets
+        | SendNowScheduler
+        | Pick<Scheduler, 'schedulerUuid'>,
 ): string | undefined =>
     'sourceSchedulerUuid' in data ? data.sourceSchedulerUuid : undefined;
 
@@ -725,7 +792,7 @@ export type NotificationPayloadBase = {
         failures?: PartialFailure[];
         notices?: DeliveryNotice[];
     };
-    scheduler: CreateSchedulerAndTargets;
+    scheduler: SchedulerAndTargets | SendNowScheduler;
 };
 
 export type SlackNotificationPayload = TraceTaskBase &

--- a/packages/common/src/utils/scheduler.ts
+++ b/packages/common/src/utils/scheduler.ts
@@ -41,9 +41,11 @@ export function getTimezoneLabel(timezone: string | undefined) {
 }
 
 export function getHumanReadableCronExpression(
-    cronExpression: string,
+    cronExpression: string | undefined,
     timezone: string,
 ) {
+    if (!cronExpression) return '';
+
     const value = cronstrue.toString(cronExpression, {
         verbose: true,
         throwExceptionOnParseError: false,

--- a/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useScheduler.ts
@@ -8,11 +8,11 @@ import {
     type ApiSchedulerRunsResponse,
     type ApiSchedulersResponse,
     type ApiTestSchedulerResponse,
-    type CreateSchedulerAndTargets,
     type KnexPaginateArgs,
     type SchedulerAndTargets,
     type SchedulerRunLog,
     type SchedulerRunStatus,
+    type SendNowScheduler,
 } from '@lightdash/common';
 import { notifications } from '@mantine/notifications';
 import {
@@ -207,7 +207,7 @@ export const getSchedulerJobStatus = async <
         body: undefined,
     });
 
-const sendNowScheduler = async (scheduler: CreateSchedulerAndTargets) =>
+const sendNowScheduler = async (scheduler: SendNowScheduler) =>
     lightdashApi<ApiTestSchedulerResponse['results']>({
         url: `/schedulers/send`,
         method: 'POST',
@@ -619,7 +619,7 @@ export const useSendNowScheduler = () => {
     const sendNowMutation = useMutation<
         ApiTestSchedulerResponse['results'],
         ApiError,
-        CreateSchedulerAndTargets
+        SendNowScheduler
     >(
         (res) => {
             showToastInfo({

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
@@ -4,12 +4,12 @@ import {
     isNumericItem,
     SchedulerFormat,
     type ApiError,
-    type CreateSchedulerAndTargets,
     type CreateSchedulerAndTargetsWithoutIds,
     type DashboardFilterableField,
     type ItemsMap,
     type ParametersValuesMap,
     type SchedulerAndTargets,
+    type SendNowScheduler,
 } from '@lightdash/common';
 import { type FormValidateInput } from '@mantine/form';
 import { type UseMutationResult } from '@tanstack/react-query';
@@ -399,45 +399,20 @@ export const useSchedulerFormModal = ({
             formResource?.type,
         );
 
-        let resource: {
-            savedChartUuid: string | null;
-            dashboardUuid: string | null;
-            savedSqlUuid: string | null;
-            appUuid: string | null;
-        };
-        if (isEditMode) {
-            resource = {
-                savedChartUuid: scheduler.data?.savedChartUuid ?? null,
-                dashboardUuid: scheduler.data?.dashboardUuid ?? null,
-                savedSqlUuid: scheduler.data?.savedSqlUuid ?? null,
-                appUuid: scheduler.data?.appUuid ?? null,
-            };
-        } else if (isApp) {
-            resource = {
-                appUuid: resourceUuid,
-                savedChartUuid: null,
-                dashboardUuid: null,
-                savedSqlUuid: null,
-            };
-        } else if (isChart) {
-            resource = {
-                savedChartUuid: resourceUuid,
-                dashboardUuid: null,
-                savedSqlUuid: null,
-                appUuid: null,
-            };
-        } else {
-            resource = {
-                dashboardUuid: resourceUuid,
-                savedChartUuid: null,
-                savedSqlUuid: null,
-                appUuid: null,
-            };
-        }
-
-        const unsavedScheduler: CreateSchedulerAndTargets = {
-            ...schedulerData,
-            ...resource,
+        const sendNowBase = {
+            name: schedulerData.name,
+            message: schedulerData.message,
+            format: schedulerData.format,
+            cron: schedulerData.cron,
+            timezone: schedulerData.timezone,
+            appName: schedulerData.appName,
+            options: schedulerData.options,
+            thresholds: schedulerData.thresholds,
+            enabled: schedulerData.enabled,
+            notificationFrequency: schedulerData.notificationFrequency,
+            includeLinks: schedulerData.includeLinks,
+            plainTextEmail: schedulerData.plainTextEmail,
+            targets: schedulerData.targets,
             createdBy: user.userUuid,
             // Carry the (possibly unsaved) AI settings so send-now runs them.
             aiAugmentation: form.values.aiAugmentation,
@@ -445,6 +420,67 @@ export const useSchedulerFormModal = ({
             // links can open the delivery.
             sourceSchedulerUuid: isEditMode ? schedulerUuid : undefined,
         };
+
+        let unsavedScheduler: SendNowScheduler;
+        const savedChartUuid = isEditMode
+            ? scheduler.data?.savedChartUuid
+            : isChart
+              ? resourceUuid
+              : null;
+        const dashboardUuid = isEditMode
+            ? scheduler.data?.dashboardUuid
+            : !isChart && !isApp
+              ? resourceUuid
+              : null;
+        const savedSqlUuid = isEditMode ? scheduler.data?.savedSqlUuid : null;
+        const appUuid = isEditMode
+            ? scheduler.data?.appUuid
+            : isApp
+              ? resourceUuid
+              : null;
+
+        if (savedChartUuid) {
+            unsavedScheduler = {
+                ...sendNowBase,
+                savedChartUuid,
+                dashboardUuid: null,
+                savedSqlUuid: null,
+                appUuid: null,
+                filters: form.values.chartFilters,
+                parameters: form.values.parameters,
+            };
+        } else if (dashboardUuid) {
+            unsavedScheduler = {
+                ...sendNowBase,
+                savedChartUuid: null,
+                dashboardUuid,
+                savedSqlUuid: null,
+                appUuid: null,
+                filters: form.values.dashboardFilters,
+                parameters: form.values.parameters,
+                customViewportWidth: form.values.customViewportWidth,
+                selectedTabs: form.values.selectedTabs,
+            };
+        } else if (savedSqlUuid) {
+            unsavedScheduler = {
+                ...sendNowBase,
+                savedChartUuid: null,
+                dashboardUuid: null,
+                savedSqlUuid,
+                appUuid: null,
+            };
+        } else if (appUuid) {
+            unsavedScheduler = {
+                ...sendNowBase,
+                savedChartUuid: null,
+                dashboardUuid: null,
+                savedSqlUuid: null,
+                appUuid,
+                appState: form.values.appState ?? undefined,
+            };
+        } else {
+            return;
+        }
 
         track({ name: EventName.SCHEDULER_SEND_NOW_BUTTON });
         sendNow(unsavedScheduler);


### PR DESCRIPTION
## What changed

## Summary

- Allow one-off scheduled-delivery payloads to omit a recurring cron while preserving resource-specific chart, dashboard, SQL chart, and app shapes.
- Send plain-text emails with no cadence when cron is omitted or empty; saved schedules retain cadence wording.
- Add regression coverage for the background dashboard email path and keep frontend/backend send-now contracts aligned.

### Validation

- `pnpm -F 'backend' exec oxfmt 'src/ee/services/SchedulerAiAugmentationService/SchedulerAiAugmentationService.ts' 'src/scheduler/SchedulerClient.test.ts' 'src/scheduler/SchedulerClient.ts' 'src/scheduler/SchedulerTask.test.ts' 'src/scheduler/SchedulerTask.ts' 'src/services/SchedulerService/SchedulerService.test.ts' 'src/services/SchedulerService/SchedulerService.ts'` — passed
- `pnpm -F 'common' exec oxfmt 'src/types/scheduler.ts' 'src/utils/scheduler.ts'` — passed
- `pnpm -F 'frontend' exec oxfmt 'src/features/scheduler/hooks/useScheduler.ts' 'src/features/scheduler/hooks/useSchedulerFormModal.ts'` — passed
- `pnpm -F 'backend' run --if-present lint` — passed
- `pnpm -F 'backend' run --if-present typecheck` — passed
- `pnpm -F 'backend' exec vitest related 'src/ee/services/SchedulerAiAugmentationService/SchedulerAiAugmentationService.ts' 'src/scheduler/SchedulerClient.test.ts' 'src/scheduler/SchedulerClient.ts' 'src/scheduler/SchedulerTask.test.ts' 'src/scheduler/SchedulerTask.ts' 'src/services/SchedulerService/SchedulerService.test.ts' 'src/services/SchedulerService/SchedulerService.ts' --run --passWithNoTests` — passed
- `pnpm -F 'common' run --if-present lint` — passed
- `pnpm -F 'common' run --if-present typecheck` — passed
- `pnpm -F 'common' exec vitest related 'src/types/scheduler.ts' 'src/utils/scheduler.ts' --run --passWithNoTests` — passed
- `pnpm -F 'frontend' run --if-present lint` — passed
- `pnpm -F 'frontend' run --if-present typecheck` — passed
- `pnpm -F 'frontend' exec vitest related 'src/features/scheduler/hooks/useScheduler.ts' 'src/features/scheduler/hooks/useSchedulerFormModal.ts' --run --passWithNoTests` — passed
- Sealed runtime proof covered omitted-cron chart delivery, empty-cron dashboard delivery, neutral copy, and saved weekly cadence — passed

### Review notes

- The shared human-readable cron formatter now treats an absent cron as an empty schedule description. An alternative is to keep the utility strict and condition every email composition call site; reviewer input is useful on whether tolerance belongs in the shared formatter.
- Inline dashboard `selectedTabs` remains optional for wire compatibility and is normalized to `null` by consumers. An alternative is requiring callers to always send `null`; reviewer input is useful on the preferred request contract.
- The existing `isCreateScheduler` guard now narrows to the explicit send-now payload shape. Renaming it to `isInlineSchedulerPayload` would be clearer but was left out to avoid unrelated call-site churn; reviewer input is useful on whether to include that rename.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10667-cde3f5ab3696.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10667

