### PR TITLE
feat: emit embed dashboard tab and tile load events

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -2309,11 +2309,29 @@ export const GenericDashboardChartTile: FC<
     const markTileScreenshotErrored = useDashboardTileStatusContext(
         (c) => c.markTileScreenshotErrored,
     );
+    const markEmbedTileComplete = useDashboardTileStatusContext(
+        (c) => c.markEmbedTileComplete,
+    );
     useEffect(() => {
         if (error !== null) {
             markTileScreenshotErrored(tile.uuid);
         }
     }, [error, markTileScreenshotErrored, tile.uuid]);
+    useEffect(() => {
+        if (
+            error !== null ||
+            (!isLoading && dashboardChartReadyQuery && resultsData)
+        ) {
+            markEmbedTileComplete(tile.uuid);
+        }
+    }, [
+        dashboardChartReadyQuery,
+        error,
+        isLoading,
+        markEmbedTileComplete,
+        resultsData,
+        tile.uuid,
+    ]);
 
     const userCanManageChart =
         dashboardChartReadyQuery?.chart &&

--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -115,6 +115,9 @@ const SqlChartTile: FC<Props> = ({
     const markTileScreenshotErrored = useDashboardTileStatusContext(
         (c) => c.markTileScreenshotErrored,
     );
+    const markEmbedTileComplete = useDashboardTileStatusContext(
+        (c) => c.markEmbedTileComplete,
+    );
     const dashboardFilters = useDashboardFiltersForTile(tile.uuid);
 
     const closeDataExportModal = useCallback(
@@ -158,7 +161,6 @@ const SqlChartTile: FC<Props> = ({
                   parameters,
               },
     );
-
     // Charts in Dashboard shouldn't have animation
     const specWithoutAnimation = useMemo(() => {
         if (!chartResultsData?.chartSpec) return chartResultsData?.chartSpec;
@@ -215,6 +217,28 @@ const SqlChartTile: FC<Props> = ({
         tile.uuid,
         markTileScreenshotReady,
         markTileScreenshotErrored,
+    ]);
+
+    useEffect(() => {
+        const hasLoadError = !savedSqlUuid || !!chartError;
+        const hasResultsError = !!chartResultsError;
+        const hasResults = !!chartResultsData;
+
+        if (
+            (!isChartLoading && hasLoadError) ||
+            (!isChartResultsFetching && (hasResultsError || hasResults))
+        ) {
+            markEmbedTileComplete(tile.uuid);
+        }
+    }, [
+        chartError,
+        chartResultsData,
+        chartResultsError,
+        isChartLoading,
+        isChartResultsFetching,
+        markEmbedTileComplete,
+        savedSqlUuid,
+        tile.uuid,
     ]);
 
     const userCanExportData = user.data?.ability.can(

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -14,7 +14,7 @@ import { Box, Button, Group, Tabs, TextInput } from '@mantine/core';
 import { IconCheck, IconPencil, IconUnlink, IconX } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
-import { useLocation, useNavigate } from 'react-router';
+import { useLocation } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
@@ -39,8 +39,10 @@ import {
     useUpdateDashboard,
 } from '../../../../../hooks/dashboard/useDashboard';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
+import useDashboardTileStatusContext from '../../../../../providers/Dashboard/useDashboardTileStatusContext';
 import { type EmbedExploreOptions } from '../../../../providers/Embed/types';
 import useEmbed from '../../../../providers/Embed/useEmbed';
+import { useEmbedDashboardTabChange } from '../../hooks/useEmbedDashboardTabChange';
 import { embedContractClass } from '../../styles/embedClassContract';
 import { useEmbedDashboard } from '../hooks';
 import { canUseEmbeddedChartBuilder } from '../utils';
@@ -59,6 +61,30 @@ const EMBED_EDIT_TILE_TYPES = [
     DashboardTileTypes.MARKDOWN,
     DashboardTileTypes.HEADING,
 ];
+
+const EmbedTileLoadTracker: FC<{
+    tile: DashboardTile;
+    hasUnmetFilterRequirements: boolean;
+}> = ({ tile, hasUnmetFilterRequirements }) => {
+    const markEmbedTileComplete = useDashboardTileStatusContext(
+        (c) => c.markEmbedTileComplete,
+    );
+    const hasQueryBlocked =
+        (tile.type === DashboardTileTypes.SAVED_CHART ||
+            tile.type === DashboardTileTypes.SQL_CHART) &&
+        hasUnmetFilterRequirements;
+    const tracksItsOwnLoad =
+        !hasQueryBlocked &&
+        (tile.type === DashboardTileTypes.SAVED_CHART ||
+            tile.type === DashboardTileTypes.SQL_CHART ||
+            tile.type === DashboardTileTypes.DATA_APP);
+
+    useEffect(() => {
+        if (!tracksItsOwnLoad) markEmbedTileComplete(tile.uuid);
+    }, [markEmbedTileComplete, tile.uuid, tracksItsOwnLoad]);
+
+    return null;
+};
 
 const EmbedDashboardGrid: FC<{
     filteredTiles: DashboardTile[];
@@ -112,6 +138,13 @@ const EmbedDashboardGrid: FC<{
             </div>
         ) : (
             <div className={tabStyles.tabGridContainer}>
+                {filteredTiles.map((tile) => (
+                    <EmbedTileLoadTracker
+                        key={tile.uuid}
+                        tile={tile}
+                        hasUnmetFilterRequirements={hasUnmetFilterRequirements}
+                    />
+                ))}
                 <ResponsiveGridLayout
                     {...gridProps}
                     layouts={layouts}
@@ -302,7 +335,6 @@ const EmbedDashboard: FC<{
         paletteUuid,
         writeActions,
     } = useEmbed();
-    const navigate = useNavigate();
     const { pathname, search } = useLocation();
     const [localDashboard, setLocalDashboard] = useState<
         EmbedDashboardType | undefined
@@ -335,7 +367,6 @@ const EmbedDashboard: FC<{
         paletteUuid,
         !initialDashboard,
     );
-
     useEffect(() => {
         if (initialDashboard) {
             setLocalDashboard(initialDashboard);
@@ -467,6 +498,17 @@ const EmbedDashboard: FC<{
 
     // Check if tabs should be enabled (more than one visible tab)
     const tabsEnabled = visibleTabs.length > 1;
+
+    // Sync tabs with the URL for direct iframes and emit user-triggered changes
+    // for both direct iframe and SDK embeds.
+    const handleTabChange = useEmbedDashboardTabChange({
+        activeTab,
+        mode,
+        pathname,
+        search,
+        setActiveTab,
+        visibleTabs,
+    });
 
     const gridProps = getResponsiveGridLayoutProps({ enableAnimation: false });
     const layouts = useMemo(
@@ -712,35 +754,6 @@ const EmbedDashboard: FC<{
 
     // Check if current tab is empty
     const isTabEmpty = tabsEnabled && filteredTiles.length === 0;
-
-    // Sync tabs with URL when user changes tab for iframes.
-    // SDK mode does not sync URL when user changes tab because
-    // the SDK app uses the same URL as the embedding app.
-    const handleTabChange = (tabUuid: string | null) => {
-        if (!tabUuid) return;
-        const tab = visibleTabs.find((t) => t.uuid === tabUuid);
-        if (tab) {
-            setActiveTab(tab);
-
-            if (mode === 'direct') {
-                const newParams = new URLSearchParams(search);
-                const currentPath = pathname;
-
-                // Update URL to include tab UUID
-                const newPath = currentPath.includes('/tabs/')
-                    ? currentPath.replace(/\/tabs\/[^/]+$/, `/tabs/${tab.uuid}`)
-                    : `${currentPath}/tabs/${tab.uuid}`;
-
-                void navigate(
-                    {
-                        pathname: newPath,
-                        search: newParams.toString(),
-                    },
-                    { replace: true },
-                );
-            }
-        }
-    };
 
     const renderEditControls = () => {
         if (!canWriteDashboard) return null;

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDataAppTile.tsx
@@ -4,7 +4,7 @@ import {
 } from '@lightdash/common';
 import { Box, Loader, Stack } from '@mantine/core';
 import { IconAppsOff } from '@tabler/icons-react';
-import { useMemo, type FC } from 'react';
+import { useCallback, useEffect, useMemo, type FC } from 'react';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
 import TileBase from '../../../../../components/DashboardTiles/TileBase';
 import AppIframePreview from '../../../../../features/apps/AppIframePreview';
@@ -12,6 +12,7 @@ import { getVisiblePreviewTokenError } from '../../../../../features/apps/hooks/
 import { useEmbedAppPreviewToken } from '../../../../../features/apps/hooks/useEmbedAppPreviewToken';
 import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
 import useDashboardFiltersForTile from '../../../../../hooks/dashboard/useDashboardFiltersForTile';
+import useDashboardTileStatusContext from '../../../../../providers/Dashboard/useDashboardTileStatusContext';
 import { convertDateDashboardFilters } from '../../../../../utils/dateFilter';
 
 type Props = {
@@ -69,6 +70,18 @@ const EmbedDataAppTile: FC<Props> = ({ tile, projectUuid }) => {
     const statusCode = visibleTokenError?.error?.statusCode;
     const isNotFound = !!appDeletedAt || statusCode === 404;
     const isForbidden = statusCode === 403;
+    const hasLoadError = isNotFound || isForbidden || !!visibleTokenError;
+    const markEmbedTileComplete = useDashboardTileStatusContext(
+        (c) => c.markEmbedTileComplete,
+    );
+    const handleIframeLoad = useCallback(
+        () => markEmbedTileComplete(uuid),
+        [markEmbedTileComplete, uuid],
+    );
+
+    useEffect(() => {
+        if (hasLoadError) markEmbedTileComplete(uuid);
+    }, [hasLoadError, markEmbedTileComplete, uuid]);
 
     return (
         <TileBase
@@ -104,6 +117,7 @@ const EmbedDataAppTile: FC<Props> = ({ tile, projectUuid }) => {
                         appUuid={appUuid}
                         identityKey={`${appUuid}:${tokenQuery.data.version}`}
                         dashboardFilters={dashboardFiltersForApp}
+                        onIframeLoad={handleIframeLoad}
                     />
                 )}
             </Box>

--- a/packages/frontend/src/ee/features/embed/events/README.md
+++ b/packages/frontend/src/ee/features/embed/events/README.md
@@ -1,0 +1,18 @@
+# Embedded dashboard events
+
+Embedded dashboards publish namespaced browser events through two transports:
+
+- SDK embeds dispatch a same-window `CustomEvent` on `window`; the payload is in `event.detail`.
+- Direct iframe embeds send a `postMessage` envelope to the validated `targetOrigin`. They also dispatch the `CustomEvent` inside the iframe.
+
+The event system must be enabled in the Lightdash embedding configuration. Direct iframes must include an allowed `targetOrigin` query parameter; wildcard origins are rejected.
+
+| Event                       | Payload                       | Trigger                                                                                                                                                                                                    |
+| --------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lightdash:filterChanged`   | `{ hasFilters, filterCount }` | The effective dashboard filter set changes after initial setup. Filter values are never included.                                                                                                          |
+| `lightdash:tabChanged`      | `{ tabIndex }`                | A viewer selects a different visible dashboard tab. Initial tab selection does not emit.                                                                                                                   |
+| `lightdash:allTilesLoaded`  | `{ tilesCount, loadTimeMs }`  | Every visible tile settles for the active dashboard load cycle. A new cycle starts when the tab, filters, parameters, date zoom, visible tiles, or refresh counter changes. Failed tiles count as settled. |
+| `lightdash:locationChanged` | `{ pathname, search, href }`  | The direct iframe location changes. SDK embeds do not emit this event.                                                                                                                                     |
+| `lightdash:chartSaved`      | `{ chartUuid, action }`       | A chart is created or updated through a direct iframe write flow.                                                                                                                                          |
+
+Each event is emitted at most once per user action or load cycle.

--- a/packages/frontend/src/ee/features/embed/hooks/useEmbedDashboardTabChange.test.tsx
+++ b/packages/frontend/src/ee/features/embed/hooks/useEmbedDashboardTabChange.test.tsx
@@ -1,0 +1,96 @@
+import { type Dashboard } from '@lightdash/common';
+import { act, renderHook } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LightdashEventType } from '../events/types';
+import { useEmbedDashboardTabChange } from './useEmbedDashboardTabChange';
+
+const dispatchEmbedEvent = vi.fn();
+vi.mock('./useEmbedEventEmitter', () => ({
+    useEmbedEventEmitter: () => ({ dispatchEmbedEvent }),
+}));
+
+const tabs = [
+    { uuid: 'tab-one', name: 'One', order: 0 },
+    { uuid: 'tab-two', name: 'Two', order: 1 },
+] as Dashboard['tabs'];
+
+describe('useEmbedDashboardTabChange', () => {
+    beforeEach(() => dispatchEmbedEvent.mockClear());
+
+    it('emits one SDK event without changing the host URL', () => {
+        const setActiveTab = vi.fn();
+        const { result } = renderHook(
+            () => {
+                const location = useLocation();
+                return {
+                    location,
+                    changeTab: useEmbedDashboardTabChange({
+                        activeTab: tabs[0],
+                        mode: 'sdk',
+                        pathname: location.pathname,
+                        search: location.search,
+                        setActiveTab,
+                        visibleTabs: tabs,
+                    }),
+                };
+            },
+            {
+                wrapper: ({ children }) => (
+                    <MemoryRouter initialEntries={['/host?customer=one']}>
+                        {children}
+                    </MemoryRouter>
+                ),
+            },
+        );
+
+        act(() => result.current.changeTab('tab-two'));
+
+        expect(setActiveTab).toHaveBeenCalledOnce();
+        expect(dispatchEmbedEvent).toHaveBeenCalledWith(
+            LightdashEventType.TabChanged,
+            { tabIndex: 1 },
+        );
+        expect(result.current.location.pathname).toBe('/host');
+    });
+
+    it('updates a direct iframe URL and ignores the active tab', () => {
+        const setActiveTab = vi.fn();
+        const { result } = renderHook(
+            () => {
+                const location = useLocation();
+                return {
+                    location,
+                    changeTab: useEmbedDashboardTabChange({
+                        activeTab: tabs[0],
+                        mode: 'direct',
+                        pathname: location.pathname,
+                        search: location.search,
+                        setActiveTab,
+                        visibleTabs: tabs,
+                    }),
+                };
+            },
+            {
+                wrapper: ({ children }) => (
+                    <MemoryRouter
+                        initialEntries={[
+                            '/embed/project/dashboard/example/tabs/tab-one?customer=one',
+                        ]}
+                    >
+                        {children}
+                    </MemoryRouter>
+                ),
+            },
+        );
+
+        act(() => result.current.changeTab('tab-one'));
+        expect(dispatchEmbedEvent).not.toHaveBeenCalled();
+
+        act(() => result.current.changeTab('tab-two'));
+        expect(result.current.location.pathname).toBe(
+            '/embed/project/dashboard/example/tabs/tab-two',
+        );
+        expect(result.current.location.search).toBe('?customer=one');
+    });
+});

--- a/packages/frontend/src/ee/features/embed/hooks/useEmbedDashboardTabChange.ts
+++ b/packages/frontend/src/ee/features/embed/hooks/useEmbedDashboardTabChange.ts
@@ -1,0 +1,69 @@
+import { type Dashboard } from '@lightdash/common';
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router';
+import { type EmbedMode } from '../../../providers/Embed/types';
+import { LightdashEventType } from '../events/types';
+import { useEmbedEventEmitter } from './useEmbedEventEmitter';
+
+type Tab = Dashboard['tabs'][number];
+
+type Args = {
+    activeTab: Tab | undefined;
+    mode: EmbedMode;
+    pathname: string;
+    search: string;
+    setActiveTab: (tab: Tab) => void;
+    visibleTabs: Tab[];
+};
+
+/** Shared user-triggered tab transition for SDK and direct iframe embeds. */
+export const useEmbedDashboardTabChange = ({
+    activeTab,
+    mode,
+    pathname,
+    search,
+    setActiveTab,
+    visibleTabs,
+}: Args) => {
+    const navigate = useNavigate();
+    const { dispatchEmbedEvent } = useEmbedEventEmitter();
+
+    return useCallback(
+        (tabUuid: string | null) => {
+            if (!tabUuid || tabUuid === activeTab?.uuid) return;
+
+            const tabIndex = visibleTabs.findIndex(
+                (tab) => tab.uuid === tabUuid,
+            );
+            if (tabIndex === -1) return;
+
+            const tab = visibleTabs[tabIndex];
+            setActiveTab(tab);
+            dispatchEmbedEvent(LightdashEventType.TabChanged, { tabIndex });
+
+            if (mode === 'direct') {
+                const newPath = pathname.includes('/tabs/')
+                    ? pathname.replace(/\/tabs\/[^/]+$/, `/tabs/${tab.uuid}`)
+                    : `${pathname}/tabs/${tab.uuid}`;
+
+                void navigate(
+                    {
+                        pathname: newPath,
+                        search: new URLSearchParams(search).toString(),
+                    },
+                    { replace: true },
+                );
+            }
+        },
+        [
+            activeTab?.uuid,
+            dispatchEmbedEvent,
+            mode,
+            navigate,
+            pathname,
+            search,
+            setActiveTab,
+            visibleTabs,
+        ],
+    );
+};

--- a/packages/frontend/src/ee/features/embed/hooks/useEmbedEventEmitter.ts
+++ b/packages/frontend/src/ee/features/embed/hooks/useEmbedEventEmitter.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { type Exact } from 'type-fest';
 import useHealth from '../../../../hooks/health/useHealth';
 import { LightdashUiEvent } from '../events/LightdashUiEvent';
@@ -16,29 +16,28 @@ import type {
  */
 export const useEmbedEventEmitter = () => {
     const { data: health } = useHealth();
-    const eventEmitter = useRef<LightdashUiEvent | null>(null);
-
-    // Initialize event system when health data is available
-    useEffect(() => {
-        if (health?.embedding?.events) {
-            const targetOrigin = LightdashUiEvent.getTargetOriginFromUrl();
-            eventEmitter.current = new LightdashUiEvent(
-                health.embedding.events,
-                targetOrigin,
-            );
-        }
-    }, [health]);
-
-    return useMemo(() => {
-        const dispatchEmbedEvent = <T extends Exact<LightdashEventPayload, T>>(
+    const eventEmitter = useMemo(
+        () =>
+            health?.embedding?.events
+                ? new LightdashUiEvent(
+                      health.embedding.events,
+                      LightdashUiEvent.getTargetOriginFromUrl(),
+                  )
+                : null,
+        [health?.embedding?.events],
+    );
+    const dispatchEmbedEvent = useCallback(
+        <T extends Exact<LightdashEventPayload, T>>(
             eventType: LightdashEventType,
             payload?: T,
         ) => {
-            if (eventEmitter.current) {
-                eventEmitter.current.dispatch(eventType, payload);
-            }
-        };
+            if (!eventEmitter) return false;
 
-        return { dispatchEmbedEvent };
-    }, []);
+            eventEmitter.dispatch(eventType, payload);
+            return true;
+        },
+        [eventEmitter],
+    );
+
+    return useMemo(() => ({ dispatchEmbedEvent }), [dispatchEmbedEvent]);
 };

--- a/packages/frontend/src/ee/features/embed/hooks/useEmbedEventEmitter.ts
+++ b/packages/frontend/src/ee/features/embed/hooks/useEmbedEventEmitter.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { type Exact } from 'type-fest';
 import useHealth from '../../../../hooks/health/useHealth';
 import { LightdashUiEvent } from '../events/LightdashUiEvent';
@@ -16,28 +16,37 @@ import type {
  */
 export const useEmbedEventEmitter = () => {
     const { data: health } = useHealth();
-    const eventEmitter = useMemo(
-        () =>
-            health?.embedding?.events
-                ? new LightdashUiEvent(
-                      health.embedding.events,
-                      LightdashUiEvent.getTargetOriginFromUrl(),
-                  )
-                : null,
-        [health?.embedding?.events],
-    );
+    const eventEmitter = useRef<LightdashUiEvent | null>(null);
+    const [isEmbedEventReady, setIsEmbedEventReady] = useState(false);
+
+    useEffect(() => {
+        if (health?.embedding?.events) {
+            eventEmitter.current = new LightdashUiEvent(
+                health.embedding.events,
+                LightdashUiEvent.getTargetOriginFromUrl(),
+            );
+            setIsEmbedEventReady(true);
+        } else {
+            eventEmitter.current = null;
+            setIsEmbedEventReady(false);
+        }
+    }, [health?.embedding?.events]);
+
     const dispatchEmbedEvent = useCallback(
         <T extends Exact<LightdashEventPayload, T>>(
             eventType: LightdashEventType,
             payload?: T,
         ) => {
-            if (!eventEmitter) return false;
+            if (!eventEmitter.current) return false;
 
-            eventEmitter.dispatch(eventType, payload);
+            eventEmitter.current.dispatch(eventType, payload);
             return true;
         },
-        [eventEmitter],
+        [],
     );
 
-    return useMemo(() => ({ dispatchEmbedEvent }), [dispatchEmbedEvent]);
+    return useMemo(
+        () => ({ dispatchEmbedEvent, isEmbedEventReady }),
+        [dispatchEmbedEvent, isEmbedEventReady],
+    );
 };

--- a/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
@@ -103,7 +103,7 @@ const DashboardTileStatusProvider: React.FC<
         (c) => c.dateZoomGranularity,
     );
     const { embedToken } = useEmbed();
-    const { dispatchEmbedEvent } = useEmbedEventEmitter();
+    const { dispatchEmbedEvent, isEmbedEventReady } = useEmbedEventEmitter();
 
     const visibleEmbedTileUuids = useMemo(() => {
         if (!dashboardTiles) return [];
@@ -186,7 +186,8 @@ const DashboardTileStatusProvider: React.FC<
     const emittedLoadCycle = useRef<string | undefined>(undefined);
 
     useEffect(() => {
-        if (!embedToken || !areAllEmbedTilesLoaded) return;
+        if (!embedToken || !isEmbedEventReady || !areAllEmbedTilesLoaded)
+            return;
         if (emittedLoadCycle.current === embedLoadCycleKey) return;
 
         const dispatched = dispatchEmbedEvent(
@@ -207,6 +208,7 @@ const DashboardTileStatusProvider: React.FC<
         dispatchEmbedEvent,
         embedLoadCycleKey,
         embedToken,
+        isEmbedEventReady,
         visibleEmbedTileUuids.length,
     ]);
 

--- a/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
@@ -9,6 +9,7 @@ import min from 'lodash/min';
 import React, {
     useCallback,
     useEffect,
+    useLayoutEffect,
     useMemo,
     useRef,
     useState,
@@ -177,12 +178,14 @@ const DashboardTileStatusProvider: React.FC<
         cycleKey: embedLoadCycleKey,
         startedAt: performance.now(),
     });
-    if (loadCycleTiming.current.cycleKey !== embedLoadCycleKey) {
-        loadCycleTiming.current = {
-            cycleKey: embedLoadCycleKey,
-            startedAt: performance.now(),
-        };
-    }
+    useLayoutEffect(() => {
+        if (loadCycleTiming.current.cycleKey !== embedLoadCycleKey) {
+            loadCycleTiming.current = {
+                cycleKey: embedLoadCycleKey,
+                startedAt: performance.now(),
+            };
+        }
+    }, [embedLoadCycleKey]);
     const emittedLoadCycle = useRef<string | undefined>(undefined);
 
     useEffect(() => {

--- a/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
@@ -6,8 +6,16 @@ import {
     type Dashboard,
 } from '@lightdash/common';
 import min from 'lodash/min';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { useLocation } from 'react-router';
+import { LightdashEventType } from '../../ee/features/embed/events/types';
+import { useEmbedEventEmitter } from '../../ee/features/embed/hooks/useEmbedEventEmitter';
 import useEmbed from '../../ee/providers/Embed/useEmbed';
 import {
     auditResponseToTileStatuses,
@@ -86,6 +94,121 @@ const DashboardTileStatusProvider: React.FC<
 
         return chartTileUuids.every((tileUuid) => loadedTiles.has(tileUuid));
     }, [dashboardTiles, loadedTiles, activeTab, dashboardTabs]);
+
+    const projectUuid = useDashboardContext((c) => c.projectUuid);
+    const dashboard = useDashboardContext((c) => c.dashboard);
+    const allFilters = useDashboardContext((c) => c.allFilters);
+    const parameterValues = useDashboardContext((c) => c.parameterValues);
+    const dateZoomGranularity = useDashboardContext(
+        (c) => c.dateZoomGranularity,
+    );
+    const { embedToken } = useEmbed();
+    const { dispatchEmbedEvent } = useEmbedEventEmitter();
+
+    const visibleEmbedTileUuids = useMemo(() => {
+        if (!dashboardTiles) return [];
+
+        const visibleTabs = dashboardTabs.filter((tab) => !tab.hidden);
+        const firstVisibleTabUuid = visibleTabs[0]?.uuid;
+
+        return dashboardTiles
+            .filter((tile) => {
+                if (!activeTab) return true;
+                if (tile.tabUuid === activeTab.uuid) return true;
+                return !tile.tabUuid && activeTab.uuid === firstVisibleTabUuid;
+            })
+            .map((tile) => tile.uuid)
+            .sort();
+    }, [activeTab, dashboardTabs, dashboardTiles]);
+
+    const embedLoadCycleKey = useMemo(
+        () =>
+            JSON.stringify({
+                dashboardUuid: dashboard?.uuid,
+                activeTabUuid: activeTab?.uuid,
+                tileUuids: visibleEmbedTileUuids,
+                allFilters,
+                parameterValues,
+                dateZoomGranularity,
+                refreshCounter,
+            }),
+        [
+            activeTab?.uuid,
+            allFilters,
+            dashboard?.uuid,
+            dateZoomGranularity,
+            parameterValues,
+            refreshCounter,
+            visibleEmbedTileUuids,
+        ],
+    );
+    const [completedEmbedTiles, setCompletedEmbedTiles] = useState<{
+        cycleKey: string;
+        tileUuids: Set<string>;
+    }>(() => ({ cycleKey: embedLoadCycleKey, tileUuids: new Set() }));
+    const markEmbedTileComplete = useCallback(
+        (tileUuid: string) => {
+            if (!embedToken) return;
+
+            setCompletedEmbedTiles((current) => {
+                const tileUuids =
+                    current.cycleKey === embedLoadCycleKey
+                        ? new Set(current.tileUuids)
+                        : new Set<string>();
+
+                if (tileUuids.has(tileUuid)) return current;
+                tileUuids.add(tileUuid);
+
+                return { cycleKey: embedLoadCycleKey, tileUuids };
+            });
+        },
+        [embedLoadCycleKey, embedToken],
+    );
+    const currentCompletedEmbedTiles =
+        completedEmbedTiles.cycleKey === embedLoadCycleKey
+            ? completedEmbedTiles.tileUuids
+            : new Set<string>();
+    const areAllEmbedTilesLoaded =
+        !!dashboardTiles &&
+        visibleEmbedTileUuids.every((tileUuid) =>
+            currentCompletedEmbedTiles.has(tileUuid),
+        );
+    const loadCycleTiming = useRef({
+        cycleKey: embedLoadCycleKey,
+        startedAt: performance.now(),
+    });
+    if (loadCycleTiming.current.cycleKey !== embedLoadCycleKey) {
+        loadCycleTiming.current = {
+            cycleKey: embedLoadCycleKey,
+            startedAt: performance.now(),
+        };
+    }
+    const emittedLoadCycle = useRef<string | undefined>(undefined);
+
+    useEffect(() => {
+        if (!embedToken || !areAllEmbedTilesLoaded) return;
+        if (emittedLoadCycle.current === embedLoadCycleKey) return;
+
+        const dispatched = dispatchEmbedEvent(
+            LightdashEventType.AllTilesLoaded,
+            {
+                tilesCount: visibleEmbedTileUuids.length,
+                loadTimeMs: Math.max(
+                    0,
+                    Math.round(
+                        performance.now() - loadCycleTiming.current.startedAt,
+                    ),
+                ),
+            },
+        );
+        if (dispatched) emittedLoadCycle.current = embedLoadCycleKey;
+    }, [
+        areAllEmbedTilesLoaded,
+        dispatchEmbedEvent,
+        embedLoadCycleKey,
+        embedToken,
+        visibleEmbedTileUuids.length,
+    ]);
 
     // Custom granularities discovered from explores: key -> label (e.g., "fiscal_quarter" -> "Fiscal Quarter")
     const [availableCustomGranularities, setAvailableCustomGranularities] =
@@ -258,10 +381,6 @@ const DashboardTileStatusProvider: React.FC<
         [],
     );
 
-    const projectUuid = useDashboardContext((c) => c.projectUuid);
-    const dashboard = useDashboardContext((c) => c.dashboard);
-    const allFilters = useDashboardContext((c) => c.allFilters);
-    const { embedToken } = useEmbed();
     const { health } = useApp();
     const { pathname } = useLocation();
     const isEmbedded = !!embedToken;
@@ -296,6 +415,7 @@ const DashboardTileStatusProvider: React.FC<
             sqlChartTilesMetadata,
             updateSqlChartTilesMetadata,
             markTileLoaded,
+            markEmbedTileComplete,
             areAllChartsLoaded,
             availableCustomGranularities,
             addAvailableCustomGranularities,
@@ -321,6 +441,7 @@ const DashboardTileStatusProvider: React.FC<
             sqlChartTilesMetadata,
             updateSqlChartTilesMetadata,
             markTileLoaded,
+            markEmbedTileComplete,
             areAllChartsLoaded,
             availableCustomGranularities,
             addAvailableCustomGranularities,

--- a/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
@@ -212,7 +212,7 @@ const DashboardTileStatusProvider: React.FC<
         embedLoadCycleKey,
         embedToken,
         isEmbedEventReady,
-        visibleEmbedTileUuids.length,
+        visibleEmbedTileUuids,
     ]);
 
     // Custom granularities discovered from explores: key -> label (e.g., "fiscal_quarter" -> "Fiscal Quarter")

--- a/packages/frontend/src/providers/Dashboard/tileStatusTypes.ts
+++ b/packages/frontend/src/providers/Dashboard/tileStatusTypes.ts
@@ -26,6 +26,8 @@ export type DashboardTileStatusContextType = {
         metadata: SqlChartTileMetadata,
     ) => void;
     markTileLoaded: (tileUuid: string) => void;
+    /** Marks a visible embed tile as settled for the current load cycle. */
+    markEmbedTileComplete: (tileUuid: string) => void;
     areAllChartsLoaded: boolean;
     availableCustomGranularities: Record<string, string>;
     addAvailableCustomGranularities: (


### PR DESCRIPTION
## Summary

- emit `lightdash:tabChanged` when an embedded dashboard viewer selects a visible tab
- emit `lightdash:allTilesLoaded` once all visible tiles settle, resetting for tab, filter, parameter, date zoom, refresh, and tile changes
- track saved charts, SQL charts, data apps, static tiles, and query-blocked tiles
- document SDK and direct iframe event behavior
- leave error emitters for a follow-up

## Validation

- `pnpm -F frontend typecheck`
- focused event tests: 27 passed
- packed this branch SDK and loaded it in embed-showcase
- live SDK embed emitted tab indices 1 and 0 and corresponding 0-tile and 12-tile completion cycles
- regular non-embed dashboard rendered and switched tabs without new runtime errors

Linear: SPK-1489