### PR TITLE
fix(backend): report accurate types for pivoted value columns

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/getPivotedColumns.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/getPivotedColumns.test.ts
@@ -110,6 +110,65 @@ describe('getPivotedColumns', () => {
         });
     });
 
+    test('value column types are derived from the aggregation and source item', () => {
+        const lastOrderAtMetric: Metric = {
+            ...revenueMetric,
+            type: MetricType.MAX,
+            name: 'last_order_at',
+            label: 'Last order at',
+            baseDimensionType: DimensionType.TIMESTAMP,
+        };
+        const isRepeatMetric: Metric = {
+            ...revenueMetric,
+            type: MetricType.BOOLEAN,
+            name: 'is_repeat',
+            label: 'Is repeat',
+        };
+        const typedItemsMap: ItemsMap = {
+            ...itemsMap,
+            orders_last_order_at: lastOrderAtMetric,
+            orders_is_repeat: isRepeatMetric,
+        };
+        const typedValueColumns: PivotValuesColumn[] = [
+            {
+                referenceField: 'orders_last_order_at',
+                pivotColumnName: 'orders_last_order_at_any_completed',
+                aggregation: VizAggregationOptions.ANY,
+                pivotValues: [],
+            },
+            {
+                referenceField: 'orders_is_repeat',
+                pivotColumnName: 'orders_is_repeat_any_completed',
+                aggregation: VizAggregationOptions.ANY,
+                pivotValues: [],
+            },
+            {
+                // Numeric aggregations always produce NUMBER.
+                referenceField: 'orders_last_order_at',
+                pivotColumnName: 'orders_last_order_at_count_completed',
+                aggregation: VizAggregationOptions.COUNT,
+                pivotValues: [],
+            },
+        ];
+        const columns = getPivotedColumns(
+            unpivotedColumns,
+            pivotConfiguration,
+            typedValueColumns,
+            typedItemsMap,
+        );
+        // A MAX metric's own type maps to NUMBER. Value-picking aggregations
+        // report the base dimension type instead.
+        expect(columns.orders_last_order_at_any_completed.type).toEqual(
+            DimensionType.TIMESTAMP,
+        );
+        expect(columns.orders_is_repeat_any_completed.type).toEqual(
+            DimensionType.BOOLEAN,
+        );
+        expect(columns.orders_last_order_at_count_completed.type).toEqual(
+            DimensionType.NUMBER,
+        );
+    });
+
     test('value columns without an items map get a reference-derived label and no provenance', () => {
         const columns = getPivotedColumns(
             unpivotedColumns,

--- a/packages/backend/src/services/AsyncQueryService/getPivotedColumns.ts
+++ b/packages/backend/src/services/AsyncQueryService/getPivotedColumns.ts
@@ -1,13 +1,57 @@
 import {
+    assertUnreachable,
+    convertItemTypeToDimensionType,
     DimensionType,
+    getItemId,
     getResultColumnMetadataFromItem,
+    isMetric,
+    MetricType,
     normalizeIndexColumns,
+    VizAggregationOptions,
+    type Item,
     type ItemsMap,
     type ParametersValuesMap,
     type PivotValuesColumn,
     type QueryHistory,
     type ResultColumns,
 } from '@lightdash/common';
+
+// Returns the type of a pivoted value column. Numeric aggregations always
+// produce NUMBER, regardless of what they aggregate. Value-picking
+// aggregations keep the source item's type; MIN and MAX metrics report their
+// base dimension's type, because the metric's own type maps to NUMBER, which
+// is incorrect for temporal bases. Columns without a resolvable source item
+// keep the NUMBER fallback.
+function getPivotedValueColumnType(
+    item: Item | undefined,
+    aggregation: VizAggregationOptions,
+): DimensionType {
+    switch (aggregation) {
+        case VizAggregationOptions.COUNT:
+        case VizAggregationOptions.SUM:
+        case VizAggregationOptions.AVERAGE:
+            return DimensionType.NUMBER;
+        case VizAggregationOptions.MIN:
+        case VizAggregationOptions.MAX:
+        case VizAggregationOptions.ANY: {
+            if (!item) return DimensionType.NUMBER;
+            if (
+                isMetric(item) &&
+                (item.type === MetricType.MIN ||
+                    item.type === MetricType.MAX) &&
+                item.baseDimensionType
+            ) {
+                return item.baseDimensionType;
+            }
+            return convertItemTypeToDimensionType(item);
+        }
+        default:
+            return assertUnreachable(
+                aggregation,
+                `Unknown pivot aggregation ${aggregation}`,
+            );
+    }
+}
 
 export function getPivotedColumns(
     unpivotedColumns: ResultColumns,
@@ -52,7 +96,15 @@ export function getPivotedColumns(
         ...indexColumnsResult,
         ...passthroughColumnsResult,
         ...pivotValuesColumns.reduce<ResultColumns>((acc, valueColumn) => {
-            const sourceItem = itemsMap?.[valueColumn.referenceField];
+            // An item contributes metadata and a type only when the column
+            // reference is the item's own field id — the same identity rule
+            // that getResultColumnMetadataFromItem applies internally.
+            const lookedUpItem = itemsMap?.[valueColumn.referenceField];
+            const sourceItem =
+                lookedUpItem &&
+                getItemId(lookedUpItem) === valueColumn.referenceField
+                    ? lookedUpItem
+                    : undefined;
             const metadata = getResultColumnMetadataFromItem(
                 sourceItem,
                 valueColumn.referenceField,
@@ -72,7 +124,10 @@ export function getPivotedColumns(
             }
             acc[valueColumn.pivotColumnName] = {
                 reference: valueColumn.pivotColumnName,
-                type: DimensionType.NUMBER,
+                type: getPivotedValueColumnType(
+                    sourceItem,
+                    valueColumn.aggregation,
+                ),
                 ...metadata,
             };
             return acc;


### PR DESCRIPTION
Closes: PROD-10690

### Description:

`getPivotedColumns` set every pivoted value column's type to `NUMBER`. This type is incorrect when a value-picking aggregation runs over a non-numeric source. For example, a `MAX` aggregation over a timestamp produced a column typed `NUMBER`, so a consumer that reads `column.type` renders those values incorrectly. Accurate column types are a requirement of the self-describing columns work (`docs/composer-viz-plan/01-design.md`, section 7).

This change derives each pivoted value column's type from its aggregation and its source item:

- `COUNT`, `SUM`, and `AVG` aggregations always produce `NUMBER`.
- `MIN`, `MAX`, and `ANY` aggregations keep the source item's type. For `MIN` and `MAX` metrics, the change uses the metric's base dimension type, because the metric's own type maps to `NUMBER`.
- Columns without a resolvable source item keep the previous `NUMBER` fallback.

The type derivation applies the same item-identity rule that #28241 introduced for metadata: an item contributes a type only when the column reference is the item's own field id. This keeps type and metadata contributions consistent.

**Why the hardcoded `NUMBER` existed.** The pivot streaming code was built for the SQL-runner pivot path, where every values column is a numeric y-axis aggregation, so `NUMBER` was correct by construction. The metric-query pivot path later routed through the same code with `ANY`, `MIN`, and `MAX` over non-numeric metrics, which made the assumption stale. An audit of consumers found none that require `NUMBER` — and one that the old value actively broke: `buildQueryReferenceCtes` maps persisted column types to a DuckDB schema (`getJsonlSqlTable` → `read_json(columns={...})`), so a composer query that references a pivoted query with a temporal value column told DuckDB to parse timestamp strings as `DOUBLE`. The corrected types parse those values properly and match how the same path already types unpivoted columns.

This change ships separately from the column-enrichment work because it changes the `type` values persisted in `query_history.columns` (see the design doc, section 3).

Unit tests cover all three rules: a `MAX` metric over a timestamp produces `TIMESTAMP`, a boolean metric with `ANY` produces `BOOLEAN`, and a `COUNT` aggregation produces `NUMBER`. Rebased on `main` after #28241 merged; the backend suite passes with 8,333 tests on the rebased head. The `catalogQuery.test.ts` resource-budget failure also occurs on `main` in this container and is unrelated to this change. Typecheck and lint pass.

### Risk assessment:

- [ ] This is a high-risk change

Low risk. Only pivoted value columns with a resolvable non-numeric source change type. Numeric pivots and columns without a source item produce the same output as before. The one downstream reader of these types (the composer's DuckDB schema for referenced results) previously mis-parsed non-numeric pivot values; the corrected types fix that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cca21BfcfumTuBfcCBVk93