### PR TITLE
feat(frontend): make login background pink

### DIFF
--- a/packages/frontend/src/components/common/AuthLayout/index.tsx
+++ b/packages/frontend/src/components/common/AuthLayout/index.tsx
@@ -1,4 +1,12 @@
-import { Box, Card, Group, Stack, Text, Title } from '@mantine/core';
+import {
+    Box,
+    Card,
+    Group,
+    Stack,
+    Text,
+    Title,
+    type MantineColor,
+} from '@mantine/core';
 import { IconCheck } from '@tabler/icons-react';
 import { type FC, type PropsWithChildren, type ReactNode } from 'react';
 import LightdashLogo from '../../LightdashLogo/LightdashLogo';
@@ -28,6 +36,7 @@ type Props = {
     cardId?: string;
     /** Pages that bring their own cards (Invite) opt out of the legacy card. */
     withLegacyCard?: boolean;
+    backgroundColor?: MantineColor;
     footer?: ReactNode;
 };
 
@@ -38,6 +47,7 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
     legacyTitle,
     cardId,
     withLegacyCard = true,
+    backgroundColor,
     footer,
     children,
 }) => {
@@ -49,32 +59,34 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
 
     if (!isNewLayout) {
         return (
-            <Page title={pageTitle} withCenteredContent withNavbar={false}>
-                <Stack w={400} mt="4xl">
-                    <Box mx="auto" my="lg">
-                        <LightdashLogo />
-                    </Box>
-                    {withLegacyCard ? (
-                        <Card
-                            id={cardId}
-                            p="xl"
-                            radius="xs"
-                            withBorder
-                            shadow="xs"
-                        >
-                            {legacyTitle && (
-                                <Title order={3} ta="center" mb="md">
-                                    {legacyTitle}
-                                </Title>
-                            )}
-                            {children}
-                        </Card>
-                    ) : (
-                        children
-                    )}
-                    {footer}
-                </Stack>
-            </Page>
+            <Box bg={backgroundColor}>
+                <Page title={pageTitle} withCenteredContent withNavbar={false}>
+                    <Stack w={400} mt="4xl">
+                        <Box mx="auto" my="lg">
+                            <LightdashLogo />
+                        </Box>
+                        {withLegacyCard ? (
+                            <Card
+                                id={cardId}
+                                p="xl"
+                                radius="xs"
+                                withBorder
+                                shadow="xs"
+                            >
+                                {legacyTitle && (
+                                    <Title order={3} ta="center" mb="md">
+                                        {legacyTitle}
+                                    </Title>
+                                )}
+                                {children}
+                            </Card>
+                        ) : (
+                            children
+                        )}
+                        {footer}
+                    </Stack>
+                </Page>
+            </Box>
         );
     }
 
@@ -128,7 +140,7 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
                     </Stack>
                 </Box>
 
-                <Box className={classes.formPanel}>
+                <Box className={classes.formPanel} bg={backgroundColor}>
                     <Stack id={cardId} className={classes.formContent} gap="xl">
                         <Group
                             gap="sm"

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -8,7 +8,7 @@ import LoginLanding from '../features/users/components/LoginLanding';
 const Login: FC<{ minimal?: boolean }> = ({ minimal = false }) => {
     if (minimal) {
         return (
-            <Stack m="xl">
+            <Stack mih="100vh" p="xl" bg="pink.1">
                 <Box mx="auto" my="lg">
                     <LightdashLogo />
                 </Box>
@@ -35,6 +35,7 @@ const Login: FC<{ minimal?: boolean }> = ({ minimal = false }) => {
             subtitle="Welcome back — pick up where you left off."
             legacyTitle="Sign in"
             cardId={LOGIN_PAGE_ID}
+            backgroundColor="pink.1"
         >
             <LoginLanding />
         </AuthLayout>


### PR DESCRIPTION
## What changed

Updated the login page to use a pale pink background while preserving the existing branded panel and sign-in interface. Other pre-auth pages keep their current backgrounds.

### Validation

- `pnpm -F 'frontend' exec oxfmt 'src/components/common/AuthLayout/index.tsx' 'src/pages/Login.tsx'` — passed
- `pnpm -F 'frontend' run --if-present lint` — passed
- `pnpm -F 'frontend' run --if-present typecheck` — passed
- `pnpm -F 'frontend' exec vitest related 'src/components/common/AuthLayout/index.tsx' 'src/pages/Login.tsx' --run --passWithNoTests` — passed

### Review notes

- Kept the `pink.1` value literal at the two login render entry points for a minimal style-only change. A shared constant would remove the duplication, but the current two explicit uses make each layout's color clear and avoid adding an abstraction for a single fixed design value.

## Proof of work

🟢 **PASS** — The committed login page now renders its login background in pink, with the sign-in interface remaining visible. HEAD matches the supplied revision and the checkout is clean.

Revision: `384daa52df738a0a9258b36431030855c6f4743e`

### Initial login page has a pink background

- Expected: Opening /login shows a pink background behind the login interface; no particular pink shade or additional behavior is required.
- Observed: The captured 1280×720 login page visibly uses a pale pink login background. Browser inspection sampled the background as RGB(255, 222, 235), and the rendered page retained the Sign in heading, email field, Continue button, and Sign up link.
- Evidence:
  - Captured and browser-inspected login screenshot: https://ld-linear-agent-v2.exe.xyz/evidence/ad21bcd5fbb905297f01b71d4f23d4df8f7f7f8561e4e15d8cedd3f334a0a5bd.png
  - Host development-environment inspection of https://ld-runner-prod-10729-5f27003ef849.exe.xyz/login found a login background computed as rgb(255, 222, 235) and an accessible Sign in form.

![Lightdash development environment screenshot](https://ld-linear-agent-v2.exe.xyz/evidence/ad21bcd5fbb905297f01b71d4f23d4df8f7f7f8561e4e15d8cedd3f334a0a5bd.png)

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10729-5f27003ef849.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10729

