### PR TITLE
feat(explorer): add sidebar keyboard shortcuts

### DIFF
--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -1,5 +1,12 @@
 import { FeatureFlags, type ChartType } from '@lightdash/common';
-import { ActionIcon, Anchor, Group, Stack, Text, Tooltip } from '@mantine/core';
+import {
+    ActionIcon,
+    Anchor,
+    Group,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
 import {
     IconArrowLeft,
     IconFilePencil,
@@ -26,6 +33,7 @@ import {
 import MantineIcon from '../../common/MantineIcon';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import { ShortcutTooltipLabel } from '../ExplorerSidebarToggle';
 import VisualizationConfig from '../VisualizationCard/VisualizationConfig';
 import { useChartTypeOptions } from '../VisualizationCardOptions/useChartTypeOptions';
 import ExplorerChartTypeGallery, {
@@ -126,7 +134,12 @@ const ExplorerChartSidebar: FC<Props> = ({ chartType, onClose }) => {
                     </Group>
                     {!isAuthoring && (
                         <Tooltip
-                            label="Close visualization config"
+                            label={
+                                <ShortcutTooltipLabel
+                                    action="Close chart sidebar"
+                                    withAlt
+                                />
+                            }
                             position="right"
                         >
                             <ActionIcon

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -1,12 +1,5 @@
 import { FeatureFlags, type ChartType } from '@lightdash/common';
-import {
-    ActionIcon,
-    Anchor,
-    Group,
-    Stack,
-    Text,
-    Tooltip,
-} from '@mantine/core';
+import { ActionIcon, Anchor, Group, Stack, Text, Tooltip } from '@mantine/core';
 import {
     IconArrowLeft,
     IconFilePencil,

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerChartSidebar.tsx
@@ -6,7 +6,7 @@ import {
     Stack,
     Text,
     Tooltip,
-} from '@mantine-8/core';
+} from '@mantine/core';
 import {
     IconArrowLeft,
     IconFilePencil,

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -6,14 +6,7 @@ import {
     findReplaceableCustomMetrics,
     getMetrics,
 } from '@lightdash/common';
-import {
-    ActionIcon,
-    Group,
-    HoverCard,
-    Menu,
-    Stack,
-    Text,
-} from '@mantine/core';
+import { ActionIcon, Group, HoverCard, Menu, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAlertTriangle,

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -75,366 +75,294 @@ interface ExplorePanelProps {
     isCollapsible?: boolean;
 }
 
-const ExplorePanel: FC<ExplorePanelProps> = memo(
-    ({ onBack, isCollapsible = false }) => {
-        const { track } = useTracking();
-        const { user } = useApp();
-        const [isEditVirtualViewOpen, setIsEditVirtualViewOpen] =
-            useState(false);
-        const [isDeleteVirtualViewOpen, setIsDeleteVirtualViewOpen] =
-            useState(false);
-        const [isVirtualViewAsCodeOpen, virtualViewAsCodeModalHandlers] =
-            useDisclosure();
-        const [, startTransition] = useTransition();
+const ExplorePanel: FC<ExplorePanelProps> = memo((props) => {
+    const { onBack, isCollapsible = false } = props;
+    const { track } = useTracking();
+    const { user } = useApp();
+    const [isEditVirtualViewOpen, setIsEditVirtualViewOpen] = useState(false);
+    const [isDeleteVirtualViewOpen, setIsDeleteVirtualViewOpen] =
+        useState(false);
+    const [isVirtualViewAsCodeOpen, virtualViewAsCodeModalHandlers] =
+        useDisclosure();
+    const [, startTransition] = useTransition();
 
-        const projectUuid = useProjectUuid();
-        const isGitProject = useIsGitProject(projectUuid ?? '');
-        const { open: openSourceCodeEditor } = useSourceCodeEditor();
-        const { data: editYamlInUiFlag } = useServerFeatureFlag(
-            FeatureFlags.EditYamlInUi,
-        );
-        const { data: mergeFlag } = useServerFeatureFlag(
-            FeatureFlags.MergeQueries,
-        );
-        const isChartGalleryEnabled = useIsChartGalleryEnabled();
-        const merge = useMergeSafe();
-        const additionalSource = merge?.additionalSources[0];
-        const [isChoosingMergeExplore, setIsChoosingMergeExplore] = useState(
-            !additionalSource?.exploreName,
-        );
-        useEffect(() => {
-            if (!additionalSource?.exploreName) setIsChoosingMergeExplore(true);
-        }, [additionalSource?.exploreName]);
-        const isGuidedMerge =
-            mergeFlag?.enabled === true &&
-            merge?.isMerging === true &&
-            !merge.readOnly;
-        const activeTableName = useExplorerSelector(selectTableName);
-        const metricQuery = useExplorerSelector(selectMetricQuery);
-        const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
+    const projectUuid = useProjectUuid();
+    const isGitProject = useIsGitProject(projectUuid ?? '');
+    const { open: openSourceCodeEditor } = useSourceCodeEditor();
+    const { data: editYamlInUiFlag } = useServerFeatureFlag(
+        FeatureFlags.EditYamlInUi,
+    );
+    const { data: mergeFlag } = useServerFeatureFlag(FeatureFlags.MergeQueries);
+    const isChartGalleryEnabled = useIsChartGalleryEnabled();
+    const merge = useMergeSafe();
+    const additionalSource = merge?.additionalSources[0];
+    const [isChoosingMergeExplore, setIsChoosingMergeExplore] = useState(
+        !additionalSource?.exploreName,
+    );
+    useEffect(() => {
+        if (!additionalSource?.exploreName) setIsChoosingMergeExplore(true);
+    }, [additionalSource?.exploreName]);
+    const isGuidedMerge =
+        mergeFlag?.enabled === true &&
+        merge?.isMerging === true &&
+        !merge.readOnly;
+    const activeTableName = useExplorerSelector(selectTableName);
+    const metricQuery = useExplorerSelector(selectMetricQuery);
+    const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
 
-        // Get savedChart from Redux
-        const savedChart = useExplorerSelector(selectSavedChart);
-        const chartUuid = savedChart?.uuid;
+    // Get savedChart from Redux
+    const savedChart = useExplorerSelector(selectSavedChart);
+    const chartUuid = savedChart?.uuid;
 
-        const dispatch = useExplorerDispatch();
+    const dispatch = useExplorerDispatch();
 
-        const toggleActiveField = useCallback(
-            (fieldId: string, isDimension: boolean) => {
-                if (isDimension) {
-                    dispatch(explorerActions.toggleDimension(fieldId));
-                } else {
-                    dispatch(explorerActions.toggleMetric(fieldId));
-                }
-            },
-            [dispatch],
-        );
-
-        const isVisualizationConfigOpen = useExplorerSelector(
-            selectIsVisualizationConfigOpen,
-        );
-
-        const {
-            data: explore,
-            isInitialLoading,
-            status,
-            error,
-        } = useExplore(activeTableName);
-
-        useEffect(() => {
-            if (
-                projectUuid &&
-                user.data?.organizationUuid &&
-                explore &&
-                additionalMetrics
-            ) {
-                const replaceableFieldsMap = findReplaceableCustomMetrics({
-                    metrics: getMetrics(explore),
-                    customMetrics: additionalMetrics,
-                });
-                const fieldsToReplace =
-                    convertReplaceableFieldMatchMapToReplaceFieldsMap(
-                        replaceableFieldsMap,
-                    );
-                if (fieldsToReplace) {
-                    dispatch(
-                        explorerActions.replaceFields({
-                            fieldsToReplace: {
-                                customMetrics: fieldsToReplace,
-                            },
-                        }),
-                    );
-                    track({
-                        name: EventName.CUSTOM_FIELDS_REPLACEMENT_APPLIED,
-                        properties: {
-                            userId: user.data.userUuid,
-                            projectId: projectUuid,
-                            organizationId: user.data.organizationUuid,
-                            chartId: chartUuid,
-                            customMetricIds: Object.keys(fieldsToReplace),
-                        },
-                    });
-                }
+    const toggleActiveField = useCallback(
+        (fieldId: string, isDimension: boolean) => {
+            if (isDimension) {
+                dispatch(explorerActions.toggleDimension(fieldId));
+            } else {
+                dispatch(explorerActions.toggleMetric(fieldId));
             }
-        }, [
-            explore,
-            additionalMetrics,
-            dispatch,
-            track,
-            user,
-            projectUuid,
-            chartUuid,
-        ]);
+        },
+        [dispatch],
+    );
 
-        const handleEditVirtualView = useCallback(() => {
-            startTransition(() => setIsEditVirtualViewOpen(true));
-        }, []);
+    const isVisualizationConfigOpen = useExplorerSelector(
+        selectIsVisualizationConfigOpen,
+    );
 
-        const handleDeleteVirtualView = useCallback(() => {
-            setIsDeleteVirtualViewOpen(true);
-        }, []);
+    const {
+        data: explore,
+        isInitialLoading,
+        status,
+        error,
+    } = useExplore(activeTableName);
 
-        const handleViewSourceCode = useCallback(() => {
-            if (!activeTableName) return;
-            openSourceCodeEditor({ explore: activeTableName });
-        }, [openSourceCodeEditor, activeTableName]);
-
-        const handleAddMergeSource = useCallback(() => {
-            if (!merge) return;
-            merge.addSource(DEFAULT_ADDITIONAL_SOURCE_ID, {
-                kind: 'source',
-                sourceId: isMergeSourceReady(metricQuery)
-                    ? DEFAULT_ADDITIONAL_SOURCE_ID
-                    : PRIMARY_SOURCE_ID,
+    useEffect(() => {
+        if (
+            projectUuid &&
+            user.data?.organizationUuid &&
+            explore &&
+            additionalMetrics
+        ) {
+            const replaceableFieldsMap = findReplaceableCustomMetrics({
+                metrics: getMetrics(explore),
+                customMetrics: additionalMetrics,
             });
-        }, [merge, metricQuery]);
-
-        const breadcrumbs = useMemo(() => {
-            if (!explore) return [];
-            const items = onBack
-                ? [
-                      { title: 'Tables', onClick: onBack },
-                      { title: explore.label, active: true },
-                  ]
-                : [{ title: explore.label, active: true }];
-            return items;
-        }, [onBack, explore]);
-
-        if (isInitialLoading) {
-            return <LoadingSkeleton />;
+            const fieldsToReplace =
+                convertReplaceableFieldMatchMapToReplaceFieldsMap(
+                    replaceableFieldsMap,
+                );
+            if (fieldsToReplace) {
+                dispatch(
+                    explorerActions.replaceFields({
+                        fieldsToReplace: {
+                            customMetrics: fieldsToReplace,
+                        },
+                    }),
+                );
+                track({
+                    name: EventName.CUSTOM_FIELDS_REPLACEMENT_APPLIED,
+                    properties: {
+                        userId: user.data.userUuid,
+                        projectId: projectUuid,
+                        organizationId: user.data.organizationUuid,
+                        chartId: chartUuid,
+                        customMetricIds: Object.keys(fieldsToReplace),
+                    },
+                });
+            }
         }
+    }, [
+        explore,
+        additionalMetrics,
+        dispatch,
+        track,
+        user,
+        projectUuid,
+        chartUuid,
+    ]);
 
-        if (!explore) return null;
+    const handleEditVirtualView = useCallback(() => {
+        startTransition(() => setIsEditVirtualViewOpen(true));
+    }, []);
 
-        const virtualViewSubject = subject('VirtualView', {
+    const handleDeleteVirtualView = useCallback(() => {
+        setIsDeleteVirtualViewOpen(true);
+    }, []);
+
+    const handleViewSourceCode = useCallback(() => {
+        if (!activeTableName) return;
+        openSourceCodeEditor({ explore: activeTableName });
+    }, [openSourceCodeEditor, activeTableName]);
+
+    const handleAddMergeSource = useCallback(() => {
+        if (!merge) return;
+        merge.addSource(DEFAULT_ADDITIONAL_SOURCE_ID, {
+            kind: 'source',
+            sourceId: isMergeSourceReady(metricQuery)
+                ? DEFAULT_ADDITIONAL_SOURCE_ID
+                : PRIMARY_SOURCE_ID,
+        });
+    }, [merge, metricQuery]);
+
+    const breadcrumbs = useMemo(() => {
+        if (!explore) return [];
+        const items = onBack
+            ? [
+                  { title: 'Tables', onClick: onBack },
+                  { title: explore.label, active: true },
+              ]
+            : [{ title: explore.label, active: true }];
+        return items;
+    }, [onBack, explore]);
+
+    if (isInitialLoading) {
+        return <LoadingSkeleton />;
+    }
+
+    if (!explore) return null;
+
+    const virtualViewSubject = subject('VirtualView', {
+        organizationUuid: user.data?.organizationUuid,
+        projectUuid,
+    });
+    const canEditVirtualView = user.data?.ability.can(
+        'create',
+        virtualViewSubject,
+    );
+    const canDeleteVirtualView = user.data?.ability.can(
+        'delete',
+        virtualViewSubject,
+    );
+    const canViewContentAsCode = user.data?.ability.can(
+        'view',
+        subject('ContentAsCode', {
             organizationUuid: user.data?.organizationUuid,
             projectUuid,
-        });
-        const canEditVirtualView = user.data?.ability.can(
-            'create',
-            virtualViewSubject,
-        );
-        const canDeleteVirtualView = user.data?.ability.can(
-            'delete',
-            virtualViewSubject,
-        );
-        const canViewContentAsCode = user.data?.ability.can(
+        }),
+    );
+    const canViewSourceCode =
+        explore.type !== ExploreType.VIRTUAL &&
+        isGitProject &&
+        !!explore.ymlPath &&
+        editYamlInUiFlag?.enabled === true &&
+        user.data?.ability.can(
             'view',
-            subject('ContentAsCode', {
+            subject('SourceCode', {
                 organizationUuid: user.data?.organizationUuid,
                 projectUuid,
             }),
-        );
-        const canViewSourceCode =
-            explore.type !== ExploreType.VIRTUAL &&
-            isGitProject &&
-            !!explore.ymlPath &&
-            editYamlInUiFlag?.enabled === true &&
-            user.data?.ability.can(
-                'view',
-                subject('SourceCode', {
-                    organizationUuid: user.data?.organizationUuid,
-                    projectUuid,
-                }),
-            ) === true;
-        const canMergeAnotherQuery =
-            explore.type !== ExploreType.VIRTUAL &&
-            mergeFlag?.enabled === true &&
-            !!merge &&
-            !merge.isMerging &&
-            !merge.readOnly;
+        ) === true;
+    const canMergeAnotherQuery =
+        explore.type !== ExploreType.VIRTUAL &&
+        mergeFlag?.enabled === true &&
+        !!merge &&
+        !merge.isMerging &&
+        !merge.readOnly;
 
-        // Only call `onBack` for 4XX errors, otherwise we lose URL state when there's a Network error or backend is down
-        if (status === 'error' && error.error.statusCode < 500) {
-            onBack?.();
-            return null;
-        }
+    // Only call `onBack` for 4XX errors, otherwise we lose URL state when there's a Network error or backend is down
+    if (status === 'error' && error.error.statusCode < 500) {
+        onBack?.();
+        return null;
+    }
 
-        return (
-            <>
-                {!isChartGalleryEnabled && (
-                    <VisualizationConfigPortal
-                        active={isVisualizationConfigOpen}
-                    />
-                )}
+    return (
+        <>
+            {!isChartGalleryEnabled && (
+                <VisualizationConfigPortal active={isVisualizationConfigOpen} />
+            )}
 
-                <Stack
-                    h="100%"
-                    className={classes.panel}
-                    data-hidden={
-                        !isChartGalleryEnabled && isVisualizationConfigOpen
-                    }
-                >
-                    {merge?.isMerging && merge.readOnly && <MergeJoinBar />}
-                    {/* The breadcrumbs, warnings and menu all belong to the
+            <Stack
+                h="100%"
+                className={classes.panel}
+                data-hidden={
+                    !isChartGalleryEnabled && isVisualizationConfigOpen
+                }
+            >
+                {merge?.isMerging && merge.readOnly && <MergeJoinBar />}
+                {/* The breadcrumbs, warnings and menu all belong to the
                     primary source's explore; shown above an added source's
                     picker they read as its header, which they are not. */}
-                    <Group
-                        justify="space-between"
-                        display={isGuidedMerge ? 'none' : undefined}
-                    >
-                        <Group gap="xs">
-                            <PageBreadcrumbs size="md" items={breadcrumbs} />
-                            {explore.type === ExploreType.EXTERNAL_SOURCE &&
-                                explore.externalSource && (
-                                    <ExternalSourceBadge
-                                        sourceRef={explore.externalSource}
-                                    />
-                                )}
-                            {explore.warnings &&
-                                explore.warnings.length > 0 && (
-                                    <HoverCard
-                                        withinPortal
-                                        position="right"
-                                        withArrow
-                                        radius="md"
-                                        shadow="subtle"
+                <Group
+                    justify="space-between"
+                    display={isGuidedMerge ? 'none' : undefined}
+                >
+                    <Group gap="xs">
+                        <PageBreadcrumbs size="md" items={breadcrumbs} />
+                        {explore.type === ExploreType.EXTERNAL_SOURCE &&
+                            explore.externalSource && (
+                                <ExternalSourceBadge
+                                    sourceRef={explore.externalSource}
+                                />
+                            )}
+                        {explore.warnings && explore.warnings.length > 0 && (
+                            <HoverCard
+                                withinPortal
+                                position="right"
+                                withArrow
+                                radius="md"
+                                shadow="subtle"
+                            >
+                                <HoverCard.Target>
+                                    <ActionIcon
+                                        variant="subtle"
+                                        color="yellow"
+                                        size="sm"
                                     >
-                                        <HoverCard.Target>
-                                            <ActionIcon
-                                                variant="subtle"
-                                                color="yellow"
-                                                size="sm"
-                                            >
-                                                <MantineIcon
-                                                    icon={IconAlertTriangle}
-                                                    color="yellow.9"
-                                                />
-                                            </ActionIcon>
-                                        </HoverCard.Target>
-                                        <HoverCard.Dropdown maw={400} p="xs">
-                                            <WarningsHoverCardContent
-                                                type="warnings"
-                                                warnings={explore.warnings}
-                                            />
-                                        </HoverCard.Dropdown>
-                                    </HoverCard>
-                                )}
-                        </Group>
-                        <Group gap="xs" wrap="nowrap">
-                            {explore.type === ExploreType.VIRTUAL &&
-                                (canEditVirtualView ||
-                                    canDeleteVirtualView ||
-                                    canViewContentAsCode) && (
-                                    <Menu withArrow offset={-2}>
-                                        <Menu.Target>
-                                            <ActionIcon
-                                                aria-label="Virtual view actions"
-                                                color="gray"
-                                                variant="transparent"
-                                            >
-                                                <MantineIcon icon={IconDots} />
-                                            </ActionIcon>
-                                        </Menu.Target>
-                                        <Menu.Dropdown>
-                                            {canEditVirtualView && (
-                                                <Menu.Item
-                                                    leftSection={
-                                                        <MantineIcon
-                                                            icon={IconPencil}
-                                                        />
-                                                    }
-                                                    onClick={
-                                                        handleEditVirtualView
-                                                    }
-                                                >
-                                                    <Text fz="xs" fw={500}>
-                                                        Edit virtual view
-                                                    </Text>
-                                                </Menu.Item>
-                                            )}
-                                            {canViewContentAsCode && (
-                                                <>
-                                                    {canEditVirtualView && (
-                                                        <Menu.Divider />
-                                                    )}
-                                                    <Menu.Label>
-                                                        Content as code
-                                                    </Menu.Label>
-                                                    <Menu.Item
-                                                        leftSection={
-                                                            <MantineIcon
-                                                                icon={IconCode}
-                                                            />
-                                                        }
-                                                        onClick={
-                                                            virtualViewAsCodeModalHandlers.open
-                                                        }
-                                                    >
-                                                        View as code
-                                                    </Menu.Item>
-                                                </>
-                                            )}
-                                            {canDeleteVirtualView && (
-                                                <>
-                                                    <Menu.Divider />
-                                                    <Menu.Item
-                                                        leftSection={
-                                                            <MantineIcon
-                                                                icon={IconTrash}
-                                                            />
-                                                        }
-                                                        color="red"
-                                                        onClick={
-                                                            handleDeleteVirtualView
-                                                        }
-                                                    >
-                                                        <Text fz="xs" fw={500}>
-                                                            Delete
-                                                        </Text>
-                                                    </Menu.Item>
-                                                </>
-                                            )}
-                                        </Menu.Dropdown>
-                                    </Menu>
-                                )}
-                            {explore.type === ExploreType.EXTERNAL_SOURCE &&
-                                explore.externalSource &&
-                                projectUuid && (
-                                    <ExternalSourceExploreMenu
-                                        projectUuid={projectUuid}
-                                        explore={explore}
-                                        sourceRef={explore.externalSource}
-                                        canMergeAnotherQuery={
-                                            canMergeAnotherQuery
-                                        }
-                                        onAddMergeSource={handleAddMergeSource}
+                                        <MantineIcon
+                                            icon={IconAlertTriangle}
+                                            color="yellow.9"
+                                        />
+                                    </ActionIcon>
+                                </HoverCard.Target>
+                                <HoverCard.Dropdown maw={400} p="xs">
+                                    <WarningsHoverCardContent
+                                        type="warnings"
+                                        warnings={explore.warnings}
                                     />
-                                )}
-                            {explore.type !== ExploreType.EXTERNAL_SOURCE &&
-                                (canViewSourceCode || canMergeAnotherQuery) && (
-                                    <Menu withArrow offset={-2}>
-                                        <Menu.Target>
-                                            <ActionIcon
-                                                aria-label="Query options"
-                                                color="gray"
-                                                variant="transparent"
+                                </HoverCard.Dropdown>
+                            </HoverCard>
+                        )}
+                    </Group>
+                    <Group gap="xs" wrap="nowrap">
+                        {explore.type === ExploreType.VIRTUAL &&
+                            (canEditVirtualView ||
+                                canDeleteVirtualView ||
+                                canViewContentAsCode) && (
+                                <Menu withArrow offset={-2}>
+                                    <Menu.Target>
+                                        <ActionIcon
+                                            aria-label="Virtual view actions"
+                                            color="gray"
+                                            variant="transparent"
+                                        >
+                                            <MantineIcon icon={IconDots} />
+                                        </ActionIcon>
+                                    </Menu.Target>
+                                    <Menu.Dropdown>
+                                        {canEditVirtualView && (
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconPencil}
+                                                    />
+                                                }
+                                                onClick={handleEditVirtualView}
                                             >
-                                                <MantineIcon icon={IconDots} />
-                                            </ActionIcon>
-                                        </Menu.Target>
-                                        <Menu.Dropdown>
-                                            {canViewSourceCode && (
+                                                <Text fz="xs" fw={500}>
+                                                    Edit virtual view
+                                                </Text>
+                                            </Menu.Item>
+                                        )}
+                                        {canViewContentAsCode && (
+                                            <>
+                                                {canEditVirtualView && (
+                                                    <Menu.Divider />
+                                                )}
+                                                <Menu.Label>
+                                                    Content as code
+                                                </Menu.Label>
                                                 <Menu.Item
                                                     leftSection={
                                                         <MantineIcon
@@ -442,99 +370,156 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(
                                                         />
                                                     }
                                                     onClick={
-                                                        handleViewSourceCode
+                                                        virtualViewAsCodeModalHandlers.open
                                                     }
                                                 >
-                                                    <Text fz="xs" fw={500}>
-                                                        View source code
-                                                    </Text>
+                                                    View as code
                                                 </Menu.Item>
-                                            )}
-                                            {canViewSourceCode &&
-                                                canMergeAnotherQuery && (
-                                                    <Menu.Divider />
-                                                )}
-                                            {canMergeAnotherQuery && (
+                                            </>
+                                        )}
+                                        {canDeleteVirtualView && (
+                                            <>
+                                                <Menu.Divider />
                                                 <Menu.Item
                                                     leftSection={
                                                         <MantineIcon
-                                                            icon={IconGitMerge}
+                                                            icon={IconTrash}
                                                         />
                                                     }
+                                                    color="red"
                                                     onClick={
-                                                        handleAddMergeSource
+                                                        handleDeleteVirtualView
                                                     }
                                                 >
                                                     <Text fz="xs" fw={500}>
-                                                        Merge another query
+                                                        Delete
                                                     </Text>
                                                 </Menu.Item>
-                                            )}
-                                        </Menu.Dropdown>
-                                    </Menu>
-                                )}
-                            {isCollapsible && <ExplorerSidebarToggle isOpen />}
-                        </Group>
-                    </Group>
-
-                    {explore.type === ExploreType.EXTERNAL_SOURCE &&
-                        canMergeAnotherQuery &&
-                        !isGuidedMerge && (
-                            <Group>
-                                <JoinWithWarehouseHint
-                                    onClick={handleAddMergeSource}
+                                            </>
+                                        )}
+                                    </Menu.Dropdown>
+                                </Menu>
+                            )}
+                        {explore.type === ExploreType.EXTERNAL_SOURCE &&
+                            explore.externalSource &&
+                            projectUuid && (
+                                <ExternalSourceExploreMenu
+                                    projectUuid={projectUuid}
+                                    explore={explore}
+                                    sourceRef={explore.externalSource}
+                                    canMergeAnotherQuery={canMergeAnotherQuery}
+                                    onAddMergeSource={handleAddMergeSource}
                                 />
-                            </Group>
-                        )}
+                            )}
+                        {explore.type !== ExploreType.EXTERNAL_SOURCE &&
+                            (canViewSourceCode || canMergeAnotherQuery) && (
+                                <Menu withArrow offset={-2}>
+                                    <Menu.Target>
+                                        <ActionIcon
+                                            aria-label="Query options"
+                                            color="gray"
+                                            variant="transparent"
+                                        >
+                                            <MantineIcon icon={IconDots} />
+                                        </ActionIcon>
+                                    </Menu.Target>
+                                    <Menu.Dropdown>
+                                        {canViewSourceCode && (
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconCode}
+                                                    />
+                                                }
+                                                onClick={handleViewSourceCode}
+                                            >
+                                                <Text fz="xs" fw={500}>
+                                                    View source code
+                                                </Text>
+                                            </Menu.Item>
+                                        )}
+                                        {canViewSourceCode &&
+                                            canMergeAnotherQuery && (
+                                                <Menu.Divider />
+                                            )}
+                                        {canMergeAnotherQuery && (
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconGitMerge}
+                                                    />
+                                                }
+                                                onClick={handleAddMergeSource}
+                                            >
+                                                <Text fz="xs" fw={500}>
+                                                    Merge another query
+                                                </Text>
+                                            </Menu.Item>
+                                        )}
+                                    </Menu.Dropdown>
+                                </Menu>
+                            )}
+                        {isCollapsible && <ExplorerSidebarToggle isOpen />}
+                    </Group>
+                </Group>
 
-                    {isGuidedMerge ? (
-                        <MergeQuerySidebar
-                            primaryExplore={explore}
-                            onPrimaryFieldChange={toggleActiveField}
-                            isChoosingAdditionalExplore={isChoosingMergeExplore}
-                            setIsChoosingAdditionalExplore={
-                                setIsChoosingMergeExplore
-                            }
-                        />
-                    ) : (
-                        <ItemDetailProvider>
-                            <ExploreTree
-                                explore={explore}
-                                onSelectedFieldChange={toggleActiveField}
+                {explore.type === ExploreType.EXTERNAL_SOURCE &&
+                    canMergeAnotherQuery &&
+                    !isGuidedMerge && (
+                        <Group>
+                            <JoinWithWarehouseHint
+                                onClick={handleAddMergeSource}
                             />
-                        </ItemDetailProvider>
+                        </Group>
                     )}
 
-                    {isEditVirtualViewOpen && (
-                        <EditVirtualViewModal
-                            opened={isEditVirtualViewOpen}
-                            onClose={() => setIsEditVirtualViewOpen(false)}
-                            activeTableName={activeTableName}
-                            setIsEditVirtualViewOpen={setIsEditVirtualViewOpen}
+                {isGuidedMerge ? (
+                    <MergeQuerySidebar
+                        primaryExplore={explore}
+                        onPrimaryFieldChange={toggleActiveField}
+                        isChoosingAdditionalExplore={isChoosingMergeExplore}
+                        setIsChoosingAdditionalExplore={
+                            setIsChoosingMergeExplore
+                        }
+                    />
+                ) : (
+                    <ItemDetailProvider>
+                        <ExploreTree
                             explore={explore}
+                            onSelectedFieldChange={toggleActiveField}
                         />
-                    )}
-                    {isDeleteVirtualViewOpen && projectUuid && (
-                        <DeleteVirtualViewModal
-                            opened={isDeleteVirtualViewOpen}
-                            onClose={() => setIsDeleteVirtualViewOpen(false)}
-                            virtualViewName={activeTableName}
-                            projectUuid={projectUuid}
-                        />
-                    )}
-                    {projectUuid && isVirtualViewAsCodeOpen && (
-                        <VirtualViewAsCodeModal
-                            opened={isVirtualViewAsCodeOpen}
-                            onClose={virtualViewAsCodeModalHandlers.close}
-                            projectUuid={projectUuid}
-                            virtualViewSlug={activeTableName}
-                        />
-                    )}
-                </Stack>
-            </>
-        );
-    },
-);
+                    </ItemDetailProvider>
+                )}
+
+                {isEditVirtualViewOpen && (
+                    <EditVirtualViewModal
+                        opened={isEditVirtualViewOpen}
+                        onClose={() => setIsEditVirtualViewOpen(false)}
+                        activeTableName={activeTableName}
+                        setIsEditVirtualViewOpen={setIsEditVirtualViewOpen}
+                        explore={explore}
+                    />
+                )}
+                {isDeleteVirtualViewOpen && projectUuid && (
+                    <DeleteVirtualViewModal
+                        opened={isDeleteVirtualViewOpen}
+                        onClose={() => setIsDeleteVirtualViewOpen(false)}
+                        virtualViewName={activeTableName}
+                        projectUuid={projectUuid}
+                    />
+                )}
+                {projectUuid && isVirtualViewAsCodeOpen && (
+                    <VirtualViewAsCodeModal
+                        opened={isVirtualViewAsCodeOpen}
+                        onClose={virtualViewAsCodeModalHandlers.close}
+                        projectUuid={projectUuid}
+                        virtualViewSlug={activeTableName}
+                    />
+                )}
+            </Stack>
+        </>
+    );
+});
 
 ExplorePanel.displayName = 'ExplorePanel';
 

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -13,7 +13,7 @@ import {
     Menu,
     Stack,
     Text,
-} from '@mantine-8/core';
+} from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAlertTriangle,

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -6,7 +6,14 @@ import {
     findReplaceableCustomMetrics,
     getMetrics,
 } from '@lightdash/common';
-import { Group, Menu, Stack, Text, ActionIcon, HoverCard } from '@mantine/core';
+import {
+    ActionIcon,
+    Group,
+    HoverCard,
+    Menu,
+    Stack,
+    Text,
+} from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAlertTriangle,
@@ -61,6 +68,7 @@ import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
 import PageBreadcrumbs from '../../common/PageBreadcrumbs';
 import { useIsChartGalleryEnabled } from '../ChartGallery/useIsChartGalleryEnabled';
+import { ExplorerSidebarToggle } from '../ExplorerSidebarToggle';
 import ExploreTree from '../ExploreTree';
 import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailProvider';
@@ -71,447 +79,469 @@ import classes from './index.module.css';
 
 interface ExplorePanelProps {
     onBack?: () => void;
+    isCollapsible?: boolean;
 }
 
-const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
-    const { track } = useTracking();
-    const { user } = useApp();
-    const [isEditVirtualViewOpen, setIsEditVirtualViewOpen] = useState(false);
-    const [isDeleteVirtualViewOpen, setIsDeleteVirtualViewOpen] =
-        useState(false);
-    const [isVirtualViewAsCodeOpen, virtualViewAsCodeModalHandlers] =
-        useDisclosure();
-    const [, startTransition] = useTransition();
+const ExplorePanel: FC<ExplorePanelProps> = memo(
+    ({ onBack, isCollapsible = false }) => {
+        const { track } = useTracking();
+        const { user } = useApp();
+        const [isEditVirtualViewOpen, setIsEditVirtualViewOpen] =
+            useState(false);
+        const [isDeleteVirtualViewOpen, setIsDeleteVirtualViewOpen] =
+            useState(false);
+        const [isVirtualViewAsCodeOpen, virtualViewAsCodeModalHandlers] =
+            useDisclosure();
+        const [, startTransition] = useTransition();
 
-    const projectUuid = useProjectUuid();
-    const isGitProject = useIsGitProject(projectUuid ?? '');
-    const { open: openSourceCodeEditor } = useSourceCodeEditor();
-    const { data: editYamlInUiFlag } = useServerFeatureFlag(
-        FeatureFlags.EditYamlInUi,
-    );
-    const { data: mergeFlag } = useServerFeatureFlag(FeatureFlags.MergeQueries);
-    const isChartGalleryEnabled = useIsChartGalleryEnabled();
-    const merge = useMergeSafe();
-    const additionalSource = merge?.additionalSources[0];
-    const [isChoosingMergeExplore, setIsChoosingMergeExplore] = useState(
-        !additionalSource?.exploreName,
-    );
-    useEffect(() => {
-        if (!additionalSource?.exploreName) setIsChoosingMergeExplore(true);
-    }, [additionalSource?.exploreName]);
-    const isGuidedMerge =
-        mergeFlag?.enabled === true &&
-        merge?.isMerging === true &&
-        !merge.readOnly;
-    const activeTableName = useExplorerSelector(selectTableName);
-    const metricQuery = useExplorerSelector(selectMetricQuery);
-    const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
+        const projectUuid = useProjectUuid();
+        const isGitProject = useIsGitProject(projectUuid ?? '');
+        const { open: openSourceCodeEditor } = useSourceCodeEditor();
+        const { data: editYamlInUiFlag } = useServerFeatureFlag(
+            FeatureFlags.EditYamlInUi,
+        );
+        const { data: mergeFlag } = useServerFeatureFlag(
+            FeatureFlags.MergeQueries,
+        );
+        const isChartGalleryEnabled = useIsChartGalleryEnabled();
+        const merge = useMergeSafe();
+        const additionalSource = merge?.additionalSources[0];
+        const [isChoosingMergeExplore, setIsChoosingMergeExplore] = useState(
+            !additionalSource?.exploreName,
+        );
+        useEffect(() => {
+            if (!additionalSource?.exploreName) setIsChoosingMergeExplore(true);
+        }, [additionalSource?.exploreName]);
+        const isGuidedMerge =
+            mergeFlag?.enabled === true &&
+            merge?.isMerging === true &&
+            !merge.readOnly;
+        const activeTableName = useExplorerSelector(selectTableName);
+        const metricQuery = useExplorerSelector(selectMetricQuery);
+        const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
 
-    // Get savedChart from Redux
-    const savedChart = useExplorerSelector(selectSavedChart);
-    const chartUuid = savedChart?.uuid;
+        // Get savedChart from Redux
+        const savedChart = useExplorerSelector(selectSavedChart);
+        const chartUuid = savedChart?.uuid;
 
-    const dispatch = useExplorerDispatch();
+        const dispatch = useExplorerDispatch();
 
-    const toggleActiveField = useCallback(
-        (fieldId: string, isDimension: boolean) => {
-            if (isDimension) {
-                dispatch(explorerActions.toggleDimension(fieldId));
-            } else {
-                dispatch(explorerActions.toggleMetric(fieldId));
-            }
-        },
-        [dispatch],
-    );
+        const toggleActiveField = useCallback(
+            (fieldId: string, isDimension: boolean) => {
+                if (isDimension) {
+                    dispatch(explorerActions.toggleDimension(fieldId));
+                } else {
+                    dispatch(explorerActions.toggleMetric(fieldId));
+                }
+            },
+            [dispatch],
+        );
 
-    const isVisualizationConfigOpen = useExplorerSelector(
-        selectIsVisualizationConfigOpen,
-    );
+        const isVisualizationConfigOpen = useExplorerSelector(
+            selectIsVisualizationConfigOpen,
+        );
 
-    const {
-        data: explore,
-        isInitialLoading,
-        status,
-        error,
-    } = useExplore(activeTableName);
+        const {
+            data: explore,
+            isInitialLoading,
+            status,
+            error,
+        } = useExplore(activeTableName);
 
-    useEffect(() => {
-        if (
-            projectUuid &&
-            user.data?.organizationUuid &&
-            explore &&
-            additionalMetrics
-        ) {
-            const replaceableFieldsMap = findReplaceableCustomMetrics({
-                metrics: getMetrics(explore),
-                customMetrics: additionalMetrics,
-            });
-            const fieldsToReplace =
-                convertReplaceableFieldMatchMapToReplaceFieldsMap(
-                    replaceableFieldsMap,
-                );
-            if (fieldsToReplace) {
-                dispatch(
-                    explorerActions.replaceFields({
-                        fieldsToReplace: {
-                            customMetrics: fieldsToReplace,
-                        },
-                    }),
-                );
-                track({
-                    name: EventName.CUSTOM_FIELDS_REPLACEMENT_APPLIED,
-                    properties: {
-                        userId: user.data.userUuid,
-                        projectId: projectUuid,
-                        organizationId: user.data.organizationUuid,
-                        chartId: chartUuid,
-                        customMetricIds: Object.keys(fieldsToReplace),
-                    },
+        useEffect(() => {
+            if (
+                projectUuid &&
+                user.data?.organizationUuid &&
+                explore &&
+                additionalMetrics
+            ) {
+                const replaceableFieldsMap = findReplaceableCustomMetrics({
+                    metrics: getMetrics(explore),
+                    customMetrics: additionalMetrics,
                 });
+                const fieldsToReplace =
+                    convertReplaceableFieldMatchMapToReplaceFieldsMap(
+                        replaceableFieldsMap,
+                    );
+                if (fieldsToReplace) {
+                    dispatch(
+                        explorerActions.replaceFields({
+                            fieldsToReplace: {
+                                customMetrics: fieldsToReplace,
+                            },
+                        }),
+                    );
+                    track({
+                        name: EventName.CUSTOM_FIELDS_REPLACEMENT_APPLIED,
+                        properties: {
+                            userId: user.data.userUuid,
+                            projectId: projectUuid,
+                            organizationId: user.data.organizationUuid,
+                            chartId: chartUuid,
+                            customMetricIds: Object.keys(fieldsToReplace),
+                        },
+                    });
+                }
             }
+        }, [
+            explore,
+            additionalMetrics,
+            dispatch,
+            track,
+            user,
+            projectUuid,
+            chartUuid,
+        ]);
+
+        const handleEditVirtualView = useCallback(() => {
+            startTransition(() => setIsEditVirtualViewOpen(true));
+        }, []);
+
+        const handleDeleteVirtualView = useCallback(() => {
+            setIsDeleteVirtualViewOpen(true);
+        }, []);
+
+        const handleViewSourceCode = useCallback(() => {
+            if (!activeTableName) return;
+            openSourceCodeEditor({ explore: activeTableName });
+        }, [openSourceCodeEditor, activeTableName]);
+
+        const handleAddMergeSource = useCallback(() => {
+            if (!merge) return;
+            merge.addSource(DEFAULT_ADDITIONAL_SOURCE_ID, {
+                kind: 'source',
+                sourceId: isMergeSourceReady(metricQuery)
+                    ? DEFAULT_ADDITIONAL_SOURCE_ID
+                    : PRIMARY_SOURCE_ID,
+            });
+        }, [merge, metricQuery]);
+
+        const breadcrumbs = useMemo(() => {
+            if (!explore) return [];
+            const items = onBack
+                ? [
+                      { title: 'Tables', onClick: onBack },
+                      { title: explore.label, active: true },
+                  ]
+                : [{ title: explore.label, active: true }];
+            return items;
+        }, [onBack, explore]);
+
+        if (isInitialLoading) {
+            return <LoadingSkeleton />;
         }
-    }, [
-        explore,
-        additionalMetrics,
-        dispatch,
-        track,
-        user,
-        projectUuid,
-        chartUuid,
-    ]);
 
-    const handleEditVirtualView = useCallback(() => {
-        startTransition(() => setIsEditVirtualViewOpen(true));
-    }, []);
+        if (!explore) return null;
 
-    const handleDeleteVirtualView = useCallback(() => {
-        setIsDeleteVirtualViewOpen(true);
-    }, []);
-
-    const handleViewSourceCode = useCallback(() => {
-        if (!activeTableName) return;
-        openSourceCodeEditor({ explore: activeTableName });
-    }, [openSourceCodeEditor, activeTableName]);
-
-    const handleAddMergeSource = useCallback(() => {
-        if (!merge) return;
-        merge.addSource(DEFAULT_ADDITIONAL_SOURCE_ID, {
-            kind: 'source',
-            sourceId: isMergeSourceReady(metricQuery)
-                ? DEFAULT_ADDITIONAL_SOURCE_ID
-                : PRIMARY_SOURCE_ID,
-        });
-    }, [merge, metricQuery]);
-
-    const breadcrumbs = useMemo(() => {
-        if (!explore) return [];
-        const items = onBack
-            ? [
-                  { title: 'Tables', onClick: onBack },
-                  { title: explore.label, active: true },
-              ]
-            : [{ title: explore.label, active: true }];
-        return items;
-    }, [onBack, explore]);
-
-    if (isInitialLoading) {
-        return <LoadingSkeleton />;
-    }
-
-    if (!explore) return null;
-
-    const virtualViewSubject = subject('VirtualView', {
-        organizationUuid: user.data?.organizationUuid,
-        projectUuid,
-    });
-    const canEditVirtualView = user.data?.ability.can(
-        'create',
-        virtualViewSubject,
-    );
-    const canDeleteVirtualView = user.data?.ability.can(
-        'delete',
-        virtualViewSubject,
-    );
-    const canViewContentAsCode = user.data?.ability.can(
-        'view',
-        subject('ContentAsCode', {
+        const virtualViewSubject = subject('VirtualView', {
             organizationUuid: user.data?.organizationUuid,
             projectUuid,
-        }),
-    );
-    const canViewSourceCode =
-        explore.type !== ExploreType.VIRTUAL &&
-        isGitProject &&
-        !!explore.ymlPath &&
-        editYamlInUiFlag?.enabled === true &&
-        user.data?.ability.can(
+        });
+        const canEditVirtualView = user.data?.ability.can(
+            'create',
+            virtualViewSubject,
+        );
+        const canDeleteVirtualView = user.data?.ability.can(
+            'delete',
+            virtualViewSubject,
+        );
+        const canViewContentAsCode = user.data?.ability.can(
             'view',
-            subject('SourceCode', {
+            subject('ContentAsCode', {
                 organizationUuid: user.data?.organizationUuid,
                 projectUuid,
             }),
-        ) === true;
-    const canMergeAnotherQuery =
-        explore.type !== ExploreType.VIRTUAL &&
-        mergeFlag?.enabled === true &&
-        !!merge &&
-        !merge.isMerging &&
-        !merge.readOnly;
+        );
+        const canViewSourceCode =
+            explore.type !== ExploreType.VIRTUAL &&
+            isGitProject &&
+            !!explore.ymlPath &&
+            editYamlInUiFlag?.enabled === true &&
+            user.data?.ability.can(
+                'view',
+                subject('SourceCode', {
+                    organizationUuid: user.data?.organizationUuid,
+                    projectUuid,
+                }),
+            ) === true;
+        const canMergeAnotherQuery =
+            explore.type !== ExploreType.VIRTUAL &&
+            mergeFlag?.enabled === true &&
+            !!merge &&
+            !merge.isMerging &&
+            !merge.readOnly;
 
-    // Only call `onBack` for 4XX errors, otherwise we lose URL state when there's a Network error or backend is down
-    if (status === 'error' && error.error.statusCode < 500) {
-        onBack?.();
-        return null;
-    }
+        // Only call `onBack` for 4XX errors, otherwise we lose URL state when there's a Network error or backend is down
+        if (status === 'error' && error.error.statusCode < 500) {
+            onBack?.();
+            return null;
+        }
 
-    return (
-        <>
-            {!isChartGalleryEnabled && (
-                <VisualizationConfigPortal active={isVisualizationConfigOpen} />
-            )}
+        return (
+            <>
+                {!isChartGalleryEnabled && (
+                    <VisualizationConfigPortal
+                        active={isVisualizationConfigOpen}
+                    />
+                )}
 
-            <Stack
-                h="100%"
-                className={classes.panel}
-                data-hidden={
-                    !isChartGalleryEnabled && isVisualizationConfigOpen
-                }
-            >
-                {merge?.isMerging && merge.readOnly && <MergeJoinBar />}
-                {/* The breadcrumbs, warnings and menu all belong to the
+                <Stack
+                    h="100%"
+                    className={classes.panel}
+                    data-hidden={
+                        !isChartGalleryEnabled && isVisualizationConfigOpen
+                    }
+                >
+                    {merge?.isMerging && merge.readOnly && <MergeJoinBar />}
+                    {/* The breadcrumbs, warnings and menu all belong to the
                     primary source's explore; shown above an added source's
                     picker they read as its header, which they are not. */}
-                <Group
-                    justify="space-between"
-                    display={isGuidedMerge ? 'none' : undefined}
-                >
-                    <Group gap="xs">
-                        <PageBreadcrumbs size="md" items={breadcrumbs} />
-                        {explore.type === ExploreType.EXTERNAL_SOURCE &&
-                            explore.externalSource && (
-                                <ExternalSourceBadge
-                                    sourceRef={explore.externalSource}
-                                />
-                            )}
-                        {explore.warnings && explore.warnings.length > 0 && (
-                            <HoverCard
-                                withinPortal
-                                position="right"
-                                withArrow
-                                radius="md"
-                                shadow="subtle"
-                            >
-                                <HoverCard.Target>
-                                    <ActionIcon
-                                        variant="subtle"
-                                        color="yellow"
-                                        size="sm"
-                                    >
-                                        <MantineIcon
-                                            icon={IconAlertTriangle}
-                                            color="yellow.9"
-                                        />
-                                    </ActionIcon>
-                                </HoverCard.Target>
-                                <HoverCard.Dropdown maw={400} p="xs">
-                                    <WarningsHoverCardContent
-                                        type="warnings"
-                                        warnings={explore.warnings}
+                    <Group
+                        justify="space-between"
+                        display={isGuidedMerge ? 'none' : undefined}
+                    >
+                        <Group gap="xs">
+                            <PageBreadcrumbs size="md" items={breadcrumbs} />
+                            {explore.type === ExploreType.EXTERNAL_SOURCE &&
+                                explore.externalSource && (
+                                    <ExternalSourceBadge
+                                        sourceRef={explore.externalSource}
                                     />
-                                </HoverCard.Dropdown>
-                            </HoverCard>
-                        )}
-                    </Group>
-                    {explore.type === ExploreType.VIRTUAL &&
-                        (canEditVirtualView ||
-                            canDeleteVirtualView ||
-                            canViewContentAsCode) && (
-                            <Menu withArrow offset={-2}>
-                                <Menu.Target>
-                                    <ActionIcon
-                                        aria-label="Virtual view actions"
-                                        color="gray"
-                                        variant="transparent"
+                                )}
+                            {explore.warnings &&
+                                explore.warnings.length > 0 && (
+                                    <HoverCard
+                                        withinPortal
+                                        position="right"
+                                        withArrow
+                                        radius="md"
+                                        shadow="subtle"
                                     >
-                                        <MantineIcon icon={IconDots} />
-                                    </ActionIcon>
-                                </Menu.Target>
-                                <Menu.Dropdown>
-                                    {canEditVirtualView && (
-                                        <Menu.Item
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconPencil}
-                                                />
-                                            }
-                                            onClick={handleEditVirtualView}
-                                        >
-                                            <Text fz="xs" fw={500}>
-                                                Edit virtual view
-                                            </Text>
-                                        </Menu.Item>
-                                    )}
-                                    {canViewContentAsCode && (
-                                        <>
-                                            {canEditVirtualView && (
-                                                <Menu.Divider />
-                                            )}
-                                            <Menu.Label>
-                                                Content as code
-                                            </Menu.Label>
-                                            <Menu.Item
-                                                leftSection={
-                                                    <MantineIcon
-                                                        icon={IconCode}
-                                                    />
-                                                }
-                                                onClick={
-                                                    virtualViewAsCodeModalHandlers.open
-                                                }
+                                        <HoverCard.Target>
+                                            <ActionIcon
+                                                variant="subtle"
+                                                color="yellow"
+                                                size="sm"
                                             >
-                                                View as code
-                                            </Menu.Item>
-                                        </>
-                                    )}
-                                    {canDeleteVirtualView && (
-                                        <>
-                                            <Menu.Divider />
-                                            <Menu.Item
-                                                leftSection={
-                                                    <MantineIcon
-                                                        icon={IconTrash}
-                                                    />
-                                                }
-                                                color="red"
-                                                onClick={
-                                                    handleDeleteVirtualView
-                                                }
-                                            >
-                                                <Text fz="xs" fw={500}>
-                                                    Delete
-                                                </Text>
-                                            </Menu.Item>
-                                        </>
-                                    )}
-                                </Menu.Dropdown>
-                            </Menu>
-                        )}
-                    {explore.type === ExploreType.EXTERNAL_SOURCE &&
-                        explore.externalSource &&
-                        projectUuid && (
-                            <ExternalSourceExploreMenu
-                                projectUuid={projectUuid}
-                                explore={explore}
-                                sourceRef={explore.externalSource}
-                                canMergeAnotherQuery={canMergeAnotherQuery}
-                                onAddMergeSource={handleAddMergeSource}
-                            />
-                        )}
-                    {explore.type !== ExploreType.EXTERNAL_SOURCE &&
-                        (canViewSourceCode || canMergeAnotherQuery) && (
-                            <Menu withArrow offset={-2}>
-                                <Menu.Target>
-                                    <ActionIcon
-                                        aria-label="Query options"
-                                        color="gray"
-                                        variant="transparent"
-                                    >
-                                        <MantineIcon icon={IconDots} />
-                                    </ActionIcon>
-                                </Menu.Target>
-                                <Menu.Dropdown>
-                                    {canViewSourceCode && (
-                                        <Menu.Item
-                                            leftSection={
-                                                <MantineIcon icon={IconCode} />
-                                            }
-                                            onClick={handleViewSourceCode}
-                                        >
-                                            <Text fz="xs" fw={500}>
-                                                View source code
-                                            </Text>
-                                        </Menu.Item>
-                                    )}
-                                    {canViewSourceCode &&
-                                        canMergeAnotherQuery && (
-                                            <Menu.Divider />
-                                        )}
-                                    {canMergeAnotherQuery && (
-                                        <Menu.Item
-                                            leftSection={
                                                 <MantineIcon
-                                                    icon={IconGitMerge}
+                                                    icon={IconAlertTriangle}
+                                                    color="yellow.9"
                                                 />
-                                            }
-                                            onClick={handleAddMergeSource}
-                                        >
-                                            <Text fz="xs" fw={500}>
-                                                Merge another query
-                                            </Text>
-                                        </Menu.Item>
-                                    )}
-                                </Menu.Dropdown>
-                            </Menu>
-                        )}
-                </Group>
-
-                {explore.type === ExploreType.EXTERNAL_SOURCE &&
-                    canMergeAnotherQuery &&
-                    !isGuidedMerge && (
-                        <Group>
-                            <JoinWithWarehouseHint
-                                onClick={handleAddMergeSource}
-                            />
+                                            </ActionIcon>
+                                        </HoverCard.Target>
+                                        <HoverCard.Dropdown maw={400} p="xs">
+                                            <WarningsHoverCardContent
+                                                type="warnings"
+                                                warnings={explore.warnings}
+                                            />
+                                        </HoverCard.Dropdown>
+                                    </HoverCard>
+                                )}
                         </Group>
+                        <Group gap="xs" wrap="nowrap">
+                            {explore.type === ExploreType.VIRTUAL &&
+                                (canEditVirtualView ||
+                                    canDeleteVirtualView ||
+                                    canViewContentAsCode) && (
+                                    <Menu withArrow offset={-2}>
+                                        <Menu.Target>
+                                            <ActionIcon
+                                                aria-label="Virtual view actions"
+                                                color="gray"
+                                                variant="transparent"
+                                            >
+                                                <MantineIcon icon={IconDots} />
+                                            </ActionIcon>
+                                        </Menu.Target>
+                                        <Menu.Dropdown>
+                                            {canEditVirtualView && (
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconPencil}
+                                                        />
+                                                    }
+                                                    onClick={
+                                                        handleEditVirtualView
+                                                    }
+                                                >
+                                                    <Text fz="xs" fw={500}>
+                                                        Edit virtual view
+                                                    </Text>
+                                                </Menu.Item>
+                                            )}
+                                            {canViewContentAsCode && (
+                                                <>
+                                                    {canEditVirtualView && (
+                                                        <Menu.Divider />
+                                                    )}
+                                                    <Menu.Label>
+                                                        Content as code
+                                                    </Menu.Label>
+                                                    <Menu.Item
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={IconCode}
+                                                            />
+                                                        }
+                                                        onClick={
+                                                            virtualViewAsCodeModalHandlers.open
+                                                        }
+                                                    >
+                                                        View as code
+                                                    </Menu.Item>
+                                                </>
+                                            )}
+                                            {canDeleteVirtualView && (
+                                                <>
+                                                    <Menu.Divider />
+                                                    <Menu.Item
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={IconTrash}
+                                                            />
+                                                        }
+                                                        color="red"
+                                                        onClick={
+                                                            handleDeleteVirtualView
+                                                        }
+                                                    >
+                                                        <Text fz="xs" fw={500}>
+                                                            Delete
+                                                        </Text>
+                                                    </Menu.Item>
+                                                </>
+                                            )}
+                                        </Menu.Dropdown>
+                                    </Menu>
+                                )}
+                            {explore.type === ExploreType.EXTERNAL_SOURCE &&
+                                explore.externalSource &&
+                                projectUuid && (
+                                    <ExternalSourceExploreMenu
+                                        projectUuid={projectUuid}
+                                        explore={explore}
+                                        sourceRef={explore.externalSource}
+                                        canMergeAnotherQuery={
+                                            canMergeAnotherQuery
+                                        }
+                                        onAddMergeSource={handleAddMergeSource}
+                                    />
+                                )}
+                            {explore.type !== ExploreType.EXTERNAL_SOURCE &&
+                                (canViewSourceCode || canMergeAnotherQuery) && (
+                                    <Menu withArrow offset={-2}>
+                                        <Menu.Target>
+                                            <ActionIcon
+                                                aria-label="Query options"
+                                                color="gray"
+                                                variant="transparent"
+                                            >
+                                                <MantineIcon icon={IconDots} />
+                                            </ActionIcon>
+                                        </Menu.Target>
+                                        <Menu.Dropdown>
+                                            {canViewSourceCode && (
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconCode}
+                                                        />
+                                                    }
+                                                    onClick={
+                                                        handleViewSourceCode
+                                                    }
+                                                >
+                                                    <Text fz="xs" fw={500}>
+                                                        View source code
+                                                    </Text>
+                                                </Menu.Item>
+                                            )}
+                                            {canViewSourceCode &&
+                                                canMergeAnotherQuery && (
+                                                    <Menu.Divider />
+                                                )}
+                                            {canMergeAnotherQuery && (
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconGitMerge}
+                                                        />
+                                                    }
+                                                    onClick={
+                                                        handleAddMergeSource
+                                                    }
+                                                >
+                                                    <Text fz="xs" fw={500}>
+                                                        Merge another query
+                                                    </Text>
+                                                </Menu.Item>
+                                            )}
+                                        </Menu.Dropdown>
+                                    </Menu>
+                                )}
+                            {isCollapsible && <ExplorerSidebarToggle isOpen />}
+                        </Group>
+                    </Group>
+
+                    {explore.type === ExploreType.EXTERNAL_SOURCE &&
+                        canMergeAnotherQuery &&
+                        !isGuidedMerge && (
+                            <Group>
+                                <JoinWithWarehouseHint
+                                    onClick={handleAddMergeSource}
+                                />
+                            </Group>
+                        )}
+
+                    {isGuidedMerge ? (
+                        <MergeQuerySidebar
+                            primaryExplore={explore}
+                            onPrimaryFieldChange={toggleActiveField}
+                            isChoosingAdditionalExplore={isChoosingMergeExplore}
+                            setIsChoosingAdditionalExplore={
+                                setIsChoosingMergeExplore
+                            }
+                        />
+                    ) : (
+                        <ItemDetailProvider>
+                            <ExploreTree
+                                explore={explore}
+                                onSelectedFieldChange={toggleActiveField}
+                            />
+                        </ItemDetailProvider>
                     )}
 
-                {isGuidedMerge ? (
-                    <MergeQuerySidebar
-                        primaryExplore={explore}
-                        onPrimaryFieldChange={toggleActiveField}
-                        isChoosingAdditionalExplore={isChoosingMergeExplore}
-                        setIsChoosingAdditionalExplore={
-                            setIsChoosingMergeExplore
-                        }
-                    />
-                ) : (
-                    <ItemDetailProvider>
-                        <ExploreTree
+                    {isEditVirtualViewOpen && (
+                        <EditVirtualViewModal
+                            opened={isEditVirtualViewOpen}
+                            onClose={() => setIsEditVirtualViewOpen(false)}
+                            activeTableName={activeTableName}
+                            setIsEditVirtualViewOpen={setIsEditVirtualViewOpen}
                             explore={explore}
-                            onSelectedFieldChange={toggleActiveField}
                         />
-                    </ItemDetailProvider>
-                )}
-
-                {isEditVirtualViewOpen && (
-                    <EditVirtualViewModal
-                        opened={isEditVirtualViewOpen}
-                        onClose={() => setIsEditVirtualViewOpen(false)}
-                        activeTableName={activeTableName}
-                        setIsEditVirtualViewOpen={setIsEditVirtualViewOpen}
-                        explore={explore}
-                    />
-                )}
-                {isDeleteVirtualViewOpen && projectUuid && (
-                    <DeleteVirtualViewModal
-                        opened={isDeleteVirtualViewOpen}
-                        onClose={() => setIsDeleteVirtualViewOpen(false)}
-                        virtualViewName={activeTableName}
-                        projectUuid={projectUuid}
-                    />
-                )}
-                {projectUuid && isVirtualViewAsCodeOpen && (
-                    <VirtualViewAsCodeModal
-                        opened={isVirtualViewAsCodeOpen}
-                        onClose={virtualViewAsCodeModalHandlers.close}
-                        projectUuid={projectUuid}
-                        virtualViewSlug={activeTableName}
-                    />
-                )}
-            </Stack>
-        </>
-    );
-});
+                    )}
+                    {isDeleteVirtualViewOpen && projectUuid && (
+                        <DeleteVirtualViewModal
+                            opened={isDeleteVirtualViewOpen}
+                            onClose={() => setIsDeleteVirtualViewOpen(false)}
+                            virtualViewName={activeTableName}
+                            projectUuid={projectUuid}
+                        />
+                    )}
+                    {projectUuid && isVirtualViewAsCodeOpen && (
+                        <VirtualViewAsCodeModal
+                            opened={isVirtualViewAsCodeOpen}
+                            onClose={virtualViewAsCodeModalHandlers.close}
+                            projectUuid={projectUuid}
+                            virtualViewSlug={activeTableName}
+                        />
+                    )}
+                </Stack>
+            </>
+        );
+    },
+);
 
 ExplorePanel.displayName = 'ExplorePanel';
 

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -4,7 +4,7 @@ import {
     FeatureFlags,
     type SummaryExplore,
 } from '@lightdash/common';
-import { TextInput, Stack, ActionIcon, Button, Group } from '@mantine/core';
+import { ActionIcon, Button, Group, Stack, TextInput } from '@mantine-8/core';
 import { useDebouncedValue, useDisclosure } from '@mantine/hooks';
 import {
     IconAlertCircle,
@@ -27,6 +27,7 @@ import { Can } from '../../../providers/Ability';
 import MantineIcon from '../../common/MantineIcon';
 import PageBreadcrumbs from '../../common/PageBreadcrumbs';
 import SuboptimalState from '../../common/SuboptimalState/SuboptimalState';
+import { ExplorerSidebarToggle } from '../ExplorerSidebarToggle';
 import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailProvider';
 import { buildExploreTree, sortExploreTree } from './exploreTree';
@@ -48,9 +49,14 @@ type Props = {
     // a table created through the upload modal is handed here instead of
     // navigating, so the host flow keeps its state.
     onExploreCreated?: (exploreName: string) => void;
+    isCollapsible?: boolean;
 };
 
-const BasePanel = ({ onExploreClick, onExploreCreated }: Props) => {
+const BasePanel = ({
+    onExploreClick,
+    onExploreCreated,
+    isCollapsible = false,
+}: Props) => {
     const navigate = useNavigate();
     const location = useLocation();
     const projectUuid = useProjectUuid();
@@ -229,30 +235,35 @@ const BasePanel = ({ onExploreClick, onExploreCreated }: Props) => {
                                     size="md"
                                     items={[{ title: 'Tables', active: true }]}
                                 />
-                                {canShowAddData && (
-                                    <Can
-                                        I="manage"
-                                        this={subject('ExternalSource', {
-                                            organizationUuid:
-                                                org?.organizationUuid,
-                                            projectUuid,
-                                        })}
-                                    >
-                                        <Button
-                                            variant="default"
-                                            size="compact-xs"
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconPlus}
-                                                    size="sm"
-                                                />
-                                            }
-                                            onClick={openAddDataModal}
+                                <Group gap="xs" wrap="nowrap">
+                                    {canShowAddData && (
+                                        <Can
+                                            I="manage"
+                                            this={subject('ExternalSource', {
+                                                organizationUuid:
+                                                    org?.organizationUuid,
+                                                projectUuid,
+                                            })}
                                         >
-                                            Add data
-                                        </Button>
-                                    </Can>
-                                )}
+                                            <Button
+                                                variant="default"
+                                                size="compact-xs"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconPlus}
+                                                        size="sm"
+                                                    />
+                                                }
+                                                onClick={openAddDataModal}
+                                            >
+                                                Add data
+                                            </Button>
+                                        </Can>
+                                    )}
+                                    {isCollapsible && (
+                                        <ExplorerSidebarToggle isOpen />
+                                    )}
+                                </Group>
                             </Group>
                         </Can>
 

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -4,7 +4,7 @@ import {
     FeatureFlags,
     type SummaryExplore,
 } from '@lightdash/common';
-import { ActionIcon, Button, Group, Stack, TextInput } from '@mantine-8/core';
+import { ActionIcon, Button, Group, Stack, TextInput } from '@mantine/core';
 import { useDebouncedValue, useDisclosure } from '@mantine/hooks';
 import {
     IconAlertCircle,

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -33,76 +33,83 @@ type Props = {
     // stay inside the embed route.
     onExploreClick?: (explore: SummaryExplore) => void;
     onBackToTables?: () => void;
+    isCollapsible?: boolean;
 };
 
-const ExploreSideBar = memo(({ onExploreClick, onBackToTables }: Props) => {
-    const projectUuid = useProjectUuid();
-    const projectRoute = useOptionalProjectRoute();
-    const projectUrlIdentifier =
-        projectRoute?.projectUrlIdentifier ?? projectUuid;
+const ExploreSideBar = memo(
+    ({ onExploreClick, onBackToTables, isCollapsible = false }: Props) => {
+        const projectUuid = useProjectUuid();
+        const projectRoute = useOptionalProjectRoute();
+        const projectUrlIdentifier =
+            projectRoute?.projectUrlIdentifier ?? projectUuid;
 
-    const tableName = useExplorerSelector(selectTableName);
-    const deferredTableName = useDeferredValue(tableName);
-    const ability = useAbilityContext();
-    const { data: org } = useOrganization();
+        const tableName = useExplorerSelector(selectTableName);
+        const deferredTableName = useDeferredValue(tableName);
+        const ability = useAbilityContext();
+        const { data: org } = useOrganization();
 
-    const queryClient = useQueryClient();
-    const dispatch = useExplorerDispatch();
-    const navigate = useNavigate();
+        const queryClient = useQueryClient();
+        const dispatch = useExplorerDispatch();
+        const navigate = useNavigate();
 
-    const clearExplore = useCallback(async () => {
-        void queryClient.cancelQueries({
-            queryKey: ['create-query'],
-            exact: false,
-        });
-        dispatch(explorerActions.reset(defaultState));
-        dispatch(explorerActions.resetQueryExecution());
-    }, [queryClient, dispatch]);
+        const clearExplore = useCallback(async () => {
+            void queryClient.cancelQueries({
+                queryKey: ['create-query'],
+                exact: false,
+            });
+            dispatch(explorerActions.reset(defaultState));
+            dispatch(explorerActions.resetQueryExecution());
+        }, [queryClient, dispatch]);
 
-    const canManageExplore = ability.can(
-        'manage',
-        subject('Explore', {
-            organizationUuid: org?.organizationUuid,
-            projectUuid,
-        }),
-    );
-    const handleBack = useCallback(() => {
-        void clearExplore();
-        if (onBackToTables) {
-            onBackToTables();
-            return;
-        }
-        void navigate(`/projects/${projectUrlIdentifier}/tables`);
-    }, [clearExplore, navigate, projectUrlIdentifier, onBackToTables]);
+        const canManageExplore = ability.can(
+            'manage',
+            subject('Explore', {
+                organizationUuid: org?.organizationUuid,
+                projectUuid,
+            }),
+        );
+        const handleBack = useCallback(() => {
+            void clearExplore();
+            if (onBackToTables) {
+                onBackToTables();
+                return;
+            }
+            void navigate(`/projects/${projectUrlIdentifier}/tables`);
+        }, [clearExplore, navigate, projectUrlIdentifier, onBackToTables]);
 
-    // When transitioning back to tables it's relatively fast so we don't show any skeleton
-    const isTransitioningToExplore = useMemo(
-        () => tableName !== deferredTableName && !!tableName,
-        [tableName, deferredTableName],
-    );
+        // When transitioning back to tables it's relatively fast so we don't show any skeleton
+        const isTransitioningToExplore = useMemo(
+            () => tableName !== deferredTableName && !!tableName,
+            [tableName, deferredTableName],
+        );
 
-    return (
-        <TrackSection name={SectionName.SIDEBAR}>
-            {isTransitioningToExplore ? (
-                <LoadingSkeleton />
-            ) : !tableName ? (
-                <Suspense fallback={<LoadingSkeleton />}>
-                    <LazyBasePanel onExploreClick={onExploreClick} />
-                </Suspense>
-            ) : (
-                <Suspense fallback={<LoadingSkeleton />}>
-                    <LazyExplorePanel
-                        onBack={
-                            onBackToTables || canManageExplore
-                                ? handleBack
-                                : undefined
-                        }
-                    />
-                </Suspense>
-            )}
-        </TrackSection>
-    );
-});
+        return (
+            <TrackSection name={SectionName.SIDEBAR}>
+                {isTransitioningToExplore ? (
+                    <LoadingSkeleton />
+                ) : !tableName ? (
+                    <Suspense fallback={<LoadingSkeleton />}>
+                        <LazyBasePanel
+                            onExploreClick={onExploreClick}
+                            isCollapsible={isCollapsible}
+                        />
+                    </Suspense>
+                ) : (
+                    <Suspense fallback={<LoadingSkeleton />}>
+                        <LazyExplorePanel
+                            onBack={
+                                onBackToTables || canManageExplore
+                                    ? handleBack
+                                    : undefined
+                            }
+                            isCollapsible={isCollapsible}
+                        />
+                    </Suspense>
+                )}
+            </TrackSection>
+        );
+    },
+);
 
 ExploreSideBar.displayName = 'ExploreSideBar';
 

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/index.tsx
@@ -36,80 +36,79 @@ type Props = {
     isCollapsible?: boolean;
 };
 
-const ExploreSideBar = memo(
-    ({ onExploreClick, onBackToTables, isCollapsible = false }: Props) => {
-        const projectUuid = useProjectUuid();
-        const projectRoute = useOptionalProjectRoute();
-        const projectUrlIdentifier =
-            projectRoute?.projectUrlIdentifier ?? projectUuid;
+const ExploreSideBar = memo((props: Props) => {
+    const { onExploreClick, onBackToTables, isCollapsible = false } = props;
+    const projectUuid = useProjectUuid();
+    const projectRoute = useOptionalProjectRoute();
+    const projectUrlIdentifier =
+        projectRoute?.projectUrlIdentifier ?? projectUuid;
 
-        const tableName = useExplorerSelector(selectTableName);
-        const deferredTableName = useDeferredValue(tableName);
-        const ability = useAbilityContext();
-        const { data: org } = useOrganization();
+    const tableName = useExplorerSelector(selectTableName);
+    const deferredTableName = useDeferredValue(tableName);
+    const ability = useAbilityContext();
+    const { data: org } = useOrganization();
 
-        const queryClient = useQueryClient();
-        const dispatch = useExplorerDispatch();
-        const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const dispatch = useExplorerDispatch();
+    const navigate = useNavigate();
 
-        const clearExplore = useCallback(async () => {
-            void queryClient.cancelQueries({
-                queryKey: ['create-query'],
-                exact: false,
-            });
-            dispatch(explorerActions.reset(defaultState));
-            dispatch(explorerActions.resetQueryExecution());
-        }, [queryClient, dispatch]);
+    const clearExplore = useCallback(async () => {
+        void queryClient.cancelQueries({
+            queryKey: ['create-query'],
+            exact: false,
+        });
+        dispatch(explorerActions.reset(defaultState));
+        dispatch(explorerActions.resetQueryExecution());
+    }, [queryClient, dispatch]);
 
-        const canManageExplore = ability.can(
-            'manage',
-            subject('Explore', {
-                organizationUuid: org?.organizationUuid,
-                projectUuid,
-            }),
-        );
-        const handleBack = useCallback(() => {
-            void clearExplore();
-            if (onBackToTables) {
-                onBackToTables();
-                return;
-            }
-            void navigate(`/projects/${projectUrlIdentifier}/tables`);
-        }, [clearExplore, navigate, projectUrlIdentifier, onBackToTables]);
+    const canManageExplore = ability.can(
+        'manage',
+        subject('Explore', {
+            organizationUuid: org?.organizationUuid,
+            projectUuid,
+        }),
+    );
+    const handleBack = useCallback(() => {
+        void clearExplore();
+        if (onBackToTables) {
+            onBackToTables();
+            return;
+        }
+        void navigate(`/projects/${projectUrlIdentifier}/tables`);
+    }, [clearExplore, navigate, projectUrlIdentifier, onBackToTables]);
 
-        // When transitioning back to tables it's relatively fast so we don't show any skeleton
-        const isTransitioningToExplore = useMemo(
-            () => tableName !== deferredTableName && !!tableName,
-            [tableName, deferredTableName],
-        );
+    // When transitioning back to tables it's relatively fast so we don't show any skeleton
+    const isTransitioningToExplore = useMemo(
+        () => tableName !== deferredTableName && !!tableName,
+        [tableName, deferredTableName],
+    );
 
-        return (
-            <TrackSection name={SectionName.SIDEBAR}>
-                {isTransitioningToExplore ? (
-                    <LoadingSkeleton />
-                ) : !tableName ? (
-                    <Suspense fallback={<LoadingSkeleton />}>
-                        <LazyBasePanel
-                            onExploreClick={onExploreClick}
-                            isCollapsible={isCollapsible}
-                        />
-                    </Suspense>
-                ) : (
-                    <Suspense fallback={<LoadingSkeleton />}>
-                        <LazyExplorePanel
-                            onBack={
-                                onBackToTables || canManageExplore
-                                    ? handleBack
-                                    : undefined
-                            }
-                            isCollapsible={isCollapsible}
-                        />
-                    </Suspense>
-                )}
-            </TrackSection>
-        );
-    },
-);
+    return (
+        <TrackSection name={SectionName.SIDEBAR}>
+            {isTransitioningToExplore ? (
+                <LoadingSkeleton />
+            ) : !tableName ? (
+                <Suspense fallback={<LoadingSkeleton />}>
+                    <LazyBasePanel
+                        onExploreClick={onExploreClick}
+                        isCollapsible={isCollapsible}
+                    />
+                </Suspense>
+            ) : (
+                <Suspense fallback={<LoadingSkeleton />}>
+                    <LazyExplorePanel
+                        onBack={
+                            onBackToTables || canManageExplore
+                                ? handleBack
+                                : undefined
+                        }
+                        isCollapsible={isCollapsible}
+                    />
+                </Suspense>
+            )}
+        </TrackSection>
+    );
+});
 
 ExploreSideBar.displayName = 'ExploreSideBar';
 

--- a/packages/frontend/src/components/Explorer/ExplorerSidebarToggle.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerSidebarToggle.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, Kbd, Text, Tooltip } from '@mantine-8/core';
+import { ActionIcon, Group, Kbd, Text, Tooltip } from '@mantine/core';
 import { useOs } from '@mantine/hooks';
 import {
     IconLayoutSidebarLeftCollapse,

--- a/packages/frontend/src/components/Explorer/ExplorerSidebarToggle.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerSidebarToggle.tsx
@@ -1,0 +1,77 @@
+import { ActionIcon, Group, Kbd, Text, Tooltip } from '@mantine-8/core';
+import { useOs } from '@mantine/hooks';
+import {
+    IconLayoutSidebarLeftCollapse,
+    IconLayoutSidebarLeftExpand,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import {
+    explorerActions,
+    useExplorerDispatch,
+} from '../../features/explorer/store';
+import MantineIcon from '../common/MantineIcon';
+
+type ShortcutTooltipLabelProps = {
+    action: string;
+    withAlt?: boolean;
+};
+
+export const ShortcutTooltipLabel: FC<ShortcutTooltipLabelProps> = ({
+    action,
+    withAlt = false,
+}) => {
+    const os = useOs();
+
+    return (
+        <Group gap="xxs" wrap="nowrap">
+            <Text fz="xs">{action}</Text>
+            <Kbd size="xs" fw={600}>
+                {os === 'macos' || os === 'ios' ? '⌘' : 'Ctrl'}
+            </Kbd>
+            {withAlt && (
+                <>
+                    <Text fz="xs">+</Text>
+                    <Kbd size="xs" fw={600}>
+                        Alt
+                    </Kbd>
+                </>
+            )}
+            <Text fz="xs">+</Text>
+            <Kbd size="xs" fw={600}>
+                B
+            </Kbd>
+        </Group>
+    );
+};
+
+export const ExplorerSidebarToggle: FC<{ isOpen: boolean }> = ({ isOpen }) => {
+    const dispatch = useExplorerDispatch();
+    const action = isOpen ? 'Close fields sidebar' : 'Open fields sidebar';
+
+    return (
+        <Tooltip
+            label={<ShortcutTooltipLabel action={action} />}
+            position={isOpen ? 'left' : 'right'}
+            withArrow
+            withinPortal
+        >
+            <ActionIcon
+                variant="subtle"
+                color="gray"
+                size="sm"
+                aria-label={action}
+                onClick={() =>
+                    dispatch(explorerActions.setIsFieldSidebarOpen(!isOpen))
+                }
+            >
+                <MantineIcon
+                    icon={
+                        isOpen
+                            ? IconLayoutSidebarLeftCollapse
+                            : IconLayoutSidebarLeftExpand
+                    }
+                />
+            </ActionIcon>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -62,6 +62,7 @@ import {
     selectHasUnsavedChanges,
     selectIsChartTypeAuthoring,
     selectIsEditMode,
+    selectIsFieldSidebarOpen,
     selectIsValidQuery,
     selectSavedChart,
     selectUnsavedChartVersion,
@@ -164,6 +165,7 @@ const SavedChartsHeader: FC = () => {
     const dispatch = useExplorerDispatch();
 
     const isEditMode = useExplorerSelector(selectIsEditMode);
+    const isFieldSidebarOpen = useExplorerSelector(selectIsFieldSidebarOpen);
     // A chart type being authored is not the chart; it finishes or cancels first.
     const isChartTypeAuthoring = useExplorerSelector(
         selectIsChartTypeAuthoring,
@@ -479,6 +481,7 @@ const SavedChartsHeader: FC = () => {
             const resetState = {
                 savedChart,
                 isEditMode,
+                isFieldSidebarOpen,
                 parameterReferences: Object.keys(savedChart.parameters ?? {}),
                 parameterDefinitions: {},
                 cachedChartConfigs: {},
@@ -508,6 +511,7 @@ const SavedChartsHeader: FC = () => {
     }, [
         dispatch,
         isEditMode,
+        isFieldSidebarOpen,
         savedChart,
         isFromDashboard,
         navigate,

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -8,7 +8,7 @@ import {
     type EChartsSeries,
     type FieldId,
 } from '@lightdash/common';
-import { Button } from '@mantine/core';
+import { Button, Tooltip } from '@mantine-8/core';
 import { useElementSize } from '@mantine/hooks';
 import {
     IconLayoutSidebarLeftCollapse,
@@ -54,6 +54,7 @@ import SortButton from '../../SortButton';
 import ExplorerChartSidebar from '../ChartGallery/ExplorerChartSidebar';
 import { useIsChartGalleryEnabled } from '../ChartGallery/useIsChartGalleryEnabled';
 import { DevCopyChartDebugData } from '../ExplorerHeader/DevCopyChartDebugData';
+import { ShortcutTooltipLabel } from '../ExplorerSidebarToggle';
 import VisualizationConfig from '../VisualizationCard/VisualizationConfig';
 import { SeriesContextMenu } from './SeriesContextMenu';
 import { useDirtyPivotConfiguration } from './useDirtyPivotConfiguration';
@@ -374,27 +375,42 @@ const VisualizationCard: FC<Props> = memo((props) => {
                                     }
                                 />
                                 {isEditMode ? (
-                                    <Button
-                                        {...COLLAPSABLE_CARD_BUTTON_PROPS}
-                                        onClick={
-                                            isVisualizationConfigOpen
-                                                ? closeVisualizationConfig
-                                                : openVisualizationConfig
-                                        }
-                                        rightSection={
-                                            <MantineIcon
-                                                icon={
+                                    <Tooltip
+                                        label={
+                                            <ShortcutTooltipLabel
+                                                action={
                                                     isVisualizationConfigOpen
-                                                        ? IconLayoutSidebarLeftCollapse
-                                                        : IconLayoutSidebarLeftExpand
+                                                        ? 'Close chart sidebar'
+                                                        : 'Open chart sidebar'
                                                 }
+                                                withAlt
                                             />
                                         }
+                                        withArrow
+                                        withinPortal
                                     >
-                                        {isVisualizationConfigOpen
-                                            ? 'Close configure'
-                                            : 'Configure'}
-                                    </Button>
+                                        <Button
+                                            {...COLLAPSABLE_CARD_BUTTON_PROPS}
+                                            onClick={
+                                                isVisualizationConfigOpen
+                                                    ? closeVisualizationConfig
+                                                    : openVisualizationConfig
+                                            }
+                                            rightSection={
+                                                <MantineIcon
+                                                    icon={
+                                                        isVisualizationConfigOpen
+                                                            ? IconLayoutSidebarLeftCollapse
+                                                            : IconLayoutSidebarLeftExpand
+                                                    }
+                                                />
+                                            }
+                                        >
+                                            {isVisualizationConfigOpen
+                                                ? 'Close configure'
+                                                : 'Configure'}
+                                        </Button>
+                                    </Tooltip>
                                 ) : null}
 
                                 {/*

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -388,6 +388,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
                                         }
                                         withArrow
                                         withinPortal
+                                        disabled={!isChartGalleryEnabled}
                                     >
                                         <Button
                                             {...COLLAPSABLE_CARD_BUTTON_PROPS}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -8,7 +8,7 @@ import {
     type EChartsSeries,
     type FieldId,
 } from '@lightdash/common';
-import { Button, Tooltip } from '@mantine-8/core';
+import { Button, Tooltip } from '@mantine/core';
 import { useElementSize } from '@mantine/hooks';
 import {
     IconLayoutSidebarLeftCollapse,

--- a/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.test.tsx
+++ b/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    createExplorerStore,
+    type ExplorerStoreState,
+} from '../../features/explorer/store';
+import { defaultState } from '../../providers/Explorer/defaultState';
+import { ExplorerSection } from '../../providers/Explorer/types';
+import { renderWithProviders } from '../../testing/testUtils';
+import { useExplorerSidebarShortcuts } from './useExplorerSidebarShortcuts';
+
+const { chartGalleryEnabled } = vi.hoisted(() => ({
+    chartGalleryEnabled: { current: true },
+}));
+
+vi.mock('./ChartGallery/useIsChartGalleryEnabled', () => ({
+    useIsChartGalleryEnabled: () => chartGalleryEnabled.current,
+}));
+
+const Harness = ({ enabled = true }: { enabled?: boolean }) => {
+    useExplorerSidebarShortcuts({ enabled });
+    return <input aria-label="Field search" />;
+};
+
+const renderHarness = ({
+    enabled = true,
+    state = {},
+}: {
+    enabled?: boolean;
+    state?: Partial<ExplorerStoreState['explorer']>;
+} = {}) => {
+    const store = createExplorerStore({
+        explorer: {
+            ...defaultState,
+            expandedSections: [ExplorerSection.RESULTS],
+            ...state,
+        },
+    });
+
+    renderWithProviders(
+        <Provider store={store}>
+            <MemoryRouter>
+                <Harness enabled={enabled} />
+            </MemoryRouter>
+        </Provider>,
+    );
+
+    return store;
+};
+
+describe('useExplorerSidebarShortcuts', () => {
+    beforeEach(() => {
+        chartGalleryEnabled.current = true;
+    });
+
+    it('toggles the field sidebar with mod+b', () => {
+        const store = renderHarness();
+
+        expect(
+            fireEvent.keyDown(window, { key: 'b', ctrlKey: true }),
+        ).toBe(false);
+        expect(store.getState().explorer.isFieldSidebarOpen).toBe(false);
+
+        fireEvent.keyDown(window, { key: 'b', ctrlKey: true });
+        expect(store.getState().explorer.isFieldSidebarOpen).toBe(true);
+    });
+
+    it('opens the visualization card and chart sidebar with mod+alt+b', () => {
+        const store = renderHarness();
+
+        fireEvent.keyDown(window, {
+            key: 'b',
+            ctrlKey: true,
+            altKey: true,
+        });
+
+        expect(store.getState().explorer.isVisualizationConfigOpen).toBe(true);
+        expect(store.getState().explorer.expandedSections).toContain(
+            ExplorerSection.VISUALIZATION,
+        );
+
+        fireEvent.keyDown(window, {
+            key: 'b',
+            ctrlKey: true,
+            altKey: true,
+        });
+        expect(store.getState().explorer.isVisualizationConfigOpen).toBe(
+            false,
+        );
+    });
+
+    it('does not register shortcuts when disabled', () => {
+        const store = renderHarness({ enabled: false });
+
+        fireEvent.keyDown(window, { key: 'b', ctrlKey: true });
+        expect(store.getState().explorer.isFieldSidebarOpen).toBe(true);
+    });
+
+    it('does not register the chart shortcut when the gallery is disabled', () => {
+        chartGalleryEnabled.current = false;
+        const store = renderHarness();
+
+        fireEvent.keyDown(window, {
+            key: 'b',
+            ctrlKey: true,
+            altKey: true,
+        });
+        expect(store.getState().explorer.isVisualizationConfigOpen).toBe(
+            false,
+        );
+    });
+
+    it('ignores shortcuts while typing in an input', () => {
+        const store = renderHarness();
+
+        fireEvent.keyDown(screen.getByRole('textbox', { name: 'Field search' }), {
+            key: 'b',
+            ctrlKey: true,
+        });
+
+        expect(store.getState().explorer.isFieldSidebarOpen).toBe(true);
+    });
+});

--- a/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.test.tsx
+++ b/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.test.tsx
@@ -92,9 +92,7 @@ describe('useExplorerSidebarShortcuts', () => {
             ctrlKey: true,
             altKey: true,
         });
-        expect(store.getState().explorer.isVisualizationConfigOpen).toBe(
-            false,
-        );
+        expect(store.getState().explorer.isVisualizationConfigOpen).toBe(false);
     });
 
     it('does not register shortcuts when disabled', () => {
@@ -116,18 +114,19 @@ describe('useExplorerSidebarShortcuts', () => {
             ctrlKey: true,
             altKey: true,
         });
-        expect(store.getState().explorer.isVisualizationConfigOpen).toBe(
-            false,
-        );
+        expect(store.getState().explorer.isVisualizationConfigOpen).toBe(false);
     });
 
     it('ignores shortcuts while typing in an input', () => {
         const store = renderHarness();
 
-        fireEvent.keyDown(screen.getByRole('textbox', { name: 'Field search' }), {
-            key: 'b',
-            ctrlKey: true,
-        });
+        fireEvent.keyDown(
+            screen.getByRole('textbox', { name: 'Field search' }),
+            {
+                key: 'b',
+                ctrlKey: true,
+            },
+        );
 
         expect(store.getState().explorer.isFieldSidebarOpen).toBe(true);
     });

--- a/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.test.tsx
+++ b/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.test.tsx
@@ -59,18 +59,24 @@ describe('useExplorerSidebarShortcuts', () => {
         const store = renderHarness();
 
         expect(
-            fireEvent.keyDown(window, { key: 'b', ctrlKey: true }),
+            fireEvent.keyDown(document.documentElement, {
+                key: 'b',
+                ctrlKey: true,
+            }),
         ).toBe(false);
         expect(store.getState().explorer.isFieldSidebarOpen).toBe(false);
 
-        fireEvent.keyDown(window, { key: 'b', ctrlKey: true });
+        fireEvent.keyDown(document.documentElement, {
+            key: 'b',
+            ctrlKey: true,
+        });
         expect(store.getState().explorer.isFieldSidebarOpen).toBe(true);
     });
 
     it('opens the visualization card and chart sidebar with mod+alt+b', () => {
         const store = renderHarness();
 
-        fireEvent.keyDown(window, {
+        fireEvent.keyDown(document.documentElement, {
             key: 'b',
             ctrlKey: true,
             altKey: true,
@@ -81,7 +87,7 @@ describe('useExplorerSidebarShortcuts', () => {
             ExplorerSection.VISUALIZATION,
         );
 
-        fireEvent.keyDown(window, {
+        fireEvent.keyDown(document.documentElement, {
             key: 'b',
             ctrlKey: true,
             altKey: true,
@@ -94,7 +100,10 @@ describe('useExplorerSidebarShortcuts', () => {
     it('does not register shortcuts when disabled', () => {
         const store = renderHarness({ enabled: false });
 
-        fireEvent.keyDown(window, { key: 'b', ctrlKey: true });
+        fireEvent.keyDown(document.documentElement, {
+            key: 'b',
+            ctrlKey: true,
+        });
         expect(store.getState().explorer.isFieldSidebarOpen).toBe(true);
     });
 
@@ -102,7 +111,7 @@ describe('useExplorerSidebarShortcuts', () => {
         chartGalleryEnabled.current = false;
         const store = renderHarness();
 
-        fireEvent.keyDown(window, {
+        fireEvent.keyDown(document.documentElement, {
             key: 'b',
             ctrlKey: true,
             altKey: true,

--- a/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.ts
+++ b/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.ts
@@ -1,9 +1,8 @@
 import { useHotkeys } from '@mantine/hooks';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
     explorerActions,
     selectChartTypeAuthoring,
-    selectIsFieldSidebarOpen,
     selectIsVisualizationConfigOpen,
     selectIsVisualizationExpanded,
     useExplorerDispatch,
@@ -15,22 +14,6 @@ import { useIsChartGalleryEnabled } from './ChartGallery/useIsChartGalleryEnable
 export const FIELD_SIDEBAR_SHORTCUT = 'mod + b';
 export const CHART_SIDEBAR_SHORTCUT = 'mod + alt + b';
 
-const debugLog = (payload: {
-    hypothesisId: string;
-    location: string;
-    message: string;
-    data: Record<string, unknown>;
-}) => {
-    // #region agent log
-    void fetch('/__cursor-debug-log', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...payload, timestamp: Date.now() }),
-        keepalive: true,
-    });
-    // #endregion
-};
-
 export const useExplorerSidebarShortcuts = ({
     enabled,
 }: {
@@ -38,7 +21,6 @@ export const useExplorerSidebarShortcuts = ({
 }) => {
     const dispatch = useExplorerDispatch();
     const isChartGalleryEnabled = useIsChartGalleryEnabled();
-    const isFieldSidebarOpen = useExplorerSelector(selectIsFieldSidebarOpen);
     const isVisualizationConfigOpen = useExplorerSelector(
         selectIsVisualizationConfigOpen,
     );
@@ -47,145 +29,32 @@ export const useExplorerSidebarShortcuts = ({
     );
     const chartTypeAuthoring = useExplorerSelector(selectChartTypeAuthoring);
 
-    useEffect(() => {
-        // #region agent log
-        debugLog({
-            hypothesisId: 'C',
-            location: 'useExplorerSidebarShortcuts.ts:registration',
-            message: 'Shortcut registration inputs',
-            data: { enabled, isChartGalleryEnabled },
-        });
-        // #endregion
-    }, [enabled, isChartGalleryEnabled]);
+    const toggleFieldSidebar = useCallback(() => {
+        dispatch(explorerActions.toggleFieldSidebar());
+    }, [dispatch]);
 
-    useEffect(() => {
-        const handleRawKeyDown = (event: KeyboardEvent) => {
-            if (event.key.toLowerCase() !== 'b') return;
+    const toggleChartSidebar = useCallback(() => {
+        if (chartTypeAuthoring !== null) return;
 
-            const target = event.target;
-            // #region agent log
-            debugLog({
-                hypothesisId: 'A,B',
-                location: 'useExplorerSidebarShortcuts.ts:raw-keydown',
-                message: 'Raw B keydown reached document',
-                data: {
-                    key: event.key,
-                    code: event.code,
-                    ctrlKey: event.ctrlKey,
-                    metaKey: event.metaKey,
-                    altKey: event.altKey,
-                    shiftKey: event.shiftKey,
-                    repeat: event.repeat,
-                    defaultPrevented: event.defaultPrevented,
-                    targetTag:
-                        target instanceof HTMLElement ? target.tagName : null,
-                    targetContentEditable:
-                        target instanceof HTMLElement
-                            ? target.isContentEditable
-                            : null,
-                },
-            });
-            // #endregion
-        };
+        if (isVisualizationConfigOpen) {
+            dispatch(explorerActions.closeVisualizationConfig());
+            return;
+        }
 
-        document.documentElement.addEventListener(
-            'keydown',
-            handleRawKeyDown,
-            true,
-        );
-        return () =>
-            document.documentElement.removeEventListener(
-                'keydown',
-                handleRawKeyDown,
-                true,
+        if (!isVisualizationExpanded) {
+            dispatch(
+                explorerActions.toggleExpandedSection(
+                    ExplorerSection.VISUALIZATION,
+                ),
             );
-    }, []);
-
-    useEffect(() => {
-        // #region agent log
-        debugLog({
-            hypothesisId: 'D,E',
-            location: 'useExplorerSidebarShortcuts.ts:state',
-            message: 'Explorer sidebar state observed',
-            data: {
-                isFieldSidebarOpen,
-                isVisualizationConfigOpen,
-                isVisualizationExpanded,
-                chartTypeAuthoring,
-            },
-        });
-        // #endregion
+        }
+        dispatch(explorerActions.openVisualizationConfig());
     }, [
         chartTypeAuthoring,
-        isFieldSidebarOpen,
+        dispatch,
         isVisualizationConfigOpen,
         isVisualizationExpanded,
     ]);
-
-    const toggleFieldSidebar = useCallback(
-        (event: KeyboardEvent) => {
-            // #region agent log
-            debugLog({
-                hypothesisId: 'A,B,D,E',
-                location: 'useExplorerSidebarShortcuts.ts:field-handler',
-                message: 'Field sidebar handler invoked',
-                data: {
-                    ctrlKey: event.ctrlKey,
-                    metaKey: event.metaKey,
-                    altKey: event.altKey,
-                    targetTag:
-                        event.target instanceof HTMLElement
-                            ? event.target.tagName
-                            : null,
-                    isFieldSidebarOpenBefore: isFieldSidebarOpen,
-                },
-            });
-            // #endregion
-            dispatch(explorerActions.toggleFieldSidebar());
-        },
-        [dispatch, isFieldSidebarOpen],
-    );
-
-    const toggleChartSidebar = useCallback(
-        (event: KeyboardEvent) => {
-            // #region agent log
-            debugLog({
-                hypothesisId: 'B,D,E',
-                location: 'useExplorerSidebarShortcuts.ts:chart-handler',
-                message: 'Chart sidebar handler invoked',
-                data: {
-                    ctrlKey: event.ctrlKey,
-                    metaKey: event.metaKey,
-                    altKey: event.altKey,
-                    isVisualizationConfigOpenBefore: isVisualizationConfigOpen,
-                    isVisualizationExpandedBefore: isVisualizationExpanded,
-                    chartTypeAuthoring,
-                },
-            });
-            // #endregion
-            if (chartTypeAuthoring !== null) return;
-
-            if (isVisualizationConfigOpen) {
-                dispatch(explorerActions.closeVisualizationConfig());
-                return;
-            }
-
-            if (!isVisualizationExpanded) {
-                dispatch(
-                    explorerActions.toggleExpandedSection(
-                        ExplorerSection.VISUALIZATION,
-                    ),
-                );
-            }
-            dispatch(explorerActions.openVisualizationConfig());
-        },
-        [
-            chartTypeAuthoring,
-            dispatch,
-            isVisualizationConfigOpen,
-            isVisualizationExpanded,
-        ],
-    );
 
     const hotkeys = useMemo<Parameters<typeof useHotkeys>[0]>(() => {
         if (!enabled) return [];

--- a/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.ts
+++ b/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.ts
@@ -1,0 +1,86 @@
+import { useHotkeys } from '@mantine/hooks';
+import { useCallback, useMemo } from 'react';
+import {
+    explorerActions,
+    selectChartTypeAuthoring,
+    selectIsVisualizationConfigOpen,
+    selectIsVisualizationExpanded,
+    useExplorerDispatch,
+    useExplorerSelector,
+} from '../../features/explorer/store';
+import { ExplorerSection } from '../../providers/Explorer/types';
+import { useIsChartGalleryEnabled } from './ChartGallery/useIsChartGalleryEnabled';
+
+export const FIELD_SIDEBAR_SHORTCUT = 'mod + b';
+export const CHART_SIDEBAR_SHORTCUT = 'mod + alt + b';
+
+export const useExplorerSidebarShortcuts = ({
+    enabled,
+}: {
+    enabled: boolean;
+}) => {
+    const dispatch = useExplorerDispatch();
+    const isChartGalleryEnabled = useIsChartGalleryEnabled();
+    const isVisualizationConfigOpen = useExplorerSelector(
+        selectIsVisualizationConfigOpen,
+    );
+    const isVisualizationExpanded = useExplorerSelector(
+        selectIsVisualizationExpanded,
+    );
+    const chartTypeAuthoring = useExplorerSelector(selectChartTypeAuthoring);
+
+    const toggleFieldSidebar = useCallback(() => {
+        dispatch(explorerActions.toggleFieldSidebar());
+    }, [dispatch]);
+
+    const toggleChartSidebar = useCallback(() => {
+        if (chartTypeAuthoring !== null) return;
+
+        if (isVisualizationConfigOpen) {
+            dispatch(explorerActions.closeVisualizationConfig());
+            return;
+        }
+
+        if (!isVisualizationExpanded) {
+            dispatch(
+                explorerActions.toggleExpandedSection(
+                    ExplorerSection.VISUALIZATION,
+                ),
+            );
+        }
+        dispatch(explorerActions.openVisualizationConfig());
+    }, [
+        chartTypeAuthoring,
+        dispatch,
+        isVisualizationConfigOpen,
+        isVisualizationExpanded,
+    ]);
+
+    const hotkeys = useMemo<Parameters<typeof useHotkeys>[0]>(() => {
+        if (!enabled) return [];
+
+        return [
+            [
+                FIELD_SIDEBAR_SHORTCUT,
+                toggleFieldSidebar,
+                { preventDefault: true },
+            ],
+            ...(isChartGalleryEnabled
+                ? ([
+                      [
+                          CHART_SIDEBAR_SHORTCUT,
+                          toggleChartSidebar,
+                          { preventDefault: true },
+                      ],
+                  ] as Parameters<typeof useHotkeys>[0])
+                : []),
+        ];
+    }, [
+        enabled,
+        isChartGalleryEnabled,
+        toggleChartSidebar,
+        toggleFieldSidebar,
+    ]);
+
+    useHotkeys(hotkeys);
+};

--- a/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.ts
+++ b/packages/frontend/src/components/Explorer/useExplorerSidebarShortcuts.ts
@@ -1,8 +1,9 @@
 import { useHotkeys } from '@mantine/hooks';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import {
     explorerActions,
     selectChartTypeAuthoring,
+    selectIsFieldSidebarOpen,
     selectIsVisualizationConfigOpen,
     selectIsVisualizationExpanded,
     useExplorerDispatch,
@@ -14,6 +15,22 @@ import { useIsChartGalleryEnabled } from './ChartGallery/useIsChartGalleryEnable
 export const FIELD_SIDEBAR_SHORTCUT = 'mod + b';
 export const CHART_SIDEBAR_SHORTCUT = 'mod + alt + b';
 
+const debugLog = (payload: {
+    hypothesisId: string;
+    location: string;
+    message: string;
+    data: Record<string, unknown>;
+}) => {
+    // #region agent log
+    void fetch('/__cursor-debug-log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...payload, timestamp: Date.now() }),
+        keepalive: true,
+    });
+    // #endregion
+};
+
 export const useExplorerSidebarShortcuts = ({
     enabled,
 }: {
@@ -21,6 +38,7 @@ export const useExplorerSidebarShortcuts = ({
 }) => {
     const dispatch = useExplorerDispatch();
     const isChartGalleryEnabled = useIsChartGalleryEnabled();
+    const isFieldSidebarOpen = useExplorerSelector(selectIsFieldSidebarOpen);
     const isVisualizationConfigOpen = useExplorerSelector(
         selectIsVisualizationConfigOpen,
     );
@@ -29,32 +47,145 @@ export const useExplorerSidebarShortcuts = ({
     );
     const chartTypeAuthoring = useExplorerSelector(selectChartTypeAuthoring);
 
-    const toggleFieldSidebar = useCallback(() => {
-        dispatch(explorerActions.toggleFieldSidebar());
-    }, [dispatch]);
+    useEffect(() => {
+        // #region agent log
+        debugLog({
+            hypothesisId: 'C',
+            location: 'useExplorerSidebarShortcuts.ts:registration',
+            message: 'Shortcut registration inputs',
+            data: { enabled, isChartGalleryEnabled },
+        });
+        // #endregion
+    }, [enabled, isChartGalleryEnabled]);
 
-    const toggleChartSidebar = useCallback(() => {
-        if (chartTypeAuthoring !== null) return;
+    useEffect(() => {
+        const handleRawKeyDown = (event: KeyboardEvent) => {
+            if (event.key.toLowerCase() !== 'b') return;
 
-        if (isVisualizationConfigOpen) {
-            dispatch(explorerActions.closeVisualizationConfig());
-            return;
-        }
+            const target = event.target;
+            // #region agent log
+            debugLog({
+                hypothesisId: 'A,B',
+                location: 'useExplorerSidebarShortcuts.ts:raw-keydown',
+                message: 'Raw B keydown reached document',
+                data: {
+                    key: event.key,
+                    code: event.code,
+                    ctrlKey: event.ctrlKey,
+                    metaKey: event.metaKey,
+                    altKey: event.altKey,
+                    shiftKey: event.shiftKey,
+                    repeat: event.repeat,
+                    defaultPrevented: event.defaultPrevented,
+                    targetTag:
+                        target instanceof HTMLElement ? target.tagName : null,
+                    targetContentEditable:
+                        target instanceof HTMLElement
+                            ? target.isContentEditable
+                            : null,
+                },
+            });
+            // #endregion
+        };
 
-        if (!isVisualizationExpanded) {
-            dispatch(
-                explorerActions.toggleExpandedSection(
-                    ExplorerSection.VISUALIZATION,
-                ),
+        document.documentElement.addEventListener(
+            'keydown',
+            handleRawKeyDown,
+            true,
+        );
+        return () =>
+            document.documentElement.removeEventListener(
+                'keydown',
+                handleRawKeyDown,
+                true,
             );
-        }
-        dispatch(explorerActions.openVisualizationConfig());
+    }, []);
+
+    useEffect(() => {
+        // #region agent log
+        debugLog({
+            hypothesisId: 'D,E',
+            location: 'useExplorerSidebarShortcuts.ts:state',
+            message: 'Explorer sidebar state observed',
+            data: {
+                isFieldSidebarOpen,
+                isVisualizationConfigOpen,
+                isVisualizationExpanded,
+                chartTypeAuthoring,
+            },
+        });
+        // #endregion
     }, [
         chartTypeAuthoring,
-        dispatch,
+        isFieldSidebarOpen,
         isVisualizationConfigOpen,
         isVisualizationExpanded,
     ]);
+
+    const toggleFieldSidebar = useCallback(
+        (event: KeyboardEvent) => {
+            // #region agent log
+            debugLog({
+                hypothesisId: 'A,B,D,E',
+                location: 'useExplorerSidebarShortcuts.ts:field-handler',
+                message: 'Field sidebar handler invoked',
+                data: {
+                    ctrlKey: event.ctrlKey,
+                    metaKey: event.metaKey,
+                    altKey: event.altKey,
+                    targetTag:
+                        event.target instanceof HTMLElement
+                            ? event.target.tagName
+                            : null,
+                    isFieldSidebarOpenBefore: isFieldSidebarOpen,
+                },
+            });
+            // #endregion
+            dispatch(explorerActions.toggleFieldSidebar());
+        },
+        [dispatch, isFieldSidebarOpen],
+    );
+
+    const toggleChartSidebar = useCallback(
+        (event: KeyboardEvent) => {
+            // #region agent log
+            debugLog({
+                hypothesisId: 'B,D,E',
+                location: 'useExplorerSidebarShortcuts.ts:chart-handler',
+                message: 'Chart sidebar handler invoked',
+                data: {
+                    ctrlKey: event.ctrlKey,
+                    metaKey: event.metaKey,
+                    altKey: event.altKey,
+                    isVisualizationConfigOpenBefore: isVisualizationConfigOpen,
+                    isVisualizationExpandedBefore: isVisualizationExpanded,
+                    chartTypeAuthoring,
+                },
+            });
+            // #endregion
+            if (chartTypeAuthoring !== null) return;
+
+            if (isVisualizationConfigOpen) {
+                dispatch(explorerActions.closeVisualizationConfig());
+                return;
+            }
+
+            if (!isVisualizationExpanded) {
+                dispatch(
+                    explorerActions.toggleExpandedSection(
+                        ExplorerSection.VISUALIZATION,
+                    ),
+                );
+            }
+            dispatch(explorerActions.openVisualizationConfig());
+        },
+        [
+            chartTypeAuthoring,
+            dispatch,
+            isVisualizationConfigOpen,
+            isVisualizationExpanded,
+        ],
+    );
 
     const hotkeys = useMemo<Parameters<typeof useHotkeys>[0]>(() => {
         if (!enabled) return [];

--- a/packages/frontend/src/features/explorer/store/buildInitialState.ts
+++ b/packages/frontend/src/features/explorer/store/buildInitialState.ts
@@ -11,6 +11,7 @@ import {
 interface BuildInitialStateOptions {
     savedChart?: SavedChart;
     isEditMode?: boolean;
+    isFieldSidebarOpen?: boolean;
     expandedSections?: ExplorerSection[];
     minimal?: boolean;
     initialState?: Partial<ExplorerReduceState>;
@@ -23,6 +24,7 @@ interface BuildInitialStateOptions {
 export const buildInitialExplorerState = ({
     savedChart,
     isEditMode = false,
+    isFieldSidebarOpen,
     expandedSections = [ExplorerSection.VISUALIZATION],
     minimal = false,
     initialState: customInitialState,
@@ -36,6 +38,10 @@ export const buildInitialExplorerState = ({
             ...defaultState,
             ...customInitialState,
             isEditMode,
+            isFieldSidebarOpen:
+                isFieldSidebarOpen ??
+                customInitialState.isFieldSidebarOpen ??
+                defaultState.isFieldSidebarOpen,
         };
 
         // Apply defaultLimit to metricQuery if provided and not already set
@@ -61,6 +67,8 @@ export const buildInitialExplorerState = ({
             ...defaultState,
             savedChart,
             isEditMode,
+            isFieldSidebarOpen:
+                isFieldSidebarOpen ?? defaultState.isFieldSidebarOpen,
             isMinimal: minimal,
             parameterReferences: Object.keys(savedChart.parameters ?? {}),
             parameterDefinitions: {},
@@ -82,6 +90,8 @@ export const buildInitialExplorerState = ({
         const baseDefaultState = {
             ...defaultState,
             isEditMode,
+            isFieldSidebarOpen:
+                isFieldSidebarOpen ?? defaultState.isFieldSidebarOpen,
             isMinimal: minimal,
             expandedSections,
         };

--- a/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
@@ -2,6 +2,35 @@ import { ChartType, type TableCalculation } from '@lightdash/common';
 import { defaultState } from '../../../providers/Explorer/defaultState';
 import { explorerActions, explorerReducer } from './explorerSlice';
 
+describe('explorerSlice field sidebar', () => {
+    it('opens, closes, and toggles the field sidebar', () => {
+        const closed = explorerReducer(
+            undefined,
+            explorerActions.setIsFieldSidebarOpen(false),
+        );
+        expect(closed.isFieldSidebarOpen).toBe(false);
+
+        const toggled = explorerReducer(
+            closed,
+            explorerActions.toggleFieldSidebar(),
+        );
+        expect(toggled.isFieldSidebarOpen).toBe(true);
+    });
+
+    it('preserves the field sidebar when clearing the query', () => {
+        const closed = explorerReducer(
+            undefined,
+            explorerActions.setIsFieldSidebarOpen(false),
+        );
+        const cleared = explorerReducer(
+            closed,
+            explorerActions.clearQuery({ defaultState, tableName: 'orders' }),
+        );
+
+        expect(cleared.isFieldSidebarOpen).toBe(false);
+    });
+});
+
 describe('explorerSlice pivot axis updates', () => {
     it('preserves both axis changes when moving a row dimension to columns', () => {
         const initialState = explorerReducer(

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -96,6 +96,12 @@ const explorerSlice = createSlice({
         setIsMinimal: (state, action: PayloadAction<boolean>) => {
             state.isMinimal = action.payload;
         },
+        setIsFieldSidebarOpen: (state, action: PayloadAction<boolean>) => {
+            state.isFieldSidebarOpen = action.payload;
+        },
+        toggleFieldSidebar: (state) => {
+            state.isFieldSidebarOpen = !state.isFieldSidebarOpen;
+        },
         setSavedChart: (
             state,
             action: PayloadAction<SavedChart | undefined>,
@@ -1129,6 +1135,7 @@ const explorerSlice = createSlice({
             const {
                 isEditMode,
                 isMinimal,
+                isFieldSidebarOpen,
                 chartSidebarStep,
                 chartTypeAuthoring,
             } = state;
@@ -1137,6 +1144,7 @@ const explorerSlice = createSlice({
                 draft.unsavedChartVersion.metricQuery.exploreName = tableName;
                 draft.isEditMode = isEditMode;
                 draft.isMinimal = isMinimal;
+                draft.isFieldSidebarOpen = isFieldSidebarOpen;
                 draft.chartSidebarStep = chartSidebarStep;
                 draft.chartTypeAuthoring = chartTypeAuthoring;
             });

--- a/packages/frontend/src/features/explorer/store/selectors.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.ts
@@ -86,6 +86,11 @@ export const selectIsVisualizationConfigOpen = createSelector(
     (explorer) => explorer.isVisualizationConfigOpen === true,
 );
 
+export const selectIsFieldSidebarOpen = createSelector(
+    [selectExplorerState],
+    (explorer) => explorer.isFieldSidebarOpen,
+);
+
 export const selectChartSidebarStep = createSelector(
     [selectExplorerState],
     (explorer) => explorer.chartSidebarStep,

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -40,6 +40,7 @@ import {
     type ExplorerReduceState,
 } from '../providers/Explorer/types';
 import useToaster from './toaster/useToaster';
+import { parseIsFieldSidebarOpen } from './useExplorerSidebarUrlState';
 
 const CHART_SIDEBAR_PARAM = 'chartSidebar';
 
@@ -430,6 +431,7 @@ export const useExplorerUrlState = (): ExplorerReduceState | undefined => {
                     parameters: {},
                     fromDashboard: fromDashboard ?? undefined,
                     isExploreFromHere: isExploreFromHere,
+                    isFieldSidebarOpen: parseIsFieldSidebarOpen(search),
                     ...parseChartSidebarFromSearchParams(search),
                     queryExecution: defaultQueryExecution,
                     preAggregate: defaultState.preAggregate,

--- a/packages/frontend/src/hooks/useExplorerSidebarUrlState.test.tsx
+++ b/packages/frontend/src/hooks/useExplorerSidebarUrlState.test.tsx
@@ -23,9 +23,7 @@ const Harness = () => {
         <>
             <div data-testid="search">{location.search}</div>
             <button
-                onClick={() =>
-                    dispatch(explorerActions.toggleFieldSidebar())
-                }
+                onClick={() => dispatch(explorerActions.toggleFieldSidebar())}
             >
                 Toggle
             </button>

--- a/packages/frontend/src/hooks/useExplorerSidebarUrlState.test.tsx
+++ b/packages/frontend/src/hooks/useExplorerSidebarUrlState.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, useLocation } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import {
+    createExplorerStore,
+    explorerActions,
+    useExplorerDispatch,
+} from '../features/explorer/store';
+import { defaultState } from '../providers/Explorer/defaultState';
+import { renderWithProviders } from '../testing/testUtils';
+import {
+    parseIsFieldSidebarOpen,
+    useExplorerSidebarUrlState,
+} from './useExplorerSidebarUrlState';
+
+const Harness = () => {
+    const dispatch = useExplorerDispatch();
+    const location = useLocation();
+    useExplorerSidebarUrlState();
+
+    return (
+        <>
+            <div data-testid="search">{location.search}</div>
+            <button
+                onClick={() =>
+                    dispatch(explorerActions.toggleFieldSidebar())
+                }
+            >
+                Toggle
+            </button>
+        </>
+    );
+};
+
+describe('useExplorerSidebarUrlState', () => {
+    it('treats an absent or unknown value as an open sidebar', () => {
+        expect(parseIsFieldSidebarOpen('')).toBe(true);
+        expect(parseIsFieldSidebarOpen('?fieldSidebar=open')).toBe(true);
+        expect(parseIsFieldSidebarOpen('?fieldSidebar=nope')).toBe(true);
+    });
+
+    it('restores the closed state from the URL', () => {
+        expect(
+            parseIsFieldSidebarOpen('?fieldSidebar=closed&fromSpace=space-1'),
+        ).toBe(false);
+    });
+
+    it('persists toggles while preserving other query parameters', async () => {
+        const store = createExplorerStore({
+            explorer: {
+                ...defaultState,
+                isFieldSidebarOpen: true,
+            },
+        });
+
+        renderWithProviders(
+            <Provider store={store}>
+                <MemoryRouter
+                    initialEntries={['/projects/project-1/tables/orders?x=1']}
+                >
+                    <Harness />
+                </MemoryRouter>
+            </Provider>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+
+        await waitFor(() => {
+            const params = new URLSearchParams(
+                screen.getByTestId('search').textContent ?? '',
+            );
+            expect(params.get('x')).toBe('1');
+            expect(params.get('fieldSidebar')).toBe('closed');
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+
+        await waitFor(() => {
+            const params = new URLSearchParams(
+                screen.getByTestId('search').textContent ?? '',
+            );
+            expect(params.get('x')).toBe('1');
+            expect(params.get('fieldSidebar')).toBeNull();
+        });
+    });
+});

--- a/packages/frontend/src/hooks/useExplorerSidebarUrlState.ts
+++ b/packages/frontend/src/hooks/useExplorerSidebarUrlState.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import {
+    selectIsFieldSidebarOpen,
+    useExplorerSelector,
+} from '../features/explorer/store';
+
+export const FIELD_SIDEBAR_PARAM = 'fieldSidebar';
+const FIELD_SIDEBAR_CLOSED_VALUE = 'closed';
+
+export const parseIsFieldSidebarOpen = (search: string): boolean =>
+    new URLSearchParams(search).get(FIELD_SIDEBAR_PARAM) !==
+    FIELD_SIDEBAR_CLOSED_VALUE;
+
+export const useExplorerSidebarUrlState = () => {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const isFieldSidebarOpen = useExplorerSelector(selectIsFieldSidebarOpen);
+
+    useEffect(() => {
+        const searchParams = new URLSearchParams(location.search);
+        const currentValue = searchParams.get(FIELD_SIDEBAR_PARAM);
+        const nextValue = isFieldSidebarOpen
+            ? null
+            : FIELD_SIDEBAR_CLOSED_VALUE;
+
+        if (currentValue === nextValue) return;
+
+        if (nextValue === null) {
+            searchParams.delete(FIELD_SIDEBAR_PARAM);
+        } else {
+            searchParams.set(FIELD_SIDEBAR_PARAM, nextValue);
+        }
+
+        void navigate(
+            {
+                pathname: location.pathname,
+                search: searchParams.toString(),
+                hash: location.hash,
+            },
+            { replace: true },
+        );
+    }, [
+        isFieldSidebarOpen,
+        location.hash,
+        location.pathname,
+        location.search,
+        navigate,
+    ]);
+};

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import { Group } from '@mantine-8/core';
 import { useHotkeys } from '@mantine/hooks';
 import { memo, useCallback, useState } from 'react';
 import { Provider } from 'react-redux';
@@ -6,12 +7,15 @@ import { useNavigate, useParams } from 'react-router';
 import Page from '../components/common/Page/Page';
 import Explorer from '../components/Explorer';
 import { useChartGalleryRightSidebar } from '../components/Explorer/ChartGallery/useChartGalleryRightSidebar';
+import { ExplorerSidebarToggle } from '../components/Explorer/ExplorerSidebarToggle';
 import ExploreSideBar from '../components/Explorer/ExploreSideBar/index';
+import { useExplorerSidebarShortcuts } from '../components/Explorer/useExplorerSidebarShortcuts';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import {
     buildInitialExplorerState,
     createExplorerStore,
     explorerActions,
+    selectIsFieldSidebarOpen,
     selectTableName,
     useExplorerDispatch,
     useExplorerSelector,
@@ -24,6 +28,7 @@ import {
     useExplorerRoute,
     useExplorerUrlState,
 } from '../hooks/useExplorerRoute';
+import { useExplorerSidebarUrlState } from '../hooks/useExplorerSidebarUrlState';
 import { useProjectUuid } from '../hooks/useProjectUuid';
 import useApp from '../providers/App/useApp';
 import { defaultState } from '../providers/Explorer/defaultState';
@@ -31,11 +36,13 @@ import { defaultState } from '../providers/Explorer/defaultState';
 const ExplorerContent = memo(() => {
     // Sync URL params to Redux
     useExplorerRoute();
+    useExplorerSidebarUrlState();
 
     // Run the query effects hook - orchestrates all query effects
     useExplorerQueryEffects();
 
     const dispatch = useExplorerDispatch();
+    const isFieldSidebarOpen = useExplorerSelector(selectIsFieldSidebarOpen);
     const rightSidebarProps = useChartGalleryRightSidebar({ enabled: true });
     const navigate = useNavigate();
     const merge = useMergeSafe();
@@ -59,15 +66,22 @@ const ExplorerContent = memo(() => {
     }, [merge, dispatch, tableId, navigate]);
 
     useHotkeys([['mod + alt + k', handleClearQuery]]);
+    useExplorerSidebarShortcuts({ enabled: true });
 
     return (
         <Page
             title={data ? data?.label : 'Tables'}
-            sidebar={<ExploreSideBar />}
+            sidebar={<ExploreSideBar isCollapsible />}
+            isSidebarOpen={isFieldSidebarOpen}
             {...rightSidebarProps}
             withFullHeight
             withPaddedContent
         >
+            {!isFieldSidebarOpen && (
+                <Group>
+                    <ExplorerSidebarToggle isOpen={false} />
+                </Group>
+            )}
             <Explorer />
         </Page>
     );

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { Group } from '@mantine-8/core';
+import { Group } from '@mantine/core';
 import { useHotkeys } from '@mantine/hooks';
 import { memo, useCallback, useState } from 'react';
 import { Provider } from 'react-redux';

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -1,24 +1,32 @@
-import { Button } from '@mantine/core';
+import { Button, Group } from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
 import { lazy, memo, Suspense, useEffect, useState } from 'react';
 import { Provider } from 'react-redux';
-import { useParams } from 'react-router';
+import { useLocation, useParams } from 'react-router';
 import ErrorState from '../components/common/ErrorState';
 import ChangeChartExploreModal from '../components/common/modal/ChangeChartExploreModal';
 import Page from '../components/common/Page/Page';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import Explorer from '../components/Explorer';
 import { useChartGalleryRightSidebar } from '../components/Explorer/ChartGallery/useChartGalleryRightSidebar';
+import { ExplorerSidebarToggle } from '../components/Explorer/ExplorerSidebarToggle';
 import LoadingSkeleton from '../components/Explorer/ExploreTree/LoadingSkeleton';
 import SavedChartsHeader from '../components/Explorer/SavedChartsHeader';
+import { useExplorerSidebarShortcuts } from '../components/Explorer/useExplorerSidebarShortcuts';
 import {
     buildInitialExplorerState,
     createExplorerStore,
     explorerActions,
+    selectIsFieldSidebarOpen,
+    useExplorerSelector,
 } from '../features/explorer/store';
 import { MergeProvider } from '../features/mergeQuery/context/MergeContext';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
+import {
+    parseIsFieldSidebarOpen,
+    useExplorerSidebarUrlState,
+} from '../hooks/useExplorerSidebarUrlState';
 import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useSavedQuery } from '../hooks/useSavedQuery';
 import useApp from '../providers/App/useApp';
@@ -32,9 +40,12 @@ const LazyExplorePanel = lazy(
 const SavedExplorerContent = memo(() => {
     const { mode } = useParams<{ mode?: string }>();
     const isEditMode = mode === 'edit';
+    const isFieldSidebarOpen = useExplorerSelector(selectIsFieldSidebarOpen);
     const rightSidebarProps = useChartGalleryRightSidebar({
         enabled: isEditMode,
     });
+    useExplorerSidebarUrlState();
+    useExplorerSidebarShortcuts({ enabled: isEditMode });
 
     // Run the query effects hook - orchestrates all query effects
     useExplorerQueryEffects();
@@ -45,14 +56,19 @@ const SavedExplorerContent = memo(() => {
             header={<SavedChartsHeader />}
             sidebar={
                 <Suspense fallback={<LoadingSkeleton />}>
-                    <LazyExplorePanel />
+                    <LazyExplorePanel isCollapsible />
                 </Suspense>
             }
-            isSidebarOpen={isEditMode}
+            isSidebarOpen={isEditMode && isFieldSidebarOpen}
             {...rightSidebarProps}
             withFullHeight
             withPaddedContent
         >
+            {isEditMode && !isFieldSidebarOpen && (
+                <Group>
+                    <ExplorerSidebarToggle isOpen={false} />
+                </Group>
+            )}
             <Explorer />
         </Page>
     );
@@ -68,6 +84,8 @@ const SavedExplorer = () => {
     }>();
 
     const isEditMode = mode === 'edit';
+    const { search } = useLocation();
+    const isFieldSidebarOpen = parseIsFieldSidebarOpen(search);
 
     const { setDashboardChartInfo } = useDashboardStorage();
 
@@ -106,6 +124,7 @@ const SavedExplorer = () => {
             const initialState = buildInitialExplorerState({
                 savedChart: data,
                 isEditMode,
+                isFieldSidebarOpen,
                 expandedSections: [ExplorerSection.VISUALIZATION],
                 defaultLimit: health.data?.query.defaultLimit,
             });
@@ -113,7 +132,13 @@ const SavedExplorer = () => {
         } else {
             store.dispatch(explorerActions.setSavedChart(data));
         }
-    }, [data, store, isEditMode, health.data?.query.defaultLimit]);
+    }, [
+        data,
+        store,
+        isEditMode,
+        isFieldSidebarOpen,
+        health.data?.query.defaultLimit,
+    ]);
 
     useEffect(() => {
         store.dispatch(explorerActions.setIsEditMode(isEditMode));

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -30,6 +30,7 @@ import {
 import { useProjectUuid } from '../hooks/useProjectUuid';
 import { useSavedQuery } from '../hooks/useSavedQuery';
 import useApp from '../providers/App/useApp';
+import { defaultState } from '../providers/Explorer/defaultState';
 import { ExplorerSection } from '../providers/Explorer/types';
 import { getCandidateExploreNames } from '../utils/exploreSplitError';
 
@@ -109,7 +110,14 @@ const SavedExplorer = () => {
     }, [data, setDashboardChartInfo]);
 
     // Create store once with useState
-    const [store] = useState(() => createExplorerStore());
+    const [store] = useState(() =>
+        createExplorerStore({
+            explorer: {
+                ...defaultState,
+                isFieldSidebarOpen,
+            },
+        }),
+    );
 
     // Reset store state when data/mode changes
     useEffect(() => {

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -1,4 +1,4 @@
-import { Button, Group } from '@mantine-8/core';
+import { Button, Group } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { lazy, memo, Suspense, useEffect, useState } from 'react';
 import { Provider } from 'react-redux';

--- a/packages/frontend/src/providers/Explorer/defaultState.ts
+++ b/packages/frontend/src/providers/Explorer/defaultState.ts
@@ -15,6 +15,7 @@ export const defaultQueryExecution: ExplorerSliceState['queryExecution'] = {
 const defaultFilters: Filters = {};
 
 export const defaultState: ExplorerSliceState = {
+    isFieldSidebarOpen: true,
     isVisualizationConfigOpen: false,
     chartSidebarStep: 'configure',
     chartTypeAuthoring: null,

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -278,6 +278,7 @@ export interface ExplorerReduceState {
         // Temporary state that tracks changes to `table calculations` - keeps track of new name and previous name to ensure these get updated correctly when making changes to the layout & config of a chart
         tableCalculations?: TableCalculationMetadata[];
     };
+    isFieldSidebarOpen: boolean;
     isVisualizationConfigOpen?: boolean;
     /** Which step the chart gallery sidebar shows when it is open. */
     chartSidebarStep: ChartSidebarStep;

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,6 +1,5 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import reactPlugin from '@vitejs/plugin-react';
-import { appendFileSync } from 'node:fs';
 import * as path from 'path';
 import { compression } from 'vite-plugin-compression2';
 import monacoEditorPlugin from 'vite-plugin-monaco-editor';
@@ -25,52 +24,6 @@ export default defineConfig({
             process.env.REACT_QUERY_DEVTOOLS_ENABLED ?? true,
     },
     plugins: [
-        {
-            name: 'cursor-debug-log',
-            configureServer(server) {
-                server.middlewares.use(
-                    '/__cursor-debug-log',
-                    (request, response, next) => {
-                        if (request.method !== 'POST') {
-                            next();
-                            return;
-                        }
-
-                        let body = '';
-                        request.setEncoding('utf8');
-                        request.on('data', (chunk) => {
-                            body += chunk;
-                        });
-                        request.on('end', () => {
-                            try {
-                                const payload = JSON.parse(body) as Record<
-                                    string,
-                                    unknown
-                                >;
-                                const safePayload = {
-                                    hypothesisId: payload.hypothesisId,
-                                    location: payload.location,
-                                    message: payload.message,
-                                    data: payload.data,
-                                    timestamp: payload.timestamp,
-                                };
-                                // #region agent log
-                                appendFileSync(
-                                    '/opt/cursor/logs/debug.log',
-                                    `${JSON.stringify(safePayload)}\n`,
-                                );
-                                // #endregion
-                                response.statusCode = 204;
-                                response.end();
-                            } catch {
-                                response.statusCode = 400;
-                                response.end();
-                            }
-                        });
-                    },
-                );
-            },
-        },
         buildHashPlugin(),
         compression({
             include: [/\.(js)$/, /\.(css)$/],

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import reactPlugin from '@vitejs/plugin-react';
+import { appendFileSync } from 'node:fs';
 import * as path from 'path';
 import { compression } from 'vite-plugin-compression2';
 import monacoEditorPlugin from 'vite-plugin-monaco-editor';
@@ -24,6 +25,52 @@ export default defineConfig({
             process.env.REACT_QUERY_DEVTOOLS_ENABLED ?? true,
     },
     plugins: [
+        {
+            name: 'cursor-debug-log',
+            configureServer(server) {
+                server.middlewares.use(
+                    '/__cursor-debug-log',
+                    (request, response, next) => {
+                        if (request.method !== 'POST') {
+                            next();
+                            return;
+                        }
+
+                        let body = '';
+                        request.setEncoding('utf8');
+                        request.on('data', (chunk) => {
+                            body += chunk;
+                        });
+                        request.on('end', () => {
+                            try {
+                                const payload = JSON.parse(body) as Record<
+                                    string,
+                                    unknown
+                                >;
+                                const safePayload = {
+                                    hypothesisId: payload.hypothesisId,
+                                    location: payload.location,
+                                    message: payload.message,
+                                    data: payload.data,
+                                    timestamp: payload.timestamp,
+                                };
+                                // #region agent log
+                                appendFileSync(
+                                    '/opt/cursor/logs/debug.log',
+                                    `${JSON.stringify(safePayload)}\n`,
+                                );
+                                // #endregion
+                                response.statusCode = 204;
+                                response.end();
+                            } catch {
+                                response.statusCode = 400;
+                                response.end();
+                            }
+                        });
+                    },
+                );
+            },
+        },
         buildHashPlugin(),
         compression({
             include: [/\.(js)$/, /\.(css)$/],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: PROD-10502

### Description:
- add `mod+b` to toggle the Explorer field sidebar and `mod+alt+b` to toggle chart configuration when the chart gallery is enabled
- add visible collapse/expand controls and keyboard shortcut hints
- persist the field-sidebar state as `fieldSidebar=closed` for reloads and shared links without affecting other tabs or sessions
- expand the Visualization section when its keyboard shortcut opens chart configuration

[explorer_sidebar_shortcuts_clean_demo.mp4](https://cursor.com/agents/bc-cc7e6193-b4df-4037-a189-158ab1eae705/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexplorer_sidebar_shortcuts_clean_demo.mp4)

### Test plan:
- [x] focused Explorer reducer, route, URL-state, hotkey, and chart-sidebar tests (51 passing)
- [x] frontend typecheck
- [x] formatting and lint checks for changed files
- [x] manual verification on table Explorer and saved-chart edit routes
- [x] verify shortcuts are ignored while a field-search input is focused

### Risk assessment:
- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->
