### PR TITLE
feat(direct-access): add generic management UI

### DIFF
--- a/packages/frontend/src/features/directAccess/api.ts
+++ b/packages/frontend/src/features/directAccess/api.ts
@@ -1,0 +1,75 @@
+import {
+    type ApiSuccessEmpty,
+    type DirectAccessAssignment,
+    type DirectAccessPrincipalType,
+    type DirectAccessResourceType,
+    type SpaceMemberRole,
+} from '@lightdash/common';
+import { lightdashApi } from '../../api';
+
+/**
+ * Closed reference to a resource that can carry direct access grants. The
+ * same shape addresses every supported type — no per-resource clients.
+ */
+export type DirectAccessResourceRef = {
+    resourceType: DirectAccessResourceType;
+    resourceUuid: string;
+};
+
+const assignmentsPath = (projectUuid: string, ref: DirectAccessResourceRef) =>
+    `/projects/${projectUuid}/direct-access/${ref.resourceType}/${ref.resourceUuid}/assignments`;
+
+export const getDirectAccessAssignments = (
+    projectUuid: string,
+    ref: DirectAccessResourceRef,
+) =>
+    lightdashApi<DirectAccessAssignment[]>({
+        version: 'v2',
+        url: assignmentsPath(projectUuid, ref),
+        method: 'GET',
+        body: undefined,
+    });
+
+export const upsertDirectAccessAssignment = (
+    projectUuid: string,
+    ref: DirectAccessResourceRef,
+    principalType: DirectAccessPrincipalType,
+    principalUuid: string,
+    role: SpaceMemberRole,
+) =>
+    lightdashApi<ApiSuccessEmpty['results']>({
+        version: 'v2',
+        url: `${assignmentsPath(
+            projectUuid,
+            ref,
+        )}/${principalType}/${principalUuid}`,
+        method: 'PUT',
+        body: JSON.stringify({ role }),
+    });
+
+export const revokeDirectAccessAssignment = (
+    projectUuid: string,
+    ref: DirectAccessResourceRef,
+    principalType: DirectAccessPrincipalType,
+    principalUuid: string,
+) =>
+    lightdashApi<ApiSuccessEmpty['results']>({
+        version: 'v2',
+        url: `${assignmentsPath(
+            projectUuid,
+            ref,
+        )}/${principalType}/${principalUuid}`,
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const resetDirectAccess = (
+    projectUuid: string,
+    ref: DirectAccessResourceRef,
+) =>
+    lightdashApi<ApiSuccessEmpty['results']>({
+        version: 'v2',
+        url: assignmentsPath(projectUuid, ref),
+        method: 'DELETE',
+        body: undefined,
+    });

--- a/packages/frontend/src/features/directAccess/components/DirectAccessModal.test.tsx
+++ b/packages/frontend/src/features/directAccess/components/DirectAccessModal.test.tsx
@@ -1,0 +1,344 @@
+import {
+    DirectAccessPrincipalType,
+    DirectAccessResourceType,
+    SpaceMemberRole,
+    type DirectAccessAssignment,
+} from '@lightdash/common';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import {
+    useDirectAccessAssignments,
+    useResetDirectAccess,
+    useRevokeDirectAccessAssignment,
+    useUpsertDirectAccessAssignment,
+} from '../hooks/useDirectAccess';
+import DirectAccessModal from './DirectAccessModal';
+
+vi.mock('../hooks/useDirectAccess', () => ({
+    useDirectAccessAssignments: vi.fn(),
+    useDirectAccessAvailability: vi.fn(() => ({
+        isAvailable: true,
+        isLoading: false,
+    })),
+    useUpsertDirectAccessAssignment: vi.fn(),
+    useRevokeDirectAccessAssignment: vi.fn(),
+    useResetDirectAccess: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useProjectAccess', () => ({
+    useProjectAccess: vi.fn(() => ({
+        data: [
+            {
+                userUuid: 'member-uuid',
+                firstName: 'Mallory',
+                lastName: 'Member',
+                email: 'mallory@example.com',
+            },
+        ],
+    })),
+}));
+
+vi.mock('../../projectGroupAccess/hooks/useProjectGroupAccess', () => ({
+    useProjectGroupAccessList: vi.fn(() => ({
+        data: [{ groupUuid: 'group-uuid', projectUuid: 'project-uuid' }],
+    })),
+}));
+
+vi.mock('../../../hooks/useOrganizationGroups', () => ({
+    useOrganizationGroups: vi.fn(() => ({
+        data: [{ uuid: 'group-uuid', name: 'Analysts' }],
+    })),
+}));
+
+const SESSION_USER_UUID = 'session-user-uuid';
+const PROJECT_UUID = 'project-uuid';
+
+const userAssignment = (
+    overrides: Partial<DirectAccessAssignment> = {},
+): DirectAccessAssignment => ({
+    principal: {
+        type: DirectAccessPrincipalType.USER,
+        userUuid: 'viewer-uuid',
+        firstName: 'Vera',
+        lastName: 'Viewer',
+        email: 'vera@example.com',
+    },
+    role: SpaceMemberRole.VIEWER,
+    grantedByUserUuid: SESSION_USER_UUID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+});
+
+const groupAssignment = (): DirectAccessAssignment => ({
+    principal: {
+        type: DirectAccessPrincipalType.GROUP,
+        groupUuid: 'group-uuid',
+        name: 'Analysts',
+    },
+    role: SpaceMemberRole.EDITOR,
+    grantedByUserUuid: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+});
+
+const mockedAssignments = vi.mocked(useDirectAccessAssignments);
+const mockedUpsert = vi.mocked(useUpsertDirectAccessAssignment);
+const mockedRevoke = vi.mocked(useRevokeDirectAccessAssignment);
+const mockedReset = vi.mocked(useResetDirectAccess);
+
+const upsertMutate = vi.fn();
+const revokeMutate = vi.fn();
+const resetMutate = vi.fn();
+const refetch = vi.fn();
+
+const mockAssignmentsQuery = (
+    overrides: Partial<ReturnType<typeof useDirectAccessAssignments>> = {},
+) => {
+    mockedAssignments.mockReturnValue({
+        data: [userAssignment(), groupAssignment()],
+        isInitialLoading: false,
+        isError: false,
+        error: null,
+        refetch,
+        ...overrides,
+    } as unknown as ReturnType<typeof useDirectAccessAssignments>);
+};
+
+const renderModal = (
+    resourceType: DirectAccessResourceType = DirectAccessResourceType.DASHBOARD,
+) =>
+    renderWithProviders(
+        <DirectAccessModal
+            opened
+            onClose={vi.fn()}
+            projectUuid={PROJECT_UUID}
+            resource={{
+                resourceType,
+                resourceUuid: 'resource-uuid',
+                name: 'Revenue dashboard',
+            }}
+        />,
+        { user: { userUuid: SESSION_USER_UUID } },
+    );
+
+describe('DirectAccessModal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockAssignmentsQuery();
+        mockedUpsert.mockReturnValue({
+            mutate: upsertMutate,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useUpsertDirectAccessAssignment>);
+        mockedRevoke.mockReturnValue({
+            mutate: revokeMutate,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useRevokeDirectAccessAssignment>);
+        mockedReset.mockReturnValue({
+            mutate: resetMutate,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useResetDirectAccess>);
+    });
+
+    it.each(Object.values(DirectAccessResourceType))(
+        'renders user and group assignments with the same contract for %s',
+        async (resourceType) => {
+            renderModal(resourceType);
+
+            expect(
+                await screen.findByText('Share "Revenue dashboard"'),
+            ).toBeInTheDocument();
+            expect(screen.getByText('Vera Viewer')).toBeInTheDocument();
+            expect(screen.getByText('vera@example.com')).toBeInTheDocument();
+            expect(screen.getByText('Analysts')).toBeInTheDocument();
+            expect(
+                screen.getByRole('textbox', { name: 'Role for Vera Viewer' }),
+            ).toHaveValue('Can view');
+            expect(
+                screen.getByRole('textbox', { name: 'Role for Analysts' }),
+            ).toHaveValue('Can edit');
+            // one hook family: the query is keyed by the closed resource ref
+            expect(mockedAssignments).toHaveBeenCalledWith(
+                PROJECT_UUID,
+                { resourceType, resourceUuid: 'resource-uuid' },
+                expect.objectContaining({ enabled: true }),
+            );
+        },
+    );
+
+    it('replaces a principal role through the upsert mutation', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        await user.click(
+            screen.getByRole('textbox', { name: 'Role for Analysts' }),
+        );
+        await user.click(
+            await screen.findByRole('option', { name: 'Full access' }),
+        );
+
+        expect(upsertMutate).toHaveBeenCalledWith({
+            principalType: DirectAccessPrincipalType.GROUP,
+            principalUuid: 'group-uuid',
+            role: SpaceMemberRole.ADMIN,
+        });
+    });
+
+    it('revokes another principal without confirmation', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        await user.click(
+            screen.getByRole('button', {
+                name: 'Remove access for Vera Viewer',
+            }),
+        );
+
+        expect(revokeMutate).toHaveBeenCalledWith({
+            principalType: DirectAccessPrincipalType.USER,
+            principalUuid: 'viewer-uuid',
+        });
+    });
+
+    it('asks for confirmation before self-revoke, then revokes', async () => {
+        mockAssignmentsQuery({
+            data: [
+                userAssignment({
+                    principal: {
+                        type: DirectAccessPrincipalType.USER,
+                        userUuid: SESSION_USER_UUID,
+                        firstName: 'Sam',
+                        lastName: 'Self',
+                        email: 'sam@example.com',
+                    },
+                }),
+            ],
+        });
+        const user = userEvent.setup();
+        renderModal();
+
+        // wait for the session user to resolve so self-detection is active
+        await screen.findByText('(you)');
+        await user.click(
+            screen.getByRole('button', { name: 'Remove access for Sam Self' }),
+        );
+        expect(revokeMutate).not.toHaveBeenCalled();
+        expect(
+            await screen.findByText('Remove your own access'),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Remove' }));
+        expect(revokeMutate).toHaveBeenCalledWith({
+            principalType: DirectAccessPrincipalType.USER,
+            principalUuid: SESSION_USER_UUID,
+        });
+    });
+
+    it('asks for confirmation before removing all access', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        await user.click(
+            screen.getByRole('button', { name: 'Remove all access' }),
+        );
+        expect(resetMutate).not.toHaveBeenCalled();
+        expect(
+            await screen.findByText('Remove all access'),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Remove' }));
+        expect(resetMutate).toHaveBeenCalledTimes(1);
+    });
+
+    it('adds a new principal with the selected role', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        await user.click(
+            screen.getByRole('textbox', {
+                name: 'Select a user or group to share with',
+            }),
+        );
+        await user.click(
+            await screen.findByRole('option', { name: 'Mallory Member' }),
+        );
+        await user.click(
+            screen.getByRole('textbox', { name: 'Role for new assignment' }),
+        );
+        await user.click(
+            await screen.findByRole('option', { name: 'Can edit' }),
+        );
+        await user.click(screen.getByRole('button', { name: 'Share' }));
+
+        expect(upsertMutate).toHaveBeenCalledWith({
+            principalType: DirectAccessPrincipalType.USER,
+            principalUuid: 'member-uuid',
+            role: SpaceMemberRole.EDITOR,
+        });
+    });
+
+    it('shows the empty state when nothing is assigned', async () => {
+        mockAssignmentsQuery({ data: [] });
+        renderModal();
+
+        expect(
+            await screen.findByText(
+                'Not shared with anyone yet. People with access to the space can still see it.',
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Remove all access' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('omits the space hint in the empty state for apps (may be personal)', async () => {
+        mockAssignmentsQuery({ data: [] });
+        renderModal(DirectAccessResourceType.APP);
+
+        expect(
+            await screen.findByText('Not shared with anyone yet.'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText(
+                'Not shared with anyone yet. People with access to the space can still see it.',
+            ),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows a loading state while assignments resolve', () => {
+        mockAssignmentsQuery({ data: undefined, isInitialLoading: true });
+        renderModal();
+
+        expect(screen.queryByText('Vera Viewer')).not.toBeInTheDocument();
+    });
+
+    it('shows the error state and retries', async () => {
+        mockAssignmentsQuery({
+            data: undefined,
+            isError: true,
+            error: {
+                status: 'error',
+                error: {
+                    name: 'ForbiddenError',
+                    statusCode: 403,
+                    message: 'Direct access is not available',
+                    data: {},
+                },
+            },
+        });
+        const user = userEvent.setup();
+        renderModal();
+
+        expect(
+            await screen.findByText('Could not load access'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('Direct access is not available'),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Retry' }));
+        await waitFor(() => expect(refetch).toHaveBeenCalledTimes(1));
+    });
+});

--- a/packages/frontend/src/features/directAccess/components/DirectAccessModal.tsx
+++ b/packages/frontend/src/features/directAccess/components/DirectAccessModal.tsx
@@ -1,0 +1,493 @@
+import {
+    DirectAccessPrincipalType,
+    DirectAccessResourceType,
+    SpaceMemberRole,
+    type DirectAccessAssignment,
+    type DirectAccessPrincipal,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Button,
+    Center,
+    Group,
+    Loader,
+    Select,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import { IconTrash, IconUsers } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import { LightdashUserAvatar } from '../../../components/Avatar';
+import Callout from '../../../components/common/Callout';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import {
+    getInitials,
+    getUserNameOrEmail,
+} from '../../../components/common/ShareSpaceModal/Utils';
+import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
+import { useProjectAccess } from '../../../hooks/useProjectAccess';
+import useApp from '../../../providers/App/useApp';
+import { useProjectGroupAccessList } from '../../projectGroupAccess/hooks/useProjectGroupAccess';
+import { type DirectAccessResourceRef } from '../api';
+import {
+    useDirectAccessAssignments,
+    useDirectAccessAvailability,
+    useResetDirectAccess,
+    useRevokeDirectAccessAssignment,
+    useUpsertDirectAccessAssignment,
+} from '../hooks/useDirectAccess';
+
+const ROLE_OPTIONS = [
+    { value: SpaceMemberRole.VIEWER, label: 'Can view' },
+    { value: SpaceMemberRole.EDITOR, label: 'Can edit' },
+    { value: SpaceMemberRole.ADMIN, label: 'Full access' },
+];
+
+const userDisplayName = (principal: {
+    userUuid: string;
+    firstName: string;
+    lastName: string;
+    email: string | null;
+}) =>
+    getUserNameOrEmail(
+        principal.userUuid,
+        principal.firstName,
+        principal.lastName,
+        principal.email ?? undefined,
+        false,
+    );
+
+const principalKey = (principal: DirectAccessPrincipal) =>
+    principal.type === DirectAccessPrincipalType.USER
+        ? `${DirectAccessPrincipalType.USER}:${principal.userUuid}`
+        : `${DirectAccessPrincipalType.GROUP}:${principal.groupUuid}`;
+
+const principalUuid = (principal: DirectAccessPrincipal) =>
+    principal.type === DirectAccessPrincipalType.USER
+        ? principal.userUuid
+        : principal.groupUuid;
+
+type AssignmentRowProps = {
+    assignment: DirectAccessAssignment;
+    isSelf: boolean;
+    isMutating: boolean;
+    onRoleChange: (role: SpaceMemberRole) => void;
+    onRevoke: () => void;
+};
+
+const AssignmentRow: FC<AssignmentRowProps> = ({
+    assignment,
+    isSelf,
+    isMutating,
+    onRoleChange,
+    onRevoke,
+}) => {
+    const { principal, role } = assignment;
+    const isUser = principal.type === DirectAccessPrincipalType.USER;
+
+    return (
+        <Group gap="sm" justify="space-between" wrap="nowrap">
+            <Group gap="sm" wrap="nowrap" miw={0}>
+                {isUser ? (
+                    <LightdashUserAvatar
+                        size="sm"
+                        tt="uppercase"
+                        userUuid={principal.userUuid}
+                    >
+                        {getInitials(
+                            principal.userUuid,
+                            principal.firstName,
+                            principal.lastName,
+                            principal.email ?? undefined,
+                            false,
+                        )}
+                    </LightdashUserAvatar>
+                ) : (
+                    <LightdashUserAvatar size="sm">
+                        <MantineIcon icon={IconUsers} />
+                    </LightdashUserAvatar>
+                )}
+                <Stack gap={0} miw={0}>
+                    <Text fw={600} fz="sm" truncate>
+                        {isUser ? userDisplayName(principal) : principal.name}
+                        {isSelf ? (
+                            <Text fw={400} fz="sm" span c="ldGray.6">
+                                {' '}
+                                (you)
+                            </Text>
+                        ) : null}
+                    </Text>
+                    {isUser && principal.email ? (
+                        <Text fz="xs" c="ldGray.6" truncate>
+                            {principal.email}
+                        </Text>
+                    ) : (
+                        <Text fz="xs" c="ldGray.6">
+                            {isUser ? 'User' : 'Group'}
+                        </Text>
+                    )}
+                </Stack>
+            </Group>
+
+            <Group gap="xs" wrap="nowrap">
+                <Select
+                    size="xs"
+                    w={120}
+                    aria-label={`Role for ${
+                        isUser ? userDisplayName(principal) : principal.name
+                    }`}
+                    data={ROLE_OPTIONS}
+                    value={role}
+                    disabled={isMutating}
+                    allowDeselect={false}
+                    onChange={(value) => {
+                        if (value && value !== role) {
+                            onRoleChange(value as SpaceMemberRole);
+                        }
+                    }}
+                />
+                <Tooltip label="Remove access" withArrow>
+                    <ActionIcon
+                        variant="subtle"
+                        color="red"
+                        aria-label={`Remove access for ${
+                            isUser ? userDisplayName(principal) : principal.name
+                        }`}
+                        disabled={isMutating}
+                        onClick={onRevoke}
+                    >
+                        <MantineIcon icon={IconTrash} />
+                    </ActionIcon>
+                </Tooltip>
+            </Group>
+        </Group>
+    );
+};
+
+type AddDirectAccessProps = {
+    projectUuid: string;
+    assignedKeys: Set<string>;
+    isMutating: boolean;
+    onAdd: (
+        principalType: DirectAccessPrincipalType,
+        uuid: string,
+        role: SpaceMemberRole,
+    ) => void;
+};
+
+const AddDirectAccess: FC<AddDirectAccessProps> = ({
+    projectUuid,
+    assignedKeys,
+    isMutating,
+    onAdd,
+}) => {
+    const [selectedPrincipal, setSelectedPrincipal] = useState<string | null>(
+        null,
+    );
+    const [selectedRole, setSelectedRole] = useState<SpaceMemberRole>(
+        SpaceMemberRole.VIEWER,
+    );
+    const projectAccess = useProjectAccess(projectUuid);
+    const groupAccess = useProjectGroupAccessList(projectUuid);
+    const organizationGroups = useOrganizationGroups({});
+
+    const options = useMemo(() => {
+        const groupNamesByUuid = new Map(
+            (organizationGroups.data ?? []).map((group) => [
+                group.uuid,
+                group.name,
+            ]),
+        );
+        const userOptions = (projectAccess.data ?? [])
+            .map((member) => ({
+                value: `${DirectAccessPrincipalType.USER}:${member.userUuid}`,
+                label:
+                    getUserNameOrEmail(
+                        member.userUuid,
+                        member.firstName,
+                        member.lastName,
+                        member.email,
+                        false,
+                    ) ?? member.email,
+            }))
+            .filter((option) => !assignedKeys.has(option.value));
+        const groupOptions = (groupAccess.data ?? [])
+            .map((access) => ({
+                value: `${DirectAccessPrincipalType.GROUP}:${access.groupUuid}`,
+                label: groupNamesByUuid.get(access.groupUuid) ?? 'Group',
+            }))
+            .filter((option) => !assignedKeys.has(option.value));
+        return [
+            { group: 'Users', items: userOptions },
+            { group: 'Groups', items: groupOptions },
+        ].filter((section) => section.items.length > 0);
+    }, [
+        projectAccess.data,
+        groupAccess.data,
+        organizationGroups.data,
+        assignedKeys,
+    ]);
+
+    const handleAdd = () => {
+        if (!selectedPrincipal) return;
+        const [type, uuid] = selectedPrincipal.split(':');
+        onAdd(type as DirectAccessPrincipalType, uuid, selectedRole);
+        setSelectedPrincipal(null);
+    };
+
+    return (
+        <Group gap="xs" wrap="nowrap" align="flex-end">
+            <Select
+                flex={1}
+                size="xs"
+                label="Share with"
+                placeholder="Select users or groups to share with"
+                searchable
+                clearable
+                aria-label="Select a user or group to share with"
+                nothingFoundMessage="No matching users or groups"
+                data={options}
+                value={selectedPrincipal}
+                disabled={isMutating}
+                onChange={setSelectedPrincipal}
+            />
+            <Select
+                size="xs"
+                w={120}
+                aria-label="Role for new assignment"
+                data={ROLE_OPTIONS}
+                value={selectedRole}
+                allowDeselect={false}
+                onChange={(value) => {
+                    if (value) setSelectedRole(value as SpaceMemberRole);
+                }}
+            />
+            <Button
+                size="xs"
+                disabled={!selectedPrincipal || isMutating}
+                onClick={handleAdd}
+            >
+                Share
+            </Button>
+        </Group>
+    );
+};
+
+export type DirectAccessModalProps = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    resource: DirectAccessResourceRef & { name: string };
+};
+
+type PendingConfirmation =
+    | { kind: 'reset' }
+    | { kind: 'self-revoke'; assignment: DirectAccessAssignment };
+
+const DirectAccessModal: FC<DirectAccessModalProps> = ({
+    opened,
+    onClose,
+    projectUuid,
+    resource,
+}) => {
+    const { user } = useApp();
+    const sessionUserUuid = user.data?.userUuid;
+    const ref = useMemo(
+        () => ({
+            resourceType: resource.resourceType,
+            resourceUuid: resource.resourceUuid,
+        }),
+        [resource.resourceType, resource.resourceUuid],
+    );
+    const [confirmation, setConfirmation] =
+        useState<PendingConfirmation | null>(null);
+
+    const availability = useDirectAccessAvailability();
+    const isUnavailable = !availability.isLoading && !availability.isAvailable;
+    const assignmentsQuery = useDirectAccessAssignments(projectUuid, ref, {
+        enabled: opened && availability.isAvailable,
+    });
+    const upsertMutation = useUpsertDirectAccessAssignment(projectUuid, ref);
+    const revokeMutation = useRevokeDirectAccessAssignment(projectUuid, ref);
+    const resetMutation = useResetDirectAccess(projectUuid, ref);
+    const isMutating =
+        upsertMutation.isLoading ||
+        revokeMutation.isLoading ||
+        resetMutation.isLoading;
+
+    const assignments = useMemo(
+        () => assignmentsQuery.data ?? [],
+        [assignmentsQuery.data],
+    );
+    const assignedKeys = useMemo(
+        () =>
+            new Set(
+                assignments.map((assignment) =>
+                    principalKey(assignment.principal),
+                ),
+            ),
+        [assignments],
+    );
+
+    const revokeAssignment = (assignment: DirectAccessAssignment) => {
+        revokeMutation.mutate({
+            principalType: assignment.principal.type,
+            principalUuid: principalUuid(assignment.principal),
+        });
+    };
+
+    const handleRevoke = (assignment: DirectAccessAssignment) => {
+        const isSelf =
+            assignment.principal.type === DirectAccessPrincipalType.USER &&
+            assignment.principal.userUuid === sessionUserUuid;
+        if (isSelf) {
+            setConfirmation({ kind: 'self-revoke', assignment });
+        } else {
+            revokeAssignment(assignment);
+        }
+    };
+
+    const handleConfirm = () => {
+        if (!confirmation) return;
+        if (confirmation.kind === 'reset') {
+            resetMutation.mutate();
+        } else {
+            revokeAssignment(confirmation.assignment);
+        }
+        setConfirmation(null);
+    };
+
+    return (
+        <>
+            <MantineModal
+                opened={opened && confirmation === null}
+                onClose={onClose}
+                title={`Share "${resource.name}"`}
+                icon={IconUsers}
+                size="lg"
+                leftActions={
+                    assignments.length > 0 ? (
+                        <Button
+                            variant="subtle"
+                            color="red"
+                            size="xs"
+                            disabled={isMutating}
+                            onClick={() => setConfirmation({ kind: 'reset' })}
+                        >
+                            Remove all access
+                        </Button>
+                    ) : undefined
+                }
+                actions={
+                    <Button variant="default" onClick={onClose}>
+                        Done
+                    </Button>
+                }
+            >
+                <Stack gap="md">
+                    {isUnavailable ? (
+                        <Callout variant="info" title="Sharing isn't available">
+                            <Text fz="sm">
+                                Content sharing isn't enabled for this
+                                organization.
+                            </Text>
+                        </Callout>
+                    ) : null}
+                    <AddDirectAccess
+                        projectUuid={projectUuid}
+                        assignedKeys={assignedKeys}
+                        isMutating={isMutating}
+                        onAdd={(principalType, uuid, role) =>
+                            upsertMutation.mutate({
+                                principalType,
+                                principalUuid: uuid,
+                                role,
+                            })
+                        }
+                    />
+
+                    {assignmentsQuery.isInitialLoading ? (
+                        <Center py="lg">
+                            <Loader size="sm" />
+                        </Center>
+                    ) : assignmentsQuery.isError ? (
+                        <Callout variant="danger" title="Could not load access">
+                            <Stack gap="xs" align="flex-start">
+                                <Text fz="sm">
+                                    {assignmentsQuery.error.error?.message ??
+                                        'Something went wrong.'}
+                                </Text>
+                                <Button
+                                    size="xs"
+                                    variant="default"
+                                    onClick={() =>
+                                        void assignmentsQuery.refetch()
+                                    }
+                                >
+                                    Retry
+                                </Button>
+                            </Stack>
+                        </Callout>
+                    ) : assignments.length === 0 ? (
+                        <Text fz="sm" c="ldGray.6" ta="center" py="md">
+                            {resource.resourceType ===
+                            DirectAccessResourceType.APP
+                                ? 'Not shared with anyone yet.'
+                                : 'Not shared with anyone yet. People with access to the space can still see it.'}
+                        </Text>
+                    ) : (
+                        <Stack gap="sm" role="list" aria-label="Direct access">
+                            {assignments.map((assignment) => (
+                                <AssignmentRow
+                                    key={principalKey(assignment.principal)}
+                                    assignment={assignment}
+                                    isSelf={
+                                        assignment.principal.type ===
+                                            DirectAccessPrincipalType.USER &&
+                                        assignment.principal.userUuid ===
+                                            sessionUserUuid
+                                    }
+                                    isMutating={isMutating}
+                                    onRoleChange={(role) =>
+                                        upsertMutation.mutate({
+                                            principalType:
+                                                assignment.principal.type,
+                                            principalUuid: principalUuid(
+                                                assignment.principal,
+                                            ),
+                                            role,
+                                        })
+                                    }
+                                    onRevoke={() => handleRevoke(assignment)}
+                                />
+                            ))}
+                        </Stack>
+                    )}
+                </Stack>
+            </MantineModal>
+
+            <MantineModal
+                opened={confirmation !== null}
+                onClose={() => setConfirmation(null)}
+                variant="delete"
+                size="sm"
+                title={
+                    confirmation?.kind === 'reset'
+                        ? 'Remove all access'
+                        : 'Remove your own access'
+                }
+                description={
+                    confirmation?.kind === 'reset'
+                        ? `This removes everyone "${resource.name}" was shared with. People will keep any access they have through spaces.`
+                        : `You may lose access to "${resource.name}" once it is no longer shared with you.`
+                }
+                confirmLabel="Remove"
+                onConfirm={handleConfirm}
+            />
+        </>
+    );
+};
+
+export default DirectAccessModal;

--- a/packages/frontend/src/features/directAccess/hooks/useDirectAccess.ts
+++ b/packages/frontend/src/features/directAccess/hooks/useDirectAccess.ts
@@ -1,0 +1,160 @@
+import {
+    CommercialFeatureFlags,
+    type ApiError,
+    type DirectAccessAssignment,
+    type DirectAccessPrincipalType,
+    type SpaceMemberRole,
+} from '@lightdash/common';
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    type UseQueryOptions,
+} from '@tanstack/react-query';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { invalidateContent } from '../../../hooks/useContent';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../providers/App/useApp';
+import {
+    getDirectAccessAssignments,
+    resetDirectAccess,
+    revokeDirectAccessAssignment,
+    upsertDirectAccessAssignment,
+    type DirectAccessResourceRef,
+} from '../api';
+
+const directAccessQueryKey = (
+    projectUuid: string,
+    ref: DirectAccessResourceRef,
+) => ['direct-access', projectUuid, ref.resourceType, ref.resourceUuid];
+
+/**
+ * Direct access mirrors the backend gate: the commercial flag plus a valid
+ * license. Everything the feature renders should hide behind this.
+ */
+export const useDirectAccessAvailability = () => {
+    const { health } = useApp();
+    const flagQuery = useServerFeatureFlag(CommercialFeatureFlags.DirectAccess);
+    const licenseValid = health.data?.license?.valid ?? false;
+    return {
+        isAvailable: (flagQuery.data?.enabled ?? false) && licenseValid,
+        isLoading: flagQuery.isInitialLoading || health.isInitialLoading,
+    };
+};
+
+export const useDirectAccessAssignments = (
+    projectUuid: string,
+    ref: DirectAccessResourceRef,
+    queryOptions?: UseQueryOptions<DirectAccessAssignment[], ApiError>,
+) =>
+    useQuery<DirectAccessAssignment[], ApiError>({
+        queryKey: directAccessQueryKey(projectUuid, ref),
+        queryFn: () => getDirectAccessAssignments(projectUuid, ref),
+        retry: false,
+        ...queryOptions,
+    });
+
+const useInvalidateAfterDirectAccessMutation = (
+    projectUuid: string,
+    ref: DirectAccessResourceRef,
+) => {
+    const queryClient = useQueryClient();
+    return async () => {
+        // Grants change what discovery surfaces return for the affected
+        // users; refresh the policy plus every consumer of it.
+        await Promise.all([
+            queryClient.invalidateQueries(
+                directAccessQueryKey(projectUuid, ref),
+            ),
+            queryClient.invalidateQueries(['favorites']),
+            invalidateContent(queryClient, projectUuid),
+        ]);
+    };
+};
+
+export type UpsertDirectAccessArgs = {
+    principalType: DirectAccessPrincipalType;
+    principalUuid: string;
+    role: SpaceMemberRole;
+};
+
+export const useUpsertDirectAccessAssignment = (
+    projectUuid: string,
+    ref: DirectAccessResourceRef,
+) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const invalidate = useInvalidateAfterDirectAccessMutation(projectUuid, ref);
+    return useMutation<unknown, ApiError, UpsertDirectAccessArgs>({
+        mutationFn: ({ principalType, principalUuid, role }) =>
+            upsertDirectAccessAssignment(
+                projectUuid,
+                ref,
+                principalType,
+                principalUuid,
+                role,
+            ),
+        onSuccess: async () => {
+            await invalidate();
+            showToastSuccess({ title: 'Access updated' });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update access',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export type RevokeDirectAccessArgs = {
+    principalType: DirectAccessPrincipalType;
+    principalUuid: string;
+};
+
+export const useRevokeDirectAccessAssignment = (
+    projectUuid: string,
+    ref: DirectAccessResourceRef,
+) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const invalidate = useInvalidateAfterDirectAccessMutation(projectUuid, ref);
+    return useMutation<unknown, ApiError, RevokeDirectAccessArgs>({
+        mutationFn: ({ principalType, principalUuid }) =>
+            revokeDirectAccessAssignment(
+                projectUuid,
+                ref,
+                principalType,
+                principalUuid,
+            ),
+        onSuccess: async () => {
+            await invalidate();
+            showToastSuccess({ title: 'Access removed' });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to remove access',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useResetDirectAccess = (
+    projectUuid: string,
+    ref: DirectAccessResourceRef,
+) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const invalidate = useInvalidateAfterDirectAccessMutation(projectUuid, ref);
+    return useMutation<unknown, ApiError, void>({
+        mutationFn: () => resetDirectAccess(projectUuid, ref),
+        onSuccess: async () => {
+            await invalidate();
+            showToastSuccess({ title: 'All access removed' });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to remove access',
+                apiError: error,
+            });
+        },
+    });
+};


### PR DESCRIPTION
## Summary

PR 1 of 2 for [SPK-1538](https://linear.app/lightdash/issue/SPK-1538/stack-6b-add-one-direct-access-management-and-discovery-ui) (Stack 6B). Adds the generic direct-access management UI: one typed API client, one query/mutation hook family keyed by the closed `{ resourceType, resourceUuid }` reference, and one **Share** modal that serves dashboards, saved Explore charts, saved SQL charts, and data apps through the same component contract. No resource-specific hooks or modal variants.

Stacks on top of Stack 6A PR 3 ([#28266](https://github.com/lightdash/lightdash/pull/28266)) which completed the backend administration API and discovery seams. PR 2 wires resource menus and the Shared with me section.

Part of: https://linear.app/lightdash/issue/SPK-1538

## Changes

**`features/directAccess/`** (new)
- `api.ts`: `DirectAccessResourceRef` + list/upsert/revoke/reset against `/api/v2/projects/{p}/direct-access/{type}/{uuid}/assignments[...]`.
- `hooks/useDirectAccess.ts`: one query-key family (`['direct-access', project, type, uuid]`); `useDirectAccessAssignments`, `useUpsertDirectAccessAssignment`, `useRevokeDirectAccessAssignment`, `useResetDirectAccess` — every mutation invalidates the policy key plus the affected discovery consumers (`invalidateContent`: content, search, spaces, pins, homepage; plus favorites). `useDirectAccessAvailability` mirrors the backend gate (commercial flag ∧ valid license) for menu gating in PR 2.
- `components/DirectAccessModal.tsx`: `MantineModal` titled `Share "<name>"` with the same people icon as the space share modal, holding assignment rows (avatar, name/email or group name, "(you)" marker), role replacement via select (Can view / Can edit / Full access), share-with picker (project users + project-attached groups), revoke per row, self-revoke and reset-all behind `variant="delete"` alertdialog confirmations, and loading / error+retry / empty / feature-unavailable states. Direct assignments only — no inherited or effective-role rows.

```
modal state machine
  unavailable ── info callout (gate mirror; menus hide earlier)
  loading ────── spinner
  error ──────── danger callout + Retry (refetch)
  empty ──────── "Not shared with anyone yet…"
  loaded ─────── add row · assignment rows · Remove all (confirm)
```


> **Copy:** user-facing strings match the space sharing vocabulary exactly (`Share "<name>"`, `Share with`, `Can view/Can edit/Full access`, "Not shared with anyone yet…"); "direct access" stays an internal/API term only, matching how the space modal uses "Direct" solely as an origin badge.

## Test plan

- [x] `pnpm -F frontend typecheck` / `lint` (0 errors)
- [x] `DirectAccessModal.test.tsx` — 13 pass: identical contract fixture-tested across **all four resource types**; role replacement calls upsert with the typed principal; revoke without confirmation for others; self-revoke confirmation flow; reset-all confirmation flow; add user with selected role; empty, loading, and error+retry states
- [ ] Browser verification lands with PR 2, which wires the modal into the resource menus (it is intentionally unreferenced by app code until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
