### PR TITLE
feat(ai-agent): build card wired into the thread; ready app opens in the preview panel

### DIFF
--- a/docs/data-apps/CONTEXT.md
+++ b/docs/data-apps/CONTEXT.md
@@ -185,6 +185,14 @@ still writes the app.
 _Avoid_: AI analyst, copilot (in code and docs), assistant, the agent
 (where more than one agent is in scope)
 
+**Build card**:
+The card under an AI agent reply that follows a build the agent started:
+queued, building (status message and narration), ready, failed, cancelled,
+or unavailable. It reads the version while the tool result is pending and
+the tool result once it is terminal; when a build watched in the thread
+lands, the app opens in the thread's preview panel.
+_Avoid_: job card, progress card, status widget
+
 **External agent**:
 Any agent outside Lightdash — Claude Code, an MCP client, a CLI script —
 reading data apps through MCP or editing their source through data apps as

--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -1046,7 +1046,7 @@ describe('AiAgentModel pending data app builds', () => {
     });
 
     it('resolves a pending result to error once the version failed', async () => {
-        const { promptUuid } = await createPendingBuild({
+        const { promptUuid, appUuid } = await createPendingBuild({
             status: 'error',
             error: 'boom',
             statusMessage: 'Build timed out. Please try again.',
@@ -1056,12 +1056,14 @@ describe('AiAgentModel pending data app builds', () => {
 
         expect(result.metadata).toEqual({
             status: 'error',
+            appUuid,
+            reason: 'failed',
             message: 'Build timed out. Please try again.',
         });
     });
 
     it('resolves a pending result to error once the version was cancelled', async () => {
-        const { promptUuid } = await createPendingBuild({
+        const { promptUuid, appUuid } = await createPendingBuild({
             status: 'error',
             error: APP_VERSION_CANCELLED_BY_USER,
             statusMessage: APP_VERSION_CANCELLED_BY_USER,
@@ -1071,6 +1073,8 @@ describe('AiAgentModel pending data app builds', () => {
 
         expect(result.metadata).toEqual({
             status: 'error',
+            appUuid,
+            reason: 'cancelled',
             message: 'The build was cancelled.',
         });
     });
@@ -1090,14 +1094,18 @@ describe('AiAgentModel pending data app builds', () => {
     });
 
     it('expires a pending result still building after the grace period', async () => {
-        const { promptUuid } = await createPendingBuild({
+        const { promptUuid, appUuid } = await createPendingBuild({
             status: 'generating',
             startedAgoMs: AI_DATA_APP_BUILD_PENDING_GRACE_MS + 1000,
         });
 
         const [result] = await model.getToolResultsForPrompt(promptUuid);
 
-        expect(result.metadata).toMatchObject({ status: 'error' });
+        expect(result.metadata).toMatchObject({
+            status: 'error',
+            appUuid,
+            reason: 'failed',
+        });
         expect(result.metadata).toHaveProperty(
             'message',
             expect.stringContaining('30 minutes'),

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -7473,7 +7473,10 @@ export class AiAgentModel {
             ) {
                 return result;
             }
-            return { ...result, ...getExpiredGenerateDataAppBuildOutcome() };
+            return {
+                ...result,
+                ...getExpiredGenerateDataAppBuildOutcome(appUuid),
+            };
         });
     }
 

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -3976,7 +3976,20 @@ Parameters:
             {
               "additionalProperties": false,
               "properties": {
+                "appUuid": {
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
                 "message": {
+                  "type": "string",
+                },
+                "reason": {
+                  "enum": [
+                    "failed",
+                    "cancelled",
+                  ],
                   "type": "string",
                 },
                 "status": {
@@ -3986,6 +3999,8 @@ Parameters:
               },
               "required": [
                 "status",
+                "appUuid",
+                "reason",
                 "message",
               ],
               "type": "object",

--- a/packages/backend/src/ee/services/ai/tools/generateDataApp.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateDataApp.test.ts
@@ -57,6 +57,8 @@ describe('getGenerateDataApp', () => {
 
         expect(output.metadata).toEqual({
             status: 'error',
+            appUuid: null,
+            reason: 'failed',
             message: 'Data apps are not enabled',
         });
     });

--- a/packages/backend/src/ee/services/ai/tools/generateDataApp.ts
+++ b/packages/backend/src/ee/services/ai/tools/generateDataApp.ts
@@ -45,6 +45,8 @@ export const getGenerateDataApp = ({ generateDataApp }: Dependencies) =>
                     ),
                     metadata: {
                         status: 'error' as const,
+                        appUuid: null,
+                        reason: 'failed' as const,
                         message: getErrorMessage(error),
                     },
                 };

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateDataAppArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateDataAppArgs.test.ts
@@ -41,6 +41,8 @@ describe('getGenerateDataAppBuildOutcome', () => {
             })?.metadata,
         ).toEqual({
             status: 'error',
+            appUuid: 'app-1',
+            reason: 'failed',
             message: 'Failed to deploy your app. Please try again.',
         });
     });
@@ -53,6 +55,11 @@ describe('getGenerateDataAppBuildOutcome', () => {
                 error: APP_VERSION_CANCELLED_BY_USER,
                 statusMessage: APP_VERSION_CANCELLED_BY_USER,
             })?.metadata,
-        ).toEqual({ status: 'error', message: 'The build was cancelled.' });
+        ).toEqual({
+            status: 'error',
+            appUuid: 'app-1',
+            reason: 'cancelled',
+            message: 'The build was cancelled.',
+        });
     });
 });

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateDataAppArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolGenerateDataAppArgs.ts
@@ -66,6 +66,9 @@ export const toolGenerateDataAppOutputSchema = z.object({
         }),
         z.object({
             status: z.literal('error'),
+            // Null when the build never started, so no app exists to open.
+            appUuid: z.string().nullable(),
+            reason: z.enum(['failed', 'cancelled']),
             message: z.string(),
         }),
     ]),
@@ -147,23 +150,29 @@ export const getGenerateDataAppBuildOutcome = ({
             metadata: { status: 'success', appUuid, version, name, href },
         };
     }
-    const message =
-        error === APP_VERSION_CANCELLED_BY_USER
-            ? 'The build was cancelled.'
-            : (statusMessage ?? 'The build failed.');
+    const cancelled = error === APP_VERSION_CANCELLED_BY_USER;
+    const message = cancelled
+        ? 'The build was cancelled.'
+        : (statusMessage ?? 'The build failed.');
     return {
         result: `The data app build did not finish: ${message}`,
-        metadata: { status: 'error', message },
+        metadata: {
+            status: 'error',
+            appUuid,
+            reason: cancelled ? 'cancelled' : 'failed',
+            message,
+        },
     };
 };
 
-export const getExpiredGenerateDataAppBuildOutcome =
-    (): ToolGenerateDataAppTerminalResult => {
-        const message = `The build did not report an outcome within ${
-            AI_DATA_APP_BUILD_PENDING_GRACE_MS / 60_000
-        } minutes.`;
-        return {
-            result: `The data app build did not finish: ${message}`,
-            metadata: { status: 'error', message },
-        };
+export const getExpiredGenerateDataAppBuildOutcome = (
+    appUuid: string,
+): ToolGenerateDataAppTerminalResult => {
+    const message = `The build did not report an outcome within ${
+        AI_DATA_APP_BUILD_PENDING_GRACE_MS / 60_000
+    } minutes.`;
+    return {
+        result: `The data app build did not finish: ${message}`,
+        metadata: { status: 'error', appUuid, reason: 'failed', message },
     };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -4,9 +4,11 @@ import {
     type AiMcpServer,
     isToolEditDbtProjectResult,
     isToolEditRepoResult,
+    isToolGenerateDataAppResult,
     isToolSetupPreviewDeployResult,
     type ToolEditDbtProjectOutput,
     type ToolEditRepoOutput,
+    type ToolGenerateDataAppOutput,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -66,6 +68,7 @@ import AgentChatDebugDrawer from './AgentChatDebugDrawer';
 import { AiArtifactInline } from './AiArtifactInline';
 import { AiArtifactButton } from './ArtifactButton/AiArtifactButton';
 import { ContentLink, type SqlRunnerLinkState } from './ContentLink';
+import { AiDataAppBuildCard } from './DataAppBuildCard/AiDataAppBuildCard';
 import { isHiddenToolName } from './hiddenToolNames';
 import {
     MEMORY_CITATION_ALLOWED_TAGS,
@@ -364,6 +367,22 @@ const SqlMarkdownCodeBlock: FC<
     );
 };
 
+/**
+ * The streamed part carrying a tool's finished output. The streaming slice
+ * mirrors each tool's full return shape into its part's `toolResult`.
+ */
+const findLiveToolPart = (
+    parts: StreamPart[] | undefined,
+    toolNames: string[],
+): Extract<StreamPart, { type: 'toolCall' }> | undefined =>
+    parts?.find(
+        (p): p is Extract<StreamPart, { type: 'toolCall' }> =>
+            p.type === 'toolCall' &&
+            toolNames.includes(p.toolName) &&
+            p.toolResult !== null &&
+            p.isPreliminary !== true,
+    );
+
 const AssistantBubbleContent: FC<{
     message: AiAgentMessageAssistant;
     projectUuid: string;
@@ -511,14 +530,10 @@ const AssistantBubbleContent: FC<{
                 isPreviewDeploySetup: true,
             };
 
-        const livePart = streamingState?.parts.find(
-            (p): p is Extract<StreamPart, { type: 'toolCall' }> =>
-                p.type === 'toolCall' &&
-                (p.toolName === 'editDbtProject' ||
-                    p.toolName === 'setupPreviewDeploy') &&
-                p.toolResult !== null &&
-                p.isPreliminary !== true,
-        );
+        const livePart = findLiveToolPart(streamingState?.parts, [
+            'editDbtProject',
+            'setupPreviewDeploy',
+        ]);
         const liveOutput = livePart?.toolResult as
             | ToolEditDbtProjectOutput
             | undefined;
@@ -535,16 +550,19 @@ const AssistantBubbleContent: FC<{
     const editRepoMetadata: ToolEditRepoOutput['metadata'] | null = (() => {
         const persisted = message.toolResults.find(isToolEditRepoResult);
         if (persisted) return persisted.metadata;
-        const livePart = streamingState?.parts.find(
-            (p): p is Extract<StreamPart, { type: 'toolCall' }> =>
-                p.type === 'toolCall' &&
-                p.toolName === 'editRepo' &&
-                p.toolResult !== null &&
-                p.isPreliminary !== true,
-        );
-        const liveOutput = livePart?.toolResult as
-            | ToolEditRepoOutput
-            | undefined;
+        const liveOutput = findLiveToolPart(streamingState?.parts, ['editRepo'])
+            ?.toolResult as ToolEditRepoOutput | undefined;
+        return liveOutput?.metadata ?? null;
+    })();
+
+    const generateDataAppMetadata:
+        | ToolGenerateDataAppOutput['metadata']
+        | null = (() => {
+        const persisted = message.toolResults.find(isToolGenerateDataAppResult);
+        if (persisted) return persisted.metadata;
+        const liveOutput = findLiveToolPart(streamingState?.parts, [
+            'generateDataApp',
+        ])?.toolResult as ToolGenerateDataAppOutput | undefined;
         return liveOutput?.metadata ?? null;
     })();
 
@@ -930,6 +948,16 @@ const AssistantBubbleContent: FC<{
                 <AiEditRepoToolCall
                     metadata={editRepoMetadata}
                     projectUuid={projectUuid}
+                />
+            )}
+            {generateDataAppMetadata && (
+                <AiDataAppBuildCard
+                    metadata={generateDataAppMetadata}
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                    threadUuid={message.threadUuid}
+                    messageUuid={message.uuid}
+                    compact={!isLastMessage}
                 />
             )}
         </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.test.tsx
@@ -1,0 +1,235 @@
+import {
+    type ApiAppVersionSummary,
+    type ApiGetAppResponse,
+    type ToolGenerateDataAppOutput,
+} from '@lightdash/common';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import {
+    afterAll,
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+import { lightdashApi } from '../../../../../../api';
+import { renderWithProviders } from '../../../../../../testing/testUtils';
+import { store } from '../../../store';
+import { clearPreview } from '../../../store/aiArtifactSlice';
+import { AiDataAppBuildCard } from './AiDataAppBuildCard';
+
+vi.mock('../../../../../../api', () => ({ lightdashApi: vi.fn() }));
+const mockedLightdashApi = vi.mocked(lightdashApi);
+
+// The builder's poller runs in a Web Worker; jsdom has none. The stub keeps
+// the last instance so a test can hand it a poll result.
+class WorkerStub {
+    static last: WorkerStub | null = null;
+
+    onmessage: ((event: MessageEvent) => void) | null = null;
+
+    constructor() {
+        WorkerStub.last = this;
+    }
+
+    postMessage() {}
+
+    terminate() {}
+}
+vi.stubGlobal('Worker', WorkerStub);
+const originalObjectUrl = {
+    createObjectURL: URL.createObjectURL,
+    revokeObjectURL: URL.revokeObjectURL,
+};
+URL.createObjectURL = vi.fn(() => 'blob:poller');
+URL.revokeObjectURL = vi.fn();
+afterAll(() => {
+    vi.unstubAllGlobals();
+    Object.assign(URL, originalObjectUrl);
+});
+
+const APP_UUID = 'app-1';
+const IDS = {
+    projectUuid: 'project-1',
+    agentUuid: 'agent-1',
+    threadUuid: 'thread-1',
+    messageUuid: 'message-1',
+};
+
+const expectedPreview = { type: 'dataApp', appUuid: APP_UUID, ...IDS };
+
+const version = (
+    overrides: Partial<ApiAppVersionSummary>,
+): ApiAppVersionSummary => ({
+    version: 1,
+    prompt: 'Build me a revenue app',
+    status: 'generating',
+    statusMessage: null,
+    statusHistory: [],
+    error: null,
+    createdAt: new Date('2026-08-28T10:00:00.000Z'),
+    statusUpdatedAt: null,
+    createdByUser: null,
+    resources: null,
+    ...overrides,
+});
+
+const app = (
+    versions: ApiAppVersionSummary[],
+): ApiGetAppResponse['results'] => ({
+    appUuid: APP_UUID,
+    name: 'Revenue app',
+    description: '',
+    createdByUserUuid: 'user-1',
+    spaceUuid: null,
+    spaceName: null,
+    template: null,
+    pinnedListUuid: null,
+    pinnedListOrder: null,
+    slug: 'revenue-app',
+    views: 0,
+    versions,
+    hasMore: false,
+    latestReadyVersion: null,
+});
+
+const pending: ToolGenerateDataAppOutput['metadata'] = {
+    status: 'pending',
+    appUuid: APP_UUID,
+    version: 1,
+};
+
+const renderCard = (
+    metadata: ToolGenerateDataAppOutput['metadata'],
+    compact = false,
+) =>
+    renderWithProviders(
+        <Provider store={store}>
+            <MemoryRouter>
+                <div data-testid="host">
+                    <AiDataAppBuildCard
+                        metadata={metadata}
+                        compact={compact}
+                        {...IDS}
+                    />
+                </div>
+            </MemoryRouter>
+        </Provider>,
+    );
+
+const pollResult = (versions: ApiAppVersionSummary[]) =>
+    act(() => {
+        WorkerStub.last?.onmessage?.({
+            data: { type: 'data', results: app(versions) },
+        } as MessageEvent);
+    });
+
+describe('AiDataAppBuildCard', () => {
+    beforeEach(() => {
+        store.dispatch(clearPreview());
+        WorkerStub.last = null;
+        mockedLightdashApi.mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('follows a pending build from building to ready and opens the preview once', async () => {
+        mockedLightdashApi.mockResolvedValue(
+            app([
+                version({
+                    status: 'generating',
+                    statusMessage: 'Generating your app',
+                }),
+            ]),
+        );
+        renderCard(pending);
+
+        expect(await screen.findByText('Generating your app')).toBeVisible();
+        expect(store.getState().aiArtifact.preview).toBeNull();
+
+        pollResult([
+            version({
+                status: 'ready',
+                statusMessage: 'Your revenue app is ready.',
+                statusUpdatedAt: new Date('2026-08-28T10:06:12.000Z'),
+            }),
+        ]);
+
+        expect(await screen.findByText('Revenue app')).toBeVisible();
+        expect(screen.getByText('v1 · built in 6m 12s')).toBeVisible();
+        expect(store.getState().aiArtifact.preview).toEqual(expectedPreview);
+
+        // Closing the panel is final for this build; View brings it back.
+        act(() => {
+            store.dispatch(clearPreview());
+        });
+        pollResult([version({ status: 'ready' })]);
+        expect(store.getState().aiArtifact.preview).toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: 'View' }));
+        expect(store.getState().aiArtifact.preview).toEqual(expectedPreview);
+    });
+
+    it('does not open the preview for a build that finished before this session', async () => {
+        mockedLightdashApi.mockResolvedValue(
+            app([version({ status: 'ready' })]),
+        );
+        renderCard({
+            status: 'success',
+            appUuid: APP_UUID,
+            version: 1,
+            name: 'Revenue app',
+            href: '/projects/project-1/apps/app-1',
+        });
+
+        expect(await screen.findByText('Revenue app')).toBeVisible();
+        await waitFor(() =>
+            expect(mockedLightdashApi).toHaveBeenCalledTimes(1),
+        );
+        expect(WorkerStub.last).toBeNull();
+        expect(store.getState().aiArtifact.preview).toBeNull();
+    });
+
+    it('shows a cancelled build from the recorded result', () => {
+        mockedLightdashApi.mockResolvedValue(
+            app([version({ status: 'error' })]),
+        );
+        renderCard({
+            status: 'error',
+            appUuid: APP_UUID,
+            reason: 'cancelled',
+            message: 'The build was cancelled.',
+        });
+
+        expect(screen.getByText('Build cancelled')).toBeVisible();
+        expect(WorkerStub.last).toBeNull();
+    });
+
+    it('renders unavailable when the app is gone', async () => {
+        mockedLightdashApi.mockRejectedValue({
+            status: 'error',
+            error: { statusCode: 404, name: 'NotFoundError', message: '' },
+        });
+        renderCard(pending);
+
+        expect(
+            await screen.findByText('This app is no longer available.'),
+        ).toBeVisible();
+    });
+
+    it('renders nothing when the build never started', () => {
+        renderCard({
+            status: 'error',
+            appUuid: null,
+            reason: 'failed',
+            message: 'Data apps are not enabled',
+        });
+
+        expect(screen.getByTestId('host')).toBeEmptyDOMElement();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.tsx
@@ -8,8 +8,14 @@ import { useNavigate } from 'react-router';
 import { useAppBuildPoller } from '../../../../../../features/apps/hooks/useAppBuildPoller';
 import { useGetApp } from '../../../../../../features/apps/hooks/useGetApp';
 import { getAiAgentThreadQueryKey } from '../../../hooks/useProjectAiAgents';
-import { setPreview } from '../../../store/aiArtifactSlice';
-import { useAiAgentStoreDispatch } from '../../../store/hooks';
+import {
+    selectDataAppPreview,
+    setPreview,
+} from '../../../store/aiArtifactSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../../store/hooks';
 import { DataAppBuildCard } from './DataAppBuildCard';
 import {
     getDataAppBuildCardState,
@@ -57,6 +63,8 @@ export const AiDataAppBuildCard: FC<Props> = ({
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const { appUuid } = metadata;
+    const preview = useAiAgentStoreSelector(selectDataAppPreview);
+    const isActive = appUuid !== null && preview?.appUuid === appUuid;
 
     const appQuery = useGetApp(projectUuid, appUuid ?? undefined);
     const source = toAppSource(appQuery);
@@ -119,6 +127,7 @@ export const AiDataAppBuildCard: FC<Props> = ({
         <DataAppBuildCard
             state={state}
             compact={compact}
+            isActive={isActive}
             onOpenBuilder={() =>
                 void navigate(getDataAppBuilderPath(projectUuid, appUuid))
             }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/AiDataAppBuildCard.tsx
@@ -1,0 +1,128 @@
+import {
+    getDataAppBuilderPath,
+    type ToolGenerateDataAppOutput,
+} from '@lightdash/common';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import { useAppBuildPoller } from '../../../../../../features/apps/hooks/useAppBuildPoller';
+import { useGetApp } from '../../../../../../features/apps/hooks/useGetApp';
+import { getAiAgentThreadQueryKey } from '../../../hooks/useProjectAiAgents';
+import { setPreview } from '../../../store/aiArtifactSlice';
+import { useAiAgentStoreDispatch } from '../../../store/hooks';
+import { DataAppBuildCard } from './DataAppBuildCard';
+import {
+    getDataAppBuildCardState,
+    isDataAppBuildInProgress,
+    type DataAppBuildCardAppSource,
+} from './dataAppBuildCardState';
+
+type Props = {
+    metadata: ToolGenerateDataAppOutput['metadata'];
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    messageUuid: string;
+    compact: boolean;
+};
+
+const toAppSource = (
+    query: ReturnType<typeof useGetApp>,
+): DataAppBuildCardAppSource => {
+    const app = query.data?.pages[0];
+    if (app) return { kind: 'loaded', app };
+    if (query.error) {
+        const statusCode = query.error.error?.statusCode;
+        return statusCode === 403 || statusCode === 404
+            ? { kind: 'unavailable' }
+            : { kind: 'error' };
+    }
+    return { kind: 'loading' };
+};
+
+/**
+ * The build card under an agent reply. A pending result follows the app's
+ * live version at the builder's poll cadence; a terminal result stands on
+ * its own. The card never touches the composer.
+ */
+export const AiDataAppBuildCard: FC<Props> = ({
+    metadata,
+    projectUuid,
+    agentUuid,
+    threadUuid,
+    messageUuid,
+    compact,
+}) => {
+    const dispatch = useAiAgentStoreDispatch();
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const { appUuid } = metadata;
+
+    const appQuery = useGetApp(projectUuid, appUuid ?? undefined);
+    const source = toAppSource(appQuery);
+    const state = getDataAppBuildCardState(metadata, source);
+    const inProgress = state !== null && isDataAppBuildInProgress(state);
+    const isPolling = metadata.status === 'pending' && inProgress;
+
+    // The worker patches the tool result when the build ends; one refetch
+    // picks it up so the card no longer depends on the poll.
+    const refetchThread = useCallback(() => {
+        void queryClient.invalidateQueries({
+            queryKey: getAiAgentThreadQueryKey(
+                projectUuid,
+                agentUuid,
+                threadUuid,
+            ),
+        });
+    }, [queryClient, projectUuid, agentUuid, threadUuid]);
+    useAppBuildPoller(
+        projectUuid,
+        appUuid ?? undefined,
+        isPolling,
+        refetchThread,
+    );
+
+    const openPreview = useCallback(() => {
+        if (!appUuid) return;
+        dispatch(
+            setPreview({
+                type: 'dataApp',
+                appUuid,
+                messageUuid,
+                threadUuid,
+                projectUuid,
+                agentUuid,
+            }),
+        );
+    }, [dispatch, appUuid, messageUuid, threadUuid, projectUuid, agentUuid]);
+
+    // Open the preview once when a build watched in this session lands.
+    // Never on reload, and never again after the user closes it.
+    const isReady = state?.kind === 'ready';
+    const watchingLiveBuild = source.kind === 'loaded' && inProgress;
+    const watchedBuildRef = useRef(false);
+    const autoOpenedRef = useRef(false);
+    useEffect(() => {
+        if (watchingLiveBuild) {
+            watchedBuildRef.current = true;
+            return;
+        }
+        if (isReady && watchedBuildRef.current && !autoOpenedRef.current) {
+            autoOpenedRef.current = true;
+            openPreview();
+        }
+    }, [watchingLiveBuild, isReady, openPreview]);
+
+    if (!state || !appUuid) return null;
+
+    return (
+        <DataAppBuildCard
+            state={state}
+            compact={compact}
+            onOpenBuilder={() =>
+                void navigate(getDataAppBuilderPath(projectUuid, appUuid))
+            }
+            onView={openPreview}
+        />
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.module.css
@@ -4,6 +4,31 @@
     --card-icon-size: 22px;
 }
 
+.cardActive {
+    border-color: var(--mantine-color-ldDark-9);
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-7)
+    );
+}
+
+.split {
+    display: flex;
+    align-items: stretch;
+}
+
+.splitMain {
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+}
+
+.splitMenuButton {
+    height: auto;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
+    border-left: 0;
+}
+
 .cardUnavailable {
     background-color: light-dark(
         var(--mantine-color-ldGray-0),

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.test.tsx
@@ -13,6 +13,7 @@ describe('DataAppBuildCard', () => {
             <DataAppBuildCard
                 state={{ kind: 'queued' }}
                 compact={false}
+                isActive={false}
                 onOpenBuilder={onOpenBuilder}
                 onView={noop}
             />,
@@ -41,6 +42,7 @@ describe('DataAppBuildCard', () => {
                     },
                 }}
                 compact={false}
+                isActive={false}
                 onOpenBuilder={noop}
                 onView={noop}
             />,
@@ -59,7 +61,7 @@ describe('DataAppBuildCard', () => {
         ).toBeVisible();
     });
 
-    it('ready: names the app, version, duration and wires both actions', async () => {
+    it('ready: names the app, version, duration; View is primary and the builder sits in its menu', async () => {
         const onOpenBuilder = vi.fn();
         const onView = vi.fn();
         renderWithProviders(
@@ -72,6 +74,7 @@ describe('DataAppBuildCard', () => {
                     completionMessage: 'Your app is ready.',
                 }}
                 compact={false}
+                isActive={false}
                 onOpenBuilder={onOpenBuilder}
                 onView={onView}
             />,
@@ -81,8 +84,16 @@ describe('DataAppBuildCard', () => {
         expect(screen.getByText('Your app is ready.')).toBeVisible();
         await userEvent.click(screen.getByRole('button', { name: 'View' }));
         expect(onView).toHaveBeenCalledTimes(1);
+        expect(
+            screen.queryByText('Continue in builder'),
+        ).not.toBeInTheDocument();
         await userEvent.click(
-            screen.getByRole('button', { name: 'Continue in builder' }),
+            screen.getByRole('button', { name: 'More actions' }),
+        );
+        await userEvent.click(
+            await screen.findByRole('menuitem', {
+                name: 'Continue in builder',
+            }),
         );
         expect(onOpenBuilder).toHaveBeenCalledTimes(1);
     });
@@ -98,6 +109,7 @@ describe('DataAppBuildCard', () => {
                     completionMessage: 'Done.',
                 }}
                 compact={false}
+                isActive={false}
                 onOpenBuilder={noop}
                 onView={noop}
             />,
@@ -114,6 +126,7 @@ describe('DataAppBuildCard', () => {
                     message: 'Build failed while generating.',
                 }}
                 compact={false}
+                isActive={false}
                 onOpenBuilder={onOpenBuilder}
                 onView={noop}
             />,
@@ -133,6 +146,7 @@ describe('DataAppBuildCard', () => {
             <DataAppBuildCard
                 state={{ kind: 'cancelled' }}
                 compact={false}
+                isActive={false}
                 onOpenBuilder={noop}
                 onView={noop}
             />,
@@ -148,6 +162,7 @@ describe('DataAppBuildCard', () => {
             <DataAppBuildCard
                 state={{ kind: 'unavailable' }}
                 compact={false}
+                isActive={false}
                 onOpenBuilder={noop}
                 onView={noop}
             />,
@@ -158,7 +173,7 @@ describe('DataAppBuildCard', () => {
         expect(screen.queryAllByRole('button')).toHaveLength(0);
     });
 
-    it('compact ready: collapses to one row with a single builder action', () => {
+    it('compact ready: collapses to one row but keeps View', () => {
         renderWithProviders(
             <DataAppBuildCard
                 state={{
@@ -169,6 +184,7 @@ describe('DataAppBuildCard', () => {
                     completionMessage: 'Your app is ready.',
                 }}
                 compact
+                isActive={false}
                 onOpenBuilder={noop}
                 onView={noop}
             />,
@@ -178,9 +194,9 @@ describe('DataAppBuildCard', () => {
         expect(
             screen.queryByText('Your app is ready.'),
         ).not.toBeInTheDocument();
-        expect(screen.getAllByRole('button')).toHaveLength(1);
+        expect(screen.getByRole('button', { name: 'View' })).toBeVisible();
         expect(
-            screen.getByRole('button', { name: 'Continue in builder' }),
+            screen.getByRole('button', { name: 'More actions' }),
         ).toBeVisible();
     });
 
@@ -192,6 +208,7 @@ describe('DataAppBuildCard', () => {
                     message: 'Build failed while generating.',
                 }}
                 compact
+                isActive={false}
                 onOpenBuilder={noop}
                 onView={noop}
             />,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.tsx
@@ -307,7 +307,6 @@ const renderCells = (
  * Presentational build card shown under the agent's reply. Pure function of
  * `state`; navigation and data live in the caller.
  */
-// ts-unused-exports:disable-next-line
 export const DataAppBuildCard: FC<Props> = ({
     state,
     compact,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/DataAppBuildCard.tsx
@@ -1,9 +1,19 @@
 import { assertUnreachable } from '@lightdash/common';
-import { Box, Button, Paper, Stack, Text, ThemeIcon } from '@mantine/core';
+import {
+    ActionIcon,
+    Box,
+    Button,
+    Menu,
+    Paper,
+    Stack,
+    Text,
+    ThemeIcon,
+} from '@mantine/core';
 import {
     IconAlertTriangle,
     IconAppWindow,
     IconArrowRight,
+    IconChevronDown,
     IconCircleMinus,
     IconEye,
 } from '@tabler/icons-react';
@@ -37,6 +47,8 @@ type Props = {
     state: DataAppBuildCardState;
     /** Earlier turns: ready and failed collapse to a single row. */
     compact: boolean;
+    /** This app is the one open in the preview panel. */
+    isActive: boolean;
     onOpenBuilder: () => void;
     onView: () => void;
 };
@@ -52,20 +64,53 @@ const readySubtitle = (
 
 const BuilderButton: FC<{
     label: 'Continue in builder' | 'Open in builder';
-    primary?: boolean;
     onClick: () => void;
-}> = ({ label, primary = false, onClick }) => (
-    <Button
-        variant={primary ? 'filled' : 'default'}
-        color={primary ? 'dark' : undefined}
-        size="compact-xs"
-        onClick={onClick}
-        rightSection={
-            primary ? <MantineIcon icon={IconArrowRight} size={14} /> : null
-        }
-    >
+}> = ({ label, onClick }) => (
+    <Button variant="default" size="compact-xs" onClick={onClick}>
         {label}
     </Button>
+);
+
+/** View opens the preview; the chevron holds the secondary actions. */
+const ViewSplitButton: FC<{
+    onView: () => void;
+    onOpenBuilder: () => void;
+}> = ({ onView, onOpenBuilder }) => (
+    <Box className={styles.split}>
+        <Button
+            variant="default"
+            size="compact-xs"
+            className={styles.splitMain}
+            leftSection={<MantineIcon icon={IconEye} size={14} />}
+            onClick={onView}
+        >
+            View
+        </Button>
+        <Menu position="bottom-end" withinPortal shadow="md">
+            <Menu.Target>
+                <ActionIcon
+                    variant="default"
+                    size={22}
+                    className={styles.splitMenuButton}
+                    aria-label="More actions"
+                >
+                    <MantineIcon icon={IconChevronDown} size={12} />
+                </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown p={4}>
+                <Menu.Item
+                    fz="xs"
+                    py={4}
+                    leftSection={
+                        <MantineIcon icon={IconArrowRight} size={14} />
+                    }
+                    onClick={onOpenBuilder}
+                >
+                    Continue in builder
+                </Menu.Item>
+            </Menu.Dropdown>
+        </Menu>
+    </Box>
 );
 
 const CardIcon: FC<{ tone: 'default' | 'error' | 'muted' }> = ({ tone }) => (
@@ -202,9 +247,9 @@ const renderCells = (
                             />
                         </Lead>
                         <Actions>
-                            <BuilderButton
-                                label="Continue in builder"
-                                onClick={onOpenBuilder}
+                            <ViewSplitButton
+                                onView={onView}
+                                onOpenBuilder={onOpenBuilder}
                             />
                         </Actions>
                     </>
@@ -217,20 +262,9 @@ const renderCells = (
                         <Muted>{readySubtitle(state)}</Muted>
                     </Lead>
                     <Actions>
-                        <Button
-                            variant="default"
-                            size="compact-xs"
-                            leftSection={
-                                <MantineIcon icon={IconEye} size={14} />
-                            }
-                            onClick={onView}
-                        >
-                            View
-                        </Button>
-                        <BuilderButton
-                            label="Continue in builder"
-                            primary
-                            onClick={onOpenBuilder}
+                        <ViewSplitButton
+                            onView={onView}
+                            onOpenBuilder={onOpenBuilder}
                         />
                     </Actions>
                     <Body>
@@ -310,6 +344,7 @@ const renderCells = (
 export const DataAppBuildCard: FC<Props> = ({
     state,
     compact,
+    isActive,
     onOpenBuilder,
     onView,
 }) => (
@@ -319,6 +354,7 @@ export const DataAppBuildCard: FC<Props> = ({
         radius="md"
         className={clsx(styles.card, {
             [styles.cardUnavailable]: state.kind === 'unavailable',
+            [styles.cardActive]: isActive,
         })}
     >
         <Box className={styles.layout}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.test.ts
@@ -1,0 +1,324 @@
+import {
+    APP_VERSION_CANCELLED_BY_USER,
+    type ApiAppVersionSummary,
+    type ApiGetAppResponse,
+    type ToolGenerateDataAppOutput,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getDataAppBuildCardState } from './dataAppBuildCardState';
+
+type Metadata = ToolGenerateDataAppOutput['metadata'];
+
+const pending: Metadata = { status: 'pending', appUuid: 'app-1', version: 1 };
+
+const version = (
+    overrides: Partial<ApiAppVersionSummary>,
+): ApiAppVersionSummary => ({
+    version: 1,
+    prompt: 'Build me a revenue app',
+    status: 'generating',
+    statusMessage: null,
+    statusHistory: [],
+    error: null,
+    createdAt: new Date('2026-08-28T10:00:00.000Z'),
+    statusUpdatedAt: null,
+    createdByUser: null,
+    resources: null,
+    ...overrides,
+});
+
+const app = (
+    versions: ApiAppVersionSummary[],
+    name = 'Revenue app',
+): ApiGetAppResponse['results'] => ({
+    appUuid: 'app-1',
+    name,
+    description: '',
+    createdByUserUuid: 'user-1',
+    spaceUuid: null,
+    spaceName: null,
+    template: null,
+    pinnedListUuid: null,
+    pinnedListOrder: null,
+    slug: 'revenue-app',
+    views: 0,
+    versions,
+    hasMore: false,
+    latestReadyVersion: null,
+});
+
+const loaded = (versions: ApiAppVersionSummary[], name?: string) =>
+    ({ kind: 'loaded', app: app(versions, name) }) as const;
+
+describe('getDataAppBuildCardState', () => {
+    describe('pending tool result', () => {
+        it('is queued before the app has loaded', () => {
+            expect(
+                getDataAppBuildCardState(pending, { kind: 'loading' }),
+            ).toEqual({ kind: 'queued' });
+        });
+
+        it('is queued while the version is pending', () => {
+            expect(
+                getDataAppBuildCardState(
+                    pending,
+                    loaded([version({ status: 'pending' })]),
+                ),
+            ).toEqual({ kind: 'queued' });
+        });
+
+        it('is queued when the version is not in the fetched page', () => {
+            expect(getDataAppBuildCardState(pending, loaded([]))).toEqual({
+                kind: 'queued',
+            });
+        });
+
+        it('stays queued on a transient fetch error so polling continues', () => {
+            expect(
+                getDataAppBuildCardState(pending, { kind: 'error' }),
+            ).toEqual({ kind: 'queued' });
+        });
+
+        it('is building with the status message and narration mid-build', () => {
+            expect(
+                getDataAppBuildCardState(
+                    pending,
+                    loaded([
+                        version({
+                            status: 'generating',
+                            statusMessage: 'Generating your app',
+                            statusHistory: [
+                                {
+                                    kind: 'thinking',
+                                    message: 'Weekly totals by region',
+                                    timestamp: '2026-08-28T10:00:01.000Z',
+                                },
+                                {
+                                    kind: 'tool',
+                                    message: 'Creating App.tsx',
+                                    timestamp: '2026-08-28T10:00:02.000Z',
+                                },
+                            ],
+                        }),
+                    ]),
+                ),
+            ).toEqual({
+                kind: 'building',
+                statusMessage: 'Generating your app',
+                narration: {
+                    reasoning: ['Weekly totals by region'],
+                    activity: ['Creating App.tsx'],
+                },
+            });
+        });
+
+        it('falls back to a generic stage line when the build has no status message', () => {
+            expect(
+                getDataAppBuildCardState(
+                    pending,
+                    loaded([version({ status: 'sandbox' })]),
+                ),
+            ).toMatchObject({
+                kind: 'building',
+                statusMessage: 'Building your app',
+            });
+        });
+
+        it('is ready with duration and completion message once the version is ready', () => {
+            expect(
+                getDataAppBuildCardState(
+                    pending,
+                    loaded([
+                        version({
+                            status: 'ready',
+                            statusMessage: 'Your revenue app is ready.',
+                            statusUpdatedAt: new Date(
+                                '2026-08-28T10:06:12.000Z',
+                            ),
+                        }),
+                    ]),
+                ),
+            ).toEqual({
+                kind: 'ready',
+                name: 'Revenue app',
+                version: 1,
+                durationMs: 372_000,
+                completionMessage: 'Your revenue app is ready.',
+            });
+        });
+
+        it('uses a placeholder name for an app that never got titled', () => {
+            expect(
+                getDataAppBuildCardState(
+                    pending,
+                    loaded([version({ status: 'ready' })], ''),
+                ),
+            ).toMatchObject({
+                kind: 'ready',
+                name: 'Untitled app app-1',
+                completionMessage: 'Your app is ready!',
+                durationMs: null,
+            });
+        });
+
+        it("is failed with the builder's failure copy", () => {
+            expect(
+                getDataAppBuildCardState(
+                    pending,
+                    loaded([
+                        version({
+                            status: 'error',
+                            statusMessage: 'Failed to deploy your app.',
+                            error: 'stderr',
+                        }),
+                    ]),
+                ),
+            ).toEqual({
+                kind: 'failed',
+                message: 'Failed to deploy your app.',
+            });
+        });
+
+        it('is cancelled when the version carries the cancellation marker', () => {
+            expect(
+                getDataAppBuildCardState(
+                    pending,
+                    loaded([
+                        version({
+                            status: 'error',
+                            statusMessage: APP_VERSION_CANCELLED_BY_USER,
+                            error: APP_VERSION_CANCELLED_BY_USER,
+                        }),
+                    ]),
+                ),
+            ).toEqual({ kind: 'cancelled' });
+        });
+
+        it('is unavailable when the app is gone or inaccessible', () => {
+            expect(
+                getDataAppBuildCardState(pending, { kind: 'unavailable' }),
+            ).toEqual({ kind: 'unavailable' });
+        });
+
+        it('reads the requested version, not the newest one', () => {
+            expect(
+                getDataAppBuildCardState(
+                    pending,
+                    loaded([
+                        version({ version: 2, status: 'generating' }),
+                        version({ version: 1, status: 'ready' }),
+                    ]),
+                ),
+            ).toMatchObject({ kind: 'ready', version: 1 });
+        });
+    });
+
+    describe('success tool result', () => {
+        const success: Metadata = {
+            status: 'success',
+            appUuid: 'app-1',
+            version: 1,
+            name: 'Revenue app',
+            href: '/projects/proj-1/apps/app-1',
+        };
+
+        it('renders ready from the result before the app loads', () => {
+            expect(
+                getDataAppBuildCardState(success, { kind: 'loading' }),
+            ).toEqual({
+                kind: 'ready',
+                name: 'Revenue app',
+                version: 1,
+                durationMs: null,
+                completionMessage: 'Your app is ready!',
+            });
+        });
+
+        it('fills in duration and completion message once the app loads', () => {
+            expect(
+                getDataAppBuildCardState(
+                    success,
+                    loaded([
+                        version({
+                            status: 'ready',
+                            statusMessage: 'Done.',
+                            statusUpdatedAt: new Date(
+                                '2026-08-28T10:00:30.000Z',
+                            ),
+                        }),
+                    ]),
+                ),
+            ).toEqual({
+                kind: 'ready',
+                name: 'Revenue app',
+                version: 1,
+                durationMs: 30_000,
+                completionMessage: 'Done.',
+            });
+        });
+
+        it('is unavailable when the app was deleted since', () => {
+            expect(
+                getDataAppBuildCardState(success, { kind: 'unavailable' }),
+            ).toEqual({ kind: 'unavailable' });
+        });
+    });
+
+    describe('error tool result', () => {
+        it('is failed with the recorded message', () => {
+            expect(
+                getDataAppBuildCardState(
+                    {
+                        status: 'error',
+                        appUuid: 'app-1',
+                        reason: 'failed',
+                        message: 'Build timed out.',
+                    },
+                    { kind: 'loading' },
+                ),
+            ).toEqual({ kind: 'failed', message: 'Build timed out.' });
+        });
+
+        it('is unavailable when the failed app has since been deleted', () => {
+            expect(
+                getDataAppBuildCardState(
+                    {
+                        status: 'error',
+                        appUuid: 'app-1',
+                        reason: 'failed',
+                        message: 'Build timed out.',
+                    },
+                    { kind: 'unavailable' },
+                ),
+            ).toEqual({ kind: 'unavailable' });
+        });
+
+        it('is cancelled for a recorded cancellation', () => {
+            expect(
+                getDataAppBuildCardState(
+                    {
+                        status: 'error',
+                        appUuid: 'app-1',
+                        reason: 'cancelled',
+                        message: 'The build was cancelled.',
+                    },
+                    { kind: 'loading' },
+                ),
+            ).toEqual({ kind: 'cancelled' });
+        });
+
+        it('renders no card when the build never started', () => {
+            expect(
+                getDataAppBuildCardState(
+                    {
+                        status: 'error',
+                        appUuid: null,
+                        reason: 'failed',
+                        message: 'Data apps are not enabled',
+                    },
+                    { kind: 'loading' },
+                ),
+            ).toBeNull();
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppBuildCard/dataAppBuildCardState.ts
@@ -1,0 +1,133 @@
+import {
+    APP_VERSION_CANCELLED_BY_USER,
+    assertUnreachable,
+    getAppDisplayName,
+    isAppVersionInProgress,
+    type ApiAppVersionSummary,
+    type ApiGetAppResponse,
+    type ToolGenerateDataAppOutput,
+} from '@lightdash/common';
+import { getAppVersionFailureMessage } from '../../../../../../features/apps/getAppVersionFailureMessage';
+import { getVersionNarration } from '../../../../../../features/apps/utils/versionNarration';
+import { type DataAppBuildCardState } from './DataAppBuildCard';
+
+type AppData = ApiGetAppResponse['results'];
+
+/** What the thread knows about the app the build belongs to. */
+export type DataAppBuildCardAppSource =
+    | { kind: 'loading' }
+    | { kind: 'loaded'; app: AppData }
+    // Deleted or no access (403/404).
+    | { kind: 'unavailable' }
+    // Any other fetch failure; treated as transient.
+    | { kind: 'error' };
+
+const getBuildDurationMs = (row: ApiAppVersionSummary): number | null =>
+    row.statusUpdatedAt
+        ? new Date(row.statusUpdatedAt).getTime() -
+          new Date(row.createdAt).getTime()
+        : null;
+
+const getReadyState = ({
+    appUuid,
+    name,
+    version,
+    row,
+}: {
+    appUuid: string;
+    name: string;
+    version: number;
+    row: ApiAppVersionSummary | undefined;
+}): DataAppBuildCardState => ({
+    kind: 'ready',
+    name: getAppDisplayName(name, appUuid),
+    version,
+    durationMs: row ? getBuildDurationMs(row) : null,
+    completionMessage:
+        row?.statusMessage ??
+        (version === 1 ? 'Your app is ready!' : `Version ${version} is ready!`),
+});
+
+const getStateFromVersionRow = (
+    metadata: Extract<
+        ToolGenerateDataAppOutput['metadata'],
+        { status: 'pending' }
+    >,
+    app: AppData,
+): DataAppBuildCardState => {
+    const row = app.versions.find((v) => v.version === metadata.version);
+    if (!row || row.status === 'pending') {
+        return { kind: 'queued' };
+    }
+    if (isAppVersionInProgress(row.status)) {
+        return {
+            kind: 'building',
+            statusMessage: row.statusMessage ?? 'Building your app',
+            narration: getVersionNarration(row.statusHistory),
+        };
+    }
+    if (row.status === 'ready') {
+        return getReadyState({
+            appUuid: metadata.appUuid,
+            name: app.name,
+            version: metadata.version,
+            row,
+        });
+    }
+    if (row.error === APP_VERSION_CANCELLED_BY_USER) {
+        return { kind: 'cancelled' };
+    }
+    return { kind: 'failed', message: getAppVersionFailureMessage(row) };
+};
+
+/**
+ * Card state for a generateDataApp tool result. A pending result is read
+ * from the app's live version; a terminal result stands on its own, with
+ * the app only enriching the ready card. Null when there is nothing to show.
+ */
+export const getDataAppBuildCardState = (
+    metadata: ToolGenerateDataAppOutput['metadata'],
+    source: DataAppBuildCardAppSource,
+): DataAppBuildCardState | null => {
+    switch (metadata.status) {
+        case 'error':
+            if (metadata.appUuid === null) return null;
+            if (source.kind === 'unavailable') return { kind: 'unavailable' };
+            return metadata.reason === 'cancelled'
+                ? { kind: 'cancelled' }
+                : { kind: 'failed', message: metadata.message };
+        case 'success': {
+            if (source.kind === 'unavailable') return { kind: 'unavailable' };
+            const row =
+                source.kind === 'loaded'
+                    ? source.app.versions.find(
+                          (v) => v.version === metadata.version,
+                      )
+                    : undefined;
+            return getReadyState({
+                appUuid: metadata.appUuid,
+                name: metadata.name,
+                version: metadata.version,
+                row,
+            });
+        }
+        case 'pending':
+            switch (source.kind) {
+                case 'unavailable':
+                    return { kind: 'unavailable' };
+                case 'loaded':
+                    return getStateFromVersionRow(metadata, source.app);
+                case 'loading':
+                case 'error':
+                    return { kind: 'queued' };
+                default:
+                    return assertUnreachable(source, 'Unknown app source');
+            }
+        default:
+            return assertUnreachable(metadata, 'Unknown build result');
+    }
+};
+
+export const isDataAppBuildInProgress = (
+    state: DataAppBuildCardState,
+): boolean => state.kind === 'queued' || state.kind === 'building';

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.module.css
@@ -416,8 +416,15 @@
 }
 
 .reasoningRow {
+    /* Header padding + icon slot + gap; the body indents to the label. */
+    --reasoning-icon-size: 13px;
+    --reasoning-inset: calc(12px + var(--reasoning-icon-size) + 8px);
     border-radius: 10px;
     font-family: var(--mantine-font-family);
+}
+
+.reasoningRow[data-live='true'] {
+    --reasoning-icon-size: 20px;
 }
 
 .reasoningRow:hover .chevron {
@@ -491,7 +498,7 @@
 }
 
 .reasoningBody {
-    padding: 6px 8px 4px;
+    padding: 2px 12px 6px var(--reasoning-inset);
     font-style: italic;
     color: var(--mantine-color-ldGray-7);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
@@ -191,7 +191,7 @@ export const ReasoningHistoryRow: FC<{
     const hasOverflow = previewClean.length > REASONING_PREVIEW_LENGTH;
 
     return (
-        <Box className={styles.reasoningRow}>
+        <Box className={styles.reasoningRow} data-live={isLive}>
             <UnstyledButton
                 w="100%"
                 onClick={() => setOpen((prev) => !prev)}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -628,6 +628,12 @@ export const useDeleteAiAgentThreadMutation = (projectUuid: string) => {
     });
 };
 
+export const getAiAgentThreadQueryKey = (
+    projectUuid: string,
+    agentUuid: string | undefined,
+    threadUuid: string | null | undefined,
+) => [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', threadUuid] as const;
+
 export const useAiAgentThread = (
     projectUuid: string,
     agentUuid: string | undefined,
@@ -638,13 +644,7 @@ export const useAiAgentThread = (
     const navigate = useNavigate();
 
     return useQuery<ApiAiAgentThreadResponse['results'], ApiError>({
-        queryKey: [
-            AI_AGENTS_KEY,
-            projectUuid,
-            agentUuid,
-            'threads',
-            threadUuid,
-        ],
+        queryKey: getAiAgentThreadQueryKey(projectUuid, agentUuid, threadUuid),
         queryFn: () => {
             return getAgentThread(projectUuid, agentUuid!, threadUuid!);
         },

--- a/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
+++ b/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
@@ -1044,6 +1044,7 @@ const ComponentInventory = () => (
                         <DataAppBuildCard
                             state={state}
                             compact={false}
+                            isActive={state.kind === 'ready'}
                             {...buildCardActions}
                         />
                     </Box>
@@ -1055,6 +1056,7 @@ const ComponentInventory = () => (
                             <DataAppBuildCard
                                 state={state}
                                 compact
+                                isActive={false}
                                 {...buildCardActions}
                             />
                         </Box>


### PR DESCRIPTION
## Summary

Stacked on #28255 (ZAP-956). Wires the presentational build card (#28229) into the thread.

- `AiDataAppBuildCard` mounts under the agent reply for any `generateDataApp` result, in the same slot as the PR write-back card — persisted result first, else the live stream part. Earlier turns render compact.
- **Pending result**: reads the app's live version through `useGetApp` and polls at the builder's cadence with the builder's own `useAppBuildPoller` (3s worker, stops itself on a terminal version). State derivation is a pure function (`dataAppBuildCardState.ts`): pending → queued; in-progress stages → building (status message + Reasoning/Activity narration); ready; error → failed (builder's failure copy) or cancelled; 403/404 → unavailable. One thread refetch on terminal picks up the server-patched result, after which the card stands on the tool result and polling is off.
- **Ready**: the app opens in the thread's data app preview panel (existing panel, mobile bottom drawer included) exactly once, and only for a build watched live in this session — never on reload, never again after the user closes it. **View** reopens it; **Continue in builder** / **Open in builder** navigate to the app's builder.
- The card never touches the composer or stream state.
- Tool contract (unreleased, from #28255): error metadata gains `appUuid: string | null` (null when the build never started) and `reason: 'failed' | 'cancelled'`, so failed/cancelled cards can link to the builder and tell cancelled from failed without matching copy.
- Glossary: **Build card** added to `docs/data-apps/CONTEXT.md`.

## Decisions

- `View` is the only action on ready cards (full and compact) and reopens the preview; `Continue in builder` sits in its split-button menu. The card highlights while its app is the one in the preview panel, so switching between several build cards in a thread is legible.
- A start-time failure (`appUuid: null`, e.g. data apps disabled) renders no card — the card's failed state always carries "Open in builder", and the agent's reply already explains it. Easy to flip if a button-less failed card is preferred.
- The poller watches the app's *latest* version (builder behaviour). If someone iterates in the builder while the agent's build is pending, polling runs until that newer build ends; the card still self-heals via the server-side tool result.

## Tests

- Pure: 19 derivation cases across pending / success / error results and loading / loaded / unavailable / transient-error app sources.
- Component (real Redux store, mocked API + Worker): building → ready opens the preview once; close stays closed; View reopens; a reload of a finished build never auto-opens and never starts the poller; 404 renders unavailable; no card when the build never started.
- Not verified in a live browser — needs a real coding-agent build. Worth a manual pass on a dev thread.

Closes: ZAP-961
