### PR TITLE
fix(auth): respect organization SSO for invite links

### DIFF
--- a/packages/backend/src/controllers/inviteLinksController.ts
+++ b/packages/backend/src/controllers/inviteLinksController.ts
@@ -1,5 +1,6 @@
 import {
     ApiErrorPayload,
+    ApiGetInviteLinkResponse,
     ApiInviteLinkResponse,
     ApiRegisterUserResponse,
     ApiSuccessEmpty,
@@ -45,10 +46,10 @@ export class InviteLinksController extends BaseController {
     @OperationId('GetInviteLink')
     async getInviteLink(
         @Path() inviteLinkCode: string,
-    ): Promise<ApiInviteLinkResponse> {
+    ): Promise<ApiGetInviteLinkResponse> {
         const inviteLink = await this.services
             .getUserService()
-            .getInviteLink(inviteLinkCode);
+            .getInviteLinkWithAuthenticationOptions(inviteLinkCode);
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -1074,6 +1074,27 @@ describe('UserService', () => {
             });
         });
 
+        test('requires SSO instead of activating the invited user when local authentication is disabled', async () => {
+            vi.mocked(inviteLinkModel.getByCode).mockResolvedValueOnce(
+                validInviteLink,
+            );
+            const service = createUserService(lightdashConfigMock);
+            vi.spyOn(service, 'isLoginMethodAllowed').mockResolvedValue(false);
+
+            await expect(
+                service.activateUserFromInviteWithoutPassword(
+                    validInviteLink.inviteCode,
+                ),
+            ).rejects.toThrow(
+                new ForbiddenError('Your organisation requires SSO sign-in'),
+            );
+
+            expect(
+                userModel.activateUserWithoutPassword,
+            ).not.toHaveBeenCalled();
+            expect(inviteLinkModel.deleteByCode).not.toHaveBeenCalled();
+        });
+
         test('rejects an expired invite without activating the user', async () => {
             vi.mocked(inviteLinkModel.getByCode).mockRejectedValueOnce(
                 new ExpiredError('Invite link expired'),
@@ -1200,6 +1221,34 @@ describe('UserService', () => {
                 organizationAllowedEmailDomainsModel.findAllowedEmailDomains,
             ).not.toHaveBeenCalled();
             expect(userModel.addProjectMemberships).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getInviteLinkWithAuthenticationOptions', () => {
+        test('returns the SSO provider and disables local invite flows when SSO is required', async () => {
+            vi.mocked(inviteLinkModel.getByCode).mockResolvedValueOnce(
+                inviteLink,
+            );
+            const service = createUserService(lightdashConfigMock);
+            vi.spyOn(service, 'getLoginOptions').mockResolvedValue({
+                showOptions: [OpenIdIdentityIssuerType.GOOGLE],
+                forceRedirect: true,
+                redirectUri: 'https://example.com/api/v1/login/google',
+            });
+            vi.spyOn(service, 'isLoginMethodAllowed').mockResolvedValue(false);
+
+            await expect(
+                service.getInviteLinkWithAuthenticationOptions(
+                    inviteLink.inviteCode,
+                ),
+            ).resolves.toEqual({
+                ...inviteLink,
+                authentication: {
+                    allowOneClickActivation: false,
+                    allowPasswordSignup: false,
+                    ssoProviders: [OpenIdIdentityIssuerType.GOOGLE],
+                },
+            });
         });
     });
 
@@ -2482,6 +2531,34 @@ describe('UserService', () => {
                 redirectUri:
                     'https://test.lightdash.cloud/api/v1/login/azuread?login_hint=user%40acme.com',
                 showOptions: ['azuread'],
+            });
+        });
+
+        test('passwordless user keeps email OTP alongside per-org SSO when local login is allowed', async () => {
+            const method = {
+                ...googleMethod,
+                organizationUuid: sessionUser.organizationUuid!,
+                allowPassword: true,
+            };
+            (
+                organizationSsoModel.findEnabledMethodsForEmailDomain as import('vitest').Mock
+            )
+                .mockResolvedValueOnce([method])
+                .mockResolvedValueOnce([method]);
+            vi.mocked(userModel.findUserByEmail)
+                .mockResolvedValueOnce(sessionUser)
+                .mockResolvedValueOnce(sessionUser);
+            vi.mocked(userModel.hasPasswordByEmail).mockResolvedValueOnce(
+                false,
+            );
+            vi.mocked(userModel.hasPassword).mockResolvedValueOnce(false);
+            vi.mocked(userModel.hasOpenIdIdentity).mockResolvedValueOnce(false);
+
+            const service = createUserService(configWithGoogleEnv);
+            expect(await service.getLoginOptions(sessionUser.email)).toEqual({
+                forceRedirect: false,
+                redirectUri: undefined,
+                showOptions: ['emailOtp', 'google'],
             });
         });
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -31,6 +31,7 @@ import {
     hasProperty,
     InviteLink,
     InviteLinkPurpose,
+    InviteLinkWithAuthenticationOptions,
     isEmailOnlyUser,
     isMobileLoginSsoProvider,
     isOpenIdIdentityIssuerType,
@@ -480,6 +481,7 @@ export class UserService extends BaseService {
                 );
             }
         } else if (
+            activateUser &&
             (await this.isLoginMethodAllowed(
                 userEmail,
                 LocalIssuerTypes.EMAIL,
@@ -487,6 +489,15 @@ export class UserService extends BaseService {
         ) {
             throw new ForbiddenError(
                 `User with email ${userEmail} is not allowed to login with password`,
+            );
+        } else if (
+            !activateUser &&
+            !(await this.isInviteLinkActivationAllowed(userEmail))
+        ) {
+            throw new ForbiddenError(
+                this.lightdashConfig.auth.disablePasswordAuthentication
+                    ? 'Passwordless invite activation is not allowed'
+                    : ORGANIZATION_SSO_REQUIRED_MESSAGE,
             );
         }
 
@@ -1595,6 +1606,36 @@ export class UserService extends BaseService {
 
     async getInviteLink(inviteCode: string): Promise<InviteLink> {
         return this.inviteLinkModel.getByCode(inviteCode);
+    }
+
+    private async isInviteLinkActivationAllowed(
+        email: string,
+    ): Promise<boolean> {
+        // One-click activation creates a signed-in session without an IdP
+        // challenge, so it follows the same policy as local authentication.
+        return this.isLoginMethodAllowed(email, LocalIssuerTypes.EMAIL);
+    }
+
+    async getInviteLinkWithAuthenticationOptions(
+        inviteCode: string,
+    ): Promise<InviteLinkWithAuthenticationOptions> {
+        const inviteLink = await this.getInviteLink(inviteCode);
+        const [loginOptions, allowPasswordSignup] = await Promise.all([
+            this.getLoginOptions(inviteLink.email),
+            this.isLoginMethodAllowed(inviteLink.email, LocalIssuerTypes.EMAIL),
+        ]);
+        const allowOneClickActivation = allowPasswordSignup;
+
+        return {
+            ...inviteLink,
+            authentication: {
+                allowOneClickActivation,
+                allowPasswordSignup,
+                ssoProviders: loginOptions.showOptions.filter(
+                    isOpenIdIdentityIssuerType,
+                ),
+            },
+        };
     }
 
     async loginWithPassword(
@@ -3988,14 +4029,20 @@ export class UserService extends BaseService {
             shouldShowEmailOtp =
                 !hasPasswordLogin && !hasOpenIdIdentity && isEmailLoginAllowed;
         }
-        const applyEmailOtpOption = (options: LoginOptionTypes[]) =>
-            shouldShowEmailOtp && options.includes(LocalIssuerTypes.EMAIL)
-                ? options.map((option) =>
-                      option === LocalIssuerTypes.EMAIL
-                          ? LocalIssuerTypes.EMAIL_OTP
-                          : option,
-                  )
-                : options;
+        const applyEmailOtpOption = (
+            options: LoginOptionTypes[],
+        ): LoginOptionTypes[] => {
+            if (!shouldShowEmailOtp) return options;
+            if (options.includes(LocalIssuerTypes.EMAIL_OTP)) return options;
+            if (options.includes(LocalIssuerTypes.EMAIL)) {
+                return options.map((option) =>
+                    option === LocalIssuerTypes.EMAIL
+                        ? LocalIssuerTypes.EMAIL_OTP
+                        : option,
+                );
+            }
+            return [LocalIssuerTypes.EMAIL_OTP, ...options];
+        };
 
         let ssoOptionsForUser: OpenIdIdentityIssuerType[];
         let passwordAllowedForUser: boolean;
@@ -4053,14 +4100,15 @@ export class UserService extends BaseService {
             };
         }
 
-        const oidcOptions = showOptions.filter(isOpenIdIdentityIssuerType);
+        const loginOptions = applyEmailOtpOption(showOptions);
+        const oidcOptions = loginOptions.filter(isOpenIdIdentityIssuerType);
         // Auto-redirect when there is genuinely a single option (one OIDC
         // provider, no password input). Wrong-account loops are mitigated
         // by forwarding `login_hint` to the provider so the right account
         // is surfaced.
-        if (oidcOptions.length === 1 && showOptions.length === 1) {
+        if (oidcOptions.length === 1 && loginOptions.length === 1) {
             return {
-                showOptions,
+                showOptions: loginOptions,
                 forceRedirect: true,
                 redirectUri: new URL(
                     `/api/v1${this.getRedirectUri(
@@ -4070,7 +4118,6 @@ export class UserService extends BaseService {
                 ).href,
             };
         }
-        const loginOptions = applyEmailOtpOption(showOptions);
         return {
             showOptions: loginOptions,
             forceRedirect: false,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -236,6 +236,7 @@ import {
 } from './oauth';
 import {
     type DeleteOpenIdentity,
+    type OpenIdIdentityIssuerType,
     type OpenIdIdentitySummary,
 } from './openIdIdentity';
 import {
@@ -1177,6 +1178,14 @@ export type InviteLink = {
     email: string;
     purpose: InviteLinkPurpose;
 };
+export type InviteLinkAuthenticationOptions = {
+    allowOneClickActivation: boolean;
+    allowPasswordSignup: boolean;
+    ssoProviders: OpenIdIdentityIssuerType[];
+};
+export type InviteLinkWithAuthenticationOptions = InviteLink & {
+    authentication: InviteLinkAuthenticationOptions;
+};
 export type CreateInviteLink = {
     email: string;
     expiresAt?: Date;
@@ -1187,6 +1196,11 @@ export type CreateInviteLink = {
 export type ApiInviteLinkResponse = {
     status: 'ok';
     results: InviteLink;
+};
+
+export type ApiGetInviteLinkResponse = {
+    status: 'ok';
+    results: InviteLinkWithAuthenticationOptions;
 };
 
 export type ApiCreateProjectResults = {

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -1183,9 +1183,9 @@ export type InviteLinkAuthenticationOptions = {
     allowPasswordSignup: boolean;
     ssoProviders: OpenIdIdentityIssuerType[];
 };
-export type InviteLinkWithAuthenticationOptions = InviteLink & {
+export interface InviteLinkWithAuthenticationOptions extends InviteLink {
     authentication: InviteLinkAuthenticationOptions;
-};
+}
 export type CreateInviteLink = {
     email: string;
     expiresAt?: Date;

--- a/packages/frontend/src/hooks/useInviteLink.tsx
+++ b/packages/frontend/src/hooks/useInviteLink.tsx
@@ -2,6 +2,7 @@ import {
     type ApiError,
     type CreateInviteLink,
     type InviteLink,
+    type InviteLinkWithAuthenticationOptions,
     type LightdashUser,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -34,14 +35,14 @@ const createInviteWith3DayExpiryQuery = async (
 };
 
 const inviteLinkQuery = async (inviteCode: string) =>
-    lightdashApi<InviteLink>({
+    lightdashApi<InviteLinkWithAuthenticationOptions>({
         url: `/invite-links/${inviteCode}`,
         method: 'GET',
         body: undefined,
     });
 
 export const useInviteLink = (inviteCode: string | undefined) =>
-    useQuery<InviteLink, ApiError>({
+    useQuery<InviteLinkWithAuthenticationOptions, ApiError>({
         queryKey: ['invite_link', inviteCode],
         queryFn: () => inviteLinkQuery(inviteCode!),
         enabled: inviteCode !== undefined,

--- a/packages/frontend/src/pages/Invite.test.tsx
+++ b/packages/frontend/src/pages/Invite.test.tsx
@@ -1,0 +1,167 @@
+import {
+    FeatureFlags,
+    type InviteLinkPurpose,
+    type InviteLinkWithAuthenticationOptions,
+    type OpenIdIdentityIssuerType,
+} from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import MantineProvider from '../providers/MantineProvider';
+import Invite from './Invite';
+
+const mocks = vi.hoisted(() => ({
+    activateInvite: vi.fn(),
+    inviteLink: {
+        expiresAt: new Date('2099-01-01'),
+        inviteCode: 'invite-code',
+        inviteUrl: 'http://localhost:3000/invite/invite-code',
+        organizationUuid: 'organization-uuid',
+        userUuid: 'user-uuid',
+        email: 'invitee@lightdash.com',
+        purpose: 'member' as InviteLinkPurpose,
+        authentication: {
+            allowOneClickActivation: false,
+            allowPasswordSignup: false,
+            ssoProviders: ['azuread' as OpenIdIdentityIssuerType],
+        } as InviteLinkWithAuthenticationOptions['authentication'],
+    } satisfies InviteLinkWithAuthenticationOptions,
+}));
+
+vi.mock('../hooks/useInviteLink', () => ({
+    useInviteLink: () => ({
+        data: mocks.inviteLink,
+        error: null,
+        isInitialLoading: false,
+    }),
+    useActivateInviteLinkMutation: () => ({
+        mutate: mocks.activateInvite,
+        isLoading: false,
+        isSuccess: false,
+    }),
+}));
+
+vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({
+        data: { id: FeatureFlags.NewOnboarding, enabled: true },
+        isInitialLoading: false,
+    }),
+}));
+
+vi.mock('../providers/App/useApp', () => ({
+    default: () => ({
+        health: {
+            data: {
+                isAuthenticated: false,
+                auth: {
+                    google: {
+                        enabled: true,
+                        loginPath: '/login/google',
+                    },
+                    azuread: {
+                        enabled: false,
+                    },
+                },
+            },
+            isInitialLoading: false,
+            status: 'success',
+        },
+    }),
+}));
+
+vi.mock('../hooks/organization/useOrganization', () => ({
+    useOrganization: () => ({ data: { name: 'Lightdash' } }),
+}));
+
+vi.mock('../hooks/toaster/useToaster', () => ({
+    default: () => ({
+        showToastError: vi.fn(),
+        showToastApiError: vi.fn(),
+    }),
+}));
+
+vi.mock('../hooks/useFlashMessages', () => ({
+    useFlashMessages: () => ({ data: undefined }),
+}));
+
+vi.mock('../providers/Tracking/useTracking', () => ({
+    default: () => ({ identify: vi.fn() }),
+}));
+
+vi.mock('../components/common/AuthLayout', () => ({
+    default: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('../components/RegisterForms/CreateUserForm', () => ({
+    default: () => <div data-testid="password-signup" />,
+}));
+
+const renderInvite = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <MantineProvider env="test">
+                <MemoryRouter
+                    initialEntries={['/invite/invite-code?from=email']}
+                >
+                    <Routes>
+                        <Route
+                            path="/invite/:inviteCode"
+                            element={<Invite />}
+                        />
+                    </Routes>
+                </MemoryRouter>
+            </MantineProvider>
+        </QueryClientProvider>,
+    );
+};
+
+describe('Invite', () => {
+    beforeEach(() => {
+        mocks.inviteLink.authentication = {
+            allowOneClickActivation: false,
+            allowPasswordSignup: false,
+            ssoProviders: ['azuread' as OpenIdIdentityIssuerType],
+        };
+    });
+
+    test('requires the configured SSO provider when the invite disallows local authentication', async () => {
+        renderInvite();
+
+        const microsoftSignUp = await screen.findByRole('link', {
+            name: /Sign up with Microsoft/,
+        });
+        expect(microsoftSignUp).toHaveAttribute(
+            'href',
+            '/api/v1/login/azuread?redirect=%2F&inviteCode=invite-code&login_hint=invitee%40lightdash.com',
+        );
+        expect(
+            screen.queryByRole('button', {
+                name: 'Continue as invitee@lightdash.com',
+            }),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByTestId('password-signup')).not.toBeInTheDocument();
+    });
+
+    test('offers SSO alongside one-click activation when both are allowed', async () => {
+        mocks.inviteLink.authentication.allowOneClickActivation = true;
+        mocks.inviteLink.authentication.allowPasswordSignup = true;
+        mocks.inviteLink.authentication.ssoProviders = [
+            'google' as OpenIdIdentityIssuerType,
+        ];
+        renderInvite();
+
+        expect(
+            await screen.findByRole('button', {
+                name: 'Continue as invitee@lightdash.com',
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('link', { name: /Sign up with Google/ }),
+        ).toBeInTheDocument();
+        expect(screen.queryByTestId('password-signup')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/pages/Invite.tsx
+++ b/packages/frontend/src/pages/Invite.tsx
@@ -1,7 +1,6 @@
 import {
     FeatureFlags,
     InviteLinkPurpose,
-    OpenIdIdentityIssuerType,
     type ActivateUserWithInviteCode,
     type ApiError,
     type CreateUserArgs,
@@ -235,11 +234,11 @@ const Invite: FC = () => {
         },
     });
 
-    const allowPasswordAuthentication =
-        !health.data?.auth.disablePasswordAuthentication;
     const isNewOnboarding = newOnboardingFlag.data?.enabled ?? false;
     const showOneClick =
-        isNewOnboarding && allowPasswordAuthentication && Boolean(inviteCode);
+        isNewOnboarding &&
+        inviteLinkQuery.data?.authentication.allowOneClickActivation &&
+        Boolean(inviteCode);
 
     useEffect(() => {
         const searchParams = new URLSearchParams(search);
@@ -261,39 +260,43 @@ const Invite: FC = () => {
         return <Navigate to={{ pathname: redirectUrl }} />;
     }
 
-    const ssoAvailable =
-        health.data?.auth.google.enabled ||
-        health.data?.auth.okta.enabled ||
-        health.data?.auth.oneLogin.enabled ||
-        health.data?.auth.azuread.enabled ||
-        health.data?.auth.oidc.enabled;
-    const ssoLogins = ssoAvailable && (
+    const ssoProviders =
+        inviteLinkQuery.data?.authentication.ssoProviders ?? [];
+    const ssoLogins = ssoProviders.length > 0 && (
         <Stack>
-            {Object.values(OpenIdIdentityIssuerType).map((providerName) => (
+            {ssoProviders.map((providerName) => (
                 <ThirdPartySignInButton
                     key={providerName}
                     providerName={providerName}
                     inviteCode={inviteCode}
+                    loginHint={inviteLinkQuery.data?.email}
+                    forceShow
                     intent="signup"
                     redirect={redirectUrl}
                 />
             ))}
         </Stack>
     );
-    const passwordLogin = allowPasswordAuthentication && inviteCode && (
-        <CreateUserForm
-            isLoading={isLoading || isSuccess}
-            readOnlyEmail={inviteLinkQuery.data?.email}
-            onSubmit={({ firstName, lastName, password }: CreateUserArgs) => {
-                mutate({
-                    inviteCode,
+    const passwordLogin = inviteLinkQuery.data?.authentication
+        .allowPasswordSignup &&
+        inviteCode && (
+            <CreateUserForm
+                isLoading={isLoading || isSuccess}
+                readOnlyEmail={inviteLinkQuery.data?.email}
+                onSubmit={({
                     firstName,
                     lastName,
                     password,
-                });
-            }}
-        />
-    );
+                }: CreateUserArgs) => {
+                    mutate({
+                        inviteCode,
+                        firstName,
+                        lastName,
+                        password,
+                    });
+                }}
+            />
+        );
     const logins = (
         <>
             {ssoLogins}
@@ -348,6 +351,20 @@ const Invite: FC = () => {
                         }
                         onActivate={() => activateInvite.mutate()}
                     />
+                    {ssoLogins && (
+                        <>
+                            <Divider
+                                my="md"
+                                labelPosition="center"
+                                label={
+                                    <Text c="ldGray.5" size="sm" fw={500}>
+                                        OR
+                                    </Text>
+                                }
+                            />
+                            {ssoLogins}
+                        </>
+                    )}
                     <PrivacyTermsFootnote />
                 </>
             ) : isLinkFromEmail || isSetupInvite ? (


### PR DESCRIPTION
Closes: #28252

### Description:

Fixes [PROD-10739](https://linear.app/lightdash/issue/PROD-10739/invite-link-fails-for-users-on-an-sso-enforced-verified-domain).

- Resolve invite authentication choices from the effective per-organization SSO policy instead of instance-level health flags.
- Require the configured IdP when local authentication is disabled, with an independent server-side activation guard that leaves rejected invite links unconsumed.
- Keep SSO available alongside one-click activation when the organization allows local sign-in.
- Preserve email OTP as a returning-login option for strictly passwordless users when local authentication is allowed alongside SSO.
- Cover the per-org Azure path where the instance-level Azure provider is disabled.

Existing unexpired invite links use the new behavior without regeneration because authentication choices are resolved when the link is opened.

### Verification:

- `pnpm -F backend test src/services/UserService.test.ts src/controllers/inviteLinksController.test.ts` (179 tests)
- `pnpm -F @lightdash/frontend test src/pages/Invite.test.tsx` (2 tests)
- Common, backend, and frontend typechecks
- Focused Oxlint and Oxfmt checks
- TSOA spec and route generation
- `git diff --check`
- Browser verification on `localhost:3000`:
  - SSO-enforced Google invite showed only Google, with the invite code and email hint preserved.
  - Password-allowed Google invite showed both one-click activation and Google.
  - No invite was consumed during the SSO-only inspection.

### Risk assessment:

- [ ] This is a high-risk change

The change is limited to invite authentication selection and passwordless returning login. Activation rechecks the effective policy server-side, so stale or manipulated UI state cannot bypass SSO enforcement.