### PR TITLE
feat(direct-access): apply resource-aware access to discovery consumers

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -913,6 +913,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     permissionsService: repository.getPermissionsService(),
                     spacePermissionService:
                         repository.getSpacePermissionService(),
+                    directAccessService: repository.getDirectAccessService(),
                     contentVerificationModel:
                         models.getContentVerificationModel(),
                     organizationSettingsModel:
@@ -1117,6 +1118,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getAdminNotificationService(),
                     spacePermissionService:
                         repository.getSpacePermissionService(),
+                    directAccessService: repository.getDirectAccessService(),
                     organizationSettingsModel:
                         models.getOrganizationSettingsModel(),
                     getDataAppCustomSqlProvenance: (args) =>

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.directAccess.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.directAccess.test.ts
@@ -218,7 +218,7 @@ describe('AppGenerateService direct app access', () => {
         ).resolves.toEqual([
             {
                 uuid: APP_UUID,
-                spaceUuid: null,
+                spaceUuid: SPACE_UUID,
                 createdBy: { userUuid: app.created_by_user_uuid },
             },
         ]);

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1372,7 +1372,9 @@ export class AppGenerateService extends BaseService {
             if (auditedAbility.cannot('view', subject('DataApp', context))) {
                 return [];
             }
-            return [context.directOnly ? { ...app, spaceUuid: null } : app];
+            // Directly shared apps keep their real parent-space reference;
+            // parent access stays independently unauthorized.
+            return [app];
         });
     }
 

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
@@ -263,6 +263,8 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
             }
             return {
                 contentType: ContentType.DASHBOARD,
+                // Filled in by ContentService for the requesting user.
+                directAccessRoles: [],
                 uuid: value.uuid,
                 slug: value.slug,
                 name: value.name,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
@@ -285,6 +285,8 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
             }
             return {
                 contentType: ContentType.DATA_APP,
+                // Filled in by ContentService for the requesting user.
+                directAccessRoles: [],
                 uuid: value.uuid,
                 slug: value.slug,
                 name: value.name,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
@@ -240,6 +240,8 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
             }
             return {
                 contentType: ContentType.CHART,
+                // Filled in by ContentService for the requesting user.
+                directAccessRoles: [],
                 uuid: value.uuid,
                 slug: value.slug,
                 name: value.name,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
@@ -227,6 +227,8 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
             }
             return {
                 contentType: ContentType.CHART,
+                // Filled in by ContentService for the requesting user.
+                directAccessRoles: [],
                 uuid: value.uuid,
                 slug: value.slug,
                 name: value.name,

--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -29,8 +29,9 @@ const getCharts = async (
     projectUuid: string,
     pinnedListUuid: string,
     allowedSpaceUuids: string[],
+    grantedChartUuids: string[] = [],
 ): Promise<ResourceViewChartItem[]> => {
-    if (allowedSpaceUuids.length === 0) {
+    if (allowedSpaceUuids.length === 0 && grantedChartUuids.length === 0) {
         return [];
     }
     const rows = (await knex('pinned_list')
@@ -73,7 +74,18 @@ const getCharts = async (
             `${SavedChartsTableName}.last_version_updated_by_user_uuid`,
             'users.user_uuid',
         )
-        .whereIn(`${SpaceTableName}.space_uuid`, allowedSpaceUuids)
+        .where((accessFilter) => {
+            void accessFilter.whereIn(
+                `${SpaceTableName}.space_uuid`,
+                allowedSpaceUuids,
+            );
+            if (grantedChartUuids.length > 0) {
+                void accessFilter.orWhereIn(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    grantedChartUuids,
+                );
+            }
+        })
         .whereNull(`${SpaceTableName}.deleted_at`)
         .andWhere('pinned_list.pinned_list_uuid', pinnedListUuid)
         .andWhere('pinned_list.project_uuid', projectUuid)
@@ -109,8 +121,9 @@ const getDashboards = async (
     projectUuid: string,
     pinnedListUuid: string,
     allowedSpaceUuids: string[],
+    grantedDashboardUuids: string[] = [],
 ): Promise<ResourceViewDashboardItem[]> => {
-    if (allowedSpaceUuids.length === 0) {
+    if (allowedSpaceUuids.length === 0 && grantedDashboardUuids.length === 0) {
         return [];
     }
     const rows = (await knex('pinned_list')
@@ -146,7 +159,18 @@ const getDashboards = async (
             'dv.dashboard_id',
         )
         .leftJoin('users', 'dv.updated_by_user_uuid', 'users.user_uuid')
-        .whereIn(`${SpaceTableName}.space_uuid`, allowedSpaceUuids)
+        .where((accessFilter) => {
+            void accessFilter.whereIn(
+                `${SpaceTableName}.space_uuid`,
+                allowedSpaceUuids,
+            );
+            if (grantedDashboardUuids.length > 0) {
+                void accessFilter.orWhereIn(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    grantedDashboardUuids,
+                );
+            }
+        })
         .whereNull(`${SpaceTableName}.deleted_at`)
         .andWhere('pinned_list.pinned_list_uuid', pinnedListUuid)
         .andWhere('pinned_list.project_uuid', projectUuid)
@@ -201,8 +225,9 @@ const getApps = async (
     projectUuid: string,
     pinnedListUuid: string,
     allowedSpaceUuids: string[],
+    grantedAppUuids: string[] = [],
 ): Promise<ResourceViewDataAppItem[]> => {
-    if (allowedSpaceUuids.length === 0) {
+    if (allowedSpaceUuids.length === 0 && grantedAppUuids.length === 0) {
         return [];
     }
     // Latest version per app — mirrors DataAppContentConfiguration
@@ -239,7 +264,8 @@ const getApps = async (
                 `${AppsTableName}.app_id`,
             ).andOnNull(`${AppsTableName}.deleted_at`);
         })
-        .innerJoin(
+        // Left join: granted personal apps have no space row.
+        .leftJoin(
             SpaceTableName,
             `${AppsTableName}.space_uuid`,
             `${SpaceTableName}.space_uuid`,
@@ -247,7 +273,18 @@ const getApps = async (
         .leftJoin(latestVersion, 'lv.app_id', `${AppsTableName}.app_id`)
         .leftJoin(latestReadyVersion, 'lrv.app_id', `${AppsTableName}.app_id`)
         .leftJoin(UserTableName, 'lv.created_by_user_uuid', 'users.user_uuid')
-        .whereIn(`${SpaceTableName}.space_uuid`, allowedSpaceUuids)
+        .where((accessFilter) => {
+            void accessFilter.whereIn(
+                `${SpaceTableName}.space_uuid`,
+                allowedSpaceUuids,
+            );
+            if (grantedAppUuids.length > 0) {
+                void accessFilter.orWhereIn(
+                    `${AppsTableName}.app_id`,
+                    grantedAppUuids,
+                );
+            }
+        })
         .whereNull(`${SpaceTableName}.deleted_at`)
         .andWhere(`${PinnedListTableName}.pinned_list_uuid`, pinnedListUuid)
         .andWhere(`${PinnedListTableName}.project_uuid`, projectUuid)
@@ -443,6 +480,11 @@ export class ResourceViewItemModel {
         projectUuid: string,
         pinnedListUuid: string,
         allowedSpacesUuids: string[],
+        granted?: {
+            chartUuids: string[];
+            dashboardUuids: string[];
+            appUuids: string[];
+        },
     ): Promise<{
         dashboards: ResourceViewDashboardItem[];
         charts: ResourceViewChartItem[];
@@ -454,18 +496,21 @@ export class ResourceViewItemModel {
                 projectUuid,
                 pinnedListUuid,
                 allowedSpacesUuids,
+                granted?.dashboardUuids,
             );
             const charts = await getCharts(
                 trx,
                 projectUuid,
                 pinnedListUuid,
                 allowedSpacesUuids,
+                granted?.chartUuids,
             );
             const apps = await getApps(
                 trx,
                 projectUuid,
                 pinnedListUuid,
                 allowedSpacesUuids,
+                granted?.appUuids,
             );
             return {
                 dashboards,

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -862,6 +862,7 @@ export class SearchModel {
                 {
                     chartType: `${tableName}.last_version_chart_kind`,
                 },
+                { dashboardUuid: `${tableName}.dashboard_uuid` },
                 { spaceUuid: `${tableName}.space_uuid` },
                 { projectUuid: `${ProjectTableName}.project_uuid` },
                 { viewsCount: `${tableName}.views_count` },
@@ -1039,6 +1040,7 @@ export class SearchModel {
                 {
                     chartType: `${SavedChartsTableName}.last_version_chart_kind`,
                 },
+                { dashboardUuid: `${SavedChartsTableName}.dashboard_uuid` },
                 { spaceUuid: 'space_uuid' },
                 { projectUuid: `${ProjectTableName}.project_uuid` },
                 { search_rank: searchRankRawSql },
@@ -1316,6 +1318,7 @@ export class SearchModel {
                 {
                     chartType: `${SavedChartsTableName}.last_version_chart_kind`,
                 },
+                { dashboardUuid: `${SavedChartsTableName}.dashboard_uuid` },
                 { spaceUuid: `${SpaceTableName}.space_uuid` },
                 { search_rank: savedChartsSearchRankRawSql },
                 { projectUuid: `${ProjectTableName}.project_uuid` },
@@ -1409,6 +1412,7 @@ export class SearchModel {
                 {
                     chartType: `${SavedSqlTableName}.last_version_chart_kind`,
                 },
+                { dashboardUuid: `${SavedSqlTableName}.dashboard_uuid` },
                 { spaceUuid: `${SavedSqlTableName}.space_uuid` },
                 { search_rank: savedSqlSearchRankRawSql },
                 { projectUuid: `${ProjectTableName}.project_uuid` },
@@ -1495,6 +1499,7 @@ export class SearchModel {
                     name: string;
                     description: string;
                     chartType: string;
+                    dashboardUuid: string | null;
                     spaceUuid: string;
                     search_rank: number;
                     projectUuid: string;
@@ -1527,6 +1532,7 @@ export class SearchModel {
             name: result.name,
             description: result.description,
             chartType: result.chartType as ChartKind, // ChartKind type from database
+            dashboardUuid: result.dashboardUuid,
             spaceUuid: result.spaceUuid,
             search_rank: result.search_rank,
             projectUuid: result.projectUuid,

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1336,6 +1336,8 @@ export class SpaceModel {
             recentlyUpdated?: boolean;
             mostPopular?: boolean;
         },
+        // Directly granted dashboards outside the given spaces to include.
+        includeUuids?: string[],
     ): Promise<SpaceDashboard[]> {
         const subQuery = this.database
             .table(DashboardsTableName)
@@ -1409,7 +1411,18 @@ export class SpaceModel {
                 `${DashboardVersionsTableName}.dashboard_id as dashboard_id`,
             ])
             .distinctOn(`${DashboardVersionsTableName}.dashboard_id`)
-            .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+            .where((accessFilter) => {
+                void accessFilter.whereIn(
+                    `${SpaceTableName}.space_uuid`,
+                    spaceUuids,
+                );
+                if (includeUuids !== undefined && includeUuids.length > 0) {
+                    void accessFilter.orWhereIn(
+                        `${DashboardsTableName}.dashboard_uuid`,
+                        includeUuids,
+                    );
+                }
+            })
             .whereNull(`${DashboardsTableName}.deleted_at`)
             .orderBy([
                 {
@@ -1496,6 +1509,8 @@ export class SpaceModel {
             recentlyUpdated?: boolean;
             mostPopular?: boolean;
         },
+        // Directly granted charts outside the given spaces to include.
+        includeUuids?: string[],
     ) {
         const {
             name: chartTable,
@@ -1504,7 +1519,18 @@ export class SpaceModel {
         } = chartsTable;
 
         let spaceChartsQuery = this.database(chartTable)
-            .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+            .where((accessFilter) => {
+                void accessFilter.whereIn(
+                    `${SpaceTableName}.space_uuid`,
+                    spaceUuids,
+                );
+                if (includeUuids !== undefined && includeUuids.length > 0) {
+                    void accessFilter.orWhereIn(
+                        `${chartTable}.${uuidColumnName}`,
+                        includeUuids,
+                    );
+                }
+            })
             .leftJoin(
                 SpaceTableName,
                 `${chartTable}.space_uuid`,
@@ -1648,6 +1674,7 @@ export class SpaceModel {
             recentlyUpdated?: boolean;
             mostPopular?: boolean;
         },
+        includeUuids?: string[],
     ): Promise<SpaceQuery[]> {
         return this.getSpaceCharts(
             {
@@ -1657,6 +1684,7 @@ export class SpaceModel {
             },
             spaceUuids,
             filters,
+            includeUuids,
         );
     }
 
@@ -1666,9 +1694,22 @@ export class SpaceModel {
             recentlyUpdated?: boolean;
             mostPopular?: boolean;
         },
+        // Directly granted charts outside the given spaces to include.
+        includeUuids?: string[],
     ): Promise<SpaceQuery[]> {
         let spaceQueriesQuery = this.database(SavedChartsTableName)
-            .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+            .where((accessFilter) => {
+                void accessFilter.whereIn(
+                    `${SpaceTableName}.space_uuid`,
+                    spaceUuids,
+                );
+                if (includeUuids !== undefined && includeUuids.length > 0) {
+                    void accessFilter.orWhereIn(
+                        `${SavedChartsTableName}.saved_query_uuid`,
+                        includeUuids,
+                    );
+                }
+            })
             .whereNull(`${SavedChartsTableName}.deleted_at`)
             .leftJoin(
                 SpaceTableName,

--- a/packages/backend/src/models/UserFavoritesModel.ts
+++ b/packages/backend/src/models/UserFavoritesModel.ts
@@ -99,8 +99,12 @@ export class UserFavoritesModel {
         projectUuid: string,
         chartUuids: string[],
         allowedSpaceUuids: string[],
+        grantedChartUuids: string[] = [],
     ): Promise<ResourceViewChartItem[]> {
-        if (chartUuids.length === 0 || allowedSpaceUuids.length === 0) {
+        if (
+            chartUuids.length === 0 ||
+            (allowedSpaceUuids.length === 0 && grantedChartUuids.length === 0)
+        ) {
             return [];
         }
         const rows = (await this.database(SavedChartsTableName)
@@ -115,7 +119,18 @@ export class UserFavoritesModel {
                 'users.user_uuid',
             )
             .whereIn(`${SavedChartsTableName}.saved_query_uuid`, chartUuids)
-            .whereIn(`${SpaceTableName}.space_uuid`, allowedSpaceUuids)
+            .where((accessFilter) => {
+                void accessFilter.whereIn(
+                    `${SpaceTableName}.space_uuid`,
+                    allowedSpaceUuids,
+                );
+                if (grantedChartUuids.length > 0) {
+                    void accessFilter.orWhereIn(
+                        `${SavedChartsTableName}.saved_query_uuid`,
+                        grantedChartUuids,
+                    );
+                }
+            })
             .whereNull(`${SavedChartsTableName}.deleted_at`)
             .whereNull(`${SpaceTableName}.deleted_at`)
             .select({
@@ -163,8 +178,13 @@ export class UserFavoritesModel {
         projectUuid: string,
         dashboardUuids: string[],
         allowedSpaceUuids: string[],
+        grantedDashboardUuids: string[] = [],
     ): Promise<ResourceViewDashboardItem[]> {
-        if (dashboardUuids.length === 0 || allowedSpaceUuids.length === 0) {
+        if (
+            dashboardUuids.length === 0 ||
+            (allowedSpaceUuids.length === 0 &&
+                grantedDashboardUuids.length === 0)
+        ) {
             return [];
         }
         const rows = (await this.database(DashboardsTableName)
@@ -189,7 +209,18 @@ export class UserFavoritesModel {
             )
             .leftJoin('users', 'dv.updated_by_user_uuid', 'users.user_uuid')
             .whereIn(`${DashboardsTableName}.dashboard_uuid`, dashboardUuids)
-            .whereIn(`${SpaceTableName}.space_uuid`, allowedSpaceUuids)
+            .where((accessFilter) => {
+                void accessFilter.whereIn(
+                    `${SpaceTableName}.space_uuid`,
+                    allowedSpaceUuids,
+                );
+                if (grantedDashboardUuids.length > 0) {
+                    void accessFilter.orWhereIn(
+                        `${DashboardsTableName}.dashboard_uuid`,
+                        grantedDashboardUuids,
+                    );
+                }
+            })
             .whereNull(`${DashboardsTableName}.deleted_at`)
             .whereNull(`${SpaceTableName}.deleted_at`)
             .select(
@@ -243,12 +274,17 @@ export class UserFavoritesModel {
         projectUuid: string,
         appUuids: string[],
         allowedSpaceUuids: string[],
+        grantedAppUuids: string[] = [],
     ): Promise<ResourceViewDataAppItem[]> {
-        if (appUuids.length === 0 || allowedSpaceUuids.length === 0) {
+        if (
+            appUuids.length === 0 ||
+            (allowedSpaceUuids.length === 0 && grantedAppUuids.length === 0)
+        ) {
             return [];
         }
+        // Left join: granted personal apps have no space row.
         const rows = (await this.database(AppsTableName)
-            .innerJoin(
+            .leftJoin(
                 SpaceTableName,
                 `${SpaceTableName}.space_uuid`,
                 `${AppsTableName}.space_uuid`,
@@ -270,7 +306,18 @@ export class UserFavoritesModel {
             )
             .whereIn(`${AppsTableName}.app_id`, appUuids)
             .andWhere(`${AppsTableName}.project_uuid`, projectUuid)
-            .whereIn(`${SpaceTableName}.space_uuid`, allowedSpaceUuids)
+            .where((accessFilter) => {
+                void accessFilter.whereIn(
+                    `${SpaceTableName}.space_uuid`,
+                    allowedSpaceUuids,
+                );
+                if (grantedAppUuids.length > 0) {
+                    void accessFilter.orWhereIn(
+                        `${AppsTableName}.app_id`,
+                        grantedAppUuids,
+                    );
+                }
+            })
             .whereNull(`${AppsTableName}.deleted_at`)
             .whereNull(`${SpaceTableName}.deleted_at`)
             .where(

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -389,6 +389,7 @@ const getMockedAsyncQueryService = (
                 directOnly: false,
             })),
         } as unknown as SpacePermissionService,
+        directAccessService: {} as never,
         organizationSettingsModel: {
             get: vi.fn(async () => ({
                 queryLimit: null,

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -279,15 +279,18 @@ export class ContentService extends BaseService {
 
         return {
             ...results,
-            data: results.data.map((item): SummaryContent => {
-                if (item.contentType !== ContentType.SPACE) {
-                    return item;
-                }
-                return {
-                    ...item,
-                    access: directAccessMap[item.uuid] ?? [],
-                };
-            }),
+            data: await this.withDirectAccessRoles(
+                user,
+                results.data.map((item): SummaryContent => {
+                    if (item.contentType !== ContentType.SPACE) {
+                        return item;
+                    }
+                    return {
+                        ...item,
+                        access: directAccessMap[item.uuid] ?? [],
+                    };
+                }),
+            ),
         };
     }
 
@@ -297,6 +300,73 @@ export class ContentService extends BaseService {
      * metadata, filters, sorting, pagination, and counts behave exactly like
      * the default listing. Never unions ordinary space-accessible content.
      */
+    /**
+     * Attaches the viewer's direct-grant roles to each row. Space-derived
+     * access already reaches the client through the space list; grants do not,
+     * so without this the client cannot tell a granted resource it may manage
+     * from one it may only view.
+     */
+    private async withDirectAccessRoles(
+        user: SessionUser,
+        rows: SummaryContent[],
+    ): Promise<SummaryContent[]> {
+        if (rows.length === 0 || user.organizationUuid === undefined) {
+            return rows;
+        }
+        const uuidsByType = rows.reduce<
+            Record<DirectAccessResourceType, string[]>
+        >(
+            (acc, row) => {
+                switch (row.contentType) {
+                    case ContentType.DASHBOARD:
+                        acc[DirectAccessResourceType.DASHBOARD].push(row.uuid);
+                        break;
+                    case ContentType.CHART:
+                        acc[
+                            row.source === ChartSourceType.SQL
+                                ? DirectAccessResourceType.SQL_CHART
+                                : DirectAccessResourceType.CHART
+                        ].push(row.uuid);
+                        break;
+                    case ContentType.DATA_APP:
+                        acc[DirectAccessResourceType.APP].push(row.uuid);
+                        break;
+                    default:
+                        break;
+                }
+                return acc;
+            },
+            {
+                [DirectAccessResourceType.DASHBOARD]: [],
+                [DirectAccessResourceType.CHART]: [],
+                [DirectAccessResourceType.SQL_CHART]: [],
+                [DirectAccessResourceType.APP]: [],
+            },
+        );
+
+        const rolesByUuid = await this.directAccessService.findGrantedRoles(
+            {
+                userUuid: user.userUuid,
+                organizationUuid: user.organizationUuid,
+            },
+            Object.entries(uuidsByType).map(([resourceType, uuids]) => ({
+                resourceType: resourceType as DirectAccessResourceType,
+                uuids,
+            })),
+        );
+        if (Object.keys(rolesByUuid).length === 0) {
+            return rows;
+        }
+
+        return rows.map((row) => {
+            const roles = rolesByUuid[row.uuid];
+            if (roles === undefined || row.contentType === ContentType.SPACE) {
+                return row;
+            }
+            return { ...row, directAccessRoles: roles };
+        });
+    }
+
     private async findSharedWithMe(
         user: SessionUser,
         filters: ContentFilters & { projectUuids: string[] },
@@ -374,9 +444,12 @@ export class ContentService extends BaseService {
             ...results,
             // Spaces are excluded from grantable content types above, so no
             // row needs the SpaceContent access enrichment.
-            data: results.data.filter(
-                (item): item is Exclude<SummaryContent, SpaceContentBase> =>
-                    item.contentType !== ContentType.SPACE,
+            data: await this.withDirectAccessRoles(
+                user,
+                results.data.filter(
+                    (item): item is Exclude<SummaryContent, SpaceContentBase> =>
+                        item.contentType !== ContentType.SPACE,
+                ),
             ),
         };
     }

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -101,6 +101,7 @@ describe('Csv service', () => {
                 dashboardModel: {} as DashboardModel,
             }),
             spacePermissionService: {} as SpacePermissionService,
+            directAccessService: {} as never,
             organizationSettingsModel: {} as OrganizationSettingsModel,
             getDataAppCustomSqlProvenance: async () => ({
                 tableCalculations: new Set(),

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.ts
@@ -83,7 +83,16 @@ export class DirectAccessService extends BaseService {
             resourceUuids: string[],
             userUuid: string,
             opts: { organizationUuid: string },
-        ) => Promise<Record<string, { projectUuid: UUID }>>;
+        ) => Promise<
+            Record<
+                string,
+                {
+                    projectUuid: UUID;
+                    userRole: SpaceMemberRole | null;
+                    groupRoles: SpaceMemberRole[];
+                }
+            >
+        >;
     } {
         switch (resourceType) {
             case DirectAccessResourceType.DASHBOARD:
@@ -100,6 +109,54 @@ export class DirectAccessService extends BaseService {
                     'Unsupported direct access resource type',
                 );
         }
+    }
+
+    /**
+     * Roles the user holds through direct grants on the given resources, keyed
+     * by resource UUID. Discovery surfaces need these to reason about what the
+     * viewer may do with a granted resource: a content grant never puts its
+     * parent space in the viewer's space list, so space-derived access alone
+     * under-reports their rights. Feature off means no roles.
+     */
+    async findGrantedRoles(
+        user: { userUuid: UUID; organizationUuid: UUID },
+        resources: { resourceType: DirectAccessResourceType; uuids: UUID[] }[],
+    ): Promise<Record<string, SpaceMemberRole[]>> {
+        const withUuids = resources.filter(({ uuids }) => uuids.length > 0);
+        if (withUuids.length === 0) {
+            return {};
+        }
+        const enabled =
+            await this.directAccessFeatureGate.isEnabledForUser(user);
+        if (!enabled) {
+            return {};
+        }
+
+        const perType = await Promise.all(
+            withUuids.map(async ({ resourceType, uuids }) =>
+                this.getGrantReadModel(resourceType).getUserAccess(
+                    uuids,
+                    user.userUuid,
+                    { organizationUuid: user.organizationUuid },
+                ),
+            ),
+        );
+
+        return perType.reduce<Record<string, SpaceMemberRole[]>>(
+            (acc, access) => {
+                Object.entries(access).forEach(([resourceUuid, grant]) => {
+                    const roles = [
+                        ...(grant.userRole ? [grant.userRole] : []),
+                        ...grant.groupRoles,
+                    ];
+                    if (roles.length > 0) {
+                        acc[resourceUuid] = roles;
+                    }
+                });
+                return acc;
+            },
+            {},
+        );
     }
 
     /**

--- a/packages/backend/src/services/FavoritesService/FavoritesService.ts
+++ b/packages/backend/src/services/FavoritesService/FavoritesService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     assertUnreachable,
     ContentType,
+    DirectAccessResourceType,
     ForbiddenError,
     ParameterError,
     ResourceViewItemType,
@@ -18,6 +19,7 @@ import { SavedChartModel } from '../../models/SavedChartModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { UserFavoritesModel } from '../../models/UserFavoritesModel';
 import { BaseService } from '../BaseService';
+import type { DirectAccessService } from '../DirectAccess/DirectAccessService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 
 type FavoritesServiceArguments = {
@@ -26,6 +28,7 @@ type FavoritesServiceArguments = {
     projectModel: ProjectModel;
     spaceModel: SpaceModel;
     spacePermissionService: SpacePermissionService;
+    directAccessService: DirectAccessService;
     savedChartModel: SavedChartModel;
     dashboardModel: DashboardModel;
     appModel: AppModel;
@@ -42,6 +45,8 @@ export class FavoritesService extends BaseService {
 
     private readonly spacePermissionService: SpacePermissionService;
 
+    private readonly directAccessService: DirectAccessService;
+
     private readonly savedChartModel: SavedChartModel;
 
     private readonly dashboardModel: DashboardModel;
@@ -54,6 +59,7 @@ export class FavoritesService extends BaseService {
         projectModel,
         spaceModel,
         spacePermissionService,
+        directAccessService,
         savedChartModel,
         dashboardModel,
         appModel,
@@ -64,6 +70,7 @@ export class FavoritesService extends BaseService {
         this.projectModel = projectModel;
         this.spaceModel = spaceModel;
         this.spacePermissionService = spacePermissionService;
+        this.directAccessService = directAccessService;
         this.savedChartModel = savedChartModel;
         this.dashboardModel = dashboardModel;
         this.appModel = appModel;
@@ -93,26 +100,66 @@ export class FavoritesService extends BaseService {
         }
 
         // Verify the user has permission to view the content they're trying to
-        // favorite. Resolve the canonical UUID from the entity since callers may
-        // pass a slug — content_uuid is a uuid column and would reject a slug.
-        let spaceUuid: string;
+        // favorite; resource-aware access so directly granted content counts.
+        // Resolve the canonical UUID from the entity since callers may pass a
+        // slug — content_uuid is a uuid column and would reject a slug.
         let resolvedContentUuid: string;
+        let canViewContent: boolean;
         switch (contentType) {
             case ContentType.SPACE:
-                spaceUuid = contentUuid;
                 resolvedContentUuid = contentUuid;
+                canViewContent = await this.spacePermissionService.can(
+                    'view',
+                    user,
+                    contentUuid,
+                );
                 break;
             case ContentType.CHART: {
                 const chart = await this.savedChartModel.get(contentUuid);
-                spaceUuid = chart.spaceUuid;
                 resolvedContentUuid = chart.uuid;
+                const context = await this.spacePermissionService.resolveAccess(
+                    user.userUuid,
+                    {
+                        type: 'chart',
+                        chartUuid: chart.uuid,
+                        dashboardUuid: chart.dashboardUuid ?? null,
+                        spaceUuid: chart.spaceUuid,
+                    },
+                );
+                canViewContent = auditedAbility.can(
+                    'view',
+                    subject('SavedChart', {
+                        ...context,
+                        metadata: {
+                            savedChartUuid: chart.uuid,
+                            savedChartName: chart.name,
+                        },
+                    }),
+                );
                 break;
             }
             case ContentType.DASHBOARD: {
                 const dashboard =
                     await this.dashboardModel.getByIdOrSlug(contentUuid);
-                spaceUuid = dashboard.spaceUuid;
                 resolvedContentUuid = dashboard.uuid;
+                const context = await this.spacePermissionService.resolveAccess(
+                    user.userUuid,
+                    {
+                        type: 'dashboard',
+                        dashboardUuid: dashboard.uuid,
+                        spaceUuid: dashboard.spaceUuid,
+                    },
+                );
+                canViewContent = auditedAbility.can(
+                    'view',
+                    subject('Dashboard', {
+                        ...context,
+                        metadata: {
+                            dashboardUuid: dashboard.uuid,
+                            dashboardName: dashboard.name,
+                        },
+                    }),
+                );
                 break;
             }
             case ContentType.DATA_APP: {
@@ -128,8 +175,24 @@ export class FavoritesService extends BaseService {
                         'Personal data apps cannot be favorited',
                     );
                 }
-                spaceUuid = app.space_uuid;
                 resolvedContentUuid = app.app_id;
+                const context = await this.spacePermissionService.resolveAccess(
+                    user.userUuid,
+                    {
+                        type: 'app',
+                        appUuid: app.app_id,
+                        organizationUuid: project.organizationUuid,
+                        projectUuid,
+                        spaceUuid: app.space_uuid,
+                    },
+                );
+                canViewContent = auditedAbility.can(
+                    'view',
+                    subject('DataApp', {
+                        ...context,
+                        createdByUserUuid: app.created_by_user_uuid,
+                    }),
+                );
                 break;
             }
             default:
@@ -139,12 +202,7 @@ export class FavoritesService extends BaseService {
                 );
         }
 
-        const canViewSpace = await this.spacePermissionService.can(
-            'view',
-            user,
-            spaceUuid,
-        );
-        if (!canViewSpace) {
+        if (!canViewContent) {
             throw new ForbiddenError();
         }
 
@@ -212,12 +270,24 @@ export class FavoritesService extends BaseService {
 
         const spaces = await this.spaceModel.find({ projectUuid });
         const spaceUuids = spaces.map((s) => s.uuid);
-        const allowedSpaceUuids =
-            await this.spacePermissionService.getAccessibleSpaceUuids(
+        const [allowedSpaceUuids, granted] = await Promise.all([
+            this.spacePermissionService.getAccessibleSpaceUuids(
                 'view',
                 user,
                 spaceUuids,
-            );
+            ),
+            // Directly granted content stays visible in the caller's own
+            // favorites even without any space access path.
+            user.organizationUuid
+                ? this.directAccessService.findSharedWithMeUuids(
+                      {
+                          userUuid: user.userUuid,
+                          organizationUuid: user.organizationUuid,
+                      },
+                      [projectUuid],
+                  )
+                : undefined,
+        ]);
 
         const favoriteRows = await this.userFavoritesModel.getFavoriteUuids(
             user.userUuid,
@@ -246,11 +316,13 @@ export class FavoritesService extends BaseService {
                 projectUuid,
                 chartUuids,
                 allowedSpaceUuids,
+                granted?.[DirectAccessResourceType.CHART],
             ),
             this.userFavoritesModel.getFavoriteDashboards(
                 projectUuid,
                 dashboardUuids,
                 allowedSpaceUuids,
+                granted?.[DirectAccessResourceType.DASHBOARD],
             ),
             this.userFavoritesModel.getFavoriteSpaces(
                 projectUuid,
@@ -261,6 +333,7 @@ export class FavoritesService extends BaseService {
                 projectUuid,
                 appUuids,
                 allowedSpaceUuids,
+                granted?.[DirectAccessResourceType.APP],
             ),
         ]);
 

--- a/packages/backend/src/services/PinningService/PinningService.ts
+++ b/packages/backend/src/services/PinningService/PinningService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    DirectAccessResourceType,
     ForbiddenError,
     ResourceViewItemType,
     type PinnedItems,
@@ -14,6 +15,7 @@ import { ResourceViewItemModel } from '../../models/ResourceViewItemModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { BaseService } from '../BaseService';
+import type { DirectAccessService } from '../DirectAccess/DirectAccessService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 
 type PinningServiceArguments = {
@@ -27,6 +29,7 @@ type PinningServiceArguments = {
     resourceViewItemModel: ResourceViewItemModel;
     projectModel: ProjectModel;
     spacePermissionService: SpacePermissionService;
+    directAccessService: DirectAccessService;
 };
 
 export class PinningService extends BaseService {
@@ -44,6 +47,8 @@ export class PinningService extends BaseService {
 
     spacePermissionService: SpacePermissionService;
 
+    directAccessService: DirectAccessService;
+
     constructor({
         dashboardModel,
         savedChartModel,
@@ -52,6 +57,7 @@ export class PinningService extends BaseService {
         resourceViewItemModel,
         projectModel,
         spacePermissionService,
+        directAccessService,
     }: PinningServiceArguments) {
         super();
         this.dashboardModel = dashboardModel;
@@ -61,6 +67,7 @@ export class PinningService extends BaseService {
         this.resourceViewItemModel = resourceViewItemModel;
         this.projectModel = projectModel;
         this.spacePermissionService = spacePermissionService;
+        this.directAccessService = directAccessService;
     }
 
     async getPinnedItems(
@@ -87,14 +94,36 @@ export class PinningService extends BaseService {
 
         const spaces = await this.spaceModel.find({ projectUuid });
         const spaceUuids = spaces.map((s) => s.uuid);
-        const allowedSpaceUuids =
-            await this.spacePermissionService.getAccessibleSpaceUuids(
+        const [allowedSpaceUuids, granted] = await Promise.all([
+            this.spacePermissionService.getAccessibleSpaceUuids(
                 'view',
                 user,
                 spaceUuids,
-            );
+            ),
+            // Pinned content the caller was directly granted stays visible
+            // even without any space access path.
+            user.organizationUuid
+                ? this.directAccessService.findSharedWithMeUuids(
+                      {
+                          userUuid: user.userUuid,
+                          organizationUuid: user.organizationUuid,
+                      },
+                      [projectUuid],
+                  )
+                : undefined,
+        ]);
+        const grantedChartUuids =
+            granted?.[DirectAccessResourceType.CHART] ?? [];
+        const grantedDashboardUuids =
+            granted?.[DirectAccessResourceType.DASHBOARD] ?? [];
+        const grantedAppUuids = granted?.[DirectAccessResourceType.APP] ?? [];
 
-        if (allowedSpaceUuids.length === 0) {
+        if (
+            allowedSpaceUuids.length === 0 &&
+            grantedChartUuids.length === 0 &&
+            grantedDashboardUuids.length === 0 &&
+            grantedAppUuids.length === 0
+        ) {
             return [];
         }
 
@@ -137,6 +166,11 @@ export class PinningService extends BaseService {
             projectUuid,
             pinnedListUuid,
             allowedSpaceUuids,
+            {
+                chartUuids: grantedChartUuids,
+                dashboardUuids: grantedDashboardUuids,
+                appUuids: grantedAppUuids,
+            },
         );
 
         return [

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -478,6 +478,14 @@ const getMockedProjectService = (
         }),
         spacePermissionService:
             overrides.spacePermissionService ?? ({} as SpacePermissionService),
+        directAccessService: {
+            findSharedWithMeUuids: vi.fn().mockResolvedValue({
+                dashboard: [],
+                chart: [],
+                sqlChart: [],
+                app: [],
+            }),
+        } as never,
         provisionPlaygroundProject: overrides.provisionPlaygroundProject,
         getAiAgentService: overrides.getAiAgentService,
         getDataAppCustomSqlProvenance:

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -71,6 +71,7 @@ import {
     DEFAULT_SPOTLIGHT_CONFIG,
     DefaultSupportedDbtVersion,
     DimensionType,
+    DirectAccessResourceType,
     DownloadFileType,
     DuckdbConnectionType,
     EnsurePlaygroundProjectResults,
@@ -345,6 +346,7 @@ import { applyLimitToSqlQuery } from '../../utils/QueryBuilder/utils';
 import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import { BaseService } from '../BaseService';
+import type { DirectAccessService } from '../DirectAccess/DirectAccessService';
 import { resolveOrganizationExportLimits } from '../OrganizationSettingsService/resolveExportLimits';
 import { type PermissionsService } from '../PermissionsService/PermissionsService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
@@ -429,6 +431,7 @@ export type ProjectServiceArguments = {
     adminNotificationService: AdminNotificationService;
     permissionsService: PermissionsService;
     spacePermissionService: SpacePermissionService;
+    directAccessService: DirectAccessService;
     natsClient?: INatsClient;
     contentVerificationModel?: ContentVerificationModel;
     organizationSettingsModel: OrganizationSettingsModel;
@@ -572,6 +575,8 @@ export class ProjectService extends BaseService {
 
     spacePermissionService: SpacePermissionService;
 
+    directAccessService: DirectAccessService;
+
     contentVerificationModel: ContentVerificationModel | undefined;
 
     organizationSettingsModel: OrganizationSettingsModel;
@@ -638,6 +643,7 @@ export class ProjectService extends BaseService {
         adminNotificationService,
         permissionsService,
         spacePermissionService,
+        directAccessService,
         contentVerificationModel,
         organizationSettingsModel,
         githubAppInstallationsModel,
@@ -688,6 +694,7 @@ export class ProjectService extends BaseService {
         this.adminNotificationService = adminNotificationService;
         this.permissionsService = permissionsService;
         this.spacePermissionService = spacePermissionService;
+        this.directAccessService = directAccessService;
         this.contentVerificationModel = contentVerificationModel;
         this.organizationSettingsModel = organizationSettingsModel;
         this.githubAppInstallationsModel = githubAppInstallationsModel;
@@ -10514,12 +10521,24 @@ export class ProjectService extends BaseService {
         }
 
         const spaces = await this.spaceModel.find({ projectUuid });
-        const allowedSpaceUuids =
-            await this.spacePermissionService.getAccessibleSpaceUuids(
+        const [allowedSpaceUuids, granted] = await Promise.all([
+            this.spacePermissionService.getAccessibleSpaceUuids(
                 'view',
                 user,
                 spaces.map((s) => s.uuid),
-            );
+            ),
+            // Directly granted content joins the homepage rails even without
+            // any space access path.
+            user.organizationUuid
+                ? this.directAccessService.findSharedWithMeUuids(
+                      {
+                          userUuid: user.userUuid,
+                          organizationUuid: user.organizationUuid,
+                      },
+                      [projectUuid],
+                  )
+                : undefined,
+        ]);
 
         const allowedSpaceUuidsSet = new Set(allowedSpaceUuids);
         const allowedSpaces = spaces.filter((space) =>
@@ -10527,6 +10546,11 @@ export class ProjectService extends BaseService {
         );
 
         const spaceUuids = allowedSpaces.map(({ uuid }) => uuid);
+        const grantedChartUuids = granted?.[DirectAccessResourceType.CHART];
+        const grantedSqlChartUuids =
+            granted?.[DirectAccessResourceType.SQL_CHART];
+        const grantedDashboardUuids =
+            granted?.[DirectAccessResourceType.DASHBOARD];
         const [
             popularCharts,
             popularSqlCharts,
@@ -10535,24 +10559,36 @@ export class ProjectService extends BaseService {
             recentSqlCharts,
             recentDashboards,
         ] = await Promise.all([
-            this.spaceModel.getSpaceQueries(spaceUuids, {
-                mostPopular: true,
-            }),
-            this.spaceModel.getSpaceSqlCharts(spaceUuids, {
-                mostPopular: true,
-            }),
-            this.spaceModel.getSpaceDashboards(spaceUuids, {
-                mostPopular: true,
-            }),
-            this.spaceModel.getSpaceQueries(spaceUuids, {
-                recentlyUpdated: true,
-            }),
-            this.spaceModel.getSpaceSqlCharts(spaceUuids, {
-                recentlyUpdated: true,
-            }),
-            this.spaceModel.getSpaceDashboards(spaceUuids, {
-                recentlyUpdated: true,
-            }),
+            this.spaceModel.getSpaceQueries(
+                spaceUuids,
+                { mostPopular: true },
+                grantedChartUuids,
+            ),
+            this.spaceModel.getSpaceSqlCharts(
+                spaceUuids,
+                { mostPopular: true },
+                grantedSqlChartUuids,
+            ),
+            this.spaceModel.getSpaceDashboards(
+                spaceUuids,
+                { mostPopular: true },
+                grantedDashboardUuids,
+            ),
+            this.spaceModel.getSpaceQueries(
+                spaceUuids,
+                { recentlyUpdated: true },
+                grantedChartUuids,
+            ),
+            this.spaceModel.getSpaceSqlCharts(
+                spaceUuids,
+                { recentlyUpdated: true },
+                grantedSqlChartUuids,
+            ),
+            this.spaceModel.getSpaceDashboards(
+                spaceUuids,
+                { recentlyUpdated: true },
+                grantedDashboardUuids,
+            ),
         ]);
 
         return {

--- a/packages/backend/src/services/SearchService/SearchService.test.ts
+++ b/packages/backend/src/services/SearchService/SearchService.test.ts
@@ -115,3 +115,172 @@ describe('SearchService.findContent', () => {
         expect(appGenerateService.filterAppsUserCanView).not.toHaveBeenCalled();
     });
 });
+
+describe('SearchService resource-aware access', () => {
+    const directViewer = {
+        userUuid: 'direct-user-uuid',
+        ability: defineUserAbility(
+            {
+                role: OrganizationMemberRole.INTERACTIVE_VIEWER,
+                organizationUuid,
+                userUuid: 'direct-user-uuid',
+                roleUuid: undefined,
+            },
+            [],
+        ),
+    } as unknown as SessionUser;
+
+    const grantOnlyContext = {
+        organizationUuid,
+        projectUuid,
+        inheritsFromOrgOrProject: false,
+        access: [
+            {
+                userUuid: 'direct-user-uuid',
+                role: 'viewer',
+                hasDirectAccess: true,
+                grantedVia: 'dashboard',
+            },
+        ],
+        admins: [],
+        directOnly: true,
+    };
+
+    it('findContent surfaces directly granted dashboards through resource targets', async () => {
+        const dashboard = {
+            uuid: 'dashboard-uuid',
+            name: 'Granted dashboard',
+            spaceUuid: 'private-space-uuid',
+            projectUuid,
+            charts: [],
+        };
+        const resolveAccessBatch = vi.fn().mockResolvedValue([
+            {
+                target: {
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard-uuid',
+                    spaceUuid: 'private-space-uuid',
+                },
+                context: grantOnlyContext,
+            },
+        ]);
+        const grantedService = new SearchService({
+            analytics: {} as never,
+            searchModel: {
+                searchDashboards: vi.fn().mockResolvedValue([dashboard]),
+                searchAllCharts: vi.fn().mockResolvedValue([]),
+                searchDataApps: vi.fn(),
+            } as never,
+            projectModel: {
+                getSummary: vi.fn().mockResolvedValue({
+                    organizationUuid,
+                    name: 'Project',
+                }),
+            } as never,
+            spaceModel: {} as never,
+            userAttributesModel: {} as never,
+            spacePermissionService: { resolveAccessBatch } as never,
+            appGenerateService: undefined,
+        });
+
+        await expect(
+            grantedService.findContent(
+                directViewer,
+                projectUuid,
+                'granted',
+                false,
+            ),
+        ).resolves.toEqual({
+            content: [{ ...dashboard, contentType: 'dashboard' }],
+        });
+        expect(resolveAccessBatch).toHaveBeenCalledWith('direct-user-uuid', [
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-uuid',
+                spaceUuid: 'private-space-uuid',
+            },
+        ]);
+    });
+
+    it('getSearchResults builds per-resource targets and drops spaceless sql rows', async () => {
+        const searchResults = {
+            spaces: [],
+            dashboards: [
+                {
+                    uuid: 'dashboard-uuid',
+                    name: 'Granted dashboard',
+                    spaceUuid: 'private-space-uuid',
+                },
+            ],
+            dashboardTabs: [],
+            savedCharts: [
+                {
+                    uuid: 'chart-uuid',
+                    name: 'Owned chart',
+                    dashboardUuid: 'dashboard-uuid',
+                    spaceUuid: 'private-space-uuid',
+                },
+            ],
+            sqlCharts: [
+                {
+                    uuid: 'sql-owned-uuid',
+                    name: 'Dashboard-owned sql',
+                    dashboardUuid: 'dashboard-uuid',
+                    spaceUuid: null,
+                },
+            ],
+            fields: [],
+            tables: [],
+            pages: [],
+            dataApps: [],
+        };
+        const resolveAccessBatch = vi.fn(async (_userUuid, targets) =>
+            targets.map((target: unknown) => ({
+                target,
+                context: grantOnlyContext,
+            })),
+        );
+        const getAccessibleSpaceUuids = vi.fn().mockResolvedValue([]);
+        const grantedService = new SearchService({
+            analytics: { track: vi.fn() } as never,
+            searchModel: {
+                search: vi.fn().mockResolvedValue(searchResults),
+            } as never,
+            projectModel: {
+                getSummary: vi.fn().mockResolvedValue({
+                    organizationUuid,
+                    name: 'Project',
+                }),
+            } as never,
+            spaceModel: {} as never,
+            userAttributesModel: {} as never,
+            spacePermissionService: {
+                resolveAccessBatch,
+                getAccessibleSpaceUuids,
+            } as never,
+            appGenerateService: undefined,
+        });
+
+        const filtered = await grantedService.getSearchResults(
+            directViewer,
+            projectUuid,
+            'granted',
+        );
+        expect(resolveAccessBatch).toHaveBeenCalledWith('direct-user-uuid', [
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-uuid',
+                spaceUuid: 'private-space-uuid',
+            },
+            {
+                type: 'chart',
+                chartUuid: 'chart-uuid',
+                dashboardUuid: 'dashboard-uuid',
+                spaceUuid: 'private-space-uuid',
+            },
+        ]);
+        expect(filtered.dashboards).toHaveLength(1);
+        expect(filtered.savedCharts).toHaveLength(1);
+        expect(filtered.sqlCharts).toHaveLength(0);
+    });
+});

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -25,7 +25,7 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { UserAttributesModel } from '../../models/UserAttributesModel';
 import { BaseService } from '../BaseService';
 import {
-    spaceContextsByUuid,
+    type AccessTarget,
     type SpacePermissionService,
 } from '../SpaceService/SpacePermissionService';
 import { checkUserAttributesAccess } from '../UserAttributesService/UserAttributeUtils';
@@ -47,6 +47,33 @@ export type FindContentSearchResult =
     | (DataAppSearchResult & { contentType: 'data_app' });
 
 export class SearchService extends BaseService {
+    private static getContentAccessTarget(
+        content: DashboardSearchResult | AllChartsSearchResult,
+    ): AccessTarget | null {
+        if ('charts' in content) {
+            return {
+                type: 'dashboard',
+                dashboardUuid: content.uuid,
+                spaceUuid: content.spaceUuid,
+            };
+        }
+        if (content.chartSource === 'sql') {
+            return content.spaceUuid
+                ? {
+                      type: 'sqlChart',
+                      savedSqlUuid: content.uuid,
+                      spaceUuid: content.spaceUuid,
+                  }
+                : null;
+        }
+        return {
+            type: 'chart',
+            chartUuid: content.uuid,
+            dashboardUuid: content.dashboardUuid,
+            spaceUuid: content.spaceUuid,
+        };
+    }
+
     private readonly searchModel: SearchModel;
 
     private readonly analytics: LightdashAnalytics;
@@ -141,16 +168,17 @@ export class SearchService extends BaseService {
             return { content: [] };
         }
 
-        const spaceUuids = [
-            ...new Set(allContent.map((content) => content.spaceUuid)),
-        ];
-        const [resolvedSpaceContexts, visibleDataApps] = await Promise.all([
+        // Resource-aware targets: direct grants on a dashboard, chart, or SQL
+        // chart count exactly like space access. Rows without a resolvable
+        // location (dashboard-owned SQL definitions have no own space) drop.
+        const contentWithTargets = allContent.flatMap((content) => {
+            const target = SearchService.getContentAccessTarget(content);
+            return target ? [{ content, target }] : [];
+        });
+        const [resolvedContexts, visibleDataApps] = await Promise.all([
             this.spacePermissionService.resolveAccessBatch(
                 user.userUuid,
-                spaceUuids.map((spaceUuid) => ({
-                    type: 'space' as const,
-                    spaceUuid,
-                })),
+                contentWithTargets.map(({ target }) => target),
             ),
             this.appGenerateService && dataAppSearchResults.length > 0
                 ? this.appGenerateService.filterAppsUserCanView(
@@ -161,25 +189,26 @@ export class SearchService extends BaseService {
                   )
                 : Promise.resolve([]),
         ]);
-        const spaceContexts = spaceContextsByUuid(resolvedSpaceContexts);
 
-        const contentWithContext = allContent.flatMap((content) => {
-            const spaceContext = spaceContexts[content.spaceUuid];
-            return spaceContext ? [{ content, spaceContext }] : [];
-        });
+        const contentWithContext = contentWithTargets.flatMap(
+            ({ content }, index) => {
+                const context = resolvedContexts[index]?.context;
+                return context ? [{ content, context }] : [];
+            },
+        );
         const accessResults = auditedAbility.canBulk(
             'view',
-            contentWithContext.map(({ content, spaceContext }) =>
+            contentWithContext.map(({ content, context }) =>
                 'charts' in content
                     ? subject('Dashboard', {
-                          ...spaceContext,
+                          ...context,
                           metadata: {
                               dashboardUuid: content.uuid,
                               dashboardName: content.name,
                           },
                       })
                     : subject('SavedChart', {
-                          ...spaceContext,
+                          ...context,
                           metadata: {
                               savedChartUuid: content.uuid,
                               savedChartName: content.name,
@@ -239,17 +268,7 @@ export class SearchService extends BaseService {
         );
 
         const spaceUuids = [
-            ...new Set([
-                ...results.dashboards.map((dashboard) => dashboard.spaceUuid),
-                ...results.dashboardTabs.map(
-                    (dashboardTab) => dashboardTab.spaceUuid,
-                ),
-                ...results.sqlCharts.map((sqlChart) => sqlChart.spaceUuid),
-                ...results.savedCharts.map(
-                    (savedChart) => savedChart.spaceUuid,
-                ),
-                ...results.spaces.map((space) => space.uuid),
-            ]),
+            ...new Set(results.spaces.map((space) => space.uuid)),
         ];
 
         const accessibleSpaceUuids =
@@ -259,17 +278,133 @@ export class SearchService extends BaseService {
                 spaceUuids,
             );
 
-        const filterItem = async (
-            item:
-                | DashboardSearchResult
-                | SpaceSearchResult
-                | SavedChartSearchResult
-                | DashboardTabResult,
-        ) => {
-            const spaceUuid: string =
-                'spaceUuid' in item ? item.spaceUuid : item.uuid;
-            return accessibleSpaceUuids.includes(spaceUuid);
+        // Content rows resolve resource-aware access in one batch so direct
+        // grants count exactly like space access; spaces themselves cannot
+        // carry grants and keep the plain space check above.
+        type SearchAccessEntry =
+            | {
+                  kind: 'dashboard';
+                  index: number;
+                  target: AccessTarget;
+                  name: string;
+                  uuid: string;
+              }
+            | {
+                  kind: 'dashboardTab';
+                  index: number;
+                  target: AccessTarget;
+                  name: string;
+                  uuid: string;
+              }
+            | {
+                  kind: 'savedChart';
+                  index: number;
+                  target: AccessTarget;
+                  name: string;
+                  uuid: string;
+              }
+            | {
+                  kind: 'sqlChart';
+                  index: number;
+                  target: AccessTarget;
+                  name: string;
+                  uuid: string;
+              };
+        const accessEntries: SearchAccessEntry[] = [
+            ...results.dashboards.map((dashboard, index) => ({
+                kind: 'dashboard' as const,
+                index,
+                target: {
+                    type: 'dashboard' as const,
+                    dashboardUuid: dashboard.uuid,
+                    spaceUuid: dashboard.spaceUuid,
+                },
+                name: dashboard.name,
+                uuid: dashboard.uuid,
+            })),
+            ...results.dashboardTabs.map((dashboardTab, index) => ({
+                kind: 'dashboardTab' as const,
+                index,
+                target: {
+                    type: 'dashboard' as const,
+                    dashboardUuid: dashboardTab.dashboardUuid,
+                    spaceUuid: dashboardTab.spaceUuid,
+                },
+                name: dashboardTab.dashboardName,
+                uuid: dashboardTab.dashboardUuid,
+            })),
+            ...results.savedCharts.map((savedChart, index) => ({
+                kind: 'savedChart' as const,
+                index,
+                target: {
+                    type: 'chart' as const,
+                    chartUuid: savedChart.uuid,
+                    dashboardUuid: savedChart.dashboardUuid,
+                    spaceUuid: savedChart.spaceUuid,
+                },
+                name: savedChart.name,
+                uuid: savedChart.uuid,
+            })),
+            // Dashboard-owned SQL definitions have no own space and drop here,
+            // matching the previous space-membership behavior.
+            ...results.sqlCharts.flatMap((sqlChart, index) =>
+                sqlChart.spaceUuid
+                    ? [
+                          {
+                              kind: 'sqlChart' as const,
+                              index,
+                              target: {
+                                  type: 'sqlChart' as const,
+                                  savedSqlUuid: sqlChart.uuid,
+                                  spaceUuid: sqlChart.spaceUuid,
+                              },
+                              name: sqlChart.name,
+                              uuid: sqlChart.uuid,
+                          },
+                      ]
+                    : [],
+            ),
+        ];
+        const resolvedContexts =
+            await this.spacePermissionService.resolveAccessBatch(
+                user.userUuid,
+                accessEntries.map(({ target }) => target),
+            );
+        const entriesWithContext = accessEntries.flatMap((entry, index) => {
+            const context = resolvedContexts[index]?.context;
+            return context ? [{ entry, context }] : [];
+        });
+        const entryAccessResults = auditedAbility.canBulk(
+            'view',
+            entriesWithContext.map(({ entry, context }) =>
+                entry.kind === 'dashboard' || entry.kind === 'dashboardTab'
+                    ? subject('Dashboard', {
+                          ...context,
+                          metadata: {
+                              dashboardUuid: entry.uuid,
+                              dashboardName: entry.name,
+                          },
+                      })
+                    : subject('SavedChart', {
+                          ...context,
+                          metadata: {
+                              savedChartUuid: entry.uuid,
+                              savedChartName: entry.name,
+                          },
+                      }),
+            ),
+        );
+        const allowedIndexes: Record<SearchAccessEntry['kind'], Set<number>> = {
+            dashboard: new Set(),
+            dashboardTab: new Set(),
+            savedChart: new Set(),
+            sqlChart: new Set(),
         };
+        entriesWithContext.forEach(({ entry }, index) => {
+            if (entryAccessResults[index]) {
+                allowedIndexes[entry.kind].add(entry.index);
+            }
+        });
 
         const hasExploreAccess = auditedAbility.can(
             'manage',
@@ -349,24 +484,7 @@ export class SearchService extends BaseService {
             }
         }
 
-        const hasDashboardAccess = await Promise.all(
-            results.dashboards.map(filterItem),
-        );
-
-        const hasDashboardTabAccess = await Promise.all(
-            results.dashboardTabs.map(filterItem),
-        );
-        const hasSavedChartAccess = await Promise.all(
-            results.savedCharts.map(filterItem),
-        );
-
-        const hasSqlChartAccess = await Promise.all(
-            results.sqlCharts.map(filterItem),
-        );
-
-        const hasSpaceAccess = await Promise.all(
-            results.spaces.map(filterItem),
-        );
+        const accessibleSpaceUuidSet = new Set(accessibleSpaceUuids);
 
         // Data apps are EE-only and have a per-app permission shape (space
         // access OR creator self-access). Skip entirely on OSS builds and
@@ -390,19 +508,21 @@ export class SearchService extends BaseService {
             ...results,
             tables: filteredTables,
             fields: filteredFields,
-            dashboards: results.dashboards.filter(
-                (_, index) => hasDashboardAccess[index],
+            dashboards: results.dashboards.filter((_, index) =>
+                allowedIndexes.dashboard.has(index),
             ),
-            dashboardTabs: results.dashboardTabs.filter(
-                (_, index) => hasDashboardTabAccess[index],
+            dashboardTabs: results.dashboardTabs.filter((_, index) =>
+                allowedIndexes.dashboardTab.has(index),
             ),
-            savedCharts: results.savedCharts.filter(
-                (_, index) => hasSavedChartAccess[index],
+            savedCharts: results.savedCharts.filter((_, index) =>
+                allowedIndexes.savedChart.has(index),
             ),
-            sqlCharts: results.sqlCharts.filter(
-                (_, index) => hasSqlChartAccess[index],
+            sqlCharts: results.sqlCharts.filter((_, index) =>
+                allowedIndexes.sqlChart.has(index),
             ),
-            spaces: results.spaces.filter((_, index) => hasSpaceAccess[index]),
+            spaces: results.spaces.filter((space) =>
+                accessibleSpaceUuidSet.has(space.uuid),
+            ),
             pages: auditedAbility.can(
                 'view',
                 subject('Analytics', {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -831,6 +831,7 @@ export class ServiceRepository
                         this.models.getResourceViewItemModel(),
                     projectModel: this.models.getProjectModel(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    directAccessService: this.getDirectAccessService(),
                 }),
         );
     }
@@ -900,6 +901,7 @@ export class ServiceRepository
                         this.getAdminNotificationService(),
                     permissionsService: this.getPermissionsService(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    directAccessService: this.getDirectAccessService(),
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
                     organizationSettingsModel:
@@ -998,6 +1000,7 @@ export class ServiceRepository
                     adminNotificationService:
                         this.getAdminNotificationService(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    directAccessService: this.getDirectAccessService(),
                     organizationSettingsModel:
                         this.models.getOrganizationSettingsModel(),
                     getDataAppCustomSqlProvenance: async () => ({
@@ -1517,6 +1520,7 @@ export class ServiceRepository
                     projectModel: this.models.getProjectModel(),
                     spaceModel: this.models.getSpaceModel(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    directAccessService: this.getDirectAccessService(),
                     savedChartModel: this.models.getSavedChartModel(),
                     dashboardModel: this.models.getDashboardModel(),
                     appModel: this.models.getAppModel(),

--- a/packages/common/src/types/content.ts
+++ b/packages/common/src/types/content.ts
@@ -3,6 +3,7 @@ import { type ContentVerificationInfo } from './contentVerification';
 import { type DashboardOwner } from './dashboard';
 import type { KnexPaginatedData } from './knex-paginate';
 import { type ChartKind } from './savedCharts';
+import { type SpaceMemberRole } from './space';
 import { type SessionUser } from './user';
 
 export enum ContentType {
@@ -66,6 +67,9 @@ export enum ChartSourceType {
 
 export interface ChartContent extends Content {
     contentType: ContentType.CHART;
+    // Roles the viewer holds on this resource through direct grants; empty
+    // when they reach it through its space (or the feature is off).
+    directAccessRoles: SpaceMemberRole[];
     source: ChartSourceType;
     chartKind: ChartKind;
     dashboard: {
@@ -78,6 +82,7 @@ export interface ChartContent extends Content {
 
 export interface DashboardContent extends Content {
     contentType: ContentType.DASHBOARD;
+    directAccessRoles: SpaceMemberRole[];
     owner: DashboardOwner | null;
 }
 
@@ -85,6 +90,7 @@ export interface DashboardContent extends Content {
 
 export interface DataAppContent extends Omit<Content, 'space' | 'pinnedList'> {
     contentType: ContentType.DATA_APP;
+    directAccessRoles: SpaceMemberRole[];
     // Personal apps have no space until their creator moves them into one.
     space: {
         uuid: string;

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -56,6 +56,8 @@ export type SavedChartSearchResult = Pick<
     'uuid' | 'name' | 'description' | 'spaceUuid' | 'projectUuid' | 'slug'
 > & {
     chartType: ChartKind;
+    /** Owning dashboard for dashboard-owned chart definitions, else null. */
+    dashboardUuid: string | null;
     validationErrors: {
         validationUuid: ValidationErrorChartResponse['validationUuid'];
         /** @deprecated Use validationUuid. Null for post-migration validations. */
@@ -84,6 +86,8 @@ export type SqlChartSearchResult = Pick<
 > & {
     uuid: SqlChart['savedSqlUuid'];
     chartType: ChartKind;
+    /** Owning dashboard for dashboard-owned chart definitions, else null. */
+    dashboardUuid: string | null;
     spaceUuid: SqlChart['space']['uuid'];
     projectUuid: SqlChart['project']['projectUuid'];
     chartSource: 'sql';
@@ -108,6 +112,8 @@ export type AllChartsSearchResult = Pick<
     'uuid' | 'name' | 'description' | 'spaceUuid' | 'projectUuid' | 'slug'
 > & {
     chartType: ChartKind;
+    /** Owning dashboard for dashboard-owned chart definitions, else null. */
+    dashboardUuid: string | null;
     chartSource: 'saved' | 'sql';
     viewsCount: number;
     firstViewedAt: string | null;


### PR DESCRIPTION
## Summary

PR 3 of 3 for [SPK-1537](https://linear.app/lightdash/issue/SPK-1537/stack-6a-unify-direct-access-administration-and-discovery) (Stack 6A). Makes the existing discovery consumers grant-aware at their existing authorization bottlenecks: directly granted content now appears in search, the omnibar, favorites, pinned items, and the homepage rails — with canonical response types and real parent data preserved. Ordinary folder browsing stays location-scoped, and no `directAccess` mode or alternate query is added to `SearchModel`.

Stacks on top of PR 2 ([#28264](https://github.com/lightdash/lightdash/pull/28264)) which landed the validated shared-with-me selector this PR reuses for collections.

Part of: https://linear.app/lightdash/issue/SPK-1537

## How each bottleneck changes

```
search / omnibar   post-fetch filter:  space-membership  →  resolveAccessBatch
(SearchService)    per row: dashboard / chart(+owning dashboard) / sqlChart
                   target, then the same CASL view subject each read path uses

favorites, pins,   pre-scoped SQL:  WHERE space IN (accessible)
homepage rails         →  WHERE (space IN accessible OR uuid IN granted)
                   granted = DirectAccessService.findSharedWithMeUuids —
                   candidates validated through the kernel's own read models,
                   so collection visibility can never disagree with runtime access
```

- **Search & omnibar** (`SearchService.getSearchResults` / `findContent`): dashboards, dashboard tabs, saved charts, and SQL charts resolve one resource-aware batch; spaces keep the plain space check (they cannot carry grants). `SearchModel` only gains a `dashboardUuid` column (additive on the search result types) so dashboard-owned charts route through their owning dashboard's grants. Dashboard-owned SQL definitions have no own space and keep dropping, as before.
- **Real parent data**: `filterAppsUserCanView` no longer nulls `spaceUuid` for direct-only viewers — the safe-parent projection Stack 6 replaces. Three sibling projections remain outside discovery (app detail response, promotion diff, content-as-code manifest) — those belong to 6B/6C decisions and are unchanged here; flagging for a call on whether to strip them next.
- **Favorites**: the listing unions granted uuids per type, and `toggleFavorite` now authorizes through the resolved resource context (a grant-only viewer can favorite their granted dashboard). The apps join becomes a left join so granted apps resolve like the content API does.
- **Pinned items**: granted charts/dashboards/apps in a pinned list stay visible to grant-only viewers; the empty-accessible-spaces short-circuit now also considers grants.
- **Homepage rails** (`getMostPopularAndRecentlyUpdated`): the three space-scoped queries take an additive `includeUuids` and rank granted content with the rest. The verified-content rail stays space-only (small follow-up, noted for 6D).
- **Feature off**: the selector returns nothing and `resolveAccessBatch` short-circuits, so every query collapses to exactly its previous shape.
- **Caches**: no discovery surface caches authorization-dependent results; the only cache on these paths is the existing 30s feature-flag gate cache, already documented on the kernel.

**Grant roles on content rows** — `ContentService` attaches `directAccessRoles: SpaceMemberRole[]` to every dashboard, chart, and data-app row (empty when the viewer reaches the resource through its space, or the feature is off), via a new `DirectAccessService.findGrantedRoles`. This closes a real gap: a content grant deliberately never puts its parent space in the viewer's space list, so a client deriving permissions from space summaries alone cannot tell a granted resource it may manage from one it may only view. The roles come from the same per-type read models the shared-with-me filter already consults, so no new query shape and no extra work when the feature is off.

## Test plan

- [x] `pnpm -F common typecheck` / `lint`, `pnpm -F backend typecheck` / `lint`
- [x] DirectAccess unit suites pass (22)
- [x] Live: `GET /api/v2/content?sharedWithMe=true` returns each row with the viewer's own grant role — admin's 20 fixtures come back `viewer`/`editor`/`admin` per the seeded cycle, and a grant-only editor sees exactly their one granted dashboard as `['editor']`
- [x] SearchService unit tests (4 pass; 2 new): granted dashboard surfaces via resource targets in `findContent`; omnibar builds per-resource targets (chart rows carry their owning dashboard) and drops spaceless SQL rows
- [x] AppGenerateService direct-access tests updated: search rows keep the real `spaceUuid`
- [x] ProjectService / CsvService / AsyncQueryService suites pass with the new dependency (286 tests)
- [x] Live on dev instance as an org editor with zero space access, one private-space dashboard granted then revoked:
  - search `Needle`: `[]` → `[granted dashboard]` → `[]`
  - homepage recently-updated: absent → present → absent
  - favorites: toggle succeeds only while granted; listing shows the real space uuid; empty after revoke
  - pinned items: pinned granted dashboard visible → empty after revoke
  - all admin/default-path listings unchanged throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

