### PR TITLE
feat(homepage): quick action target for a specific space and in-app CTA links

### DIFF
--- a/packages/common/src/ee/homepage/schema.test.ts
+++ b/packages/common/src/ee/homepage/schema.test.ts
@@ -38,6 +38,11 @@ const validConfig: HomepageConfig = {
                                 dashboardUuid: 'd2',
                                 label: 'KPIs',
                             },
+                            {
+                                type: 'space',
+                                spaceUuid: 's1',
+                                label: 'Finance',
+                            },
                         ],
                     },
                 },
@@ -116,6 +121,23 @@ describe('parseHomepageConfig', () => {
                                 target: {
                                     type: 'link' as const,
                                     url: 'https://example.com/survey',
+                                },
+                            },
+                        },
+                    ],
+                },
+                {
+                    id: 'row-2',
+                    blocks: [
+                        {
+                            id: 'b3',
+                            type: 'cta' as const,
+                            config: {
+                                buttonLabel: 'Finance space',
+                                target: {
+                                    type: 'space' as const,
+                                    spaceUuid: 's1',
+                                    label: 'Finance',
                                 },
                             },
                         },

--- a/packages/common/src/ee/homepage/schema.ts
+++ b/packages/common/src/ee/homepage/schema.ts
@@ -105,6 +105,11 @@ const quickActionSchema = z
             dashboardUuid: z.string(),
             label: z.string(),
         }),
+        z.object({
+            type: z.literal('space'),
+            spaceUuid: z.string(),
+            label: z.string(),
+        }),
     ])
     .and(z.object({ primary: z.boolean().optional() }));
 
@@ -122,6 +127,11 @@ const ctaTargetSchema = z.discriminatedUnion('type', [
     z.object({
         type: z.literal('dashboard'),
         dashboardUuid: z.string(),
+        label: z.string(),
+    }),
+    z.object({
+        type: z.literal('space'),
+        spaceUuid: z.string(),
         label: z.string(),
     }),
     z.object({ type: z.literal('link'), url: z.string() }),

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -168,7 +168,8 @@ export type HomepageQuickActionTarget =
     | { type: 'run-query' }
     | { type: 'browse-dashboards' }
     | { type: 'browse-spaces' }
-    | { type: 'dashboard'; dashboardUuid: string; label: string };
+    | { type: 'dashboard'; dashboardUuid: string; label: string }
+    | { type: 'space'; spaceUuid: string; label: string };
 
 /** Any quick action can be promoted to the row's primary one, which renders
  * as the same chip inverted. Optional so older configs still load. */

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.test.tsx
@@ -1,0 +1,72 @@
+import {
+    type HomepageCtaBlock,
+    type HomepageCtaTarget,
+} from '@lightdash/common';
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { CtaBlockView } from './CtaBlock';
+
+vi.mock('../../../../hooks/appearance/useProjectColorPalette', () => ({
+    useProjectColorPalette: () => ({ data: undefined }),
+}));
+vi.mock('../../../../hooks/organization/useOrganizationBrand', () => ({
+    useOrganizationBrand: () => ({ data: undefined }),
+}));
+vi.mock('../../../../hooks/useProjectRoute', () => ({
+    useProjectUrlIdentifier: () => 'p1',
+}));
+vi.mock('../../../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track: vi.fn() }),
+}));
+vi.mock('../hooks/useHomepageAiState', () => ({
+    useHomepageAiState: () => ({ canAskAi: true }),
+}));
+vi.mock('../hooks/useRuntimeEmptyBlocks', () => ({
+    useReportRuntimeEmpty: vi.fn(),
+}));
+
+const block = (target: HomepageCtaTarget): HomepageCtaBlock => ({
+    id: 'b1',
+    type: 'cta',
+    config: { buttonLabel: 'Go', target },
+});
+
+const renderCta = (target: HomepageCtaTarget) =>
+    render(
+        <MantineProvider env="test">
+            <MemoryRouter>
+                <CtaBlockView
+                    block={block(target)}
+                    projectUuid="p1"
+                    itemSpan={null}
+                />
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+describe('CtaBlockView links', () => {
+    it('opens external custom links in a new tab', () => {
+        renderCta({ type: 'link', url: 'https://example.com/survey' });
+        const link = screen.getByRole('link');
+        expect(link).toHaveAttribute('href', 'https://example.com/survey');
+        expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('navigates same-origin custom links in-app', () => {
+        renderCta({
+            type: 'link',
+            url: `${window.location.origin}/projects/p1/spaces/s1`,
+        });
+        const link = screen.getByRole('link');
+        expect(link).toHaveAttribute('href', '/projects/p1/spaces/s1');
+        expect(link).not.toHaveAttribute('target');
+    });
+
+    it('navigates a space target in-app', () => {
+        renderCta({ type: 'space', spaceUuid: 's1', label: 'Finance' });
+        const link = screen.getByRole('link');
+        expect(link).toHaveAttribute('href', '/projects/p1/spaces/s1');
+        expect(link).not.toHaveAttribute('target');
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.tsx
@@ -25,6 +25,7 @@ import { useOrganizationBrand } from '../../../../hooks/organization/useOrganiza
 import { useProjectUrlIdentifier } from '../../../../hooks/useProjectRoute';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
+import { resolveInternalPath } from '../../../../utils/url';
 import { useHomepageAiState } from '../hooks/useHomepageAiState';
 import { useReportRuntimeEmpty } from '../hooks/useRuntimeEmptyBlocks';
 import classes from './blockStyles.module.css';
@@ -48,6 +49,8 @@ const targetUrl = (
             return `/projects/${projectUrlIdentifier}/spaces`;
         case 'dashboard':
             return `/projects/${projectUrlIdentifier}/dashboards/${target.dashboardUuid}/view`;
+        case 'space':
+            return `/projects/${projectUrlIdentifier}/spaces/${target.spaceUuid}`;
         case 'link':
             return target.url;
         default:
@@ -175,7 +178,9 @@ const CtaBanner: FC<{
         return <div {...shared}>{body}</div>;
     }
     const url = targetUrl(config.target, projectUuid, projectUrlIdentifier);
-    return config.target.type === 'link' ? (
+    const internalPath =
+        config.target.type === 'link' ? resolveInternalPath(url) : url;
+    return internalPath === null ? (
         <a
             href={url}
             target="_blank"
@@ -186,7 +191,7 @@ const CtaBanner: FC<{
             {body}
         </a>
     ) : (
-        <Link to={url} onClick={onNavigate} {...shared}>
+        <Link to={internalPath} onClick={onNavigate} {...shared}>
             {body}
         </Link>
     );
@@ -303,10 +308,12 @@ export const CtaBlockBuild: FC<BuildComponentProps> = ({
     const config = block.config;
     const patch = (partial: Partial<CtaConfig>) =>
         onChange({ ...block, config: { ...config, ...partial } });
-    // A stored dashboard target (config-as-code) keeps rendering; the picker
-    // covers the built-in destinations plus a free URL.
+    // A stored dashboard or space target (config-as-code) keeps rendering; the
+    // picker covers the built-in destinations plus a free URL.
     const targetChoice: TargetChoice =
-        config.target.type === 'dashboard' ? 'link' : config.target.type;
+        config.target.type === 'dashboard' || config.target.type === 'space'
+            ? 'link'
+            : config.target.type;
     return (
         <Stack gap="sm">
             <CtaBanner

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -46,7 +46,7 @@ type StaticActionDefinition = {
 };
 
 const STATIC_ACTIONS: Record<
-    Exclude<HomepageQuickAction['type'], 'dashboard'>,
+    Exclude<HomepageQuickAction['type'], 'dashboard' | 'space'>,
     StaticActionDefinition
 > = {
     'ask-ai': {
@@ -75,10 +75,16 @@ const STATIC_ACTIONS: Record<
     },
 };
 
-const actionKey = (action: HomepageQuickAction): string =>
-    action.type === 'dashboard'
-        ? `dashboard-${action.dashboardUuid}`
-        : action.type;
+const actionKey = (action: HomepageQuickAction): string => {
+    switch (action.type) {
+        case 'dashboard':
+            return `dashboard-${action.dashboardUuid}`;
+        case 'space':
+            return `space-${action.spaceUuid}`;
+        default:
+            return action.type;
+    }
+};
 
 const actionPresentation = (
     action: HomepageQuickAction,
@@ -91,6 +97,14 @@ const actionPresentation = (
             title: action.label,
             description: 'Open this dashboard.',
             url: `/projects/${projectUrlIdentifier}/dashboards/${action.dashboardUuid}/view`,
+        };
+    }
+    if (action.type === 'space') {
+        return {
+            icon: IconFolder,
+            title: action.label,
+            description: 'Open this space.',
+            url: `/projects/${projectUrlIdentifier}/spaces/${action.spaceUuid}`,
         };
     }
     const { url, ...definition } = STATIC_ACTIONS[action.type];
@@ -154,18 +168,38 @@ export const QuickActionCards: FC<{
     );
 };
 
-const DashboardPickerModal: FC<{
-    opened: boolean;
+type PickableContentType = ContentType.DASHBOARD | ContentType.SPACE;
+
+const PICKER_COPY: Record<
+    PickableContentType,
+    { title: string; placeholder: string; icon: Icon }
+> = {
+    [ContentType.DASHBOARD]: {
+        title: 'Pick a dashboard',
+        placeholder: 'Search dashboards…',
+        icon: IconLayoutDashboard,
+    },
+    [ContentType.SPACE]: {
+        title: 'Pick a space',
+        placeholder: 'Search spaces…',
+        icon: IconFolder,
+    },
+};
+
+const ContentPickerModal: FC<{
+    contentType: PickableContentType | null;
     onClose: () => void;
     projectUuid: string;
-    onPick: (dashboardUuid: string, label: string) => void;
-}> = ({ opened, onClose, projectUuid, onPick }) => {
+    onPick: (uuid: string, label: string) => void;
+}> = ({ contentType, onClose, projectUuid, onPick }) => {
+    const opened = contentType !== null;
+    const copy = PICKER_COPY[contentType ?? ContentType.DASHBOARD];
     const [search, setSearch] = useState('');
     const [debouncedSearch] = useDebouncedValue(search, 300);
     const { data, isFetching } = useInfiniteContent(
         {
             projectUuids: [projectUuid],
-            contentTypes: [ContentType.DASHBOARD],
+            contentTypes: [contentType ?? ContentType.DASHBOARD],
             search: debouncedSearch.length > 0 ? debouncedSearch : undefined,
             pageSize: 25,
         },
@@ -176,12 +210,12 @@ const DashboardPickerModal: FC<{
         <MantineModal
             opened={opened}
             onClose={onClose}
-            title="Pick a dashboard"
+            title={copy.title}
             size="lg"
         >
             <Stack gap="sm">
                 <TextInput
-                    placeholder="Search dashboards…"
+                    placeholder={copy.placeholder}
                     value={search}
                     onChange={(e) => setSearch(e.currentTarget.value)}
                     rightSection={isFetching ? <Loader size="xs" /> : null}
@@ -196,10 +230,7 @@ const DashboardPickerModal: FC<{
                             className={classes.pickerRow}
                             onClick={() => onPick(content.uuid, content.name)}
                         >
-                            <MantineIcon
-                                icon={IconLayoutDashboard}
-                                color="ldGray.6"
-                            />
+                            <MantineIcon icon={copy.icon} color="ldGray.6" />
                             <Text size="sm" fw={500} flex={1} truncate>
                                 {content.name}
                             </Text>
@@ -235,7 +266,8 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
     onChange,
 }) => {
     const { canAskAi } = useHomepageAiState(projectUuid);
-    const [isDashboardPickerOpen, setIsDashboardPickerOpen] = useState(false);
+    const [pickerContentType, setPickerContentType] =
+        useState<PickableContentType | null>(null);
     if (block.type !== 'quick-actions') return null;
 
     const setActions = (actions: HomepageQuickAction[]) =>
@@ -397,9 +429,19 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                             leftSection={
                                 <MantineIcon icon={IconLayoutDashboard} />
                             }
-                            onClick={() => setIsDashboardPickerOpen(true)}
+                            onClick={() =>
+                                setPickerContentType(ContentType.DASHBOARD)
+                            }
                         >
                             A specific dashboard…
+                        </Menu.Item>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconFolder} />}
+                            onClick={() =>
+                                setPickerContentType(ContentType.SPACE)
+                            }
+                        >
+                            A specific space…
                         </Menu.Item>
                     </Menu.Dropdown>
                 </Menu>
@@ -410,23 +452,22 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                     </Text>
                 </Box>
             </Group>
-            <DashboardPickerModal
-                opened={isDashboardPickerOpen}
-                onClose={() => setIsDashboardPickerOpen(false)}
+            <ContentPickerModal
+                contentType={pickerContentType}
+                onClose={() => setPickerContentType(null)}
                 projectUuid={projectUuid}
-                onPick={(dashboardUuid, label) => {
+                onPick={(uuid, label) => {
+                    const picked: HomepageQuickAction =
+                        pickerContentType === ContentType.SPACE
+                            ? { type: 'space', spaceUuid: uuid, label }
+                            : { type: 'dashboard', dashboardUuid: uuid, label };
                     const alreadyAdded = block.config.actions.some(
-                        (action) =>
-                            action.type === 'dashboard' &&
-                            action.dashboardUuid === dashboardUuid,
+                        (action) => actionKey(action) === actionKey(picked),
                     );
                     if (!alreadyAdded) {
-                        setActions([
-                            ...block.config.actions,
-                            { type: 'dashboard', dashboardUuid, label },
-                        ]);
+                        setActions([...block.config.actions, picked]);
                     }
-                    setIsDashboardPickerOpen(false);
+                    setPickerContentType(null);
                 }}
             />
         </Stack>


### PR DESCRIPTION

<img width="1567" height="97" alt="quick-action-space-chips" src="https://github.com/user-attachments/assets/02df28b7-4f3e-464e-9997-64c94e47dc74" />
Quick actions could only point at the spaces list or a specific dashboard, so a homepage had no way to send viewers straight into the space that curates their content. The only workaround, a CTA custom link pasted with a space URL, opened in a new tab with a full page load because every custom link was treated as external.

Closes: #28085
