### PR TITLE
fix(homepage): edit quick actions as the chip row they publish to

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -7,6 +7,7 @@ import {
     Group,
     Loader,
     Menu,
+    Paper,
     Stack,
     Text,
     TextInput,
@@ -292,7 +293,7 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
 
     return (
         <Stack gap="xs">
-            <Stack gap={4}>
+            <Group gap={8} className={classes.editableChipRow}>
                 {block.config.actions.map((action, index) => {
                     const presentation = actionPresentation(
                         action,
@@ -301,101 +302,120 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                     // Matches the view: no agent, no Ask AI row
                     if (action.type === 'ask-ai' && !canAskAi) return null;
                     return (
-                        <Group
+                        <Box
                             key={actionKey(action)}
-                            gap="xs"
-                            wrap="nowrap"
-                            p="xs"
-                            className={classes.actionRow}
+                            className={classes.editableChip}
                         >
-                            <MantineIcon
-                                icon={presentation.icon}
-                                color="ldGray.6"
-                            />
-                            <Text size="sm" fw={500} flex={1}>
-                                {presentation.title}
-                            </Text>
-                            <Tooltip
-                                label={
+                            <span
+                                className={`${classes.quickActionChip}${
                                     action.primary
-                                        ? 'Primary action'
-                                        : 'Make primary'
-                                }
-                                withinPortal
+                                        ? ` ${classes.quickActionChipPrimary}`
+                                        : ''
+                                }`}
                             >
-                                <ActionIcon
-                                    variant="subtle"
+                                <MantineIcon
+                                    icon={presentation.icon}
+                                    size={14}
                                     color={
-                                        action.primary ? 'yellow' : 'ldGray.6'
+                                        action.primary ? 'inherit' : 'ldGray.6'
                                     }
-                                    size="sm"
-                                    aria-label={`Make ${presentation.title} the primary action`}
-                                    aria-pressed={action.primary === true}
-                                    onClick={() =>
-                                        // Only one primary per row
-                                        setActions(
-                                            block.config.actions.map(
-                                                (item, i) => ({
-                                                    ...item,
-                                                    primary:
-                                                        i === index
-                                                            ? !action.primary
-                                                            : false,
-                                                }),
-                                            ),
-                                        )
-                                    }
-                                >
-                                    <MantineIcon
-                                        icon={
+                                />
+                                {presentation.title}
+                            </span>
+                            <Paper
+                                p={4}
+                                shadow="sm"
+                                className={classes.editableChipActions}
+                            >
+                                <Group gap={2} wrap="nowrap">
+                                    <Tooltip
+                                        label={
                                             action.primary
-                                                ? IconStarFilled
-                                                : IconStar
+                                                ? 'Primary action'
+                                                : 'Make primary'
                                         }
-                                    />
-                                </ActionIcon>
-                            </Tooltip>
-                            <ActionIcon
-                                variant="subtle"
-                                color="ldGray.6"
-                                size="sm"
-                                disabled={index === 0}
-                                aria-label={`Move ${presentation.title} earlier`}
-                                onClick={() => move(index, -1)}
-                            >
-                                <MantineIcon icon={IconArrowLeft} />
-                            </ActionIcon>
-                            <ActionIcon
-                                variant="subtle"
-                                color="ldGray.6"
-                                size="sm"
-                                disabled={
-                                    index === block.config.actions.length - 1
-                                }
-                                aria-label={`Move ${presentation.title} later`}
-                                onClick={() => move(index, 1)}
-                            >
-                                <MantineIcon icon={IconArrowRight} />
-                            </ActionIcon>
-                            <ActionIcon
-                                variant="subtle"
-                                color="ldGray.6"
-                                size="sm"
-                                aria-label={`Remove ${presentation.title}`}
-                                onClick={() =>
-                                    setActions(
-                                        block.config.actions.filter(
-                                            (_, i) => i !== index,
-                                        ),
-                                    )
-                                }
-                            >
-                                <MantineIcon icon={IconX} />
-                            </ActionIcon>
-                        </Group>
+                                        withinPortal
+                                    >
+                                        <ActionIcon
+                                            variant="subtle"
+                                            color={
+                                                action.primary
+                                                    ? 'yellow'
+                                                    : 'ldGray.6'
+                                            }
+                                            size="sm"
+                                            aria-label={`Make ${presentation.title} the primary action`}
+                                            aria-pressed={
+                                                action.primary === true
+                                            }
+                                            onClick={() =>
+                                                // Only one primary per row
+                                                setActions(
+                                                    block.config.actions.map(
+                                                        (item, i) => ({
+                                                            ...item,
+                                                            primary:
+                                                                i === index
+                                                                    ? !action.primary
+                                                                    : false,
+                                                        }),
+                                                    ),
+                                                )
+                                            }
+                                        >
+                                            <MantineIcon
+                                                icon={
+                                                    action.primary
+                                                        ? IconStarFilled
+                                                        : IconStar
+                                                }
+                                            />
+                                        </ActionIcon>
+                                    </Tooltip>
+                                    <ActionIcon
+                                        variant="subtle"
+                                        color="ldGray.6"
+                                        size="sm"
+                                        disabled={index === 0}
+                                        aria-label={`Move ${presentation.title} earlier`}
+                                        onClick={() => move(index, -1)}
+                                    >
+                                        <MantineIcon icon={IconArrowLeft} />
+                                    </ActionIcon>
+                                    <ActionIcon
+                                        variant="subtle"
+                                        color="ldGray.6"
+                                        size="sm"
+                                        disabled={
+                                            index ===
+                                            block.config.actions.length - 1
+                                        }
+                                        aria-label={`Move ${presentation.title} later`}
+                                        onClick={() => move(index, 1)}
+                                    >
+                                        <MantineIcon icon={IconArrowRight} />
+                                    </ActionIcon>
+                                    <ActionIcon
+                                        variant="subtle"
+                                        color="ldGray.6"
+                                        size="sm"
+                                        aria-label={`Remove ${presentation.title}`}
+                                        onClick={() =>
+                                            setActions(
+                                                block.config.actions.filter(
+                                                    (_, i) => i !== index,
+                                                ),
+                                            )
+                                        }
+                                    >
+                                        <MantineIcon icon={IconX} />
+                                    </ActionIcon>
+                                </Group>
+                            </Paper>
+                        </Box>
                     );
                 })}
-            </Stack>
+            </Group>
             <Group gap="xs">
                 <Menu position="bottom-start">
                     <Menu.Target>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -293,7 +293,7 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
 
     return (
         <Stack gap="xs">
-            <Group gap={8} className={classes.editableChipRow}>
+            <Group gap={8} justify="center" className={classes.editableChipRow}>
                 {block.config.actions.map((action, index) => {
                     const presentation = actionPresentation(
                         action,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -373,9 +373,39 @@ a .hoverCard:hover,
     min-height: 0;
 }
 
-.actionRow {
-    border: 1px solid var(--mantine-color-ldGray-3);
-    border-radius: 8px;
+/* Builder chips: rendered like the published row so admins see the real
+ * layout; the edit controls float above the hovered chip. */
+.editableChipRow {
+    /* room for the floating actions so the first row is not clipped */
+    padding-top: 28px;
+}
+
+.editableChip {
+    position: relative;
+}
+
+.editableChipActions {
+    display: none;
+    position: absolute;
+    bottom: calc(100% + 4px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+}
+
+/* Invisible bridge over the gap so moving up into the actions keeps hover. */
+.editableChipActions::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    height: 6px;
+}
+
+.editableChip:hover .editableChipActions,
+.editableChip:focus-within .editableChipActions {
+    display: block;
 }
 
 .plainLink {
@@ -610,10 +640,17 @@ a .hoverCard:hover,
         border-color 0.15s ease;
 }
 
+.quickActionChip:hover {
+    text-decoration: none;
+    color: inherit;
+    background: var(--mantine-color-ldGray-0);
+    border-color: var(--mantine-color-ldGray-3);
+}
+
 /* Primary quick action: same box, inverted. Colours only — no size change, so
- * it can't introduce a height difference next to its siblings. */
-.quickActionChipPrimary,
-.quickActionChipPrimary:hover {
+ * it can't introduce a height difference next to its siblings. Doubled class
+ * so it outranks the base hover rule. */
+.quickActionChip.quickActionChipPrimary {
     background: light-dark(
         var(--mantine-color-dark-9),
         var(--mantine-color-gray-0)
@@ -625,11 +662,16 @@ a .hoverCard:hover,
     color: light-dark(#fff, var(--mantine-color-dark-9));
 }
 
-.quickActionChip:hover {
-    text-decoration: none;
-    color: inherit;
-    background: var(--mantine-color-ldGray-0);
-    border-color: var(--mantine-color-ldGray-3);
+.quickActionChip.quickActionChipPrimary:hover {
+    background: light-dark(
+        var(--mantine-color-dark-7),
+        var(--mantine-color-gray-2)
+    );
+    border-color: light-dark(
+        var(--mantine-color-dark-7),
+        var(--mantine-color-gray-2)
+    );
+    color: light-dark(#fff, var(--mantine-color-dark-9));
 }
 
 /* --- Resource cards ---------------------------------------------------- */

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -387,20 +387,11 @@ a .hoverCard:hover,
 .editableChipActions {
     display: none;
     position: absolute;
-    bottom: calc(100% + 4px);
+    /* Overlaps the chip's top edge so the two read as one piece. */
+    bottom: calc(100% - 6px);
     left: 50%;
     transform: translateX(-50%);
     z-index: 10;
-}
-
-/* Invisible bridge over the gap so moving up into the actions keeps hover. */
-.editableChipActions::after {
-    content: '';
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    height: 6px;
 }
 
 .editableChip:hover .editableChipActions,


### PR DESCRIPTION
The builder listed quick actions as a vertical stack of rows with inline controls, so admins could not see how the row would wrap or which chip was primary until they previewed. The edit controls now float above the hovered chip, the way dashboard tiles expose theirs. While there, the primary chip lost its inverted colour on hover in both the builder and the published homepage, because the base hover rule outranked the primary one.
