### PR TITLE
feat(direct-access): add sharedWithMe selector to v2 content endpoint

### DIFF
--- a/packages/backend/src/controllers/v2/ContentController.ts
+++ b/packages/backend/src/controllers/v2/ContentController.ts
@@ -63,6 +63,7 @@ export class ContentController extends BaseController {
         @Query() includePersonalDataApps?: boolean,
         @Query() dataAppVizsFilter?: 'exclude' | 'only',
         @Query() ownerUserUuids?: string[],
+        @Query() sharedWithMe?: boolean,
     ): Promise<ApiContentResponse> {
         const { user } = getAccountApiAccessContext(req.account!);
         this.setStatus(200);
@@ -79,6 +80,7 @@ export class ContentController extends BaseController {
                     includePersonalDataApps,
                     dataAppVizsFilter,
                     ownerUserUuids,
+                    sharedWithMe,
                 },
                 {
                     sortBy,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
@@ -62,6 +62,7 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                     if (
                         !filters.deleted &&
                         !filters.dataApps &&
+                        !filters.sharedWithMe &&
                         filters.dataAppVizsFilter !== 'only'
                     ) {
                         void personalFilter.whereNotNull(

--- a/packages/backend/src/models/ContentModel/ContentModelTypes.ts
+++ b/packages/backend/src/models/ContentModel/ContentModelTypes.ts
@@ -38,6 +38,12 @@ export type ContentFilters = {
     deleted?: boolean;
     deletedByUserUuids?: string[];
     /**
+     * Shared-with-me hydration: `uuids` holds resources the caller was
+     * directly granted, so per-space and personal-app visibility scoping is
+     * relaxed — authorization was already decided from the grant tables.
+     */
+    sharedWithMe?: boolean;
+    /**
      * Only dashboards have owners, so this filter restricts results to
      * dashboards owned by one of these users (other content types are
      * excluded entirely while it is set).

--- a/packages/backend/src/models/DirectAccessModel.integration.test.ts
+++ b/packages/backend/src/models/DirectAccessModel.integration.test.ts
@@ -623,6 +623,77 @@ describe('DirectAccessModel generic store PostgreSQL integration', () => {
         });
     });
 
+    describe('findCandidateResourceUuidsForUser', () => {
+        it('collects user grants, group grants, and deduplicates overlap', async () => {
+            const userGrantedUuid = await createDashboard();
+            const groupGrantedUuid = await createDashboard();
+            const overlapUuid = await createDashboard();
+            const ungrantedUuid = await createDashboard();
+            await transaction(DashboardUserAccessTableName).insert([
+                {
+                    dashboard_uuid: userGrantedUuid,
+                    user_uuid: userUuid,
+                    space_role: SpaceMemberRole.VIEWER,
+                    granted_by_user_uuid: userUuid,
+                },
+                {
+                    dashboard_uuid: overlapUuid,
+                    user_uuid: userUuid,
+                    space_role: SpaceMemberRole.VIEWER,
+                    granted_by_user_uuid: userUuid,
+                },
+            ]);
+            await transaction(DashboardGroupAccessTableName).insert([
+                {
+                    dashboard_uuid: groupGrantedUuid,
+                    group_uuid: groupUuid,
+                    space_role: SpaceMemberRole.EDITOR,
+                    granted_by_user_uuid: userUuid,
+                },
+                {
+                    dashboard_uuid: overlapUuid,
+                    group_uuid: groupUuid,
+                    space_role: SpaceMemberRole.EDITOR,
+                    granted_by_user_uuid: userUuid,
+                },
+            ]);
+
+            const candidates = await store.findCandidateResourceUuidsForUser(
+                DirectAccessResourceType.DASHBOARD,
+                userUuid,
+            );
+            expect(candidates.sort()).toEqual(
+                [userGrantedUuid, groupGrantedUuid, overlapUuid].sort(),
+            );
+            expect(candidates).not.toContain(ungrantedUuid);
+        });
+
+        it('ignores grants made to groups the user is not a member of', async () => {
+            const dashboardUuid = await createDashboard();
+            const [otherGroup] = await transaction(GroupTableName)
+                .insert({
+                    organization_id: organizationId,
+                    name: `Direct access store other group ${randomUUID()}`,
+                    created_by_user_uuid: userUuid,
+                    updated_by_user_uuid: userUuid,
+                })
+                .returning('group_uuid');
+            await transaction(DashboardGroupAccessTableName).insert({
+                dashboard_uuid: dashboardUuid,
+                group_uuid: otherGroup.group_uuid,
+                space_role: SpaceMemberRole.VIEWER,
+                granted_by_user_uuid: userUuid,
+            });
+
+            await expect(
+                store.findCandidateResourceUuidsForUser(
+                    DirectAccessResourceType.DASHBOARD,
+                    userUuid,
+                ),
+            ).resolves.toEqual([]);
+        });
+    });
+
     describe('replacePolicy', () => {
         it('atomically replaces the whole policy', async () => {
             const dashboardUuid = await createDashboard();

--- a/packages/backend/src/models/DirectAccessModel.ts
+++ b/packages/backend/src/models/DirectAccessModel.ts
@@ -21,6 +21,7 @@ import {
 } from '../database/entities/dashboardAccess';
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { EmailTableName } from '../database/entities/emails';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
 import { GroupTableName } from '../database/entities/groups';
 import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectTableName } from '../database/entities/projects';
@@ -892,6 +893,45 @@ export class DirectAccessModel {
                     'Unsupported direct access resource type',
                 );
         }
+    }
+
+    /**
+     * Uuids of resources of one type that carry a persisted grant for the
+     * user or any of their groups. A cheap candidate scan only — callers must
+     * validate candidates through the type's read model (`getUserAccess`) so
+     * inert grants (lost membership, deleted resources, ineligible ownership)
+     * never surface.
+     */
+    async findCandidateResourceUuidsForUser(
+        resourceType: DirectAccessResourceType,
+        userUuid: UUID,
+    ): Promise<UUID[]> {
+        const config = TABLE_CONFIG[resourceType];
+        const rows: { resourceUuid: string }[] = await this.database(
+            config.userTable,
+        )
+            .select({
+                resourceUuid: `${config.userTable}.${config.resourceColumn}`,
+            })
+            .where(`${config.userTable}.user_uuid`, userUuid)
+            .unionAll(
+                this.database(config.groupTable)
+                    .select({
+                        resourceUuid: `${config.groupTable}.${config.resourceColumn}`,
+                    })
+                    .innerJoin(
+                        GroupMembershipTableName,
+                        `${GroupMembershipTableName}.group_uuid`,
+                        `${config.groupTable}.group_uuid`,
+                    )
+                    .innerJoin(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${GroupMembershipTableName}.user_id`,
+                    )
+                    .where(`${UserTableName}.user_uuid`, userUuid),
+            );
+        return [...new Set(rows.map((row) => row.resourceUuid))];
     }
 
     // ------------------------------------------------------------------

--- a/packages/backend/src/services/ContentService/ContentService.test.ts
+++ b/packages/backend/src/services/ContentService/ContentService.test.ts
@@ -64,10 +64,12 @@ const createService = ({
     contentModel = {} as ContentModel,
     spaceModel = {} as SpaceModel,
     spacePermissionService = {} as SpacePermissionService,
+    sharedWithMeUuids = { dashboard: [], chart: [], sqlChart: [], app: [] },
 }: {
     contentModel?: ContentModel;
     spaceModel?: SpaceModel;
     spacePermissionService?: SpacePermissionService;
+    sharedWithMeUuids?: Record<string, string[]>;
 } = {}) => {
     const projectModel = {
         getAllByOrganizationUuid: vi.fn().mockResolvedValue([
@@ -106,6 +108,9 @@ const createService = ({
         deleteChartValidations: vi.fn().mockResolvedValue(undefined),
         deleteDashboardValidations: vi.fn().mockResolvedValue(undefined),
     };
+    const directAccessService = {
+        findSharedWithMeUuids: vi.fn().mockResolvedValue(sharedWithMeUuids),
+    };
 
     return {
         service: new ContentService({
@@ -119,6 +124,7 @@ const createService = ({
                 savedChartService as unknown as SavedChartService,
             savedSqlService: savedSqlService as unknown as SavedSqlService,
             spacePermissionService,
+            directAccessService: directAccessService as never,
             validationModel: validationModel as unknown as ValidationModel,
             appMoveService: undefined,
             appGenerateService: undefined,
@@ -129,6 +135,7 @@ const createService = ({
         dashboardService,
         spaceService,
         validationModel,
+        directAccessService,
     };
 };
 
@@ -578,5 +585,146 @@ describe('ContentService.findDeleted', () => {
             }),
         ).rejects.toThrow(ForbiddenError);
         expect(findDeletedContents).not.toHaveBeenCalled();
+    });
+});
+
+describe('ContentService.find sharedWithMe', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const emptyModelPage = async (): Promise<
+        KnexPaginatedData<SummaryContent[]>
+    > => ({
+        pagination: {
+            page: 1,
+            pageSize: 10,
+            totalPageCount: 1,
+            totalResults: 2,
+        },
+        data: [],
+    });
+
+    it('hydrates only granted uuids without space scoping', async () => {
+        const findSummaryContents = vi.fn(emptyModelPage);
+        const getAccessibleSpaceUuids = vi.fn();
+        const deps = createService({
+            contentModel: {
+                findSummaryContents,
+            } as unknown as ContentModel,
+            spacePermissionService: {
+                getAccessibleSpaceUuids,
+            } as unknown as SpacePermissionService,
+            sharedWithMeUuids: {
+                dashboard: ['dashboard-1'],
+                chart: ['chart-1'],
+                sqlChart: ['sql-chart-1'],
+                app: ['app-1'],
+            },
+        });
+
+        await deps.service.find(
+            createUser(),
+            { sharedWithMe: true },
+            {},
+            { page: 1, pageSize: 10 },
+        );
+
+        expect(
+            deps.directAccessService.findSharedWithMeUuids,
+        ).toHaveBeenCalledWith({ userUuid, organizationUuid }, [projectUuid]);
+        expect(getAccessibleSpaceUuids).not.toHaveBeenCalled();
+        expect(findSummaryContents).toHaveBeenCalledWith(
+            {
+                projectUuids: [projectUuid],
+                uuids: ['dashboard-1', 'chart-1', 'sql-chart-1', 'app-1'],
+                contentTypes: [
+                    ContentType.DASHBOARD,
+                    ContentType.CHART,
+                    ContentType.DATA_APP,
+                ],
+                search: undefined,
+                dataAppVizsFilter: undefined,
+                sharedWithMe: true,
+            },
+            expect.any(Object),
+            expect.objectContaining({ page: 1, pageSize: 10 }),
+        );
+    });
+
+    it('restricts to requested grantable content types', async () => {
+        const findSummaryContents = vi.fn(emptyModelPage);
+        const deps = createService({
+            contentModel: {
+                findSummaryContents,
+            } as unknown as ContentModel,
+            sharedWithMeUuids: {
+                dashboard: ['dashboard-1'],
+                chart: ['chart-1'],
+                sqlChart: [],
+                app: ['app-1'],
+            },
+        });
+
+        await deps.service.find(
+            createUser(),
+            { sharedWithMe: true, contentTypes: [ContentType.DASHBOARD] },
+            {},
+            { page: 1, pageSize: 10 },
+        );
+
+        expect(findSummaryContents).toHaveBeenCalledWith(
+            expect.objectContaining({
+                uuids: ['dashboard-1'],
+                contentTypes: [ContentType.DASHBOARD],
+            }),
+            expect.any(Object),
+            expect.any(Object),
+        );
+    });
+
+    it('returns an empty page without querying content when nothing is granted', async () => {
+        const findSummaryContents = vi.fn(emptyModelPage);
+        const deps = createService({
+            contentModel: {
+                findSummaryContents,
+            } as unknown as ContentModel,
+        });
+
+        await expect(
+            deps.service.find(
+                createUser(),
+                { sharedWithMe: true },
+                {},
+                { page: 2, pageSize: 25 },
+            ),
+        ).resolves.toEqual({
+            data: [],
+            pagination: {
+                page: 2,
+                pageSize: 25,
+                totalPageCount: 0,
+                totalResults: 0,
+            },
+        });
+        expect(findSummaryContents).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty page for space-only requests without resolving grants', async () => {
+        const deps = createService({
+            sharedWithMeUuids: { dashboard: ['dashboard-1'] },
+        });
+
+        await expect(
+            deps.service.find(
+                createUser(),
+                { sharedWithMe: true, contentTypes: [ContentType.SPACE] },
+                {},
+                { page: 1, pageSize: 10 },
+            ),
+        ).resolves.toMatchObject({ data: [] });
+        expect(
+            deps.directAccessService.findSharedWithMeUuids,
+        ).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -12,6 +12,7 @@ import {
     DeletedContentFilters,
     DeletedContentItem,
     DeletedContentWithDescendants,
+    DirectAccessResourceType,
     ForbiddenError,
     getErrorMessage,
     KnexPaginateArgs,
@@ -37,6 +38,7 @@ import { ValidationModel } from '../../models/ValidationModel/ValidationModel';
 import { wrapSentryTransaction } from '../../utils';
 import { BaseService } from '../BaseService';
 import { DashboardService } from '../DashboardService/DashboardService';
+import type { DirectAccessService } from '../DirectAccess/DirectAccessService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import { SavedSqlService } from '../SavedSqlService/SavedSqlService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
@@ -52,6 +54,7 @@ type ContentServiceArguments = {
     savedChartService: SavedChartService;
     savedSqlService: SavedSqlService;
     spacePermissionService: SpacePermissionService;
+    directAccessService: DirectAccessService;
     validationModel: ValidationModel;
     appMoveService: BulkActionable<Knex> | undefined;
     appGenerateService: AppGenerateService | undefined;
@@ -76,6 +79,8 @@ export class ContentService extends BaseService {
 
     spacePermissionService: SpacePermissionService;
 
+    directAccessService: DirectAccessService;
+
     validationModel: ValidationModel;
 
     appMoveService: BulkActionable<Knex> | undefined;
@@ -95,6 +100,7 @@ export class ContentService extends BaseService {
         this.savedChartService = args.savedChartService;
         this.savedSqlService = args.savedSqlService;
         this.spacePermissionService = args.spacePermissionService;
+        this.directAccessService = args.directAccessService;
         this.validationModel = args.validationModel;
         this.appMoveService = args.appMoveService;
         this.appGenerateService = args.appGenerateService;
@@ -166,6 +172,15 @@ export class ContentService extends BaseService {
             );
             allowedProjectUuids = allowedProjectUuids.filter(
                 (_, index) => accessResults[index],
+            );
+        }
+
+        if (filters.sharedWithMe === true) {
+            return this.findSharedWithMe(
+                user,
+                { ...filters, projectUuids: allowedProjectUuids },
+                queryArgs,
+                paginateArgs,
             );
         }
 
@@ -273,6 +288,96 @@ export class ContentService extends BaseService {
                     access: directAccessMap[item.uuid] ?? [],
                 };
             }),
+        };
+    }
+
+    /**
+     * Shared with me: only resources directly granted to the caller or their
+     * groups, hydrated through the ordinary content configurations so parent
+     * metadata, filters, sorting, pagination, and counts behave exactly like
+     * the default listing. Never unions ordinary space-accessible content.
+     */
+    private async findSharedWithMe(
+        user: SessionUser,
+        filters: ContentFilters & { projectUuids: string[] },
+        queryArgs: ContentArgs,
+        paginateArgs: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<SummaryContent[]>> {
+        const emptyPage: KnexPaginatedData<SummaryContent[]> = {
+            data: [],
+            pagination: {
+                ...paginateArgs,
+                totalPageCount: 0,
+                totalResults: 0,
+            },
+        };
+        // Spaces cannot receive direct grants.
+        const grantableTypes = [
+            ContentType.DASHBOARD,
+            ContentType.CHART,
+            ContentType.DATA_APP,
+        ];
+        const contentTypes = filters.contentTypes
+            ? filters.contentTypes.filter((contentType) =>
+                  grantableTypes.includes(contentType),
+              )
+            : grantableTypes;
+        if (contentTypes.length === 0 || user.organizationUuid === undefined) {
+            return emptyPage;
+        }
+
+        const granted = await this.directAccessService.findSharedWithMeUuids(
+            {
+                userUuid: user.userUuid,
+                organizationUuid: user.organizationUuid,
+            },
+            filters.projectUuids,
+        );
+        const grantedUuids = [
+            ...(contentTypes.includes(ContentType.DASHBOARD)
+                ? granted[DirectAccessResourceType.DASHBOARD]
+                : []),
+            ...(contentTypes.includes(ContentType.CHART)
+                ? [
+                      ...granted[DirectAccessResourceType.CHART],
+                      ...granted[DirectAccessResourceType.SQL_CHART],
+                  ]
+                : []),
+            ...(contentTypes.includes(ContentType.DATA_APP)
+                ? granted[DirectAccessResourceType.APP]
+                : []),
+        ];
+        // Caller-provided uuid/space filters restrict the granted set —
+        // they never widen it into ordinary space-accessible content.
+        const requestedUuids = filters.uuids ? new Set(filters.uuids) : null;
+        const uuids = requestedUuids
+            ? grantedUuids.filter((uuid) => requestedUuids.has(uuid))
+            : grantedUuids;
+        if (uuids.length === 0) {
+            return emptyPage;
+        }
+
+        const results = await this.contentModel.findSummaryContents(
+            {
+                projectUuids: filters.projectUuids,
+                uuids,
+                spaceUuids: filters.spaceUuids,
+                contentTypes,
+                search: filters.search,
+                dataAppVizsFilter: filters.dataAppVizsFilter,
+                sharedWithMe: true,
+            },
+            queryArgs,
+            paginateArgs,
+        );
+        return {
+            ...results,
+            // Spaces are excluded from grantable content types above, so no
+            // row needs the SpaceContent access enrichment.
+            data: results.data.filter(
+                (item): item is Exclude<SummaryContent, SpaceContentBase> =>
+                    item.contentType !== ContentType.SPACE,
+            ),
         };
     }
 

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
@@ -100,6 +100,7 @@ const buildService = ({
 } = {}) => {
     const directAccessModel = {
         findResourceLocation: vi.fn().mockResolvedValue(location ?? undefined),
+        findCandidateResourceUuidsForUser: vi.fn().mockResolvedValue([]),
         listAssignments: vi.fn().mockResolvedValue([]),
         upsertAccess: vi.fn().mockResolvedValue({
             organizationId: 1,
@@ -134,22 +135,30 @@ const buildService = ({
                   .mockRejectedValue(
                       new ForbiddenError('Direct access is not available'),
                   ),
+        isEnabledForUser: vi.fn().mockResolvedValue(enabled),
     };
     const spacePermissionService = {
         resolveAccess: vi.fn().mockResolvedValue(context),
     };
+    const grantReadModel = { getUserAccess: vi.fn().mockResolvedValue({}) };
+
     const service = new DirectAccessService({
         directAccessModel: directAccessModel as unknown as DirectAccessModel,
         spacePermissionService:
             spacePermissionService as unknown as SpacePermissionService,
         directAccessFeatureGate:
             directAccessFeatureGate as unknown as DirectAccessFeatureGate,
+        appAccessModel: grantReadModel as never,
+        dashboardAccessModel: grantReadModel as never,
+        savedChartAccessModel: grantReadModel as never,
+        savedSqlAccessModel: grantReadModel as never,
     });
     return {
         service,
         directAccessModel,
         directAccessFeatureGate,
         spacePermissionService,
+        grantReadModel,
     };
 };
 
@@ -382,5 +391,76 @@ describe('DirectAccessService', () => {
                 }),
             }),
         );
+    });
+});
+
+describe('DirectAccessService.findSharedWithMeUuids', () => {
+    const requester = {
+        userUuid: USER_UUID,
+        organizationUuid: ORGANIZATION_UUID,
+    };
+
+    it('returns nothing when the feature is off, without scanning grants', async () => {
+        const { service, directAccessModel } = buildService({
+            enabled: false,
+        });
+        await expect(
+            service.findSharedWithMeUuids(requester, [PROJECT_UUID]),
+        ).resolves.toEqual({
+            dashboard: [],
+            chart: [],
+            sqlChart: [],
+            app: [],
+        });
+        expect(
+            directAccessModel.findCandidateResourceUuidsForUser,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('returns nothing when no projects are allowed', async () => {
+        const { service, directAccessModel } = buildService();
+        await expect(
+            service.findSharedWithMeUuids(requester, []),
+        ).resolves.toEqual({
+            dashboard: [],
+            chart: [],
+            sqlChart: [],
+            app: [],
+        });
+        expect(
+            directAccessModel.findCandidateResourceUuidsForUser,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('validates candidates through the read models and filters by project', async () => {
+        const { service, directAccessModel, grantReadModel } = buildService();
+        directAccessModel.findCandidateResourceUuidsForUser.mockImplementation(
+            async (resourceType: DirectAccessResourceType) =>
+                resourceType === DirectAccessResourceType.DASHBOARD
+                    ? ['dashboard-live', 'dashboard-inert', 'dashboard-other']
+                    : [],
+        );
+        grantReadModel.getUserAccess.mockResolvedValue({
+            // 'dashboard-inert' dropped by the read model (lost membership);
+            // 'dashboard-other' filtered out by project scope below.
+            'dashboard-live': { projectUuid: PROJECT_UUID },
+            'dashboard-other': { projectUuid: 'other-project-uuid' },
+        });
+
+        await expect(
+            service.findSharedWithMeUuids(requester, [PROJECT_UUID]),
+        ).resolves.toEqual({
+            dashboard: ['dashboard-live'],
+            chart: [],
+            sqlChart: [],
+            app: [],
+        });
+        expect(grantReadModel.getUserAccess).toHaveBeenCalledWith(
+            ['dashboard-live', 'dashboard-inert', 'dashboard-other'],
+            USER_UUID,
+            { organizationUuid: ORGANIZATION_UUID },
+        );
+        // Types with no candidates skip validation entirely.
+        expect(grantReadModel.getUserAccess).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.ts
@@ -12,10 +12,14 @@ import {
     type UUID,
 } from '@lightdash/common';
 import { createActorFromAccount } from '../../logging/caslAuditWrapper';
+import { type AppAccessModel } from '../../models/AppAccessModel';
+import { type DashboardAccessModel } from '../../models/DashboardAccessModel';
 import {
     type DirectAccessModel,
     type DirectAccessResourceLocation,
 } from '../../models/DirectAccessModel';
+import { type SavedChartAccessModel } from '../../models/SavedChartAccessModel';
+import { type SavedSqlAccessModel } from '../../models/SavedSqlAccessModel';
 import { BaseService } from '../BaseService';
 import {
     type AccessTarget,
@@ -31,7 +35,13 @@ type DirectAccessServiceArguments = {
     directAccessModel: DirectAccessModel;
     spacePermissionService: SpacePermissionService;
     directAccessFeatureGate: DirectAccessFeatureGate;
+    appAccessModel: AppAccessModel;
+    dashboardAccessModel: DashboardAccessModel;
+    savedChartAccessModel: SavedChartAccessModel;
+    savedSqlAccessModel: SavedSqlAccessModel;
 };
+
+export type SharedWithMeUuids = Record<DirectAccessResourceType, UUID[]>;
 
 /**
  * One administration seam for direct access across every registered resource
@@ -49,11 +59,102 @@ export class DirectAccessService extends BaseService {
 
     private readonly directAccessFeatureGate: DirectAccessFeatureGate;
 
+    private readonly appAccessModel: AppAccessModel;
+
+    private readonly dashboardAccessModel: DashboardAccessModel;
+
+    private readonly savedChartAccessModel: SavedChartAccessModel;
+
+    private readonly savedSqlAccessModel: SavedSqlAccessModel;
+
     constructor(args: DirectAccessServiceArguments) {
         super();
         this.directAccessModel = args.directAccessModel;
         this.spacePermissionService = args.spacePermissionService;
         this.directAccessFeatureGate = args.directAccessFeatureGate;
+        this.appAccessModel = args.appAccessModel;
+        this.dashboardAccessModel = args.dashboardAccessModel;
+        this.savedChartAccessModel = args.savedChartAccessModel;
+        this.savedSqlAccessModel = args.savedSqlAccessModel;
+    }
+
+    private getGrantReadModel(resourceType: DirectAccessResourceType): {
+        getUserAccess: (
+            resourceUuids: string[],
+            userUuid: string,
+            opts: { organizationUuid: string },
+        ) => Promise<Record<string, { projectUuid: UUID }>>;
+    } {
+        switch (resourceType) {
+            case DirectAccessResourceType.DASHBOARD:
+                return this.dashboardAccessModel;
+            case DirectAccessResourceType.CHART:
+                return this.savedChartAccessModel;
+            case DirectAccessResourceType.SQL_CHART:
+                return this.savedSqlAccessModel;
+            case DirectAccessResourceType.APP:
+                return this.appAccessModel;
+            default:
+                return assertUnreachable(
+                    resourceType,
+                    'Unsupported direct access resource type',
+                );
+        }
+    }
+
+    /**
+     * Resources of every type that are directly granted to the user or their
+     * groups, deduplicated and restricted to the given projects. Candidates
+     * from the grant tables are validated through each type's read model, so
+     * inert grants (lost membership, inactive granted groups, deleted or
+     * ineligible resources) never surface. Feature off means no results —
+     * grant rows are preserved but stay invisible.
+     */
+    async findSharedWithMeUuids(
+        user: { userUuid: UUID; organizationUuid: UUID },
+        projectUuids: UUID[],
+    ): Promise<SharedWithMeUuids> {
+        const empty: SharedWithMeUuids = {
+            [DirectAccessResourceType.DASHBOARD]: [],
+            [DirectAccessResourceType.CHART]: [],
+            [DirectAccessResourceType.SQL_CHART]: [],
+            [DirectAccessResourceType.APP]: [],
+        };
+        if (projectUuids.length === 0) {
+            return empty;
+        }
+        const enabled =
+            await this.directAccessFeatureGate.isEnabledForUser(user);
+        if (!enabled) {
+            return empty;
+        }
+
+        const allowedProjects = new Set(projectUuids);
+        const resourceTypes = Object.values(DirectAccessResourceType);
+        const entries = await Promise.all(
+            resourceTypes.map(async (resourceType) => {
+                const candidates =
+                    await this.directAccessModel.findCandidateResourceUuidsForUser(
+                        resourceType,
+                        user.userUuid,
+                    );
+                if (candidates.length === 0) {
+                    return [resourceType, []] as const;
+                }
+                const access = await this.getGrantReadModel(
+                    resourceType,
+                ).getUserAccess(candidates, user.userUuid, {
+                    organizationUuid: user.organizationUuid,
+                });
+                const uuids = Object.entries(access)
+                    .filter(([, grant]) =>
+                        allowedProjects.has(grant.projectUuid),
+                    )
+                    .map(([resourceUuid]) => resourceUuid);
+                return [resourceType, uuids] as const;
+            }),
+        );
+        return Object.fromEntries(entries) as SharedWithMeUuids;
     }
 
     private static toAccessTarget(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1158,6 +1158,11 @@ export class ServiceRepository
                     directAccessModel: this.models.getDirectAccessModel(),
                     spacePermissionService: this.getSpacePermissionService(),
                     directAccessFeatureGate: this.getDirectAccessFeatureGate(),
+                    appAccessModel: this.models.getAppAccessModel(),
+                    dashboardAccessModel: this.models.getDashboardAccessModel(),
+                    savedChartAccessModel:
+                        this.models.getSavedChartAccessModel(),
+                    savedSqlAccessModel: this.models.getSavedSqlAccessModel(),
                 }),
         );
     }
@@ -1475,6 +1480,7 @@ export class ServiceRepository
                     savedChartService: this.getSavedChartService(),
                     savedSqlService: this.getSavedSqlService(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    directAccessService: this.getDirectAccessService(),
                     validationModel: this.models.getValidationModel(),
                     // Only wired when EE license is active. Core builds get
                     // undefined and fail DATA_APP moves with a clear error.


### PR DESCRIPTION
## Summary

PR 2 of 3 for [SPK-1537](https://linear.app/lightdash/issue/SPK-1537/stack-6a-unify-direct-access-administration-and-discovery) (Stack 6A). Adds `sharedWithMe=true` to the existing `GET /api/v2/content` endpoint: it returns only resources directly granted to the current user or their groups, hydrated through the existing `ContentModel` configurations and the existing `ApiContentResponse`. No dedicated route, DTO, or alternate hydration pipeline. Absent or `false`, the endpoint's behavior is unchanged.

Stacks on top of PR 1 ([#28263](https://github.com/lightdash/lightdash/pull/28263)) which landed the generic administration store and `DirectAccessService`.

Part of: https://linear.app/lightdash/issue/SPK-1537

## How it works

```
sharedWithMe=true
  ── project CASL filter (unchanged)
  ── DirectAccessService.findSharedWithMeUuids
        ├─ feature gate (off → empty; grant rows stay inert)
        ├─ candidate scan of the 8 grant tables (user + groups)
        └─ validation through each type's EXISTING read model
           (getUserAccess: lost membership, inactive granted groups,
            deleted / ineligible resources never surface) + project filter
  ── dedupe (user/group and multi-group overlap collapse per resource)
  ── ContentModel.findSummaryContents({ uuids: granted, sharedWithMe: true })
        └─ ordinary configurations: search, sorting, pagination, counts
```

- Candidates are validated through the same `getUserAccess` queries the authorization kernel uses, so selector visibility and runtime access can never disagree.
- Selection and dedup happen before filters, sorting, pagination, and counts; pages stay stable via the existing uuid tiebreaker.
- Real parent space uuid and name are preserved on every row; parent-space endpoints remain independently unauthorized. Personal apps keep their `space: null` shape (one `ContentFilters.sharedWithMe` flag relaxes the personal-app hiding for the granted uuid set only).
- Spaces cannot receive grants, so the selector restricts `contentTypes` to dashboard/chart/data_app; a spaces-only request returns an empty page without touching the grant tables.
- Caller-provided `uuids`/`spaceUuids` filters intersect the granted set — they can narrow it, never widen it into ordinary space-accessible content.

## Test plan

- [x] `pnpm -F backend typecheck` / `lint`
- [x] `ContentService` unit tests (20 pass; 4 new): granted-uuid hydration without space scoping, content-type intersection, empty-grant empty page without a content query, spaces-only short-circuit — plus all existing default-path tests unchanged
- [x] `DirectAccessService` unit tests (11 pass; 3 new): feature-off returns empty without scanning, empty project scope short-circuits, candidates validated through read models and project-filtered
- [x] PG integration (17 pass in the store suite; 2 new): candidate scan collects user + group grants with overlap dedupe; grants to non-member groups excluded
- [x] `pnpm generate-api` — `sharedWithMe` parameter present on `/api/v2/content` (generated files not committed)
- [x] Live on dev instance as an org editor with no space access: private-space dashboard invisible in default listing → user + group grants added → `sharedWithMe=true` returns exactly one row with the real space name and `totalResults: 1`; default listing still excludes it (no union); `sharedWithMe=false` identical to absent; `search` and `contentTypes` filters compose; reset → empty again

🤖 Generated with [Claude Code](https://claude.com/claude-code)
