### PR TITLE
feat(direct-access): wire resource menus and Shared with me

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -498,6 +498,22 @@ const SPACES_ROUTES: RouteObject[] = [
         },
     },
     {
+        path: 'shared-with-me',
+        lazy: async () => {
+            const SharedWithMe = await loadLazyRouteDefault(
+                './pages/SharedWithMe',
+                () => import('./pages/SharedWithMe'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.SHARED_WITH_ME}>
+                        <SharedWithMe />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
+    {
         path: 'spaces/:spaceUuid',
         lazy: async () => {
             const Space = await loadLazyRouteDefault(

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    DirectAccessResourceType,
     ChartSourceType,
     canMutateVerifiedContent,
     ContentType,
@@ -46,6 +47,7 @@ import {
     IconStar,
     IconStarFilled,
     IconTrash,
+    IconUsers,
 } from '@tabler/icons-react';
 import {
     lazy,
@@ -62,6 +64,11 @@ import ChartAsCodeModal from '../../../features/contentAsCode/components/ChartAs
 import DismissedDraftAlert from '../../../features/contentAsCode/components/DismissedDraftAlert';
 import DraftOverlayFailureAlert from '../../../features/contentAsCode/components/DraftOverlayFailureAlert';
 import { useReopenDraftMutation } from '../../../features/contentAsCode/hooks/useContentDrafts';
+import {
+    DirectAccessModal,
+    useCanManageDirectAccess,
+    useDirectAccessAvailability,
+} from '../../../features/directAccess';
 import {
     explorerActions,
     selectHasUnsavedChanges,
@@ -227,6 +234,16 @@ const SavedChartsHeader: FC = () => {
         useDisclosure();
     const [isChangeExploreModalOpen, changeExploreModalHandlers] =
         useDisclosure();
+    const [isDirectAccessModalOpen, directAccessModalHandlers] =
+        useDisclosure(false);
+    const directAccessAvailability = useDirectAccessAvailability();
+    const canManageChartAccess = useCanManageDirectAccess({
+        projectUuid,
+        spaceUuid: savedChart?.spaceUuid ?? null,
+        createdByUserUuid: null,
+        access: savedChart?.access ?? [],
+        grantRoles: [],
+    });
     const [isTransferToSpaceModalOpen, transferToSpaceModalHandlers] =
         useDisclosure();
     const [isChartAsCodeModalOpen, chartAsCodeModalHandlers] = useDisclosure();
@@ -917,6 +934,22 @@ const SavedChartsHeader: FC = () => {
                                         </Menu.Item>
                                     )}
 
+                                {directAccessAvailability.isAvailable &&
+                                    canManageChartAccess &&
+                                    !chartBelongsToDashboard &&
+                                    savedChart && (
+                                        <Menu.Item
+                                            leftSection={
+                                                <MantineIcon icon={IconUsers} />
+                                            }
+                                            onClick={
+                                                directAccessModalHandlers.open
+                                            }
+                                        >
+                                            Share
+                                        </Menu.Item>
+                                    )}
+
                                 {userCanManageChart &&
                                     !chartBelongsToDashboard && (
                                         <Menu.Item
@@ -1263,6 +1296,18 @@ const SavedChartsHeader: FC = () => {
                 />
             )}
 
+            {isDirectAccessModalOpen && projectUuid && savedChart && (
+                <DirectAccessModal
+                    opened={isDirectAccessModalOpen}
+                    onClose={directAccessModalHandlers.close}
+                    projectUuid={projectUuid}
+                    resource={{
+                        resourceType: DirectAccessResourceType.CHART,
+                        resourceUuid: savedChart.uuid,
+                        name: savedChart.name,
+                    }}
+                />
+            )}
             {isTransferToSpaceModalOpen && projectUuid && (
                 <TransferItemsModal
                     projectUuid={projectUuid}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    DirectAccessResourceType,
     canMutateVerifiedContent,
     ContentType,
     ResourceViewItemType,
@@ -45,6 +46,7 @@ import {
     IconStarFilled,
     IconTrash,
     IconUpload,
+    IconUsers,
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -52,6 +54,11 @@ import { Link, useLocation, useNavigate } from 'react-router';
 import { useToggle } from 'react-use';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import DashboardAsCodeModal from '../../../features/contentAsCode/components/DashboardAsCodeModal';
+import {
+    DirectAccessModal,
+    useCanManageDirectAccess,
+    useDirectAccessAvailability,
+} from '../../../features/directAccess';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
     usePromoteDashboardDiffMutation,
@@ -174,6 +181,16 @@ const DashboardHeader = memo(
             useToggle(false);
         const [isTransferToSpaceModalOpen, transferToSpaceModalHandlers] =
             useDisclosure(false);
+        const [isDirectAccessModalOpen, directAccessModalHandlers] =
+            useDisclosure(false);
+        const directAccessAvailability = useDirectAccessAvailability();
+        const canManageDashboardAccess = useCanManageDirectAccess({
+            projectUuid,
+            spaceUuid: dashboard.spaceUuid,
+            createdByUserUuid: null,
+            access: dashboard.access ?? [],
+            grantRoles: [],
+        });
         const [isPreAggAuditOpen, preAggAuditHandlers] = useDisclosure(false);
         const [isPreAggRefreshOpen, preAggRefreshHandlers] =
             useDisclosure(false);
@@ -516,6 +533,19 @@ const DashboardHeader = memo(
                         />
                     )}
 
+                    {isDirectAccessModalOpen && projectUuid && (
+                        <DirectAccessModal
+                            opened={isDirectAccessModalOpen}
+                            onClose={directAccessModalHandlers.close}
+                            projectUuid={projectUuid}
+                            resource={{
+                                resourceType:
+                                    DirectAccessResourceType.DASHBOARD,
+                                resourceUuid: dashboard.uuid,
+                                name: dashboard.name,
+                            }}
+                        />
+                    )}
                     {isTransferToSpaceModalOpen && projectUuid && (
                         <TransferItemsModal
                             projectUuid={projectUuid}
@@ -870,6 +900,22 @@ const DashboardHeader = memo(
                                             >
                                                 Move dashboard
                                             </Menu.Item>
+
+                                            {directAccessAvailability.isAvailable &&
+                                                canManageDashboardAccess && (
+                                                    <Menu.Item
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={IconUsers}
+                                                            />
+                                                        }
+                                                        onClick={
+                                                            directAccessModalHandlers.open
+                                                        }
+                                                    >
+                                                        Share
+                                                    </Menu.Item>
+                                                )}
                                         </>
                                     )}
 

--- a/packages/frontend/src/components/common/ResourceView/AdminContentViewFilter.tsx
+++ b/packages/frontend/src/components/common/ResourceView/AdminContentViewFilter.tsx
@@ -11,14 +11,20 @@ import React from 'react';
 import MantineIcon from '../MantineIcon';
 import styles from './AdminContentViewFilter.module.css';
 
+export type ContentViewValue = 'shared' | 'shared-with-me' | 'all';
+
 type AdminContentViewFilterProps = {
     withDivider?: boolean;
     segmentedControlProps?: Omit<
         SegmentedControlProps,
         'data' | 'value' | 'onChange'
     >;
-    value: 'all' | 'shared';
-    onChange: (value: 'all' | 'shared') => void;
+    value: ContentViewValue;
+    onChange: (value: ContentViewValue) => void;
+    /** Adds the all-user "Shared with me" segment (root browsing only). */
+    withSharedWithMe?: boolean;
+    /** Hides the admin-only segment for non-admin viewers. */
+    withAdminView?: boolean;
 };
 
 const AdminContentViewFilter: React.FC<AdminContentViewFilterProps> = ({
@@ -26,6 +32,8 @@ const AdminContentViewFilter: React.FC<AdminContentViewFilterProps> = ({
     segmentedControlProps,
     value,
     onChange,
+    withSharedWithMe = false,
+    withAdminView = true,
 }) => {
     return (
         <>
@@ -48,38 +56,56 @@ const AdminContentViewFilter: React.FC<AdminContentViewFilterProps> = ({
                         label: (
                             <Center px={'xxs'}>
                                 <Text fz="sm" c="ldDark.9">
-                                    Shared with me
+                                    Spaces
                                 </Text>
                             </Center>
                         ),
                     },
-                    {
-                        value: 'all',
-                        label: (
-                            <Center px={'xxs'}>
-                                <Tooltip
-                                    withArrow
-                                    withinPortal
-                                    position="top"
-                                    label={
-                                        'View all public and private spaces in your organization'
-                                    }
-                                >
-                                    <MantineIcon
-                                        icon={IconInfoCircle}
-                                        color="ldGray.6"
-                                    />
-                                </Tooltip>
-                                <Text fz="sm" c="ldDark.9" ml={'xxs'}>
-                                    Admin Content View
-                                </Text>
-                            </Center>
-                        ),
-                    },
+                    ...(withSharedWithMe
+                        ? [
+                              {
+                                  value: 'shared-with-me',
+                                  label: (
+                                      <Center px={'xxs'}>
+                                          <Text fz="sm" c="ldDark.9">
+                                              Shared with me
+                                          </Text>
+                                      </Center>
+                                  ),
+                              },
+                          ]
+                        : []),
+                    ...(withAdminView
+                        ? [
+                              {
+                                  value: 'all',
+                                  label: (
+                                      <Center px={'xxs'}>
+                                          <Tooltip
+                                              withArrow
+                                              withinPortal
+                                              position="top"
+                                              label={
+                                                  'View all public and private spaces in your organization'
+                                              }
+                                          >
+                                              <MantineIcon
+                                                  icon={IconInfoCircle}
+                                                  color="ldGray.6"
+                                              />
+                                          </Tooltip>
+                                          <Text fz="sm" c="ldDark.9" ml={'xxs'}>
+                                              Admin Content View
+                                          </Text>
+                                      </Center>
+                                  ),
+                              },
+                          ]
+                        : []),
                 ]}
                 value={value}
                 onChange={(newValue) => {
-                    onChange(newValue as 'all' | 'shared');
+                    onChange(newValue as ContentViewValue);
                 }}
             />
         </>

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -12,6 +12,7 @@ import {
     isResourceViewSpaceItem,
     type ApiContentBulkActionBody,
     type ResourceViewItem,
+    type SpaceMemberRole,
     type SpaceSummary,
 } from '@lightdash/common';
 import {
@@ -60,7 +61,9 @@ import {
 import MantineIcon from '../MantineIcon';
 import TransferItemsModal from '../TransferItemsModal/TransferItemsModal';
 import { UserSelect } from '../UserSelect';
-import AdminContentViewFilter from './AdminContentViewFilter';
+import AdminContentViewFilter, {
+    type ContentViewValue,
+} from './AdminContentViewFilter';
 import ContentTypeFilter from './ContentTypeFilter';
 import classes from './InfiniteResourceTable.module.css';
 import InfiniteResourceTableColumnName from './InfiniteResourceTableColumnName';
@@ -84,6 +87,7 @@ type ResourceView2Props = Partial<ContentTableOptions<ResourceViewItem>> & {
         | 'contentTypes'
         | 'includePersonalDataApps'
         | 'dataAppVizsFilter'
+        | 'sharedWithMe'
     > & {
         projectUuid: string;
     };
@@ -96,6 +100,17 @@ type ResourceView2Props = Partial<ContentTableOptions<ResourceViewItem>> & {
     columnVisibility?: ColumnVisibilityConfig;
     adminContentView?: boolean;
     initialAdminContentViewValue?: 'all' | 'shared';
+    /**
+     * Controlled content-view toggle for the root browsing surface:
+     * Spaces | Shared with me | Admin Content View. When provided it
+     * replaces the uncontrolled admin-only control.
+     */
+    contentView?: {
+        value: ContentViewValue;
+        onChange: (value: ContentViewValue) => void;
+        withSharedWithMe: boolean;
+        withAdminView: boolean;
+    };
     showDataAppVersionStatus?: boolean;
 };
 
@@ -182,6 +197,7 @@ const InfiniteResourceTable = ({
     columnVisibility,
     adminContentView = false,
     initialAdminContentViewValue = 'shared',
+    contentView,
     showDataAppVersionStatus = false,
     ...contentTableProps
 }: ResourceView2Props) => {
@@ -283,6 +299,18 @@ const InfiniteResourceTable = ({
                     return (
                         <Text fz={12} fw={500} c="dimmed">
                             -
+                        </Text>
+                    );
+                }
+
+                // Inaccessible parent space: real name, non-navigable.
+                const inaccessibleSpaceName = item.data.spaceUuid
+                    ? contentSpaceNames[item.data.spaceUuid]
+                    : undefined;
+                if (inaccessibleSpaceName) {
+                    return (
+                        <Text fz={12} fw={500} c="ldGray.7">
+                            {inaccessibleSpaceName}
                         </Text>
                     );
                 }
@@ -480,12 +508,47 @@ const InfiniteResourceTable = ({
                 sortDirection: sortBy?.sortDirection,
                 includePersonalDataApps: filters.includePersonalDataApps,
                 dataAppVizsFilter: filters.dataAppVizsFilter,
+                sharedWithMe: filters.sharedWithMe,
                 ownerUserUuids: selectedOwnerUserUuid
                     ? [selectedOwnerUserUuid]
                     : undefined,
             },
             { keepPreviousData: true },
         );
+
+    // Real parent names for rows whose space the viewer cannot access
+    // (directly shared content): shown as non-navigable context.
+    // Grant roles per resource: a direct grant never puts its space in the
+    // viewer's space list, so the row menu cannot infer these from spaces.
+    const contentGrantRoles = useMemo(() => {
+        const roles: Record<string, SpaceMemberRole[]> = {};
+        data?.pages.forEach((page) => {
+            page.data.forEach((content) => {
+                if (
+                    content.contentType !== ContentType.SPACE &&
+                    content.directAccessRoles.length > 0
+                ) {
+                    roles[content.uuid] = content.directAccessRoles;
+                }
+            });
+        });
+        return roles;
+    }, [data]);
+
+    const contentSpaceNames = useMemo(() => {
+        const names: Record<string, string> = {};
+        data?.pages.forEach((page) => {
+            page.data.forEach((content) => {
+                if (
+                    content.contentType !== ContentType.SPACE &&
+                    content.space
+                ) {
+                    names[content.space.uuid] = content.space.name;
+                }
+            });
+        });
+        return names;
+    }, [data]);
 
     const flatData = useMemo(() => {
         if (!data || !spaces) return [];
@@ -494,13 +557,23 @@ const InfiniteResourceTable = ({
             .filter((item) => {
                 if (!isResourceViewSpaceItem(item)) return true;
                 if (!userCanManageProject) return true;
-                if (selectedAdminContentType === 'all') return true;
+                if (
+                    (contentView?.value ?? selectedAdminContentType) === 'all'
+                ) {
+                    return true;
+                }
 
                 const space = spaces.find((s) => s.uuid === item.data.uuid);
                 if (!space) return false;
                 return space.inheritsFromOrgOrProject || !!space.userAccess;
             });
-    }, [data, userCanManageProject, spaces, selectedAdminContentType]);
+    }, [
+        data,
+        userCanManageProject,
+        spaces,
+        selectedAdminContentType,
+        contentView?.value,
+    ]);
 
     // Temporary workaround to resolve a memoization issue with react-mantine-table.
     // In certain scenarios, the content fails to render properly even when the data is updated.
@@ -707,10 +780,25 @@ const InfiniteResourceTable = ({
                                 </>
                             ) : null}
 
-                            {adminContentView ? (
+                            {contentView &&
+                            (contentView.withSharedWithMe ||
+                                contentView.withAdminView) ? (
+                                <AdminContentViewFilter
+                                    value={contentView.value}
+                                    onChange={contentView.onChange}
+                                    withSharedWithMe={
+                                        contentView.withSharedWithMe
+                                    }
+                                    withAdminView={contentView.withAdminView}
+                                />
+                            ) : adminContentView ? (
                                 <AdminContentViewFilter
                                     value={selectedAdminContentType}
-                                    onChange={setSelectedAdminContentType}
+                                    onChange={(value) => {
+                                        if (value !== 'shared-with-me') {
+                                            setSelectedAdminContentType(value);
+                                        }
+                                    }}
                                 />
                             ) : null}
 
@@ -809,6 +897,9 @@ const InfiniteResourceTable = ({
                     <ResourceActionMenu
                         disabled={isSelected}
                         item={row.original}
+                        grantRoles={
+                            contentGrantRoles[row.original.data.uuid] ?? []
+                        }
                         onAction={handleAction}
                     />
                 </Box>

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -2,10 +2,12 @@ import { subject } from '@casl/ability';
 import {
     assertUnreachable,
     ChartSourceType,
+    DirectAccessResourceType,
     isResourceViewItemChart,
     isResourceViewItemDashboard,
     ResourceViewItemType,
     type ResourceViewItem,
+    type SpaceMemberRole,
 } from '@lightdash/common';
 import { ActionIcon, Box, Menu, Tooltip } from '@mantine/core';
 import {
@@ -32,6 +34,11 @@ import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/As
 import { FavoritePersonalDataAppModal } from '../../../features/apps/components/FavoritePersonalDataAppModal';
 import { PromoteAppModal } from '../../../features/apps/components/PromoteAppModal';
 import { useDuplicateApp } from '../../../features/apps/hooks/useDuplicateApp';
+import {
+    DirectAccessModal,
+    useCanManageDirectAccess,
+    useDirectAccessAvailability,
+} from '../../../features/directAccess';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
     usePromoteChartDiffMutation,
@@ -65,6 +72,8 @@ export interface ResourceViewActionMenuCommonProps {
 interface ResourceViewActionMenuProps extends ResourceViewActionMenuCommonProps {
     disabled?: boolean;
     item: ResourceViewItem;
+    /** Roles the viewer holds on this item through direct grants. */
+    grantRoles?: SpaceMemberRole[];
     allowDelete?: boolean;
     hideVerification?: boolean;
     isOpen?: boolean;
@@ -75,6 +84,7 @@ interface ResourceViewActionMenuProps extends ResourceViewActionMenuCommonProps 
 const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     disabled = false,
     item,
+    grantRoles = [],
     allowDelete = true,
     hideVerification = false,
     isOpen,
@@ -88,11 +98,31 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     const projectUuid = useProjectUuid();
     const { data: project } = useProject(projectUuid);
     const [isPromoteAppOpen, setIsPromoteAppOpen] = useState(false);
+    const [isManageAccessOpen, setIsManageAccessOpen] = useState(false);
+    const directAccessAvailability = useDirectAccessAvailability();
     const [isFavoriteSpaceModalOpen, setIsFavoriteSpaceModalOpen] =
         useState(false);
     const { mutate: duplicateApp } = useDuplicateApp();
     const organizationUuid = user.data?.organizationUuid;
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
+    // Direct grants are the second path to a resource: without them the
+    // per-type checks below see an empty access list and hide every action.
+    const grantAccess = user.data?.userUuid
+        ? grantRoles.map((role) => ({ userUuid: user.data!.userUuid, role }))
+        : [];
+    const canManageAccess = useCanManageDirectAccess({
+        projectUuid,
+        spaceUuid:
+            item.type === ResourceViewItemType.SPACE
+                ? null
+                : (item.data.spaceUuid ?? null),
+        createdByUserUuid:
+            item.type === ResourceViewItemType.DATA_APP
+                ? item.data.createdByUserUuid
+                : null,
+        access: [],
+        grantRoles,
+    });
     const isPinned = !!item.data.pinnedListUuid;
     const isDashboardPage = location.pathname.includes('/dashboards');
 
@@ -177,6 +207,17 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                 : 'Move to space'
             : 'Move';
 
+    const directAccessResourceType =
+        item.type === ResourceViewItemType.DASHBOARD
+            ? DirectAccessResourceType.DASHBOARD
+            : item.type === ResourceViewItemType.CHART
+              ? isSqlChart
+                  ? DirectAccessResourceType.SQL_CHART
+                  : DirectAccessResourceType.CHART
+              : item.type === ResourceViewItemType.DATA_APP
+                ? DirectAccessResourceType.APP
+                : null;
+
     const favoritesContext = useFavoritesContext();
     const isFavorited = favoritesContext?.isFavorited(item.data.uuid) ?? false;
 
@@ -194,7 +235,10 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                         subject('SqlRunner', {
                             organizationUuid,
                             projectUuid,
-                            access: userAccess ? [userAccess] : [],
+                            access: [
+                                ...(userAccess ? [userAccess] : []),
+                                ...grantAccess,
+                            ],
                         }),
                     ) === true &&
                     user.data?.ability?.can(
@@ -203,7 +247,10 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                             ...item.data,
                             projectUuid,
                             organizationUuid,
-                            access: userAccess ? [userAccess] : [],
+                            access: [
+                                ...(userAccess ? [userAccess] : []),
+                                ...grantAccess,
+                            ],
                         }),
                     ) === true;
             } else {
@@ -214,7 +261,10 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                             ...item.data,
                             projectUuid,
                             organizationUuid,
-                            access: userAccess ? [userAccess] : [],
+                            access: [
+                                ...(userAccess ? [userAccess] : []),
+                                ...grantAccess,
+                            ],
                         }),
                     ) === true;
             }
@@ -231,7 +281,10 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                         ...item.data,
                         projectUuid,
                         organizationUuid,
-                        access: userAccess ? [userAccess] : [],
+                        access: [
+                            ...(userAccess ? [userAccess] : []),
+                            ...grantAccess,
+                        ],
                     }),
                 ) === true;
             break;
@@ -262,7 +315,10 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                     subject('DataApp', {
                         organizationUuid,
                         projectUuid,
-                        access: userAccess ? [userAccess] : [],
+                        access: [
+                            ...(userAccess ? [userAccess] : []),
+                            ...grantAccess,
+                        ],
                         createdByUserUuid: item.data.createdByUserUuid,
                     }),
                 ) === true;
@@ -663,6 +719,26 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                 {moveActionLabel}
                             </Menu.Item>
 
+                            {directAccessAvailability.isAvailable &&
+                                directAccessResourceType !== null &&
+                                canManageAccess && (
+                                    <Menu.Item
+                                        component="button"
+                                        role="menuitem"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconUsers}
+                                                size={18}
+                                            />
+                                        }
+                                        onClick={() => {
+                                            setIsManageAccessOpen(true);
+                                        }}
+                                    >
+                                        Share
+                                    </Menu.Item>
+                                )}
+
                             {item.type === ResourceViewItemType.SPACE && (
                                 <Menu.Item
                                     component="button"
@@ -747,6 +823,20 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                         appUuid={item.data.uuid}
                         opened
                         onClose={() => setIsPromoteAppOpen(false)}
+                    />
+                )}
+            {isManageAccessOpen &&
+                projectUuid &&
+                directAccessResourceType !== null && (
+                    <DirectAccessModal
+                        opened
+                        onClose={() => setIsManageAccessOpen(false)}
+                        projectUuid={projectUuid}
+                        resource={{
+                            resourceType: directAccessResourceType,
+                            resourceUuid: item.data.uuid,
+                            name: item.data.name,
+                        }}
                     />
                 )}
             {isFavoriteSpaceModalOpen &&

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -92,7 +92,14 @@ const SpaceSelector = ({
             {userCanManageProject ? (
                 <AdminContentViewFilter
                     value={selectedAdminContentType}
-                    onChange={setSelectedAdminContentType}
+                    onChange={(value) => {
+                        // Folder scoping only: this selector never renders the
+                        // all-user "Shared with me" segment, so the control's
+                        // wider union narrows back to the two modes here.
+                        if (value !== 'shared-with-me') {
+                            setSelectedAdminContentType(value);
+                        }
+                    }}
                     withDivider={false}
                     segmentedControlProps={{
                         flex: '0 0 auto',

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    DirectAccessResourceType,
     getAppDisplayName,
     isApiError,
     type AppVersionStatus,
@@ -28,6 +29,7 @@ import {
     IconSend,
     IconSparkles,
     IconTrash,
+    IconUsers,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState, type FC, type ReactNode } from 'react';
@@ -40,6 +42,11 @@ import useToaster from '../../../hooks/toaster/useToaster';
 import { useProject } from '../../../hooks/useProject';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
+import {
+    DirectAccessModal,
+    useCanManageDirectAccess,
+    useDirectAccessAvailability,
+} from '../../directAccess';
 import { AppSchedulersModal } from '../../scheduler/components/SchedulerModals';
 import { AppSyncModal } from '../../sync/components';
 import {
@@ -222,6 +229,16 @@ const AppHeaderActions: FC<Props> = ({
     const [isMoveToSpaceOpen, setIsMoveToSpaceOpen] = useState(false);
     const [isPromoteModalOpen, setIsPromoteModalOpen] = useState(false);
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [isDirectAccessModalOpen, setIsDirectAccessModalOpen] =
+        useState(false);
+    const directAccessAvailability = useDirectAccessAvailability();
+    const canManageAppAccess = useCanManageDirectAccess({
+        projectUuid,
+        spaceUuid: appSpaceUuid ?? null,
+        createdByUserUuid: appCreatedByUserUuid ?? null,
+        access: [],
+        grantRoles: [],
+    });
 
     const handleDuplicate = useCallback(() => {
         duplicateMutate(
@@ -461,6 +478,22 @@ const AppHeaderActions: FC<Props> = ({
                                     Promote
                                 </Menu.Item>
                             )}
+                            {directAccessAvailability.isAvailable &&
+                                canManageAppAccess && (
+                                    <Menu.Item
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconUsers}
+                                                size={14}
+                                            />
+                                        }
+                                        onClick={() =>
+                                            setIsDirectAccessModalOpen(true)
+                                        }
+                                    >
+                                        Share
+                                    </Menu.Item>
+                                )}
                             <Menu.Divider />
                             <Menu.Item
                                 color="red"
@@ -495,6 +528,18 @@ const AppHeaderActions: FC<Props> = ({
                     initialDescription={appDescription ?? ''}
                     onClose={() => setIsUpdateModalOpen(false)}
                     onConfirm={() => setIsUpdateModalOpen(false)}
+                />
+            )}
+            {isDirectAccessModalOpen && (
+                <DirectAccessModal
+                    opened={isDirectAccessModalOpen}
+                    onClose={() => setIsDirectAccessModalOpen(false)}
+                    projectUuid={projectUuid}
+                    resource={{
+                        resourceType: DirectAccessResourceType.APP,
+                        resourceUuid: appUuid,
+                        name: appName,
+                    }}
                 />
             )}
             {isMoveToSpaceOpen && (

--- a/packages/frontend/src/features/directAccess/components/DirectAccessModal.test.tsx
+++ b/packages/frontend/src/features/directAccess/components/DirectAccessModal.test.tsx
@@ -27,8 +27,8 @@ vi.mock('../hooks/useDirectAccess', () => ({
     useResetDirectAccess: vi.fn(),
 }));
 
-vi.mock('../../../hooks/useProjectAccess', () => ({
-    useProjectAccess: vi.fn(() => ({
+vi.mock('../../../hooks/useOrganizationUsers', () => ({
+    useOrganizationUsers: vi.fn(() => ({
         data: [
             {
                 userUuid: 'member-uuid',

--- a/packages/frontend/src/features/directAccess/components/DirectAccessModal.tsx
+++ b/packages/frontend/src/features/directAccess/components/DirectAccessModal.tsx
@@ -27,7 +27,7 @@ import {
     getUserNameOrEmail,
 } from '../../../components/common/ShareSpaceModal/Utils';
 import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
-import { useProjectAccess } from '../../../hooks/useProjectAccess';
+import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import useApp from '../../../providers/App/useApp';
 import { useProjectGroupAccessList } from '../../projectGroupAccess/hooks/useProjectGroupAccess';
 import { type DirectAccessResourceRef } from '../api';
@@ -189,7 +189,7 @@ const AddDirectAccess: FC<AddDirectAccessProps> = ({
     const [selectedRole, setSelectedRole] = useState<SpaceMemberRole>(
         SpaceMemberRole.VIEWER,
     );
-    const projectAccess = useProjectAccess(projectUuid);
+    const organizationUsers = useOrganizationUsers({ projectUuid });
     const groupAccess = useProjectGroupAccessList(projectUuid);
     const organizationGroups = useOrganizationGroups({});
 
@@ -200,7 +200,7 @@ const AddDirectAccess: FC<AddDirectAccessProps> = ({
                 group.name,
             ]),
         );
-        const userOptions = (projectAccess.data ?? [])
+        const userOptions = (organizationUsers.data ?? [])
             .map((member) => ({
                 value: `${DirectAccessPrincipalType.USER}:${member.userUuid}`,
                 label:
@@ -224,7 +224,7 @@ const AddDirectAccess: FC<AddDirectAccessProps> = ({
             { group: 'Groups', items: groupOptions },
         ].filter((section) => section.items.length > 0);
     }, [
-        projectAccess.data,
+        organizationUsers.data,
         groupAccess.data,
         organizationGroups.data,
         assignedKeys,

--- a/packages/frontend/src/features/directAccess/hooks/useCanManageDirectAccess.ts
+++ b/packages/frontend/src/features/directAccess/hooks/useCanManageDirectAccess.ts
@@ -1,0 +1,73 @@
+import { subject } from '@casl/ability';
+import { type SpaceMemberRole } from '@lightdash/common';
+import { useSpaceSummaries } from '../../../hooks/useSpaces';
+import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
+import useApp from '../../../providers/App/useApp';
+
+type DirectAccessManageTarget = {
+    projectUuid: string | undefined;
+    /** Personal data apps have no space and authorize against their creator. */
+    spaceUuid: string | null;
+    createdByUserUuid: string | null;
+    /** Access entries the resource itself reports for the viewer. */
+    access: { userUuid: string; role: SpaceMemberRole }[];
+    /** Roles held through direct grants on this resource. */
+    grantRoles: SpaceMemberRole[];
+};
+
+/**
+ * Mirrors the backend's `authorizeManage`: managing who a resource is shared
+ * with is a space-admin power (creator rights for space-less apps), not the
+ * same thing as being able to edit the resource. Access can arrive through the
+ * space, through the resource's own access rows, or through a direct grant —
+ * a grant never puts its parent space in the viewer's space list, so the space
+ * summaries alone under-report what the viewer may do.
+ */
+export const useCanManageDirectAccess = ({
+    projectUuid,
+    spaceUuid,
+    createdByUserUuid,
+    access,
+    grantRoles,
+}: DirectAccessManageTarget): boolean => {
+    const ability = useAbilityContext();
+    const { user } = useApp();
+    const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
+    const organizationUuid = user.data?.organizationUuid;
+    const userUuid = user.data?.userUuid;
+
+    if (!projectUuid || !userUuid) return false;
+
+    const spaceAccess = spaceUuid
+        ? spaces.find((space) => space.uuid === spaceUuid)?.userAccess
+        : undefined;
+    const resolvedAccess = [
+        ...access,
+        ...(spaceAccess ? [spaceAccess] : []),
+        ...grantRoles.map((role) => ({ userUuid, role })),
+    ];
+
+    // Not memoized on purpose: every caller passes fresh arrays (`[]`,
+    // `chart.access ?? []`), so a memo would miss its cache on every render
+    // while pretending otherwise. The work is one array build plus a CASL
+    // check, the same shape the surrounding menus already do inline.
+    return spaceUuid !== null
+        ? ability.can(
+              'manage',
+              subject('Space', {
+                  organizationUuid,
+                  projectUuid,
+                  access: resolvedAccess,
+              }),
+          )
+        : ability.can(
+              'manage',
+              subject('DataApp', {
+                  organizationUuid,
+                  projectUuid,
+                  access: resolvedAccess,
+                  // A null creator can never match the self rule.
+                  createdByUserUuid: createdByUserUuid ?? '',
+              }),
+          );
+};

--- a/packages/frontend/src/features/directAccess/index.ts
+++ b/packages/frontend/src/features/directAccess/index.ts
@@ -1,0 +1,3 @@
+export { default as DirectAccessModal } from './components/DirectAccessModal';
+export { useDirectAccessAvailability } from './hooks/useDirectAccess';
+export { useCanManageDirectAccess } from './hooks/useCanManageDirectAccess';

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -1,5 +1,8 @@
 import { subject } from '@casl/ability';
-import { DashboardTileTypes } from '@lightdash/common';
+import {
+    DashboardTileTypes,
+    DirectAccessResourceType,
+} from '@lightdash/common';
 import {
     Group,
     Paper,
@@ -17,6 +20,7 @@ import {
     IconDots,
     IconLayoutGridAdd,
     IconTrash,
+    IconUsers,
 } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';
@@ -27,6 +31,11 @@ import { TitleBreadCrumbs } from '../../../../components/Explorer/SavedChartsHea
 import AddTilesToDashboardModal from '../../../../components/SavedDashboards/AddTilesToDashboardModal';
 import { useProject } from '../../../../hooks/useProject';
 import useApp from '../../../../providers/App/useApp';
+import {
+    DirectAccessModal,
+    useCanManageDirectAccess,
+    useDirectAccessAvailability,
+} from '../../../directAccess';
 import { PromotionConfirmDialog } from '../../../promotion/components/PromotionConfirmDialog';
 import {
     getSchedulerUuidFromUrlParams,
@@ -55,6 +64,18 @@ export const HeaderView: FC = () => {
     const savedSqlChart = useAppSelector(
         (state) => state.sqlRunner.savedSqlChart,
     );
+    const [isDirectAccessModalOpen, directAccessModalHandlers] =
+        useDisclosure(false);
+    const directAccessAvailability = useDirectAccessAvailability();
+    const canManageSqlChartAccess = useCanManageDirectAccess({
+        projectUuid,
+        spaceUuid: savedSqlChart?.space.uuid ?? null,
+        createdByUserUuid: null,
+        access: savedSqlChart?.space.userAccess
+            ? [savedSqlChart.space.userAccess]
+            : [],
+        grantRoles: [],
+    });
     const isAddToDashboardModalOpen = useAppSelector(
         (state) => state.sqlRunner.modals.addToDashboard.isOpen,
     );
@@ -299,6 +320,21 @@ export const HeaderView: FC = () => {
                                             </div>
                                         </Tooltip>
                                     )}
+                                    {directAccessAvailability.isAvailable &&
+                                        canManageSqlChartAccess && (
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconUsers}
+                                                    />
+                                                }
+                                                onClick={
+                                                    directAccessModalHandlers.open
+                                                }
+                                            >
+                                                Share
+                                            </Menu.Item>
+                                        )}
                                     {canManageChart && (
                                         <Menu.Item
                                             leftSection={
@@ -326,6 +362,19 @@ export const HeaderView: FC = () => {
                     </Group>
                 </Group>
             </Paper>
+
+            {isDirectAccessModalOpen && savedSqlChart && (
+                <DirectAccessModal
+                    opened={isDirectAccessModalOpen}
+                    onClose={directAccessModalHandlers.close}
+                    projectUuid={projectUuid}
+                    resource={{
+                        resourceType: DirectAccessResourceType.SQL_CHART,
+                        resourceUuid: savedSqlChart.savedSqlUuid,
+                        name: savedSqlChart.name,
+                    }}
+                />
+            )}
 
             <DeleteSqlChartModal
                 projectUuid={projectUuid}

--- a/packages/frontend/src/hooks/useContent.ts
+++ b/packages/frontend/src/hooks/useContent.ts
@@ -39,6 +39,8 @@ export type ContentArgs = {
     dataAppVizsFilter?: 'exclude' | 'only';
     // Restrict to dashboards owned by these users (other content types are excluded)
     ownerUserUuids?: string[];
+    // Only resources directly granted to the caller or their groups.
+    sharedWithMe?: boolean;
 };
 
 const contentTypeLabel = (contentType: ContentType): string =>

--- a/packages/frontend/src/pages/SharedWithMe.tsx
+++ b/packages/frontend/src/pages/SharedWithMe.tsx
@@ -1,0 +1,17 @@
+import { type FC } from 'react';
+import { Navigate } from 'react-router';
+import { useProjectUuid } from '../hooks/useProjectUuid';
+
+// Deep link kept for old bookmarks; the view lives on the Spaces page.
+const SharedWithMe: FC = () => {
+    const projectUuid = useProjectUuid()!;
+
+    return (
+        <Navigate
+            to={`/projects/${projectUuid}/spaces?view=shared-with-me`}
+            replace
+        />
+    );
+};
+
+export default SharedWithMe;

--- a/packages/frontend/src/pages/Spaces.module.css
+++ b/packages/frontend/src/pages/Spaces.module.css
@@ -1,0 +1,4 @@
+/* Keeps the header button's footprint while a view has nothing to add */
+.hiddenAction {
+    visibility: hidden;
+}

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -3,21 +3,29 @@ import { ContentType, LightdashMode } from '@lightdash/common';
 import { Group, Stack, Button } from '@mantine/core';
 import { IconFolderPlus, IconPlus } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
+import { useNavigate } from 'react-router';
 import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
+import { type ContentViewValue } from '../components/common/ResourceView/AdminContentViewFilter';
 import InfiniteResourceTable from '../components/common/ResourceView/InfiniteResourceTable';
 import { ColumnVisibility } from '../components/common/ResourceView/types';
 import SpaceActionModal from '../components/common/SpaceActionModal';
 import { ActionType } from '../components/common/SpaceActionModal/types';
 import ForbiddenPanel from '../components/ForbiddenPanel';
+import { useDirectAccessAvailability } from '../features/directAccess';
 import { useProjectUuid } from '../hooks/useProjectUuid';
+import useSearchParams from '../hooks/useSearchParams';
 import useApp from '../providers/App/useApp';
 import { FavoritesProvider } from '../providers/Favorites/FavoritesProvider';
+import styles from './Spaces.module.css';
 
 const Spaces: FC = () => {
     const projectUuid = useProjectUuid()!;
 
     const { user, health } = useApp();
+    const navigate = useNavigate();
+    const viewParam = useSearchParams('view');
+    const directAccessAvailability = useDirectAccessAvailability();
 
     const isDemo = health.data?.mode === LightdashMode.DEMO;
 
@@ -42,6 +50,23 @@ const Spaces: FC = () => {
         }),
     );
 
+    const withSharedWithMe = directAccessAvailability.isAvailable;
+    const withAdminView = userCanManageProject === true;
+
+    // URL is the source of truth so /spaces?view=shared-with-me deep links work
+    const view: ContentViewValue =
+        viewParam === 'shared-with-me' && withSharedWithMe
+            ? 'shared-with-me'
+            : viewParam === 'all' && withAdminView
+              ? 'all'
+              : 'shared';
+    const setView = (newView: ContentViewValue) => {
+        void navigate(
+            { search: newView === 'shared' ? '' : `?view=${newView}` },
+            { replace: true },
+        );
+    };
+
     if (
         user.data?.ability?.cannot(
             'view',
@@ -54,6 +79,14 @@ const Spaces: FC = () => {
     ) {
         return <ForbiddenPanel />;
     }
+
+    const isSharedWithMe = view === 'shared-with-me';
+    const contentViewProps = {
+        value: view,
+        onChange: setView,
+        withSharedWithMe,
+        withAdminView,
+    };
 
     return (
         <FavoritesProvider projectUuid={projectUuid}>
@@ -78,33 +111,70 @@ const Spaces: FC = () => {
                                 <Button
                                     leftSection={<IconPlus size={18} />}
                                     onClick={handleCreateSpace}
+                                    className={
+                                        isSharedWithMe
+                                            ? styles.hiddenAction
+                                            : undefined
+                                    }
+                                    aria-hidden={isSharedWithMe}
+                                    tabIndex={isSharedWithMe ? -1 : undefined}
                                 >
                                     Add
                                 </Button>
                             )}
                         </Group>
                     </Group>
-                    <InfiniteResourceTable
-                        filters={{
-                            projectUuid,
-                            spaceUuids: [],
-                            contentTypes: [ContentType.SPACE],
-                        }}
-                        contentTypeFilter={{
-                            defaultValue: ContentType.SPACE,
-                            options: [],
-                        }}
-                        columnVisibility={{
-                            [ColumnVisibility.SPACE]: false,
-                            [ColumnVisibility.UPDATED_AT]: false,
-                            [ColumnVisibility.VIEWS]: false,
-                            [ColumnVisibility.ACCESS]: true,
-                            [ColumnVisibility.CONTENT]: true,
-                        }}
-                        adminContentView={userCanManageProject}
-                        enableBottomToolbar={false}
-                        enableRowSelection={userCanManageSpace}
-                    />
+                    {isSharedWithMe ? (
+                        <InfiniteResourceTable
+                            key="shared-with-me"
+                            filters={{
+                                projectUuid,
+                                spaceUuids: [],
+                                contentTypes: [
+                                    ContentType.DASHBOARD,
+                                    ContentType.CHART,
+                                    ContentType.DATA_APP,
+                                ],
+                                sharedWithMe: true,
+                            }}
+                            columnVisibility={{
+                                [ColumnVisibility.SPACE]: false,
+                                [ColumnVisibility.UPDATED_AT]: true,
+                                [ColumnVisibility.VIEWS]: true,
+                                [ColumnVisibility.ACCESS]: false,
+                                [ColumnVisibility.CONTENT]: false,
+                            }}
+                            contentView={contentViewProps}
+                            enableBottomToolbar={false}
+                            enableRowSelection={false}
+                            emptyState={{
+                                title: 'Nothing has been shared with you yet.',
+                            }}
+                        />
+                    ) : (
+                        <InfiniteResourceTable
+                            key="spaces"
+                            filters={{
+                                projectUuid,
+                                spaceUuids: [],
+                                contentTypes: [ContentType.SPACE],
+                            }}
+                            contentTypeFilter={{
+                                defaultValue: ContentType.SPACE,
+                                options: [],
+                            }}
+                            columnVisibility={{
+                                [ColumnVisibility.SPACE]: false,
+                                [ColumnVisibility.UPDATED_AT]: false,
+                                [ColumnVisibility.VIEWS]: false,
+                                [ColumnVisibility.ACCESS]: true,
+                                [ColumnVisibility.CONTENT]: true,
+                            }}
+                            contentView={contentViewProps}
+                            enableBottomToolbar={false}
+                            enableRowSelection={userCanManageSpace}
+                        />
+                    )}
 
                     {isCreateModalOpen && (
                         <SpaceActionModal

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -45,6 +45,7 @@ export enum PageName {
     NO_PROJECT_ACCESS = 'no_project_access',
     SPACE = 'space',
     SPACES = 'spaces',
+    SHARED_WITH_ME = 'shared_with_me',
     SHARE = 'share',
     USER_ACTIVITY = 'user_activity',
     QUERY_HISTORY = 'query_history',


### PR DESCRIPTION
## Summary

PR 2 of 2 for [SPK-1538](https://linear.app/lightdash/issue/SPK-1538/stack-6b-add-one-direct-access-management-and-discovery-ui) (Stack 6B). Wires the generic management modal into the four eligible resource menus and adds the all-user Shared with me section on top of the existing content table — no resource-specific components, no alternate read pipeline, no parent-space suppression.

Stacks on top of PR 1 ([#28273](https://github.com/lightdash/lightdash/pull/28273)) which landed the client, hook family, and modal.

Part of: https://linear.app/lightdash/issue/SPK-1538

## Changes

**Resource menus** — one `Share` item each in the dashboard header, saved-chart header, SQL-runner header, data-app header, and the content-table row menu (`ResourceActionMenu`), opening the shared modal with the typed resource ref. Copy and placement mirror the space row menu, which already reads `Move` / `Share`. Dashboard-owned chart definitions never show it (`!chartBelongsToDashboard`), matching the backend's eligibility rule.

**Gating mirrors `authorizeManage`, not resource-edit rights.** Managing who a resource is shared with is a space-admin power (creator rights for space-less apps); being able to edit the resource is not enough. `useCanManageDirectAccess` evaluates exactly that predicate — `manage:Space` on the resolved access, or `manage:DataApp` with the creator for personal apps — over access from three sources: the resource's own rows, the space summary, and `directAccessRoles` from the content row. Two defects this fixes:

```
              Can view    Can edit    Full access
before  hdr   —           Share ✗     Share ✓        ✗ = shown, API 403
        row   —           —           — ✗            ✗ = hidden, API allows
after   hdr   —           —           Share ✓
        row   —           edit only   full + Share
```

Direct grants also now feed the row menu's existing per-type manage checks, so a Can-edit grantee gets Rename/Move/Delete there instead of an empty menu — the row menu previously derived those from space summaries, which structurally omit grant-only spaces.

**Shared with me** — a segment of the Spaces page control, not a separate page:

```
regular user   Spaces | Shared with me
admin          Spaces | Shared with me | Admin Content View
```

- `AdminContentViewFilter` builds its segments from two new flags (`withSharedWithMe`, `withAdminView`); `InfiniteResourceTable` accepts a controlled `contentView` for the root browsing surface and keeps its uncontrolled admin-only path for folder pages (`pages/Space.tsx`), where content stays location-scoped.
- `pages/Spaces.tsx` swaps the table in place per segment and syncs the choice to `?view=`, so `/spaces?view=shared-with-me` is a deep link. The Add button stays mounted (hidden) across the swap so the header does not shift.
- The Shared with me table is the existing `InfiniteResourceTable` with `sharedWithMe: true`, so cards, search, sorting, pagination, and navigation are all reused. Columns are Name / Last Modified / Views — the Space column is hidden here, since the parent space is not where the viewer's access comes from. Empty state: "Nothing has been shared with you yet."
- `InfiniteResourceTable` passes `sharedWithMe` through to the content query and keeps one fallback in the Space column for the surfaces that do show it (All dashboards, All saved charts, search): when the parent space is not in the viewer's accessible summaries, the **real** space name from the content response renders as plain, non-navigable text — no sentinels, no nullable types.
- `/projects/:projectUuid/shared-with-me` redirects into the view. No Browse-menu entry: Browse lists page destinations, and a view state of All Spaces does not belong there any more than `Admin Content View` does.
- Admins and regular users get identical Shared with me semantics (backend enforces direct-grants-only; verified live in 6A).

## Test plan

- [x] `pnpm -F frontend typecheck` / `lint` (0 errors)
- [x] Component tests: 21 pass (directAccess modal ×13, BrowseMenu, AppHeaderActions)
- [x] Browser (chrome-devtools on the live dev stack, admin + grant-only editor in isolated sessions):
  - dashboard menu → modal: shared with a user, replaced role viewer→editor (persisted via the admin API), reset-all confirmation, modal refreshes to empty state
  - saved-chart menu shows the item and opens the modal with the chart ref
  - grant-only viewer sees **no** manage item on the granted dashboard
  - content row menu reads `Move` / `Share` and opens `Share "Jaffle dashboard"`
  - grant-role matrix as a non-admin editor, one dashboard in a private space they cannot otherwise reach — header and row menu agree at every level: Can view → no manage items; Can edit → edit actions, no `Share`; Full access → edit actions plus `Share`
  - Spaces page control renders `Spaces | Shared with me | Admin Content View` for the admin, switches the table in place, and writes `?view=shared-with-me`; measured the Add button and table top before/after the switch — identical positions, no layout shift
  - Shared with me with 20 fixtures (5 dashboards, 5 Explore charts, 5 SQL charts, 5 data apps owned by another user, each shared directly): all 20 list with Name / Last Modified / Views, rows navigate to the resource, and after revoke the view shows "Nothing has been shared with you yet."
  - share picker lists project users and project-attached groups
- [ ] SQL-chart and data-app menu items follow the identical pattern but weren't browser-exercised (no saved SQL charts or apps in the dev seed); covered by typecheck + the shared modal's fixture tests across all four types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
