### PR TITLE
feat(chart-types): unlink connections from the attach picker

### DIFF
--- a/packages/frontend/src/features/apps/AppResourcePicker.module.css
+++ b/packages/frontend/src/features/apps/AppResourcePicker.module.css
@@ -91,11 +91,6 @@
     }
 }
 
-.chartItemHint {
-    flex-shrink: 0;
-    white-space: nowrap;
-}
-
 .chartItemSelectedIcon {
     display: inline-flex;
     align-items: center;

--- a/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
@@ -30,6 +30,10 @@ vi.mock('../externalConnections/hooks/useExternalConnections', () => ({
         })) as unknown as ExternalConnection[],
     }),
 }));
+const unlink = vi.fn();
+vi.mock('../externalConnections/hooks/useUnlinkAppExternalConnection', () => ({
+    useUnlinkAppExternalConnection: () => ({ mutate: unlink }),
+}));
 vi.mock('../externalConnections/hooks/useAppExternalConnections', () => ({
     useAppExternalConnections: (
         _projectUuid: string | undefined,
@@ -173,19 +177,15 @@ it('counts linked and newly selected connections together, without double counti
     expect(screen.getByText('3')).toBeInTheDocument();
 });
 
-it('marks connections the app already links, unless they are selected again', () => {
+it('shows linked connections as checked, and unlinks them on click', () => {
+    const onSelect = vi.fn();
+    const onDeselect = vi.fn();
     render(
         <MantineProvider env="test">
             <ConnectionPickerView
-                selectedConnections={[
-                    {
-                        externalConnectionUuid: 'c-selected',
-                        name: 'Selected API',
-                        alias: 'selected_api',
-                    },
-                ]}
-                onSelect={() => undefined}
-                onDeselect={() => undefined}
+                selectedConnections={[]}
+                onSelect={onSelect}
+                onDeselect={onDeselect}
                 onDone={() => undefined}
                 enabled
                 linkedAppUuid="app-1"
@@ -193,17 +193,36 @@ it('marks connections the app already links, unless they are selected again', ()
         </MantineProvider>,
     );
 
-    const hints = screen.getAllByText('Linked');
-    expect(hints).toHaveLength(1);
-    expect(hints[0].parentElement).toHaveTextContent('Linked API');
+    const linkedRow = screen.getByRole('checkbox', { name: /Linked API/ });
+    expect(linkedRow).toBeChecked();
+    expect(
+        screen.getByRole('checkbox', { name: /Plain API/ }),
+    ).not.toBeChecked();
+
+    fireEvent.click(linkedRow);
+    expect(unlink).toHaveBeenCalledWith({
+        projectUuid: 'project-1',
+        appUuid: 'app-1',
+        alias: 'linked_api',
+        name: 'Linked API',
+    });
+    expect(onDeselect).toHaveBeenCalledWith('c-linked');
+    expect(onSelect).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Plain API/ }));
+    expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ externalConnectionUuid: 'c-plain' }),
+    );
 });
 
-it('shows no linked hint before a first build exists', () => {
+it('never unlinks before a first build exists', () => {
+    unlink.mockClear();
+    const onSelect = vi.fn();
     render(
         <MantineProvider env="test">
             <ConnectionPickerView
                 selectedConnections={[]}
-                onSelect={() => undefined}
+                onSelect={onSelect}
                 onDeselect={() => undefined}
                 onDone={() => undefined}
                 enabled
@@ -211,5 +230,9 @@ it('shows no linked hint before a first build exists', () => {
         </MantineProvider>,
     );
 
-    expect(screen.queryByText('Linked')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('checkbox', { name: /Linked API/ }));
+    expect(unlink).not.toHaveBeenCalled();
+    expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ externalConnectionUuid: 'c-linked' }),
+    );
 });

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -64,6 +64,7 @@ import { useProjectUuid } from '../../hooks/useProjectUuid';
 import useApp from '../../providers/App/useApp';
 import { useAppExternalConnections } from '../externalConnections/hooks/useAppExternalConnections';
 import { useExternalConnections } from '../externalConnections/hooks/useExternalConnections';
+import { useUnlinkAppExternalConnection } from '../externalConnections/hooks/useUnlinkAppExternalConnection';
 import { uniqueAliasFromName } from '../externalConnections/utils/aliasFromName';
 import classes from './AppResourcePicker.module.css';
 import {
@@ -944,8 +945,8 @@ export const ConnectionPickerView: FC<{
     onDeselect: (uuid: string) => void;
     onDone: () => void;
     enabled: boolean;
-    /** App whose existing links mark rows as already linked; omit before a
-     *  first build, when nothing can be linked yet. */
+    /** App whose existing links show as checked rows that unlink on click;
+     *  omit before a first build, when nothing can be linked yet. */
     linkedAppUuid?: string;
 }> = ({
     selectedConnections,
@@ -964,15 +965,17 @@ export const ConnectionPickerView: FC<{
         enabled ? projectUuid : undefined,
         linkedAppUuid,
     );
-    const linkedUuids = useMemo(
+    const linkedAliases = useMemo(
         () =>
-            new Set(
-                (existingLinks ?? []).map(
-                    (link) => link.connection.externalConnectionUuid,
-                ),
+            new Map(
+                (existingLinks ?? []).map((link) => [
+                    link.connection.externalConnectionUuid,
+                    link.alias,
+                ]),
             ),
         [existingLinks],
     );
+    const { mutate: unlink } = useUnlinkAppExternalConnection();
 
     // Only project/org admins can create connections; mirror the gate the
     // Project Settings → Data app connections page uses.
@@ -1018,7 +1021,18 @@ export const ConnectionPickerView: FC<{
 
     const handleToggle = useCallback(
         (connection: ExternalConnection) => {
-            if (selectedUuids.has(connection.externalConnectionUuid)) {
+            const linkedAlias = linkedAliases.get(
+                connection.externalConnectionUuid,
+            );
+            if (linkedAlias !== undefined && projectUuid && linkedAppUuid) {
+                unlink({
+                    projectUuid,
+                    appUuid: linkedAppUuid,
+                    alias: linkedAlias,
+                    name: connection.name,
+                });
+                onDeselect(connection.externalConnectionUuid);
+            } else if (selectedUuids.has(connection.externalConnectionUuid)) {
                 onDeselect(connection.externalConnectionUuid);
             } else {
                 onSelect({
@@ -1031,7 +1045,16 @@ export const ConnectionPickerView: FC<{
                 });
             }
         },
-        [onSelect, onDeselect, selectedConnections, selectedUuids],
+        [
+            linkedAliases,
+            linkedAppUuid,
+            onDeselect,
+            onSelect,
+            projectUuid,
+            selectedConnections,
+            selectedUuids,
+            unlink,
+        ],
     );
 
     return (
@@ -1065,18 +1088,21 @@ export const ConnectionPickerView: FC<{
                     </Stack>
                 ) : (
                     filtered.map((connection) => {
-                        const isSelected = selectedUuids.has(
-                            connection.externalConnectionUuid,
-                        );
-                        const isLinked = linkedUuids.has(
-                            connection.externalConnectionUuid,
-                        );
+                        const isChecked =
+                            selectedUuids.has(
+                                connection.externalConnectionUuid,
+                            ) ||
+                            linkedAliases.has(
+                                connection.externalConnectionUuid,
+                            );
                         return (
                             <Box
                                 key={connection.externalConnectionUuid}
                                 className={`${classes.chartItem} ${
-                                    isSelected ? classes.chartItemSelected : ''
+                                    isChecked ? classes.chartItemSelected : ''
                                 }`}
+                                aria-checked={isChecked}
+                                role="checkbox"
                                 onClick={() => handleToggle(connection)}
                             >
                                 <MantineIcon icon={IconPlugConnected} />
@@ -1088,16 +1114,7 @@ export const ConnectionPickerView: FC<{
                                         {connection.origin}
                                     </Text>
                                 </Box>
-                                {!isSelected && isLinked && (
-                                    <Text
-                                        size="xs"
-                                        c="dimmed"
-                                        className={classes.chartItemHint}
-                                    >
-                                        Linked
-                                    </Text>
-                                )}
-                                {isSelected && (
+                                {isChecked && (
                                     <Box
                                         className={
                                             classes.chartItemSelectedIcon

--- a/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.test.tsx
+++ b/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.test.tsx
@@ -1,0 +1,76 @@
+import { type AppExternalConnectionLinked } from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { type FC, type PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../api';
+import { useUnlinkAppExternalConnection } from './useUnlinkAppExternalConnection';
+
+vi.mock('../../../api', () => ({ lightdashApi: vi.fn() }));
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastInfo: vi.fn(), showToastApiError: vi.fn() }),
+}));
+
+const queryKey = ['app-external-connections', 'project-1', 'app-1'];
+const links = [
+    { alias: 'weather', connection: { externalConnectionUuid: 'c-weather' } },
+    { alias: 'images', connection: { externalConnectionUuid: 'c-images' } },
+] as unknown as AppExternalConnectionLinked[];
+
+const setup = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+    queryClient.setQueryData(queryKey, links);
+    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+    const { result } = renderHook(() => useUnlinkAppExternalConnection(), {
+        wrapper,
+    });
+    return { queryClient, result };
+};
+
+describe('useUnlinkAppExternalConnection', () => {
+    it('DELETEs by alias and drops the link from the cache', async () => {
+        vi.mocked(lightdashApi).mockResolvedValue(undefined as never);
+        const { queryClient, result } = setup();
+
+        result.current.mutate({
+            projectUuid: 'project-1',
+            appUuid: 'app-1',
+            alias: 'weather',
+            name: 'Weather',
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(lightdashApi).toHaveBeenCalledWith({
+            url: '/ee/projects/project-1/apps/app-1/external-connections/weather',
+            method: 'DELETE',
+            body: undefined,
+        });
+        expect(queryClient.getQueryData(queryKey)).toEqual([links[1]]);
+    });
+
+    it('restores the link when the request fails', async () => {
+        vi.mocked(lightdashApi).mockRejectedValue({
+            error: { message: 'nope' },
+        });
+        const { queryClient, result } = setup();
+
+        result.current.mutate({
+            projectUuid: 'project-1',
+            appUuid: 'app-1',
+            alias: 'weather',
+            name: 'Weather',
+        });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(queryClient.getQueryData(queryKey)).toEqual(links);
+    });
+});

--- a/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.ts
@@ -1,0 +1,63 @@
+import {
+    type ApiError,
+    type AppExternalConnectionLinked,
+} from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+type UnlinkParams = {
+    projectUuid: string;
+    appUuid: string;
+    alias: string;
+    name: string;
+};
+
+const unlinkAppExternalConnection = async ({
+    projectUuid,
+    appUuid,
+    alias,
+}: UnlinkParams) =>
+    lightdashApi<undefined>({
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}/external-connections/${encodeURIComponent(
+            alias,
+        )}`,
+        method: 'DELETE',
+        body: undefined,
+    });
+
+/** Unlinks optimistically: the app keeps calling the alias until it is
+ *  rebuilt, so the toast points at the composer. */
+export const useUnlinkAppExternalConnection = () => {
+    const queryClient = useQueryClient();
+    const { showToastInfo, showToastApiError } = useToaster();
+    return useMutation<undefined, ApiError, UnlinkParams>({
+        mutationFn: unlinkAppExternalConnection,
+        onMutate: async ({ projectUuid, appUuid, alias }) => {
+            const queryKey = ['app-external-connections', projectUuid, appUuid];
+            await queryClient.cancelQueries({ queryKey });
+            queryClient.setQueryData<AppExternalConnectionLinked[]>(
+                queryKey,
+                (links) => links?.filter((link) => link.alias !== alias),
+            );
+        },
+        onSuccess: (_data, { name }) => {
+            showToastInfo({
+                title: `Unlinked ${name}`,
+                subtitle:
+                    'The chart type still calls it until you ask for a change.',
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to unlink connection',
+                apiError: error,
+            });
+        },
+        onSettled: async (_data, _error, { projectUuid, appUuid }) => {
+            await queryClient.invalidateQueries({
+                queryKey: ['app-external-connections', projectUuid, appUuid],
+            });
+        },
+    });
+};

--- a/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useUnlinkAppExternalConnection.ts
@@ -26,20 +26,36 @@ const unlinkAppExternalConnection = async ({
         body: undefined,
     });
 
-/** Unlinks optimistically: the app keeps calling the alias until it is
- *  rebuilt, so the toast points at the composer. */
+const linksQueryKey = (projectUuid: string, appUuid: string) => [
+    'app-external-connections',
+    projectUuid,
+    appUuid,
+];
+
+/** Unlinks optimistically and rolls back on failure. The app keeps calling
+ *  the alias until it is rebuilt, so the toast points at the composer. */
 export const useUnlinkAppExternalConnection = () => {
     const queryClient = useQueryClient();
     const { showToastInfo, showToastApiError } = useToaster();
-    return useMutation<undefined, ApiError, UnlinkParams>({
+    return useMutation<
+        undefined,
+        ApiError,
+        UnlinkParams,
+        { previousLinks: AppExternalConnectionLinked[] | undefined }
+    >({
         mutationFn: unlinkAppExternalConnection,
         onMutate: async ({ projectUuid, appUuid, alias }) => {
-            const queryKey = ['app-external-connections', projectUuid, appUuid];
+            const queryKey = linksQueryKey(projectUuid, appUuid);
             await queryClient.cancelQueries({ queryKey });
+            const previousLinks =
+                queryClient.getQueryData<AppExternalConnectionLinked[]>(
+                    queryKey,
+                );
             queryClient.setQueryData<AppExternalConnectionLinked[]>(
                 queryKey,
                 (links) => links?.filter((link) => link.alias !== alias),
             );
+            return { previousLinks };
         },
         onSuccess: (_data, { name }) => {
             showToastInfo({
@@ -48,7 +64,11 @@ export const useUnlinkAppExternalConnection = () => {
                     'The chart type still calls it until you ask for a change.',
             });
         },
-        onError: ({ error }) => {
+        onError: ({ error }, { projectUuid, appUuid }, context) => {
+            queryClient.setQueryData(
+                linksQueryKey(projectUuid, appUuid),
+                context?.previousLinks,
+            );
             showToastApiError({
                 title: 'Failed to unlink connection',
                 apiError: error,
@@ -56,7 +76,7 @@ export const useUnlinkAppExternalConnection = () => {
         },
         onSettled: async (_data, _error, { projectUuid, appUuid }) => {
             await queryClient.invalidateQueries({
-                queryKey: ['app-external-connections', projectUuid, appUuid],
+                queryKey: linksQueryKey(projectUuid, appUuid),
             });
         },
     });


### PR DESCRIPTION
Relates: #28056
Relates: PROD-10583

### Description:

Follow-up to #28136. Connections a chart type already links now show as checked rows in the attach picker and unlink on click, the same gesture that deselects a pending one. The attach indicator counts linked and newly selected connections together and refreshes when a build lands.

Unlinking removes the link only; the generated code is left as it is, so the chart type keeps calling the alias until the next change is built. The toast says so and points at the composer.

- New `useUnlinkAppExternalConnection` mutation (optimistic, `DELETE apps/{appUuid}/external-connections/{alias}`).
- Picker rows are real checkboxes (`role="checkbox"`, `aria-checked`), linked or pending.
- Tests cover unlink on click, no unlink before a first build, and the combined count.

### Risk assessment:

- [ ] This is a high-risk change