### PR TITLE
fix(cli): force selected content uploads

### DIFF
--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -93,6 +93,7 @@ const {
     summarizeUploadChanges,
     upsertAiAgents,
     upsertExternalConnections,
+    upsertResources,
     upsertSpaces,
     upsertVirtualViews,
     validateSpaceIdentity,
@@ -428,6 +429,106 @@ const makeChart = (series: Series[]): ChartAsCode =>
         },
         dashboardSlug: undefined,
     }) as ChartAsCode;
+
+describe('upsertResources force behavior', () => {
+    let tmpDir: string;
+    const unchangedChart = () => ({
+        ...makeChart([]),
+        needsUpdating: false,
+    });
+    const upsertCharts = (force: boolean, slugs: string[]) =>
+        upsertResources(
+            'charts',
+            'project-uuid',
+            {},
+            force,
+            slugs,
+            true,
+            tmpDir,
+            false,
+            false,
+            false,
+            1,
+            [unchangedChart()],
+        );
+
+    beforeEach(async () => {
+        vi.mocked(lightdashApi).mockReset();
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'upload-force-test-'));
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('skips an unchanged chart during an unfiltered upload', async () => {
+        await upsertCharts(false, []);
+
+        expect(lightdashApi).not.toHaveBeenCalled();
+    });
+
+    it('force-upserts an explicitly selected unchanged chart', async () => {
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            charts: [{ action: 'update', data: { uuid: 'chart-uuid' } }],
+            dashboards: [],
+            spaces: [],
+        } as never);
+
+        await upsertCharts(false, ['pivoted-chart']);
+
+        expect(lightdashApi).toHaveBeenCalledOnce();
+        expect(
+            JSON.parse(vi.mocked(lightdashApi).mock.calls[0][0].body as string),
+        ).toMatchObject({ force: true, slug: 'pivoted-chart' });
+    });
+
+    it('force-upserts an explicitly selected unchanged dashboard', async () => {
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            charts: [],
+            dashboards: [
+                { action: 'update', data: { uuid: 'dashboard-uuid' } },
+            ],
+            spaces: [],
+        } as never);
+
+        await upsertResources(
+            'dashboards',
+            'project-uuid',
+            {},
+            false,
+            ['revenue-dashboard'],
+            true,
+            tmpDir,
+            false,
+            false,
+            false,
+            1,
+            [makeLooseDashboard('revenue-dashboard', [])],
+        );
+
+        expect(lightdashApi).toHaveBeenCalledOnce();
+        expect(
+            JSON.parse(vi.mocked(lightdashApi).mock.calls[0][0].body as string),
+        ).toMatchObject({ force: true, slug: 'revenue-dashboard' });
+    });
+
+    it('keeps global force behavior for unfiltered uploads', async () => {
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            charts: [{ action: 'update', data: { uuid: 'chart-uuid' } }],
+            dashboards: [],
+            spaces: [],
+        } as never);
+
+        await upsertCharts(true, []);
+
+        expect(lightdashApi).toHaveBeenCalledOnce();
+        expect(
+            JSON.parse(vi.mocked(lightdashApi).mock.calls[0][0].body as string),
+        ).toMatchObject({ force: true, slug: 'pivoted-chart' });
+    });
+});
 
 describe('getDashboardChartSlugs', () => {
     let tmpDir: string;

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -3196,6 +3196,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
     logContentAsCodeDiscovery(`Found ${items.length} ${type} files`);
 
     const hasFilter = slugs.length > 0;
+    const shouldForce = force || hasFilter;
     const filteredItems = hasFilter
         ? items.filter((item) => slugs.includes(item.slug))
         : items;
@@ -3261,7 +3262,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 type,
                 projectId,
                 changes,
-                force,
+                shouldForce,
                 config,
                 skipSpaceCreate,
                 publicSpaceCreate,
@@ -3285,8 +3286,8 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
 
         Object.values(grouped).forEach((spaceItems: ItemWithUpdate[]) => {
             // Pick the first item that will actually trigger an API call
-            // (and thus create the space). If force is true, any item works.
-            const seedIndex = force
+            // (and thus create the space). Forced selections can use any item.
+            const seedIndex = shouldForce
                 ? 0
                 : spaceItems.findIndex((i) => i.needsUpdating);
             if (seedIndex >= 0) {
@@ -3319,7 +3320,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                     seedItems.has(item),
                 );
                 if (!alreadySeeded) {
-                    const seedIndex = force
+                    const seedIndex = shouldForce
                         ? 0
                         : dashboardItems.findIndex((i) => i.needsUpdating);
                     if (seedIndex >= 0) {
@@ -3344,7 +3345,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 type,
                 projectId,
                 changes,
-                force,
+                shouldForce,
                 config,
                 skipSpaceCreate,
                 publicSpaceCreate,
@@ -3364,7 +3365,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                         type,
                         projectId,
                         changes,
-                        force,
+                        shouldForce,
                         config,
                         skipSpaceCreate,
                         publicSpaceCreate,
@@ -4754,6 +4755,7 @@ export const testHelpers = {
     upsertAiAgents,
     upsertExternalConnections,
     upsertSpaces,
+    upsertResources,
     upsertVirtualViews,
     validateSpaceIdentity,
     writeSpaceFiles,


### PR DESCRIPTION
## Summary
- force-upsert charts and dashboards explicitly selected by slug
- preserve unfiltered diff/no-op behavior
- preserve global `--force` behavior

## Tests
- 97 focused CLI tests
- full CLI suite: 627 tests
- CLI typecheck, lint, format

Closes #28224