### PR TITLE
feat(pop): add to-date comparison mode

### DIFF
--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -264,6 +264,7 @@ export type DbSavedChartAdditionalMetric = {
     time_dimension_id?: string | null;
     granularity?: string | null;
     period_offset?: number | null;
+    comparison_mode?: string | null;
 };
 export type DbSavedChartAdditionalMetricInsert = Omit<
     DbSavedChartAdditionalMetric,
@@ -309,6 +310,7 @@ export type DBFilteredAdditionalMetrics = Pick<
             | 'time_dimension_id'
             | 'granularity'
             | 'period_offset'
+            | 'comparison_mode'
         >
     >;
 

--- a/packages/backend/src/database/migrations/20260828120000_add_pop_comparison_mode.ts
+++ b/packages/backend/src/database/migrations/20260828120000_add_pop_comparison_mode.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+const AdditionalMetricsTableName = 'saved_queries_version_additional_metrics';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+    await knex.schema.alterTable(AdditionalMetricsTableName, (table) => {
+        table.text('comparison_mode').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '5s'`);
+    await knex.schema.alterTable(AdditionalMetricsTableName, (table) => {
+        table.dropColumn('comparison_mode');
+    });
+}

--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -1,4 +1,4 @@
-import { AnyType } from '@lightdash/common';
+import { AnyType, MetricType, TimeFrames } from '@lightdash/common';
 import knex from 'knex';
 import type { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
@@ -20,6 +20,40 @@ const projectSlugUniqueViolation = (): DatabaseError => {
     error.constraint = 'saved_queries_project_uuid_slug_unique';
     return error;
 };
+
+const savedPopMetric = {
+    name: 'revenue__pop',
+    label: 'Revenue (Previous month)',
+    type: MetricType.SUM,
+    sql: '${TABLE}.revenue',
+    table: 'orders',
+    uuid: 'metric-uuid',
+    generation_type: 'periodOverPeriod',
+    base_metric_id: 'orders_revenue',
+    time_dimension_id: 'orders_order_date_month',
+    granularity: TimeFrames.MONTH,
+    period_offset: 1,
+} as AnyType;
+
+describe('convertDbSavedChartAdditionalMetricToAdditionalMetric', () => {
+    test.each([
+        { persistedMode: 'toDate', expectedMode: 'toDate' },
+        { persistedMode: null, expectedMode: 'full' },
+    ])(
+        'restores $expectedMode mode from a saved PoP metric',
+        ({ persistedMode, expectedMode }) => {
+            const result =
+                SavedChartModel.convertDbSavedChartAdditionalMetricToAdditionalMetric(
+                    {
+                        ...savedPopMetric,
+                        comparison_mode: persistedMode,
+                    },
+                );
+
+            expect(result.comparisonMode).toBe(expectedMode);
+        },
+    );
+});
 
 describe('createSavedChart', () => {
     const database = knex({ client: MockClient, dialect: 'pg' });
@@ -96,6 +130,57 @@ describe('createSavedChart', () => {
         );
         expect(chartInsert?.sql).toContain('"project_uuid"');
         expect(chartInsert?.bindings).toContain(projectUuid);
+    });
+
+    test('persists the comparison mode for generated PoP metrics', async () => {
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const spaceUuid = '33333333-3333-4333-8333-333333333333';
+
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SavedChartSlugMappingsTableName).responseOnce([]);
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+        tracker.on
+            .insert(SavedChartsTableName)
+            .responseOnce([
+                { saved_query_id: 11, saved_query_uuid: 'chart-uuid' },
+            ]);
+        tracker.on
+            .insert('saved_queries_versions')
+            .responseOnce([{ saved_queries_version_id: 13 }]);
+        tracker.on
+            .insert('saved_queries_version_additional_metrics')
+            .responseOnce([]);
+
+        await createSavedChart(
+            database,
+            projectUuid,
+            '11111111-1111-4111-8111-111111111111',
+            {
+                ...chartInput,
+                spaceUuid,
+                dashboardUuid: null,
+                metricQuery: {
+                    ...chartInput.metricQuery,
+                    additionalMetrics: [
+                        {
+                            ...savedPopMetric,
+                            generationType: 'periodOverPeriod',
+                            baseMetricId: savedPopMetric.base_metric_id,
+                            timeDimensionId: savedPopMetric.time_dimension_id,
+                            granularity: TimeFrames.MONTH,
+                            periodOffset: 1,
+                            comparisonMode: 'toDate',
+                        },
+                    ],
+                },
+            },
+        );
+
+        const additionalMetricInsert = tracker.history.insert.find((query) =>
+            query.sql.includes('saved_queries_version_additional_metrics'),
+        );
+        expect(additionalMetricInsert?.sql).toContain('"comparison_mode"');
+        expect(additionalMetricInsert?.bindings).toContain('toDate');
     });
 
     test('writes project_uuid for charts created in dashboards', async () => {

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -53,6 +53,7 @@ import {
     UpdatedByUser,
     UpdateMultipleSavedChart,
     UpdateSavedChart,
+    type PeriodOverPeriodComparisonMode,
     type UUID,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
@@ -440,6 +441,7 @@ const createSavedChartVersion = async (
                     additionalMetric.periodOffset !== undefined
                         ? additionalMetric.periodOffset
                         : null,
+                comparison_mode: additionalMetric.comparisonMode ?? null,
             })),
         );
     });
@@ -982,6 +984,8 @@ export class SavedChartModel {
             ...(additionalMetric.generation_type && {
                 generationType:
                     additionalMetric.generation_type as 'periodOverPeriod',
+                comparisonMode: (additionalMetric.comparison_mode ??
+                    'full') as PeriodOverPeriodComparisonMode,
             }),
             ...(additionalMetric.base_metric_id && {
                 baseMetricId: additionalMetric.base_metric_id,
@@ -2125,6 +2129,7 @@ export class SavedChartModel {
                         'time_dimension_id',
                         'granularity',
                         'period_offset',
+                        'comparison_mode',
                     ])
                     .where('saved_queries_version_id', savedQueriesVersionId);
 

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -23,6 +23,8 @@ import {
 import { type Filters, type MetricFilterRule } from './filter';
 import { type TimeFrames } from './timeFrames';
 
+export type PeriodOverPeriodComparisonMode = 'full' | 'toDate';
+
 export interface AdditionalMetric {
     /** Display label for the metric */
     label?: string;
@@ -84,6 +86,11 @@ export interface AdditionalMetric {
      * For PoP-generated metrics, the number of periods to offset by (>= 1).
      */
     periodOffset?: number;
+    /**
+     * Whether the comparison uses the full period or the matching elapsed period.
+     * Missing values from older saved charts are treated as full-period comparisons.
+     */
+    comparisonMode?: PeriodOverPeriodComparisonMode;
 }
 
 export const isAdditionalMetric = (value: AnyType): value is AdditionalMetric =>

--- a/packages/common/src/types/periodOverPeriodComparison.test.ts
+++ b/packages/common/src/types/periodOverPeriodComparison.test.ts
@@ -119,4 +119,25 @@ describe('periodOverPeriodComparison helpers', () => {
             'orders.payment_id',
         ]);
     });
+
+    test('generated to-date PoP metrics describe the matched elapsed period', () => {
+        const { additionalMetric } = buildPopAdditionalMetric({
+            metric: {
+                table: 'orders',
+                name: 'revenue',
+                label: 'Revenue',
+                type: MetricType.SUM,
+                sql: '${TABLE}.revenue',
+            } as Metric,
+            timeDimensionId: 'orders_order_date_month',
+            granularity: TimeFrames.MONTH,
+            periodOffset: 1,
+            comparisonMode: 'toDate',
+        });
+
+        expect(additionalMetric).toMatchObject({
+            label: 'Revenue (Previous month to date)',
+            comparisonMode: 'toDate',
+        });
+    });
 });

--- a/packages/common/src/types/periodOverPeriodComparison.ts
+++ b/packages/common/src/types/periodOverPeriodComparison.ts
@@ -7,6 +7,7 @@ import {
     type AdditionalMetric,
     type MetricOverrides,
     type MetricQuery,
+    type PeriodOverPeriodComparisonMode,
 } from './metricQuery';
 import { TimeFrames } from './timeFrames';
 
@@ -97,11 +98,15 @@ export const buildPopAdditionalMetricName = ({
 export const getPopPeriodLabel = (
     granularity: TimeFrames,
     periodOffset: number,
+    comparisonMode: PeriodOverPeriodComparisonMode = 'full',
 ) => {
     const label = timeFrameConfigs[granularity]?.getLabel() || granularity;
-    return periodOffset === 1
-        ? `Previous ${String(label).toLowerCase()}`
-        : `${periodOffset} ${String(label).toLowerCase()}s ago`;
+    const periodLabel =
+        periodOffset === 1
+            ? `Previous ${String(label).toLowerCase()}`
+            : `${periodOffset} ${String(label).toLowerCase()}s ago`;
+
+    return comparisonMode === 'toDate' ? `${periodLabel} to date` : periodLabel;
 };
 
 export const getPopComparisonConfigKey = ({
@@ -147,6 +152,7 @@ export const buildPopAdditionalMetric = ({
     timeDimensionId,
     granularity,
     periodOffset,
+    comparisonMode = 'full',
 }: {
     metric: Pick<
         Metric,
@@ -165,6 +171,7 @@ export const buildPopAdditionalMetric = ({
     timeDimensionId: string;
     granularity: TimeFrames;
     periodOffset: number;
+    comparisonMode?: PeriodOverPeriodComparisonMode;
 }): { additionalMetric: AdditionalMetric; metricId: string } => {
     const baseMetricId = getItemId(metric);
     const popName = buildPopAdditionalMetricName({
@@ -182,6 +189,7 @@ export const buildPopAdditionalMetric = ({
         label: `${metric.label} (${getPopPeriodLabel(
             granularity,
             periodOffset,
+            comparisonMode,
         )})`,
         description: metric.description,
         type: metric.type,
@@ -197,6 +205,7 @@ export const buildPopAdditionalMetric = ({
         timeDimensionId,
         granularity,
         periodOffset,
+        comparisonMode,
     };
 
     return { additionalMetric, metricId: popMetricId };

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -389,6 +389,40 @@ describe('addFilterRule', () => {
         });
         expect(result).toEqual(expectedFiltersWithCustomSqlDimension);
     });
+
+    test('adds a period-to-date filter with the requested period', () => {
+        const field = {
+            ...dimension('created_at_month', 'orders'),
+            type: DimensionType.DATE,
+            timeInterval: TimeFrames.MONTH,
+        } as const;
+
+        const result = addFilterRule({
+            filters: {},
+            field,
+            operator: FilterOperator.IN_PERIOD_TO_DATE,
+            settings: {
+                unitOfTime: UnitOfTime.months,
+                completed: false,
+            },
+        });
+
+        expect(result.dimensions).toEqual({
+            id: 'uuid',
+            and: [
+                {
+                    id: 'uuid',
+                    target: { fieldId: 'orders_created_at_month' },
+                    operator: FilterOperator.IN_PERIOD_TO_DATE,
+                    values: [],
+                    settings: {
+                        unitOfTime: UnitOfTime.months,
+                        completed: false,
+                    },
+                },
+            ],
+        });
+    });
 });
 
 describe('createFilterRuleFromField — time-interval DATE dims', () => {

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -40,6 +40,7 @@ import {
     type DashboardFilterRule,
     type DashboardFilters,
     type DateFilterRule,
+    type DateFilterSettings,
     type FieldTarget,
     type FilterDashboardToRule,
     type FilterGroup,
@@ -462,7 +463,7 @@ export const createFilterRuleFromField = (
     field: FilterableField,
     value?: AnyType,
     timezone?: string,
-    operator: QuickFilterOperator = FilterOperator.EQUALS,
+    operator: FilterOperator = FilterOperator.EQUALS,
 ): FilterRule => {
     const isExclude = operator === FilterOperator.NOT_EQUALS;
     let ruleOperator: FilterOperator = operator;
@@ -768,7 +769,8 @@ type AddFilterRuleArgs = {
     targetFieldId?: string;
     value?: AnyType;
     timezone?: string;
-    operator?: QuickFilterOperator;
+    operator?: FilterOperator;
+    settings?: DateFilterSettings;
 };
 
 export const addFilterRule = ({
@@ -778,6 +780,7 @@ export const addFilterRule = ({
     value,
     timezone,
     operator,
+    settings,
 }: AddFilterRuleArgs): Filters => {
     const groupKey = ((f: AnyType) => {
         if (isDimension(f) || isCustomSqlDimension(f)) {
@@ -795,15 +798,18 @@ export const addFilterRule = ({
         timezone,
         operator,
     );
-    const rule = targetFieldId
-        ? {
-              ...createdRule,
-              target: {
-                  ...createdRule.target,
-                  fieldId: targetFieldId,
-              },
-          }
-        : createdRule;
+    const rule = {
+        ...createdRule,
+        ...(settings ? { settings } : {}),
+        ...(targetFieldId
+            ? {
+                  target: {
+                      ...createdRule.target,
+                      fieldId: targetFieldId,
+                  },
+              }
+            : {}),
+    };
     return {
         ...filters,
         [groupKey]: {

--- a/packages/frontend/src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal.tsx
+++ b/packages/frontend/src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal.tsx
@@ -1,5 +1,8 @@
 import {
+    addFilterRule,
     buildPopAdditionalMetric,
+    FilterOperator,
+    getFilterRules,
     getGranularityRank,
     getItemId,
     getPopPeriodLabel,
@@ -7,10 +10,12 @@ import {
     isDimension,
     isSupportedPeriodOverPeriodGranularity,
     timeFrameConfigs,
+    TimeFrames,
+    UnitOfTime,
     type Dimension,
     type ItemsMap,
     type Metric,
-    type TimeFrames,
+    type PeriodOverPeriodComparisonMode,
 } from '@lightdash/common';
 import { Group, Select, Stack, Text, Tooltip } from '@mantine/core';
 import { IconTimelineEvent } from '@tabler/icons-react';
@@ -19,6 +24,7 @@ import {
     explorerActions,
     selectAdditionalMetrics,
     selectDimensions,
+    selectFilters,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
@@ -26,12 +32,20 @@ import Callout from '../../common/Callout';
 import MantineModal from '../../common/MantineModal';
 import { NumberInput } from '../../common/NumberInput';
 
+const TO_DATE_UNITS: Partial<Record<TimeFrames, UnitOfTime>> = {
+    [TimeFrames.WEEK]: UnitOfTime.weeks,
+    [TimeFrames.MONTH]: UnitOfTime.months,
+    [TimeFrames.QUARTER]: UnitOfTime.quarters,
+    [TimeFrames.YEAR]: UnitOfTime.years,
+};
+
 const PeriodOverPeriodComparisonModalContent: FC<{
     metric: Metric;
     itemsMap: ItemsMap;
 }> = ({ metric, itemsMap }) => {
     const dispatch = useExplorerDispatch();
     const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
+    const filters = useExplorerSelector(selectFilters);
 
     const selectedDimensions = useExplorerSelector(selectDimensions);
 
@@ -102,6 +116,8 @@ const PeriodOverPeriodComparisonModalContent: FC<{
     const selectedTimeDimensionId =
         singleTimeDimension?.value ?? chosenTimeDimensionId;
     const [periodOffset, setPeriodOffset] = useState<number>(1);
+    const [comparisonMode, setComparisonMode] =
+        useState<PeriodOverPeriodComparisonMode>('full');
 
     const selectedDimensionObj = useMemo(() => {
         if (!selectedTimeDimensionId || !itemsMap) return null;
@@ -131,10 +147,49 @@ const PeriodOverPeriodComparisonModalContent: FC<{
         [periodOffset],
     );
 
+    const toDateUnit = selectedGranularity
+        ? TO_DATE_UNITS[selectedGranularity]
+        : undefined;
+
     const timeDimensionId = useMemo(() => {
         if (!selectedDimensionObj) return null;
         return getItemId(selectedDimensionObj);
     }, [selectedDimensionObj]);
+
+    const toDateFilterAlreadyExists = useMemo(
+        () =>
+            !!timeDimensionId &&
+            !!toDateUnit &&
+            getFilterRules(filters).some(
+                (filter) =>
+                    filter.target.fieldId === timeDimensionId &&
+                    filter.operator === FilterOperator.IN_PERIOD_TO_DATE &&
+                    filter.settings?.unitOfTime === toDateUnit &&
+                    filter.disabled !== true,
+            ),
+        [filters, timeDimensionId, toDateUnit],
+    );
+
+    const effectiveComparisonMode = toDateFilterAlreadyExists
+        ? 'toDate'
+        : comparisonMode;
+    const comparisonModeOptions = useMemo(
+        () => [
+            {
+                value: 'full',
+                label: 'Full periods',
+                disabled: toDateFilterAlreadyExists,
+            },
+            {
+                value: 'toDate',
+                label: selectedGranularityLabel
+                    ? `All ${selectedGranularityLabel.toLowerCase()}s to date`
+                    : 'All periods to date',
+                disabled: !toDateUnit,
+            },
+        ],
+        [selectedGranularityLabel, toDateFilterAlreadyExists, toDateUnit],
+    );
 
     const popAlreadyExists = useMemo(() => {
         if (!timeDimensionId || !selectedGranularity) return false;
@@ -170,8 +225,29 @@ const PeriodOverPeriodComparisonModalContent: FC<{
             timeDimensionId,
             granularity: selectedGranularity,
             periodOffset: effectivePeriodOffset,
+            comparisonMode: effectiveComparisonMode,
         });
         dispatch(explorerActions.addAdditionalMetric(additionalMetric));
+
+        if (
+            effectiveComparisonMode === 'toDate' &&
+            toDateUnit &&
+            !toDateFilterAlreadyExists
+        ) {
+            dispatch(
+                explorerActions.setFilters(
+                    addFilterRule({
+                        filters,
+                        field: selectedDimensionObj,
+                        operator: FilterOperator.IN_PERIOD_TO_DATE,
+                        settings: {
+                            unitOfTime: toDateUnit,
+                            completed: false,
+                        },
+                    }),
+                ),
+            );
+        }
 
         dispatch(explorerActions.requestQueryExecution());
         dispatch(
@@ -179,12 +255,16 @@ const PeriodOverPeriodComparisonModalContent: FC<{
         );
     }, [
         dispatch,
+        effectiveComparisonMode,
         effectivePeriodOffset,
+        filters,
+        metric,
         popAlreadyExists,
         selectedDimensionObj,
         selectedGranularity,
         timeDimensionId,
-        metric,
+        toDateFilterAlreadyExists,
+        toDateUnit,
     ]);
 
     return (
@@ -230,7 +310,16 @@ const PeriodOverPeriodComparisonModalContent: FC<{
                         }
                         data={selectData}
                         value={selectedTimeDimensionId}
-                        onChange={setSelectedTimeDimensionId}
+                        onChange={(value) => {
+                            setSelectedTimeDimensionId(value);
+                            const item = value ? itemsMap[value] : undefined;
+                            const interval = isDimension(item)
+                                ? item.timeInterval
+                                : undefined;
+                            if (!interval || !TO_DATE_UNITS[interval]) {
+                                setComparisonMode('full');
+                            }
+                        }}
                         disabled={!canConfigure}
                         renderOption={renderSelectOption}
                         searchable
@@ -257,6 +346,20 @@ const PeriodOverPeriodComparisonModalContent: FC<{
                     </Text>
                 </Group>
 
+                <Select
+                    label="Comparison mode"
+                    data={comparisonModeOptions}
+                    value={effectiveComparisonMode}
+                    onChange={(value) => {
+                        if (value) {
+                            setComparisonMode(
+                                value as PeriodOverPeriodComparisonMode,
+                            );
+                        }
+                    }}
+                    allowDeselect={false}
+                />
+
                 {selectedGranularity && timeDimensionId ? (
                     <Text size="sm" c="dimmed">
                         This will create:{' '}
@@ -265,6 +368,7 @@ const PeriodOverPeriodComparisonModalContent: FC<{
                             {`(${getPopPeriodLabel(
                                 selectedGranularity,
                                 effectivePeriodOffset,
+                                effectiveComparisonMode,
                             )})`}
                         </Text>
                     </Text>

--- a/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
@@ -1,4 +1,14 @@
-import { ChartType, type TableCalculation } from '@lightdash/common';
+import {
+    buildPopAdditionalMetric,
+    ChartType,
+    FilterOperator,
+    MetricType,
+    TimeFrames,
+    UnitOfTime,
+    type FilterRule,
+    type Filters,
+    type TableCalculation,
+} from '@lightdash/common';
 import { defaultState } from '../../../providers/Explorer/defaultState';
 import { explorerActions, explorerReducer } from './explorerSlice';
 
@@ -323,4 +333,139 @@ describe('explorerSlice chart type authoring', () => {
         expect(cleared.chartSidebarStep).toBe('configure');
         expect(cleared.unsavedChartVersion.tableName).toBe('orders');
     });
+});
+
+describe('explorerSlice period comparison filters', () => {
+    it.each([
+        [TimeFrames.WEEK, UnitOfTime.weeks, 1, 'Revenue (Previous week)'],
+        [TimeFrames.MONTH, UnitOfTime.months, 1, 'Revenue (Previous month)'],
+        [
+            TimeFrames.QUARTER,
+            UnitOfTime.quarters,
+            1,
+            'Revenue (Previous quarter)',
+        ],
+        [TimeFrames.YEAR, UnitOfTime.years, 2, 'Revenue (2 years ago)'],
+    ])(
+        'renames a %s to-date comparison when its chart filter is removed',
+        (granularity, unitOfTime, periodOffset, label) => {
+            const { additionalMetric, metricId } = buildPopAdditionalMetric({
+                metric: {
+                    table: 'orders',
+                    name: 'revenue',
+                    label: 'Revenue',
+                    type: MetricType.SUM,
+                    sql: '${TABLE}.revenue',
+                },
+                timeDimensionId: 'orders_order_date_month',
+                granularity,
+                periodOffset,
+                comparisonMode: 'toDate',
+            });
+            const filters: Filters = {
+                dimensions: {
+                    id: 'root',
+                    and: [
+                        {
+                            id: 'to-date',
+                            target: { fieldId: 'orders_order_date_month' },
+                            operator: FilterOperator.IN_PERIOD_TO_DATE,
+                            settings: { unitOfTime },
+                        },
+                    ],
+                },
+            };
+            const withMetric = explorerReducer(
+                undefined,
+                explorerActions.addAdditionalMetric(additionalMetric),
+            );
+            const initial = explorerReducer(
+                withMetric,
+                explorerActions.setFilters(filters),
+            );
+            const result = explorerReducer(
+                initial,
+                explorerActions.setFilters({}),
+            );
+
+            expect(
+                result.unsavedChartVersion.metricQuery.additionalMetrics,
+            ).toEqual([{ ...additionalMetric, label, comparisonMode: 'full' }]);
+            expect(result.unsavedChartVersion.metricQuery.metrics).toContain(
+                metricId,
+            );
+        },
+    );
+
+    it.each([
+        ['active nested match', {}, 'toDate'],
+        ['disabled match', { disabled: true }, 'full'],
+        [
+            'another field',
+            { target: { fieldId: 'orders_shipped_month' } },
+            'full',
+        ],
+        [
+            'another period',
+            { settings: { unitOfTime: UnitOfTime.years } },
+            'full',
+        ],
+        [
+            'another operator',
+            { operator: FilterOperator.IN_THE_CURRENT },
+            'full',
+        ],
+    ] as const)(
+        'preserves custom labels and checks the remaining filter: %s',
+        (_name, override, comparisonMode) => {
+            const rule: FilterRule = {
+                id: 'to-date',
+                target: { fieldId: 'orders_order_date_month' },
+                operator: FilterOperator.IN_PERIOD_TO_DATE,
+                settings: { unitOfTime: UnitOfTime.months },
+            };
+            const { additionalMetric } = buildPopAdditionalMetric({
+                metric: {
+                    table: 'orders',
+                    name: 'revenue',
+                    label: 'Revenue',
+                    type: MetricType.SUM,
+                    sql: '${TABLE}.revenue',
+                },
+                timeDimensionId: 'orders_order_date_month',
+                granularity: TimeFrames.MONTH,
+                periodOffset: 1,
+                comparisonMode: 'toDate',
+            });
+            const customMetric = {
+                ...additionalMetric,
+                label: 'Custom comparison',
+            };
+            const initial = explorerReducer(
+                explorerReducer(
+                    undefined,
+                    explorerActions.addAdditionalMetric(customMetric),
+                ),
+                explorerActions.setFilters({
+                    dimensions: { id: 'root', and: [rule] },
+                }),
+            );
+            const filters: Filters = {
+                dimensions: {
+                    id: 'root',
+                    and: [{ id: 'nested', or: [{ ...rule, ...override }] }],
+                },
+            };
+            const result = explorerReducer(
+                initial,
+                explorerActions.setFilters(filters),
+            );
+            expect(
+                result.unsavedChartVersion.metricQuery.additionalMetrics,
+            ).toEqual([{ ...customMetric, comparisonMode }]);
+            expect(result.unsavedChartVersion.metricQuery.filters).toEqual(
+                filters,
+            );
+        },
+    );
 });

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -1,12 +1,17 @@
 import {
     ChartType,
     convertFieldRefToFieldId,
+    FilterOperator,
     getFieldRef,
+    getFilterRulesFromGroup,
     getItemId,
+    getPopPeriodLabel,
+    isPeriodOverPeriodAdditionalMetric,
     isSqlTableCalculation,
     lightdashVariablePattern,
     maybeReplaceFieldsInChartVersion,
     toggleArrayValue,
+    timeframeToUnitOfTime,
     updateFieldIdInFilters,
     type AdditionalMetric,
     type ChartConfig,
@@ -192,7 +197,41 @@ const explorerSlice = createSlice({
         },
 
         setFilters: (state, action: PayloadAction<MetricQuery['filters']>) => {
-            state.unsavedChartVersion.metricQuery.filters = action.payload;
+            const metricQuery = state.unsavedChartVersion.metricQuery;
+            metricQuery.filters = action.payload;
+            const dimensionFilters = getFilterRulesFromGroup(
+                action.payload.dimensions,
+            );
+            metricQuery.additionalMetrics?.forEach((metric) => {
+                if (
+                    !isPeriodOverPeriodAdditionalMetric(metric) ||
+                    metric.comparisonMode !== 'toDate'
+                )
+                    return;
+
+                const hasToDateFilter = dimensionFilters.some(
+                    (filter) =>
+                        !filter.disabled &&
+                        filter.operator === FilterOperator.IN_PERIOD_TO_DATE &&
+                        filter.target.fieldId === metric.timeDimensionId &&
+                        filter.settings?.unitOfTime ===
+                            timeframeToUnitOfTime(metric.granularity),
+                );
+                if (hasToDateFilter) return;
+
+                const suffix = ` (${getPopPeriodLabel(
+                    metric.granularity,
+                    metric.periodOffset,
+                    'toDate',
+                )})`;
+                if (metric.label?.endsWith(suffix)) {
+                    metric.label = `${metric.label.slice(0, -suffix.length)} (${getPopPeriodLabel(
+                        metric.granularity,
+                        metric.periodOffset,
+                    )})`;
+                }
+                metric.comparisonMode = 'full';
+            });
         },
 
         setSortFields: (state, action: PayloadAction<SortField[]>) => {


### PR DESCRIPTION
## What changed

## Summary

Adds full-period and to-date modes for period-over-period comparisons, including week/month/quarter/year chart filters, generated labels, and saved-chart persistence.

Removing or disabling the matching to-date chart filter now resets affected comparisons to full-period mode and removes the generated “to date” label suffix. Metric IDs, formatting, and custom labels remain unchanged; active matching filters retain the to-date mode.

### Review notes

- This follow-up handles the requested transition from to-date to full-period. Automatically restoring the to-date label when a filter is re-added or re-enabled is a reasonable alternative and remains a follow-up behavior for product review.
- Comparison identity still excludes mode because the filter applies chart-wide; supporting coexisting full/toDate versions would need a separate behavior decision.
- Persistence retains the existing nullable-text metadata convention; a database constraint and runtime validation would offer stricter enforcement.

## Verification

Follow-up fixed point: 6be060bfec3c3b8009ecc7c68ed7916762218c38. Commit: fef5bdffe6f2512141ebae8f96ac91864ae3d8eb. Worktree clean.

- `pnpm -F frontend test src/features/explorer/store/explorerSlice.test.ts` — first run reproduced the stale label/mode failure; after implementation, 20 tests passed.
- Extended the regression cases for week/month/quarter/year, multi-period offsets, disabled filters, other fields/operators/periods, nested matching filters, and custom labels.
- `pnpm -F frontend exec vitest related src/features/explorer/store/explorerSlice.ts src/features/explorer/store/explorerSlice.test.ts --run` — 64 test files passed, 474 tests passed.
- `pnpm -F frontend typecheck` — passed.
- `pnpm -F frontend lint` — passed with no warnings or errors.
- `pnpm -F frontend exec oxfmt src/features/explorer/store/explorerSlice.ts src/features/explorer/store/explorerSlice.test.ts` — applied formatting.
- `pnpm -F frontend exec oxfmt src/features/explorer/store/explorerSlice.ts src/features/explorer/store/explorerSlice.test.ts --check` — passed.
- `git diff --check` — passed.
- Independent standards review: no findings. Spec review: no blocking findings; noted the one-way transition as a judgment call.
- Attempted a development-environment walkthrough for adding a to-date comparison and clearing its filter. Capture failed at the metric column context-menu click with a 10-second timeout. No successful visual artifact; browser behavior is not claimed as verified.
- Commit hooks passed, including frontend lint/format and unused-export checks.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-5865-f0fdb5ea2501.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [PROD-5865](https://linear.app/lightdash/issue/PROD-5865)

