### PR TITLE
feat(direct-access): administer dashboard and chart access

### DIFF
--- a/packages/backend/src/models/DashboardAccessModel.ts
+++ b/packages/backend/src/models/DashboardAccessModel.ts
@@ -1,4 +1,9 @@
-import { NotFoundError, type SpaceMemberRole } from '@lightdash/common';
+import {
+    NotFoundError,
+    type DirectAccessOrigin,
+    type KnexPaginateArgs,
+    type SpaceMemberRole,
+} from '@lightdash/common';
 import { type Knex } from 'knex';
 import {
     DashboardGroupAccessTableName,
@@ -11,6 +16,10 @@ import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectTableName } from '../database/entities/projects';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
+import {
+    getDirectAccessGroupRolesForUsers,
+    getDirectAccessList,
+} from './directAccessAdminModelUtils';
 import {
     getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
@@ -25,6 +34,12 @@ import {
 } from './directAccessModelUtils';
 
 export type DashboardDirectAccess = DirectAccess;
+
+const adminTableConfig = {
+    userAccessTable: DashboardUserAccessTableName,
+    groupAccessTable: DashboardGroupAccessTableName,
+    resourceColumn: 'dashboard_uuid',
+};
 
 /**
  * Pure data access for dashboard direct grants. Authorization (CASL, role
@@ -262,6 +277,41 @@ export class DashboardAccessModel {
             ]);
             return { ...context, revokedUsers, revokedGroups };
         });
+    }
+
+    async getDirectAccessList(
+        resourceUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
+        options: {
+            paginateArgs?: KnexPaginateArgs;
+            searchQuery?: string;
+            principal?: {
+                origin: DirectAccessOrigin;
+                uuid: string;
+            };
+        } = {},
+    ) {
+        return getDirectAccessList(
+            this.database,
+            adminTableConfig,
+            { resourceUuid, organizationUuid, projectUuid },
+            options,
+        );
+    }
+
+    async getGroupRolesForUsers(
+        resourceUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
+        userUuids: string[],
+    ): Promise<Record<string, SpaceMemberRole[]>> {
+        return getDirectAccessGroupRolesForUsers(
+            this.database,
+            adminTableConfig,
+            { resourceUuid, organizationUuid, projectUuid },
+            userUuids,
+        );
     }
 
     async getUserAccess(

--- a/packages/backend/src/models/DirectAccessModels.integration.test.ts
+++ b/packages/backend/src/models/DirectAccessModels.integration.test.ts
@@ -1,4 +1,5 @@
 import {
+    DirectAccessOrigin,
     OrganizationMemberRole,
     ProjectMemberRole,
     SEED_ORG_1_ADMIN,
@@ -174,10 +175,51 @@ describe('dashboard direct access model PostgreSQL integration', () => {
             [dashboardUuid]: {
                 organizationUuid,
                 projectUuid,
+                spaceUuid: expect.any(String),
                 userRole: SpaceMemberRole.VIEWER,
                 groupRoles: [SpaceMemberRole.ADMIN],
             },
         });
+    });
+
+    it('lists active direct principals and their resource group roles', async () => {
+        const { data } = await model.getDirectAccessList(
+            dashboardUuid,
+            organizationUuid,
+            projectUuid,
+        );
+
+        expect(data).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    origin: DirectAccessOrigin.USER,
+                    principalUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    directRole: SpaceMemberRole.VIEWER,
+                }),
+                expect.objectContaining({
+                    origin: DirectAccessOrigin.GROUP,
+                    principalUuid: groupUuid,
+                    directRole: SpaceMemberRole.ADMIN,
+                }),
+            ]),
+        );
+        await expect(
+            model.getGroupRolesForUsers(
+                dashboardUuid,
+                organizationUuid,
+                projectUuid,
+                [SEED_ORG_1_ADMIN.user_uuid],
+            ),
+        ).resolves.toEqual({
+            [SEED_ORG_1_ADMIN.user_uuid]: [SpaceMemberRole.ADMIN],
+        });
+        await expect(
+            model.getDirectAccessList(
+                dashboardUuid,
+                organizationUuid,
+                randomUUID(),
+            ),
+        ).resolves.toEqual({ data: [] });
     });
 
     it('makes a group grant inert immediately after membership removal', async () => {

--- a/packages/backend/src/models/SavedChartAccessModel.integration.test.ts
+++ b/packages/backend/src/models/SavedChartAccessModel.integration.test.ts
@@ -1,5 +1,6 @@
 import {
     ChartKind,
+    DirectAccessOrigin,
     OrganizationMemberRole,
     ProjectMemberRole,
     SEED_ORG_1_ADMIN,
@@ -525,6 +526,41 @@ describe('SavedChartAccessModel PostgreSQL integration', () => {
             .returning('saved_query_uuid');
         return chart.saved_query_uuid;
     };
+
+    it('lists direct principals for independently saved charts only', async () => {
+        await upsertUser(SpaceMemberRole.VIEWER);
+        await upsertGroup(SpaceMemberRole.EDITOR);
+
+        const { data } = await model.getDirectAccessList(
+            fixture.directChartUuid,
+            fixture.organizationUuid,
+            fixture.projectUuid,
+        );
+        expect(data).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    origin: DirectAccessOrigin.USER,
+                    principalUuid: fixture.userUuid,
+                    directRole: SpaceMemberRole.VIEWER,
+                }),
+                expect.objectContaining({
+                    origin: DirectAccessOrigin.GROUP,
+                    principalUuid: fixture.groupUuid,
+                    directRole: SpaceMemberRole.EDITOR,
+                }),
+            ]),
+        );
+        await expect(
+            model.getGroupRolesForUsers(
+                fixture.directChartUuid,
+                fixture.organizationUuid,
+                fixture.projectUuid,
+                [fixture.userUuid],
+            ),
+        ).resolves.toEqual({
+            [fixture.userUuid]: [SpaceMemberRole.EDITOR],
+        });
+    });
 
     it('accepts every current project-access path for user principals', async () => {
         const [role] = await transaction(RolesTableName)

--- a/packages/backend/src/models/SavedChartAccessModel.ts
+++ b/packages/backend/src/models/SavedChartAccessModel.ts
@@ -1,6 +1,8 @@
 import {
     NotFoundError,
     ParameterError,
+    type DirectAccessOrigin,
+    type KnexPaginateArgs,
     type SpaceMemberRole,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
@@ -17,6 +19,10 @@ import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import {
+    getDirectAccessGroupRolesForUsers,
+    getDirectAccessList,
+} from './directAccessAdminModelUtils';
+import {
     getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
@@ -30,6 +36,12 @@ import {
 } from './directAccessModelUtils';
 
 export type SavedChartDirectAccess = DirectAccess;
+
+const adminTableConfig = {
+    userAccessTable: SavedChartUserAccessTableName,
+    groupAccessTable: SavedChartGroupAccessTableName,
+    resourceColumn: 'saved_chart_uuid',
+};
 
 type SavedChartOwnership = {
     spaceId: number | null;
@@ -423,6 +435,41 @@ export class SavedChartAccessModel {
             ]);
             return { ...context, revokedUsers, revokedGroups };
         });
+    }
+
+    async getDirectAccessList(
+        resourceUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
+        options: {
+            paginateArgs?: KnexPaginateArgs;
+            searchQuery?: string;
+            principal?: {
+                origin: DirectAccessOrigin;
+                uuid: string;
+            };
+        } = {},
+    ) {
+        return getDirectAccessList(
+            this.database,
+            adminTableConfig,
+            { resourceUuid, organizationUuid, projectUuid },
+            options,
+        );
+    }
+
+    async getGroupRolesForUsers(
+        resourceUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
+        userUuids: string[],
+    ): Promise<Record<string, SpaceMemberRole[]>> {
+        return getDirectAccessGroupRolesForUsers(
+            this.database,
+            adminTableConfig,
+            { resourceUuid, organizationUuid, projectUuid },
+            userUuids,
+        );
     }
 
     async getUserAccess(

--- a/packages/backend/src/models/directAccessAdminModelUtils.ts
+++ b/packages/backend/src/models/directAccessAdminModelUtils.ts
@@ -1,0 +1,259 @@
+import {
+    DirectAccessOrigin,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
+    type SpaceMemberRole,
+} from '@lightdash/common';
+import type { Knex } from 'knex';
+import { EmailTableName } from '../database/entities/emails';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectTableName } from '../database/entities/projects';
+import { UserTableName } from '../database/entities/users';
+import KnexPaginate from '../database/pagination';
+import {
+    getActiveGrantedGroupPredicate,
+    getActiveProjectMemberPredicate,
+} from './directAccessModelUtils';
+import { getColumnMatchRegexQuery } from './SearchModel/utils/search';
+
+export type DirectAccessListRow =
+    | {
+          origin: DirectAccessOrigin.USER;
+          principalUuid: string;
+          firstName: string;
+          lastName: string;
+          email: string;
+          isInternal: boolean;
+          directRole: SpaceMemberRole;
+      }
+    | {
+          origin: DirectAccessOrigin.GROUP;
+          principalUuid: string;
+          name: string;
+          directRole: SpaceMemberRole;
+      };
+
+export type DirectAccessAdminTableConfig = {
+    userAccessTable: string;
+    groupAccessTable: string;
+    resourceColumn: string;
+};
+
+type DirectAccessAdminContext = {
+    resourceUuid: string;
+    organizationUuid: string;
+    projectUuid: string;
+};
+
+type Principal =
+    | { origin: DirectAccessOrigin.USER; uuid: string }
+    | { origin: DirectAccessOrigin.GROUP; uuid: string };
+
+const joinProject = (join: Knex.JoinClause, projectUuid: string): void => {
+    join.onVal(`${ProjectTableName}.project_uuid`, projectUuid);
+};
+
+export const getDirectAccessList = async (
+    database: Knex,
+    config: DirectAccessAdminTableConfig,
+    context: DirectAccessAdminContext,
+    {
+        paginateArgs,
+        searchQuery,
+        principal,
+    }: {
+        paginateArgs?: KnexPaginateArgs;
+        searchQuery?: string;
+        principal?: Principal;
+    } = {},
+): Promise<KnexPaginatedData<DirectAccessListRow[]>> => {
+    const users = database(config.userAccessTable)
+        .innerJoin(
+            UserTableName,
+            `${UserTableName}.user_uuid`,
+            `${config.userAccessTable}.user_uuid`,
+        )
+        .innerJoin(ProjectTableName, (join) =>
+            joinProject(join, context.projectUuid),
+        )
+        .innerJoin(
+            OrganizationMembershipsTableName,
+            function joinCurrentOrganizationMembership() {
+                this.on(
+                    `${OrganizationMembershipsTableName}.user_id`,
+                    `${UserTableName}.user_id`,
+                ).andOn(
+                    `${OrganizationMembershipsTableName}.organization_id`,
+                    `${ProjectTableName}.organization_id`,
+                );
+            },
+        )
+        .innerJoin(
+            OrganizationTableName,
+            `${OrganizationTableName}.organization_id`,
+            `${ProjectTableName}.organization_id`,
+        )
+        .leftJoin(EmailTableName, function joinPrimaryEmail() {
+            this.on(
+                `${EmailTableName}.user_id`,
+                `${UserTableName}.user_id`,
+            ).andOnVal(`${EmailTableName}.is_primary`, true);
+        })
+        .where(
+            `${config.userAccessTable}.${config.resourceColumn}`,
+            context.resourceUuid,
+        )
+        .where(
+            `${OrganizationTableName}.organization_uuid`,
+            context.organizationUuid,
+        )
+        .where(getActiveProjectMemberPredicate(database))
+        .select({
+            origin: database.raw('?', [DirectAccessOrigin.USER]),
+            principalUuid: `${config.userAccessTable}.user_uuid`,
+            firstName: `${UserTableName}.first_name`,
+            lastName: `${UserTableName}.last_name`,
+            email: database.raw('COALESCE(??, ?)', [
+                `${EmailTableName}.email`,
+                '',
+            ]),
+            isInternal: `${UserTableName}.is_internal`,
+            name: database.raw('NULL::text'),
+            directRole: `${config.userAccessTable}.space_role`,
+        });
+    const groups = database(config.groupAccessTable)
+        .innerJoin(ProjectTableName, (join) =>
+            joinProject(join, context.projectUuid),
+        )
+        .innerJoin(
+            OrganizationTableName,
+            `${OrganizationTableName}.organization_id`,
+            `${ProjectTableName}.organization_id`,
+        )
+        .innerJoin(GroupTableName, function joinOrganizationGroup() {
+            this.on(
+                `${GroupTableName}.group_uuid`,
+                `${config.groupAccessTable}.group_uuid`,
+            ).andOn(
+                `${GroupTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            );
+        })
+        .where(
+            `${config.groupAccessTable}.${config.resourceColumn}`,
+            context.resourceUuid,
+        )
+        .where(
+            `${OrganizationTableName}.organization_uuid`,
+            context.organizationUuid,
+        )
+        .where(
+            getActiveGrantedGroupPredicate(database, config.groupAccessTable),
+        )
+        .select({
+            origin: database.raw('?', [DirectAccessOrigin.GROUP]),
+            principalUuid: `${config.groupAccessTable}.group_uuid`,
+            firstName: database.raw('NULL::text'),
+            lastName: database.raw('NULL::text'),
+            email: database.raw('NULL::text'),
+            isInternal: database.raw('NULL::boolean'),
+            name: `${GroupTableName}.name`,
+            directRole: `${config.groupAccessTable}.space_role`,
+        });
+
+    let query = database
+        .select<DirectAccessListRow[]>('*')
+        .from(users.unionAll(groups).as('direct_access'));
+    if (searchQuery) {
+        query = getColumnMatchRegexQuery(query, searchQuery, [
+            'firstName',
+            'lastName',
+            'email',
+            'name',
+        ]);
+    }
+    if (principal) {
+        void query
+            .where('origin', principal.origin)
+            .where('principalUuid', principal.uuid);
+    }
+    void query
+        .orderByRaw('LOWER(COALESCE(??, ??, ?))', ['name', 'firstName', ''])
+        .orderBy('origin')
+        .orderBy('principalUuid');
+
+    return KnexPaginate.paginate(query, paginateArgs);
+};
+
+export const getDirectAccessGroupRolesForUsers = async (
+    database: Knex,
+    config: DirectAccessAdminTableConfig,
+    context: DirectAccessAdminContext,
+    userUuids: string[],
+): Promise<Record<string, SpaceMemberRole[]>> => {
+    if (userUuids.length === 0) return {};
+    const rows = await database(config.groupAccessTable)
+        .innerJoin(
+            GroupMembershipTableName,
+            `${GroupMembershipTableName}.group_uuid`,
+            `${config.groupAccessTable}.group_uuid`,
+        )
+        .innerJoin(
+            UserTableName,
+            `${UserTableName}.user_id`,
+            `${GroupMembershipTableName}.user_id`,
+        )
+        .innerJoin(ProjectTableName, (join) =>
+            joinProject(join, context.projectUuid),
+        )
+        .innerJoin(
+            OrganizationMembershipsTableName,
+            function joinCurrentOrganizationMembership() {
+                this.on(
+                    `${OrganizationMembershipsTableName}.user_id`,
+                    `${UserTableName}.user_id`,
+                ).andOn(
+                    `${OrganizationMembershipsTableName}.organization_id`,
+                    `${ProjectTableName}.organization_id`,
+                );
+            },
+        )
+        .innerJoin(
+            OrganizationTableName,
+            `${OrganizationTableName}.organization_id`,
+            `${ProjectTableName}.organization_id`,
+        )
+        .where(
+            `${config.groupAccessTable}.${config.resourceColumn}`,
+            context.resourceUuid,
+        )
+        .whereIn(`${UserTableName}.user_uuid`, userUuids)
+        .where(
+            `${OrganizationTableName}.organization_uuid`,
+            context.organizationUuid,
+        )
+        .where(
+            `${GroupMembershipTableName}.organization_id`,
+            database.ref(`${ProjectTableName}.organization_id`),
+        )
+        .where(getActiveProjectMemberPredicate(database))
+        .where(
+            getActiveGrantedGroupPredicate(database, config.groupAccessTable),
+        )
+        .select<{ userUuid: string; role: SpaceMemberRole }[]>({
+            userUuid: `${UserTableName}.user_uuid`,
+            role: `${config.groupAccessTable}.space_role`,
+        });
+
+    const rolesByUserUuid: Record<string, SpaceMemberRole[]> = {};
+    for (const { userUuid, role } of rows) {
+        rolesByUserUuid[userUuid] = [
+            ...(rolesByUserUuid[userUuid] ?? []),
+            role,
+        ];
+    }
+    return rolesByUserUuid;
+};

--- a/packages/backend/src/services/DirectAccess/BaseResourceAccessHandler.test.ts
+++ b/packages/backend/src/services/DirectAccess/BaseResourceAccessHandler.test.ts
@@ -1,0 +1,314 @@
+import { Ability } from '@casl/ability';
+import {
+    DirectAccessOrigin,
+    NotFoundError,
+    OrganizationMemberRole,
+    SpaceMemberRole,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import { vi } from 'vitest';
+import type { DirectAccessListRow } from '../../models/directAccessAdminModelUtils';
+import type { DirectAccessMutationResult } from '../../models/directAccessModelUtils';
+import type { AccessContextForCasl } from '../SpaceService/SpacePermissionService';
+import {
+    BaseResourceAccessHandler,
+    type DirectAccessResourceAdapter,
+    type DirectAccessTarget,
+} from './BaseResourceAccessHandler';
+import {
+    runResourceAccessHandlerConformance,
+    type ResourceAccessHandlerConformanceHarness,
+} from './ResourceAccessHandler.conformance';
+
+const ORGANIZATION_UUID = '00000000-0000-4000-8000-000000000001';
+const PROJECT_UUID = '00000000-0000-4000-8000-000000000002';
+const SPACE_UUID = '00000000-0000-4000-8000-000000000003';
+const RESOURCE_UUID = '00000000-0000-4000-8000-000000000004';
+const ACTOR_UUID = '00000000-0000-4000-8000-000000000005';
+
+const createUser = (): SessionUser =>
+    ({
+        userUuid: ACTOR_UUID,
+        userId: 1,
+        email: 'editor@example.com',
+        firstName: 'Ed',
+        lastName: 'Itor',
+        organizationUuid: ORGANIZATION_UUID,
+        organizationName: 'Lightdash',
+        organizationCreatedAt: new Date('2026-08-27T00:00:00Z'),
+        role: OrganizationMemberRole.MEMBER,
+        isTrackingAnonymized: false,
+        isMarketingOptedIn: false,
+        isSetupComplete: true,
+        isActive: true,
+        createdAt: new Date('2026-08-27T00:00:00Z'),
+        updatedAt: new Date('2026-08-27T00:00:00Z'),
+        timezone: null,
+        avatarUrl: null,
+        avatarGradient: null,
+        ability: new Ability<PossibleAbilities>([]),
+        abilityRules: [],
+    }) as SessionUser;
+
+const mutationResult = (
+    beforeRole: SpaceMemberRole | null,
+    afterRole: SpaceMemberRole | null,
+): DirectAccessMutationResult => ({
+    organizationId: 1,
+    organizationUuid: ORGANIZATION_UUID,
+    projectId: 1,
+    projectUuid: PROJECT_UUID,
+    beforeRole,
+    afterRole,
+});
+
+const createHarness = (): ResourceAccessHandlerConformanceHarness => {
+    const user = createUser();
+    let actorRole: SpaceMemberRole | undefined = SpaceMemberRole.EDITOR;
+    let enabled = true;
+    let eligible = true;
+    let targetError: Error | undefined;
+    let rows: DirectAccessListRow[] = [];
+
+    const target: DirectAccessTarget = {
+        resourceUuid: RESOURCE_UUID,
+        organizationUuid: ORGANIZATION_UUID,
+        projectUuid: PROJECT_UUID,
+        spaceUuid: SPACE_UUID,
+        accessTarget: {
+            type: 'dashboard',
+            dashboardUuid: RESOURCE_UUID,
+            spaceUuid: SPACE_UUID,
+        },
+        canReceiveDirectAccess: true,
+    };
+    const getTarget = vi.fn(async () => {
+        if (targetError) throw targetError;
+        return { ...target, canReceiveDirectAccess: eligible };
+    });
+    const upsertUserAccess = vi.fn(
+        async (
+            _target: DirectAccessTarget,
+            input: {
+                userUuid: string;
+                role: SpaceMemberRole;
+                actor: SessionUser;
+            },
+        ) => {
+            const existing = rows.find(
+                (row) =>
+                    row.origin === DirectAccessOrigin.USER &&
+                    row.principalUuid === input.userUuid,
+            );
+            rows = rows.filter(
+                (row) =>
+                    row.origin !== DirectAccessOrigin.USER ||
+                    row.principalUuid !== input.userUuid,
+            );
+            rows.push({
+                origin: DirectAccessOrigin.USER,
+                principalUuid: input.userUuid,
+                firstName: 'Test',
+                lastName: 'User',
+                email: 'test@example.com',
+                isInternal: false,
+                directRole: input.role,
+            });
+            return mutationResult(existing?.directRole ?? null, input.role);
+        },
+    );
+    const upsertGroupAccess = vi.fn(
+        async (
+            _target: DirectAccessTarget,
+            input: { groupUuid: string; role: SpaceMemberRole },
+        ) => {
+            const existing = rows.find(
+                (row) =>
+                    row.origin === DirectAccessOrigin.GROUP &&
+                    row.principalUuid === input.groupUuid,
+            );
+            rows = rows.filter(
+                (row) =>
+                    row.origin !== DirectAccessOrigin.GROUP ||
+                    row.principalUuid !== input.groupUuid,
+            );
+            rows.push({
+                origin: DirectAccessOrigin.GROUP,
+                principalUuid: input.groupUuid,
+                name: 'Test group',
+                directRole: input.role,
+            });
+            return mutationResult(existing?.directRole ?? null, input.role);
+        },
+    );
+    const revokeUserAccess = vi.fn(
+        async (_target: DirectAccessTarget, input: { userUuid: string }) => {
+            const existing = rows.find(
+                (row) =>
+                    row.origin === DirectAccessOrigin.USER &&
+                    row.principalUuid === input.userUuid,
+            );
+            rows = rows.filter(
+                (row) =>
+                    row.origin !== DirectAccessOrigin.USER ||
+                    row.principalUuid !== input.userUuid,
+            );
+            return mutationResult(existing?.directRole ?? null, null);
+        },
+    );
+    const resetAccess = vi.fn(async () => {
+        const revokedUsers = rows.filter(
+            ({ origin }) => origin === DirectAccessOrigin.USER,
+        ).length;
+        const revokedGroups = rows.length - revokedUsers;
+        rows = [];
+        return {
+            organizationId: 1,
+            organizationUuid: ORGANIZATION_UUID,
+            projectId: 1,
+            projectUuid: PROJECT_UUID,
+            revokedUsers,
+            revokedGroups,
+        };
+    });
+    const adapter: DirectAccessResourceAdapter = {
+        auditResourceType: 'Dashboard',
+        getTarget,
+        getDirectAccessList: vi.fn(async (_target, options) => ({
+            data: rows.filter(
+                (row) =>
+                    !options.principal ||
+                    (row.origin === options.principal.origin &&
+                        row.principalUuid === options.principal.uuid),
+            ),
+            ...(options.paginateArgs
+                ? {
+                      pagination: {
+                          ...options.paginateArgs,
+                          totalPageCount: rows.length > 0 ? 1 : 0,
+                          totalResults: rows.length,
+                      },
+                  }
+                : {}),
+        })),
+        getGroupRolesForUsers: vi.fn(async () => ({})),
+        upsertUserAccess,
+        upsertGroupAccess,
+        revokeUserAccess,
+        revokeGroupAccess: vi.fn(
+            async (_target, input: { groupUuid: string }) => {
+                const existing = rows.find(
+                    (row) =>
+                        row.origin === DirectAccessOrigin.GROUP &&
+                        row.principalUuid === input.groupUuid,
+                );
+                rows = rows.filter(
+                    (row) =>
+                        row.origin !== DirectAccessOrigin.GROUP ||
+                        row.principalUuid !== input.groupUuid,
+                );
+                return mutationResult(existing?.directRole ?? null, null);
+            },
+        ),
+        resetAccess,
+    };
+    const context = (): AccessContextForCasl => ({
+        organizationUuid: ORGANIZATION_UUID,
+        projectUuid: PROJECT_UUID,
+        inheritsFromOrgOrProject: false,
+        directOnly: true,
+        admins: [],
+        access: actorRole
+            ? [
+                  {
+                      userUuid: ACTOR_UUID,
+                      role: actorRole,
+                      hasDirectAccess: true,
+                      projectRole: undefined,
+                      inheritedRole: undefined,
+                      inheritedFrom: undefined,
+                  },
+              ]
+            : [],
+    });
+    const handler = new BaseResourceAccessHandler(
+        adapter,
+        {
+            resolveAccess: vi.fn(async () => context()),
+            getSpaceAccessContextForUsers: vi.fn(async () => ({
+                ...context(),
+                access: [],
+            })),
+            mergeAdminAccess: vi.fn((accessContext) => accessContext.access),
+        },
+        { isEnabledForUser: vi.fn(async () => enabled) },
+        vi.fn(),
+    );
+
+    return {
+        handler,
+        input: {
+            user,
+            projectUuid: PROJECT_UUID,
+            resourceUuid: RESOURCE_UUID,
+        },
+        setActorRole: (role) => {
+            actorRole = role;
+        },
+        setEnabled: (value) => {
+            enabled = value;
+        },
+        setEligible: (value) => {
+            eligible = value;
+        },
+        setTargetError: (error) => {
+            targetError = error;
+        },
+        seedUserGrant: (userUuid, role) => {
+            rows.push({
+                origin: DirectAccessOrigin.USER,
+                principalUuid: userUuid,
+                firstName: 'Test',
+                lastName: 'User',
+                email: 'test@example.com',
+                isInternal: false,
+                directRole: role,
+            });
+        },
+        seedGroupGrant: (groupUuid, role) => {
+            rows.push({
+                origin: DirectAccessOrigin.GROUP,
+                principalUuid: groupUuid,
+                name: 'Test group',
+                directRole: role,
+            });
+        },
+        calls: {
+            getTarget: () => getTarget.mock.calls.length,
+            upsertUser: () => upsertUserAccess.mock.calls.length,
+            revokeUser: () => revokeUserAccess.mock.calls.length,
+            reset: () => resetAccess.mock.calls.length,
+        },
+    };
+};
+
+runResourceAccessHandlerConformance('BaseResourceAccessHandler', createHarness);
+
+test('preserves unknown implementation failures', async () => {
+    const harness = createHarness();
+    harness.setTargetError(new Error('database unavailable'));
+
+    await expect(harness.handler.listAccess(harness.input)).rejects.toThrow(
+        'database unavailable',
+    );
+});
+
+test('normalizes missing resources', async () => {
+    const harness = createHarness();
+    harness.setTargetError(new NotFoundError('dashboard missing'));
+
+    await expect(
+        harness.handler.listAccess(harness.input),
+    ).rejects.toMatchObject({ message: 'Access target not found' });
+});

--- a/packages/backend/src/services/DirectAccess/BaseResourceAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/BaseResourceAccessHandler.ts
@@ -16,6 +16,7 @@ import {
 } from '@lightdash/common';
 import { validate as isValidUuid } from 'uuid';
 import { createActorFromUser } from '../../logging/caslAuditWrapper';
+import type { DirectAccessListRow } from '../../models/directAccessAdminModelUtils';
 import type {
     DirectAccessMutationResult,
     DirectAccessResetResult,
@@ -36,23 +37,6 @@ import type {
     ResourceAccessHandler,
     ResourceAccessInput,
 } from './ResourceAccessHandler';
-
-export type DirectAccessListRow =
-    | {
-          origin: DirectAccessOrigin.USER;
-          principalUuid: string;
-          firstName: string;
-          lastName: string;
-          email: string;
-          isInternal: boolean;
-          directRole: SpaceMemberRole;
-      }
-    | {
-          origin: DirectAccessOrigin.GROUP;
-          principalUuid: string;
-          name: string;
-          directRole: SpaceMemberRole;
-      };
 
 export type DirectAccessTarget = {
     resourceUuid: string;

--- a/packages/backend/src/services/DirectAccess/DashboardAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/DashboardAccessHandler.ts
@@ -1,0 +1,150 @@
+import type { SessionUser, SpaceMemberRole } from '@lightdash/common';
+import type { DashboardAccessModel } from '../../models/DashboardAccessModel';
+import type { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import {
+    BaseResourceAccessHandler,
+    type DirectAccessResourceAdapter,
+    type DirectAccessTarget,
+} from './BaseResourceAccessHandler';
+import type { DirectAccessAuditLogger } from './directAccessAudit';
+import type { DirectAccessFeatureGate } from './DirectAccessFeatureGate';
+import type { ResourceAccessInput } from './ResourceAccessHandler';
+
+type DashboardAccessTarget = DirectAccessTarget & {
+    resourceUuid: string;
+};
+
+class DashboardAccessAdapter implements DirectAccessResourceAdapter<DashboardAccessTarget> {
+    readonly auditResourceType = 'Dashboard';
+
+    constructor(
+        private readonly accessModel: DashboardAccessModel,
+        private readonly dashboardModel: DashboardModel,
+    ) {}
+
+    async getTarget({
+        projectUuid,
+        resourceUuid,
+    }: ResourceAccessInput): Promise<DashboardAccessTarget> {
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            resourceUuid,
+            { projectUuid },
+        );
+        return {
+            resourceUuid: dashboard.uuid,
+            organizationUuid: dashboard.organizationUuid,
+            projectUuid: dashboard.projectUuid,
+            spaceUuid: dashboard.spaceUuid,
+            accessTarget: {
+                type: 'dashboard',
+                dashboardUuid: dashboard.uuid,
+                spaceUuid: dashboard.spaceUuid,
+            },
+            canReceiveDirectAccess: true,
+        };
+    }
+
+    getDirectAccessList(
+        target: DashboardAccessTarget,
+        options: Parameters<DashboardAccessModel['getDirectAccessList']>[3],
+    ) {
+        return this.accessModel.getDirectAccessList(
+            target.resourceUuid,
+            target.organizationUuid,
+            target.projectUuid,
+            options,
+        );
+    }
+
+    getGroupRolesForUsers(target: DashboardAccessTarget, userUuids: string[]) {
+        return this.accessModel.getGroupRolesForUsers(
+            target.resourceUuid,
+            target.organizationUuid,
+            target.projectUuid,
+            userUuids,
+        );
+    }
+
+    upsertUserAccess(
+        target: DashboardAccessTarget,
+        input: { userUuid: string; role: SpaceMemberRole; actor: SessionUser },
+    ) {
+        return this.accessModel.upsertUserAccess({
+            resourceUuid: target.resourceUuid,
+            organizationUuid: target.organizationUuid,
+            userUuid: input.userUuid,
+            role: input.role,
+            grantedByUserUuid: input.actor.userUuid,
+        });
+    }
+
+    upsertGroupAccess(
+        target: DashboardAccessTarget,
+        input: {
+            groupUuid: string;
+            role: SpaceMemberRole;
+            actor: SessionUser;
+        },
+    ) {
+        return this.accessModel.upsertGroupAccess({
+            resourceUuid: target.resourceUuid,
+            organizationUuid: target.organizationUuid,
+            groupUuid: input.groupUuid,
+            role: input.role,
+            grantedByUserUuid: input.actor.userUuid,
+        });
+    }
+
+    revokeUserAccess(
+        target: DashboardAccessTarget,
+        input: { userUuid: string },
+    ) {
+        return this.accessModel.revokeUserAccess({
+            resourceUuid: target.resourceUuid,
+            organizationUuid: target.organizationUuid,
+            userUuid: input.userUuid,
+        });
+    }
+
+    revokeGroupAccess(
+        target: DashboardAccessTarget,
+        input: { groupUuid: string },
+    ) {
+        return this.accessModel.revokeGroupAccess({
+            resourceUuid: target.resourceUuid,
+            organizationUuid: target.organizationUuid,
+            groupUuid: input.groupUuid,
+        });
+    }
+
+    resetAccess(target: DashboardAccessTarget) {
+        return this.accessModel.resetAccess({
+            resourceUuid: target.resourceUuid,
+            organizationUuid: target.organizationUuid,
+        });
+    }
+}
+
+export class DashboardAccessHandler extends BaseResourceAccessHandler<DashboardAccessTarget> {
+    constructor({
+        dashboardAccessModel,
+        dashboardModel,
+        spacePermissionService,
+        featureGate,
+        auditLogger,
+    }: {
+        dashboardAccessModel: DashboardAccessModel;
+        dashboardModel: DashboardModel;
+        spacePermissionService: SpacePermissionService;
+        featureGate: DirectAccessFeatureGate;
+        auditLogger?: DirectAccessAuditLogger;
+    }) {
+        super(
+            new DashboardAccessAdapter(dashboardAccessModel, dashboardModel),
+            spacePermissionService,
+            featureGate,
+            auditLogger,
+        );
+    }
+}

--- a/packages/backend/src/services/DirectAccess/SavedChartAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/SavedChartAccessHandler.ts
@@ -1,0 +1,150 @@
+import type { SessionUser, SpaceMemberRole } from '@lightdash/common';
+import type { SavedChartAccessModel } from '../../models/SavedChartAccessModel';
+import type { SavedChartModel } from '../../models/SavedChartModel';
+import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import {
+    BaseResourceAccessHandler,
+    type DirectAccessResourceAdapter,
+    type DirectAccessTarget,
+} from './BaseResourceAccessHandler';
+import type { DirectAccessAuditLogger } from './directAccessAudit';
+import type { DirectAccessFeatureGate } from './DirectAccessFeatureGate';
+import type { ResourceAccessInput } from './ResourceAccessHandler';
+
+type SavedChartAccessTarget = DirectAccessTarget & {
+    resourceUuid: string;
+};
+
+class SavedChartAccessAdapter implements DirectAccessResourceAdapter<SavedChartAccessTarget> {
+    readonly auditResourceType = 'SavedChart';
+
+    constructor(
+        private readonly accessModel: SavedChartAccessModel,
+        private readonly savedChartModel: SavedChartModel,
+    ) {}
+
+    async getTarget({
+        projectUuid,
+        resourceUuid,
+    }: ResourceAccessInput): Promise<SavedChartAccessTarget> {
+        const chart = await this.savedChartModel.get(resourceUuid, undefined, {
+            projectUuid,
+        });
+        return {
+            resourceUuid: chart.uuid,
+            organizationUuid: chart.organizationUuid,
+            projectUuid: chart.projectUuid,
+            spaceUuid: chart.spaceUuid,
+            accessTarget: {
+                type: 'chart',
+                chartUuid: chart.uuid,
+                dashboardUuid: chart.dashboardUuid,
+                spaceUuid: chart.spaceUuid,
+            },
+            canReceiveDirectAccess: chart.dashboardUuid === null,
+        };
+    }
+
+    getDirectAccessList(
+        target: SavedChartAccessTarget,
+        options: Parameters<SavedChartAccessModel['getDirectAccessList']>[3],
+    ) {
+        return this.accessModel.getDirectAccessList(
+            target.resourceUuid,
+            target.organizationUuid,
+            target.projectUuid,
+            options,
+        );
+    }
+
+    getGroupRolesForUsers(target: SavedChartAccessTarget, userUuids: string[]) {
+        return this.accessModel.getGroupRolesForUsers(
+            target.resourceUuid,
+            target.organizationUuid,
+            target.projectUuid,
+            userUuids,
+        );
+    }
+
+    upsertUserAccess(
+        target: SavedChartAccessTarget,
+        input: { userUuid: string; role: SpaceMemberRole; actor: SessionUser },
+    ) {
+        return this.accessModel.upsertUserAccess({
+            resourceUuid: target.resourceUuid,
+            organizationUuid: target.organizationUuid,
+            userUuid: input.userUuid,
+            role: input.role,
+            grantedByUserUuid: input.actor.userUuid,
+        });
+    }
+
+    upsertGroupAccess(
+        target: SavedChartAccessTarget,
+        input: {
+            groupUuid: string;
+            role: SpaceMemberRole;
+            actor: SessionUser;
+        },
+    ) {
+        return this.accessModel.upsertGroupAccess({
+            resourceUuid: target.resourceUuid,
+            organizationUuid: target.organizationUuid,
+            groupUuid: input.groupUuid,
+            role: input.role,
+            grantedByUserUuid: input.actor.userUuid,
+        });
+    }
+
+    revokeUserAccess(
+        target: SavedChartAccessTarget,
+        input: { userUuid: string },
+    ) {
+        return this.accessModel.revokeUserAccess({
+            resourceUuid: target.resourceUuid,
+            organizationUuid: target.organizationUuid,
+            userUuid: input.userUuid,
+        });
+    }
+
+    revokeGroupAccess(
+        target: SavedChartAccessTarget,
+        input: { groupUuid: string },
+    ) {
+        return this.accessModel.revokeGroupAccess({
+            resourceUuid: target.resourceUuid,
+            organizationUuid: target.organizationUuid,
+            groupUuid: input.groupUuid,
+        });
+    }
+
+    resetAccess(target: SavedChartAccessTarget) {
+        return this.accessModel.resetAccess({
+            resourceUuid: target.resourceUuid,
+            organizationUuid: target.organizationUuid,
+        });
+    }
+}
+
+export class SavedChartAccessHandler extends BaseResourceAccessHandler<SavedChartAccessTarget> {
+    constructor({
+        savedChartAccessModel,
+        savedChartModel,
+        spacePermissionService,
+        featureGate,
+        auditLogger,
+    }: {
+        savedChartAccessModel: SavedChartAccessModel;
+        savedChartModel: SavedChartModel;
+        spacePermissionService: SpacePermissionService;
+        featureGate: DirectAccessFeatureGate;
+        auditLogger?: DirectAccessAuditLogger;
+    }) {
+        super(
+            new SavedChartAccessAdapter(savedChartAccessModel, savedChartModel),
+            spacePermissionService,
+            featureGate,
+            auditLogger,
+        );
+    }
+}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1528/stack-5a-build-direct-access-administration-api

## Summary

PR 2 of 5. Adds dashboard and independently saved Explore-chart administration adapters over the shared policy from [#28245](https://github.com/lightdash/lightdash/pull/28245).

Stacks on top of PR 1 ([#28245](https://github.com/lightdash/lightdash/pull/28245)), which defines the canonical handler contract and policy kernel.

## Changes

- Adds one tenant-scoped, paginated list implementation reused by all grant tables.
- Adapts existing dashboard and saved-chart mutation models to the shared contract.
- Resolves dashboard-owned charts through their dashboard, then rejects independent grants only after authorization.
- Filters removed users, inactive users, and groups without current project access from direct/effective lists.
- Instantiates the shared conformance suite for the first concrete resources.

## Ownership semantics

```text
Dashboard                    -> dashboard grant
Independent Explore chart    -> saved-chart grant
Dashboard-owned chart        -> dashboard grant; chart policy rejected
```

## Test plan

- [x] Shared handler conformance: 16/16
- [x] Dashboard PostgreSQL integration: 11/11
- [x] Saved-chart PostgreSQL integration: 60/60
- [x] Common and backend typecheck, lint, and formatting
- [x] Cross-organization, removed-principal, deleted-owner, stale-ownership, idempotency, and concurrent-write cases
