### PR TITLE
fix(ai): respect OpenAI reasoning flag

### DIFF
--- a/packages/backend/src/ee/services/ai/models/index.test.ts
+++ b/packages/backend/src/ee/services/ai/models/index.test.ts
@@ -42,6 +42,20 @@ const copilotConfigWithStreaming = (supportsStreaming: boolean) => ({
     },
 });
 
+const copilotConfigWithZeroDataRetention = () => {
+    const config = copilotConfigWithStreaming(true);
+    return {
+        ...config,
+        providers: {
+            ...config.providers,
+            openai: {
+                ...config.providers.openai,
+                zeroDataRetention: true,
+            },
+        },
+    };
+};
+
 describe('getDefaultModel', () => {
     it('returns the default model when the configured provider is present', () => {
         expect(getDefaultModel(baseCopilotConfig)).toEqual({
@@ -93,8 +107,60 @@ describe('getModel', () => {
         expect(providerOptions.openai.parallelToolCalls).toBe(false);
     });
 
-    it('keeps preset-specific provider options while staying sequential', () => {
+    it('uses low OpenAI reasoning without summaries when extended reasoning is disabled', () => {
+        const { callOptions, providerOptions } = getModel(
+            copilotConfigWithStreaming(true),
+            {
+                enableReasoning: false,
+                modelName: 'gpt-5.5',
+            },
+        );
+
+        if (!providerOptions || !('openai' in providerOptions)) {
+            throw new Error('expected openai provider options');
+        }
+        expect(callOptions).toEqual({});
+        expect(providerOptions.openai.reasoningEffort).toBe('low');
+        expect(providerOptions.openai.reasoningSummary).toBeUndefined();
+    });
+
+    it.each([false, true])(
+        'keeps OpenAI zero data retention stateless when extended reasoning is %s',
+        (enableReasoning) => {
+            const { providerOptions } = getModel(
+                copilotConfigWithZeroDataRetention(),
+                {
+                    enableReasoning,
+                    modelName: 'gpt-5.5',
+                },
+            );
+
+            if (!providerOptions || !('openai' in providerOptions)) {
+                throw new Error('expected openai provider options');
+            }
+            expect(providerOptions.openai.store).toBe(false);
+            expect(providerOptions.openai.include).toEqual([
+                'reasoning.encrypted_content',
+            ]);
+        },
+    );
+
+    it('enables OpenAI reasoning only when requested', () => {
         const { providerOptions } = getModel(copilotConfigWithStreaming(true), {
+            enableReasoning: true,
+            modelName: 'gpt-5.5',
+        });
+
+        if (!providerOptions || !('openai' in providerOptions)) {
+            throw new Error('expected openai provider options');
+        }
+        expect(providerOptions.openai.reasoningEffort).toBe('medium');
+        expect(providerOptions.openai.reasoningSummary).toBe('auto');
+    });
+
+    it('keeps preset-specific reasoning effort when enabled', () => {
+        const { providerOptions } = getModel(copilotConfigWithStreaming(true), {
+            enableReasoning: true,
             modelName: 'gpt-5-mini',
         });
 

--- a/packages/backend/src/ee/services/ai/models/openai-gpt.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-gpt.ts
@@ -2,7 +2,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { DEFAULT_OPENAI_BASE_URL } from '../../../../config/aiConfigSchema';
 import { LightdashConfig } from '../../../../config/parseConfig';
 import { ModelPreset } from './presets';
-import { AiModel } from './types';
+import { AiModel, ProviderOptionsMap } from './types';
 
 const PROVIDER = 'openai';
 
@@ -21,37 +21,40 @@ export const getOpenaiGptmodel = (
     const { supportsReasoning, modelId } = preset;
 
     const model = openai(modelId);
-
-    const reasoningEnabled = supportsReasoning;
-    const reasoningEffort = options?.enableReasoning ? 'medium' : 'low';
+    const extendedReasoningEnabled =
+        options?.enableReasoning === true && supportsReasoning;
+    const { reasoningEffort: presetReasoningEffort, ...presetProviderOptions } =
+        preset.providerOptions ?? {};
+    const reasoningProviderOptions = supportsReasoning
+        ? ({
+              reasoningEffort:
+                  presetReasoningEffort ??
+                  (extendedReasoningEnabled ? 'medium' : 'low'),
+              ...(extendedReasoningEnabled && {
+                  // Request a summary so extended reasoning reaches the client.
+                  reasoningSummary: 'auto',
+              }),
+          } satisfies ProviderOptionsMap[typeof PROVIDER])
+        : undefined;
 
     return {
         model,
-        callOptions: {
-            ...preset.callOptions,
-            // temperature is not supported when reasoning is enabled
-            ...(reasoningEnabled
-                ? { temperature: undefined }
-                : { temperature: 0.2 }),
-        },
+        callOptions: preset.callOptions,
         providerOptions: {
             [PROVIDER]: {
+                ...presetProviderOptions,
                 // Force sequential tool execution: parallel tool calls in one
                 // step can drop some executions (no query, no result), so the
-                // agent stalls. Interim mitigation; a preset can override.
+                // agent stalls.
                 parallelToolCalls: false,
-                // Defaulting to Low as GPT-5 models without reasoning are not better than GPT-4.1
-                ...(reasoningEnabled && {
-                    reasoningSummary: 'auto',
-                    reasoningEffort,
-                }),
-                // ZDR: use encrypted reasoning items instead of server-stored IDs
+                ...reasoningProviderOptions,
+                // OpenAI Zero Data Retention (ZDR) organizations do not persist
+                // reasoning IDs; return encrypted content for stateless follow-ups.
                 ...(config.zeroDataRetention &&
-                    reasoningEnabled && {
+                    supportsReasoning && {
                         store: false,
                         include: ['reasoning.encrypted_content'],
                     }),
-                ...(preset.providerOptions || {}),
             },
         },
     };


### PR DESCRIPTION
Related: ZAP-963
Related: ZAP-920
Related: #28262

### Description

Cloud defaults AI agents to OpenAI/GPT-5.4 while extended thinking defaults off. Keep disabled requests at the model's low or preset baseline effort without summaries; omitting effort would let OpenAI default to medium. Enabled requests stream summaries and use the model preset's effort.

Preserve OpenAI Zero Data Retention compatibility for every reasoning-capable model by returning encrypted reasoning content for stateless follow-up steps.

Use preset call options directly instead of rebuilding them with temperature overrides.

### Verification

- `pnpm -F backend test src/ee/services/ai/models/index.test.ts`
- `NODE_OPTIONS="--max-old-space-size=8192" pnpm -F backend typecheck`
- `NODE_OPTIONS="--max-old-space-size=8192" pnpm -F backend lint`
- `pnpm -F backend format`
- `oxlint -D unicorn/no-useless-spread` on changed files

### Risk assessment

- [x] This is a high-risk change

Changes invocation behavior for the deployed default AI provider. Human peer review is required before merge.

