### PR TITLE
fix(content-as-code): apply draft policy to bulk edits

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -246,6 +246,87 @@ describe('CoderService', () => {
         });
     });
 
+    describe('draft space overlays', () => {
+        const publishedChart = {
+            uuid: 'chart-uuid',
+            slug: 'chart-slug',
+            name: 'Chart',
+            description: null,
+            spaceUuid: 'published-space',
+            dashboardUuid: null,
+            tableName: 'orders',
+            metricQuery: {
+                metrics: [],
+                dimensions: [],
+                filters: {},
+                sorts: [],
+                limit: 500,
+                tableCalculations: [],
+            },
+            chartConfig: { type: ChartType.TABLE, config: {} },
+            tableConfig: {},
+            pivotConfig: undefined,
+            parameters: undefined,
+            merge: null,
+            updatedAt: new Date('2026-08-27T00:00:00Z'),
+        };
+        const publishedDashboard = {
+            uuid: 'dashboard-uuid',
+            slug: 'dashboard-slug',
+            name: 'Dashboard',
+            description: null,
+            spaceUuid: 'published-space',
+            tiles: [],
+            tabs: [],
+            filters: {
+                dimensions: [],
+                metrics: [],
+                tableCalculations: [],
+            },
+            config: {},
+            updatedAt: new Date('2026-08-27T00:00:00Z'),
+        };
+        const service = new CoderService({
+            savedChartModel: {
+                get: vi.fn().mockResolvedValue(publishedChart),
+            },
+            dashboardModel: {
+                getByIdOrSlug: vi.fn().mockResolvedValue(publishedDashboard),
+            },
+            spaceModel: {
+                find: vi.fn(async ({ spaceUuids }: AnyType) =>
+                    spaceUuids.map((uuid: string) => ({
+                        uuid,
+                        name: 'Draft space',
+                        path: 'draft_space',
+                    })),
+                ),
+            },
+            contentVerificationModel: {
+                getByContentUuids: vi.fn().mockResolvedValue(new Map()),
+            },
+        } as AnyType);
+
+        it('renders a chart draft move as the target space slug', async () => {
+            const result = await service.getPortableChartAsCodeWithOverlay(
+                'project-uuid',
+                publishedChart.uuid,
+                { spaceUuid: 'draft-space' },
+            );
+
+            expect(result.spaceSlug).toBe('draft-space');
+        });
+
+        it('renders a dashboard draft move as the target space slug', async () => {
+            const result = await service.getDashboardAsCodeWithOverlay(
+                publishedDashboard.uuid,
+                { spaceUuid: 'draft-space' },
+            );
+
+            expect(result.spaceSlug).toBe('draft-space');
+        });
+    });
+
     describe('getTileSlugForTileUuid', () => {
         it('should return undefined when chart tile slug is null', () => {
             const mockDashboard = {

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -2906,6 +2906,9 @@ export class CoderService extends BaseService {
                 parameters: fields.parameters,
             }),
             ...(fields.merge !== undefined && { merge: fields.merge }),
+            ...(fields.spaceUuid !== undefined && {
+                spaceUuid: fields.spaceUuid,
+            }),
         };
         const spaces = await this.spaceModel.find({
             spaceUuids: merged.spaceUuid ? [merged.spaceUuid] : [],
@@ -2994,6 +2997,9 @@ export class CoderService extends BaseService {
             ...(fields.filters !== undefined && { filters: fields.filters }),
             ...(fields.tabs !== undefined && { tabs: fields.tabs }),
             ...(fields.config !== undefined && { config: fields.config }),
+            ...(fields.spaceUuid !== undefined && {
+                spaceUuid: fields.spaceUuid,
+            }),
         };
         const spaces = await this.spaceModel.find({
             spaceUuids: merged.spaceUuid ? [merged.spaceUuid] : [],

--- a/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.drafts.test.ts
@@ -15,6 +15,7 @@ const editorUser = {
     userUuid: 'editor-uuid',
     ability: new Ability<PossibleAbilities>([
         { action: 'delete', subject: 'Dashboard' },
+        { action: 'update', subject: 'Dashboard' },
     ]),
 } as unknown as SessionUser;
 
@@ -23,6 +24,7 @@ const reviewerUser = {
     ability: new Ability<PossibleAbilities>([
         { action: 'delete', subject: 'Dashboard' },
         { action: 'manage', subject: 'ContentAsCode' },
+        { action: 'update', subject: 'Dashboard' },
     ]),
 } as unknown as SessionUser;
 
@@ -46,6 +48,8 @@ type Overrides = {
     openDraftsForContent?: { draft: object }[];
     orphanedCharts?: { uuid: string }[];
     softDeleteEnabled?: boolean;
+    dashboards?: AnyType[];
+    managedSlugs?: string[];
 };
 
 const buildService = (overrides: Overrides = {}) => {
@@ -56,14 +60,22 @@ const buildService = (overrides: Overrides = {}) => {
                 ? overrides.settings
                 : { syncEnabled: true },
         );
-    const snapshotGet = vi
-        .fn()
-        .mockResolvedValue(
-            'snapshot' in overrides
+    const snapshotGet = vi.fn(
+        async (_projectUuid: string, _contentType: string, slug: string) => {
+            if (overrides.managedSlugs) {
+                return overrides.managedSlugs.includes(slug)
+                    ? { snapshotHash: 'abc' }
+                    : undefined;
+            }
+            return 'snapshot' in overrides
                 ? overrides.snapshot
-                : { snapshotHash: 'abc' },
-        );
-    const upsertOpenDraft = vi.fn().mockResolvedValue(undefined);
+                : { snapshotHash: 'abc' };
+        },
+    );
+    const upsertOpenDraft = vi.fn(async (args: AnyType) => ({
+        uuid: 'draft-uuid',
+        draft: args.draft,
+    }));
     const listOpenForContent = vi
         .fn()
         .mockResolvedValue(overrides.openDraftsForContent ?? []);
@@ -77,6 +89,16 @@ const buildService = (overrides: Overrides = {}) => {
         );
     const dashboardPermanentDelete = vi.fn().mockResolvedValue(dashboardDao);
     const dashboardSoftDelete = vi.fn().mockResolvedValue(dashboardDao);
+    const dashboards = overrides.dashboards ?? [dashboardDao];
+    const getDashboard = (uuid: string) =>
+        dashboards.find((candidate) => candidate.uuid === uuid) ?? dashboardDao;
+    const dashboardUpdateMultiple = vi.fn(
+        async (_projectUuid: string, updates: AnyType[]) =>
+            updates.map((update) => ({
+                ...getDashboard(update.uuid),
+                ...update,
+            })),
+    );
     const service = new DashboardService({
         lightdashConfig: {
             ...lightdashConfigMock,
@@ -88,7 +110,8 @@ const buildService = (overrides: Overrides = {}) => {
         analytics: analyticsMock,
         dashboardModel: {
             getOrphanedCharts,
-            getByIdOrSlug: vi.fn().mockResolvedValue(dashboardDao),
+            getByIdOrSlug: vi.fn(async (uuid: string) => getDashboard(uuid)),
+            updateMultiple: dashboardUpdateMultiple,
             permanentDelete: dashboardPermanentDelete,
             softDelete: dashboardSoftDelete,
         } as AnyType,
@@ -137,6 +160,7 @@ const buildService = (overrides: Overrides = {}) => {
         permanentDelete,
         dashboardPermanentDelete,
         dashboardSoftDelete,
+        dashboardUpdateMultiple,
     };
 };
 
@@ -222,6 +246,139 @@ describe('DashboardService drafts gating (sync + git-backed only)', () => {
         );
         expect(result).toBeUndefined();
         expect(upsertOpenDraft).not.toHaveBeenCalled();
+    });
+
+    it('turns a Git-backed dashboard move into a portable draft field', async () => {
+        const { service, upsertOpenDraft } = buildService();
+
+        const result = await service.update(editorUser, dashboardDao.uuid, {
+            name: dashboardDao.name,
+            spaceUuid: 'new-space-uuid',
+        });
+
+        expect(result).toMatchObject({
+            spaceUuid: 'new-space-uuid',
+            hasUnpublishedChanges: true,
+        });
+        expect(upsertOpenDraft).toHaveBeenCalledWith(
+            expect.objectContaining({
+                draft: expect.objectContaining({
+                    spaceUuid: 'new-space-uuid',
+                }),
+            }),
+        );
+    });
+
+    it('drafts only Git-backed dashboards in a mixed bulk update', async () => {
+        const managedDashboard = {
+            ...dashboardDao,
+            uuid: 'managed-dashboard',
+            slug: 'managed-dashboard',
+        };
+        const uiOnlyDashboard = {
+            ...dashboardDao,
+            uuid: 'ui-only-dashboard',
+            slug: 'ui-only-dashboard',
+        };
+        const { service, dashboardUpdateMultiple, upsertOpenDraft } =
+            buildService({
+                dashboards: [managedDashboard, uiOnlyDashboard],
+                managedSlugs: [managedDashboard.slug],
+            });
+        const updates = [managedDashboard, uiOnlyDashboard].map((item) => ({
+            uuid: item.uuid,
+            name: `${item.name} updated`,
+            description: 'Updated description',
+            spaceUuid: 'new-space-uuid',
+        }));
+
+        const results = await service.updateMultiple(
+            editorUser,
+            PROJECT_UUID,
+            updates,
+        );
+
+        expect(upsertOpenDraft).toHaveBeenCalledTimes(1);
+        expect(upsertOpenDraft).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contentUuid: managedDashboard.uuid,
+                draft: expect.objectContaining({
+                    spaceUuid: 'new-space-uuid',
+                }),
+            }),
+        );
+        expect(dashboardUpdateMultiple).toHaveBeenCalledWith(PROJECT_UUID, [
+            updates[1],
+        ]);
+        expect(results).toMatchObject([
+            { uuid: managedDashboard.uuid, hasUnpublishedChanges: true },
+            { uuid: uiOnlyDashboard.uuid },
+        ]);
+        expect(results[1]).not.toHaveProperty('hasUnpublishedChanges');
+    });
+
+    it('persists safe drafts before a mixed bulk publish failure', async () => {
+        const managedDashboard = {
+            ...dashboardDao,
+            uuid: 'managed-dashboard',
+            slug: 'managed-dashboard',
+        };
+        const uiOnlyDashboard = {
+            ...dashboardDao,
+            uuid: 'ui-only-dashboard',
+            slug: 'ui-only-dashboard',
+        };
+        const { service, dashboardUpdateMultiple, upsertOpenDraft } =
+            buildService({
+                dashboards: [managedDashboard, uiOnlyDashboard],
+                managedSlugs: [managedDashboard.slug],
+            });
+        dashboardUpdateMultiple.mockRejectedValueOnce(
+            new Error('published transaction failed'),
+        );
+        const updates = [managedDashboard, uiOnlyDashboard].map((item) => ({
+            uuid: item.uuid,
+            name: `${item.name} updated`,
+            description: 'Updated description',
+            spaceUuid: item.spaceUuid,
+        }));
+
+        await expect(
+            service.updateMultiple(editorUser, PROJECT_UUID, updates),
+        ).rejects.toThrow('published transaction failed');
+        expect(upsertOpenDraft).toHaveBeenCalledTimes(1);
+        expect(upsertOpenDraft.mock.invocationCallOrder[0]).toBeLessThan(
+            dashboardUpdateMultiple.mock.invocationCallOrder[0],
+        );
+    });
+
+    it('publishes every bulk dashboard update for a Content as Code manager', async () => {
+        const managedDashboard = {
+            ...dashboardDao,
+            uuid: 'managed-dashboard',
+            slug: 'managed-dashboard',
+        };
+        const { service, dashboardUpdateMultiple, upsertOpenDraft } =
+            buildService({
+                dashboards: [managedDashboard],
+                managedSlugs: [managedDashboard.slug],
+            });
+        const updates = [
+            {
+                uuid: managedDashboard.uuid,
+                name: 'Manager update',
+                description: 'Updated description',
+                spaceUuid: managedDashboard.spaceUuid,
+            },
+        ];
+
+        await service.updateMultiple(reviewerUser, PROJECT_UUID, updates);
+
+        expect(upsertOpenDraft).not.toHaveBeenCalled();
+        expect(dashboardUpdateMultiple).toHaveBeenCalledWith(
+            PROJECT_UUID,
+            updates,
+        );
     });
 
     it('blocks an editor from deleting a Git-backed dashboard', async () => {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -145,7 +145,13 @@ type ContentAsCodeDeleteOptions = SoftDeleteOptions & {
 type DashboardDraftOverlay = Partial<
     Pick<
         DashboardDAO,
-        'name' | 'description' | 'tiles' | 'filters' | 'tabs' | 'config'
+        | 'name'
+        | 'description'
+        | 'tiles'
+        | 'filters'
+        | 'tabs'
+        | 'config'
+        | 'spaceUuid'
     >
 >;
 
@@ -168,6 +174,7 @@ const assertDashboardDraftOverlay: (
         filters: isRecord,
         tabs: Array.isArray,
         config: isRecord,
+        spaceUuid: (value) => typeof value === 'string',
     };
     for (const [field, validate] of Object.entries(validators)) {
         if (
@@ -1784,6 +1791,9 @@ export class DashboardService
             ...(fields.filters !== undefined && { filters: fields.filters }),
             ...(fields.tabs !== undefined && { tabs: fields.tabs }),
             ...(fields.config !== undefined && { config: fields.config }),
+            ...(fields.spaceUuid !== undefined && {
+                spaceUuid: fields.spaceUuid,
+            }),
         };
     }
 
@@ -1798,29 +1808,47 @@ export class DashboardService
         existingDashboardDao: DashboardDAO,
         dashboardFields: object,
     ): Promise<Dashboard | undefined> {
+        if (!(await this.shouldStoreDraft(user, existingDashboardDao))) {
+            return undefined;
+        }
+        return this.storeDraft(user, existingDashboardDao, dashboardFields);
+    }
+
+    private async shouldStoreDraft(
+        user: SessionUser,
+        existingDashboardDao: Pick<DashboardDAO, 'projectUuid' | 'slug'>,
+    ): Promise<boolean> {
         const settings = await this.contentAsCodeProjectSettingsModel.get(
             existingDashboardDao.projectUuid,
         );
-        if (!settings?.syncEnabled) return undefined;
+        if (!settings?.syncEnabled) return false;
         const snapshot = await this.contentAsCodeSnapshotModel.get(
             existingDashboardDao.projectUuid,
             ContentAsCodeType.DASHBOARD,
             existingDashboardDao.slug,
         );
-        if (snapshot === undefined) return undefined;
+        if (snapshot === undefined) return false;
         if (
             await this.canManageContentAsCode(
                 user,
                 existingDashboardDao.projectUuid,
             )
         ) {
-            return undefined;
+            return false;
         }
-        const overlaid = DashboardService.mergeDraftIntoDashboard(
+        return true;
+    }
+
+    private async storeDraft(
+        user: SessionUser,
+        existingDashboardDao: DashboardDAO,
+        dashboardFields: object,
+    ): Promise<Dashboard> {
+        DashboardService.mergeDraftIntoDashboard(
             existingDashboardDao,
             dashboardFields,
         );
-        await this.contentDraftModel.upsertOpenDraft({
+        const stored = await this.contentDraftModel.upsertOpenDraft({
             projectUuid: existingDashboardDao.projectUuid,
             contentType: 'dashboard',
             contentUuid: existingDashboardDao.uuid,
@@ -1828,9 +1856,13 @@ export class DashboardService
             authorUserUuid: user.userUuid,
             draft: dashboardFields,
         });
+        const overlaid = DashboardService.mergeDraftIntoDashboard(
+            existingDashboardDao,
+            stored.draft,
+        );
         const space = await this.spacePermissionService.resolveAccess(
             user.userUuid,
-            { type: 'space', spaceUuid: existingDashboardDao.spaceUuid },
+            { type: 'space', spaceUuid: overlaid.spaceUuid },
         );
         return {
             ...overlaid,
@@ -2373,7 +2405,7 @@ export class DashboardService
         dashboards: UpdateMultipleDashboards[],
     ): Promise<Dashboard[]> {
         const auditedAbility = this.createAuditedAbility(user);
-        const userHasAccessToDashboards = await Promise.all(
+        const dashboardContexts = await Promise.all(
             dashboards.map(async (dashboardToUpdate) => {
                 const dashboard = await this.dashboardModel.getByIdOrSlug(
                     dashboardToUpdate.uuid,
@@ -2409,24 +2441,24 @@ export class DashboardService
                         metadata: { dashboardUuid: dashboardToUpdate.uuid },
                     }),
                 );
-                return (
-                    canUpdateDashboardInCurrentSpace &&
-                    canUpdateDashboardInNewSpace
-                );
+                return {
+                    dashboardToUpdate,
+                    dashboard,
+                    hasAccess:
+                        canUpdateDashboardInCurrentSpace &&
+                        canUpdateDashboardInNewSpace,
+                };
             }),
         );
 
-        if (userHasAccessToDashboards.some((hasAccess) => !hasAccess)) {
+        if (dashboardContexts.some(({ hasAccess }) => !hasAccess)) {
             throw new ForbiddenError(
                 "You don't have access to some of the dashboards you are trying to update.",
             );
         }
 
         await Promise.all(
-            dashboards.map(async (dashboardToUpdate) => {
-                const dashboard = await this.dashboardModel.getByIdOrSlug(
-                    dashboardToUpdate.uuid,
-                );
+            dashboardContexts.map(async ({ dashboard }) => {
                 await this.assertCanMutateVerifiedDashboard({
                     user,
                     dashboardUuid: dashboard.uuid,
@@ -2436,19 +2468,32 @@ export class DashboardService
             }),
         );
 
-        this.analytics.track({
-            event: 'dashboard.updated_multiple',
-            userId: user.userUuid,
-            properties: {
-                dashboardIds: dashboards.map((dashboard) => dashboard.uuid),
-                projectId: projectUuid,
-            },
-        });
-
-        const updatedDashboards = await this.dashboardModel.updateMultiple(
-            projectUuid,
-            dashboards,
+        const shouldStoreDraft = await Promise.all(
+            dashboardContexts.map(({ dashboard }) =>
+                this.shouldStoreDraft(user, dashboard),
+            ),
         );
+        // Draft upserts are idempotent and happen before the transactional
+        // published update, so a retry cannot duplicate or partially publish.
+        const draftResults = await Promise.all(
+            dashboardContexts.map(
+                async ({ dashboardToUpdate, dashboard }, index) =>
+                    shouldStoreDraft[index]
+                        ? this.storeDraft(user, dashboard, dashboardToUpdate)
+                        : undefined,
+            ),
+        );
+
+        const directUpdates = dashboards.filter(
+            (_dashboard, index) => !shouldStoreDraft[index],
+        );
+        const updatedDashboards =
+            directUpdates.length > 0
+                ? await this.dashboardModel.updateMultiple(
+                      projectUuid,
+                      directUpdates,
+                  )
+                : [];
 
         const updatedDashboardsWithSpacesAccess = updatedDashboards.map(
             async (dashboard) => {
@@ -2470,7 +2515,26 @@ export class DashboardService
             },
         );
 
-        return Promise.all(updatedDashboardsWithSpacesAccess);
+        const directResults = await Promise.all(
+            updatedDashboardsWithSpacesAccess,
+        );
+        const directResultsByUuid = new Map(
+            directResults.map((dashboard) => [dashboard.uuid, dashboard]),
+        );
+        this.analytics.track({
+            event: 'dashboard.updated_multiple',
+            userId: user.userUuid,
+            properties: {
+                dashboardIds: dashboards.map((dashboard) => dashboard.uuid),
+                projectId: projectUuid,
+            },
+        });
+        return dashboards.map((dashboard, index) => {
+            const result =
+                draftResults[index] ?? directResultsByUuid.get(dashboard.uuid);
+            if (!result) throw new NotFoundError('Dashboard not found');
+            return result;
+        });
     }
 
     async delete(

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.drafts.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.drafts.test.ts
@@ -57,6 +57,7 @@ const reviewer = {
     ability: new Ability<PossibleAbilities>([
         { action: 'manage', subject: 'ContentAsCode' },
         { action: 'delete', subject: 'SavedChart' },
+        { action: 'update', subject: 'SavedChart' },
     ]),
 } as unknown as SessionUser;
 
@@ -68,6 +69,8 @@ const buildService = (
         snapshot?: object;
         draft?: object;
         softDeleteEnabled?: boolean;
+        charts?: AnyType[];
+        managedSlugs?: string[];
     } = {},
 ) => {
     const settingsGet = vi
@@ -77,13 +80,18 @@ const buildService = (
                 ? overrides.settings
                 : { syncEnabled: true },
         );
-    const snapshotGet = vi
-        .fn()
-        .mockResolvedValue(
-            'snapshot' in overrides
+    const snapshotGet = vi.fn(
+        async (_projectUuid: string, _contentType: string, slug: string) => {
+            if (overrides.managedSlugs) {
+                return overrides.managedSlugs.includes(slug)
+                    ? { snapshotHash: 'hash' }
+                    : undefined;
+            }
+            return 'snapshot' in overrides
                 ? overrides.snapshot
-                : { snapshotHash: 'hash' },
-        );
+                : { snapshotHash: 'hash' };
+        },
+    );
     const upsertOpenDraft = vi.fn(async (args: AnyType) => ({
         uuid: 'draft-uuid',
         draft: args.draft,
@@ -95,11 +103,21 @@ const buildService = (
         findLatestDismissedDraft: vi.fn().mockResolvedValue(undefined),
         countOpenForContent: vi.fn().mockResolvedValue(0),
     };
+    const charts = overrides.charts ?? [chart];
+    const getChart = (uuid: string) =>
+        charts.find((candidate) => candidate.uuid === uuid) ?? chart;
     const savedChartModel = {
-        get: vi.fn().mockResolvedValue(chart),
-        getSummary: vi.fn().mockResolvedValue(chart),
+        get: vi.fn(async (uuid: string) => getChart(uuid)),
+        getSummary: vi.fn(async (uuid: string) => getChart(uuid)),
         createVersion: vi.fn(),
         update: vi.fn(),
+        updateMultiple: vi.fn(
+            async (_projectUuid: string, updates: AnyType[]) =>
+                updates.map((update) => ({
+                    ...getChart(update.uuid),
+                    ...update,
+                })),
+        ),
         permanentDelete: vi.fn().mockResolvedValue(chart),
         softDelete: vi.fn().mockResolvedValue(chart),
     };
@@ -221,6 +239,137 @@ describe('SavedChartService chart drafts', () => {
             hasUnpublishedChanges: true,
         });
         expect(savedChartModel.update).not.toHaveBeenCalled();
+    });
+
+    it('turns a Git-backed chart move into a portable draft field', async () => {
+        const { service, savedChartModel, upsertOpenDraft } = buildService();
+
+        const result = await service.update(editor, chart.uuid, {
+            spaceUuid: 'new-space-uuid',
+        });
+
+        expect(result).toMatchObject({
+            spaceUuid: 'new-space-uuid',
+            hasUnpublishedChanges: true,
+        });
+        expect(upsertOpenDraft).toHaveBeenCalledWith(
+            expect.objectContaining({
+                draft: expect.objectContaining({
+                    spaceUuid: 'new-space-uuid',
+                }),
+            }),
+        );
+        expect(savedChartModel.update).not.toHaveBeenCalled();
+    });
+
+    it('drafts only Git-backed charts in a mixed bulk update', async () => {
+        const managedChart = {
+            ...chart,
+            uuid: 'managed-chart',
+            slug: 'managed-chart',
+        };
+        const uiOnlyChart = {
+            ...chart,
+            uuid: 'ui-only-chart',
+            slug: 'ui-only-chart',
+        };
+        const { service, savedChartModel, upsertOpenDraft } = buildService({
+            charts: [managedChart, uiOnlyChart],
+            managedSlugs: [managedChart.slug],
+        });
+        const updates = [managedChart, uiOnlyChart].map((item) => ({
+            uuid: item.uuid,
+            name: `${item.name} updated`,
+            description: item.description,
+            spaceUuid: 'new-space-uuid',
+        }));
+
+        const results = await service.updateMultiple(
+            editor,
+            chart.projectUuid,
+            updates,
+        );
+
+        expect(upsertOpenDraft).toHaveBeenCalledTimes(1);
+        expect(upsertOpenDraft).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contentUuid: managedChart.uuid,
+                draft: expect.objectContaining({
+                    spaceUuid: 'new-space-uuid',
+                }),
+            }),
+        );
+        expect(savedChartModel.updateMultiple).toHaveBeenCalledWith(
+            chart.projectUuid,
+            [updates[1]],
+        );
+        expect(results).toMatchObject([
+            { uuid: managedChart.uuid, hasUnpublishedChanges: true },
+            { uuid: uiOnlyChart.uuid },
+        ]);
+        expect(results[1]).not.toHaveProperty('hasUnpublishedChanges');
+    });
+
+    it('persists safe drafts before a mixed bulk publish failure', async () => {
+        const managedChart = {
+            ...chart,
+            uuid: 'managed-chart',
+            slug: 'managed-chart',
+        };
+        const uiOnlyChart = {
+            ...chart,
+            uuid: 'ui-only-chart',
+            slug: 'ui-only-chart',
+        };
+        const { service, savedChartModel, upsertOpenDraft } = buildService({
+            charts: [managedChart, uiOnlyChart],
+            managedSlugs: [managedChart.slug],
+        });
+        savedChartModel.updateMultiple.mockRejectedValueOnce(
+            new Error('published transaction failed'),
+        );
+        const updates = [managedChart, uiOnlyChart].map((item) => ({
+            uuid: item.uuid,
+            name: `${item.name} updated`,
+            description: item.description,
+            spaceUuid: item.spaceUuid,
+        }));
+
+        await expect(
+            service.updateMultiple(editor, chart.projectUuid, updates),
+        ).rejects.toThrow('published transaction failed');
+        expect(upsertOpenDraft).toHaveBeenCalledTimes(1);
+        expect(upsertOpenDraft.mock.invocationCallOrder[0]).toBeLessThan(
+            savedChartModel.updateMultiple.mock.invocationCallOrder[0],
+        );
+    });
+
+    it('publishes every bulk chart update for a Content as Code manager', async () => {
+        const managedChart = {
+            ...chart,
+            uuid: 'managed-chart',
+            slug: 'managed-chart',
+        };
+        const { service, savedChartModel, upsertOpenDraft } = buildService({
+            charts: [managedChart],
+            managedSlugs: [managedChart.slug],
+        });
+        const updates = [
+            {
+                uuid: managedChart.uuid,
+                name: 'Manager update',
+                description: managedChart.description,
+                spaceUuid: managedChart.spaceUuid,
+            },
+        ];
+
+        await service.updateMultiple(reviewer, chart.projectUuid, updates);
+
+        expect(upsertOpenDraft).not.toHaveBeenCalled();
+        expect(savedChartModel.updateMultiple).toHaveBeenCalledWith(
+            chart.projectUuid,
+            updates,
+        );
     });
 
     it('publishes UI-only charts through the existing path', async () => {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -142,6 +142,7 @@ type ChartDraftOverlay = Partial<
         | 'pivotConfig'
         | 'parameters'
         | 'merge'
+        | 'spaceUuid'
     >
 > & { verified?: boolean };
 
@@ -165,6 +166,7 @@ const assertChartDraftOverlay: (
         pivotConfig: isRecord,
         parameters: isRecord,
         merge: (value) => value === null || isRecord(value),
+        spaceUuid: (value) => typeof value === 'string',
         verified: (value) => typeof value === 'boolean',
     };
     for (const [field, validate] of Object.entries(validators)) {
@@ -773,6 +775,9 @@ export class SavedChartService
                 parameters: draft.parameters,
             }),
             ...(draft.merge !== undefined && { merge: draft.merge }),
+            ...(draft.spaceUuid !== undefined && {
+                spaceUuid: draft.spaceUuid,
+            }),
         };
     }
 
@@ -787,21 +792,51 @@ export class SavedChartService
         },
     ): Promise<SavedChart | undefined> {
         if (Object.keys(draftFields).length === 0) return undefined;
+        if (!(await this.shouldStoreDraft(user, existingChart))) {
+            return undefined;
+        }
+        return this.storeDraft(
+            user,
+            existingChart,
+            draftFields,
+            verificationAfterUpdate,
+            spaceContext,
+        );
+    }
+
+    private async shouldStoreDraft(
+        user: SessionUser,
+        existingChart: Pick<SavedChartDAO, 'projectUuid' | 'slug'>,
+    ): Promise<boolean> {
         const settings = await this.contentAsCodeProjectSettingsModel.get(
             existingChart.projectUuid,
         );
-        if (!settings?.syncEnabled) return undefined;
+        if (!settings?.syncEnabled) return false;
         const snapshot = await this.contentAsCodeSnapshotModel.get(
             existingChart.projectUuid,
             ContentAsCodeType.CHART,
             existingChart.slug,
         );
-        if (snapshot === undefined) return undefined;
+        if (snapshot === undefined) return false;
         if (
             await this.canManageContentAsCode(user, existingChart.projectUuid)
         ) {
-            return undefined;
+            return false;
         }
+        return true;
+    }
+
+    private async storeDraft(
+        user: SessionUser,
+        existingChart: SavedChartDAO | ChartSummary,
+        draftFields: ChartDraftOverlay,
+        verificationAfterUpdate: ContentVerificationInfo | null,
+        spaceContext: {
+            inheritsFromOrgOrProject: boolean;
+            access: SpaceAccess[];
+        },
+    ): Promise<SavedChart> {
+        assertChartDraftOverlay(draftFields);
         const stored = await this.contentDraftModel.upsertOpenDraft({
             projectUuid: existingChart.projectUuid,
             contentType: 'chart',
@@ -1274,6 +1309,9 @@ export class SavedChartService
             ...(chartUpdate.description !== undefined && {
                 description: chartUpdate.description,
             }),
+            ...(chartUpdate.spaceUuid !== undefined && {
+                spaceUuid: chartUpdate.spaceUuid,
+            }),
             ...(chartUpdate.name !== undefined ||
             chartUpdate.description !== undefined
                 ? { verified: verificationAfterUpdate !== null }
@@ -1483,17 +1521,30 @@ export class SavedChartService
         // current and target space are checked with space access.
         const chartSpaceContexts = await Promise.all(
             data.map(async (chart) => {
-                const { spaceUuid: currentSpaceUuid } =
-                    await this.savedChartModel.getSummary(chart.uuid);
-                const spaceContexts = await Promise.all(
-                    [currentSpaceUuid, chart.spaceUuid].map((spaceUuid) =>
-                        this.spacePermissionService.resolveAccess(
-                            user.userUuid,
-                            { type: 'space', spaceUuid },
+                const existingChart = await this.savedChartModel.getSummary(
+                    chart.uuid,
+                );
+                const { spaceUuid: currentSpaceUuid } = existingChart;
+                const [spaceContexts, verification] = await Promise.all([
+                    Promise.all(
+                        [currentSpaceUuid, chart.spaceUuid].map((spaceUuid) =>
+                            this.spacePermissionService.resolveAccess(
+                                user.userUuid,
+                                { type: 'space', spaceUuid },
+                            ),
                         ),
                     ),
-                );
-                return { chart, spaceContexts };
+                    this.contentVerificationModel.getByContent(
+                        ContentType.CHART,
+                        chart.uuid,
+                    ),
+                ]);
+                return {
+                    chart,
+                    existingChart,
+                    spaceContexts,
+                    verification,
+                };
             }),
         );
         const auditedAbility = this.createAuditedAbility(user);
@@ -1518,23 +1569,55 @@ export class SavedChartService
         }
 
         await Promise.all(
-            data.map(async (chart) => {
-                const summary = await this.savedChartModel.getSummary(
-                    chart.uuid,
-                );
+            chartSpaceContexts.map(async ({ existingChart }) => {
                 await this.assertCanMutateVerifiedChart({
                     user,
-                    chartUuid: chart.uuid,
-                    projectUuid: summary.projectUuid,
-                    organizationUuid: summary.organizationUuid,
+                    chartUuid: existingChart.uuid,
+                    projectUuid: existingChart.projectUuid,
+                    organizationUuid: existingChart.organizationUuid,
                 });
             }),
         );
 
-        const savedChartsDaos = await this.savedChartModel.updateMultiple(
-            projectUuid,
-            data,
+        const shouldStoreDraft = await Promise.all(
+            chartSpaceContexts.map(({ existingChart }) =>
+                this.shouldStoreDraft(user, existingChart),
+            ),
         );
+        // Draft upserts are idempotent and happen before the transactional
+        // published update, so a retry cannot duplicate or partially publish.
+        const draftResults = await Promise.all(
+            chartSpaceContexts.map(
+                async (
+                    { chart, existingChart, spaceContexts, verification },
+                    index,
+                ) =>
+                    shouldStoreDraft[index]
+                        ? this.storeDraft(
+                              user,
+                              existingChart,
+                              {
+                                  name: chart.name,
+                                  description: chart.description,
+                                  spaceUuid: chart.spaceUuid,
+                              },
+                              verification,
+                              spaceContexts[1],
+                          )
+                        : undefined,
+            ),
+        );
+
+        const directUpdates = data.filter(
+            (_chart, index) => !shouldStoreDraft[index],
+        );
+        const savedChartsDaos =
+            directUpdates.length > 0
+                ? await this.savedChartModel.updateMultiple(
+                      projectUuid,
+                      directUpdates,
+                  )
+                : [];
         const savedCharts = await Promise.all(
             savedChartsDaos.map(async (savedChart) => {
                 const { inheritsFromOrgOrProject, access } =
@@ -1549,6 +1632,9 @@ export class SavedChartService
                 };
             }),
         );
+        const savedChartsByUuid = new Map(
+            savedCharts.map((savedChart) => [savedChart.uuid, savedChart]),
+        );
         this.analytics.track({
             event: 'saved_chart.updated_multiple',
             userId: user.userUuid,
@@ -1557,7 +1643,12 @@ export class SavedChartService
                 projectId: projectUuid,
             },
         });
-        return savedCharts;
+        return data.map((chart, index) => {
+            const result =
+                draftResults[index] ?? savedChartsByUuid.get(chart.uuid);
+            if (!result) throw new NotFoundError('Saved query not found');
+            return result;
+        });
     }
 
     async delete(


### PR DESCRIPTION
Closes #28225

## What changed
- classify each bulk chart/dashboard edit using the strict sync-enabled + matching-snapshot gate
- save managed editor items as author drafts while publishing UI-only items in the same batch normally
- keep Content-as-Code manager batches on the direct mutation path
- preserve input order and return unpublished markers only for drafted items
- include space moves in draft overlays and canonical review/write-back YAML
- preflight the full batch; persist retry-safe drafts before the transactional published subset

## Validation
- 197 adjacent backend tests passed
- backend typecheck passed
- targeted backend lint and formatting passed