### PR TITLE
feat(direct-access): administer data app access

### DIFF
--- a/packages/backend/src/models/AppAccessModel.integration.test.ts
+++ b/packages/backend/src/models/AppAccessModel.integration.test.ts
@@ -1,4 +1,6 @@
 import {
+    DirectAccessOrigin,
+    OrganizationMemberRole,
     ProjectMemberRole,
     SEED_ORG_1_ADMIN,
     SEED_PROJECT,
@@ -13,6 +15,7 @@ import {
 import { AppsTableName } from '../database/entities/apps';
 import { GroupMembershipTableName } from '../database/entities/groupMemberships';
 import { GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
 import { ProjectTableName } from '../database/entities/projects';
@@ -159,6 +162,174 @@ describe('AppAccessModel PostgreSQL integration', () => {
                 groupRoles: [SpaceMemberRole.EDITOR],
             },
         });
+    });
+
+    it.each(['personal', 'space-backed'] as const)(
+        'writes, lists, revokes, and resets %s app grants',
+        async (kind) => {
+            const appUuid =
+                kind === 'personal' ? personalAppUuid : spaceAppUuid;
+            const expectation = {
+                organizationUuid,
+                projectUuid,
+                spaceUuid: kind === 'personal' ? null : spaceUuid,
+            };
+
+            await expect(
+                model.upsertUserAccess({
+                    resourceUuid: appUuid,
+                    userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    role: SpaceMemberRole.ADMIN,
+                    grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    ...expectation,
+                }),
+            ).resolves.toMatchObject({
+                beforeRole: SpaceMemberRole.VIEWER,
+                afterRole: SpaceMemberRole.ADMIN,
+            });
+            await expect(
+                model.upsertGroupAccess({
+                    resourceUuid: appUuid,
+                    groupUuid,
+                    role: SpaceMemberRole.VIEWER,
+                    grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    ...expectation,
+                }),
+            ).resolves.toMatchObject({
+                beforeRole: SpaceMemberRole.EDITOR,
+                afterRole: SpaceMemberRole.VIEWER,
+            });
+
+            const { data } = await model.getDirectAccessList(
+                appUuid,
+                organizationUuid,
+                projectUuid,
+            );
+            expect(data).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        origin: DirectAccessOrigin.USER,
+                        principalUuid: SEED_ORG_1_ADMIN.user_uuid,
+                        directRole: SpaceMemberRole.ADMIN,
+                    }),
+                    expect.objectContaining({
+                        origin: DirectAccessOrigin.GROUP,
+                        principalUuid: groupUuid,
+                        directRole: SpaceMemberRole.VIEWER,
+                    }),
+                ]),
+            );
+            await expect(
+                model.getGroupRolesForUsers(
+                    appUuid,
+                    organizationUuid,
+                    projectUuid,
+                    [SEED_ORG_1_ADMIN.user_uuid],
+                ),
+            ).resolves.toEqual({
+                [SEED_ORG_1_ADMIN.user_uuid]: [SpaceMemberRole.VIEWER],
+            });
+
+            await expect(
+                model.revokeUserAccess({
+                    resourceUuid: appUuid,
+                    userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    ...expectation,
+                }),
+            ).resolves.toMatchObject({
+                beforeRole: SpaceMemberRole.ADMIN,
+                afterRole: null,
+            });
+            await expect(
+                model.revokeUserAccess({
+                    resourceUuid: appUuid,
+                    userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                    ...expectation,
+                }),
+            ).resolves.toMatchObject({ beforeRole: null, afterRole: null });
+            await expect(
+                model.resetAccess({ resourceUuid: appUuid, ...expectation }),
+            ).resolves.toMatchObject({ revokedUsers: 0, revokedGroups: 1 });
+        },
+    );
+
+    it('reports organization, project, and group administrators for personal apps', async () => {
+        await expect(
+            model.getAdminRolesForUsers(organizationUuid, projectUuid, [
+                SEED_ORG_1_ADMIN.user_uuid,
+            ]),
+        ).resolves.toEqual({
+            [SEED_ORG_1_ADMIN.user_uuid]: [SpaceMemberRole.ADMIN],
+        });
+
+        await transaction(OrganizationMembershipsTableName)
+            .where({ organization_id: organizationId, user_id: userId })
+            .update({ role: OrganizationMemberRole.MEMBER });
+        await transaction(ProjectGroupAccessTableName)
+            .where({ project_uuid: projectUuid, group_uuid: groupUuid })
+            .update({ role: ProjectMemberRole.ADMIN });
+        await expect(
+            model.getAdminRolesForUsers(organizationUuid, projectUuid, [
+                SEED_ORG_1_ADMIN.user_uuid,
+            ]),
+        ).resolves.toEqual({
+            [SEED_ORG_1_ADMIN.user_uuid]: [SpaceMemberRole.ADMIN],
+        });
+    });
+
+    it('rejects stale app locations before writing', async () => {
+        await transaction(AppsTableName)
+            .where('app_id', personalAppUuid)
+            .update({ space_uuid: spaceUuid });
+        await expect(
+            model.upsertUserAccess({
+                resourceUuid: personalAppUuid,
+                userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                role: SpaceMemberRole.EDITOR,
+                grantedByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                organizationUuid,
+                projectUuid,
+                spaceUuid: null,
+            }),
+        ).rejects.toMatchObject({ name: 'NotFoundError' });
+        await expect(
+            transaction(AppUserAccessTableName)
+                .where({
+                    app_uuid: personalAppUuid,
+                    user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+                })
+                .first('space_role'),
+        ).resolves.toMatchObject({ space_role: SpaceMemberRole.VIEWER });
+    });
+
+    it('rejects deleted apps and deleted owner spaces before writing', async () => {
+        await transaction(AppsTableName)
+            .where('app_id', personalAppUuid)
+            .update({ deleted_at: new Date() });
+        await transaction(SpaceTableName)
+            .where('space_uuid', spaceUuid)
+            .update({
+                deleted_at: new Date(),
+                deleted_by_user_uuid: SEED_ORG_1_ADMIN.user_uuid,
+            });
+
+        await Promise.all(
+            (
+                [
+                    [personalAppUuid, null],
+                    [spaceAppUuid, spaceUuid],
+                ] as const
+            ).map(async ([resourceUuid, appSpaceUuid]) =>
+                expect(
+                    model.resetAccess({
+                        resourceUuid,
+                        organizationUuid,
+                        projectUuid,
+                        spaceUuid: appSpaceUuid,
+                    }),
+                ).rejects.toMatchObject({ name: 'NotFoundError' }),
+            ),
+        );
     });
 
     it('tracks moves without transferring grants to new app identities', async () => {

--- a/packages/backend/src/models/AppAccessModel.ts
+++ b/packages/backend/src/models/AppAccessModel.ts
@@ -1,3 +1,11 @@
+import {
+    NotFoundError,
+    OrganizationMemberRole,
+    ProjectMemberRole,
+    SpaceMemberRole,
+    type DirectAccessOrigin,
+    type KnexPaginateArgs,
+} from '@lightdash/common';
 import { type Knex } from 'knex';
 import {
     AppGroupAccessTableName,
@@ -7,19 +15,462 @@ import { AppsTableName } from '../database/entities/apps';
 import { GroupMembershipTableName } from '../database/entities/groupMemberships';
 import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import { OrganizationTableName } from '../database/entities/organizations';
+import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
 import { ProjectTableName } from '../database/entities/projects';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import {
+    getDirectAccessGroupRolesForUsers,
+    getDirectAccessList,
+} from './directAccessAdminModelUtils';
+import {
     getActiveGrantedGroupPredicate,
     getActiveProjectMemberPredicate,
     groupDirectAccessRows,
+    validateDirectAccessGroup,
+    validateDirectAccessUser,
     type DirectAccess,
+    type DirectAccessMutationContext,
+    type DirectAccessMutationResult,
+    type DirectAccessResetResult,
     type DirectAccessRow,
 } from './directAccessModelUtils';
 
+type AppMutationExpectation = {
+    organizationUuid: string;
+    projectUuid: string;
+    spaceUuid: string | null;
+};
+
+const adminTableConfig = {
+    userAccessTable: AppUserAccessTableName,
+    groupAccessTable: AppGroupAccessTableName,
+    resourceColumn: 'app_uuid',
+};
+
 export class AppAccessModel {
     constructor(private readonly database: Knex) {}
+
+    private static async getMutationContext(
+        trx: Knex,
+        resourceUuid: string,
+        expected: AppMutationExpectation,
+    ): Promise<DirectAccessMutationContext> {
+        const candidate = await trx(AppsTableName)
+            .where('app_id', resourceUuid)
+            .where('project_uuid', expected.projectUuid)
+            .whereNull('deleted_at')
+            .select<{ spaceUuid: string | null }>({ spaceUuid: 'space_uuid' })
+            .first();
+        if (
+            candidate === undefined ||
+            candidate.spaceUuid !== expected.spaceUuid
+        ) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        const candidateProject = await trx(ProjectTableName)
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, expected.projectUuid)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                expected.organizationUuid,
+            )
+            .select<DirectAccessMutationContext>({
+                organizationId: `${OrganizationTableName}.organization_id`,
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectId: `${ProjectTableName}.project_id`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+            })
+            .first();
+        if (candidateProject === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        const organization = await trx(OrganizationTableName)
+            .where('organization_id', candidateProject.organizationId)
+            .where('organization_uuid', expected.organizationUuid)
+            .select<{ organizationId: number; organizationUuid: string }>({
+                organizationId: 'organization_id',
+                organizationUuid: 'organization_uuid',
+            })
+            .forNoKeyUpdate(OrganizationTableName)
+            .first();
+        const project = await trx(ProjectTableName)
+            .where('project_id', candidateProject.projectId)
+            .where('organization_id', candidateProject.organizationId)
+            .where('project_uuid', expected.projectUuid)
+            .select<{ projectId: number; projectUuid: string }>({
+                projectId: 'project_id',
+                projectUuid: 'project_uuid',
+            })
+            .forNoKeyUpdate(ProjectTableName)
+            .first();
+        if (organization === undefined || project === undefined) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        if (expected.spaceUuid !== null) {
+            const space = await trx(SpaceTableName)
+                .where('space_uuid', expected.spaceUuid)
+                .where('project_id', project.projectId)
+                .whereNull('deleted_at')
+                .select('space_uuid')
+                .forNoKeyUpdate(SpaceTableName)
+                .first();
+            if (space === undefined) {
+                throw new NotFoundError('Direct access target not found');
+            }
+        }
+
+        const app = await trx(AppsTableName)
+            .where('app_id', resourceUuid)
+            .where('project_uuid', project.projectUuid)
+            .whereNull('deleted_at')
+            .select<{ spaceUuid: string | null }>({ spaceUuid: 'space_uuid' })
+            .forUpdate(AppsTableName)
+            .first();
+        if (app === undefined || app.spaceUuid !== expected.spaceUuid) {
+            throw new NotFoundError('Direct access target not found');
+        }
+
+        return {
+            organizationId: organization.organizationId,
+            organizationUuid: organization.organizationUuid,
+            projectId: project.projectId,
+            projectUuid: project.projectUuid,
+        };
+    }
+
+    async upsertUserAccess({
+        resourceUuid,
+        userUuid,
+        role,
+        grantedByUserUuid,
+        ...expected
+    }: {
+        resourceUuid: string;
+        userUuid: string;
+        role: SpaceMemberRole;
+        grantedByUserUuid: string;
+    } & AppMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const context = await AppAccessModel.getMutationContext(
+                trx,
+                resourceUuid,
+                expected,
+            );
+            if (!(await validateDirectAccessUser(trx, context, userUuid))) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(AppUserAccessTableName)
+                .where({ app_uuid: resourceUuid, user_uuid: userUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            await trx(AppUserAccessTableName)
+                .insert({
+                    app_uuid: resourceUuid,
+                    user_uuid: userUuid,
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                })
+                .onConflict(['app_uuid', 'user_uuid'])
+                .merge({
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: role,
+            };
+        });
+    }
+
+    async upsertGroupAccess({
+        resourceUuid,
+        groupUuid,
+        role,
+        grantedByUserUuid,
+        ...expected
+    }: {
+        resourceUuid: string;
+        groupUuid: string;
+        role: SpaceMemberRole;
+        grantedByUserUuid: string;
+    } & AppMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const context = await AppAccessModel.getMutationContext(
+                trx,
+                resourceUuid,
+                expected,
+            );
+            if (!(await validateDirectAccessGroup(trx, context, groupUuid))) {
+                throw new NotFoundError('Direct access target not found');
+            }
+            const existing = await trx(AppGroupAccessTableName)
+                .where({ app_uuid: resourceUuid, group_uuid: groupUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            await trx(AppGroupAccessTableName)
+                .insert({
+                    app_uuid: resourceUuid,
+                    group_uuid: groupUuid,
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                })
+                .onConflict(['app_uuid', 'group_uuid'])
+                .merge({
+                    space_role: role,
+                    granted_by_user_uuid: grantedByUserUuid,
+                    updated_at: trx.fn.now(),
+                });
+            return {
+                ...context,
+                beforeRole: existing?.space_role ?? null,
+                afterRole: role,
+            };
+        });
+    }
+
+    async revokeUserAccess({
+        resourceUuid,
+        userUuid,
+        ...expected
+    }: {
+        resourceUuid: string;
+        userUuid: string;
+    } & AppMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const context = await AppAccessModel.getMutationContext(
+                trx,
+                resourceUuid,
+                expected,
+            );
+            const existing = await trx(AppUserAccessTableName)
+                .where({ app_uuid: resourceUuid, user_uuid: userUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            if (existing === undefined) {
+                return { ...context, beforeRole: null, afterRole: null };
+            }
+            await trx(AppUserAccessTableName)
+                .where({ app_uuid: resourceUuid, user_uuid: userUuid })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing.space_role,
+                afterRole: null,
+            };
+        });
+    }
+
+    async revokeGroupAccess({
+        resourceUuid,
+        groupUuid,
+        ...expected
+    }: {
+        resourceUuid: string;
+        groupUuid: string;
+    } & AppMutationExpectation): Promise<DirectAccessMutationResult> {
+        return this.database.transaction(async (trx) => {
+            const context = await AppAccessModel.getMutationContext(
+                trx,
+                resourceUuid,
+                expected,
+            );
+            const existing = await trx(AppGroupAccessTableName)
+                .where({ app_uuid: resourceUuid, group_uuid: groupUuid })
+                .first<{ space_role: SpaceMemberRole }>('space_role')
+                .forUpdate();
+            if (existing === undefined) {
+                return { ...context, beforeRole: null, afterRole: null };
+            }
+            await trx(AppGroupAccessTableName)
+                .where({ app_uuid: resourceUuid, group_uuid: groupUuid })
+                .delete();
+            return {
+                ...context,
+                beforeRole: existing.space_role,
+                afterRole: null,
+            };
+        });
+    }
+
+    async resetAccess({
+        resourceUuid,
+        ...expected
+    }: {
+        resourceUuid: string;
+    } & AppMutationExpectation): Promise<DirectAccessResetResult> {
+        return this.database.transaction(async (trx) => {
+            const context = await AppAccessModel.getMutationContext(
+                trx,
+                resourceUuid,
+                expected,
+            );
+            const [revokedUsers, revokedGroups] = await Promise.all([
+                trx(AppUserAccessTableName)
+                    .where('app_uuid', resourceUuid)
+                    .delete(),
+                trx(AppGroupAccessTableName)
+                    .where('app_uuid', resourceUuid)
+                    .delete(),
+            ]);
+            return { ...context, revokedUsers, revokedGroups };
+        });
+    }
+
+    async getDirectAccessList(
+        resourceUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
+        options: {
+            paginateArgs?: KnexPaginateArgs;
+            searchQuery?: string;
+            principal?: { origin: DirectAccessOrigin; uuid: string };
+        } = {},
+    ) {
+        return getDirectAccessList(
+            this.database,
+            adminTableConfig,
+            { resourceUuid, organizationUuid, projectUuid },
+            options,
+        );
+    }
+
+    async getGroupRolesForUsers(
+        resourceUuid: string,
+        organizationUuid: string,
+        projectUuid: string,
+        userUuids: string[],
+    ): Promise<Record<string, SpaceMemberRole[]>> {
+        return getDirectAccessGroupRolesForUsers(
+            this.database,
+            adminTableConfig,
+            { resourceUuid, organizationUuid, projectUuid },
+            userUuids,
+        );
+    }
+
+    async getAdminRolesForUsers(
+        organizationUuid: string,
+        projectUuid: string,
+        userUuids: string[],
+    ): Promise<Record<string, SpaceMemberRole[]>> {
+        if (userUuids.length === 0) return {};
+        const projectMembers = this.database(ProjectMembershipsTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${ProjectMembershipsTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_id`,
+                `${ProjectMembershipsTableName}.user_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(
+                `${ProjectMembershipsTableName}.role`,
+                ProjectMemberRole.ADMIN,
+            )
+            .whereIn(`${UserTableName}.user_uuid`, userUuids)
+            .select<{ userUuid: string }[]>({
+                userUuid: `${UserTableName}.user_uuid`,
+            });
+        const organizationMembers = this.database(
+            OrganizationMembershipsTableName,
+        )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${OrganizationMembershipsTableName}.organization_id`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.organization_id`,
+                `${OrganizationTableName}.organization_id`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_id`,
+                `${OrganizationMembershipsTableName}.user_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(
+                `${OrganizationMembershipsTableName}.role`,
+                OrganizationMemberRole.ADMIN,
+            )
+            .whereIn(`${UserTableName}.user_uuid`, userUuids)
+            .select<{ userUuid: string }[]>({
+                userUuid: `${UserTableName}.user_uuid`,
+            });
+        const groupMembers = this.database(ProjectGroupAccessTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${ProjectGroupAccessTableName}.project_uuid`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .innerJoin(
+                GroupMembershipTableName,
+                `${GroupMembershipTableName}.group_uuid`,
+                `${ProjectGroupAccessTableName}.group_uuid`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${UserTableName}.user_id`,
+                `${GroupMembershipTableName}.user_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .where(
+                `${ProjectGroupAccessTableName}.role`,
+                ProjectMemberRole.ADMIN,
+            )
+            .where(
+                `${GroupMembershipTableName}.organization_id`,
+                this.database.ref(`${ProjectTableName}.organization_id`),
+            )
+            .whereIn(`${UserTableName}.user_uuid`, userUuids)
+            .select<{ userUuid: string }[]>({
+                userUuid: `${UserTableName}.user_uuid`,
+            });
+        const rows = await projectMembers.union([
+            organizationMembers,
+            groupMembers,
+        ]);
+        return Object.fromEntries(
+            rows.map(({ userUuid }) => [userUuid, [SpaceMemberRole.ADMIN]]),
+        );
+    }
 
     async getUserAccess(
         appUuids: string[],

--- a/packages/backend/src/services/DirectAccess/AppAccessHandler.ts
+++ b/packages/backend/src/services/DirectAccess/AppAccessHandler.ts
@@ -1,0 +1,162 @@
+import type { SessionUser, SpaceMemberRole } from '@lightdash/common';
+import type { AppAccessModel } from '../../models/AppAccessModel';
+import type { AppModel } from '../../models/AppModel';
+import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import {
+    BaseResourceAccessHandler,
+    type DirectAccessResourceAdapter,
+    type DirectAccessTarget,
+} from './BaseResourceAccessHandler';
+import type { DirectAccessAuditLogger } from './directAccessAudit';
+import type { DirectAccessFeatureGate } from './DirectAccessFeatureGate';
+import type { ResourceAccessInput } from './ResourceAccessHandler';
+
+type AppAccessTarget = DirectAccessTarget & {
+    resourceUuid: string;
+};
+
+class AppAccessAdapter implements DirectAccessResourceAdapter<AppAccessTarget> {
+    readonly auditResourceType = 'App';
+
+    constructor(
+        private readonly accessModel: AppAccessModel,
+        private readonly appModel: AppModel,
+    ) {}
+
+    async getTarget({
+        projectUuid,
+        resourceUuid,
+    }: ResourceAccessInput): Promise<AppAccessTarget> {
+        const app = await this.appModel.getApp(resourceUuid, projectUuid);
+        return {
+            resourceUuid: app.app_id,
+            organizationUuid: app.organization_uuid,
+            projectUuid: app.project_uuid,
+            spaceUuid: app.space_uuid,
+            accessTarget: {
+                type: 'app',
+                appUuid: app.app_id,
+                organizationUuid: app.organization_uuid,
+                projectUuid: app.project_uuid,
+                spaceUuid: app.space_uuid,
+            },
+            canReceiveDirectAccess: true,
+        };
+    }
+
+    private static expectation(target: AppAccessTarget) {
+        return {
+            organizationUuid: target.organizationUuid,
+            projectUuid: target.projectUuid,
+            spaceUuid: target.spaceUuid,
+        };
+    }
+
+    getDirectAccessList(
+        target: AppAccessTarget,
+        options: Parameters<AppAccessModel['getDirectAccessList']>[3],
+    ) {
+        return this.accessModel.getDirectAccessList(
+            target.resourceUuid,
+            target.organizationUuid,
+            target.projectUuid,
+            options,
+        );
+    }
+
+    getGroupRolesForUsers(target: AppAccessTarget, userUuids: string[]) {
+        return this.accessModel.getGroupRolesForUsers(
+            target.resourceUuid,
+            target.organizationUuid,
+            target.projectUuid,
+            userUuids,
+        );
+    }
+
+    getAdditionalEffectiveRolesForUsers(
+        target: AppAccessTarget,
+        userUuids: string[],
+    ) {
+        return this.accessModel.getAdminRolesForUsers(
+            target.organizationUuid,
+            target.projectUuid,
+            userUuids,
+        );
+    }
+
+    upsertUserAccess(
+        target: AppAccessTarget,
+        input: { userUuid: string; role: SpaceMemberRole; actor: SessionUser },
+    ) {
+        return this.accessModel.upsertUserAccess({
+            resourceUuid: target.resourceUuid,
+            userUuid: input.userUuid,
+            role: input.role,
+            grantedByUserUuid: input.actor.userUuid,
+            ...AppAccessAdapter.expectation(target),
+        });
+    }
+
+    upsertGroupAccess(
+        target: AppAccessTarget,
+        input: {
+            groupUuid: string;
+            role: SpaceMemberRole;
+            actor: SessionUser;
+        },
+    ) {
+        return this.accessModel.upsertGroupAccess({
+            resourceUuid: target.resourceUuid,
+            groupUuid: input.groupUuid,
+            role: input.role,
+            grantedByUserUuid: input.actor.userUuid,
+            ...AppAccessAdapter.expectation(target),
+        });
+    }
+
+    revokeUserAccess(target: AppAccessTarget, input: { userUuid: string }) {
+        return this.accessModel.revokeUserAccess({
+            resourceUuid: target.resourceUuid,
+            userUuid: input.userUuid,
+            ...AppAccessAdapter.expectation(target),
+        });
+    }
+
+    revokeGroupAccess(target: AppAccessTarget, input: { groupUuid: string }) {
+        return this.accessModel.revokeGroupAccess({
+            resourceUuid: target.resourceUuid,
+            groupUuid: input.groupUuid,
+            ...AppAccessAdapter.expectation(target),
+        });
+    }
+
+    resetAccess(target: AppAccessTarget) {
+        return this.accessModel.resetAccess({
+            resourceUuid: target.resourceUuid,
+            ...AppAccessAdapter.expectation(target),
+        });
+    }
+}
+
+export class AppAccessHandler extends BaseResourceAccessHandler<AppAccessTarget> {
+    constructor({
+        appAccessModel,
+        appModel,
+        spacePermissionService,
+        featureGate,
+        auditLogger,
+    }: {
+        appAccessModel: AppAccessModel;
+        appModel: AppModel;
+        spacePermissionService: SpacePermissionService;
+        featureGate: DirectAccessFeatureGate;
+        auditLogger?: DirectAccessAuditLogger;
+    }) {
+        super(
+            new AppAccessAdapter(appAccessModel, appModel),
+            spacePermissionService,
+            featureGate,
+            auditLogger,
+        );
+    }
+}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1528/stack-5a-build-direct-access-administration-api

## Summary

PR 4 of 5. Adds complete direct-access administration for personal and space-backed data apps without crossing into generation or external-connection services.

Stacks on top of PR 3 ([#28247](https://github.com/lightdash/lightdash/pull/28247)), which adds the saved-SQL handler and mutation model.

## Changes

- Extends `AppAccessModel` with user/group upsert, idempotent revoke, reset, searchable list, and effective-role reads.
- Revalidates the nullable app location under organization, project, optional space, then app locks.
- Supports personal and space-backed apps through the same handler contract.
- Supplements personal-app effective roles with additive organization/project admin recovery.
- Uses `AppModel.getApp` for project-scoped lookup and avoids generation or analytics side effects.

## Location semantics

```text
Personal app       -> project + app lock
Space-backed app   -> project + space + app lock
Concurrent move    -> stale expectation rejected; no authority transfer
```

## Test plan

- [x] App PostgreSQL integration: 8/8
- [x] Shared handler conformance remains 16/16
- [x] Backend typecheck, lint, and formatting
- [x] Personal/space writes, lists, admin recovery, stale move, deleted app, deleted space, revoke, and reset cases
