### PR TITLE
feat(direct-access): administer SQL chart access

### DIFF
--- a/packages/backend/src/models/SavedSqlAccessModel.integration.test.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.integration.test.ts
@@ -1,4 +1,5 @@
 import {
+    DirectAccessOrigin,
     OrganizationMemberRole,
     ProjectMemberRole,
     SEED_ORG_1_ADMIN,
@@ -110,6 +111,173 @@ describe('SavedSqlAccessModel PostgreSQL integration', () => {
             .returning('saved_sql_uuid');
         return chart.saved_sql_uuid;
     };
+
+    const createProjectGroup = async () => {
+        const [group] = await transaction(GroupTableName)
+            .insert({
+                organization_id: organizationId,
+                name: `SQL access group ${randomUUID()}`,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                updated_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })
+            .returning('group_uuid');
+        await transaction(GroupMembershipTableName).insert({
+            organization_id: organizationId,
+            group_uuid: group.group_uuid,
+            user_id: adminUserId,
+        });
+        await transaction(ProjectGroupAccessTableName).insert({
+            project_uuid: projectUuid,
+            group_uuid: group.group_uuid,
+            role: ProjectMemberRole.VIEWER,
+        });
+        return group.group_uuid;
+    };
+
+    it('writes, lists, revokes, and resets direct grants', async () => {
+        const savedSqlUuid = await createSpaceChart();
+        const groupUuid = await createProjectGroup();
+        const expectation = {
+            organizationUuid,
+            projectUuid,
+            spaceUuid,
+            dashboardUuid: null,
+        };
+
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: savedSqlUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.VIEWER,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                ...expectation,
+            }),
+        ).resolves.toMatchObject({
+            beforeRole: null,
+            afterRole: SpaceMemberRole.VIEWER,
+        });
+        await expect(
+            model.upsertGroupAccess({
+                resourceUuid: savedSqlUuid,
+                groupUuid,
+                role: SpaceMemberRole.EDITOR,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                ...expectation,
+            }),
+        ).resolves.toMatchObject({
+            beforeRole: null,
+            afterRole: SpaceMemberRole.EDITOR,
+        });
+
+        const { data } = await model.getDirectAccessList(
+            savedSqlUuid,
+            organizationUuid,
+            projectUuid,
+        );
+        expect(data).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    origin: DirectAccessOrigin.USER,
+                    principalUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    directRole: SpaceMemberRole.VIEWER,
+                }),
+                expect.objectContaining({
+                    origin: DirectAccessOrigin.GROUP,
+                    principalUuid: groupUuid,
+                    directRole: SpaceMemberRole.EDITOR,
+                }),
+            ]),
+        );
+        await expect(
+            model.getGroupRolesForUsers(
+                savedSqlUuid,
+                organizationUuid,
+                projectUuid,
+                [SEED_ORG_1_ADMIN.user_uuid],
+            ),
+        ).resolves.toEqual({
+            [SEED_ORG_1_ADMIN.user_uuid]: [SpaceMemberRole.EDITOR],
+        });
+
+        await expect(
+            model.revokeUserAccess({
+                resourceUuid: savedSqlUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                ...expectation,
+            }),
+        ).resolves.toMatchObject({
+            beforeRole: SpaceMemberRole.VIEWER,
+            afterRole: null,
+        });
+        await expect(
+            model.revokeUserAccess({
+                resourceUuid: savedSqlUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                ...expectation,
+            }),
+        ).resolves.toMatchObject({ beforeRole: null, afterRole: null });
+        await expect(
+            model.resetAccess({ resourceUuid: savedSqlUuid, ...expectation }),
+        ).resolves.toMatchObject({ revokedUsers: 0, revokedGroups: 1 });
+    });
+
+    it('rejects writes to dashboard-owned SQL charts', async () => {
+        const [dashboard] = await transaction(DashboardsTableName)
+            .insert({
+                project_uuid: projectUuid,
+                name: `SQL owner ${randomUUID()}`,
+                description: undefined,
+                space_id: spaceId,
+                slug: `sql-owner-${randomUUID()}`,
+            })
+            .returning('dashboard_uuid');
+        const [chart] = await transaction(SavedSqlTableName)
+            .insert({
+                project_uuid: projectUuid,
+                space_uuid: null,
+                dashboard_uuid: dashboard.dashboard_uuid,
+                name: `Owned SQL chart ${randomUUID()}`,
+                description: null,
+                slug: `owned-sql-${randomUUID()}`,
+                created_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            })
+            .returning('saved_sql_uuid');
+
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: chart.saved_sql_uuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.VIEWER,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                organizationUuid,
+                projectUuid,
+                spaceUuid: null,
+                dashboardUuid: dashboard.dashboard_uuid,
+            }),
+        ).rejects.toMatchObject({ name: 'ParameterError' });
+    });
+
+    it('rejects stale target expectations before writing', async () => {
+        const savedSqlUuid = await createSpaceChart();
+
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: savedSqlUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.VIEWER,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                organizationUuid,
+                projectUuid: randomUUID(),
+                spaceUuid,
+                dashboardUuid: null,
+            }),
+        ).rejects.toMatchObject({ name: 'NotFoundError' });
+        await expect(
+            transaction(SavedSqlUserAccessTableName).where({
+                saved_sql_uuid: savedSqlUuid,
+            }),
+        ).resolves.toHaveLength(0);
+    });
 
     it('resolves current user and group grants for active space charts only', async () => {
         const activeChartUuid = await createSpaceChart();

--- a/packages/backend/src/models/SavedSqlAccessModel.ts
+++ b/packages/backend/src/models/SavedSqlAccessModel.ts
@@ -1,4 +1,12 @@
+import {
+    NotFoundError,
+    ParameterError,
+    type DirectAccessOrigin,
+    type KnexPaginateArgs,
+    type SpaceMemberRole,
+} from '@lightdash/common';
 import { type Knex } from 'knex';
+import { DashboardsTableName } from '../database/entities/dashboards';
 import { GroupMembershipTableName } from '../database/entities/groupMemberships';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { OrganizationTableName } from '../database/entities/organizations';
@@ -11,17 +19,431 @@ import {
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import {
+    getDirectAccessGroupRolesForUsers,
+    getDirectAccessList,
+} from './directAccessAdminModelUtils';
+import {
     getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
+    validateDirectAccessGroup,
+    validateDirectAccessUser,
     type DirectAccess,
+    type DirectAccessMutationContext,
+    type DirectAccessMutationResult,
+    type DirectAccessResetResult,
     type DirectAccessRow,
 } from './directAccessModelUtils';
 
 export type SavedSqlDirectAccess = DirectAccess;
 
+type SavedSqlOwnership = {
+    spaceUuid: string | null;
+    dashboardUuid: string | null;
+};
+
+type SavedSqlMutationTarget = {
+    context: DirectAccessMutationContext;
+    ownership: SavedSqlOwnership;
+};
+
+export type SavedSqlMutationExpectation = SavedSqlOwnership & {
+    organizationUuid: string;
+    projectUuid: string;
+};
+
+export const canReceiveSavedSqlDirectAccess = ({
+    spaceUuid,
+    dashboardUuid,
+}: SavedSqlOwnership): boolean => spaceUuid !== null && dashboardUuid === null;
+
+const adminTableConfig = {
+    userAccessTable: SavedSqlUserAccessTableName,
+    groupAccessTable: SavedSqlGroupAccessTableName,
+    resourceColumn: 'saved_sql_uuid',
+};
+
 export class SavedSqlAccessModel {
     constructor(private readonly database: Knex) {}
+
+    private static async getMutationTarget(
+        trx: Knex,
+        resourceUuid: string,
+        expected: SavedSqlMutationExpectation,
+    ): Promise<SavedSqlMutationTarget> {
+        const candidateChart = await trx(SavedSqlTableName)
+            .where(`${SavedSqlTableName}.saved_sql_uuid`, resourceUuid)
+            .where(`${SavedSqlTableName}.project_uuid`, expected.projectUuid)
+            .whereNull(`${SavedSqlTableName}.deleted_at`)
+            .select<SavedSqlOwnership>({
+                spaceUuid: `${SavedSqlTableName}.space_uuid`,
+                dashboardUuid: `${SavedSqlTableName}.dashboard_uuid`,
+            })
+            .first();
+        if (candidateChart === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        let ownerSpaceId: number;
+        if (candidateChart.spaceUuid !== null) {
+            const candidateSpace = await trx(SpaceTableName)
+                .where('space_uuid', candidateChart.spaceUuid)
+                .whereNull('deleted_at')
+                .select<{ spaceId: number }>({ spaceId: 'space_id' })
+                .first();
+            if (candidateSpace === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            ownerSpaceId = candidateSpace.spaceId;
+        } else {
+            if (candidateChart.dashboardUuid === null) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const candidateDashboard = await trx(DashboardsTableName)
+                .where('dashboard_uuid', candidateChart.dashboardUuid)
+                .whereNull('deleted_at')
+                .select<{ spaceId: number }>({ spaceId: 'space_id' })
+                .first();
+            if (candidateDashboard === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            ownerSpaceId = candidateDashboard.spaceId;
+        }
+
+        const candidateOwner = await trx(SpaceTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(`${SpaceTableName}.space_id`, ownerSpaceId)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                expected.organizationUuid,
+            )
+            .where(`${ProjectTableName}.project_uuid`, expected.projectUuid)
+            .select<DirectAccessMutationContext>({
+                organizationId: `${OrganizationTableName}.organization_id`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectId: `${ProjectTableName}.project_id`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+            })
+            .first();
+        if (candidateOwner === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        const organization = await trx(OrganizationTableName)
+            .where('organization_id', candidateOwner.organizationId)
+            .where('organization_uuid', expected.organizationUuid)
+            .select<{ organizationId: number; organizationUuid: string }>({
+                organizationId: 'organization_id',
+                organizationUuid: 'organization_uuid',
+            })
+            .forNoKeyUpdate(OrganizationTableName)
+            .first();
+        const project = await trx(ProjectTableName)
+            .where('project_id', candidateOwner.projectId)
+            .where('organization_id', candidateOwner.organizationId)
+            .where('project_uuid', expected.projectUuid)
+            .select<{ projectId: number; projectUuid: string }>({
+                projectId: 'project_id',
+                projectUuid: 'project_uuid',
+            })
+            .forNoKeyUpdate(ProjectTableName)
+            .first();
+        if (organization === undefined || project === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+        const space = await trx(SpaceTableName)
+            .where('space_id', ownerSpaceId)
+            .where('project_id', project.projectId)
+            .whereNull('deleted_at')
+            .select<{ spaceUuid: string }>({ spaceUuid: 'space_uuid' })
+            .forNoKeyUpdate(SpaceTableName)
+            .first();
+        if (space === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+        if (candidateChart.dashboardUuid !== null) {
+            const dashboard = await trx(DashboardsTableName)
+                .where('dashboard_uuid', candidateChart.dashboardUuid)
+                .where('space_id', ownerSpaceId)
+                .where('project_uuid', project.projectUuid)
+                .whereNull('deleted_at')
+                .select('dashboard_uuid')
+                .forNoKeyUpdate(DashboardsTableName)
+                .first();
+            if (dashboard === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
+        }
+
+        const chart = await trx(SavedSqlTableName)
+            .where('saved_sql_uuid', resourceUuid)
+            .whereNull('deleted_at')
+            .select<SavedSqlOwnership & { projectUuid: string }>({
+                spaceUuid: 'space_uuid',
+                dashboardUuid: 'dashboard_uuid',
+                projectUuid: 'project_uuid',
+            })
+            .forUpdate(SavedSqlTableName)
+            .first();
+        if (
+            chart === undefined ||
+            chart.spaceUuid !== expected.spaceUuid ||
+            chart.dashboardUuid !== expected.dashboardUuid ||
+            chart.spaceUuid !== candidateChart.spaceUuid ||
+            chart.dashboardUuid !== candidateChart.dashboardUuid ||
+            chart.projectUuid !== project.projectUuid ||
+            (chart.spaceUuid !== null && chart.spaceUuid !== space.spaceUuid)
+        ) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        return {
+            context: {
+                organizationId: organization.organizationId,
+                organizationUuid: organization.organizationUuid,
+                projectId: project.projectId,
+                projectUuid: project.projectUuid,
+            },
+            ownership: {
+                spaceUuid: chart.spaceUuid,
+                dashboardUuid: chart.dashboardUuid,
+            },
+        };
+    }
+
+    async upsertUserAccess({
+        resourceUuid,
+        userUuid,
+        role,
+        grantedByUserUuid,
+        ...expected
+    }: {
+        resourceUuid: string;
+        userUuid: string;
+        role: SpaceMemberRole;
+        grantedByUserUuid: string;
+    } & SavedSqlMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const { context, ownership } =
+                await SavedSqlAccessModel.getMutationTarget(
+                    trx,
+                    resourceUuid,
+                    expected,
+                );
+            if (!canReceiveSavedSqlDirectAccess(ownership)) {
+                throw new ParameterError(
+                    'Cannot grant direct access to a dashboard-owned SQL chart; grant access to its dashboard instead',
+                );
+            }
+            if (!(await validateDirectAccessUser(trx, context, userUuid))) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(SavedSqlUserAccessTableName)
+                .where({ saved_sql_uuid: resourceUuid, user_uuid: userUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            await trx(SavedSqlUserAccessTableName)
+                .insert({
+                    saved_sql_uuid: resourceUuid,
+                    user_uuid: userUuid,
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                })
+                .onConflict(['saved_sql_uuid', 'user_uuid'])
+                .merge({
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: role,
+            };
+        });
+    }
+
+    async upsertGroupAccess({
+        resourceUuid,
+        groupUuid,
+        role,
+        grantedByUserUuid,
+        ...expected
+    }: {
+        resourceUuid: string;
+        groupUuid: string;
+        role: SpaceMemberRole;
+        grantedByUserUuid: string;
+    } & SavedSqlMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const { context, ownership } =
+                await SavedSqlAccessModel.getMutationTarget(
+                    trx,
+                    resourceUuid,
+                    expected,
+                );
+            if (!canReceiveSavedSqlDirectAccess(ownership)) {
+                throw new ParameterError(
+                    'Cannot grant direct access to a dashboard-owned SQL chart; grant access to its dashboard instead',
+                );
+            }
+            if (!(await validateDirectAccessGroup(trx, context, groupUuid))) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(SavedSqlGroupAccessTableName)
+                .where({ saved_sql_uuid: resourceUuid, group_uuid: groupUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            await trx(SavedSqlGroupAccessTableName)
+                .insert({
+                    saved_sql_uuid: resourceUuid,
+                    group_uuid: groupUuid,
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                })
+                .onConflict(['saved_sql_uuid', 'group_uuid'])
+                .merge({
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: role,
+            };
+        });
+    }
+
+    async revokeUserAccess({
+        resourceUuid,
+        userUuid,
+        ...expected
+    }: {
+        resourceUuid: string;
+        userUuid: string;
+    } & SavedSqlMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const { context } = await SavedSqlAccessModel.getMutationTarget(
+                trx,
+                resourceUuid,
+                expected,
+            );
+            const existing = await trx(SavedSqlUserAccessTableName)
+                .where({ saved_sql_uuid: resourceUuid, user_uuid: userUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            if (existing === undefined) {
+                return { ...context, beforeRole: null, afterRole: null };
+            }
+            await trx(SavedSqlUserAccessTableName)
+                .where({ saved_sql_uuid: resourceUuid, user_uuid: userUuid })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing.space_role,
+                afterRole: null,
+            };
+        });
+    }
+
+    async revokeGroupAccess({
+        resourceUuid,
+        groupUuid,
+        ...expected
+    }: {
+        resourceUuid: string;
+        groupUuid: string;
+    } & SavedSqlMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const { context } = await SavedSqlAccessModel.getMutationTarget(
+                trx,
+                resourceUuid,
+                expected,
+            );
+            const existing = await trx(SavedSqlGroupAccessTableName)
+                .where({ saved_sql_uuid: resourceUuid, group_uuid: groupUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            if (existing === undefined) {
+                return { ...context, beforeRole: null, afterRole: null };
+            }
+            await trx(SavedSqlGroupAccessTableName)
+                .where({ saved_sql_uuid: resourceUuid, group_uuid: groupUuid })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing.space_role,
+                afterRole: null,
+            };
+        });
+    }
+
+    async resetAccess({
+        resourceUuid,
+        ...expected
+    }: {
+        resourceUuid: string;
+    } & SavedSqlMutationExpectation): Promise<DirectAccessResetResult> {
+        return this.database.transaction(async (trx) => {
+            const { context } = await SavedSqlAccessModel.getMutationTarget(
+                trx,
+                resourceUuid,
+                expected,
+            );
+            const [revokedUsers, revokedGroups] = await Promise.all([
+                trx(SavedSqlUserAccessTableName)
+                    .where('saved_sql_uuid', resourceUuid)
+                    .delete(),
+                trx(SavedSqlGroupAccessTableName)
+                    .where('saved_sql_uuid', resourceUuid)
+                    .delete(),
+            ]);
+            return { ...context, revokedUsers, revokedGroups };
+        });
+    }
+
+    async getDirectAccessList(
+        resourceUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
+        options: {
+            paginateArgs?: KnexPaginateArgs;
+            searchQuery?: string;
+            principal?: { origin: DirectAccessOrigin; uuid: string };
+        } = {},
+    ) {
+        return getDirectAccessList(
+            this.database,
+            adminTableConfig,
+            { resourceUuid, organizationUuid, projectUuid },
+            options,
+        );
+    }
+
+    async getGroupRolesForUsers(
+        resourceUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
+        userUuids: string[],
+    ): Promise<Record<string, SpaceMemberRole[]>> {
+        return getDirectAccessGroupRolesForUsers(
+            this.database,
+            adminTableConfig,
+            { resourceUuid, organizationUuid, projectUuid },
+            userUuids,
+        );
+    }
 
     async getUserAccess(
         savedSqlUuids: string[],

--- a/packages/backend/src/services/DirectAccess/SavedSqlAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/SavedSqlAccessHandler.ts
@@ -1,0 +1,178 @@
+import type { SessionUser, SpaceMemberRole } from '@lightdash/common';
+import type {
+    SavedSqlAccessModel,
+    SavedSqlMutationExpectation,
+} from '../../models/SavedSqlAccessModel';
+import { canReceiveSavedSqlDirectAccess } from '../../models/SavedSqlAccessModel';
+import type { SavedSqlModel } from '../../models/SavedSqlModel';
+import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import {
+    BaseResourceAccessHandler,
+    type DirectAccessResourceAdapter,
+    type DirectAccessTarget,
+} from './BaseResourceAccessHandler';
+import type { DirectAccessAuditLogger } from './directAccessAudit';
+import type { DirectAccessFeatureGate } from './DirectAccessFeatureGate';
+import type { ResourceAccessInput } from './ResourceAccessHandler';
+
+type SavedSqlAccessTarget = DirectAccessTarget & {
+    storedSpaceUuid: string | null;
+    dashboardUuid: string | null;
+};
+
+class SavedSqlAccessAdapter implements DirectAccessResourceAdapter<SavedSqlAccessTarget> {
+    readonly auditResourceType = 'SavedSql';
+
+    constructor(
+        private readonly accessModel: SavedSqlAccessModel,
+        private readonly savedSqlModel: SavedSqlModel,
+    ) {}
+
+    async getTarget({
+        projectUuid,
+        resourceUuid,
+    }: ResourceAccessInput): Promise<SavedSqlAccessTarget> {
+        const chart = await this.savedSqlModel.getByUuid(resourceUuid, {
+            projectUuid,
+        });
+        const dashboardUuid = chart.dashboard?.uuid ?? null;
+        const spaceUuid = dashboardUuid === null ? chart.space.uuid : null;
+        return {
+            resourceUuid: chart.savedSqlUuid,
+            organizationUuid: chart.organization.organizationUuid,
+            projectUuid: chart.project.projectUuid,
+            spaceUuid: chart.space.uuid,
+            storedSpaceUuid: spaceUuid,
+            dashboardUuid,
+            accessTarget: dashboardUuid
+                ? {
+                      type: 'dashboard',
+                      dashboardUuid,
+                      spaceUuid: chart.space.uuid,
+                  }
+                : {
+                      type: 'sqlChart',
+                      savedSqlUuid: chart.savedSqlUuid,
+                      spaceUuid: chart.space.uuid,
+                  },
+            canReceiveDirectAccess: canReceiveSavedSqlDirectAccess({
+                spaceUuid,
+                dashboardUuid,
+            }),
+        };
+    }
+
+    private static expectation(
+        target: SavedSqlAccessTarget,
+    ): SavedSqlMutationExpectation {
+        return {
+            organizationUuid: target.organizationUuid,
+            projectUuid: target.projectUuid,
+            spaceUuid: target.storedSpaceUuid,
+            dashboardUuid: target.dashboardUuid,
+        };
+    }
+
+    getDirectAccessList(
+        target: SavedSqlAccessTarget,
+        options: Parameters<SavedSqlAccessModel['getDirectAccessList']>[3],
+    ) {
+        return this.accessModel.getDirectAccessList(
+            target.resourceUuid,
+            target.organizationUuid,
+            target.projectUuid,
+            options,
+        );
+    }
+
+    getGroupRolesForUsers(target: SavedSqlAccessTarget, userUuids: string[]) {
+        return this.accessModel.getGroupRolesForUsers(
+            target.resourceUuid,
+            target.organizationUuid,
+            target.projectUuid,
+            userUuids,
+        );
+    }
+
+    upsertUserAccess(
+        target: SavedSqlAccessTarget,
+        input: { userUuid: string; role: SpaceMemberRole; actor: SessionUser },
+    ) {
+        return this.accessModel.upsertUserAccess({
+            resourceUuid: target.resourceUuid,
+            userUuid: input.userUuid,
+            role: input.role,
+            grantedByUserUuid: input.actor.userUuid,
+            ...SavedSqlAccessAdapter.expectation(target),
+        });
+    }
+
+    upsertGroupAccess(
+        target: SavedSqlAccessTarget,
+        input: {
+            groupUuid: string;
+            role: SpaceMemberRole;
+            actor: SessionUser;
+        },
+    ) {
+        return this.accessModel.upsertGroupAccess({
+            resourceUuid: target.resourceUuid,
+            groupUuid: input.groupUuid,
+            role: input.role,
+            grantedByUserUuid: input.actor.userUuid,
+            ...SavedSqlAccessAdapter.expectation(target),
+        });
+    }
+
+    revokeUserAccess(
+        target: SavedSqlAccessTarget,
+        input: { userUuid: string },
+    ) {
+        return this.accessModel.revokeUserAccess({
+            resourceUuid: target.resourceUuid,
+            userUuid: input.userUuid,
+            ...SavedSqlAccessAdapter.expectation(target),
+        });
+    }
+
+    revokeGroupAccess(
+        target: SavedSqlAccessTarget,
+        input: { groupUuid: string },
+    ) {
+        return this.accessModel.revokeGroupAccess({
+            resourceUuid: target.resourceUuid,
+            groupUuid: input.groupUuid,
+            ...SavedSqlAccessAdapter.expectation(target),
+        });
+    }
+
+    resetAccess(target: SavedSqlAccessTarget) {
+        return this.accessModel.resetAccess({
+            resourceUuid: target.resourceUuid,
+            ...SavedSqlAccessAdapter.expectation(target),
+        });
+    }
+}
+
+export class SavedSqlAccessHandler extends BaseResourceAccessHandler<SavedSqlAccessTarget> {
+    constructor({
+        savedSqlAccessModel,
+        savedSqlModel,
+        spacePermissionService,
+        featureGate,
+        auditLogger,
+    }: {
+        savedSqlAccessModel: SavedSqlAccessModel;
+        savedSqlModel: SavedSqlModel;
+        spacePermissionService: SpacePermissionService;
+        featureGate: DirectAccessFeatureGate;
+        auditLogger?: DirectAccessAuditLogger;
+    }) {
+        super(
+            new SavedSqlAccessAdapter(savedSqlAccessModel, savedSqlModel),
+            spacePermissionService,
+            featureGate,
+            auditLogger,
+        );
+    }
+}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1528/stack-5a-build-direct-access-administration-api

## Summary

PR 3 of 5. Adds tenant-safe direct-grant writes, searchable lists, and the concrete handler for independently saved SQL charts.

Stacks on top of PR 2 ([#28246](https://github.com/lightdash/lightdash/pull/28246)), which adds the shared list queries and dashboard/Explore adapters.

## Changes

- Adds user/group upsert, idempotent revoke, reset, list, and group-effective-role operations.
- Locks organization, project, owner space/dashboard, then SQL chart before revalidating the stored ownership tuple.
- Resolves dashboard-owned SQL through its dashboard and rejects an independent policy after caller authorization.
- Keeps API and account conversion out of the handler; it accepts `SessionUser` through the shared contract.

## Ownership semantics

```text
Independent SQL chart     -> SQL-chart grant
Dashboard-owned SQL       -> dashboard grant; SQL policy rejected
Stale ownership tuple     -> normalized not found; no write
```

## Test plan

- [x] Saved-SQL PostgreSQL integration: 5/5
- [x] Shared handler conformance remains 16/16
- [x] Backend typecheck, lint, and formatting
- [x] User/group write, list, revoke, reset, dashboard ownership, project membership, and stale expectation cases
