### PR TITLE
feat(data-apps): apply viewer-scoped direct access

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -11,6 +11,12 @@ import {
     AnalyticsDashboardViewsTableName,
 } from '../database/entities/analytics';
 import {
+    AppGroupAccessTable,
+    AppGroupAccessTableName,
+    AppUserAccessTable,
+    AppUserAccessTableName,
+} from '../database/entities/appAccess';
+import {
     AppsTable,
     AppsTableName,
     AppVersionsTable,
@@ -789,6 +795,8 @@ declare module 'knex/types/tables' {
         [ContentVerificationTableName]: ContentVerificationTable;
         [AppsTableName]: AppsTable;
         [AppVersionsTableName]: AppVersionsTable;
+        [AppUserAccessTableName]: AppUserAccessTable;
+        [AppGroupAccessTableName]: AppGroupAccessTable;
         [AiRouterTableName]: AiRouterTable;
         [AiRouterDecisionTableName]: AiRouterDecisionTable;
         [ExternalConnectionsTableName]: ExternalConnectionsTable;

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1776,6 +1776,7 @@ export type DataAppVersionFailedEvent = BaseTrack & {
         schedulerWaitMs?: number;
         claudeEffort: DataAppClaudeEffort;
         failureStage:
+            | 'authorization'
             | 'sandbox'
             | 'catalog'
             | 'generating'

--- a/packages/backend/src/database/entities/appAccess.ts
+++ b/packages/backend/src/database/entities/appAccess.ts
@@ -1,0 +1,35 @@
+import { type SpaceMemberRole } from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const AppUserAccessTableName = 'app_user_access';
+export const AppGroupAccessTableName = 'app_group_access';
+
+export type DbAppUserAccess = {
+    app_uuid: string;
+    user_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AppUserAccessTable = Knex.CompositeTableType<
+    DbAppUserAccess,
+    Omit<DbAppUserAccess, 'created_at' | 'updated_at'>,
+    Pick<DbAppUserAccess, 'space_role' | 'granted_by_user_uuid' | 'updated_at'>
+>;
+
+export type DbAppGroupAccess = {
+    app_uuid: string;
+    group_uuid: string;
+    space_role: SpaceMemberRole;
+    granted_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AppGroupAccessTable = Knex.CompositeTableType<
+    DbAppGroupAccess,
+    Omit<DbAppGroupAccess, 'created_at' | 'updated_at'>,
+    Pick<DbAppGroupAccess, 'space_role' | 'granted_by_user_uuid' | 'updated_at'>
+>;

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -424,6 +424,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectModel: models.getProjectModel(),
                     projectParametersModel: models.getProjectParametersModel(),
                     spaceModel: models.getSpaceModel(),
+                    userModel: models.getUserModel(),
                     savedChartModel: models.getSavedChartModel(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.appCode.test.ts
@@ -214,6 +214,7 @@ function buildService(
         analytics: analytics as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
+        userModel: {} as never,
         appModel: appModel as never,
         featureFlagModel: featureFlagModel as never,
         organizationDesignModel: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.buildFromSource.test.ts
@@ -36,6 +36,7 @@ type ServiceWithPrivates = {
     uploadToS3: ReturnType<typeof vi.fn>;
     suspendSandbox: ReturnType<typeof vi.fn>;
     markError: ReturnType<typeof vi.fn>;
+    authorizePipelineExecution: ReturnType<typeof vi.fn>;
 };
 
 const fakeSandbox: SandboxStub = {
@@ -94,6 +95,7 @@ function buildService(
         analytics: {} as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
+        userModel: {} as never,
         appModel: appModel as never,
         featureFlagModel: {
             get: vi.fn().mockResolvedValue({ enabled: true }),
@@ -139,6 +141,7 @@ function buildService(
     service.uploadToS3 = vi.fn().mockResolvedValue(100);
     service.suspendSandbox = vi.fn().mockResolvedValue(undefined);
     service.markError = vi.fn().mockResolvedValue(true);
+    service.authorizePipelineExecution = vi.fn().mockResolvedValue({});
 
     return { service, appModel };
 }
@@ -149,6 +152,26 @@ describe('AppGenerateService.runBuildFromSourcePipeline', () => {
         fakeSandbox.pause.mockReset().mockResolvedValue(undefined);
     });
 
+    it('stops before build setup when queued authorization is no longer valid', async () => {
+        const { service } = buildService();
+        service.authorizePipelineExecution.mockRejectedValueOnce(
+            new Error('revoked'),
+        );
+        service.runBuild = vi.fn();
+
+        await service.runBuildFromSourcePipeline(makePayload());
+
+        expect(service.markError).toHaveBeenCalledWith(
+            'app-uuid-1',
+            1,
+            expect.any(Error),
+            'Build stopped because access is no longer available.',
+        );
+        expect(service.getS3Client).not.toHaveBeenCalled();
+        expect(service.createSandbox).not.toHaveBeenCalled();
+        expect(service.runBuild).not.toHaveBeenCalled();
+    });
+
     it('happy path: advances sandbox→building→packaging→ready, uploads, no markError', async () => {
         const { service, appModel } = buildService();
 
@@ -157,6 +180,10 @@ describe('AppGenerateService.runBuildFromSourcePipeline', () => {
             .mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
 
         await service.runBuildFromSourcePipeline(makePayload());
+
+        expect(service.authorizePipelineExecution).toHaveBeenCalledWith(
+            makePayload(),
+        );
 
         const calls = appModel.updateVersionStatusIfInProgress.mock
             .calls as unknown[][];

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.clarifyApp.test.ts
@@ -69,6 +69,7 @@ function buildService() {
         analytics: { track: vi.fn() } as never,
         analyticsModel: {} as never,
         catalogModel: { getCatalogItemsSummary } as never,
+        userModel: {} as never,
         appModel: {} as never,
         featureFlagModel: {
             get: vi.fn().mockResolvedValue({ enabled: true }),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppPreviewScope.test.ts
@@ -82,6 +82,7 @@ const buildService = () =>
         analytics: {} as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
+        userModel: {} as never,
         appModel: {
             listAppsByProject: vi.fn().mockResolvedValue([
                 {
@@ -111,7 +112,16 @@ const buildService = () =>
         savedChartModel: {} as never,
         schedulerClient: {} as never,
         savedChartService: {} as never,
-        spacePermissionService: {} as never,
+        spacePermissionService: {
+            resolveAccess: vi.fn().mockResolvedValue({
+                organizationUuid: ORG_UUID,
+                projectUuid: OWN_PREVIEW_UUID,
+                inheritsFromOrgOrProject: false,
+                access: [],
+                admins: [],
+                directOnly: false,
+            }),
+        } as never,
         coderService: {} as never,
         dashboardService: {} as never,
         projectService: {} as never,
@@ -157,6 +167,7 @@ describe('DataApp preview scopes', () => {
 
         await expect(
             service.canViewApp(user, {
+                app_id: 'app-uuid',
                 organization_uuid: ORG_UUID,
                 project_uuid: OWN_PREVIEW_UUID,
                 space_uuid: null,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
@@ -56,6 +56,7 @@ function buildService(
         analytics: analytics as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
+        userModel: {} as never,
         appModel: appModel as never,
         featureFlagModel: {
             get: vi.fn().mockResolvedValue({ enabled: true }),
@@ -74,7 +75,16 @@ function buildService(
         savedChartModel: {} as never,
         schedulerClient: schedulerClient as never,
         savedChartService: {} as never,
-        spacePermissionService: {} as never,
+        spacePermissionService: {
+            resolveAccess: vi.fn().mockResolvedValue({
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+                inheritsFromOrgOrProject: false,
+                access: [],
+                admins: [],
+                directOnly: false,
+            }),
+        } as never,
         coderService: {} as never,
         dashboardService: {} as never,
         projectService: {} as never,
@@ -90,7 +100,7 @@ function buildService(
     // Bypass real CASL — the mapping/flow is what these tests cover.
     (
         service as unknown as { createAuditedAbility: () => unknown }
-    ).createAuditedAbility = () => ({ cannot: () => false });
+    ).createAuditedAbility = () => ({ can: () => true, cannot: () => false });
     return { service, appModel, schedulerClient, analytics };
 }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -81,6 +81,7 @@ function buildService(
         analytics: {} as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
+        userModel: {} as never,
         appModel: appModel as never,
         featureFlagModel: {
             get: vi.fn().mockResolvedValue({ enabled: true }),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.directAccess.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.directAccess.test.ts
@@ -1,0 +1,285 @@
+import { Ability } from '@casl/ability';
+import {
+    ForbiddenError,
+    ProjectType,
+    SpaceMemberRole,
+    type SessionUser,
+} from '@lightdash/common';
+import { verifyPreviewTokenClaims } from '../../../routers/appPreviewToken';
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({ generateObject: vi.fn() }));
+
+const USER_UUID = 'user-uuid';
+const APP_UUID = '11111111-1111-4111-8111-111111111111';
+const PROJECT_UUID = 'project-uuid';
+const ORGANIZATION_UUID = 'organization-uuid';
+const SPACE_UUID = 'space-uuid';
+
+const app = {
+    app_id: APP_UUID,
+    project_uuid: PROJECT_UUID,
+    organization_uuid: ORGANIZATION_UUID,
+    space_uuid: SPACE_UUID,
+    created_by_user_uuid: 'owner-uuid',
+    template: null,
+};
+
+const buildUser = (): SessionUser => {
+    const ability = new Ability([
+        {
+            action: 'view',
+            subject: 'DataApp',
+            conditions: {
+                projectUuid: PROJECT_UUID,
+                access: { $elemMatch: { userUuid: USER_UUID } },
+            },
+        },
+        {
+            action: 'manage',
+            subject: 'DataApp',
+            conditions: {
+                projectUuid: PROJECT_UUID,
+                access: {
+                    $elemMatch: {
+                        userUuid: USER_UUID,
+                        role: SpaceMemberRole.EDITOR,
+                    },
+                },
+            },
+        },
+    ]);
+    return {
+        userUuid: USER_UUID,
+        organizationUuid: ORGANIZATION_UUID,
+        isActive: true,
+        ability,
+        abilityRules: ability.rules,
+    } as unknown as SessionUser;
+};
+
+const buildService = (role: SpaceMemberRole) => {
+    const appModel = {
+        findApp: vi.fn().mockResolvedValue(app),
+        getApp: vi.fn().mockResolvedValue(app),
+        getAppByUuidOrSlug: vi.fn().mockResolvedValue(app),
+        getAppWithVersions: vi.fn().mockResolvedValue({
+            name: 'Granted app',
+            description: 'Description',
+            createdByUserUuid: app.created_by_user_uuid,
+            organizationUuid: ORGANIZATION_UUID,
+            spaceUuid: SPACE_UUID,
+            spaceName: 'Private parent',
+            template: null,
+            slug: 'granted-app',
+            viewsCount: 3,
+            pinnedListUuid: 'private-list',
+            pinnedListOrder: 1,
+            versions: [
+                {
+                    version: 2,
+                    prompt: 'generation prompt',
+                    status: 'ready',
+                    status_message: null,
+                    status_history: [],
+                    error: null,
+                    resources: null,
+                    dependencies: null,
+                    viz_schema: null,
+                    created_at: new Date(),
+                    status_updated_at: new Date(),
+                    created_by_user_uuid: 'owner-uuid',
+                    created_by_user_first_name: 'Owner',
+                    created_by_user_last_name: 'User',
+                },
+            ],
+            hasMore: false,
+        }),
+        getLatestReadyVersion: vi.fn().mockResolvedValue({ version: 2 }),
+        moveToSpace: vi.fn(),
+    };
+    const accessContext = {
+        organizationUuid: ORGANIZATION_UUID,
+        projectUuid: PROJECT_UUID,
+        inheritsFromOrgOrProject: false,
+        admins: [],
+        access: [
+            {
+                userUuid: USER_UUID,
+                role,
+                hasDirectAccess: true,
+                grantedVia: 'app' as const,
+            },
+        ],
+        directOnly: true,
+    };
+    const spacePermissionService = {
+        resolveAccess: vi.fn().mockResolvedValue(accessContext),
+        resolveAccessBatch: vi
+            .fn()
+            .mockResolvedValue([{ context: accessContext }]),
+    };
+    const userModel = {
+        findSessionUserAndOrgByUuid: vi.fn().mockResolvedValue(buildUser()),
+    };
+    const service = new AppGenerateService({
+        lightdashConfig: {
+            lightdashSecrets: {
+                active: 'test-secret',
+                fallbacks: [],
+                all: ['test-secret'],
+            },
+        } as never,
+        analytics: { track: vi.fn() } as never,
+        analyticsModel: {} as never,
+        catalogModel: {} as never,
+        userModel: userModel as never,
+        appModel: appModel as never,
+        featureFlagModel: {
+            get: vi.fn().mockResolvedValue({ enabled: true }),
+        } as never,
+        organizationDesignModel: {} as never,
+        pinnedListModel: {} as never,
+        projectModel: {
+            getSummary: vi.fn().mockResolvedValue({
+                organizationUuid: ORGANIZATION_UUID,
+                type: ProjectType.DEFAULT,
+                createdByUserUuid: 'project-owner-uuid',
+                upstreamProjectUuid: null,
+            }),
+        } as never,
+        projectParametersModel: {} as never,
+        spaceModel: {} as never,
+        savedChartModel: {} as never,
+        schedulerClient: {} as never,
+        savedChartService: {} as never,
+        spacePermissionService: spacePermissionService as never,
+        coderService: {} as never,
+        dashboardService: {} as never,
+        projectService: {} as never,
+        promoteService: {} as never,
+        externalConnectionModel: {
+            getBrowserImageOrigins: vi.fn().mockResolvedValue([]),
+        } as never,
+        sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {} as never,
+    });
+    return { appModel, service, spacePermissionService, userModel };
+};
+
+describe('AppGenerateService direct app access', () => {
+    it('gives a direct Viewer the normal app read surface without parent metadata', async () => {
+        const { service, spacePermissionService } = buildService(
+            SpaceMemberRole.VIEWER,
+        );
+        const user = buildUser();
+
+        await expect(
+            service.getAppVersions(user, PROJECT_UUID, APP_UUID, {}),
+        ).resolves.toMatchObject({
+            spaceUuid: null,
+            spaceName: null,
+            pinnedListUuid: null,
+            versions: [{ version: 2, prompt: 'generation prompt' }],
+        });
+
+        const token = await service.getPreviewToken(
+            user,
+            PROJECT_UUID,
+            APP_UUID,
+            1,
+        );
+        expect(
+            verifyPreviewTokenClaims(token, {
+                active: 'test-secret',
+                fallbacks: [],
+                all: ['test-secret'],
+            }),
+        ).toMatchObject({ ok: true });
+
+        await expect(
+            service.filterAppsUserCanView(
+                user,
+                ORGANIZATION_UUID,
+                PROJECT_UUID,
+                [
+                    {
+                        uuid: APP_UUID,
+                        spaceUuid: SPACE_UUID,
+                        createdBy: { userUuid: app.created_by_user_uuid },
+                    },
+                ],
+            ),
+        ).resolves.toEqual([
+            {
+                uuid: APP_UUID,
+                spaceUuid: null,
+                createdBy: { userUuid: app.created_by_user_uuid },
+            },
+        ]);
+        expect(
+            spacePermissionService.resolveAccessBatch,
+        ).toHaveBeenCalledOnce();
+    });
+
+    it('gives a direct Editor the normal app manage surface', async () => {
+        const { appModel, service } = buildService(SpaceMemberRole.EDITOR);
+
+        await service.moveToSpace(buildUser(), {
+            projectUuid: PROJECT_UUID,
+            itemUuid: APP_UUID,
+            targetSpaceUuid: 'target-space-uuid',
+        });
+
+        expect(appModel.moveToSpace).toHaveBeenCalledWith(
+            {
+                appId: APP_UUID,
+                projectUuid: PROJECT_UUID,
+                targetSpaceUuid: 'target-space-uuid',
+            },
+            { tx: undefined },
+        );
+    });
+
+    it('re-authorizes queued access after revocation', async () => {
+        const { service, spacePermissionService, userModel } = buildService(
+            SpaceMemberRole.EDITOR,
+        );
+        const queuedAuthorization = service as unknown as {
+            authorizePipelineExecution: (payload: {
+                appUuid: string;
+                organizationUuid: string;
+                projectUuid: string;
+                userUuid: string;
+            }) => Promise<SessionUser>;
+        };
+        const payload = {
+            appUuid: APP_UUID,
+            version: 2,
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            userUuid: USER_UUID,
+        };
+
+        await expect(
+            queuedAuthorization.authorizePipelineExecution(payload),
+        ).resolves.toBe(await userModel.findSessionUserAndOrgByUuid());
+        spacePermissionService.resolveAccess.mockResolvedValue({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            inheritsFromOrgOrProject: false,
+            admins: [],
+            access: [],
+            directOnly: false,
+        });
+
+        await expect(
+            queuedAuthorization.authorizePipelineExecution(payload),
+        ).rejects.toThrow(ForbiddenError);
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
@@ -63,6 +63,7 @@ function buildService() {
             catalogModel: {
                 getChartUsageByTable: async () => new Map<string, number>(),
             } as never,
+            userModel: {} as never,
             appModel: {} as never,
             featureFlagModel: featureFlagModel as never,
             organizationDesignModel: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.getAppCode.test.ts
@@ -21,7 +21,7 @@ vi.mock('ai', () => ({
 
 // Mock appAuthz so permission checks are controllable in tests
 vi.mock('./appAuthz', () => ({
-    assertCanViewApp: vi.fn().mockResolvedValue(undefined),
+    assertCanViewApp: vi.fn().mockResolvedValue({ directOnly: false } as never),
 }));
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -212,6 +212,7 @@ function buildService(overrides: {
         analytics: { track: analyticsTrackSpy } as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
+        userModel: {} as never,
         appModel: fullAppModel as never,
         featureFlagModel: featureFlagModel as never,
         organizationDesignModel: fullOrganizationDesignModel as never,
@@ -260,7 +261,9 @@ describe('AppGenerateService.getAppCode', () => {
     });
 
     beforeEach(() => {
-        vi.mocked(assertCanViewApp).mockResolvedValue(undefined);
+        vi.mocked(assertCanViewApp).mockResolvedValue({
+            directOnly: false,
+        } as never);
         analyticsTrackSpy.mockClear();
     });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.readDataApp.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.readDataApp.test.ts
@@ -77,6 +77,7 @@ function buildService(appModel: Record<string, unknown>): AppGenerateService {
         analytics: { track: vi.fn() } as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
+        userModel: {} as never,
         appModel: {
             findAppBySlug: vi.fn().mockResolvedValue(fakeApp),
             countVersions: vi.fn().mockResolvedValue(2),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -157,6 +157,7 @@ import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { ProjectParametersModel } from '../../../models/ProjectParametersModel';
 import { SavedChartModel } from '../../../models/SavedChartModel';
 import { SpaceModel } from '../../../models/SpaceModel';
+import { type UserModel } from '../../../models/UserModel';
 import {
     mintPreviewToken,
     verifyPreviewTokenClaims,
@@ -201,6 +202,10 @@ import {
 import {
     assertCanViewEmbeddedApp,
     assertCanViewApp as assertUserCanViewApp,
+    getAppViewAuthorizationContext,
+    type AppViewAuthorizationContext,
+    type AppViewAuthzApp,
+    type AppViewAuthzDeps,
     type DataAppProjectContext,
 } from './appAuthz';
 import { getBundleServableChecker } from './appBundleStorage';
@@ -340,6 +345,7 @@ type AppGenerateServiceDeps = {
     projectModel: ProjectModel;
     projectParametersModel: ProjectParametersModel;
     spaceModel: SpaceModel;
+    userModel: Pick<UserModel, 'findSessionUserAndOrgByUuid'>;
     savedChartModel: SavedChartModel;
     schedulerClient: CommercialSchedulerClient;
     savedChartService: SavedChartService;
@@ -542,6 +548,8 @@ export class AppGenerateService extends BaseService {
 
     private readonly spaceModel: SpaceModel;
 
+    private readonly userModel: Pick<UserModel, 'findSessionUserAndOrgByUuid'>;
+
     private readonly savedChartModel: SavedChartModel;
 
     private readonly schedulerClient: CommercialSchedulerClient;
@@ -584,6 +592,7 @@ export class AppGenerateService extends BaseService {
         projectModel,
         projectParametersModel,
         spaceModel,
+        userModel,
         savedChartModel,
         schedulerClient,
         savedChartService,
@@ -608,6 +617,7 @@ export class AppGenerateService extends BaseService {
         this.projectModel = projectModel;
         this.projectParametersModel = projectParametersModel;
         this.spaceModel = spaceModel;
+        this.userModel = userModel;
         this.savedChartModel = savedChartModel;
         this.schedulerClient = schedulerClient;
         this.savedChartService = savedChartService;
@@ -730,29 +740,57 @@ export class AppGenerateService extends BaseService {
      *   `createdByUserUuid` lets the creator match the self rule. Project
      *   admins always match via the project-wide rule.
      */
-    private async assertCanViewApp(
+    private getAppViewAuthzDeps(
         user: SessionUser,
-        app: Pick<
-            DbApp,
-            'project_uuid' | 'space_uuid' | 'created_by_user_uuid'
-        > & {
-            organization_uuid: string;
-        },
-    ): Promise<void> {
-        await assertUserCanViewApp(
-            {
-                auditedAbility: this.createAuditedAbility(user),
-                resolveAccess: (userUuid, spaceUuid) =>
-                    this.spacePermissionService.resolveAccess(userUuid, {
-                        type: 'space',
-                        spaceUuid,
-                    }),
-                getProjectContext: (projectUuid) =>
-                    this.getDataAppProjectContext(projectUuid),
-            },
+        {
+            projectContext,
+            includeDeleted = false,
+        }: {
+            projectContext?: DataAppProjectContext;
+            includeDeleted?: boolean;
+        } = {},
+    ): AppViewAuthzDeps {
+        return {
+            auditedAbility: this.createAuditedAbility(user),
+            resolveAccess: (userUuid, targetApp) =>
+                this.spacePermissionService.resolveAccess(
+                    userUuid,
+                    {
+                        type: 'app',
+                        appUuid: targetApp.app_id,
+                        organizationUuid: targetApp.organization_uuid,
+                        projectUuid: targetApp.project_uuid,
+                        spaceUuid: targetApp.space_uuid,
+                    },
+                    { includeDeleted },
+                ),
+            getProjectContext: (projectUuid) =>
+                projectContext
+                    ? Promise.resolve(projectContext)
+                    : this.getDataAppProjectContext(projectUuid),
+        };
+    }
+
+    private async resolveAppAuthorizationContext(
+        user: SessionUser,
+        app: AppViewAuthzApp,
+        options: {
+            projectContext?: DataAppProjectContext;
+            includeDeleted?: boolean;
+        } = {},
+    ): Promise<AppViewAuthorizationContext> {
+        return getAppViewAuthorizationContext(
+            this.getAppViewAuthzDeps(user, options),
             user,
             app,
         );
+    }
+
+    private async assertCanViewApp(
+        user: SessionUser,
+        app: AppViewAuthzApp,
+    ): Promise<AppViewAuthorizationContext> {
+        return assertUserCanViewApp(this.getAppViewAuthzDeps(user), user, app);
     }
 
     /**
@@ -767,30 +805,72 @@ export class AppGenerateService extends BaseService {
         user: SessionUser,
         app: Pick<
             DbApp,
-            'project_uuid' | 'space_uuid' | 'created_by_user_uuid'
+            'app_id' | 'project_uuid' | 'space_uuid' | 'created_by_user_uuid'
         > & {
             organization_uuid: string;
         },
         errorMessage: string,
         extraContext: Record<string, unknown> = {},
-    ): Promise<DataAppProjectContext> {
-        const spaceContext = app.space_uuid
-            ? await this.spacePermissionService.resolveAccess(user.userUuid, {
-                  type: 'space',
-                  spaceUuid: app.space_uuid,
-              })
-            : {};
-        return this.assertDataAppAbility(
+        { includeDeleted = false }: { includeDeleted?: boolean } = {},
+    ): Promise<AppViewAuthorizationContext> {
+        const appContext = await this.resolveAppAuthorizationContext(
+            user,
+            app,
+            {
+                includeDeleted,
+            },
+        );
+        await this.assertDataAppAbility(
             user,
             'manage',
             app.project_uuid,
             errorMessage,
             {
-                ...spaceContext,
-                createdByUserUuid: app.created_by_user_uuid,
+                ...appContext,
                 ...extraContext,
             },
         );
+        return appContext;
+    }
+
+    /**
+     * Re-authorize queued work as the principal recorded on the job. Payload
+     * snapshots are useful inputs, but never authorization evidence: the app
+     * must still be manageable by that same user when the worker starts.
+     */
+    private async authorizePipelineExecution(
+        payload: Pick<
+            AppGeneratePipelineJobPayload,
+            'appUuid' | 'organizationUuid' | 'projectUuid' | 'userUuid'
+        >,
+    ): Promise<SessionUser> {
+        const user = await this.userModel.findSessionUserAndOrgByUuid(
+            payload.userUuid,
+            payload.organizationUuid,
+        );
+        if (!user.isActive) {
+            throw new ForbiddenError(
+                'The recorded data app principal is no longer active',
+            );
+        }
+        await this.assertDataAppsEnabled(user);
+
+        const app = await this.appModel.getApp(
+            payload.appUuid,
+            payload.projectUuid,
+        );
+        if (app.organization_uuid !== payload.organizationUuid) {
+            throw new ForbiddenError(
+                'Data app is not available in this organization',
+            );
+        }
+        await this.assertCanManageApp(
+            user,
+            app,
+            'Insufficient permissions to build this data app',
+        );
+
+        return user;
     }
 
     private static getAnthropicApiKey(copilot: CopilotConfig): string {
@@ -1228,39 +1308,28 @@ export class AppGenerateService extends BaseService {
         user: SessionUser,
         app: Pick<
             DbApp,
-            'project_uuid' | 'space_uuid' | 'created_by_user_uuid'
+            'app_id' | 'project_uuid' | 'space_uuid' | 'created_by_user_uuid'
         > & {
             organization_uuid: string;
         },
         projectContext?: DataAppProjectContext,
     ): Promise<boolean> {
-        const [spaceContext, resolvedProjectContext] = await Promise.all([
-            app.space_uuid
-                ? this.spacePermissionService.resolveAccess(user.userUuid, {
-                      type: 'space',
-                      spaceUuid: app.space_uuid,
-                  })
-                : Promise.resolve({}),
-            projectContext ?? this.getDataAppProjectContext(app.project_uuid),
-        ]);
-        const auditedAbility = this.createAuditedAbility(user);
-        return auditedAbility.can(
+        const context = await this.resolveAppAuthorizationContext(user, app, {
+            projectContext,
+        });
+        return this.createAuditedAbility(user).can(
             'view',
-            subject('DataApp', {
-                ...resolvedProjectContext,
-                ...spaceContext,
-                createdByUserUuid: app.created_by_user_uuid,
-            }),
+            subject('DataApp', context),
         );
     }
 
     /**
      * Bulk filter for callers that have a list of apps already loaded
-     * (e.g. SearchService). Resolves space access contexts in parallel —
-     * one `resolveAccess` call per app with a space.
+     * (e.g. SearchService).
      */
     async filterAppsUserCanView<
         T extends {
+            uuid: string;
             spaceUuid: string | null;
             createdBy: { userUuid: string } | null;
         },
@@ -1271,23 +1340,35 @@ export class AppGenerateService extends BaseService {
         apps: T[],
     ): Promise<T[]> {
         const projectContext = await this.getDataAppProjectContext(projectUuid);
-        const checks = await Promise.all(
-            apps.map((app) =>
-                this.canViewApp(
-                    user,
-                    {
-                        organization_uuid: organizationUuid,
-                        project_uuid: projectUuid,
-                        space_uuid: app.spaceUuid,
-                        // A null createdBy can never match the self rule — coerce
-                        // to a sentinel that won't equal any real userUuid.
-                        created_by_user_uuid: app.createdBy?.userUuid ?? '',
-                    },
-                    projectContext,
-                ),
-            ),
-        );
-        return apps.filter((_, i) => checks[i]);
+        const accessResults =
+            await this.spacePermissionService.resolveAccessBatch(
+                user.userUuid,
+                apps.map((app) => ({
+                    type: 'app' as const,
+                    appUuid: app.uuid,
+                    organizationUuid,
+                    projectUuid,
+                    spaceUuid: app.spaceUuid,
+                })),
+            );
+        const auditedAbility = this.createAuditedAbility(user);
+        return apps.flatMap((app, index) => {
+            const accessContext = accessResults[index]?.context;
+            if (accessContext === undefined) {
+                return [];
+            }
+            const context = {
+                ...projectContext,
+                ...accessContext,
+                // A null createdBy can never match the self rule — coerce to a
+                // sentinel that won't equal any real userUuid.
+                createdByUserUuid: app.createdBy?.userUuid ?? '',
+            };
+            if (auditedAbility.cannot('view', subject('DataApp', context))) {
+                return [];
+            }
+            return [context.directOnly ? { ...app, spaceUuid: null } : app];
+        });
     }
 
     /**
@@ -2029,6 +2110,7 @@ export class AppGenerateService extends BaseService {
     private async trackVersionFailed(
         payload: AppGeneratePipelineJobPayload,
         failureStage:
+            | 'authorization'
             | 'sandbox'
             | 'catalog'
             | 'generating'
@@ -4394,6 +4476,32 @@ export class AppGenerateService extends BaseService {
             return;
         }
 
+        try {
+            await this.authorizePipelineExecution(payload);
+        } catch (error) {
+            this.logger.warn(
+                `App ${appUuid}: pipeline authorization failed for user ${payload.userUuid} on version ${version}: ${getErrorMessage(error)}`,
+            );
+            const marked = await this.markError(
+                appUuid,
+                version,
+                error,
+                'Build stopped because access is no longer available.',
+            );
+            if (marked) {
+                await this.trackVersionFailed(
+                    payload,
+                    'authorization',
+                    error,
+                    {},
+                    null,
+                    0,
+                    { schedulerWaitMs },
+                );
+            }
+            return;
+        }
+
         let codingAgentEnv: Record<string, string>;
         let copilot: ResolvedCopilotConfig;
         let s3Client: S3Client;
@@ -6755,7 +6863,6 @@ export class AppGenerateService extends BaseService {
                 `Cannot restore version ${sourceVersion}: status is ${source.status}, expected ready`,
             );
         }
-
         const newVersion = (latestVersion?.version ?? 0) + 1;
         const { client: s3Client, bucket } = this.getS3Client();
 
@@ -7185,7 +7292,7 @@ export class AppGenerateService extends BaseService {
     ): Promise<PromoteAppDiff> {
         await this.assertDataAppsEnabled(user);
         const sourceApp = await this.appModel.getApp(appUuid, projectUuid);
-        await this.assertCanManageApp(
+        const sourceAuthorization = await this.assertCanManageApp(
             user,
             sourceApp,
             'Insufficient permissions to promote this data app',
@@ -7198,10 +7305,10 @@ export class AppGenerateService extends BaseService {
             sourceApp,
             upstreamProjectUuid,
         );
-
-        const space = sourceApp.space_uuid
-            ? await this.spaceModel.getSpaceSummary(sourceApp.space_uuid)
-            : null;
+        const space =
+            !sourceAuthorization.directOnly && sourceApp.space_uuid
+                ? await this.spaceModel.getSpaceSummary(sourceApp.space_uuid)
+                : null;
 
         return {
             action: upstreamApp ? 'update' : 'create',
@@ -7237,7 +7344,7 @@ export class AppGenerateService extends BaseService {
         await this.assertDataAppsEnabled(user);
 
         const sourceApp = await this.appModel.getApp(appUuid, projectUuid);
-        await this.assertCanManageApp(
+        const sourceAuthorization = await this.assertCanManageApp(
             user,
             sourceApp,
             'Insufficient permissions to promote this data app',
@@ -7266,17 +7373,17 @@ export class AppGenerateService extends BaseService {
                 'Cannot promote an app that has no successful version',
             );
         }
-
         // Resolve the upstream space (creating it + ancestors if missing) so
         // the production app mirrors the preview app's placement. Spaceless
         // apps land at the project root.
-        const targetSpaceUuid = sourceApp.space_uuid
-            ? await this.promoteService.getOrCreateUpstreamSpace(
-                  user,
-                  sourceApp.space_uuid,
-                  upstreamProjectUuid,
-              )
-            : null;
+        const targetSpaceUuid =
+            !sourceAuthorization.directOnly && sourceApp.space_uuid
+                ? await this.promoteService.getOrCreateUpstreamSpace(
+                      user,
+                      sourceApp.space_uuid,
+                      upstreamProjectUuid,
+                  )
+                : null;
 
         // Designs are org-scoped and the preview shares the upstream org, so
         // the design carries over — but guard against a since-deleted design.
@@ -7604,7 +7711,6 @@ export class AppGenerateService extends BaseService {
                 'Cannot duplicate an app that has no successful version',
             );
         }
-
         const sourceLinks = await this.externalConnectionModel.listAppLinks(
             sourceApp.app_id,
         );
@@ -8150,7 +8256,8 @@ export class AppGenerateService extends BaseService {
             hasMore,
         } = await this.appModel.getAppWithVersions(appUuid, projectUuid, opts);
 
-        await this.assertCanViewApp(user, {
+        const appAuthorization = await this.assertCanViewApp(user, {
+            app_id: appUuid,
             project_uuid: projectUuid,
             space_uuid: spaceUuid,
             organization_uuid: organizationUuid,
@@ -8166,13 +8273,15 @@ export class AppGenerateService extends BaseService {
             name,
             description,
             createdByUserUuid,
-            spaceUuid,
-            spaceName,
+            spaceUuid: appAuthorization.directOnly ? null : spaceUuid,
+            spaceName: appAuthorization.directOnly ? null : spaceName,
             template,
             slug,
             views: viewsCount,
-            pinnedListUuid,
-            pinnedListOrder,
+            pinnedListUuid: appAuthorization.directOnly ? null : pinnedListUuid,
+            pinnedListOrder: appAuthorization.directOnly
+                ? null
+                : pinnedListOrder,
             versions: versions.map((v) => ({
                 version: v.version,
                 prompt: v.prompt,
@@ -8361,6 +8470,7 @@ export class AppGenerateService extends BaseService {
             );
         }
         await this.assertCanViewApp(user, {
+            app_id: dataAppViz.app_id,
             project_uuid: dataAppViz.project_uuid,
             space_uuid: dataAppViz.space_uuid,
             organization_uuid: dataAppViz.organization_uuid,
@@ -8918,11 +9028,12 @@ export class AppGenerateService extends BaseService {
             });
         } else {
             await this.assertDataAppsEnabled(user);
-            await this.assertDataAppAbility(
+            await this.assertCanManageApp(
                 user,
-                'manage',
-                projectUuid,
+                app,
                 'Insufficient permissions to restore data apps',
+                {},
+                { includeDeleted: true },
             );
         }
 
@@ -8963,11 +9074,12 @@ export class AppGenerateService extends BaseService {
             });
         } else {
             await this.assertDataAppsEnabled(user);
-            await this.assertDataAppAbility(
+            await this.assertCanManageApp(
                 user,
-                'manage',
-                projectUuid,
+                app,
                 'Insufficient permissions to delete data apps',
+                {},
+                { includeDeleted: true },
             );
         }
 
@@ -10099,13 +10211,14 @@ export class AppGenerateService extends BaseService {
 
         const app = await this.appModel.findApp(payload.appUuid, projectUuid);
         if (!app || app.organization_uuid !== organizationUuid) return empty();
-        const [spaceContext, projectContext] = await Promise.all([
-            app.space_uuid
-                ? this.spacePermissionService.resolveAccess(account.user.id, {
-                      type: 'space',
-                      spaceUuid: app.space_uuid,
-                  })
-                : Promise.resolve({}),
+        const [accessContext, projectContext] = await Promise.all([
+            this.spacePermissionService.resolveAccess(account.user.id, {
+                type: 'app',
+                appUuid: app.app_id,
+                organizationUuid: app.organization_uuid,
+                projectUuid: app.project_uuid,
+                spaceUuid: app.space_uuid,
+            }),
             this.getDataAppProjectContext(projectUuid),
         ]);
         const auditedAbility = this.createAuditedAbility(account);
@@ -10114,7 +10227,7 @@ export class AppGenerateService extends BaseService {
                 'view',
                 subject('DataApp', {
                     ...projectContext,
-                    ...spaceContext,
+                    ...accessContext,
                     createdByUserUuid: app.created_by_user_uuid,
                 }),
             )
@@ -10316,7 +10429,7 @@ export class AppGenerateService extends BaseService {
             projectUuid,
             appUuidOrSlug,
         );
-        await this.assertCanViewApp(user, app);
+        const appAuthorization = await this.assertCanViewApp(user, app);
 
         let resolvedVersion: number;
         let versionRow: DbAppVersion | null;
@@ -10380,9 +10493,10 @@ export class AppGenerateService extends BaseService {
 
         // In-space apps emit the space as a content-as-code path so uploads
         // can recreate placement; personal apps omit the key.
-        const appSpace = app.space_uuid
-            ? await this.spaceModel.getSpaceSummary(app.space_uuid)
-            : null;
+        const appSpace =
+            !appAuthorization.directOnly && app.space_uuid
+                ? await this.spaceModel.getSpaceSummary(app.space_uuid)
+                : null;
 
         const manifest = buildManifest({
             slug: app.slug,
@@ -11355,6 +11469,20 @@ export class AppGenerateService extends BaseService {
         payload: AppBuildFromSourceJobPayload,
     ): Promise<void> {
         const { appUuid, version, organizationUuid, projectUuid } = payload;
+        try {
+            await this.authorizePipelineExecution(payload);
+        } catch (error) {
+            this.logger.warn(
+                `App ${appUuid}: source-build authorization failed for user ${payload.userUuid} on version ${version}: ${getErrorMessage(error)}`,
+            );
+            await this.markError(
+                appUuid,
+                version,
+                error,
+                'Build stopped because access is no longer available.',
+            );
+            return;
+        }
         const { client, bucket } = this.getS3Client();
         const copilot = await this.getCodingAgentConfig(organizationUuid);
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -86,7 +86,14 @@ function buildService(
     };
 
     const spacePermissionService = {
-        resolveAccess: vi.fn().mockResolvedValue({}),
+        resolveAccess: vi.fn().mockResolvedValue({
+            organizationUuid: USER_ORG_UUID,
+            projectUuid: PROJECT_UUID,
+            inheritsFromOrgOrProject: false,
+            access: [],
+            admins: [],
+            directOnly: false,
+        }),
     };
 
     const analytics = { track: vi.fn() };
@@ -103,6 +110,7 @@ function buildService(
         analytics: analytics as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
+        userModel: {} as never,
         appModel: appModel as never,
         featureFlagModel: featureFlagModel as never,
         organizationDesignModel: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts
@@ -12,7 +12,10 @@ vi.mock('ai', () => ({
     generateObject: vi.fn(),
 }));
 vi.mock('./appAuthz', () => ({
-    assertCanViewApp: vi.fn().mockResolvedValue(undefined),
+    assertCanViewApp: vi.fn().mockResolvedValue({ directOnly: false }),
+    getAppViewAuthorizationContext: vi
+        .fn()
+        .mockResolvedValue({ directOnly: false }),
 }));
 
 const PROJECT_UUID = 'proj-uuid-1';
@@ -144,6 +147,7 @@ function buildService() {
         analytics: { track: vi.fn() } as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,
+        userModel: {} as never,
         appModel: appModel as never,
         featureFlagModel: featureFlagModel as never,
         organizationDesignModel: organizationDesignModel as never,
@@ -155,7 +159,14 @@ function buildService() {
         schedulerClient: {} as never,
         savedChartService: {} as never,
         spacePermissionService: {
-            resolveAccess: vi.fn().mockResolvedValue({}),
+            resolveAccess: vi.fn().mockResolvedValue({
+                organizationUuid: ORG_UUID,
+                projectUuid: PROJECT_UUID,
+                inheritsFromOrgOrProject: false,
+                access: [],
+                admins: [],
+                directOnly: false,
+            }),
         } as never,
         coderService: {} as never,
         dashboardService: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
@@ -7,8 +7,10 @@ import {
 } from '@lightdash/common';
 import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
 import { type AppModel } from '../../../models/AppModel';
+import { type AccessContextForCasl } from '../../../services/SpaceService/SpacePermissionService';
 
 export type AppViewAuthzApp = {
+    app_id: string;
     project_uuid: string;
     space_uuid: string | null;
     created_by_user_uuid: string;
@@ -27,43 +29,45 @@ export type AppViewAuthzDeps = {
     auditedAbility: CaslAuditWrapper<Ability>;
     resolveAccess: (
         userUuid: string,
-        spaceUuid: string,
-    ) => Promise<Record<string, unknown>>;
+        app: AppViewAuthzApp,
+    ) => Promise<AccessContextForCasl>;
     getProjectContext: (projectUuid: string) => Promise<DataAppProjectContext>;
 };
 
-async function userCanViewApp(
+export type AppViewAuthorizationContext = DataAppProjectContext &
+    AccessContextForCasl & {
+        createdByUserUuid: string;
+    };
+
+export async function getAppViewAuthorizationContext(
     deps: AppViewAuthzDeps,
-    user: SessionUser,
+    user: Pick<SessionUser, 'userUuid'>,
     app: AppViewAuthzApp,
-): Promise<boolean> {
-    const [spaceContext, projectContext] = await Promise.all([
-        app.space_uuid
-            ? deps.resolveAccess(user.userUuid, app.space_uuid)
-            : Promise.resolve({}),
+): Promise<AppViewAuthorizationContext> {
+    const [accessContext, projectContext] = await Promise.all([
+        deps.resolveAccess(user.userUuid, app),
         deps.getProjectContext(app.project_uuid),
     ]);
-    return deps.auditedAbility.can(
-        'view',
-        subject('DataApp', {
-            ...projectContext,
-            ...spaceContext,
-            createdByUserUuid: app.created_by_user_uuid,
-        }),
-    );
+
+    return {
+        ...projectContext,
+        ...accessContext,
+        createdByUserUuid: app.created_by_user_uuid,
+    };
 }
 
 export async function assertCanViewApp(
     deps: AppViewAuthzDeps,
     user: SessionUser,
     app: AppViewAuthzApp,
-): Promise<void> {
-    const allowed = await userCanViewApp(deps, user, app);
-    if (!allowed) {
+): Promise<AppViewAuthorizationContext> {
+    const context = await getAppViewAuthorizationContext(deps, user, app);
+    if (deps.auditedAbility.cannot('view', subject('DataApp', context))) {
         throw new ForbiddenError(
             'Insufficient permissions to access this data app',
         );
     }
+    return context;
 }
 
 export type EmbeddedAppViewAuthzDeps = {

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -175,7 +175,14 @@ function buildService(opts: {
         externalConnectionModel: model as never,
         appModel: {} as never,
         spacePermissionService: {
-            resolveAccess: vi.fn().mockResolvedValue({}),
+            resolveAccess: vi.fn().mockResolvedValue({
+                organizationUuid: orgUuid,
+                projectUuid,
+                inheritsFromOrgOrProject: false,
+                access: [],
+                admins: [],
+                directOnly: false,
+            }),
         } as never,
         analytics: { track: vi.fn() } as never,
         googleTokenProvider: {

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -623,10 +623,13 @@ export class ExternalConnectionService extends BaseService {
             await assertCanViewApp(
                 {
                     auditedAbility: this.createAuditedAbility(user),
-                    resolveAccess: (userUuid, spaceUuid) =>
+                    resolveAccess: (userUuid, targetApp) =>
                         this.spacePermissionService.resolveAccess(userUuid, {
-                            type: 'space',
-                            spaceUuid,
+                            type: 'app',
+                            appUuid: targetApp.app_id,
+                            organizationUuid: targetApp.organization_uuid,
+                            projectUuid: targetApp.project_uuid,
+                            spaceUuid: targetApp.space_uuid,
                         }),
                     getProjectContext: (appProjectUuid) =>
                         this.getDataAppProjectContext(appProjectUuid),

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -13488,6 +13488,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'union',
             subSchemas: [
+                { dataType: 'enum', enums: ['app'] },
                 { dataType: 'enum', enums: ['dashboard'] },
                 { dataType: 'enum', enums: ['saved_chart'] },
                 { dataType: 'enum', enums: ['sql_chart'] },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14229,7 +14229,7 @@
             },
             "GrantSource": {
                 "type": "string",
-                "enum": ["dashboard", "saved_chart", "sql_chart"]
+                "enum": ["app", "dashboard", "saved_chart", "sql_chart"]
             },
             "SpaceAccess": {
                 "properties": {

--- a/packages/backend/src/models/AppAccessModel.integration.test.ts
+++ b/packages/backend/src/models/AppAccessModel.integration.test.ts
@@ -1,0 +1,217 @@
+import {
+    ProjectMemberRole,
+    SEED_ORG_1_ADMIN,
+    SEED_PROJECT,
+    SpaceMemberRole,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { randomUUID } from 'node:crypto';
+import {
+    AppGroupAccessTableName,
+    AppUserAccessTableName,
+} from '../database/entities/appAccess';
+import { AppsTableName } from '../database/entities/apps';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { GroupTableName } from '../database/entities/groups';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectTableName } from '../database/entities/projects';
+import { SpaceTableName } from '../database/entities/spaces';
+import { UserTableName } from '../database/entities/users';
+import { getTestContext } from '../vitest.setup.integration';
+import { AppAccessModel } from './AppAccessModel';
+
+describe('AppAccessModel PostgreSQL integration', () => {
+    let database: Knex;
+    let transaction: Knex.Transaction;
+    let model: AppAccessModel;
+    let organizationId: number;
+    let organizationUuid: string;
+    let projectUuid: string;
+    let spaceUuid: string;
+    let userId: number;
+    let personalAppUuid: string;
+    let spaceAppUuid: string;
+    let groupUuid: string;
+
+    beforeAll(() => {
+        database = getTestContext().db;
+    });
+
+    beforeEach(async () => {
+        transaction = await database.transaction();
+        model = new AppAccessModel(transaction);
+
+        const projectSpace = await transaction(SpaceTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(
+                `${ProjectTableName}.project_uuid`,
+                SEED_PROJECT.project_uuid,
+            )
+            .select<{
+                organizationId: number;
+                organizationUuid: string;
+                projectUuid: string;
+                spaceUuid: string;
+            }>({
+                organizationId: `${OrganizationTableName}.organization_id`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+                spaceUuid: `${SpaceTableName}.space_uuid`,
+            })
+            .first();
+        const seedUser = await transaction(UserTableName)
+            .where('user_uuid', SEED_ORG_1_ADMIN.user_uuid)
+            .first<{ userId: number }>({ userId: 'user_id' });
+        if (projectSpace === undefined || seedUser === undefined) {
+            throw new Error('Seed app access fixtures not found');
+        }
+        ({ organizationId, organizationUuid, projectUuid, spaceUuid } =
+            projectSpace);
+        userId = seedUser.userId;
+
+        [personalAppUuid, spaceAppUuid] = await Promise.all(
+            [null, spaceUuid].map(async (appSpaceUuid) => {
+                const [inserted] = await transaction(AppsTableName)
+                    .insert({
+                        project_uuid: projectUuid,
+                        created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                        slug: `app-access-${randomUUID()}`,
+                        space_uuid: appSpaceUuid,
+                    })
+                    .returning('app_id');
+                return inserted.app_id;
+            }),
+        );
+
+        const [group] = await transaction(GroupTableName)
+            .insert({
+                organization_id: organizationId,
+                name: `App access ${randomUUID()}`,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                updated_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })
+            .returning('group_uuid');
+        groupUuid = group.group_uuid;
+        await transaction(GroupMembershipTableName).insert({
+            organization_id: organizationId,
+            group_uuid: groupUuid,
+            user_id: userId,
+        });
+        await transaction(ProjectGroupAccessTableName).insert({
+            project_uuid: projectUuid,
+            group_uuid: groupUuid,
+            role: ProjectMemberRole.VIEWER,
+        });
+        await transaction(AppUserAccessTableName).insert(
+            [personalAppUuid, spaceAppUuid].map((appUuid) => ({
+                app_uuid: appUuid,
+                user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                space_role: SpaceMemberRole.VIEWER,
+                granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })),
+        );
+        await transaction(AppGroupAccessTableName).insert(
+            [personalAppUuid, spaceAppUuid].map((appUuid) => ({
+                app_uuid: appUuid,
+                group_uuid: groupUuid,
+                space_role: SpaceMemberRole.EDITOR,
+                granted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })),
+        );
+    });
+
+    afterEach(async () => {
+        if (!transaction.isCompleted()) {
+            await transaction.rollback();
+        }
+    });
+
+    it('resolves direct user and group roles for personal and space-backed apps', async () => {
+        await expect(
+            model.getUserAccess(
+                [personalAppUuid, spaceAppUuid],
+                SEED_ORG_1_ADMIN.user_uuid,
+                { organizationUuid },
+            ),
+        ).resolves.toEqual({
+            [personalAppUuid]: {
+                organizationUuid,
+                projectUuid,
+                spaceUuid: null,
+                userRole: SpaceMemberRole.VIEWER,
+                groupRoles: [SpaceMemberRole.EDITOR],
+            },
+            [spaceAppUuid]: {
+                organizationUuid,
+                projectUuid,
+                spaceUuid,
+                userRole: SpaceMemberRole.VIEWER,
+                groupRoles: [SpaceMemberRole.EDITOR],
+            },
+        });
+    });
+
+    it('tracks moves without transferring grants to new app identities', async () => {
+        await transaction(AppsTableName)
+            .where('app_id', personalAppUuid)
+            .update({ space_uuid: spaceUuid });
+        await expect(
+            model.getUserAccess([personalAppUuid], SEED_ORG_1_ADMIN.user_uuid, {
+                organizationUuid,
+            }),
+        ).resolves.toHaveProperty(`${personalAppUuid}.spaceUuid`, spaceUuid);
+
+        const [copy] = await transaction(AppsTableName)
+            .insert({
+                project_uuid: projectUuid,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                slug: `app-access-copy-${randomUUID()}`,
+                space_uuid: spaceUuid,
+            })
+            .returning('app_id');
+        await expect(
+            model.getUserAccess([copy.app_id], SEED_ORG_1_ADMIN.user_uuid, {
+                organizationUuid,
+            }),
+        ).resolves.toEqual({});
+    });
+
+    it('supports deleted-app lifecycle authorization without cross-org access', async () => {
+        await transaction(AppsTableName)
+            .where('app_id', personalAppUuid)
+            .update({
+                deleted_at: new Date(),
+                deleted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            });
+        await expect(
+            model.getUserAccess([personalAppUuid], SEED_ORG_1_ADMIN.user_uuid, {
+                organizationUuid,
+            }),
+        ).resolves.toEqual({});
+        await expect(
+            model.getUserAccess([personalAppUuid], SEED_ORG_1_ADMIN.user_uuid, {
+                organizationUuid,
+                includeDeleted: true,
+            }),
+        ).resolves.toHaveProperty(
+            `${personalAppUuid}.userRole`,
+            SpaceMemberRole.VIEWER,
+        );
+        await expect(
+            model.getUserAccess([personalAppUuid], SEED_ORG_1_ADMIN.user_uuid, {
+                organizationUuid: randomUUID(),
+                includeDeleted: true,
+            }),
+        ).resolves.toEqual({});
+    });
+});

--- a/packages/backend/src/models/AppAccessModel.ts
+++ b/packages/backend/src/models/AppAccessModel.ts
@@ -1,0 +1,192 @@
+import { type Knex } from 'knex';
+import {
+    AppGroupAccessTableName,
+    AppUserAccessTableName,
+} from '../database/entities/appAccess';
+import { AppsTableName } from '../database/entities/apps';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectTableName } from '../database/entities/projects';
+import { SpaceTableName } from '../database/entities/spaces';
+import { UserTableName } from '../database/entities/users';
+import {
+    getActiveGrantedGroupPredicate,
+    getActiveProjectMemberPredicate,
+    groupDirectAccessRows,
+    type DirectAccess,
+    type DirectAccessRow,
+} from './directAccessModelUtils';
+
+export class AppAccessModel {
+    constructor(private readonly database: Knex) {}
+
+    async getUserAccess(
+        appUuids: string[],
+        userUuid: string,
+        {
+            trx = this.database,
+            organizationUuid,
+            includeDeleted = false,
+        }: {
+            trx?: Knex;
+            organizationUuid: string;
+            includeDeleted?: boolean;
+        },
+    ): Promise<Record<string, DirectAccess>> {
+        const uniqueAppUuids = [...new Set(appUuids)];
+        if (uniqueAppUuids.length === 0) {
+            return {};
+        }
+
+        const joinAppProject = (join: Knex.JoinClause) => {
+            join.on(
+                `${ProjectTableName}.project_uuid`,
+                `${AppsTableName}.project_uuid`,
+            );
+        };
+        const joinAppSpace = (join: Knex.JoinClause) => {
+            join.on(
+                `${SpaceTableName}.space_uuid`,
+                `${AppsTableName}.space_uuid`,
+            ).andOn(
+                `${SpaceTableName}.project_id`,
+                `${ProjectTableName}.project_id`,
+            );
+        };
+        const whereAppLocationIsActive = (query: Knex.QueryBuilder) => {
+            void query
+                .whereNull(`${AppsTableName}.space_uuid`)
+                .orWhere((spaceApp) => {
+                    void spaceApp
+                        .whereNotNull(`${SpaceTableName}.space_uuid`)
+                        .whereNull(`${SpaceTableName}.deleted_at`);
+                });
+        };
+
+        const rows: DirectAccessRow[] = await trx(AppUserAccessTableName)
+            .select({
+                resourceUuid: `${AppUserAccessTableName}.app_uuid`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+                spaceUuid: `${AppsTableName}.space_uuid`,
+                role: `${AppUserAccessTableName}.space_role`,
+                groupUuid: trx.raw('NULL'),
+            })
+            .innerJoin(
+                AppsTableName,
+                `${AppsTableName}.app_id`,
+                `${AppUserAccessTableName}.app_uuid`,
+            )
+            .innerJoin(ProjectTableName, joinAppProject)
+            .leftJoin(SpaceTableName, joinAppSpace)
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_uuid`,
+                `${AppUserAccessTableName}.user_uuid`,
+            )
+            .innerJoin(
+                OrganizationMembershipsTableName,
+                function joinCurrentOrganizationMembership() {
+                    this.on(
+                        `${OrganizationMembershipsTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOn(
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    );
+                },
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .whereIn(`${AppUserAccessTableName}.app_uuid`, uniqueAppUuids)
+            .where(`${AppUserAccessTableName}.user_uuid`, userUuid)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(getActiveProjectMemberPredicate(trx))
+            .modify((query) => {
+                if (!includeDeleted) {
+                    void query.whereNull(`${AppsTableName}.deleted_at`);
+                }
+            })
+            .where(whereAppLocationIsActive)
+            .unionAll(
+                trx(AppGroupAccessTableName)
+                    .select({
+                        resourceUuid: `${AppGroupAccessTableName}.app_uuid`,
+                        organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                        projectUuid: `${ProjectTableName}.project_uuid`,
+                        spaceUuid: `${AppsTableName}.space_uuid`,
+                        role: `${AppGroupAccessTableName}.space_role`,
+                        groupUuid: `${AppGroupAccessTableName}.group_uuid`,
+                    })
+                    .innerJoin(
+                        AppsTableName,
+                        `${AppsTableName}.app_id`,
+                        `${AppGroupAccessTableName}.app_uuid`,
+                    )
+                    .innerJoin(ProjectTableName, joinAppProject)
+                    .leftJoin(SpaceTableName, joinAppSpace)
+                    .innerJoin(
+                        OrganizationTableName,
+                        `${OrganizationTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    )
+                    .innerJoin(
+                        GroupMembershipTableName,
+                        `${GroupMembershipTableName}.group_uuid`,
+                        `${AppGroupAccessTableName}.group_uuid`,
+                    )
+                    .innerJoin(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${GroupMembershipTableName}.user_id`,
+                    )
+                    .innerJoin(
+                        OrganizationMembershipsTableName,
+                        function joinCurrentOrganizationMembership() {
+                            this.on(
+                                `${OrganizationMembershipsTableName}.user_id`,
+                                `${UserTableName}.user_id`,
+                            ).andOn(
+                                `${OrganizationMembershipsTableName}.organization_id`,
+                                `${ProjectTableName}.organization_id`,
+                            );
+                        },
+                    )
+                    .whereIn(
+                        `${AppGroupAccessTableName}.app_uuid`,
+                        uniqueAppUuids,
+                    )
+                    .where(`${UserTableName}.user_uuid`, userUuid)
+                    .where(
+                        `${OrganizationTableName}.organization_uuid`,
+                        organizationUuid,
+                    )
+                    .where(getActiveProjectMemberPredicate(trx))
+                    .where(
+                        `${GroupMembershipTableName}.organization_id`,
+                        trx.ref(`${ProjectTableName}.organization_id`),
+                    )
+                    .where(
+                        getActiveGrantedGroupPredicate(
+                            trx,
+                            AppGroupAccessTableName,
+                        ),
+                    )
+                    .modify((query) => {
+                        if (!includeDeleted) {
+                            void query.whereNull(`${AppsTableName}.deleted_at`);
+                        }
+                    })
+                    .where(whereAppLocationIsActive),
+            );
+
+        return groupDirectAccessRows(rows);
+    }
+}

--- a/packages/backend/src/models/DirectAccessModels.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.test.ts
@@ -2,8 +2,10 @@ import { SpaceMemberRole } from '@lightdash/common';
 import knex, { type Knex } from 'knex';
 import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
 import { lightdashConfigMock } from '../config/lightdashConfig.mock';
+import { AppUserAccessTableName } from '../database/entities/appAccess';
 import { DashboardUserAccessTableName } from '../database/entities/dashboardAccess';
 import { type UtilRepository } from '../utils/UtilRepository';
+import { AppAccessModel } from './AppAccessModel';
 import { DashboardAccessModel } from './DashboardAccessModel';
 import { ModelRepository } from './ModelRepository';
 
@@ -71,6 +73,64 @@ describe('dashboard direct access read model', () => {
     });
 });
 
+describe('app direct access read model', () => {
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('does not query for an empty resource list', async () => {
+        await expect(
+            new AppAccessModel(database).getUserAccess([], 'user-uuid', {
+                organizationUuid: 'organization-uuid',
+            }),
+        ).resolves.toEqual({});
+        expect(tracker.history.select).toHaveLength(0);
+    });
+
+    it('preserves personal app location while grouping user and group roles', async () => {
+        tracker.on.select(AppUserAccessTableName).responseOnce([
+            {
+                resourceUuid: 'app-a',
+                organizationUuid: 'organization-uuid',
+                projectUuid: 'project-uuid',
+                spaceUuid: null,
+                role: SpaceMemberRole.VIEWER,
+                groupUuid: null,
+            },
+            {
+                resourceUuid: 'app-a',
+                organizationUuid: 'organization-uuid',
+                projectUuid: 'project-uuid',
+                spaceUuid: null,
+                role: SpaceMemberRole.EDITOR,
+                groupUuid: 'group-a',
+            },
+        ]);
+
+        await expect(
+            new AppAccessModel(database).getUserAccess(
+                ['app-a', 'app-a'],
+                'user-uuid',
+                { organizationUuid: 'organization-uuid' },
+            ),
+        ).resolves.toEqual({
+            'app-a': {
+                organizationUuid: 'organization-uuid',
+                projectUuid: 'project-uuid',
+                spaceUuid: null,
+                userRole: SpaceMemberRole.VIEWER,
+                groupRoles: [SpaceMemberRole.EDITOR],
+            },
+        });
+    });
+});
+
 describe('dashboard direct access model wiring', () => {
     it('exposes a memoized DashboardAccessModel', () => {
         const models = new ModelRepository({
@@ -84,5 +144,17 @@ describe('dashboard direct access model wiring', () => {
         expect(models.getDashboardAccessModel()).toBe(
             models.getDashboardAccessModel(),
         );
+    });
+});
+
+describe('app direct access model wiring', () => {
+    it('exposes a memoized AppAccessModel', () => {
+        const models = new ModelRepository({
+            database: {} as Knex,
+            lightdashConfig: lightdashConfigMock,
+            utils: {} as UtilRepository,
+        });
+        expect(models.getAppAccessModel()).toBeInstanceOf(AppAccessModel);
+        expect(models.getAppAccessModel()).toBe(models.getAppAccessModel());
     });
 });

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -4,6 +4,7 @@ import { PreAggregateDailyStatsModel } from '../ee/models/PreAggregateDailyStats
 import { PreAggregateModel } from '../ee/models/PreAggregateModel';
 import { type UtilRepository } from '../utils/UtilRepository';
 import { AnalyticsModel } from './AnalyticsModel';
+import { AppAccessModel } from './AppAccessModel';
 import { AppModel } from './AppModel';
 import { CatalogModel } from './CatalogModel/CatalogModel';
 import { CommentModel } from './CommentModel/CommentModel';
@@ -88,6 +89,7 @@ import { WarehouseConnectCodeModel } from './WarehouseConnectCodeModel';
 
 export type ModelManifest = {
     analyticsModel: AnalyticsModel;
+    appAccessModel: AppAccessModel;
     appModel: AppModel;
     commentModel: CommentModel;
     dashboardModel: DashboardModel;
@@ -291,6 +293,13 @@ export class ModelRepository
         return this.getModel(
             'analyticsModel',
             () => new AnalyticsModel({ database: this.database }),
+        );
+    }
+
+    public getAppAccessModel(): AppAccessModel {
+        return this.getModel(
+            'appAccessModel',
+            () => new AppAccessModel(this.database),
         );
     }
 

--- a/packages/backend/src/models/directAccessModelUtils.ts
+++ b/packages/backend/src/models/directAccessModelUtils.ts
@@ -16,9 +16,9 @@ import { UserTableName } from '../database/entities/users';
 export type DirectAccess = {
     organizationUuid: UUID;
     projectUuid: UUID;
-    // Space the granted resource actually lives in; lets callers verify the
-    // grant belongs to the space context they are extending.
-    spaceUuid: UUID;
+    // Space the granted resource actually lives in; personal apps have no
+    // space and use their project context as the authorization baseline.
+    spaceUuid: UUID | null;
     userRole: SpaceMemberRole | null;
     groupRoles: SpaceMemberRole[];
 };
@@ -27,7 +27,7 @@ export type DirectAccessRow = {
     resourceUuid: UUID;
     organizationUuid: UUID;
     projectUuid: UUID;
-    spaceUuid: UUID;
+    spaceUuid: UUID | null;
     role: SpaceMemberRole;
     groupUuid: UUID | null;
 };

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -191,7 +191,7 @@ const lookupSpaceContext = (spaceUuid: string) => {
 
 const spacePermissionService = {
     resolveAccess: vi.fn(async (_userUuid: string, target: AccessTarget) => ({
-        ...lookupSpaceContext(target.spaceUuid),
+        ...lookupSpaceContext(target.spaceUuid ?? ''),
         directOnly: false,
     })),
     resolveAccessBatch: vi.fn(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1143,6 +1143,7 @@ export class ServiceRepository
                 new SpacePermissionService({
                     spaceModel: this.models.getSpaceModel(),
                     spacePermissionModel: this.models.getSpacePermissionModel(),
+                    appAccessModel: this.models.getAppAccessModel(),
                     dashboardAccessModel: this.models.getDashboardAccessModel(),
                     savedChartAccessModel:
                         this.models.getSavedChartAccessModel(),

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -100,6 +100,9 @@ describe('SpacePermissionService', () => {
         spaceModel: {} as SpaceModel,
         spacePermissionModel:
             mockPermissionModel as unknown as SpacePermissionModel,
+        appAccessModel: {
+            getUserAccess: vi.fn(async () => ({})),
+        } as never,
         dashboardAccessModel:
             dashboardAccessModel as unknown as DashboardAccessModel,
         savedChartAccessModel: {
@@ -1812,14 +1815,19 @@ describe('resolveAccess', () => {
     const createService = ({
         enabled,
         grants = {},
+        appGrants = {},
         context = spaceContext,
     }: {
         enabled: boolean;
         grants?: Record<string, unknown>;
+        appGrants?: Record<string, unknown>;
         context?: typeof spaceContext;
     }) => {
         const dashboardAccessModel = {
             getUserAccess: vi.fn(async () => grants),
+        };
+        const appAccessModel = {
+            getUserAccess: vi.fn(async () => appGrants),
         };
         const directAccessFeatureGate = {
             isEnabledForUser: vi.fn(async () => enabled),
@@ -1827,6 +1835,7 @@ describe('resolveAccess', () => {
         const service = new SpacePermissionService({
             spaceModel: {} as SpaceModel,
             spacePermissionModel: {} as unknown as SpacePermissionModel,
+            appAccessModel: appAccessModel as never,
             dashboardAccessModel:
                 dashboardAccessModel as unknown as DashboardAccessModel,
             savedChartAccessModel: {
@@ -1839,7 +1848,12 @@ describe('resolveAccess', () => {
                 directAccessFeatureGate as unknown as DirectAccessFeatureGate,
         });
         mockSpaceContexts(service, { 'space-uuid': context });
-        return { service, dashboardAccessModel, directAccessFeatureGate };
+        return {
+            service,
+            appAccessModel,
+            dashboardAccessModel,
+            directAccessFeatureGate,
+        };
     };
 
     test('returns the plain space context while the feature is off', async () => {
@@ -1997,6 +2011,113 @@ describe('resolveAccess', () => {
             service.resolveAccess('user-uuid', dashboardTarget),
         ).rejects.toThrow(ParameterError);
     });
+
+    test.each([
+        { label: 'personal', spaceUuid: null },
+        { label: 'space-backed', spaceUuid: 'space-uuid' },
+    ])('appends direct app grants for $label apps', async ({ spaceUuid }) => {
+        const { service, appAccessModel } = createService({
+            enabled: true,
+            appGrants: {
+                'app-uuid': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    spaceUuid,
+                    userRole: SpaceMemberRole.VIEWER,
+                    groupRoles: [SpaceMemberRole.EDITOR],
+                },
+            },
+        });
+
+        const result = await service.resolveAccess('user-uuid', {
+            type: 'app',
+            appUuid: 'app-uuid',
+            organizationUuid: 'organization-uuid',
+            projectUuid: 'project-uuid',
+            spaceUuid,
+        });
+
+        expect(result).toMatchObject({
+            organizationUuid: 'organization-uuid',
+            projectUuid: 'project-uuid',
+            directOnly: true,
+            access: [
+                {
+                    userUuid: 'user-uuid',
+                    role: SpaceMemberRole.VIEWER,
+                    grantedVia: 'app',
+                },
+                {
+                    userUuid: 'user-uuid',
+                    role: SpaceMemberRole.EDITOR,
+                    grantedVia: 'app',
+                },
+            ],
+        });
+        expect(appAccessModel.getUserAccess).toHaveBeenCalledWith(
+            ['app-uuid'],
+            'user-uuid',
+            { organizationUuid: 'organization-uuid' },
+        );
+    });
+
+    test('keeps personal app grants inert while direct access is disabled', async () => {
+        const { service, appAccessModel } = createService({
+            enabled: false,
+            appGrants: {
+                'app-uuid': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    spaceUuid: null,
+                    userRole: SpaceMemberRole.VIEWER,
+                    groupRoles: [],
+                },
+            },
+        });
+
+        await expect(
+            service.resolveAccess('user-uuid', {
+                type: 'app',
+                appUuid: 'app-uuid',
+                organizationUuid: 'organization-uuid',
+                projectUuid: 'project-uuid',
+                spaceUuid: null,
+            }),
+        ).resolves.toEqual({
+            organizationUuid: 'organization-uuid',
+            projectUuid: 'project-uuid',
+            inheritsFromOrgOrProject: false,
+            access: [],
+            admins: [],
+            directOnly: false,
+        });
+        expect(appAccessModel.getUserAccess).not.toHaveBeenCalled();
+    });
+
+    test('rejects app references whose resolved location does not match', async () => {
+        const { service } = createService({
+            enabled: true,
+            appGrants: {
+                'app-uuid': {
+                    organizationUuid: 'organization-uuid',
+                    projectUuid: 'project-uuid',
+                    spaceUuid: null,
+                    userRole: SpaceMemberRole.VIEWER,
+                    groupRoles: [],
+                },
+            },
+        });
+
+        await expect(
+            service.resolveAccess('user-uuid', {
+                type: 'app',
+                appUuid: 'app-uuid',
+                organizationUuid: 'organization-uuid',
+                projectUuid: 'project-uuid',
+                spaceUuid: 'space-uuid',
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
 });
 
 describe('resolveAccessBatch', () => {
@@ -2029,6 +2150,9 @@ describe('resolveAccessBatch', () => {
         const service = new SpacePermissionService({
             spaceModel: {} as SpaceModel,
             spacePermissionModel: {} as unknown as SpacePermissionModel,
+            appAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
             dashboardAccessModel:
                 dashboardAccessModel as unknown as DashboardAccessModel,
             savedChartAccessModel: savedChartAccessModel as never,
@@ -2450,6 +2574,9 @@ describe('resolveAccess space-saved chart target', () => {
         const service = new SpacePermissionService({
             spaceModel: {} as SpaceModel,
             spacePermissionModel: {} as unknown as SpacePermissionModel,
+            appAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
             dashboardAccessModel: {
                 getUserAccess: vi.fn(async () => ({})),
             } as never,
@@ -2551,6 +2678,9 @@ describe('resolveAccess saved SQL chart target', () => {
         const service = new SpacePermissionService({
             spaceModel: {} as SpaceModel,
             spacePermissionModel: {} as unknown as SpacePermissionModel,
+            appAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
             dashboardAccessModel: {
                 getUserAccess: vi.fn(async () => ({})),
             } as never,
@@ -2663,6 +2793,9 @@ describe('resolveAccess chart ownership routing', () => {
         const service = new SpacePermissionService({
             spaceModel: {} as SpaceModel,
             spacePermissionModel: {} as unknown as SpacePermissionModel,
+            appAccessModel: {
+                getUserAccess: vi.fn(async () => ({})),
+            } as never,
             dashboardAccessModel: dashboardAccessModel as never,
             savedChartAccessModel: savedChartAccessModel as never,
             savedSqlAccessModel: {

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -24,6 +24,7 @@ import {
     type SpaceShare,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { type AppAccessModel } from '../../models/AppAccessModel';
 import { type DashboardAccessModel } from '../../models/DashboardAccessModel';
 import { type DirectAccess } from '../../models/directAccessModelUtils';
 import { type SavedChartAccessModel } from '../../models/SavedChartAccessModel';
@@ -61,20 +62,31 @@ export type AccessTarget =
           dashboardUuid: string | null;
           spaceUuid: string;
       }
+    | {
+          type: 'app';
+          appUuid: string;
+          organizationUuid: string;
+          projectUuid: string;
+          spaceUuid: string | null;
+      }
     | { type: 'sqlChart'; savedSqlUuid: string; spaceUuid: string };
 
 // A content type's direct-grant lookup (e.g. DashboardAccessModel.getUserAccess
 // or SavedChartAccessModel.getUserAccess), pre-bound to the requesting user.
 type GrantLookup = (
     resourceUuids: string[],
-    opts: { organizationUuid: string; trx?: Knex },
+    opts: {
+        organizationUuid: string;
+        trx?: Knex;
+        includeDeleted?: boolean;
+    },
 ) => Promise<Record<string, DirectAccess>>;
 
 type DirectGrantTarget = {
     source: GrantSource;
     resourceUuid: string;
     resourceLabel: string;
-    spaceUuid: string;
+    spaceUuid: string | null;
 };
 
 export type AccessContextForCasl = SpaceAccessContextForCasl & {
@@ -108,6 +120,8 @@ export class SpacePermissionService extends BaseService {
 
     private readonly spacePermissionModel: SpacePermissionModel;
 
+    private readonly appAccessModel: AppAccessModel;
+
     private readonly dashboardAccessModel: DashboardAccessModel;
 
     private readonly savedChartAccessModel: SavedChartAccessModel;
@@ -119,6 +133,7 @@ export class SpacePermissionService extends BaseService {
     constructor({
         spaceModel,
         spacePermissionModel,
+        appAccessModel,
         dashboardAccessModel,
         savedChartAccessModel,
         savedSqlAccessModel,
@@ -126,6 +141,7 @@ export class SpacePermissionService extends BaseService {
     }: {
         spaceModel: SpaceModel;
         spacePermissionModel: SpacePermissionModel;
+        appAccessModel: AppAccessModel;
         dashboardAccessModel: DashboardAccessModel;
         savedChartAccessModel: SavedChartAccessModel;
         savedSqlAccessModel: SavedSqlAccessModel;
@@ -134,6 +150,7 @@ export class SpacePermissionService extends BaseService {
         super();
         this.spaceModel = spaceModel;
         this.spacePermissionModel = spacePermissionModel;
+        this.appAccessModel = appAccessModel;
         this.dashboardAccessModel = dashboardAccessModel;
         this.savedChartAccessModel = savedChartAccessModel;
         this.savedSqlAccessModel = savedSqlAccessModel;
@@ -254,11 +271,15 @@ export class SpacePermissionService extends BaseService {
     async resolveAccess(
         userUuid: string,
         target: AccessTarget,
-        { trx }: { trx?: Knex } = {},
+        {
+            trx,
+            includeDeleted = false,
+        }: { trx?: Knex; includeDeleted?: boolean } = {},
     ): Promise<AccessContextForCasl> {
         const [result] = await this.resolveAccessTargets(userUuid, [target], {
             onMismatch: 'throw',
             trx,
+            includeDeleted,
         });
         const context = result?.context;
         if (context === undefined) {
@@ -324,6 +345,13 @@ export class SpacePermissionService extends BaseService {
                     resourceLabel: 'Saved SQL chart',
                     spaceUuid: target.spaceUuid,
                 };
+            case 'app':
+                return {
+                    source: 'app',
+                    resourceUuid: target.appUuid,
+                    resourceLabel: 'Data app',
+                    spaceUuid: target.spaceUuid,
+                };
             default:
                 return assertUnreachable(
                     target,
@@ -355,6 +383,13 @@ export class SpacePermissionService extends BaseService {
                         userUuid,
                         opts,
                     );
+            case 'app':
+                return (resourceUuids, opts) =>
+                    this.appAccessModel.getUserAccess(
+                        resourceUuids,
+                        userUuid,
+                        opts,
+                    );
             default:
                 return assertUnreachable(
                     source,
@@ -369,9 +404,11 @@ export class SpacePermissionService extends BaseService {
         {
             onMismatch,
             trx,
+            includeDeleted = false,
         }: {
             onMismatch: 'throw' | 'fallback';
             trx?: Knex;
+            includeDeleted?: boolean;
         },
     ): Promise<AccessResult<T>[]> {
         if (targets.length === 0) {
@@ -379,37 +416,65 @@ export class SpacePermissionService extends BaseService {
         }
 
         const uniqueSpaceUuids = [
-            ...new Set(targets.map((target) => target.spaceUuid)),
+            ...new Set(
+                targets.flatMap((target) =>
+                    target.spaceUuid === null ? [] : [target.spaceUuid],
+                ),
+            ),
         ];
         const spaceContexts = await this.getSpacesCaslContext(
             uniqueSpaceUuids,
             { userUuid },
             { trx },
         );
-        const spaceOnly = (target: T): AccessContextForCasl | undefined => {
-            const context = spaceContexts[target.spaceUuid];
-            return context ? { ...context, directOnly: false } : undefined;
+        const baselineOnly = (target: T): AccessContextForCasl | undefined => {
+            if (target.spaceUuid === null) {
+                if (target.type !== 'app') {
+                    return undefined;
+                }
+                return {
+                    organizationUuid: target.organizationUuid,
+                    projectUuid: target.projectUuid,
+                    inheritsFromOrgOrProject: false,
+                    access: [],
+                    admins: [],
+                    directOnly: false,
+                };
+            }
+            const { spaceUuid } = target;
+            const context = spaceContexts[spaceUuid];
+            if (context === undefined) {
+                return undefined;
+            }
+            if (
+                target.type === 'app' &&
+                (context.organizationUuid !== target.organizationUuid ||
+                    context.projectUuid !== target.projectUuid)
+            ) {
+                return undefined;
+            }
+            return { ...context, directOnly: false };
         };
         const resultFor = (
             target: T,
             context: AccessContextForCasl | undefined,
         ): AccessResult<T> => ({ target, context });
         const grantTargets = targets.flatMap((target) => {
-            const spaceContext = spaceContexts[target.spaceUuid];
+            const baselineContext = baselineOnly(target);
             const grantTarget =
                 SpacePermissionService.getDirectGrantTarget(target);
-            return grantTarget && spaceContext
+            return grantTarget && baselineContext
                 ? [
                       {
                           ...grantTarget,
-                          organizationUuid: spaceContext.organizationUuid,
+                          organizationUuid: baselineContext.organizationUuid,
                       },
                   ]
                 : [];
         });
         if (grantTargets.length === 0) {
             return targets.map((target) =>
-                resultFor(target, spaceOnly(target)),
+                resultFor(target, baselineOnly(target)),
             );
         }
 
@@ -432,7 +497,7 @@ export class SpacePermissionService extends BaseService {
             });
         if (!directAccessEnabled) {
             return targets.map((target) =>
-                resultFor(target, spaceOnly(target)),
+                resultFor(target, baselineOnly(target)),
             );
         }
 
@@ -448,7 +513,13 @@ export class SpacePermissionService extends BaseService {
                 source,
                 grants: await this.getGrantLookup(userUuid, source)(
                     [...resourceUuids],
-                    trx ? { organizationUuid, trx } : { organizationUuid },
+                    {
+                        organizationUuid,
+                        ...(trx ? { trx } : {}),
+                        ...(source === 'app' && includeDeleted
+                            ? { includeDeleted: true }
+                            : {}),
+                    },
                 ),
             })),
         );
@@ -458,24 +529,24 @@ export class SpacePermissionService extends BaseService {
         >(grantResults.map(({ source, grants }) => [source, grants]));
 
         return targets.map((target) => {
-            const spaceContext = spaceContexts[target.spaceUuid];
+            const baselineContext = baselineOnly(target);
             const grantTarget =
                 SpacePermissionService.getDirectGrantTarget(target);
-            if (spaceContext === undefined || grantTarget === undefined) {
-                return resultFor(target, spaceOnly(target));
+            if (baselineContext === undefined || grantTarget === undefined) {
+                return resultFor(target, baselineContext);
             }
             const grant = grantsBySource.get(grantTarget.source)?.[
                 grantTarget.resourceUuid
             ];
             if (grant === undefined) {
-                return resultFor(target, spaceOnly(target));
+                return resultFor(target, baselineContext);
             }
             const grantRoles = [
                 ...(grant.userRole ? [grant.userRole] : []),
                 ...grant.groupRoles,
             ];
             if (grantRoles.length === 0) {
-                return resultFor(target, spaceOnly(target));
+                return resultFor(target, baselineContext);
             }
             const isMismatched = grant.spaceUuid !== target.spaceUuid;
             if (isMismatched && onMismatch === 'throw') {
@@ -484,12 +555,12 @@ export class SpacePermissionService extends BaseService {
                 );
             }
             if (isMismatched) {
-                return resultFor(target, spaceOnly(target));
+                return resultFor(target, baselineContext);
             }
             return resultFor(
                 target,
                 SpacePermissionService.withGrantAccess(
-                    spaceContext,
+                    baselineContext,
                     userUuid,
                     grantRoles,
                     grantTarget.source,

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -156,7 +156,7 @@ export type SpaceInheritanceChain = {
 
 // Which content type's direct grant synthesized an access row. Grows one
 // member per content type that ships direct grants.
-export type GrantSource = 'dashboard' | 'saved_chart' | 'sql_chart';
+export type GrantSource = 'app' | 'dashboard' | 'saved_chart' | 'sql_chart';
 
 // Access data for checking Space access permissions with CASL where only the role/access data matters.
 export type SpaceAccess = {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1252/stack-4-apply-viewer-scoped-direct-access-to-data-apps

## Summary

PR 4 of 5 for SPK-1252. Applies direct user and group grants to data apps as if the app lived in a virtual one-app space: the existing DataApp Viewer, Editor, and Admin CASL rules remain the source of truth.

This stack consumes grants only. Shared access-management handlers and routes remain in Stack 5.

## Changes

- Adds a read-only `AppAccessModel` for personal and space-backed apps.
- Extends the shared `GrantSource` union with `app` and routes app targets through `SpacePermissionService` alongside dashboard, saved-chart, and saved-SQL grants.
- Appends direct roles as ordinary access rows tagged `grantedVia: 'app'`; existing space access remains additive.
- Batches app access resolution on search/list filtering instead of issuing one grant lookup per app.
- Reuses existing DataApp abilities across runtime, versions, authoring, visualization, linked external connections, and lifecycle operations.
- Keeps inaccessible parent-space metadata private for direct-only users in version responses, search results, promotion placement, and content-as-code manifests.
- Preserves grants when the same app moves or is soft-deleted/restored; new app identities receive no grants.
- Reauthorizes the recorded session user when queued generation and source-build jobs start.
- Keeps explicit preview tokens on their existing stateless authorization contract, matching ordinary space-backed apps.
- Makes no SessionUser/RegisteredAccount conversion changes and adds no public or internal grant-management handler.

## Authorization flow

```text
user/group app grant ---> ordinary access row (`grantedVia: app`)
                                      |
                                      +--> existing DataApp Viewer/Editor/Admin rules

real parent space access ---> existing space path
direct-only access --------> parent metadata remains hidden
```

## Size

- Production: 608 additions, 154 deletions (762 changed lines)
- Tests: 800 additions, 11 deletions (811 changed lines)
- Total: 1,573 changed lines

The production delta is below 1K; the remaining difference from the saved-chart read PR is app-specific personal-app, async-build, version, promotion, and runtime integration.

## Test plan

- [x] Changed backend unit suite: 16 files, 345 tests
- [x] PostgreSQL `AppAccessModel` integration suite: 3 tests
- [x] `pnpm -F common typecheck`
- [x] `pnpm -F backend typecheck`
- [x] Full backend/common lint
- [x] Full backend/common formatting checks
- [x] Regenerated API schema for the additive `GrantSource` enum member
- [x] Rebased onto `origin/main` at `525672938d`

Local integration setup lacks a `dbt1.12` executable, so the unrelated seed compilation used the installed `dbt1.11` binary through a temporary command shim; the PostgreSQL app-access assertions themselves ran normally.

## Notes

This follows the chart/dashboard single-kernel pattern: read-side grants are resolved in `SpacePermissionService`, while grant-management API work is a separate stack.

## Live permission validation

- [x] Live API/PostgreSQL permission matrix: 50/50 scenarios passed on pushed head `7cad4399ab`
- [x] Covers user/group Viewer, Editor, and Admin; additive space access; scope and membership failures; personal apps; parent masking; search; moves; restore; and queued-worker reauthorization
- [x] Revoking access after enqueue fails closed before sandbox or LLM generation
- [x] Fixtures removed and seeded user plus API/scheduler environment restored
