### PR TITLE
fix(ai-agent): top-align build card icon with the title line

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.module.css
@@ -51,13 +51,17 @@
 .lead {
     grid-column: 1;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: var(--mantine-spacing-xs);
     min-width: 0;
 }
 
+/* Icon lines up with the first text line: single-line text centres within
+   the icon's height, a subtitle simply extends below. */
 .leadText {
     min-width: 0;
+    min-height: var(--card-icon-size);
+    justify-content: center;
 }
 
 .full {


### PR DESCRIPTION
Relates: ZAP-957

### Description:

Follow-up to #28229. The card's lead icon was vertically centred against title + subtitle, so on the ready card it floated between the two lines. The lead now top-aligns and the text block centres itself within the icon's height, so single-line rows look the same as before and two-line leads put the icon on the title line.

### Risk assessment:

- [ ] This is a high-risk change

CSS-only change to an unwired Storybook component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbhqkNhmBGtHG4zD9SDP79