### PR TITLE
fix(mcp): clarify rollout contract snapshot

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -26,7 +26,7 @@ describe('defineTool', () => {
         expect(mcpView.outputSchema).toBeDefined();
     });
 
-    it('keeps runtime-selected filter expression definitions out of default arrays', () => {
+    it('keeps rollout-only filter expression definitions out of stable default arrays', () => {
         expect(
             mcpToolDefinitions.includes(runQueryFilterExpressionToolDefinition),
         ).toBe(false);

--- a/packages/common/src/schemas/generateMcpToolsSnapshot.ts
+++ b/packages/common/src/schemas/generateMcpToolsSnapshot.ts
@@ -5,20 +5,18 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 import { mcpToolDefinitions } from '../ee/AiAgent/schemas/tools/toolDefinitions';
 
 /**
- * Generates a committed snapshot of the DECLARED MCP tool surface
- * (`packages/common/src/schemas/json/mcp-tools-1.0.json`) consumed by the
- * release-safety marker's MCP breaking-change diff (PROD-8359, P3 —
- * `scripts/mcp-tools-diff.ts`).
+ * Generates the committed stable/default MCP tool surface used for
+ * release-safety checks.
  *
- * The snapshot is built from `mcpToolDefinitions` (every MCP-available tool, the
- * superset that ignores runtime feature-flag gating) via each tool's `for('mcp')`
- * view, serializing the input/output Zod schemas to JSON Schema with the same
- * `zodToJsonSchema(..., { target: 'jsonSchema7' })` settings as the runtime
- * contract snapshot test (`mcpToolContracts.snapshot.test.ts`). Tools and object
- * keys are sorted so the file is byte-stable across regenerations.
+ * `mcpToolDefinitions` intentionally excludes temporary runtime-selected
+ * rollout variants with the same public tool names. Flag-ON rollout contracts
+ * are covered by runtime contract snapshots. When a rollout variant replaces
+ * the default, promote it into the default definitions and regenerate this
+ * snapshot.
  *
- * Mirrors `generateChartAsCodeSchema.ts`: run to write the file, or with
- * `--check` to fail when the committed file is stale (CI freshness guard).
+ * Input and output schemas use the runtime contract snapshot's JSON Schema
+ * settings. Tools and object keys are sorted for byte-stable regeneration. Run
+ * with `--check` to verify the committed snapshot is current.
  */
 
 type JsonValue =

--- a/scripts/mcp-tools-diff.ts
+++ b/scripts/mcp-tools-diff.ts
@@ -1,34 +1,19 @@
 /**
- * MCP tool-surface breaking-change detection (PROD-8359, Phase 3).
+ * MCP stable/default tool-surface breaking-change detection.
  *
- * Populates the release-safety marker's `api.mcp` block by diffing a committed
- * snapshot of the MCP tool surface (`packages/common/src/schemas/json/mcp-tools-1.0.json`,
- * produced by `packages/common/src/schemas/generateMcpToolsSnapshot.ts` via the
- * root `generate:mcp-tools-snapshot` script in `postgenerate-api`) between the
- * PREVIOUS release tag and HEAD.
+ * Populates the release-safety marker's `api.mcp` block by diffing the committed
+ * stable/default MCP surface between the previous release tag and HEAD.
+ * Ordinary per-request availability gating does not remove stable tools from
+ * this surface. Temporary, off-by-default rollout variants with the same public
+ * tool names are intentionally excluded until they replace the defaults.
  *
- * The snapshot is the DECLARED MCP tool set (`mcpToolDefinitions` from
- * `@lightdash/common`, the superset of every MCP-available tool) — not the
- * flag-gated runtime subset. Flag-gating (aiWriteback / content-writes /
- * project-pinned) is an operator's per-request runtime choice, not a release
- * change, so the declared surface is the correct unit for a release signal.
+ * The diff is a deliberately conservative floor: it flags four input-contract
+ * regressions, but not additive changes or output, description, or annotation
+ * changes. Both snapshot sides are read from git, never the working tree.
+ * Missing, unreadable, or unparseable snapshots return `checked: false` rather
+ * than asserting an unproven safe result or failing the release.
  *
- * The diff is a deliberately CONSERVATIVE floor (à la a SQL-shape linter): it
- * flags the four input-contract regressions a caller would actually hit, may
- * over-flag, but never under-flags them. It does NOT treat additive changes
- * (new tool, new optional input) or output-schema/description/annotation changes
- * as breaking — those don't break a caller's existing request.
- *
- * Both snapshot sides are read from git (`git show <ref>:<path>`), like the P1
- * migration detector and the P2 REST diff — never the working tree.
- *
- * FAIL-SAFE (soft): a snapshot absent at either ref (e.g. the first release
- * after this lands), unreadable, or unparseable degrades to `checked: false`
- * (the honest "not checked" stub); the generator then does NOT add `mcp` to
- * `capabilities`. It never asserts an unproven "no break" and never fails the
- * release.
- *
- * CLI:  npx tsx scripts/mcp-tools-diff.ts --last-tag 0.3260.2 [--new-ref HEAD]
+ * CLI: npx tsx scripts/mcp-tools-diff.ts --last-tag 0.3260.2 [--new-ref HEAD]
  */
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';


### PR DESCRIPTION
Related: ZAP-963
Related: ZAP-920
Related: #28262

Clarifies that the committed MCP release-safety snapshot represents the stable default contract while same-name, off-by-default rollout variants remain covered by runtime snapshots.

No MCP schema, runtime selection, feature-flag behavior, generated snapshot, or release-safety classifier changes.

Risk: low — documentation and test-description changes only; runtime behavior is unchanged.
