### PR TITLE
feat(direct-access): expose resource access API

### DIFF
--- a/packages/backend/src/controllers/v2/DirectAccessController.ts
+++ b/packages/backend/src/controllers/v2/DirectAccessController.ts
@@ -1,0 +1,241 @@
+import {
+    assertRegisteredAccount,
+    type ApiDirectAccessGrantResponse,
+    type ApiDirectAccessListResponse,
+    type ApiErrorPayload,
+    type ApiSuccessEmpty,
+    type DirectAccessResourceType,
+    type DirectAccessRoleAssignment,
+    type KnexPaginateArgs,
+} from '@lightdash/common';
+import {
+    Body,
+    Delete,
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Put,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../authentication/middlewares';
+import { BaseController } from '../baseController';
+
+@Route('/api/v2/projects/{projectUuid}/access/{resourceType}/{resourceUuid}')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('v2', 'Direct access')
+export class DirectAccessController extends BaseController {
+    /**
+     * List direct grants for a resource.
+     * @summary List direct access
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('listResourceDirectAccess')
+    async listAccess(
+        @Path() projectUuid: string,
+        @Path() resourceType: DirectAccessResourceType,
+        @Path() resourceUuid: string,
+        @Request() req: express.Request,
+        @Query() page?: number,
+        @Query() pageSize?: number,
+        @Query() searchQuery?: string,
+    ): Promise<ApiDirectAccessListResponse> {
+        assertRegisteredAccount(req.account);
+        const paginateArgs: KnexPaginateArgs | undefined =
+            page !== undefined || pageSize !== undefined
+                ? { page: page ?? 1, pageSize: pageSize ?? 100 }
+                : undefined;
+        return {
+            status: 'ok',
+            results: await this.services
+                .getDirectAccessService()
+                .getHandler(resourceType)
+                .listAccess({
+                    user: toSessionUser(req.account),
+                    projectUuid,
+                    resourceUuid,
+                    paginateArgs,
+                    filters: { searchQuery },
+                }),
+        };
+    }
+
+    /**
+     * Replace a user's direct role on a resource.
+     * @summary Replace user direct access
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Put('/users/{userUuid}')
+    @OperationId('replaceResourceUserDirectAccess')
+    async replaceUserRole(
+        @Path() projectUuid: string,
+        @Path() resourceType: DirectAccessResourceType,
+        @Path() resourceUuid: string,
+        @Path() userUuid: string,
+        @Body() body: DirectAccessRoleAssignment,
+        @Request() req: express.Request,
+    ): Promise<ApiDirectAccessGrantResponse> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getDirectAccessService()
+                .getHandler(resourceType)
+                .replaceUserRole({
+                    user: toSessionUser(req.account),
+                    projectUuid,
+                    resourceUuid,
+                    userUuid,
+                    role: body.role,
+                }),
+        };
+    }
+
+    /**
+     * Revoke a user's direct role on a resource.
+     * @summary Revoke user direct access
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('/users/{userUuid}')
+    @OperationId('revokeResourceUserDirectAccess')
+    async revokeUser(
+        @Path() projectUuid: string,
+        @Path() resourceType: DirectAccessResourceType,
+        @Path() resourceUuid: string,
+        @Path() userUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getDirectAccessService()
+            .getHandler(resourceType)
+            .revokeUser({
+                user: toSessionUser(req.account),
+                projectUuid,
+                resourceUuid,
+                userUuid,
+            });
+        return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * Replace a group's direct role on a resource.
+     * @summary Replace group direct access
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Put('/groups/{groupUuid}')
+    @OperationId('replaceResourceGroupDirectAccess')
+    async replaceGroupRole(
+        @Path() projectUuid: string,
+        @Path() resourceType: DirectAccessResourceType,
+        @Path() resourceUuid: string,
+        @Path() groupUuid: string,
+        @Body() body: DirectAccessRoleAssignment,
+        @Request() req: express.Request,
+    ): Promise<ApiDirectAccessGrantResponse> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getDirectAccessService()
+                .getHandler(resourceType)
+                .replaceGroupRole({
+                    user: toSessionUser(req.account),
+                    projectUuid,
+                    resourceUuid,
+                    groupUuid,
+                    role: body.role,
+                }),
+        };
+    }
+
+    /**
+     * Revoke a group's direct role on a resource.
+     * @summary Revoke group direct access
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('/groups/{groupUuid}')
+    @OperationId('revokeResourceGroupDirectAccess')
+    async revokeGroup(
+        @Path() projectUuid: string,
+        @Path() resourceType: DirectAccessResourceType,
+        @Path() resourceUuid: string,
+        @Path() groupUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getDirectAccessService()
+            .getHandler(resourceType)
+            .revokeGroup({
+                user: toSessionUser(req.account),
+                projectUuid,
+                resourceUuid,
+                groupUuid,
+            });
+        return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * Revoke every direct grant on a resource.
+     * @summary Reset direct access
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('/')
+    @OperationId('resetResourceDirectAccess')
+    async resetAccess(
+        @Path() projectUuid: string,
+        @Path() resourceType: DirectAccessResourceType,
+        @Path() resourceUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getDirectAccessService()
+            .getHandler(resourceType)
+            .reset({
+                user: toSessionUser(req.account),
+                projectUuid,
+                resourceUuid,
+            });
+        return { status: 'ok', results: undefined };
+    }
+}

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.ts
@@ -1,0 +1,15 @@
+import type { DirectAccessResourceType } from '@lightdash/common';
+import type { ResourceAccessHandler } from './ResourceAccessHandler';
+
+export class DirectAccessService {
+    constructor(
+        private readonly handlers: Record<
+            DirectAccessResourceType,
+            ResourceAccessHandler
+        >,
+    ) {}
+
+    getHandler(resourceType: DirectAccessResourceType): ResourceAccessHandler {
+        return this.handlers[resourceType];
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -31,7 +31,12 @@ import { ContentVerificationService } from './ContentVerificationService';
 import { CsvService } from './CsvService/CsvService';
 import { DashboardService } from './DashboardService/DashboardService';
 import { DeployService } from './DeployService';
+import { AppAccessHandler } from './DirectAccess/AppAccessHandler';
+import { DashboardAccessHandler } from './DirectAccess/DashboardAccessHandler';
 import { DirectAccessFeatureGate } from './DirectAccess/DirectAccessFeatureGate';
+import { DirectAccessService } from './DirectAccess/DirectAccessService';
+import { SavedChartAccessHandler } from './DirectAccess/SavedChartAccessHandler';
+import { SavedSqlAccessHandler } from './DirectAccess/SavedSqlAccessHandler';
 import { DownloadFileService } from './DownloadFileService/DownloadFileService';
 import { EmailWhitelabelService } from './EmailWhitelabelService/EmailWhitelabelService';
 import { FavoritesService } from './FavoritesService/FavoritesService';
@@ -101,6 +106,8 @@ interface ServiceManifest {
     csvService: CsvService;
     dashboardService: DashboardService;
     deployService: DeployService;
+    directAccessFeatureGate: DirectAccessFeatureGate;
+    directAccessService: DirectAccessService;
     downloadFileService: DownloadFileService;
     favoritesService: FavoritesService;
     gitIntegrationService: GitIntegrationService;
@@ -379,6 +386,51 @@ export class ServiceRepository
                     csvService: this.getCsvService(),
                 }),
         );
+    }
+
+    public getDirectAccessFeatureGate(): DirectAccessFeatureGate {
+        return this.getService(
+            'directAccessFeatureGate',
+            () =>
+                new DirectAccessFeatureGate(
+                    this.models.getFeatureFlagModel(),
+                    this.getLicenseService(),
+                ),
+        );
+    }
+
+    public getDirectAccessService(): DirectAccessService {
+        return this.getService('directAccessService', () => {
+            const spacePermissionService = this.getSpacePermissionService();
+            const featureGate = this.getDirectAccessFeatureGate();
+            return new DirectAccessService({
+                dashboard: new DashboardAccessHandler({
+                    dashboardAccessModel: this.models.getDashboardAccessModel(),
+                    dashboardModel: this.models.getDashboardModel(),
+                    spacePermissionService,
+                    featureGate,
+                }),
+                savedChart: new SavedChartAccessHandler({
+                    savedChartAccessModel:
+                        this.models.getSavedChartAccessModel(),
+                    savedChartModel: this.models.getSavedChartModel(),
+                    spacePermissionService,
+                    featureGate,
+                }),
+                savedSqlChart: new SavedSqlAccessHandler({
+                    savedSqlAccessModel: this.models.getSavedSqlAccessModel(),
+                    savedSqlModel: this.models.getSavedSqlModel(),
+                    spacePermissionService,
+                    featureGate,
+                }),
+                dataApp: new AppAccessHandler({
+                    appAccessModel: this.models.getAppAccessModel(),
+                    appModel: this.models.getAppModel(),
+                    spacePermissionService,
+                    featureGate,
+                }),
+            });
+        });
     }
 
     public getCommentService(): CommentService {
@@ -1148,10 +1200,7 @@ export class ServiceRepository
                     savedChartAccessModel:
                         this.models.getSavedChartAccessModel(),
                     savedSqlAccessModel: this.models.getSavedSqlAccessModel(),
-                    directAccessFeatureGate: new DirectAccessFeatureGate(
-                        this.models.getFeatureFlagModel(),
-                        this.getLicenseService(),
-                    ),
+                    directAccessFeatureGate: this.getDirectAccessFeatureGate(),
                 }),
         );
     }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1528/stack-5a-build-direct-access-administration-api

## Summary

PR 5 of 5. Exposes the four concrete handlers through one project-scoped v2 API with exactly six operations.

Stacks on top of PR 4 ([#28248](https://github.com/lightdash/lightdash/pull/28248)), which completes personal and space-backed data-app administration.

## Changes

- Adds a typed dispatcher for `dashboard`, `savedChart`, `savedSqlChart`, and `dataApp`.
- Adds list, replace/revoke user, replace/revoke group, and reset routes.
- Applies API-key/session authentication to every route and demo-mode protection to writes.
- Converts the registered account to `SessionUser` only at the controller boundary.
- Reuses one memoized feature gate across access resolution and administration handlers.

## Request flow

```text
v2 route -> typed dispatcher -> concrete handler -> FK-backed grant model
              4 resource types      shared policy      tenant locks
```

## Test plan

- [x] Common and backend typecheck
- [x] Common and backend lint and formatting
- [x] `pnpm generate-api`; reviewed exactly six generated operations and enum validation
- [x] Runtime smoke: API health 200, unknown resource type 422, disabled feature 403 before lookup
- [x] Full stack PostgreSQL integrations: 84/84
- [x] Fifty direct HTTP/DB scenarios across all resource, principal, role, ownership, tenant, idempotency, pagination, search, and audit paths

Live-matrix result: 50/50 scenarios passed through the local API against PostgreSQL (54 HTTP requests). Every successful write was checked in the grant tables, denied writes were checked for non-mutation, 26 expected mutation/reset audit events were observed, and temporary fixtures were cleaned.
