### PR TITLE
feat(ai-agent): data app build card with Storybook states

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.module.css
@@ -1,0 +1,69 @@
+.card {
+    container-type: inline-size;
+    /* ThemeIcon size="sm"; body text indents past it to line up with the title. */
+    --card-icon-size: 22px;
+}
+
+.cardUnavailable {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-7)
+    );
+}
+
+/* Two columns: leading cells on the left, actions on the right; full-width
+   cells (body, narration) span both. Auto-placement keeps the actions on the
+   same row as whatever leading cell precedes them. */
+.layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    column-gap: var(--mantine-spacing-sm);
+    row-gap: var(--mantine-spacing-xs);
+    align-items: center;
+    align-content: start;
+}
+
+.lead {
+    grid-column: 1;
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    min-width: 0;
+}
+
+.leadText {
+    min-width: 0;
+}
+
+.full {
+    grid-column: 1 / -1;
+}
+
+.body {
+    grid-column: 1 / -1;
+    padding-left: calc(var(--card-icon-size) + var(--mantine-spacing-xs));
+}
+
+.actions {
+    grid-column: 2;
+    justify-self: end;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+}
+
+/* Phone width: one column, actions always last. */
+@container (max-width: 420px) {
+    .layout {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    .lead,
+    .actions {
+        grid-column: 1;
+    }
+    .actions {
+        order: 100;
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.test.tsx
@@ -1,0 +1,206 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../../testing/testUtils';
+import { DataAppBuildCard } from './DataAppBuildCard';
+
+const noop = () => undefined;
+
+describe('DataAppBuildCard', () => {
+    it('queued: explains the wait and offers the builder', async () => {
+        const onOpenBuilder = vi.fn();
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{ kind: 'queued' }}
+                compact={false}
+                onOpenBuilder={onOpenBuilder}
+                onView={noop}
+            />,
+        );
+        expect(screen.getByText('Building data app')).toBeVisible();
+        expect(
+            screen.getByText(
+                'Starting the build. This can take a few minutes.',
+            ),
+        ).toBeVisible();
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Continue in builder' }),
+        );
+        expect(onOpenBuilder).toHaveBeenCalledTimes(1);
+    });
+
+    it('building: shows the live status message and narration rows', () => {
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{
+                    kind: 'building',
+                    statusMessage: 'Building your app',
+                    narration: {
+                        reasoning: ['Totals should reconcile against revenue'],
+                        activity: ['Ran 5 queries'],
+                    },
+                }}
+                compact={false}
+                onOpenBuilder={noop}
+                onView={noop}
+            />,
+        );
+        expect(screen.getByText('Building data app')).toBeVisible();
+        expect(screen.getByText('Building your app')).toBeVisible();
+        expect(screen.getByText('Reasoning')).toBeVisible();
+        expect(screen.getByText('Activity')).toBeVisible();
+        expect(
+            screen.getByText(
+                "Builds in the background, so it's safe to close the tab.",
+            ),
+        ).toBeVisible();
+        expect(
+            screen.getByRole('button', { name: 'Continue in builder' }),
+        ).toBeVisible();
+    });
+
+    it('ready: names the app, version, duration and wires both actions', async () => {
+        const onOpenBuilder = vi.fn();
+        const onView = vi.fn();
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{
+                    kind: 'ready',
+                    name: 'Weekly revenue by region',
+                    version: 1,
+                    durationMs: 372_000,
+                    completionMessage: 'Your app is ready.',
+                }}
+                compact={false}
+                onOpenBuilder={onOpenBuilder}
+                onView={onView}
+            />,
+        );
+        expect(screen.getByText('Weekly revenue by region')).toBeVisible();
+        expect(screen.getByText('v1 · built in 6m 12s')).toBeVisible();
+        expect(screen.getByText('Your app is ready.')).toBeVisible();
+        await userEvent.click(screen.getByRole('button', { name: 'View' }));
+        expect(onView).toHaveBeenCalledTimes(1);
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Continue in builder' }),
+        );
+        expect(onOpenBuilder).toHaveBeenCalledTimes(1);
+    });
+
+    it('ready: omits the duration when unknown', () => {
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{
+                    kind: 'ready',
+                    name: 'Weekly revenue by region',
+                    version: 3,
+                    durationMs: null,
+                    completionMessage: 'Done.',
+                }}
+                compact={false}
+                onOpenBuilder={noop}
+                onView={noop}
+            />,
+        );
+        expect(screen.getByText('v3')).toBeVisible();
+    });
+
+    it('failed: shows the builder failure message and opens the builder', async () => {
+        const onOpenBuilder = vi.fn();
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{
+                    kind: 'failed',
+                    message: 'Build failed while generating.',
+                }}
+                compact={false}
+                onOpenBuilder={onOpenBuilder}
+                onView={noop}
+            />,
+        );
+        expect(screen.getByText("The app couldn't be built")).toBeVisible();
+        expect(
+            screen.getByText('Build failed while generating.'),
+        ).toBeVisible();
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Open in builder' }),
+        );
+        expect(onOpenBuilder).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancelled: one row with the builder action', () => {
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{ kind: 'cancelled' }}
+                compact={false}
+                onOpenBuilder={noop}
+                onView={noop}
+            />,
+        );
+        expect(screen.getByText('Build cancelled')).toBeVisible();
+        expect(
+            screen.getByRole('button', { name: 'Open in builder' }),
+        ).toBeVisible();
+    });
+
+    it('unavailable: no actions at all', () => {
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{ kind: 'unavailable' }}
+                compact={false}
+                onOpenBuilder={noop}
+                onView={noop}
+            />,
+        );
+        expect(
+            screen.getByText('This app is no longer available.'),
+        ).toBeVisible();
+        expect(screen.queryAllByRole('button')).toHaveLength(0);
+    });
+
+    it('compact ready: collapses to one row with a single builder action', () => {
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{
+                    kind: 'ready',
+                    name: 'Weekly revenue by region',
+                    version: 1,
+                    durationMs: 372_000,
+                    completionMessage: 'Your app is ready.',
+                }}
+                compact
+                onOpenBuilder={noop}
+                onView={noop}
+            />,
+        );
+        expect(screen.getByText('Weekly revenue by region')).toBeVisible();
+        expect(screen.getByText('v1 · built in 6m 12s')).toBeVisible();
+        expect(
+            screen.queryByText('Your app is ready.'),
+        ).not.toBeInTheDocument();
+        expect(screen.getAllByRole('button')).toHaveLength(1);
+        expect(
+            screen.getByRole('button', { name: 'Continue in builder' }),
+        ).toBeVisible();
+    });
+
+    it('compact failed: one row joining title and message', () => {
+        renderWithProviders(
+            <DataAppBuildCard
+                state={{
+                    kind: 'failed',
+                    message: 'Build failed while generating.',
+                }}
+                compact
+                onOpenBuilder={noop}
+                onView={noop}
+            />,
+        );
+        expect(
+            screen.getByText(
+                "The app couldn't be built. Build failed while generating.",
+            ),
+        ).toBeVisible();
+        expect(screen.getAllByRole('button')).toHaveLength(1);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.tsx
@@ -1,0 +1,329 @@
+import { assertUnreachable } from '@lightdash/common';
+import { Box, Button, Paper, Stack, Text, ThemeIcon } from '@mantine/core';
+import {
+    IconAlertTriangle,
+    IconAppWindow,
+    IconArrowRight,
+    IconCircleMinus,
+    IconEye,
+} from '@tabler/icons-react';
+import clsx from 'clsx';
+import { type FC, type ReactNode } from 'react';
+import MantineIcon from '../../../../../../components/common/MantineIcon';
+import AppVersionNarration from '../../../../../../features/apps/components/AppVersionNarration';
+import { formatBuildDuration } from '../../../../../../features/apps/utils/formatBuildDuration';
+import { type AppVersionNarrationData } from '../../../../../../features/apps/utils/versionNarration';
+import styles from './DataAppBuildCard.module.css';
+
+export type DataAppBuildCardState =
+    | { kind: 'queued' }
+    | {
+          kind: 'building';
+          statusMessage: string;
+          narration: AppVersionNarrationData;
+      }
+    | {
+          kind: 'ready';
+          name: string;
+          version: number;
+          durationMs: number | null;
+          completionMessage: string;
+      }
+    | { kind: 'failed'; message: string }
+    | { kind: 'cancelled' }
+    | { kind: 'unavailable' };
+
+type Props = {
+    state: DataAppBuildCardState;
+    /** Earlier turns: ready and failed collapse to a single row. */
+    compact: boolean;
+    onOpenBuilder: () => void;
+    onView: () => void;
+};
+
+const FAILED_TITLE = "The app couldn't be built";
+
+const readySubtitle = (
+    state: Extract<DataAppBuildCardState, { kind: 'ready' }>,
+) =>
+    state.durationMs === null
+        ? `v${state.version}`
+        : `v${state.version} · built in ${formatBuildDuration(state.durationMs)}`;
+
+const BuilderButton: FC<{
+    label: 'Continue in builder' | 'Open in builder';
+    primary?: boolean;
+    onClick: () => void;
+}> = ({ label, primary = false, onClick }) => (
+    <Button
+        variant={primary ? 'filled' : 'default'}
+        color={primary ? 'dark' : undefined}
+        size="compact-xs"
+        onClick={onClick}
+        rightSection={
+            primary ? <MantineIcon icon={IconArrowRight} size={14} /> : null
+        }
+    >
+        {label}
+    </Button>
+);
+
+const CardIcon: FC<{ tone: 'default' | 'error' | 'muted' }> = ({ tone }) => (
+    <ThemeIcon
+        size="sm"
+        variant={tone === 'error' ? 'light' : 'default'}
+        color={tone === 'error' ? 'red' : undefined}
+        c={tone === 'muted' ? 'ldGray.5' : undefined}
+    >
+        <MantineIcon
+            icon={tone === 'error' ? IconAlertTriangle : IconAppWindow}
+            size={14}
+        />
+    </ThemeIcon>
+);
+
+/** Icon + title (+ subtitle) cell; sits left of the actions on wide cards. */
+const Lead: FC<{ icon: ReactNode; children: ReactNode }> = ({
+    icon,
+    children,
+}) => (
+    <Box className={styles.lead}>
+        {icon}
+        <Stack gap={0} className={styles.leadText}>
+            {children}
+        </Stack>
+    </Box>
+);
+
+const Actions: FC<{ children: ReactNode }> = ({ children }) => (
+    <Box className={styles.actions}>{children}</Box>
+);
+
+/** Full-width cell indented to the title's left edge. */
+const Body: FC<{ children: ReactNode }> = ({ children }) => (
+    <Box className={styles.body}>{children}</Box>
+);
+
+const Title: FC<{ children: ReactNode }> = ({ children }) => (
+    <Text size="xs" fw={500} truncate>
+        {children}
+    </Text>
+);
+
+const Muted: FC<{ children: ReactNode }> = ({ children }) => (
+    <Text size="xs" c="ldGray.6">
+        {children}
+    </Text>
+);
+
+/** One-line "title · detail" header used by rows that must stay single-line. */
+const InlineTitle: FC<{ title: string; detail: string }> = ({
+    title,
+    detail,
+}) => (
+    <Text size="xs" truncate>
+        <Text span fw={500} inherit>
+            {title}
+        </Text>
+        <Text span c="ldGray.6" inherit>
+            {' · '}
+        </Text>
+        <Text span c="ldGray.6" inherit>
+            {detail}
+        </Text>
+    </Text>
+);
+
+const renderCells = (
+    state: DataAppBuildCardState,
+    compact: boolean,
+    onOpenBuilder: () => void,
+    onView: () => void,
+): ReactNode => {
+    switch (state.kind) {
+        case 'queued':
+            return (
+                <>
+                    <Lead icon={<CardIcon tone="default" />}>
+                        <Title>Building data app</Title>
+                    </Lead>
+                    <Actions>
+                        <BuilderButton
+                            label="Continue in builder"
+                            onClick={onOpenBuilder}
+                        />
+                    </Actions>
+                    <Body>
+                        <Muted>
+                            Starting the build. This can take a few minutes.
+                        </Muted>
+                    </Body>
+                </>
+            );
+        case 'building':
+            return (
+                <>
+                    <Box className={styles.full}>
+                        <Lead icon={<CardIcon tone="default" />}>
+                            <InlineTitle
+                                title="Building data app"
+                                detail={state.statusMessage}
+                            />
+                        </Lead>
+                    </Box>
+                    <Box className={styles.full}>
+                        <AppVersionNarration
+                            narration={state.narration}
+                            isLive
+                        />
+                    </Box>
+                    <Box className={styles.lead}>
+                        <Muted>
+                            Builds in the background, so it's safe to close the
+                            tab.
+                        </Muted>
+                    </Box>
+                    <Actions>
+                        <BuilderButton
+                            label="Continue in builder"
+                            onClick={onOpenBuilder}
+                        />
+                    </Actions>
+                </>
+            );
+        case 'ready':
+            if (compact) {
+                return (
+                    <>
+                        <Lead icon={<CardIcon tone="default" />}>
+                            <InlineTitle
+                                title={state.name}
+                                detail={readySubtitle(state)}
+                            />
+                        </Lead>
+                        <Actions>
+                            <BuilderButton
+                                label="Continue in builder"
+                                onClick={onOpenBuilder}
+                            />
+                        </Actions>
+                    </>
+                );
+            }
+            return (
+                <>
+                    <Lead icon={<CardIcon tone="default" />}>
+                        <Title>{state.name}</Title>
+                        <Muted>{readySubtitle(state)}</Muted>
+                    </Lead>
+                    <Actions>
+                        <Button
+                            variant="default"
+                            size="compact-xs"
+                            leftSection={
+                                <MantineIcon icon={IconEye} size={14} />
+                            }
+                            onClick={onView}
+                        >
+                            View
+                        </Button>
+                        <BuilderButton
+                            label="Continue in builder"
+                            primary
+                            onClick={onOpenBuilder}
+                        />
+                    </Actions>
+                    <Body>
+                        <Text size="xs">{state.completionMessage}</Text>
+                    </Body>
+                </>
+            );
+        case 'failed':
+            if (compact) {
+                return (
+                    <>
+                        <Lead icon={<CardIcon tone="error" />}>
+                            <Text size="xs" c="ldGray.6" lineClamp={2}>
+                                {`${FAILED_TITLE}. ${state.message}`}
+                            </Text>
+                        </Lead>
+                        <Actions>
+                            <BuilderButton
+                                label="Open in builder"
+                                onClick={onOpenBuilder}
+                            />
+                        </Actions>
+                    </>
+                );
+            }
+            return (
+                <>
+                    <Lead icon={<CardIcon tone="error" />}>
+                        <Title>{FAILED_TITLE}</Title>
+                    </Lead>
+                    <Actions>
+                        <BuilderButton
+                            label="Open in builder"
+                            onClick={onOpenBuilder}
+                        />
+                    </Actions>
+                    <Body>
+                        <Muted>{state.message}</Muted>
+                    </Body>
+                </>
+            );
+        case 'cancelled':
+            return (
+                <>
+                    <Lead
+                        icon={
+                            <ThemeIcon size="sm" variant="default">
+                                <MantineIcon icon={IconCircleMinus} size={14} />
+                            </ThemeIcon>
+                        }
+                    >
+                        <Title>Build cancelled</Title>
+                    </Lead>
+                    <Actions>
+                        <BuilderButton
+                            label="Open in builder"
+                            onClick={onOpenBuilder}
+                        />
+                    </Actions>
+                </>
+            );
+        case 'unavailable':
+            return (
+                <Lead icon={<CardIcon tone="muted" />}>
+                    <Muted>This app is no longer available.</Muted>
+                </Lead>
+            );
+        default:
+            return assertUnreachable(state, 'Unknown build card state');
+    }
+};
+
+/**
+ * Presentational build card shown under the agent's reply. Pure function of
+ * `state`; navigation and data live in the caller.
+ */
+// ts-unused-exports:disable-next-line
+export const DataAppBuildCard: FC<Props> = ({
+    state,
+    compact,
+    onOpenBuilder,
+    onView,
+}) => (
+    <Paper
+        withBorder
+        p="sm"
+        radius="md"
+        className={clsx(styles.card, {
+            [styles.cardUnavailable]: state.kind === 'unavailable',
+        })}
+    >
+        <Box className={styles.layout}>
+            {renderCells(state, compact, onOpenBuilder, onView)}
+        </Box>
+    </Paper>
+);

--- a/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
+++ b/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
@@ -24,6 +24,10 @@ import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
 import { AgentChatDisplay } from '../ee/features/aiCopilot/components/ChatElements/AgentChatDisplay';
 import { AgentSuggestionChips } from '../ee/features/aiCopilot/components/ChatElements/AgentSuggestionChips';
+import {
+    DataAppBuildCard,
+    type DataAppBuildCardState,
+} from '../ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard';
 import { DotsLoader } from '../ee/features/aiCopilot/components/ChatElements/DotsLoader/DotsLoader';
 import { ReasoningHistoryRow } from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard';
 import { LiveActivityCard } from '../ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard';
@@ -772,6 +776,38 @@ const StorySurface = ({ children }: { children: ReactNode }) => (
     </Box>
 );
 
+const buildCardStates: DataAppBuildCardState[] = [
+    { kind: 'queued' },
+    {
+        kind: 'building',
+        statusMessage: 'Building your app',
+        narration: {
+            reasoning: ['Totals should reconcile against the revenue metric.'],
+            activity: ['Ran 5 queries · 26 weeks · 4 regions'],
+        },
+    },
+    {
+        kind: 'ready',
+        name: 'Weekly revenue by region',
+        version: 1,
+        durationMs: 372_000,
+        completionMessage:
+            'Your app is ready. Five regional pages, weekly revenue over the last 26 weeks.',
+    },
+    {
+        kind: 'failed',
+        message:
+            'The build failed while generating your app. Nothing was published.',
+    },
+    { kind: 'cancelled' },
+    { kind: 'unavailable' },
+];
+
+const buildCardActions = {
+    onOpenBuilder: () => undefined,
+    onView: () => undefined,
+};
+
 const Section = ({
     title,
     description,
@@ -997,6 +1033,34 @@ const ComponentInventory = () => (
                 </Stack>
             </Section>
         </SimpleGrid>
+
+        <Section
+            title="DataAppBuildCard"
+            description="Real build card under an agent reply: the six states, then the compact ready / failed rows used on earlier turns."
+        >
+            <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+                {buildCardStates.map((state) => (
+                    <Box key={state.kind}>
+                        <DataAppBuildCard
+                            state={state}
+                            compact={false}
+                            {...buildCardActions}
+                        />
+                    </Box>
+                ))}
+                {buildCardStates
+                    .filter((s) => s.kind === 'ready' || s.kind === 'failed')
+                    .map((state) => (
+                        <Box key={`compact-${state.kind}`}>
+                            <DataAppBuildCard
+                                state={state}
+                                compact
+                                {...buildCardActions}
+                            />
+                        </Box>
+                    ))}
+            </SimpleGrid>
+        </Section>
 
         <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
             <Section

--- a/packages/frontend/src/stories/DataAppBuildCard.stories.tsx
+++ b/packages/frontend/src/stories/DataAppBuildCard.stories.tsx
@@ -1,0 +1,106 @@
+import { Box, Stack } from '@mantine/core';
+import '@mantine/core/styles.css';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import {
+    DataAppBuildCard,
+    type DataAppBuildCardState,
+} from '../ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard';
+import MantineBaseProvider from '../providers/MantineBaseProvider';
+
+const APP_NAME = 'Weekly revenue by region';
+
+const states = {
+    queued: { kind: 'queued' },
+    building: {
+        kind: 'building',
+        statusMessage: 'Building your app',
+        narration: {
+            reasoning: [
+                'Totals should reconcile against the existing revenue metric, so every page reads from the semantic layer.',
+            ],
+            activity: ['Ran 5 queries · 26 weeks · 4 regions'],
+        },
+    },
+    ready: {
+        kind: 'ready',
+        name: APP_NAME,
+        version: 1,
+        durationMs: 372_000,
+        completionMessage:
+            'Your app is ready. Five regional pages, weekly revenue over the last 26 weeks.',
+    },
+    failed: {
+        kind: 'failed',
+        message:
+            'The build failed while generating your app. Nothing was published.',
+    },
+    cancelled: { kind: 'cancelled' },
+    unavailable: { kind: 'unavailable' },
+} satisfies Record<string, DataAppBuildCardState>;
+
+const meta: Meta<typeof DataAppBuildCard> = {
+    title: 'AI Copilot/DataAppBuildCard',
+    component: DataAppBuildCard,
+    args: {
+        compact: false,
+        onOpenBuilder: fn(),
+        onView: fn(),
+    },
+    decorators: [
+        (renderStory) => (
+            <MantineBaseProvider>
+                <Stack w={720} p="md">
+                    {renderStory()}
+                </Stack>
+            </MantineBaseProvider>
+        ),
+    ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DataAppBuildCard>;
+
+export const Queued: Story = { args: { state: states.queued } };
+
+export const Building: Story = { args: { state: states.building } };
+
+export const Ready: Story = { args: { state: states.ready } };
+
+export const ReadyWithoutDuration: Story = {
+    args: { state: { ...states.ready, version: 3, durationMs: null } },
+};
+
+export const Failed: Story = { args: { state: states.failed } };
+
+export const Cancelled: Story = { args: { state: states.cancelled } };
+
+export const Unavailable: Story = { args: { state: states.unavailable } };
+
+export const CompactReady: Story = {
+    args: { state: states.ready, compact: true },
+};
+
+export const CompactFailed: Story = {
+    args: { state: states.failed, compact: true },
+};
+
+/** Every state at a phone-width column; nothing should overflow. */
+export const MobileWidth: Story = {
+    render: (args) => (
+        <Box w={320}>
+            <Stack gap="sm">
+                {Object.values(states).map((state) => (
+                    <DataAppBuildCard
+                        key={state.kind}
+                        {...args}
+                        state={state}
+                    />
+                ))}
+                <DataAppBuildCard {...args} state={states.ready} compact />
+                <DataAppBuildCard {...args} state={states.failed} compact />
+            </Stack>
+        </Box>
+    ),
+};


### PR DESCRIPTION
Closes: ZAP-957

### Description:

Presentational `DataAppBuildCard` the agent thread will render under a reply once a data-app build is wired in (ZAP-956/ZAP-958). Driven by a single `DataAppBuildCardState` union plus a `compact` flag; action handlers are props — no fetching, routing, or store inside.

- Six states per the ticket table: queued, building (live status message + the builder's shared `AppVersionNarration` Reasoning/Activity rows), ready, failed, cancelled, unavailable.
- Compact ready / failed collapse to one row with the action on the right.
- One CSS-grid layout: title on the left, actions on the title line (building keeps its action in the footer next to "Builds in the background…"), body text indented to the title edge. Container query drops actions below the title at phone width.
- Storybook: `AI Copilot/DataAppBuildCard` — one story per state, `ReadyWithoutDuration`, `CompactReady`, `CompactFailed`, `MobileWidth`; plus a `DataAppBuildCard` section in the Agent Chat Workbench inventory.
- Behavioural tests for each state's copy and callback wiring.

### Verification

- `pnpm -F frontend test` (full suite), typecheck, oxlint, oxfmt, ts-unused-exports
- Rendered in Storybook at 720px and 320px; no console errors

### Risk assessment:

- [ ] This is a high-risk change

New unwired component + stories only; no production surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbhqkNhmBGtHG4zD9SDP79