### PR TITLE
feat: add chart URL slug rename action

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/ChartSlugRenameModal.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/ChartSlugRenameModal.tsx
@@ -1,0 +1,150 @@
+import {
+    ContentType,
+    generateSlug,
+    type ApiError,
+    type ApiSuccessEmpty,
+    type ContentSlugRenameRequest,
+} from '@lightdash/common';
+import { Button, Paper, Stack, Text, TextInput } from '@mantine/core';
+import { useForm, zodResolver } from '@mantine/form';
+import { IconLink } from '@tabler/icons-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { type FC } from 'react';
+import { z } from 'zod';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { invalidateContent } from '../../../hooks/useContent';
+import MantineModal from '../../common/MantineModal';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    onRenamed: (slug: string) => void;
+    projectUuid: string;
+    projectUrlIdentifier: string;
+    currentSlug: string;
+};
+
+const ChartSlugRenameModal: FC<Props> = ({
+    opened,
+    onClose,
+    onRenamed,
+    projectUuid,
+    projectUrlIdentifier,
+    currentSlug,
+}) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess } = useToaster();
+    const form = useForm({
+        initialValues: { slug: currentSlug },
+        validate: zodResolver(
+            z.object({
+                slug: z
+                    .string()
+                    .trim()
+                    .min(1, 'Enter a slug')
+                    .max(255, 'Slugs must be 255 characters or fewer')
+                    .refine(
+                        (value) => generateSlug(value) === value,
+                        'Use lowercase letters, numbers, and hyphens only',
+                    )
+                    .refine(
+                        (value) => value !== currentSlug,
+                        'Enter a different slug',
+                    ),
+            }),
+        ),
+    });
+
+    const renameMutation = useMutation<
+        ApiSuccessEmpty['results'],
+        ApiError,
+        ContentSlugRenameRequest
+    >(
+        (body) =>
+            lightdashApi<ApiSuccessEmpty['results']>({
+                url: `/projects/${projectUuid}/slugs/rename`,
+                method: 'POST',
+                body: JSON.stringify(body),
+            }),
+        {
+            onSuccess: async (_, { to }) => {
+                await Promise.all([
+                    invalidateContent(queryClient, projectUuid),
+                    queryClient.invalidateQueries(['saved_query']),
+                ]);
+                showToastSuccess({ title: 'Chart URL slug changed' });
+                onRenamed(to);
+            },
+            onError: ({ error }) => {
+                form.setFieldError('slug', error.message);
+            },
+        },
+    );
+
+    const newSlug = form.values.slug.trim();
+    const newUrl = `${window.location.origin}/projects/${projectUrlIdentifier}/saved/${newSlug}/view`;
+
+    const handleSubmit = form.onSubmit(({ slug }) => {
+        renameMutation.mutate({
+            resourceType: ContentType.CHART,
+            from: currentSlug,
+            to: slug.trim(),
+        });
+    });
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Change URL slug"
+            icon={IconLink}
+            size="lg"
+            cancelDisabled={renameMutation.isLoading}
+            actions={
+                <Button
+                    type="submit"
+                    form="chart-slug-rename-form"
+                    loading={renameMutation.isLoading}
+                    disabled={!form.isDirty()}
+                >
+                    Change slug
+                </Button>
+            }
+        >
+            <form id="chart-slug-rename-form" onSubmit={handleSubmit}>
+                <Stack gap="md">
+                    <Text size="sm" c="dimmed">
+                        Change the last part of this chart&apos;s URL. Existing
+                        links will keep working.
+                    </Text>
+                    <TextInput
+                        label="New slug"
+                        description="Lowercase letters, numbers, and hyphens"
+                        data-autofocus
+                        maxLength={255}
+                        disabled={renameMutation.isLoading}
+                        onFocus={(event) => event.currentTarget.select()}
+                        {...form.getInputProps('slug')}
+                    />
+                    <Stack gap={6}>
+                        <Text size="sm" fw={500}>
+                            URL preview
+                        </Text>
+                        <Paper withBorder bg="gray.0" p="sm">
+                            <Text
+                                component="code"
+                                size="xs"
+                                style={{ overflowWrap: 'anywhere' }}
+                            >
+                                {newUrl}
+                            </Text>
+                        </Paper>
+                    </Stack>
+                </Stack>
+            </form>
+        </MantineModal>
+    );
+};
+
+export default ChartSlugRenameModal;

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -36,6 +36,7 @@ import {
     IconFolderSymlink,
     IconHistory,
     IconLayoutGridAdd,
+    IconLink,
     IconMaximize,
     IconMinimize,
     IconPencil,
@@ -130,6 +131,7 @@ import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardM
 import SaveChartButton, {
     type VerificationSavePrompt,
 } from '../SaveChartButton';
+import ChartSlugRenameModal from './ChartSlugRenameModal';
 import { TitleBreadCrumbs } from './TitleBreadcrumbs';
 
 const isChartPath = (
@@ -228,6 +230,8 @@ const SavedChartsHeader: FC = () => {
     const [isTransferToSpaceModalOpen, transferToSpaceModalHandlers] =
         useDisclosure();
     const [isChartAsCodeModalOpen, chartAsCodeModalHandlers] = useDisclosure();
+    const [isChartSlugRenameModalOpen, chartSlugRenameModalHandlers] =
+        useDisclosure();
 
     const { user, health } = useApp();
     const { mutateAsync: contentAction, isLoading: isContentActionLoading } =
@@ -1020,22 +1024,44 @@ const SavedChartsHeader: FC = () => {
                                         </Menu.Item>
                                     )}
 
-                                {userCanViewContentAsCode && savedChart && (
-                                    <>
-                                        <Menu.Divider />
-                                        <Menu.Label>Content as code</Menu.Label>
-                                        <Menu.Item
-                                            leftSection={
-                                                <MantineIcon icon={IconCode} />
-                                            }
-                                            onClick={
-                                                chartAsCodeModalHandlers.open
-                                            }
-                                        >
-                                            View as code
-                                        </Menu.Item>
-                                    </>
-                                )}
+                                {savedChart &&
+                                    (userCanViewContentAsCode ||
+                                        userCanManageChart) && (
+                                        <>
+                                            <Menu.Divider />
+                                            <Menu.Label>
+                                                Content as code
+                                            </Menu.Label>
+                                            {userCanViewContentAsCode && (
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconCode}
+                                                        />
+                                                    }
+                                                    onClick={
+                                                        chartAsCodeModalHandlers.open
+                                                    }
+                                                >
+                                                    View as code
+                                                </Menu.Item>
+                                            )}
+                                            {userCanManageChart && (
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconLink}
+                                                        />
+                                                    }
+                                                    onClick={
+                                                        chartSlugRenameModalHandlers.open
+                                                    }
+                                                >
+                                                    Change URL slug
+                                                </Menu.Item>
+                                            )}
+                                        </>
+                                    )}
 
                                 <Menu.Divider />
                                 <Menu.Label>Integrations</Menu.Label>
@@ -1302,6 +1328,26 @@ const SavedChartsHeader: FC = () => {
                     projectUuid={projectUuid}
                     chartUuid={savedChart.uuid}
                     hasUnsavedChanges={hasUnsavedChanges && isEditMode}
+                />
+            )}
+            {isChartSlugRenameModalOpen && savedChart && projectUuid && (
+                <ChartSlugRenameModal
+                    opened={isChartSlugRenameModalOpen}
+                    onClose={chartSlugRenameModalHandlers.close}
+                    onRenamed={(slug) => {
+                        chartSlugRenameModalHandlers.close();
+                        const routeMode = isEditMode ? 'edit' : 'view';
+                        void navigate(
+                            {
+                                pathname: `/projects/${projectUrlIdentifier}/saved/${slug}/${routeMode}`,
+                                search,
+                            },
+                            { replace: true },
+                        );
+                    }}
+                    projectUuid={projectUuid}
+                    projectUrlIdentifier={projectUrlIdentifier}
+                    currentSlug={savedChart.slug}
                 />
             )}
         </TrackSection>


### PR DESCRIPTION
Closes: [SPK-1129](https://linear.app/lightdash/issue/SPK-1129/add-chart-slug-rename-action-to-the-chart-overflow-menu)

![CleanShot 2026-08-28 at 10.35.07.png](https://app.graphite.com/user-attachments/assets/2aa1e011-edcf-4849-9fc9-9346e9fafc98.png)



![CleanShot 2026-08-28 at 10.34.38.png](https://app.graphite.com/user-attachments/assets/2fec7964-f592-4dcd-968b-fd27f757f25f.png)



### Description:

Adds a **Change URL slug** action beside **View as code** in the saved chart overflow menu.

- Uses the existing chart slug rename API and permissions
- Validates slug formatting and displays API collisions inline
- Shows a wrapped preview of the resulting chart URL
- Explains that existing links continue working through the automatic alias
- Refreshes chart data and navigates to the new canonical URL while preserving view/edit mode and query parameters
- Uses a wider modal so long chart URLs remain readable

The modal intentionally does not ask users to run a CLI command after renaming. The broader content-as-code multi-writer/conflict problem is tracked separately in [SPK-1535](https://linear.app/lightdash/issue/SPK-1535/content-as-code-lacks-conflict-detection-when-multiple-files-target) and does not block this UI feature.

### Validation:

- Manually exercised the rename flow against the local Jaffle Shop project
- Targeted frontend formatting check passed
- Targeted frontend lint passed with zero warnings/errors
- Commit hooks passed, including unused-export validation

### Risk assessment:

- [ ] This is a high-risk change