### PR TITLE
fix(chart-types): pivot sample data for previews with a series field

### DIFF
--- a/docs/pivoting.md
+++ b/docs/pivoting.md
@@ -77,7 +77,7 @@ is spread yet):
 
 **Phase 2 — spread (Stage 3).** `runQueryAndTransformRows` groups the rows sharing
 a `row_index` and emits one wide row when `row_index` changes. The value column
-`revenue_sum` is suffixed with the group-by raw value (`getValueColumnFieldName`
+`revenue_sum` is suffixed with the group-by raw value (`getPivotValueColumnName`
 gives `revenue_sum`, then `_<status>`), producing one JSONL row per `row_index`:
 
 ```json
@@ -153,6 +153,10 @@ Cross-cutting terms only — fuller definitions live in the linked package docs.
   `indexValues`, `dataValues`, totals) and the flattened TanStack column metadata.
 - **`NULL_PIVOT_KEY`** — collision-safe placeholder used in a value column's
   suffix when a group-by value is `null`, so it doesn't collide with the base column.
+- **`getPivotValueColumnName`** (`packages/common/src/pivot/pivotColumnName.ts`) —
+  the single rule for naming a spread value column. The pivot SQL alias, the
+  result transform, and the chart-type previews all compose names through it, so
+  a lookup built on one side always resolves on the other.
 
 ## Related docs
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -57,6 +57,7 @@ import {
     getMetricOverridesWithPopInheritance,
     getMetrics,
     getMetricsWithValidParameters,
+    getPivotValueColumnName,
     getUserAttributeQueryTags,
     hasReservedParameterReference,
     isCartesianChartConfig,
@@ -333,10 +334,6 @@ type ExecuteMergeQueryInternalArgs = Omit<
         | { type: 'resolved'; configuration: PivotConfiguration };
 };
 
-// NULL pivot keys collide with the unsuffixed base column when joined
-// (`[null].join('_') === ''`). Wrapped in `<>` so it strips cleanly via
-// friendlyName if it ever surfaces in a label fallback.
-const NULL_PIVOT_KEY = '<null>';
 export const QUEUED_QUERY_EXPIRED_MESSAGE =
     'Your query expired while waiting in the queue. Please try again.';
 
@@ -2597,21 +2594,6 @@ export class AsyncQueryService extends ProjectService {
                               };
                           }) ?? [];
 
-                      // Suffix the value column with the group by columns to avoid collisions.
-                      // E.g. if we have a row with the value 1 and the group by columns are ['a', 'b'],
-                      // then the value column will be 'value_1_a_b'.
-                      const valueSuffix =
-                          pivotValues.length > 0
-                              ? pivotValues
-                                    .map((p) =>
-                                        p.value === null ||
-                                        p.value === undefined
-                                            ? NULL_PIVOT_KEY
-                                            : p.value,
-                                    )
-                                    .join('_')
-                              : '';
-
                       // eslint-disable-next-line @typescript-eslint/no-loop-func -- forEach is synchronous, executes within current loop iteration
                       valuesColumns.forEach((col) => {
                           const valueColumnField =
@@ -2619,11 +2601,13 @@ export class AsyncQueryService extends ProjectService {
                                   col.reference,
                                   col.aggregation,
                               );
-                          // Truthy check on valueSuffix preserves backwards-compat for
-                          // empty-string pivot values (unsuffixed column).
-                          const valueColumnReference = valueSuffix
-                              ? `${valueColumnField}_${valueSuffix}`
-                              : valueColumnField;
+                          // Suffix the value column with the group by values to
+                          // avoid collisions, e.g. 'value_any_a_b'.
+                          const valueColumnReference = getPivotValueColumnName(
+                              col.reference,
+                              col.aggregation,
+                              pivotValues.map((p) => p.value),
+                          );
 
                           valuesColumnData.set(valueColumnReference, {
                               referenceField: col.reference, // The original y field name

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -5,6 +5,7 @@ import {
     getAggregatedField,
     getItemId,
     getParsedReference,
+    getPivotValueColumnBaseName,
     hasPivotFunctions,
     isCustomBinDimension,
     isDimension,
@@ -546,7 +547,7 @@ export class PivotQueryBuilder {
         reference: string,
         aggregation: string,
     ): string {
-        return `${reference}_${aggregation}`;
+        return getPivotValueColumnBaseName(reference, aggregation);
     }
 
     /**

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -86,6 +86,7 @@ export * from './ee';
 export * from './preAggregates';
 export * from './pivot/derivePivotConfigFromChart';
 export * from './pivot/deriveDataAppVizPivotConfig';
+export * from './pivot/pivotColumnName';
 export * from './pivot/pivotConfig';
 export * from './pivot/pivotQueryResults';
 export * from './pivot/utils';

--- a/packages/common/src/pivot/index.ts
+++ b/packages/common/src/pivot/index.ts
@@ -1,4 +1,5 @@
 export * from './derivePivotConfigFromChart';
+export * from './pivotColumnName';
 export * from './pivotConfig';
 export * from './pivotQueryResults';
 export * from './utils';

--- a/packages/common/src/pivot/pivotColumnName.test.ts
+++ b/packages/common/src/pivot/pivotColumnName.test.ts
@@ -1,0 +1,88 @@
+import { VizAggregationOptions } from '../visualizations/types';
+import {
+    getPivotValueColumnBaseName,
+    getPivotValueColumnName,
+    NULL_PIVOT_KEY,
+} from './pivotColumnName';
+
+describe('getPivotValueColumnBaseName', () => {
+    it('suffixes the reference with the aggregation', () => {
+        expect(
+            getPivotValueColumnBaseName(
+                'orders_total_order_amount',
+                VizAggregationOptions.SUM,
+            ),
+        ).toBe('orders_total_order_amount_sum');
+    });
+});
+
+describe('getPivotValueColumnName', () => {
+    it('returns the base name when there are no group-by values', () => {
+        expect(
+            getPivotValueColumnName('views', VizAggregationOptions.SUM, []),
+        ).toBe('views_sum');
+    });
+
+    it('appends a single group-by value', () => {
+        expect(
+            getPivotValueColumnName(
+                'payments_total_revenue',
+                VizAggregationOptions.ANY,
+                ['bank_transfer'],
+            ),
+        ).toBe('payments_total_revenue_any_bank_transfer');
+    });
+
+    it('appends multiple group-by values in order', () => {
+        expect(
+            getPivotValueColumnName('value', VizAggregationOptions.ANY, [
+                'a',
+                'b',
+            ]),
+        ).toBe('value_any_a_b');
+    });
+
+    it('substitutes the null placeholder for null and undefined values', () => {
+        expect(
+            getPivotValueColumnName('value', VizAggregationOptions.ANY, [null]),
+        ).toBe(`value_any_${NULL_PIVOT_KEY}`);
+        expect(
+            getPivotValueColumnName('value', VizAggregationOptions.ANY, [
+                undefined,
+            ]),
+        ).toBe(`value_any_${NULL_PIVOT_KEY}`);
+    });
+
+    it('substitutes the null placeholder per value, keeping the others', () => {
+        expect(
+            getPivotValueColumnName('value', VizAggregationOptions.ANY, [
+                'a',
+                null,
+                'b',
+            ]),
+        ).toBe(`value_any_a_${NULL_PIVOT_KEY}_b`);
+    });
+
+    it('keeps a single empty-string group-by value on the unsuffixed base name', () => {
+        expect(
+            getPivotValueColumnName('value', VizAggregationOptions.ANY, ['']),
+        ).toBe('value_any');
+    });
+
+    it('does not collide a null group-by value with the base name', () => {
+        expect(
+            getPivotValueColumnName('value', VizAggregationOptions.ANY, [null]),
+        ).not.toBe(
+            getPivotValueColumnName('value', VizAggregationOptions.ANY, []),
+        );
+    });
+
+    it('stringifies non-string group-by values', () => {
+        expect(
+            getPivotValueColumnName('value', VizAggregationOptions.ANY, [
+                false,
+                7,
+            ]),
+        ).toBe('value_any_false_7');
+    });
+});

--- a/packages/common/src/pivot/pivotColumnName.ts
+++ b/packages/common/src/pivot/pivotColumnName.ts
@@ -1,0 +1,45 @@
+/**
+ * The single rule for naming a pivoted value column.
+ *
+ * The pivot SQL aliases each aggregated column, the result transform spreads
+ * flat rows onto those names, and previews fabricate rows keyed the same way.
+ * All three must agree or lookups silently miss, so they all compose the name
+ * here rather than reproducing the string locally.
+ */
+
+/**
+ * Placeholder for a `null` group-by value in a column name. Without it
+ * `[null].join('_')` yields `''`, which collides with the unsuffixed base
+ * column. Wrapped in `<>` so it strips cleanly via `friendlyName` if it ever
+ * surfaces in a label fallback.
+ */
+export const NULL_PIVOT_KEY = '<null>';
+
+/**
+ * Name of a value column before the group-by suffix — also the alias the pivot
+ * query gives the aggregated column, so the transform can read it back.
+ */
+export const getPivotValueColumnBaseName = (
+    reference: string,
+    aggregation: string,
+): string => `${reference}_${aggregation}`;
+
+/**
+ * Name of a pivoted value column: the base name suffixed with the group-by
+ * values of its pivot column, in group-by order.
+ */
+export const getPivotValueColumnName = (
+    reference: string,
+    aggregation: string,
+    pivotValues: readonly unknown[],
+): string => {
+    const baseName = getPivotValueColumnBaseName(reference, aggregation);
+    const valueSuffix = pivotValues
+        .map((value) =>
+            value === null || value === undefined ? NULL_PIVOT_KEY : value,
+        )
+        .join('_');
+    // Truthy check, not a length check: it keeps a single empty-string group-by
+    // value on the unsuffixed base column, as it has always been named.
+    return valueSuffix ? `${baseName}_${valueSuffix}` : baseName;
+};

--- a/packages/frontend/src/components/MetricQueryData/utils.ts
+++ b/packages/frontend/src/components/MetricQueryData/utils.ts
@@ -1,8 +1,10 @@
 import {
     formatItemValue,
     getItemId,
+    getPivotValueColumnName,
     hashFieldReference,
     isDimension,
+    VizAggregationOptions,
     type EChartsSeries,
     type ItemsMap,
     type ResultValue,
@@ -56,10 +58,6 @@ const extractFieldValuesFromClickEvent = (
     );
 };
 
-// Backend uses '<null>' as the suffix for null pivot values in the SQL pivot
-// column name (see NULL_PIVOT_KEY in AsyncQueryService.ts). Keep in sync.
-const NULL_PIVOT_KEY = '<null>';
-
 /**
  * Generates possible column names for a pivot reference to handle both
  * old format (field.pivotField.value) and new SQL pivot format (field_any_value)
@@ -73,17 +71,18 @@ const getPivotColumnNames = (pivotReference: {
     // Old format: field.pivotField.value (using hashFieldReference)
     names.push(hashFieldReference(pivotReference));
 
-    // New SQL pivot format: field_any_value. For null/undefined pivot values,
-    // backend writes '<null>' instead of letting JS coerce to 'null' /
-    // 'undefined' (PROD-7896 — without this the column lookup fails for null
-    // pivot segments and the click falls back to the wrong selectedField).
+    // New SQL pivot format, named by the same rule the backend pivot uses —
+    // including its '<null>' placeholder (PROD-7896 — without it the column
+    // lookup fails for null pivot segments and the click falls back to the
+    // wrong selectedField).
     if (pivotReference.pivotValues && pivotReference.pivotValues.length > 0) {
-        const pivotValue = pivotReference.pivotValues[0].value;
-        const suffix =
-            pivotValue === null || pivotValue === undefined
-                ? NULL_PIVOT_KEY
-                : pivotValue;
-        names.push(`${pivotReference.field}_any_${suffix}`);
+        names.push(
+            getPivotValueColumnName(
+                pivotReference.field,
+                VizAggregationOptions.ANY,
+                [pivotReference.pivotValues[0].value],
+            ),
+        );
     }
 
     return names;

--- a/packages/frontend/src/features/chartTypes/utils/sampleVizContext.test.ts
+++ b/packages/frontend/src/features/chartTypes/utils/sampleVizContext.test.ts
@@ -109,14 +109,17 @@ describe('buildSampleVizContext', () => {
         });
 
         it('indexes rows on the dimension and keys metrics by pivot column', () => {
-            const context = buildSampleVizContext(schema);
-            const pivotColumnNames = context.pivotDetails!.valuesColumns.map(
+            const { rows, pivotDetails } = buildSampleVizContext(schema);
+
+            expect(pivotDetails).not.toBeNull();
+            if (!pivotDetails) return;
+            const pivotColumnNames = pivotDetails.valuesColumns.map(
                 ({ pivotColumnName }) => pivotColumnName,
             );
 
             // One row per category, not one per category × series value.
-            expect(context.rows.length).toBe(6);
-            for (const row of context.rows) {
+            expect(rows.length).toBe(6);
+            for (const row of rows) {
                 expect(Object.keys(row).sort()).toEqual(
                     ['sample_category', ...pivotColumnNames].sort(),
                 );

--- a/packages/frontend/src/features/chartTypes/utils/sampleVizContext.test.ts
+++ b/packages/frontend/src/features/chartTypes/utils/sampleVizContext.test.ts
@@ -24,6 +24,11 @@ const schema: DataAppVizSchema = {
     colorPalette: null,
 };
 
+const flatSchema: DataAppVizSchema = {
+    ...schema,
+    fields: schema.fields.filter((f) => f.type !== 'series'),
+};
+
 describe('buildSampleVizContext', () => {
     it('maps every declared field, required or not', () => {
         const context = buildSampleVizContext(schema);
@@ -35,37 +40,10 @@ describe('buildSampleVizContext', () => {
         ]);
     });
 
-    it('writes a cell for every mapped column in every row', () => {
+    it('resolves options to their declared defaults', () => {
         const context = buildSampleVizContext(schema);
 
-        expect(context.rows.length).toBeGreaterThan(0);
-        for (const row of context.rows) {
-            for (const columnId of Object.values(context.fieldMapping)) {
-                expect(row[columnId].value.raw).toBeDefined();
-                expect(row[columnId].value.formatted).not.toBe('');
-            }
-        }
-    });
-
-    it('gives dimensions date raw values with display-formatted labels', () => {
-        const context = buildSampleVizContext(schema);
-        const columnId = context.fieldMapping.category;
-
-        for (const row of context.rows) {
-            const { raw, formatted } = row[columnId].value;
-            expect(Number.isNaN(Date.parse(String(raw)))).toBe(false);
-            expect(formatted).not.toBe(String(raw));
-        }
-    });
-
-    it('crosses categories with the series split', () => {
-        const withSeries = buildSampleVizContext(schema);
-        const withoutSeries = buildSampleVizContext({
-            ...schema,
-            fields: schema.fields.filter((f) => f.type !== 'series'),
-        });
-
-        expect(withSeries.rows.length).toBe(withoutSeries.rows.length * 3);
+        expect(context.options).toEqual({ showLegend: true });
     });
 
     it('is deterministic', () => {
@@ -74,9 +52,120 @@ describe('buildSampleVizContext', () => {
         );
     });
 
-    it('resolves options to their declared defaults', () => {
-        const context = buildSampleVizContext(schema);
+    describe('without a series field', () => {
+        it('leaves the rows flat', () => {
+            const context = buildSampleVizContext(flatSchema);
 
-        expect(context.options).toEqual({ showLegend: true });
+            expect(context.pivotDetails).toBeNull();
+            expect(context.rows.length).toBe(6);
+        });
+
+        it('writes a cell for every mapped column in every row', () => {
+            const context = buildSampleVizContext(flatSchema);
+
+            for (const row of context.rows) {
+                for (const columnId of Object.values(context.fieldMapping)) {
+                    expect(row[columnId].value.raw).toBeDefined();
+                    expect(row[columnId].value.formatted).not.toBe('');
+                }
+            }
+        });
+
+        it('gives dimensions date raw values with display-formatted labels', () => {
+            const context = buildSampleVizContext(flatSchema);
+            const columnId = context.fieldMapping.category;
+
+            for (const row of context.rows) {
+                const { raw, formatted } = row[columnId].value;
+                expect(Number.isNaN(Date.parse(String(raw)))).toBe(false);
+                expect(formatted).not.toBe(String(raw));
+            }
+        });
+    });
+
+    describe('with a series field', () => {
+        it('pivots the metric into one column per series value', () => {
+            const context = buildSampleVizContext(schema);
+
+            expect(context.pivotDetails?.valuesColumns).toEqual([
+                expect.objectContaining({
+                    referenceField: 'sample_value',
+                    pivotColumnName: 'sample_value_any_Series A',
+                    pivotValues: [
+                        {
+                            referenceField: 'sample_split',
+                            value: 'Series A',
+                            formatted: 'Series A',
+                        },
+                    ],
+                }),
+                expect.objectContaining({
+                    pivotColumnName: 'sample_value_any_Series B',
+                }),
+                expect.objectContaining({
+                    pivotColumnName: 'sample_value_any_Series C',
+                }),
+            ]);
+        });
+
+        it('indexes rows on the dimension and keys metrics by pivot column', () => {
+            const context = buildSampleVizContext(schema);
+            const pivotColumnNames = context.pivotDetails!.valuesColumns.map(
+                ({ pivotColumnName }) => pivotColumnName,
+            );
+
+            // One row per category, not one per category × series value.
+            expect(context.rows.length).toBe(6);
+            for (const row of context.rows) {
+                expect(Object.keys(row).sort()).toEqual(
+                    ['sample_category', ...pivotColumnNames].sort(),
+                );
+                for (const columnName of pivotColumnNames) {
+                    expect(typeof row[columnName].value.raw).toBe('number');
+                }
+            }
+        });
+
+        it('declares the dimension as the index and the series as the pivot column', () => {
+            const context = buildSampleVizContext(schema);
+
+            expect(context.pivotDetails?.indexColumn).toEqual([
+                { reference: 'sample_category', type: 'time' },
+            ]);
+            expect(context.pivotDetails?.groupByColumns).toEqual([
+                { reference: 'sample_split' },
+            ]);
+        });
+
+        it('describes the unpivoted columns behind the pivot', () => {
+            const context = buildSampleVizContext(schema);
+
+            expect(context.pivotDetails?.originalColumns).toEqual({
+                sample_category: {
+                    reference: 'sample_category',
+                    type: 'date',
+                    label: 'Category',
+                },
+                sample_split: {
+                    reference: 'sample_split',
+                    type: 'string',
+                    label: 'Split',
+                },
+                sample_value: {
+                    reference: 'sample_value',
+                    type: 'number',
+                    label: 'Value',
+                },
+            });
+        });
+
+        it('stays flat when there is no metric to spread', () => {
+            const context = buildSampleVizContext({
+                ...schema,
+                fields: schema.fields.filter((f) => f.type !== 'metric'),
+            });
+
+            expect(context.pivotDetails).toBeNull();
+        });
     });
 });

--- a/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
+++ b/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
@@ -10,6 +10,7 @@ import {
     type DataAppVizOptionValues,
     type DataAppVizSchema,
     type PivotValuesColumn,
+    type ResultColumn,
     type ResultColumns,
     type ResultRow,
 } from '@lightdash/common';
@@ -59,23 +60,37 @@ type SampleFields = {
     metrics: DataAppVizField[];
 };
 
+const sampleResultColumn = (
+    field: DataAppVizField,
+    type: DimensionType,
+): ResultColumn => ({
+    reference: sampleColumnId(field),
+    type,
+    label: field.label,
+});
+
 /** Column metadata for the unpivoted sample shape, which pivoted previews carry
  *  as `pivotDetails.originalColumns`. */
 const buildOriginalColumns = ({
     dimensions,
     series,
     metrics,
-}: SampleFields): ResultColumns =>
-    Object.fromEntries(
-        [
-            ...dimensions.map((field) => [field, DimensionType.DATE] as const),
-            ...series.map((field) => [field, DimensionType.STRING] as const),
-            ...metrics.map((field) => [field, DimensionType.NUMBER] as const),
-        ].map(([field, type]) => [
-            sampleColumnId(field),
-            { reference: sampleColumnId(field), type, label: field.label },
-        ]),
+}: SampleFields): ResultColumns => {
+    const columns: ResultColumn[] = [
+        ...dimensions.map((field) =>
+            sampleResultColumn(field, DimensionType.DATE),
+        ),
+        ...series.map((field) =>
+            sampleResultColumn(field, DimensionType.STRING),
+        ),
+        ...metrics.map((field) =>
+            sampleResultColumn(field, DimensionType.NUMBER),
+        ),
+    ];
+    return Object.fromEntries(
+        columns.map((column) => [column.reference, column]),
     );
+};
 
 /** One row per category, crossed with the series split. */
 const buildFlatSample = ({

--- a/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
+++ b/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
@@ -2,6 +2,7 @@ import {
     DimensionType,
     ECHARTS_DEFAULT_COLORS,
     getEffectiveOptionValues,
+    getPivotValueColumnName,
     VizAggregationOptions,
     VizIndexType,
     type DataAppVizContext,
@@ -40,14 +41,16 @@ const cell = (
     value: { raw, formatted },
 });
 
-/** Mirrors how the backend names a spread metric column, so previews resolve
+/** Names a spread metric column with the shared pivot rule, so previews resolve
  *  row keys exactly as they do against a real pivoted query. */
 const samplePivotColumnName = (
     metric: DataAppVizField,
     seriesValues: string[],
 ): string =>
-    [sampleColumnId(metric), VizAggregationOptions.ANY, ...seriesValues].join(
-        '_',
+    getPivotValueColumnName(
+        sampleColumnId(metric),
+        VizAggregationOptions.ANY,
+        seriesValues,
     );
 
 type SampleFields = {

--- a/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
+++ b/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
@@ -1,10 +1,15 @@
 import {
+    DimensionType,
     ECHARTS_DEFAULT_COLORS,
     getEffectiveOptionValues,
+    VizAggregationOptions,
+    VizIndexType,
     type DataAppVizContext,
     type DataAppVizField,
     type DataAppVizOptionValues,
     type DataAppVizSchema,
+    type PivotValuesColumn,
+    type ResultColumns,
     type ResultRow,
 } from '@lightdash/common';
 
@@ -35,23 +40,46 @@ const cell = (
     value: { raw, formatted },
 });
 
-/**
- * Deterministic `DataAppVizContext` fabricated from a declared schema alone,
- * so previews can render without real data.
- */
-export const buildSampleVizContext = (
-    schema: DataAppVizSchema,
-    colorPalette: string[] = ECHARTS_DEFAULT_COLORS,
-    optionValues: DataAppVizOptionValues = {},
-): DataAppVizContext => {
-    const dimensions = schema.fields.filter((f) => f.type === 'dimension');
-    const series = schema.fields.filter((f) => f.type === 'series');
-    const metrics = schema.fields.filter((f) => f.type === 'metric');
-
-    const fieldMapping = Object.fromEntries(
-        schema.fields.map((field) => [field.name, sampleColumnId(field)]),
+/** Mirrors how the backend names a spread metric column, so previews resolve
+ *  row keys exactly as they do against a real pivoted query. */
+const samplePivotColumnName = (
+    metric: DataAppVizField,
+    seriesValues: string[],
+): string =>
+    [sampleColumnId(metric), VizAggregationOptions.ANY, ...seriesValues].join(
+        '_',
     );
 
+type SampleFields = {
+    dimensions: DataAppVizField[];
+    series: DataAppVizField[];
+    metrics: DataAppVizField[];
+};
+
+/** Column metadata for the unpivoted sample shape, which pivoted previews carry
+ *  as `pivotDetails.originalColumns`. */
+const buildOriginalColumns = ({
+    dimensions,
+    series,
+    metrics,
+}: SampleFields): ResultColumns =>
+    Object.fromEntries(
+        [
+            ...dimensions.map((field) => [field, DimensionType.DATE] as const),
+            ...series.map((field) => [field, DimensionType.STRING] as const),
+            ...metrics.map((field) => [field, DimensionType.NUMBER] as const),
+        ].map(([field, type]) => [
+            sampleColumnId(field),
+            { reference: sampleColumnId(field), type, label: field.label },
+        ]),
+    );
+
+/** One row per category, crossed with the series split. */
+const buildFlatSample = ({
+    dimensions,
+    series,
+    metrics,
+}: SampleFields): Pick<DataAppVizContext, 'rows' | 'pivotDetails'> => {
     const seriesCount = series.length > 0 ? SAMPLE_SERIES.length : 1;
     const rows: ResultRow[] = [];
     for (let s = 0; s < seriesCount; s++) {
@@ -73,15 +101,109 @@ export const buildSampleVizContext = (
             rows.push(row);
         }
     }
+    return { rows, pivotDetails: null };
+};
+
+/** The pivoted counterpart of the flat sample: each metric spread into one
+ *  column per series value, keyed and described as the backend would. */
+const buildPivotedSample = ({
+    dimensions,
+    series,
+    metrics,
+}: SampleFields): Pick<DataAppVizContext, 'rows' | 'pivotDetails'> => {
+    // Every series slot binds the same sample split, so a pivot column group
+    // repeats one series value per slot.
+    const seriesValueTuples = SAMPLE_SERIES.map((value) =>
+        series.map(() => value),
+    );
+
+    const valuesColumns: PivotValuesColumn[] = seriesValueTuples.flatMap(
+        (seriesValues, s) =>
+            metrics.map((metric) => ({
+                referenceField: sampleColumnId(metric),
+                pivotColumnName: samplePivotColumnName(metric, seriesValues),
+                aggregation: VizAggregationOptions.ANY,
+                pivotValues: series.map((field, i) => ({
+                    referenceField: sampleColumnId(field),
+                    value: seriesValues[i],
+                    formatted: seriesValues[i],
+                })),
+                columnIndex: s + 1,
+            })),
+    );
+
+    // With no dimension to index on, every flat row collapses onto one row.
+    const rowCount = dimensions.length > 0 ? SAMPLE_CATEGORIES.length : 1;
+    const rows: ResultRow[] = [];
+    for (let c = 0; c < rowCount; c++) {
+        const row: ResultRow = {};
+        dimensions.forEach((field, d) => {
+            const month = SAMPLE_CATEGORIES[(c + d) % SAMPLE_CATEGORIES.length];
+            row[sampleColumnId(field)] = cell(month.raw, month.formatted);
+        });
+        seriesValueTuples.forEach((seriesValues, s) => {
+            metrics.forEach((metric, m) => {
+                row[samplePivotColumnName(metric, seriesValues)] = cell(
+                    sampleMetricValue(s * SAMPLE_CATEGORIES.length + c, m),
+                );
+            });
+        });
+        rows.push(row);
+    }
 
     return {
-        fieldMapping,
         rows,
+        pivotDetails: {
+            totalColumnCount: valuesColumns.length,
+            // Sample dimensions are always dates.
+            indexColumn: dimensions.map((field) => ({
+                reference: sampleColumnId(field),
+                type: VizIndexType.TIME,
+            })),
+            valuesColumns,
+            groupByColumns: series.map((field) => ({
+                reference: sampleColumnId(field),
+            })),
+            sortBy: undefined,
+            originalColumns: buildOriginalColumns({
+                dimensions,
+                series,
+                metrics,
+            }),
+        },
+    };
+};
+
+/**
+ * Deterministic `DataAppVizContext` fabricated from a declared schema alone,
+ * so previews can render without real data.
+ */
+export const buildSampleVizContext = (
+    schema: DataAppVizSchema,
+    colorPalette: string[] = ECHARTS_DEFAULT_COLORS,
+    optionValues: DataAppVizOptionValues = {},
+): DataAppVizContext => {
+    const fields: SampleFields = {
+        dimensions: schema.fields.filter((f) => f.type === 'dimension'),
+        series: schema.fields.filter((f) => f.type === 'series'),
+        metrics: schema.fields.filter((f) => f.type === 'metric'),
+    };
+
+    // A chart type that declares a series field renders from pivoted rows, so
+    // its sample must be pivoted too or it finds no series and draws nothing.
+    // A series field with no metric has nothing to spread — as on the backend,
+    // that keeps the flat sample.
+    const shouldPivot = fields.series.length > 0 && fields.metrics.length > 0;
+
+    return {
+        fieldMapping: Object.fromEntries(
+            schema.fields.map((field) => [field.name, sampleColumnId(field)]),
+        ),
         options: getEffectiveOptionValues(schema.configOptions, optionValues),
         colorPalette,
-        pivotDetails: null,
         // Sample rows come from no query — there is nothing to drill into.
         underlyingData: { enabled: false },
         drillDown: { enabled: false },
+        ...(shouldPivot ? buildPivotedSample(fields) : buildFlatSample(fields)),
     };
 };


### PR DESCRIPTION
## Summary

Chart types that group data by a series field rendered fine on saved charts and in the explorer, but previewed blank in the chart type gallery, the gallery detail modal, and the builder canvas.

Those three surfaces are the only consumers of `buildSampleVizContext`, which fabricated rows in the flat (unpivoted) shape with `pivotDetails: null`. A chart type built around a series field reads pivoted rows, so it found no series and drew nothing — no error, just an empty preview. Deterministic per chart type, so the gallery misrepresented types that work perfectly on real data.

`buildSampleVizContext` now generates the sample already pivoted when the schema declares both a series field and a metric to spread:

- metrics are spread into one column per sample series value
- `pivotDetails` carries the matching `indexColumn`, `groupByColumns`, `valuesColumns` and `originalColumns`, so a viz resolves row keys through `valuesColumns` exactly as it does against a real query
- rows are indexed on the dimension rather than crossed with the series split, matching the row collapse the backend does

A series field with no metric has nothing to spread — as on the backend, where `deriveDataAppVizPivotConfiguration` returns no pivot config for empty `valuesColumns` — so that case keeps the flat sample. Types without a series field are unchanged.

## Sharing the pivot column naming rule

Naming the spread columns meant reproducing how the backend names them, which turned out to be composed in several places that had already drifted. The rule now lives once, in `packages/common/src/pivot/pivotColumnName.ts` (`getPivotValueColumnName`), and is used by the pivot SQL alias, the backend result transform, these previews, and the chart-click column lookup.

That last one is a small incidental fix: `MetricQueryData/utils.ts` carried its own `NULL_PIVOT_KEY` copy with a "keep in sync" comment, and for an empty-string pivot value it produced a trailing underscore where the backend produces none. It builds lookup *candidates* that are membership-tested, so a wrong candidate simply never matched — routing it through the shared helper can only start matching where it previously failed.

`PivotQueryBuilder.getValueColumnFieldName` is kept as a thin delegate rather than churning its ~15 call sites; it is the SQL-alias vocabulary in that file.

Deliberately left alone: `ProjectService.pivotQueryWorkerTask` has an older copy whose rules genuinely differ (no null placeholder, suffix appended unconditionally). Sharing the helper there would change the column names that legacy download path emits for null and empty group-by values — arguably a fix, but a behaviour change with no covering tests, so it wants its own ticket.

## Test plan

- [x] `pnpm -F common test src/pivot/pivotColumnName.test.ts` — 9 tests on the shared helper, including the null/undefined placeholder and empty-suffix cases
- [x] `pnpm -F frontend test src/features/chartTypes/utils/sampleVizContext.test.ts` — 11 tests split by shape: flat schemas keep their existing row/cell assertions; series schemas assert pivot column naming, row keys, index/groupBy declaration, `originalColumns`, and the no-metric fallback
- [x] `pnpm -F frontend test src/components/MetricQueryData/utils.test.ts`, `pnpm -F backend test src/services/AsyncQueryService/AsyncQueryService.test.ts`, `PivotQueryBuilder.test.ts` — existing suites on the touched composition sites
- [x] `typecheck` and `lint` for common, frontend and backend
- [ ] A chart type with a series field shows a populated preview in the gallery, the detail modal, and the builder canvas
- [ ] A chart type without a series field previews exactly as before

Closes: GLITCH-701