### PR TITLE
fix(content-as-code): block managed content deletion

### DIFF
--- a/packages/backend/src/services/ContentService/ContentService.test.ts
+++ b/packages/backend/src/services/ContentService/ContentService.test.ts
@@ -504,6 +504,38 @@ describe('ContentService.bulkDelete', () => {
         ).not.toHaveBeenCalled();
     });
 
+    it('reports the Content as Code reason when bulk deletion is blocked', async () => {
+        const deps = createService();
+        deps.savedChartService.delete.mockRejectedValueOnce(
+            new ForbiddenError(
+                'This chart is managed by Content as Code and can only be deleted by a Content as Code manager.',
+                { contentAsCodeManaged: true },
+            ),
+        );
+
+        const results = await deps.service.bulkDelete(
+            createUser(),
+            projectUuid,
+            [
+                {
+                    uuid: 'managed-chart-uuid',
+                    contentType: ContentType.CHART,
+                    source: ChartSourceType.DBT_EXPLORE,
+                },
+            ],
+        );
+
+        expect(results).toEqual({
+            deletedCount: 0,
+            skipped: [
+                expect.objectContaining({
+                    uuid: 'managed-chart-uuid',
+                    reason: expect.stringContaining('Content as Code'),
+                }),
+            ],
+        });
+    });
+
     it('rejects a project the user cannot view', async () => {
         const deps = createService();
         deps.projectModel.getSummary.mockResolvedValue({

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -566,7 +566,8 @@ export class ContentService extends BaseService {
                     uuid: item.uuid,
                     contentType: item.contentType,
                     reason:
-                        error instanceof ForbiddenError
+                        error instanceof ForbiddenError &&
+                        error.data.contentAsCodeManaged !== true
                             ? 'You do not have permission to delete this content'
                             : getErrorMessage(error),
                 });

--- a/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
@@ -13,7 +13,17 @@ const SPACE_UUID = 'space-uuid';
 
 const editorUser = {
     userUuid: 'editor-uuid',
-    ability: new Ability<PossibleAbilities>([]),
+    ability: new Ability<PossibleAbilities>([
+        { action: 'delete', subject: 'Dashboard' },
+    ]),
+} as unknown as SessionUser;
+
+const reviewerUser = {
+    userUuid: 'reviewer-uuid',
+    ability: new Ability<PossibleAbilities>([
+        { action: 'delete', subject: 'Dashboard' },
+        { action: 'manage', subject: 'ContentAsCode' },
+    ]),
 } as unknown as SessionUser;
 
 const dashboardDao = {
@@ -35,6 +45,7 @@ type Overrides = {
     snapshot?: object | undefined;
     openDraftsForContent?: { draft: object }[];
     orphanedCharts?: { uuid: string }[];
+    softDeleteEnabled?: boolean;
 };
 
 const buildService = (overrides: Overrides = {}) => {
@@ -64,16 +75,31 @@ const buildService = (overrides: Overrides = {}) => {
         .mockImplementation((uuid: string) =>
             Promise.resolve({ uuid, projectUuid: PROJECT_UUID }),
         );
+    const dashboardPermanentDelete = vi.fn().mockResolvedValue(dashboardDao);
+    const dashboardSoftDelete = vi.fn().mockResolvedValue(dashboardDao);
     const service = new DashboardService({
-        lightdashConfig: lightdashConfigMock,
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            softDelete: {
+                ...lightdashConfigMock.softDelete,
+                enabled: overrides.softDeleteEnabled ?? false,
+            },
+        },
         analytics: analyticsMock,
-        dashboardModel: { getOrphanedCharts } as AnyType,
+        dashboardModel: {
+            getOrphanedCharts,
+            getByIdOrSlug: vi.fn().mockResolvedValue(dashboardDao),
+            permanentDelete: dashboardPermanentDelete,
+            softDelete: dashboardSoftDelete,
+        } as AnyType,
         spaceModel: {} as AnyType,
         analyticsModel: {} as AnyType,
         pinnedListModel: {} as AnyType,
         schedulerModel: {} as AnyType,
         searchModel: {} as AnyType,
-        schedulerService: {} as AnyType,
+        schedulerService: {
+            softDeleteByDashboardUuid: vi.fn(),
+        } as AnyType,
         savedChartModel: { permanentDelete } as AnyType,
         savedSqlModel: {} as AnyType,
         savedChartService: {} as AnyType,
@@ -98,7 +124,9 @@ const buildService = (overrides: Overrides = {}) => {
                 directOnly: false,
             }),
         } as AnyType,
-        contentVerificationModel: {} as AnyType,
+        contentVerificationModel: {
+            getByContent: vi.fn().mockResolvedValue(undefined),
+        } as AnyType,
     });
     return {
         service,
@@ -107,6 +135,8 @@ const buildService = (overrides: Overrides = {}) => {
         upsertOpenDraft,
         listOpenForContent,
         permanentDelete,
+        dashboardPermanentDelete,
+        dashboardSoftDelete,
     };
 };
 
@@ -185,20 +215,96 @@ describe('DashboardService drafts gating (sync + git-backed only)', () => {
 
     it('publishes normally for content-as-code managers', async () => {
         const { service, upsertOpenDraft } = buildService();
-        const reviewer = {
-            userUuid: 'reviewer-uuid',
-            ability: new Ability<PossibleAbilities>([
-                { action: 'manage', subject: 'ContentAsCode' },
-            ]),
-        } as unknown as SessionUser;
         const result = await service['maybeStoreDraft'](
-            reviewer,
+            reviewerUser,
             dashboardDao,
             draftFields,
         );
         expect(result).toBeUndefined();
         expect(upsertOpenDraft).not.toHaveBeenCalled();
     });
+
+    it('blocks an editor from deleting a Git-backed dashboard', async () => {
+        const { service, dashboardPermanentDelete, dashboardSoftDelete } =
+            buildService();
+
+        await expect(
+            service.delete(editorUser, dashboardDao.uuid),
+        ).rejects.toThrow('This dashboard is managed by Content as Code');
+        expect(dashboardPermanentDelete).not.toHaveBeenCalled();
+        expect(dashboardSoftDelete).not.toHaveBeenCalled();
+    });
+
+    it('deletes a UI-only dashboard normally', async () => {
+        const { service, dashboardPermanentDelete } = buildService({
+            snapshot: undefined,
+        });
+
+        await expect(
+            service.delete(editorUser, dashboardDao.uuid),
+        ).resolves.toBeUndefined();
+        expect(dashboardPermanentDelete).toHaveBeenCalledWith(
+            dashboardDao.uuid,
+        );
+    });
+
+    it('soft-deletes a UI-only dashboard normally', async () => {
+        const { service, dashboardPermanentDelete, dashboardSoftDelete } =
+            buildService({
+                snapshot: undefined,
+                softDeleteEnabled: true,
+            });
+
+        await expect(
+            service.delete(editorUser, dashboardDao.uuid),
+        ).resolves.toBeUndefined();
+        expect(dashboardSoftDelete).toHaveBeenCalledWith(
+            dashboardDao.uuid,
+            editorUser.userUuid,
+        );
+        expect(dashboardPermanentDelete).not.toHaveBeenCalled();
+    });
+
+    it('deletes normally when Content as Code sync is disabled', async () => {
+        const { service, dashboardPermanentDelete, snapshotGet } = buildService(
+            { settings: { syncEnabled: false } },
+        );
+
+        await expect(
+            service.delete(editorUser, dashboardDao.uuid),
+        ).resolves.toBeUndefined();
+        expect(snapshotGet).not.toHaveBeenCalled();
+        expect(dashboardPermanentDelete).toHaveBeenCalledWith(
+            dashboardDao.uuid,
+        );
+    });
+
+    it('lets a content-as-code manager delete a Git-backed dashboard', async () => {
+        const { service, dashboardPermanentDelete } = buildService();
+
+        await expect(
+            service.delete(reviewerUser, dashboardDao.uuid),
+        ).resolves.toBeUndefined();
+        expect(dashboardPermanentDelete).toHaveBeenCalledWith(
+            dashboardDao.uuid,
+        );
+    });
+
+    it.each(['softDelete', 'permanentDelete'] as const)(
+        'does not let an internal %s call bypass the Git-backed policy',
+        async (method) => {
+            const { service, dashboardPermanentDelete, dashboardSoftDelete } =
+                buildService();
+
+            await expect(
+                service[method](editorUser, dashboardDao.uuid, {
+                    bypassPermissions: true,
+                }),
+            ).rejects.toThrow('This dashboard is managed by Content as Code');
+            expect(dashboardPermanentDelete).not.toHaveBeenCalled();
+            expect(dashboardSoftDelete).not.toHaveBeenCalled();
+        },
+    );
 });
 
 describe('DashboardService draft overlay is opt-in', () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -138,6 +138,10 @@ type DashboardServiceArguments = {
     contentVerificationModel: ContentVerificationModel;
 };
 
+type ContentAsCodeDeleteOptions = SoftDeleteOptions & {
+    contentAsCodePolicyChecked?: boolean;
+};
+
 type DashboardDraftOverlay = Partial<
     Pick<
         DashboardDAO,
@@ -1739,6 +1743,31 @@ export class DashboardService
         );
     }
 
+    private async assertCanDeleteGitBackedDashboard(
+        user: SessionUser,
+        dashboard: Pick<DashboardDAO, 'projectUuid' | 'slug'>,
+    ): Promise<void> {
+        const settings = await this.contentAsCodeProjectSettingsModel.get(
+            dashboard.projectUuid,
+        );
+        if (!settings?.syncEnabled) return;
+
+        const snapshot = await this.contentAsCodeSnapshotModel.get(
+            dashboard.projectUuid,
+            ContentAsCodeType.DASHBOARD,
+            dashboard.slug,
+        );
+        if (snapshot === undefined) return;
+        if (await this.canManageContentAsCode(user, dashboard.projectUuid)) {
+            return;
+        }
+
+        throw new ForbiddenError(
+            'This dashboard is managed by Content as Code and can only be deleted by a Content as Code manager.',
+            { contentAsCodeManaged: true },
+        );
+    }
+
     private static mergeDraftIntoDashboard<T extends DashboardDAO>(
         dashboard: T,
         draft: unknown,
@@ -2447,7 +2476,7 @@ export class DashboardService
     async delete(
         user: SessionUser,
         dashboardUuidOrSlug: UuidOrSlug,
-        options?: SoftDeleteOptions & { projectUuid?: string },
+        options?: ContentAsCodeDeleteOptions,
     ): Promise<void> {
         const dashboardToDelete = await this.dashboardModel.getByIdOrSlug(
             dashboardUuidOrSlug,
@@ -2490,6 +2519,8 @@ export class DashboardService
                 organizationUuid,
             });
         }
+
+        await this.assertCanDeleteGitBackedDashboard(user, dashboardToDelete);
 
         if (hasChartsInDashboard(dashboardToDelete)) {
             try {
@@ -2544,10 +2575,12 @@ export class DashboardService
         if (this.lightdashConfig.softDelete.enabled) {
             await this.softDelete(user, resolvedUuid, {
                 bypassPermissions: true, // perms checked above
+                contentAsCodePolicyChecked: true,
             });
         } else {
             await this.permanentDelete(user, resolvedUuid, {
                 bypassPermissions: true, // perms checked above
+                contentAsCodePolicyChecked: true,
             });
         }
 
@@ -2565,7 +2598,7 @@ export class DashboardService
     async softDelete(
         user: SessionUser,
         dashboardUuidOrSlug: UuidOrSlug,
-        options?: SoftDeleteOptions,
+        options?: ContentAsCodeDeleteOptions,
     ): Promise<void> {
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuidOrSlug);
@@ -2606,6 +2639,10 @@ export class DashboardService
                 projectUuid: dashboard.projectUuid,
                 organizationUuid: dashboard.organizationUuid,
             });
+        }
+
+        if (!options?.contentAsCodePolicyChecked) {
+            await this.assertCanDeleteGitBackedDashboard(user, dashboard);
         }
 
         const deletedDashboard = await this.dashboardModel.softDelete(
@@ -2682,7 +2719,7 @@ export class DashboardService
     async permanentDelete(
         user: SessionUser,
         dashboardUuidOrSlug: UuidOrSlug,
-        options?: SoftDeleteOptions,
+        options?: ContentAsCodeDeleteOptions,
     ): Promise<void> {
         // 'any' so this works whether called directly on a soft-deleted
         // dashboard (restore-then-purge flow) or via `delete()` on a
@@ -2711,6 +2748,10 @@ export class DashboardService
             ) {
                 throw new ForbiddenError();
             }
+        }
+
+        if (!options?.contentAsCodePolicyChecked) {
+            await this.assertCanDeleteGitBackedDashboard(user, dashboard);
         }
 
         await this.dashboardModel.permanentDelete(dashboard.uuid);

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.drafts.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.drafts.test.ts
@@ -47,7 +47,7 @@ const chart = {
 const editor = {
     userUuid: 'editor-uuid',
     ability: new Ability<PossibleAbilities>([
-        { action: ['view', 'update'], subject: 'SavedChart' },
+        { action: ['view', 'update', 'delete'], subject: 'SavedChart' },
     ]),
     abilityRules: [],
 } as unknown as SessionUser;
@@ -56,6 +56,7 @@ const reviewer = {
     userUuid: 'reviewer-uuid',
     ability: new Ability<PossibleAbilities>([
         { action: 'manage', subject: 'ContentAsCode' },
+        { action: 'delete', subject: 'SavedChart' },
     ]),
 } as unknown as SessionUser;
 
@@ -66,6 +67,7 @@ const buildService = (
         settings?: object;
         snapshot?: object;
         draft?: object;
+        softDeleteEnabled?: boolean;
     } = {},
 ) => {
     const settingsGet = vi
@@ -98,22 +100,35 @@ const buildService = (
         getSummary: vi.fn().mockResolvedValue(chart),
         createVersion: vi.fn(),
         update: vi.fn(),
+        permanentDelete: vi.fn().mockResolvedValue(chart),
+        softDelete: vi.fn().mockResolvedValue(chart),
     };
     const service = new SavedChartService({
         analytics: analyticsMock,
-        lightdashConfig: lightdashConfigMock,
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            softDelete: {
+                ...lightdashConfigMock.softDelete,
+                enabled: overrides.softDeleteEnabled ?? false,
+            },
+        },
         projectModel: {
             get: vi.fn().mockResolvedValue({
                 projectUuid: chart.projectUuid,
                 organizationUuid: chart.organizationUuid,
             }),
+            getExploreFromCache: vi
+                .fn()
+                .mockRejectedValue(new Error('No cached explore in unit test')),
         },
         savedChartModel,
         spaceModel: {},
         analyticsModel: {},
         pinnedListModel: {},
         schedulerModel: {},
-        schedulerService: {},
+        schedulerService: {
+            softDeleteByChartUuid: vi.fn(),
+        },
         schedulerClient: {},
         slackClient: {},
         dashboardModel: {},
@@ -239,6 +254,85 @@ describe('SavedChartService chart drafts', () => {
         expect(result).toBeUndefined();
         expect(upsertOpenDraft).not.toHaveBeenCalled();
     });
+
+    it('blocks an editor from deleting a Git-backed chart', async () => {
+        const { service, savedChartModel } = buildService();
+
+        await expect(service.delete(editor, chart.uuid)).rejects.toThrow(
+            'This chart is managed by Content as Code',
+        );
+        expect(savedChartModel.permanentDelete).not.toHaveBeenCalled();
+        expect(savedChartModel.softDelete).not.toHaveBeenCalled();
+    });
+
+    it('deletes a UI-only chart normally', async () => {
+        const { service, savedChartModel } = buildService({
+            snapshot: undefined,
+        });
+
+        await expect(
+            service.delete(editor, chart.uuid),
+        ).resolves.toBeUndefined();
+        expect(savedChartModel.permanentDelete).toHaveBeenCalledWith(
+            chart.uuid,
+        );
+    });
+
+    it('soft-deletes a UI-only chart normally', async () => {
+        const { service, savedChartModel } = buildService({
+            snapshot: undefined,
+            softDeleteEnabled: true,
+        });
+
+        await expect(
+            service.delete(editor, chart.uuid),
+        ).resolves.toBeUndefined();
+        expect(savedChartModel.softDelete).toHaveBeenCalledWith(
+            chart.uuid,
+            editor.userUuid,
+        );
+        expect(savedChartModel.permanentDelete).not.toHaveBeenCalled();
+    });
+
+    it('deletes normally when Content as Code sync is disabled', async () => {
+        const { service, savedChartModel, snapshotGet } = buildService({
+            settings: { syncEnabled: false },
+        });
+
+        await expect(
+            service.delete(editor, chart.uuid),
+        ).resolves.toBeUndefined();
+        expect(snapshotGet).not.toHaveBeenCalled();
+        expect(savedChartModel.permanentDelete).toHaveBeenCalledWith(
+            chart.uuid,
+        );
+    });
+
+    it('lets a content-as-code manager delete a Git-backed chart', async () => {
+        const { service, savedChartModel } = buildService();
+
+        await expect(
+            service.delete(reviewer, chart.uuid),
+        ).resolves.toBeUndefined();
+        expect(savedChartModel.permanentDelete).toHaveBeenCalledWith(
+            chart.uuid,
+        );
+    });
+
+    it.each(['softDelete', 'permanentDelete'] as const)(
+        'does not let an internal %s call bypass the Git-backed policy',
+        async (method) => {
+            const { service, savedChartModel } = buildService();
+
+            await expect(
+                service[method](editor, chart.uuid, {
+                    bypassPermissions: true,
+                }),
+            ).rejects.toThrow('This chart is managed by Content as Code');
+            expect(savedChartModel.permanentDelete).not.toHaveBeenCalled();
+            expect(savedChartModel.softDelete).not.toHaveBeenCalled();
+        },
+    );
 
     it("overlays only the caller's draft", async () => {
         const { service, findOpenDraft } = buildService({

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -126,6 +126,10 @@ type SavedChartServiceArguments = {
     contentDraftModel: ContentDraftModel;
 };
 
+type ContentAsCodeDeleteOptions = SoftDeleteOptions & {
+    contentAsCodePolicyChecked?: boolean;
+};
+
 type ChartDraftOverlay = Partial<
     Pick<
         SavedChartDAO,
@@ -713,6 +717,29 @@ export class SavedChartService
                 createdByUserUuid: project.createdByUserUuid,
                 metadata: { slug: '' },
             }),
+        );
+    }
+
+    private async assertCanDeleteGitBackedChart(
+        user: SessionUser,
+        chart: Pick<SavedChartDAO, 'projectUuid' | 'slug'>,
+    ): Promise<void> {
+        const settings = await this.contentAsCodeProjectSettingsModel.get(
+            chart.projectUuid,
+        );
+        if (!settings?.syncEnabled) return;
+
+        const snapshot = await this.contentAsCodeSnapshotModel.get(
+            chart.projectUuid,
+            ContentAsCodeType.CHART,
+            chart.slug,
+        );
+        if (snapshot === undefined) return;
+        if (await this.canManageContentAsCode(user, chart.projectUuid)) return;
+
+        throw new ForbiddenError(
+            'This chart is managed by Content as Code and can only be deleted by a Content as Code manager.',
+            { contentAsCodeManaged: true },
         );
     }
 
@@ -1536,7 +1563,7 @@ export class SavedChartService
     async delete(
         user: SessionUser,
         savedChartUuid: string,
-        options?: SoftDeleteOptions & { projectUuid?: string },
+        options?: ContentAsCodeDeleteOptions,
     ): Promise<void> {
         const {
             uuid: resolvedUuid,
@@ -1544,6 +1571,7 @@ export class SavedChartService
             projectUuid,
             spaceUuid,
             dashboardUuid,
+            slug,
             metricQuery: { metrics, dimensions },
             tableName,
         } = await this.savedChartModel.get(savedChartUuid, undefined, {
@@ -1595,13 +1623,20 @@ export class SavedChartService
             });
         }
 
+        await this.assertCanDeleteGitBackedChart(user, {
+            projectUuid,
+            slug,
+        });
+
         if (this.lightdashConfig.softDelete.enabled) {
             await this.softDelete(user, resolvedUuid, {
                 bypassPermissions: true, // perms checked above
+                contentAsCodePolicyChecked: true,
             });
         } else {
             await this.permanentDelete(user, resolvedUuid, {
                 bypassPermissions: true, // perms checked above
+                contentAsCodePolicyChecked: true,
             });
         }
 
@@ -1643,8 +1678,14 @@ export class SavedChartService
     async softDelete(
         user: SessionUser,
         savedChartUuid: string,
-        options?: SoftDeleteOptions,
+        options?: ContentAsCodeDeleteOptions,
     ): Promise<void> {
+        const chart =
+            !options?.contentAsCodePolicyChecked || !options?.bypassPermissions
+                ? await this.savedChartModel.get(savedChartUuid, undefined, {
+                      projectUuid: options?.projectUuid,
+                  })
+                : undefined;
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'delete', {
                 type: 'SavedChart',
@@ -1652,7 +1693,7 @@ export class SavedChartService
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         } else {
-            const chart = await this.savedChartModel.get(savedChartUuid);
+            if (!chart) throw new NotFoundError('Chart not found');
             const { inheritsFromOrgOrProject, access } =
                 await this.spacePermissionService.resolveAccess(user.userUuid, {
                     type: 'chart',
@@ -1685,6 +1726,10 @@ export class SavedChartService
                 projectUuid: chart.projectUuid,
                 organizationUuid: chart.organizationUuid,
             });
+        }
+
+        if (!options?.contentAsCodePolicyChecked && chart) {
+            await this.assertCanDeleteGitBackedChart(user, chart);
         }
 
         const deletedChart = await this.savedChartModel.softDelete(
@@ -3110,8 +3155,15 @@ export class SavedChartService
     async permanentDelete(
         user: SessionUser,
         chartUuid: string,
-        options?: SoftDeleteOptions,
+        options?: ContentAsCodeDeleteOptions,
     ): Promise<void> {
+        const deletedChart =
+            !options?.contentAsCodePolicyChecked || !options?.bypassPermissions
+                ? await this.savedChartModel.get(chartUuid, undefined, {
+                      deleted: true,
+                      projectUuid: options?.projectUuid,
+                  })
+                : undefined;
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'DeletedContent',
@@ -3119,11 +3171,7 @@ export class SavedChartService
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         } else {
-            const deletedChart = await this.savedChartModel.get(
-                chartUuid,
-                undefined,
-                { deleted: true, projectUuid: options?.projectUuid },
-            );
+            if (!deletedChart) throw new NotFoundError('Chart not found');
             const { organizationUuid, projectUuid } = deletedChart;
 
             const auditedAbility = this.createAuditedAbility(user);
@@ -3157,6 +3205,10 @@ export class SavedChartService
                     'You can only permanently delete content you deleted',
                 );
             }
+        }
+
+        if (!options?.contentAsCodePolicyChecked && deletedChart) {
+            await this.assertCanDeleteGitBackedChart(user, deletedChart);
         }
 
         await this.savedChartModel.permanentDelete(chartUuid);


### PR DESCRIPTION
Closes #28226

## What changed
- block non-Content-as-Code managers from deleting snapshot-backed charts and dashboards while sync is enabled
- enforce the same policy in normal, soft, permanent, permission-bypass, and bulk deletion paths
- keep deletion unchanged for UI-only content, sync-disabled projects, and Content-as-Code managers
- preserve the actionable Content as Code reason in bulk-delete results

## Validation
- 126 adjacent backend tests passed
- backend typecheck passed
- targeted backend lint and formatting passed