### PR TITLE
feat(direct-access): define administration handler contract

### DIFF
--- a/packages/backend/src/services/DirectAccess/BaseResourceAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/BaseResourceAccessHandler.ts
@@ -1,0 +1,504 @@
+import { subject } from '@casl/ability';
+import {
+    DirectAccessOrigin,
+    ForbiddenError,
+    getHighestSpaceRole,
+    NotFoundError,
+    ParameterError,
+    SpaceMemberRole,
+    SpaceRoleOrder,
+    type DirectAccessGrant,
+    type DirectAccessList,
+    type DirectAccessListFilters,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
+    type SessionUser,
+} from '@lightdash/common';
+import { validate as isValidUuid } from 'uuid';
+import { createActorFromUser } from '../../logging/caslAuditWrapper';
+import type {
+    DirectAccessMutationResult,
+    DirectAccessResetResult,
+} from '../../models/directAccessModelUtils';
+import { BaseService } from '../BaseService';
+import type {
+    AccessContextForCasl,
+    AccessTarget,
+    SpacePermissionService,
+} from '../SpaceService/SpacePermissionService';
+import {
+    auditDirectAccessMutation,
+    auditDirectAccessReset,
+    type DirectAccessAuditLogger,
+} from './directAccessAudit';
+import type { DirectAccessFeatureGate } from './DirectAccessFeatureGate';
+import type {
+    ResourceAccessHandler,
+    ResourceAccessInput,
+} from './ResourceAccessHandler';
+
+export type DirectAccessListRow =
+    | {
+          origin: DirectAccessOrigin.USER;
+          principalUuid: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+          isInternal: boolean;
+          directRole: SpaceMemberRole;
+      }
+    | {
+          origin: DirectAccessOrigin.GROUP;
+          principalUuid: string;
+          name: string;
+          directRole: SpaceMemberRole;
+      };
+
+export type DirectAccessTarget = {
+    resourceUuid: string;
+    organizationUuid: string;
+    projectUuid: string;
+    spaceUuid: string | null;
+    accessTarget: AccessTarget;
+    canReceiveDirectAccess: boolean;
+};
+
+type Principal =
+    | { origin: DirectAccessOrigin.USER; uuid: string }
+    | { origin: DirectAccessOrigin.GROUP; uuid: string };
+
+export interface DirectAccessResourceAdapter<
+    TTarget extends DirectAccessTarget = DirectAccessTarget,
+> {
+    auditResourceType: string;
+    getTarget(input: ResourceAccessInput): Promise<TTarget>;
+    getDirectAccessList(
+        target: TTarget,
+        options: {
+            paginateArgs?: KnexPaginateArgs;
+            searchQuery?: string;
+            principal?: Principal;
+        },
+    ): Promise<KnexPaginatedData<DirectAccessListRow[]>>;
+    getGroupRolesForUsers(
+        target: TTarget,
+        userUuids: string[],
+    ): Promise<Record<string, SpaceMemberRole[]>>;
+    getAdditionalEffectiveRolesForUsers?(
+        target: TTarget,
+        userUuids: string[],
+    ): Promise<Record<string, SpaceMemberRole[]>>;
+    upsertUserAccess(
+        target: TTarget,
+        input: { userUuid: string; role: SpaceMemberRole; actor: SessionUser },
+    ): Promise<DirectAccessMutationResult>;
+    upsertGroupAccess(
+        target: TTarget,
+        input: { groupUuid: string; role: SpaceMemberRole; actor: SessionUser },
+    ): Promise<DirectAccessMutationResult>;
+    revokeUserAccess(
+        target: TTarget,
+        input: { userUuid: string },
+    ): Promise<DirectAccessMutationResult>;
+    revokeGroupAccess(
+        target: TTarget,
+        input: { groupUuid: string },
+    ): Promise<DirectAccessMutationResult>;
+    resetAccess(target: TTarget): Promise<DirectAccessResetResult>;
+}
+
+const DEFAULT_ACCESS_LIST_PAGE: KnexPaginateArgs = {
+    page: 1,
+    pageSize: 100,
+};
+
+const hasAtLeastRole = (
+    role: SpaceMemberRole,
+    minimum: SpaceMemberRole,
+): boolean => SpaceRoleOrder[role] >= SpaceRoleOrder[minimum];
+
+export class BaseResourceAccessHandler<
+    TTarget extends DirectAccessTarget = DirectAccessTarget,
+>
+    extends BaseService
+    implements ResourceAccessHandler
+{
+    constructor(
+        private readonly adapter: DirectAccessResourceAdapter<TTarget>,
+        private readonly spacePermissionService: Pick<
+            SpacePermissionService,
+            | 'resolveAccess'
+            | 'getSpaceAccessContextForUsers'
+            | 'mergeAdminAccess'
+        >,
+        private readonly featureGate: Pick<
+            DirectAccessFeatureGate,
+            'isEnabledForUser'
+        >,
+        private readonly auditLogger?: DirectAccessAuditLogger,
+    ) {
+        super();
+    }
+
+    private async resolveTarget(input: ResourceAccessInput): Promise<{
+        target: TTarget;
+        actorRole: SpaceMemberRole;
+    }> {
+        if (
+            !(await this.featureGate.isEnabledForUser({
+                userUuid: input.user.userUuid,
+                organizationUuid: input.user.organizationUuid,
+            }))
+        ) {
+            throw new ForbiddenError('Direct access is not available');
+        }
+        if (!isValidUuid(input.resourceUuid)) {
+            throw new NotFoundError('Access target not found');
+        }
+
+        let target: TTarget;
+        let context: AccessContextForCasl;
+        try {
+            target = await this.adapter.getTarget(input);
+            context = await this.spacePermissionService.resolveAccess(
+                input.user.userUuid,
+                target.accessTarget,
+            );
+        } catch (error) {
+            if (
+                error instanceof NotFoundError ||
+                error instanceof ForbiddenError ||
+                error instanceof ParameterError
+            ) {
+                throw new NotFoundError('Access target not found');
+            }
+            throw error;
+        }
+
+        const auditedAbility = this.createAuditedAbility(input.user);
+        const isProjectAdmin = auditedAbility.can(
+            'manage',
+            subject('Project', {
+                organizationUuid: target.organizationUuid,
+                projectUuid: target.projectUuid,
+            }),
+        );
+        const actorRole = isProjectAdmin
+            ? SpaceMemberRole.ADMIN
+            : getHighestSpaceRole(
+                  context.access
+                      .filter(
+                          ({ userUuid }) => userUuid === input.user.userUuid,
+                      )
+                      .map(({ role }) => role),
+              );
+        if (actorRole === undefined) {
+            throw new NotFoundError('Access target not found');
+        }
+        if (!target.canReceiveDirectAccess) {
+            throw new ParameterError(
+                'This resource inherits access and cannot receive direct grants',
+            );
+        }
+        return { target, actorRole };
+    }
+
+    private static assertCanInspect(actorRole: SpaceMemberRole): void {
+        if (!hasAtLeastRole(actorRole, SpaceMemberRole.EDITOR)) {
+            throw new ForbiddenError(
+                'Editor access or higher is required to manage access',
+            );
+        }
+    }
+
+    private static assertCanManageRole(
+        actorRole: SpaceMemberRole,
+        role?: SpaceMemberRole,
+    ): void {
+        BaseResourceAccessHandler.assertCanInspect(actorRole);
+        if (role && !hasAtLeastRole(actorRole, role)) {
+            throw new ForbiddenError(
+                'Cannot manage a role above your effective access',
+            );
+        }
+    }
+
+    private async resolveGrants(
+        target: TTarget,
+        rows: DirectAccessListRow[],
+    ): Promise<DirectAccessGrant[]> {
+        const userUuids = rows.flatMap((row) =>
+            row.origin === DirectAccessOrigin.USER ? [row.principalUuid] : [],
+        );
+        if (userUuids.length === 0) {
+            return rows.map((row) => {
+                if (row.origin !== DirectAccessOrigin.GROUP) {
+                    throw new Error('Unexpected direct access principal');
+                }
+                return {
+                    principal: {
+                        type: DirectAccessOrigin.GROUP,
+                        uuid: row.principalUuid,
+                        name: row.name,
+                    },
+                    directRole: row.directRole,
+                };
+            });
+        }
+
+        const additionalRolesPromise = this.adapter
+            .getAdditionalEffectiveRolesForUsers
+            ? this.adapter.getAdditionalEffectiveRolesForUsers(
+                  target,
+                  userUuids,
+              )
+            : Promise.resolve<Record<string, SpaceMemberRole[]>>({});
+        const [groupRoles, spaceContext, additionalRoles] = await Promise.all([
+            this.adapter.getGroupRolesForUsers(target, userUuids),
+            target.spaceUuid
+                ? this.spacePermissionService.getSpaceAccessContextForUsers(
+                      userUuids,
+                      target.spaceUuid,
+                  )
+                : undefined,
+            additionalRolesPromise,
+        ]);
+        const inheritedRoles = new Map<string, SpaceMemberRole[]>();
+        if (spaceContext) {
+            for (const access of this.spacePermissionService.mergeAdminAccess(
+                spaceContext,
+            )) {
+                const roles = inheritedRoles.get(access.userUuid) ?? [];
+                roles.push(access.role);
+                inheritedRoles.set(access.userUuid, roles);
+            }
+        }
+
+        return rows.map((row) => {
+            if (row.origin === DirectAccessOrigin.GROUP) {
+                return {
+                    principal: {
+                        type: DirectAccessOrigin.GROUP,
+                        uuid: row.principalUuid,
+                        name: row.name,
+                    },
+                    directRole: row.directRole,
+                };
+            }
+            return {
+                principal: {
+                    type: DirectAccessOrigin.USER,
+                    uuid: row.principalUuid,
+                    firstName: row.firstName,
+                    lastName: row.lastName,
+                    email: row.email,
+                    isInternal: row.isInternal,
+                },
+                directRole: row.directRole,
+                effectiveRole:
+                    getHighestSpaceRole([
+                        row.directRole,
+                        ...(groupRoles[row.principalUuid] ?? []),
+                        ...(inheritedRoles.get(row.principalUuid) ?? []),
+                        ...(additionalRoles[row.principalUuid] ?? []),
+                    ]) ?? row.directRole,
+            };
+        });
+    }
+
+    private async getDirectGrant(
+        target: TTarget,
+        principal: Principal,
+    ): Promise<DirectAccessGrant | undefined> {
+        const { data } = await this.adapter.getDirectAccessList(target, {
+            principal,
+        });
+        const [grant] = await this.resolveGrants(target, data);
+        return grant;
+    }
+
+    private async getGrant(
+        target: TTarget,
+        principal: Principal,
+    ): Promise<DirectAccessGrant> {
+        const grant = await this.getDirectGrant(target, principal);
+        if (!grant) {
+            throw new NotFoundError('Direct access grant not found');
+        }
+        return grant;
+    }
+
+    private auditMutation(
+        user: SessionUser,
+        target: TTarget,
+        principal: { type: 'user' | 'group'; uuid: string },
+        result: DirectAccessMutationResult,
+    ): void {
+        auditDirectAccessMutation({
+            actor: createActorFromUser(user),
+            context: user.requestContext ?? {},
+            resourceType: this.adapter.auditResourceType,
+            resourceUuid: target.resourceUuid,
+            principal,
+            result,
+            auditLogger: this.auditLogger,
+        });
+    }
+
+    async listAccess({
+        paginateArgs,
+        filters,
+        ...input
+    }: ResourceAccessInput & {
+        paginateArgs?: KnexPaginateArgs;
+        filters?: DirectAccessListFilters;
+    }): Promise<DirectAccessList> {
+        const { target, actorRole } = await this.resolveTarget(input);
+        BaseResourceAccessHandler.assertCanInspect(actorRole);
+        const { data, pagination } = await this.adapter.getDirectAccessList(
+            target,
+            {
+                paginateArgs: paginateArgs ?? DEFAULT_ACCESS_LIST_PAGE,
+                searchQuery: filters?.searchQuery,
+            },
+        );
+        return {
+            data: await this.resolveGrants(target, data),
+            ...(pagination ? { pagination } : {}),
+        };
+    }
+
+    async replaceUserRole({
+        userUuid,
+        role,
+        ...input
+    }: ResourceAccessInput & {
+        userUuid: string;
+        role: SpaceMemberRole;
+    }): Promise<DirectAccessGrant> {
+        const { target, actorRole } = await this.resolveTarget(input);
+        const principal = { origin: DirectAccessOrigin.USER, uuid: userUuid };
+        const existing = await this.getDirectGrant(target, principal);
+        BaseResourceAccessHandler.assertCanManageRole(
+            actorRole,
+            existing?.directRole,
+        );
+        BaseResourceAccessHandler.assertCanManageRole(actorRole, role);
+        const result = await this.adapter.upsertUserAccess(target, {
+            userUuid,
+            role,
+            actor: input.user,
+        });
+        this.auditMutation(
+            input.user,
+            target,
+            { type: 'user', uuid: userUuid },
+            result,
+        );
+        return this.getGrant(target, principal);
+    }
+
+    async replaceGroupRole({
+        groupUuid,
+        role,
+        ...input
+    }: ResourceAccessInput & {
+        groupUuid: string;
+        role: SpaceMemberRole;
+    }): Promise<DirectAccessGrant> {
+        const { target, actorRole } = await this.resolveTarget(input);
+        const principal = {
+            origin: DirectAccessOrigin.GROUP,
+            uuid: groupUuid,
+        };
+        const existing = await this.getDirectGrant(target, principal);
+        BaseResourceAccessHandler.assertCanManageRole(
+            actorRole,
+            existing?.directRole,
+        );
+        BaseResourceAccessHandler.assertCanManageRole(actorRole, role);
+        const result = await this.adapter.upsertGroupAccess(target, {
+            groupUuid,
+            role,
+            actor: input.user,
+        });
+        this.auditMutation(
+            input.user,
+            target,
+            { type: 'group', uuid: groupUuid },
+            result,
+        );
+        return this.getGrant(target, principal);
+    }
+
+    async revokeUser({
+        userUuid,
+        ...input
+    }: ResourceAccessInput & { userUuid: string }): Promise<void> {
+        const { target, actorRole } = await this.resolveTarget(input);
+        if (userUuid !== input.user.userUuid) {
+            const existing = await this.getDirectGrant(target, {
+                origin: DirectAccessOrigin.USER,
+                uuid: userUuid,
+            });
+            BaseResourceAccessHandler.assertCanManageRole(
+                actorRole,
+                existing?.directRole,
+            );
+        }
+        const result = await this.adapter.revokeUserAccess(target, {
+            userUuid,
+        });
+        this.auditMutation(
+            input.user,
+            target,
+            { type: 'user', uuid: userUuid },
+            result,
+        );
+    }
+
+    async revokeGroup({
+        groupUuid,
+        ...input
+    }: ResourceAccessInput & { groupUuid: string }): Promise<void> {
+        const { target, actorRole } = await this.resolveTarget(input);
+        const existing = await this.getDirectGrant(target, {
+            origin: DirectAccessOrigin.GROUP,
+            uuid: groupUuid,
+        });
+        BaseResourceAccessHandler.assertCanManageRole(
+            actorRole,
+            existing?.directRole,
+        );
+        const result = await this.adapter.revokeGroupAccess(target, {
+            groupUuid,
+        });
+        this.auditMutation(
+            input.user,
+            target,
+            { type: 'group', uuid: groupUuid },
+            result,
+        );
+    }
+
+    async reset(input: ResourceAccessInput): Promise<void> {
+        const { target, actorRole } = await this.resolveTarget(input);
+        BaseResourceAccessHandler.assertCanInspect(actorRole);
+        const { data } = await this.adapter.getDirectAccessList(target, {});
+        for (const row of data) {
+            BaseResourceAccessHandler.assertCanManageRole(
+                actorRole,
+                row.directRole,
+            );
+        }
+        const result = await this.adapter.resetAccess(target);
+        auditDirectAccessReset({
+            actor: createActorFromUser(input.user),
+            context: input.user.requestContext ?? {},
+            resourceType: this.adapter.auditResourceType,
+            resourceUuid: target.resourceUuid,
+            result,
+            auditLogger: this.auditLogger,
+        });
+    }
+}

--- a/packages/backend/src/services/DirectAccess/ResourceAccessHandler.conformance.ts
+++ b/packages/backend/src/services/DirectAccess/ResourceAccessHandler.conformance.ts
@@ -1,0 +1,218 @@
+import {
+    DirectAccessOrigin,
+    ForbiddenError,
+    NotFoundError,
+    ParameterError,
+    SpaceMemberRole,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import type {
+    ResourceAccessHandler,
+    ResourceAccessInput,
+} from './ResourceAccessHandler';
+
+export type ResourceAccessHandlerConformanceHarness = {
+    handler: ResourceAccessHandler;
+    input: ResourceAccessInput;
+    setActorRole(role: SpaceMemberRole | undefined): void;
+    setEnabled(enabled: boolean): void;
+    setEligible(eligible: boolean): void;
+    setTargetError(error: Error | undefined): void;
+    seedUserGrant(userUuid: string, role: SpaceMemberRole): void;
+    seedGroupGrant(groupUuid: string, role: SpaceMemberRole): void;
+    calls: {
+        getTarget(): number;
+        upsertUser(): number;
+        revokeUser(): number;
+        reset(): number;
+    };
+};
+
+export const runResourceAccessHandlerConformance = (
+    name: string,
+    createHarness: () => ResourceAccessHandlerConformanceHarness,
+): void => {
+    describe(`${name} resource access conformance`, () => {
+        it('checks the feature gate before resource lookup', async () => {
+            const harness = createHarness();
+            harness.setEnabled(false);
+
+            await expect(
+                harness.handler.listAccess(harness.input),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(harness.calls.getTarget()).toBe(0);
+        });
+
+        it('rejects malformed resource UUIDs before resource lookup', async () => {
+            const harness = createHarness();
+
+            await expect(
+                harness.handler.listAccess({
+                    ...harness.input,
+                    resourceUuid: 'not-a-uuid',
+                }),
+            ).rejects.toBeInstanceOf(NotFoundError);
+            expect(harness.calls.getTarget()).toBe(0);
+        });
+
+        it('normalizes unavailable targets', async () => {
+            const harness = createHarness();
+            harness.setTargetError(new ForbiddenError());
+
+            await expect(
+                harness.handler.listAccess(harness.input),
+            ).rejects.toMatchObject({ message: 'Access target not found' });
+        });
+
+        it('does not reveal an ineligible target to an unauthorized caller', async () => {
+            const harness = createHarness();
+            harness.setEligible(false);
+            harness.setActorRole(undefined);
+
+            await expect(
+                harness.handler.listAccess(harness.input),
+            ).rejects.toBeInstanceOf(NotFoundError);
+        });
+
+        it('reports inherited-only targets after authorization', async () => {
+            const harness = createHarness();
+            harness.setEligible(false);
+
+            await expect(
+                harness.handler.listAccess(harness.input),
+            ).rejects.toBeInstanceOf(ParameterError);
+        });
+
+        it('prevents viewers from inspecting access', async () => {
+            const harness = createHarness();
+            harness.setActorRole(SpaceMemberRole.VIEWER);
+
+            await expect(
+                harness.handler.listAccess(harness.input),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+        });
+
+        it('allows editors to inspect access', async () => {
+            const harness = createHarness();
+            harness.seedUserGrant('user-2', SpaceMemberRole.VIEWER);
+
+            await expect(
+                harness.handler.listAccess(harness.input),
+            ).resolves.toMatchObject({
+                data: [
+                    {
+                        principal: {
+                            type: DirectAccessOrigin.USER,
+                            uuid: 'user-2',
+                        },
+                        directRole: SpaceMemberRole.VIEWER,
+                    },
+                ],
+            });
+        });
+
+        it('allows editors to grant Viewer or Editor but not Admin', async () => {
+            const harness = createHarness();
+
+            await expect(
+                harness.handler.replaceUserRole({
+                    ...harness.input,
+                    userUuid: 'user-2',
+                    role: SpaceMemberRole.EDITOR,
+                }),
+            ).resolves.toMatchObject({ directRole: SpaceMemberRole.EDITOR });
+            await expect(
+                harness.handler.replaceUserRole({
+                    ...harness.input,
+                    userUuid: 'user-3',
+                    role: SpaceMemberRole.ADMIN,
+                }),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(harness.calls.upsertUser()).toBe(1);
+        });
+
+        it('prevents editors from changing an existing Admin grant', async () => {
+            const harness = createHarness();
+            harness.seedUserGrant('user-2', SpaceMemberRole.ADMIN);
+
+            await expect(
+                harness.handler.replaceUserRole({
+                    ...harness.input,
+                    userUuid: 'user-2',
+                    role: SpaceMemberRole.EDITOR,
+                }),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(harness.calls.upsertUser()).toBe(0);
+        });
+
+        it('allows a viewer to revoke their own direct grant', async () => {
+            const harness = createHarness();
+            harness.setActorRole(SpaceMemberRole.VIEWER);
+            harness.seedUserGrant(
+                harness.input.user.userUuid,
+                SpaceMemberRole.VIEWER,
+            );
+
+            await expect(
+                harness.handler.revokeUser({
+                    ...harness.input,
+                    userUuid: harness.input.user.userUuid,
+                }),
+            ).resolves.toBeUndefined();
+            expect(harness.calls.revokeUser()).toBe(1);
+        });
+
+        it('keeps non-self revokes within the caller role ceiling', async () => {
+            const harness = createHarness();
+            harness.seedUserGrant('user-2', SpaceMemberRole.ADMIN);
+
+            await expect(
+                harness.handler.revokeUser({
+                    ...harness.input,
+                    userUuid: 'user-2',
+                }),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(harness.calls.revokeUser()).toBe(0);
+        });
+
+        it('makes missing principal revokes idempotent after authorization', async () => {
+            const harness = createHarness();
+
+            await expect(
+                harness.handler.revokeUser({
+                    ...harness.input,
+                    userUuid: 'unknown-user',
+                }),
+            ).resolves.toBeUndefined();
+            expect(harness.calls.revokeUser()).toBe(1);
+        });
+
+        it('prevents an Editor reset from removing Admin grants', async () => {
+            const harness = createHarness();
+            harness.seedGroupGrant('group-1', SpaceMemberRole.ADMIN);
+
+            await expect(
+                harness.handler.reset(harness.input),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(harness.calls.reset()).toBe(0);
+        });
+
+        it('allows Admin to manage and reset every grant role', async () => {
+            const harness = createHarness();
+            harness.setActorRole(SpaceMemberRole.ADMIN);
+            harness.seedGroupGrant('group-1', SpaceMemberRole.ADMIN);
+
+            await expect(
+                harness.handler.replaceGroupRole({
+                    ...harness.input,
+                    groupUuid: 'group-2',
+                    role: SpaceMemberRole.ADMIN,
+                }),
+            ).resolves.toMatchObject({ directRole: SpaceMemberRole.ADMIN });
+            await expect(
+                harness.handler.reset(harness.input),
+            ).resolves.toBeUndefined();
+            expect(harness.calls.reset()).toBe(1);
+        });
+    });
+};

--- a/packages/backend/src/services/DirectAccess/ResourceAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/ResourceAccessHandler.ts
@@ -1,0 +1,47 @@
+import type {
+    DirectAccessGrant,
+    DirectAccessList,
+    DirectAccessListFilters,
+    KnexPaginateArgs,
+    SessionUser,
+    SpaceMemberRole,
+} from '@lightdash/common';
+
+export type ResourceAccessInput = {
+    user: SessionUser;
+    projectUuid: string;
+    resourceUuid: string;
+};
+
+export interface ResourceAccessHandler {
+    listAccess(
+        input: ResourceAccessInput & {
+            paginateArgs?: KnexPaginateArgs;
+            filters?: DirectAccessListFilters;
+        },
+    ): Promise<DirectAccessList>;
+
+    replaceUserRole(
+        input: ResourceAccessInput & {
+            userUuid: string;
+            role: SpaceMemberRole;
+        },
+    ): Promise<DirectAccessGrant>;
+
+    revokeUser(
+        input: ResourceAccessInput & { userUuid: string },
+    ): Promise<void>;
+
+    replaceGroupRole(
+        input: ResourceAccessInput & {
+            groupUuid: string;
+            role: SpaceMemberRole;
+        },
+    ): Promise<DirectAccessGrant>;
+
+    revokeGroup(
+        input: ResourceAccessInput & { groupUuid: string },
+    ): Promise<void>;
+
+    reset(input: ResourceAccessInput): Promise<void>;
+}

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -616,6 +616,22 @@ export class SpacePermissionService extends BaseService {
         return ctx;
     }
 
+    async getSpaceAccessContextForUsers(
+        userUuids: string[],
+        spaceUuid: string,
+    ): Promise<SpaceAccessContextForCasl> {
+        const accessContext = await this.getSpacesCaslContext([spaceUuid], {
+            userUuids,
+        });
+        const ctx = accessContext[spaceUuid];
+        if (!ctx) {
+            throw new NotFoundError(
+                `Couldn't find access context for space ${spaceUuid}`,
+            );
+        }
+        return ctx;
+    }
+
     mergeAdminAccess(ctx: SpaceAccessContextForCasl): SpaceAccess[] {
         const existingAccessUuids = new Set(
             ctx.access.map((access) => access.userUuid),

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -122,6 +122,7 @@ export * from './types/content';
 export * from './types/contentSlug';
 export * from './types/contentVerification';
 export * from './types/dashboard';
+export * from './types/directAccess';
 export * from './types/emailWhitelabel';
 export * from './types/dataTimezonePreview';
 export * from './types/fieldImpact';

--- a/packages/common/src/types/directAccess.ts
+++ b/packages/common/src/types/directAccess.ts
@@ -1,0 +1,64 @@
+import type { KnexPaginatedData } from './knex-paginate';
+import type { SpaceMemberRole } from './space';
+
+export const DIRECT_ACCESS_RESOURCE_TYPES = [
+    'dashboard',
+    'savedChart',
+    'savedSqlChart',
+    'dataApp',
+] as const;
+
+export type DirectAccessResourceType =
+    (typeof DIRECT_ACCESS_RESOURCE_TYPES)[number];
+
+export enum DirectAccessOrigin {
+    USER = 'user',
+    GROUP = 'group',
+}
+
+export type DirectAccessUserPrincipal = {
+    type: DirectAccessOrigin.USER;
+    uuid: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    isInternal: boolean;
+};
+
+export type DirectAccessGroupPrincipal = {
+    type: DirectAccessOrigin.GROUP;
+    uuid: string;
+    name: string;
+};
+
+export type DirectAccessGrant =
+    | {
+          principal: DirectAccessUserPrincipal;
+          directRole: SpaceMemberRole;
+          /** Highest additive resource role before capability scopes. */
+          effectiveRole: SpaceMemberRole;
+      }
+    | {
+          principal: DirectAccessGroupPrincipal;
+          directRole: SpaceMemberRole;
+      };
+
+export type DirectAccessListFilters = {
+    searchQuery?: string;
+};
+
+export type DirectAccessList = KnexPaginatedData<DirectAccessGrant[]>;
+
+export type DirectAccessRoleAssignment = {
+    role: SpaceMemberRole;
+};
+
+export type ApiDirectAccessListResponse = {
+    status: 'ok';
+    results: DirectAccessList;
+};
+
+export type ApiDirectAccessGrantResponse = {
+    status: 'ok';
+    results: DirectAccessGrant;
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1528/stack-5a-build-direct-access-administration-api

## Summary

PR 1 of 5. Defines the canonical six-operation resource-access contract and the shared authorization, normalization, list-shaping, idempotency, and audit policy. It deliberately exposes no route until every resource adapter is present.

## Changes

- Adds canonical common request, response, principal, grant, and resource-discriminator types.
- Adds the `ResourceAccessHandler` contract and reusable conformance harness.
- Resolves caller role from grant-aware space context while retaining organization/project-admin recovery.
- Enforces feature-gate-first lookup, Viewer/Editor/Admin delegation ceilings, self-revoke, and inherited-resource rejection.
- Adds batched access-context lookup for list effective-role calculation.

## Stack shape

```text
v2 controller                 PR 5
      |
shared handler policy    <-- this PR
      |
resource adapters          PRs 2-4
```

## Test plan

- [x] Common and backend typecheck
- [x] Common and backend lint
- [x] Formatting and `git diff --check`
- [x] Shared handler conformance suite passes 16/16 once instantiated by PR 2
- [x] Confirmed this PR adds no public route
