### PR TITLE
fix(ai): clarify filter expression guidance

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/__snapshots__/systemV2.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/prompts/__snapshots__/systemV2.test.ts.snap
@@ -8,8 +8,8 @@ exports[`getSystemPromptV2 filter expressions > renders expression-only filter g
 For \`generateVisualization\`, \`dimensions\`, \`metrics\`, and \`tableCalculations\` are independent string expressions or null.
 
 - A non-null category contains one raw string expression.
-- Dimension fields belong only in \`dimensions\`.
-- Metric fields belong only in \`metrics\`.
+- Choose the category from discovered field metadata (its dimension/metric kind), never from a field name or whether a numeric field sounds metric-like. A raw numeric dimension belongs in \`dimensions\`; only metrics and custom metrics belong in \`metrics\`.
+- A field used only to restrict rows stays in its filter expression. Do not add it to \`queryConfig.dimensions\` unless the user asked to group by or display it: extra selected dimensions change aggregation and table-calculation grain.
 - Table calculations belong only in \`tableCalculations\`.
 - Each category is flat and uses AND or OR, never both.
 - The three categories combine implicitly with AND.

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
@@ -91,10 +91,36 @@ describe('getSystemPromptV2 filter expressions', () => {
         expect(section).not.toContain('filter objects');
         expect(section).not.toContain('filters: {');
         expect(section).not.toContain('"filters"');
-        expect(section).not.toContain('queryConfig');
+        expect(section).not.toContain('queryConfig: {');
+        expect(section).not.toContain('"queryConfig"');
         expect(
             content.match(/### Generated raw expression matrix/g),
         ).toHaveLength(1);
+    });
+
+    test('uses metadata-based filter categories without changing query grain', () => {
+        const section = extractExpressionFilterSection(
+            promptText({
+                availableExplores: [],
+                enableFilterExpressions: true,
+            }),
+        );
+
+        expect(section).toContain(
+            'category from discovered field metadata (its dimension/metric kind)',
+        );
+        expect(section).toContain(
+            'raw numeric dimension belongs in `dimensions`',
+        );
+        expect(section).toContain(
+            'only metrics and custom metrics belong in `metrics`',
+        );
+        expect(section).toContain(
+            'Do not add it to `queryConfig.dimensions` unless the user asked to group by or display it',
+        );
+        expect(section).toContain(
+            'extra selected dimensions change aggregation and table-calculation grain',
+        );
     });
 
     test('leaves no template placeholders in either mode', () => {

--- a/packages/backend/src/ee/services/ai/prompts/systemV2FilterGuidance.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2FilterGuidance.ts
@@ -148,8 +148,8 @@ export const FILTER_EXPRESSION_GUIDANCE_SECTION = `## Filter expressions
 For \`generateVisualization\`, \`dimensions\`, \`metrics\`, and \`tableCalculations\` are independent string expressions or null.
 
 - A non-null category contains one raw string expression.
-- Dimension fields belong only in \`dimensions\`.
-- Metric fields belong only in \`metrics\`.
+- Choose the category from discovered field metadata (its dimension/metric kind), never from a field name or whether a numeric field sounds metric-like. A raw numeric dimension belongs in \`dimensions\`; only metrics and custom metrics belong in \`metrics\`.
+- A field used only to restrict rows stays in its filter expression. Do not add it to \`queryConfig.dimensions\` unless the user asked to group by or display it: extra selected dimensions change aggregation and table-calculation grain.
 - Table calculations belong only in \`tableCalculations\`.
 - Each category is flat and uses AND or OR, never both.
 - The three categories combine implicitly with AND.


### PR DESCRIPTION
Related: ZAP-963
Related: ZAP-920
Related: #28262

Clarifies feature-flagged filter-expression guidance:
- derive filter category from discovered field metadata
- retain row-only fields in filter expressions without changing query grain

Risk: low — prompt-only guidance with focused tests; no query execution behavior changes.