### PR TITLE
fix: promote renamed preview chart slugs

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -44,6 +44,7 @@ import {
     CachedExploreTableName,
     ProjectTableName,
 } from '../../database/entities/projects';
+import { SavedChartsTableName } from '../../database/entities/savedCharts';
 import { SavedChartSlugMappingsTableName } from '../../database/entities/savedChartSlugMappings';
 import {
     SpaceTableName,
@@ -545,6 +546,41 @@ describe('ProjectModel', () => {
         );
         expect(insertQuery.bindings).not.toContain('source-chart-1');
         expect(insertQuery.bindings).not.toContain('source-chart-2');
+    });
+
+    test('resolves the original chart UUID from preview content mapping', async () => {
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ saved_query_id: 22 }]);
+        tracker.on.select('preview_content').responseOnce([
+            {
+                project_uuid: 'source-project',
+                content_mapping: {
+                    charts: [{ id: 11, newId: 22 }],
+                    chartVersions: [],
+                    spaces: [],
+                    dashboards: [],
+                    dashboardVersions: [],
+                    savedSql: [],
+                    savedSqlVersions: [],
+                    aiAgents: [],
+                },
+            },
+        ]);
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ saved_query_uuid: 'source-chart-uuid' }]);
+
+        await expect(
+            model.getUpstreamChartUuidFromPreview(
+                'preview-project',
+                'preview-chart-uuid',
+            ),
+        ).resolves.toBe('source-chart-uuid');
+
+        expect(tracker.history.select[2].bindings).toEqual(
+            expect.arrayContaining(['source-project', 11]),
+        );
     });
 
     describe('should convert outdated metric filters in explores', () => {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -4432,6 +4432,43 @@ export class ProjectModel {
         return typeof match?.newId === 'string' ? match.newId : null;
     }
 
+    async getUpstreamChartUuidFromPreview(
+        previewProjectUuid: string,
+        previewChartUuid: string,
+    ): Promise<string | null> {
+        const previewChart = await this.database(SavedChartsTableName)
+            .select('saved_query_id')
+            .where('project_uuid', previewProjectUuid)
+            .where('saved_query_uuid', previewChartUuid)
+            .whereNull('deleted_at')
+            .first();
+        if (!previewChart) return null;
+
+        const previewContent = await this.database('preview_content')
+            .select<
+                {
+                    project_uuid: string;
+                    content_mapping: PreviewContentMapping;
+                }[]
+            >('project_uuid', 'content_mapping')
+            .where('preview_project_uuid', previewProjectUuid)
+            .orderBy('created_at', 'desc')
+            .first();
+        const sourceMapping = previewContent?.content_mapping.charts.find(
+            ({ newId }) => Number(newId) === previewChart.saved_query_id,
+        );
+        if (!previewContent || !sourceMapping) return null;
+
+        const upstreamChart = await this.database(SavedChartsTableName)
+            .select('saved_query_uuid')
+            .where('project_uuid', previewContent.project_uuid)
+            .where('saved_query_id', sourceMapping.id)
+            .whereNull('deleted_at')
+            .first();
+
+        return upstreamChart?.saved_query_uuid ?? null;
+    }
+
     // Easier to mock in ProjectService
     // eslint-disable-next-line class-methods-use-this
     getWarehouseClientFromCredentials(

--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -1,5 +1,6 @@
 import { AnyType } from '@lightdash/common';
 import knex from 'knex';
+import type { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { DatabaseError } from 'pg';
 import { lightdashConfigMock } from '../config/lightdashConfig.mock';
@@ -464,6 +465,35 @@ describe('renameSlug', () => {
         );
     });
 
+    test('uses a supplied transaction without starting a nested transaction', async () => {
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ saved_query_uuid: chartUuid, deleted_at: null }]);
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ slug: 'old-orders' }]);
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
+        tracker.on
+            .insert(SavedChartSlugMappingsTableName)
+            .responseOnce([{ saved_query_uuid: chartUuid }]);
+        tracker.on.update(SavedChartsTableName).responseOnce(1);
+
+        await model.renameSlug(
+            {
+                projectUuid,
+                savedChartUuid: chartUuid,
+                from: 'old-orders',
+                to: 'new-orders',
+            },
+            database as unknown as Knex.Transaction,
+        );
+
+        expect(database.transaction).not.toHaveBeenCalled();
+        expect(tracker.history.insert).toHaveLength(1);
+        expect(tracker.history.update).toHaveLength(1);
+    });
+
     test('treats an alias-to-current replay as idempotent', async () => {
         tracker.on.select(SavedChartsTableName).responseOnce([]);
         tracker.on
@@ -769,6 +799,25 @@ describe('update', () => {
         expect(updateQuery.sql).not.toContain('"dashboard_uuid"');
         expect(updateQuery.bindings).toContain(projectUuid);
         expect(updateQuery.bindings).toContain(chartUuid);
+    });
+
+    test('updates through a supplied transaction without hydrating the chart', async () => {
+        const chartUuid = '11111111-1111-4111-8111-111111111111';
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ project_uuid: projectUuid }]);
+        tracker.on.update(SavedChartsTableName).responseOnce(1);
+        const getSpy = vi.spyOn(model, 'get');
+
+        await model.updateInTransaction(
+            chartUuid,
+            { name: 'Renamed chart' },
+            database as unknown as Knex.Transaction,
+        );
+
+        expect(getSpy).not.toHaveBeenCalled();
+        expect(tracker.history.update).toHaveLength(1);
     });
 
     test('rejects moving a chart to a space in another project', async () => {

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1116,11 +1116,12 @@ export class SavedChartModel {
         return this.get(savedChartUuid);
     }
 
-    async update(
+    private async updateChart(
+        database: Knex,
         savedChartUuid: string,
         data: UpdateSavedChart,
-    ): Promise<SavedChartDAO> {
-        const savedChart = await this.database(SavedChartsTableName)
+    ): Promise<void> {
+        const savedChart = await database(SavedChartsTableName)
             .select(`${SavedChartsTableName}.project_uuid`)
             .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
             .whereNull(`${SavedChartsTableName}.deleted_at`)
@@ -1131,7 +1132,7 @@ export class SavedChartModel {
 
         let targetSpaceId: number | undefined;
         if (data.spaceUuid !== undefined) {
-            const space = await this.database(SpaceTableName)
+            const space = await database(SpaceTableName)
                 .innerJoin(
                     ProjectTableName,
                     `${ProjectTableName}.project_id`,
@@ -1150,7 +1151,7 @@ export class SavedChartModel {
             targetSpaceId = space.space_id;
         }
 
-        await this.database(SavedChartsTableName)
+        await database(SavedChartsTableName)
             .update({
                 name: data.name,
                 description: data.description,
@@ -1161,21 +1162,39 @@ export class SavedChartModel {
             })
             .where('saved_query_uuid', savedChartUuid)
             .whereNull('deleted_at');
+    }
+
+    async update(
+        savedChartUuid: string,
+        data: UpdateSavedChart,
+    ): Promise<SavedChartDAO> {
+        await this.updateChart(this.database, savedChartUuid, data);
         return this.get(savedChartUuid);
     }
 
-    async renameSlug({
-        projectUuid,
-        savedChartUuid,
-        from,
-        to,
-    }: {
-        projectUuid: string;
-        savedChartUuid: string;
-        from: string;
-        to: string;
-    }): Promise<void> {
-        return this.database.transaction(async (trx) => {
+    async updateInTransaction(
+        savedChartUuid: string,
+        data: UpdateSavedChart,
+        transaction: Knex.Transaction,
+    ): Promise<void> {
+        await this.updateChart(transaction, savedChartUuid, data);
+    }
+
+    async renameSlug(
+        {
+            projectUuid,
+            savedChartUuid,
+            from,
+            to,
+        }: {
+            projectUuid: string;
+            savedChartUuid: string;
+            from: string;
+            to: string;
+        },
+        transaction?: Knex.Transaction,
+    ): Promise<void> {
+        const rename = async (trx: Knex) => {
             const slugsToLock = [...new Set([from, to])].sort();
             for (const slug of slugsToLock) {
                 // eslint-disable-next-line no-await-in-loop
@@ -1258,7 +1277,12 @@ export class SavedChartModel {
                     `Chart slug "${chart.slug}" changed while it was being renamed`,
                 );
             }
-        });
+        };
+
+        if (transaction) {
+            return rename(transaction);
+        }
+        return this.database.transaction(rename);
     }
 
     async updateMultiple(

--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -8,6 +8,7 @@ import {
     SessionUser,
     type PromotionChanges,
 } from '@lightdash/common';
+import type { Knex } from 'knex';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
@@ -44,7 +45,10 @@ const projectModel = {
     getSummary: vi.fn(async () => ({
         upstreamProjectUuid: existingUpstreamDashboard.projectUuid,
     })),
+    getUpstreamChartUuidFromPreview: vi.fn(async () => null),
 };
+
+const chartTransaction = {} as Knex.Transaction;
 
 const savedChartModel = {
     getSummary: vi.fn(async () => ({
@@ -53,7 +57,41 @@ const savedChartModel = {
     get: vi.fn(async () => promotedChart.chart),
     find: vi.fn(async () => [existingUpstreamChart.chart]),
     create: vi.fn(async () => existingUpstreamChart.chart),
+    createVersion: vi.fn(async () => existingUpstreamChart.chart),
+    updateInTransaction: vi.fn(async () => undefined),
+    renameSlug: vi.fn(async () => undefined),
+    transaction: vi.fn(
+        async (callback: (transaction: Knex.Transaction) => Promise<unknown>) =>
+            callback(chartTransaction),
+    ),
 };
+
+beforeEach(() => {
+    projectModel.getUpstreamChartUuidFromPreview
+        .mockReset()
+        .mockResolvedValue(null);
+    savedChartModel.get.mockReset().mockResolvedValue(promotedChart.chart);
+    savedChartModel.find
+        .mockReset()
+        .mockResolvedValue([existingUpstreamChart.chart]);
+    savedChartModel.create
+        .mockReset()
+        .mockResolvedValue(existingUpstreamChart.chart);
+    savedChartModel.createVersion
+        .mockReset()
+        .mockResolvedValue(existingUpstreamChart.chart);
+    savedChartModel.updateInTransaction
+        .mockReset()
+        .mockResolvedValue(undefined);
+    savedChartModel.renameSlug.mockReset().mockResolvedValue(undefined);
+    savedChartModel.transaction
+        .mockReset()
+        .mockImplementation(
+            async (
+                callback: (transaction: Knex.Transaction) => Promise<unknown>,
+            ) => callback(chartTransaction),
+        );
+});
 
 const savedSqlModel = {
     getByUuid: vi.fn(async () => promotedSqlChart),
@@ -246,6 +284,91 @@ describe('PromoteService chart changes', () => {
         expect(changes.spaces[0].data).toEqual({
             ...existingUpstreamChart.space,
         });
+    });
+
+    test('getChartChanges treats a canonical slug rename as an update', async () => {
+        (spaceModel.find as import('vitest').Mock).mockImplementationOnce(
+            async () => [upstreamSpace],
+        );
+
+        const changes = await service.getChartChanges(
+            {
+                ...promotedChart,
+                chart: {
+                    ...promotedChart.chart,
+                    slug: 'renamed-chart',
+                },
+            },
+            existingUpstreamChart,
+        );
+
+        expect(changes.charts[0]).toMatchObject({
+            action: PromotionAction.UPDATE,
+            data: { slug: 'renamed-chart' },
+        });
+    });
+
+    test('getChartChanges treats a repeated promoted rename as idempotent', async () => {
+        (spaceModel.find as import('vitest').Mock).mockImplementationOnce(
+            async () => [upstreamSpace],
+        );
+        const renamedChart = {
+            ...promotedChart.chart,
+            slug: 'renamed-chart',
+        };
+
+        const changes = await service.getChartChanges(
+            {
+                ...promotedChart,
+                chart: renamedChart,
+            },
+            {
+                ...existingUpstreamChart,
+                chart: renamedChart,
+            },
+        );
+
+        expect(changes.charts[0].action).toBe(PromotionAction.NO_CHANGES);
+    });
+
+    test('resolves a renamed preview chart through its original content mapping', async () => {
+        const renamedPreviewChart = {
+            ...promotedChart.chart,
+            slug: 'renamed-chart',
+        };
+        (
+            projectModel.getUpstreamChartUuidFromPreview as import('vitest').Mock
+        ).mockResolvedValueOnce(existingUpstreamChart.chart!.uuid);
+        (savedChartModel.get as import('vitest').Mock).mockImplementation(
+            async (chartUuid: string) =>
+                chartUuid === renamedPreviewChart.uuid
+                    ? renamedPreviewChart
+                    : existingUpstreamChart.chart,
+        );
+        (spaceModel.find as import('vitest').Mock).mockResolvedValueOnce([
+            upstreamSpace,
+        ]);
+
+        const result = await service.getPromoteCharts(
+            user,
+            existingUpstreamChart.projectUuid,
+            renamedPreviewChart.uuid,
+        );
+
+        expect(result.upstreamChart.chart?.uuid).toBe(
+            existingUpstreamChart.chart!.uuid,
+        );
+        expect(savedChartModel.find).not.toHaveBeenCalled();
+        expect(savedChartModel.get).toHaveBeenNthCalledWith(
+            2,
+            existingUpstreamChart.chart!.uuid,
+            undefined,
+            { projectUuid: existingUpstreamChart.projectUuid },
+        );
+
+        (savedChartModel.get as import('vitest').Mock).mockImplementation(
+            async () => promotedChart.chart,
+        );
     });
 
     test('getChartChanges update chart and create space', async () => {
@@ -1036,6 +1159,147 @@ describe('PromoteService promoting and mutating changes', () => {
         expect(newChanges.charts[0].data.uuid).toEqual(
             existingUpstreamChart.chart?.uuid,
         );
+    });
+
+    test('renames and updates an upstream chart in one transaction', async () => {
+        const upstreamChart = {
+            ...existingUpstreamChart.chart!,
+            slug: 'original-chart',
+        };
+        const renamedChart = {
+            ...promotedChart.chart,
+            uuid: upstreamChart.uuid,
+            oldUuid: promotedChart.chart.uuid,
+            projectUuid: existingUpstreamChart.projectUuid,
+            spaceUuid: existingUpstreamChart.space!.uuid,
+            spaceSlug: promotedChart.space.slug,
+            spacePath: promotedChart.space.path,
+            slug: 'renamed-chart',
+        };
+        const changes: PromotionChanges = {
+            spaces: [],
+            dashboards: [],
+            charts: [
+                {
+                    action: PromotionAction.UPDATE,
+                    data: renamedChart,
+                },
+            ],
+        };
+        (savedChartModel.get as import('vitest').Mock)
+            .mockResolvedValueOnce(upstreamChart)
+            .mockResolvedValueOnce({
+                ...upstreamChart,
+                slug: renamedChart.slug,
+            });
+
+        await service.upsertCharts(user, changes);
+
+        expect(savedChartModel.transaction).toHaveBeenCalledTimes(1);
+        expect(savedChartModel.renameSlug).toHaveBeenCalledWith(
+            {
+                projectUuid: existingUpstreamChart.projectUuid,
+                savedChartUuid: upstreamChart.uuid,
+                from: 'original-chart',
+                to: 'renamed-chart',
+            },
+            chartTransaction,
+        );
+        expect(savedChartModel.updateInTransaction).toHaveBeenCalledWith(
+            upstreamChart.uuid,
+            expect.objectContaining({ name: renamedChart.name }),
+            chartTransaction,
+        );
+        expect(savedChartModel.createVersion).toHaveBeenCalledWith(
+            upstreamChart.uuid,
+            expect.objectContaining({ slug: 'renamed-chart' }),
+            user,
+            chartTransaction,
+        );
+    });
+
+    test('stops before metadata and version writes when a slug collision is rejected', async () => {
+        const upstreamChart = {
+            ...existingUpstreamChart.chart!,
+            slug: 'original-chart',
+        };
+        const renamedChart = {
+            ...promotedChart.chart,
+            uuid: upstreamChart.uuid,
+            oldUuid: promotedChart.chart.uuid,
+            projectUuid: existingUpstreamChart.projectUuid,
+            spaceUuid: existingUpstreamChart.space!.uuid,
+            spaceSlug: promotedChart.space.slug,
+            spacePath: promotedChart.space.path,
+            slug: 'occupied-chart',
+        };
+        const changes: PromotionChanges = {
+            spaces: [],
+            dashboards: [],
+            charts: [
+                {
+                    action: PromotionAction.UPDATE,
+                    data: renamedChart,
+                },
+            ],
+        };
+        (savedChartModel.get as import('vitest').Mock).mockResolvedValueOnce(
+            upstreamChart,
+        );
+        (
+            savedChartModel.renameSlug as import('vitest').Mock
+        ).mockRejectedValueOnce(new Error('slug collision'));
+
+        await expect(service.upsertCharts(user, changes)).rejects.toThrow(
+            'slug collision',
+        );
+
+        expect(savedChartModel.updateInTransaction).not.toHaveBeenCalled();
+        expect(savedChartModel.createVersion).not.toHaveBeenCalled();
+    });
+
+    test('can safely retry when version creation fails after a slug rename', async () => {
+        const upstreamChart = {
+            ...existingUpstreamChart.chart!,
+            slug: 'original-chart',
+        };
+        const renamedChart = {
+            ...promotedChart.chart,
+            uuid: upstreamChart.uuid,
+            oldUuid: promotedChart.chart.uuid,
+            projectUuid: existingUpstreamChart.projectUuid,
+            spaceUuid: existingUpstreamChart.space!.uuid,
+            spaceSlug: promotedChart.space.slug,
+            spacePath: promotedChart.space.path,
+            slug: 'renamed-chart',
+        };
+        const changes: PromotionChanges = {
+            spaces: [],
+            dashboards: [],
+            charts: [
+                {
+                    action: PromotionAction.UPDATE,
+                    data: renamedChart,
+                },
+            ],
+        };
+        (savedChartModel.get as import('vitest').Mock).mockResolvedValue(
+            upstreamChart,
+        );
+        (
+            savedChartModel.createVersion as import('vitest').Mock
+        ).mockRejectedValueOnce(new Error('version write failed'));
+
+        await expect(service.upsertCharts(user, changes)).rejects.toThrow(
+            'version write failed',
+        );
+        await expect(
+            service.upsertCharts(user, changes),
+        ).resolves.toBeDefined();
+
+        expect(savedChartModel.transaction).toHaveBeenCalledTimes(2);
+        expect(savedChartModel.renameSlug).toHaveBeenCalledTimes(2);
+        expect(savedChartModel.createVersion).toHaveBeenCalledTimes(2);
     });
 
     test('create charts and update dashboard tile uuids if a new chart created', async () => {

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -236,18 +236,33 @@ export class PromoteService extends BaseService {
         if (cachedUpstreamChart !== undefined) {
             upstreamChart = cachedUpstreamChart;
         } else {
-            const upstreamCharts = await this.savedChartModel.find({
-                projectUuid: upstreamProjectUuid,
-                slug: savedChart.slug,
-                includeOrphanChartsWithinDashboard,
-            });
-            if (upstreamCharts.length > 1) {
-                throw new AlreadyExistsError(
-                    `There are multiple charts with the same identifier ${savedChart.slug}`,
+            const mappedUpstreamChartUuid =
+                savedChart.projectUuid === upstreamProjectUuid
+                    ? null
+                    : await this.projectModel.getUpstreamChartUuidFromPreview(
+                          savedChart.projectUuid,
+                          savedChart.uuid,
+                      );
+            if (mappedUpstreamChartUuid) {
+                upstreamChart = await this.savedChartModel.get(
+                    mappedUpstreamChartUuid,
+                    undefined,
+                    { projectUuid: upstreamProjectUuid },
                 );
+            } else {
+                const upstreamCharts = await this.savedChartModel.find({
+                    projectUuid: upstreamProjectUuid,
+                    slug: savedChart.slug,
+                    includeOrphanChartsWithinDashboard,
+                });
+                if (upstreamCharts.length > 1) {
+                    throw new AlreadyExistsError(
+                        `There are multiple charts with the same identifier ${savedChart.slug}`,
+                    );
+                }
+                upstreamChart =
+                    upstreamCharts.length === 1 ? upstreamCharts[0] : undefined;
             }
-            upstreamChart =
-                upstreamCharts.length === 1 ? upstreamCharts[0] : undefined;
         }
 
         const upstreamSpaces = await this.spaceModel.find({
@@ -807,7 +822,8 @@ export class PromoteService extends BaseService {
         return (
             promotedChart.updatedAt > upstreamChart.updatedAt ||
             promotedChart.name !== upstreamChart.name ||
-            promotedChart.description !== upstreamChart.description
+            promotedChart.description !== upstreamChart.description ||
+            promotedChart.slug !== upstreamChart.slug
         );
     }
 
@@ -835,25 +851,9 @@ export class PromoteService extends BaseService {
             (change) => change.action === PromotionAction.NO_CHANGES,
         );
 
-        await Promise.all(
-            charts
-                .filter((change) => change.action === PromotionAction.UPDATE)
-                .map((chartChange) => {
-                    const changeChart = chartChange.data;
-                    // We also update chart name and description if they have changed
-                    return this.savedChartModel.update(changeChart.uuid, {
-                        name: changeChart.name,
-                        description: changeChart.description,
-                        spaceUuid: isChartWithinDashboard(changeChart)
-                            ? undefined
-                            : changeChart.spaceUuid,
-                    });
-                }),
-        );
-
         const updatedChartPromises = charts
             .filter((change) => change.action === PromotionAction.UPDATE)
-            .map((chartChange) => {
+            .map(async (chartChange) => {
                 const changeChart = chartChange.data;
 
                 const chartData =
@@ -872,14 +872,54 @@ export class PromoteService extends BaseService {
                               updatedByUser: user,
                               slug: changeChart.slug,
                           };
-                return this.savedChartModel
-                    .createVersion(changeChart.uuid, chartData, user)
-                    .then((updatedChart) => ({
-                        ...updatedChart,
-                        oldUuid: changeChart.oldUuid,
-                        spaceSlug: changeChart.spaceSlug,
-                        spacePath: changeChart.spacePath,
-                    }));
+                const currentChart = await this.savedChartModel.get(
+                    changeChart.uuid,
+                    undefined,
+                    { projectUuid: changeChart.projectUuid },
+                );
+
+                await this.savedChartModel.transaction(async (transaction) => {
+                    if (currentChart.slug !== changeChart.slug) {
+                        await this.savedChartModel.renameSlug(
+                            {
+                                projectUuid: changeChart.projectUuid,
+                                savedChartUuid: changeChart.uuid,
+                                from: currentChart.slug,
+                                to: changeChart.slug,
+                            },
+                            transaction,
+                        );
+                    }
+                    await this.savedChartModel.updateInTransaction(
+                        changeChart.uuid,
+                        {
+                            name: changeChart.name,
+                            description: changeChart.description,
+                            spaceUuid: isChartWithinDashboard(changeChart)
+                                ? undefined
+                                : changeChart.spaceUuid,
+                        },
+                        transaction,
+                    );
+                    await this.savedChartModel.createVersion(
+                        changeChart.uuid,
+                        chartData,
+                        user,
+                        transaction,
+                    );
+                });
+
+                const updatedChart = await this.savedChartModel.get(
+                    changeChart.uuid,
+                    undefined,
+                    { projectUuid: changeChart.projectUuid },
+                );
+                return {
+                    ...updatedChart,
+                    oldUuid: changeChart.oldUuid,
+                    spaceSlug: changeChart.spaceSlug,
+                    spacePath: changeChart.spacePath,
+                };
             });
         const updatedCharts = await Promise.all(updatedChartPromises);
 


### PR DESCRIPTION
## What

- resolve preview charts through preview content mappings before matching by slug
- promote chart slug renames onto the existing upstream chart instead of creating duplicates
- apply slug, metadata, and version updates in one transaction
- preserve collision handling, rollback/retry behavior, and preview alias isolation

## Why

Promoting a renamed chart from a preview project previously matched only by slug. The renamed preview chart was therefore treated as new content and duplicated in the production project.

## Validation

- focused backend tests: 133 passed, 1 skipped
- backend typecheck
- targeted backend lint and formatting
- live preview promotion kept the original chart UUID and chart count
- repeated promotion was idempotent
- production slug collisions returned 409 without partial updates
- preview-only aliases were not imported

Linear: SPK-1120