### PR TITLE
fix: keep composer tools visible on desktop

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -209,11 +209,7 @@ export const AgentChatInput = ({
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const app = useApp();
-    // Resolved on first render so the toolbar never renders the desktop layout
-    // on a phone before settling.
-    const isMobile = useMediaQuery('(max-width: 768px)', undefined, {
-        getInitialValueInEffect: false,
-    });
+    const isMobile = useMediaQuery('(max-width: 768px)');
     const [value, setValueState] = useState(defaultValue ?? '');
     const [externalSourceAttachments, setExternalSourceAttachments] = useState<
         ExternalSourceAttachment[]


### PR DESCRIPTION
### Description:

- Keep SQL Runner and Deep research controls visible on desktop
- Collapse composer tools into the options menu only on mobile viewports

### Testing:

- AgentChatInput.deepResearch.test.tsx: 9 passed
- Desktop 1440px and mobile 390px browser verification

### Risk assessment:

- [ ] This is a high-risk change

Low risk: one frontend media-query initialization change.