### PR TITLE
style(auth): make login background pink

### DIFF
--- a/packages/frontend/src/components/common/AuthLayout/index.tsx
+++ b/packages/frontend/src/components/common/AuthLayout/index.tsx
@@ -28,6 +28,8 @@ type Props = {
     cardId?: string;
     /** Pages that bring their own cards (Invite) opt out of the legacy card. */
     withLegacyCard?: boolean;
+    backgroundColor?: string;
+    brandBackgroundColor?: string;
     footer?: ReactNode;
 };
 
@@ -38,6 +40,8 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
     legacyTitle,
     cardId,
     withLegacyCard = true,
+    backgroundColor,
+    brandBackgroundColor,
     footer,
     children,
 }) => {
@@ -48,7 +52,7 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
     }
 
     if (!isNewLayout) {
-        return (
+        const page = (
             <Page title={pageTitle} withCenteredContent withNavbar={false}>
                 <Stack w={400} mt="4xl">
                     <Box mx="auto" my="lg">
@@ -76,6 +80,8 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
                 </Stack>
             </Page>
         );
+
+        return backgroundColor ? <Box bg={backgroundColor}>{page}</Box> : page;
     }
 
     return (
@@ -83,7 +89,7 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
             <DocumentTitle title={pageTitle} />
 
             <Box className={classes.root}>
-                <Box className={classes.brandPanel}>
+                <Box className={classes.brandPanel} bg={brandBackgroundColor}>
                     <Box className={classes.decorationTop} aria-hidden />
                     <Box className={classes.decorationBottom} aria-hidden />
 
@@ -128,7 +134,7 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
                     </Stack>
                 </Box>
 
-                <Box className={classes.formPanel}>
+                <Box className={classes.formPanel} bg={backgroundColor}>
                     <Stack id={cardId} className={classes.formContent} gap="xl">
                         <Group
                             gap="sm"

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -8,7 +8,7 @@ import LoginLanding from '../features/users/components/LoginLanding';
 const Login: FC<{ minimal?: boolean }> = ({ minimal = false }) => {
     if (minimal) {
         return (
-            <Stack m="xl">
+            <Stack bg="pink.0" mih="100vh" p="xl">
                 <Box mx="auto" my="lg">
                     <LightdashLogo />
                 </Box>
@@ -35,6 +35,8 @@ const Login: FC<{ minimal?: boolean }> = ({ minimal = false }) => {
             subtitle="Welcome back — pick up where you left off."
             legacyTitle="Sign in"
             cardId={LOGIN_PAGE_ID}
+            backgroundColor="pink.0"
+            brandBackgroundColor="pink.7"
         >
             <LoginLanding />
         </AuthLayout>


### PR DESCRIPTION
## What changed

## Summary
- Give every login layout a pink background without changing other authentication pages
- Use a deeper pink for the split-screen brand panel to preserve readable white branding
- Keep the login form on a pale pink surface

### Validation
- `pnpm -F 'frontend' exec oxfmt 'src/components/common/AuthLayout/index.tsx' 'src/pages/Login.tsx'` — passed
- `pnpm -F 'frontend' run --if-present lint` — passed
- `pnpm -F 'frontend' run --if-present typecheck` — passed
- `pnpm -F 'frontend' exec vitest related 'src/components/common/AuthLayout/index.tsx' 'src/pages/Login.tsx' --run --passWithNoTests` — passed

### Review notes
- Kept `pink.0` literal at the two login render variants for a minimal visual patch. A shared semantic constant would prevent those values drifting; reviewer input is useful if login palette decisions are expected to be centralized.
- Kept the existing neutral loading spinner while the layout feature flag resolves. A full-viewport pink loading surface would avoid a brief color transition; reviewer input is useful on whether that transient state should also adopt the login background.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10726-496703f72219.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10726

