### PR TITLE
feat(frontend): make login background pink

### DIFF
--- a/packages/frontend/src/components/common/AuthLayout/index.tsx
+++ b/packages/frontend/src/components/common/AuthLayout/index.tsx
@@ -28,6 +28,7 @@ type Props = {
     cardId?: string;
     /** Pages that bring their own cards (Invite) opt out of the legacy card. */
     withLegacyCard?: boolean;
+    backgroundColor?: string;
     footer?: ReactNode;
 };
 
@@ -38,43 +39,50 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
     legacyTitle,
     cardId,
     withLegacyCard = true,
+    backgroundColor,
     footer,
     children,
 }) => {
     const { isNewLayout, isInitialLoading } = useAuthLayoutVariant();
 
     if (isInitialLoading) {
-        return <PageSpinner />;
+        return (
+            <Box bg={backgroundColor} mih="100vh">
+                <PageSpinner />
+            </Box>
+        );
     }
 
     if (!isNewLayout) {
         return (
-            <Page title={pageTitle} withCenteredContent withNavbar={false}>
-                <Stack w={400} mt="4xl">
-                    <Box mx="auto" my="lg">
-                        <LightdashLogo />
-                    </Box>
-                    {withLegacyCard ? (
-                        <Card
-                            id={cardId}
-                            p="xl"
-                            radius="xs"
-                            withBorder
-                            shadow="xs"
-                        >
-                            {legacyTitle && (
-                                <Title order={3} ta="center" mb="md">
-                                    {legacyTitle}
-                                </Title>
-                            )}
-                            {children}
-                        </Card>
-                    ) : (
-                        children
-                    )}
-                    {footer}
-                </Stack>
-            </Page>
+            <Box bg={backgroundColor} mih="100vh">
+                <Page title={pageTitle} withCenteredContent withNavbar={false}>
+                    <Stack w={400} mt="4xl">
+                        <Box mx="auto" my="lg">
+                            <LightdashLogo />
+                        </Box>
+                        {withLegacyCard ? (
+                            <Card
+                                id={cardId}
+                                p="xl"
+                                radius="xs"
+                                withBorder
+                                shadow="xs"
+                            >
+                                {legacyTitle && (
+                                    <Title order={3} ta="center" mb="md">
+                                        {legacyTitle}
+                                    </Title>
+                                )}
+                                {children}
+                            </Card>
+                        ) : (
+                            children
+                        )}
+                        {footer}
+                    </Stack>
+                </Page>
+            </Box>
         );
     }
 
@@ -83,7 +91,7 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
             <DocumentTitle title={pageTitle} />
 
             <Box className={classes.root}>
-                <Box className={classes.brandPanel}>
+                <Box className={classes.brandPanel} bg={backgroundColor}>
                     <Box className={classes.decorationTop} aria-hidden />
                     <Box className={classes.decorationBottom} aria-hidden />
 
@@ -128,7 +136,7 @@ const AuthLayout: FC<PropsWithChildren<Props>> = ({
                     </Stack>
                 </Box>
 
-                <Box className={classes.formPanel}>
+                <Box className={classes.formPanel} bg={backgroundColor}>
                     <Stack id={cardId} className={classes.formContent} gap="xl">
                         <Group
                             gap="sm"

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -8,7 +8,7 @@ import LoginLanding from '../features/users/components/LoginLanding';
 const Login: FC<{ minimal?: boolean }> = ({ minimal = false }) => {
     if (minimal) {
         return (
-            <Stack m="xl">
+            <Stack bg="pink" mih="100vh" p="xl">
                 <Box mx="auto" my="lg">
                     <LightdashLogo />
                 </Box>
@@ -35,6 +35,7 @@ const Login: FC<{ minimal?: boolean }> = ({ minimal = false }) => {
             subtitle="Welcome back — pick up where you left off."
             legacyTitle="Sign in"
             cardId={LOGIN_PAGE_ID}
+            backgroundColor="pink"
         >
             <LoginLanding />
         </AuthLayout>


### PR DESCRIPTION
## What changed

Updated the login experience to use a pink, full-viewport background across loading, legacy, split-screen, responsive, and mobile render variants. Other authentication pages retain their existing backgrounds.

### Validation
- `pnpm -F frontend exec oxfmt src/components/common/AuthLayout/index.tsx src/pages/Login.tsx --check` — passed
- `pnpm -F frontend run --if-present lint` — passed
- `pnpm -F frontend run --if-present typecheck` — passed
- `pnpm -F frontend exec vitest related src/components/common/AuthLayout/index.tsx src/pages/Login.tsx --run --passWithNoTests` — passed
- Sealed browser verification confirmed `/login` renders `rgb(230, 73, 128)` across the full 1280×720 viewport.

## Proof of work

🟢 **PASS** — The initial unauthenticated /login page renders a full-viewport pink background at the committed revision.

Revision: `cfbf41ccdf9128e6292ff915181e7c28e7fbb831`

### Initial unauthenticated login page has a pink background

- Expected: Loading /login displays the login form over a pink background covering the 1280×720 viewport.
- Observed: The final URL was /login at 1280×720. #lightdash-login-page matched once and was visible. The stable full-page AuthLayout container selected by div:has(> #page-root) matched once, was visible, measured 720px high, and had computed background-color rgb(230, 73, 128). #page-root also matched once, was visible, and measured 720px high.
- Evidence:
  - Durable screenshot: https://ld-linear-agent-v2.exe.xyz/evidence/ebf1c1d0b11f622ed2b56253a1fe45e8711442accadedc89497e25696a8fbc5d.png
  - Same-page structured observation: final URL https://ld-runner-prod-10759-e6756e4e1ef7.exe.xyz/login; viewport 1280×720; #lightdash-login-page matchCount=1, visible=true; div:has(> #page-root) matchCount=1, visible=true, background-color=rgb(230, 73, 128), height=720px; #page-root matchCount=1, visible=true, height=720px.
  - Host preflight validated revision cfbf41ccdf9128e6292ff915181e7c28e7fbb831 with worktree clean.

![Lightdash development environment screenshot](https://ld-linear-agent-v2.exe.xyz/evidence/ebf1c1d0b11f622ed2b56253a1fe45e8711442accadedc89497e25696a8fbc5d.png)

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10759-e6756e4e1ef7.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10759

