### PR TITLE
feat(chart-types): push host-resolved colors to custom chart types

### DIFF
--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -1148,14 +1148,18 @@ export type DataAppVizDrillDownIntent = {
 // field id, the host-fetched result rows the renderer reads, the effective
 // config option values (stored value ?? declared default), and the palette
 // resolved for this chart (org → project → space → dashboard → chart, dark-mode
-// corrected). `colorPalette` is pushed whether or not the viz declared one, so a
-// viz that colours series never has to check first. `underlyingData.enabled` and
-// `drillDown.enabled` are required so every push site decides availability explicitly.
+// corrected), plus the host-resolved colors for pivot columns and raw dimension
+// values. `colorPalette` is pushed whether or not the viz declared one, so a viz
+// that colours series never has to check first. `underlyingData.enabled` and
+// `drillDown.enabled` are required so every push site decides availability
+// explicitly.
 export type DataAppVizContext = {
     fieldMapping: Record<string, string>;
     rows: ResultRow[];
     options: Record<string, DataAppVizOptionValue>;
     colorPalette: string[];
+    seriesColors: Record<string, string>;
+    valueColors: Record<string, Record<string, string>>;
     pivotDetails: ReadyQueryResultsPage['pivotDetails'];
     underlyingData: { enabled: boolean };
     drillDown: { enabled: boolean };

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -1,6 +1,9 @@
+import { DimensionType, FieldType } from '@lightdash/common';
 import { MantineProvider } from '@mantine/core';
 import { act, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChartColorMappingContext } from '../../hooks/useChartColorConfig/context';
+import { getMantineThemeOverride } from '../../theme';
 
 // Mirrors the real hook's failSilently contract: TrackingContextType | undefined.
 type TrackingMockContext = { track: (...args: unknown[]) => void } | undefined;
@@ -13,7 +16,12 @@ const mocks = vi.hoisted(() => ({
                   version: number;
                   latestBuildInProgress: boolean;
                   schema: {
-                      fields: Array<never>;
+                      fields: Array<{
+                          name: string;
+                          label: string;
+                          type: 'dimension';
+                          required: boolean;
+                      }>;
                       configOptions: Array<{
                           type: 'text';
                           name: string;
@@ -101,6 +109,9 @@ vi.mock('../../hooks/useExplore', () => ({
         return { data: mocks.explore.current };
     },
 }));
+vi.mock('../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({ data: { enabled: true } }),
+}));
 vi.mock('../../providers/App/useApp', () => ({
     default: () => ({
         user: {
@@ -128,7 +139,7 @@ vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
                               dataAppVizUuid: mocks.dataAppVizUuid.current,
                               dataAppVizVersion:
                                   mocks.dataAppVizVersion.current,
-                              fieldMapping: { category: 'orders.category' },
+                              fieldMapping: { category: 'orders_category' },
                               optionValues: { title: 12 },
                           },
                 setDataAppVizVersion: mocks.setDataAppVizVersion,
@@ -136,8 +147,27 @@ vi.mock('../LightdashVisualization/useVisualizationContext', () => ({
         },
         savedChartUuid: 'saved-chart-uuid',
         resultsData: {
-            rows: [{ 'orders.category': { value: { raw: 'Hardware' } } }],
+            rows: [
+                {
+                    orders_category: {
+                        value: { raw: 'Hardware', formatted: 'Hardware' },
+                    },
+                },
+            ],
             setFetchAll: mocks.setFetchAll,
+        },
+        itemsMap: {
+            orders_category: {
+                fieldType: FieldType.DIMENSION,
+                type: DimensionType.STRING,
+                name: 'category',
+                label: 'Category',
+                table: 'orders',
+                tableLabel: 'Orders',
+                sql: '${TABLE}.category',
+                hidden: false,
+                colors: { Hardware: '#00ff00' },
+            },
         },
         colorPalette: ['#7162FF'],
         ...mocks.vizContextOverrides.current,
@@ -159,19 +189,30 @@ function apiError(statusCode: number) {
     };
 }
 
-const renderRenderer = (props?: Parameters<typeof DataAppVizRenderer>[0]) =>
-    render(
-        <MantineProvider env="test">
+const rendererElement = (props?: Parameters<typeof DataAppVizRenderer>[0]) => (
+    <MantineProvider env="test" theme={getMantineThemeOverride('light')}>
+        <ChartColorMappingContext.Provider value={{ colorMappings: new Map() }}>
             <DataAppVizRenderer {...props} />
-        </MantineProvider>,
-    );
+        </ChartColorMappingContext.Provider>
+    </MantineProvider>
+);
+
+const renderRenderer = (props?: Parameters<typeof DataAppVizRenderer>[0]) =>
+    render(rendererElement(props));
 
 const readyMetadata = () => ({
     state: 'ready' as const,
     version: 7,
     latestBuildInProgress: false,
     schema: {
-        fields: [],
+        fields: [
+            {
+                name: 'category',
+                label: 'Category',
+                type: 'dimension' as const,
+                required: true,
+            },
+        ],
         configOptions: [
             {
                 type: 'text' as const,
@@ -324,6 +365,10 @@ describe('DataAppVizRenderer', () => {
                 dataAppVizContext: expect.objectContaining({
                     options: { title: 'Sales' },
                     colorPalette: ['#7162FF'],
+                    seriesColors: {},
+                    valueColors: {
+                        orders_category: { Hardware: '#00ff00' },
+                    },
                 }),
             }),
             undefined,
@@ -491,11 +536,7 @@ describe('DataAppVizRenderer screenshot-ready contract', () => {
         expect(onScreenshotReady).not.toHaveBeenCalled();
 
         mocks.vizContextOverrides.current = {};
-        view.rerender(
-            <MantineProvider env="test">
-                <DataAppVizRenderer onScreenshotReady={onScreenshotReady} />
-            </MantineProvider>,
-        );
+        view.rerender(rendererElement({ onScreenshotReady }));
 
         expect(onScreenshotReady).toHaveBeenCalledTimes(1);
     });
@@ -535,11 +576,7 @@ describe('DataAppVizRenderer screenshot-ready contract', () => {
                 vi.advanceTimersByTime(SCREENSHOT_READY_FALLBACK_MS - 1000);
             });
             const second = vi.fn();
-            view.rerender(
-                <MantineProvider env="test">
-                    <DataAppVizRenderer onScreenshotReady={second} />
-                </MantineProvider>,
-            );
+            view.rerender(rendererElement({ onScreenshotReady: second }));
             act(() => {
                 vi.advanceTimersByTime(1000);
             });

--- a/packages/frontend/src/components/DataAppVizRenderer/index.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.tsx
@@ -4,6 +4,8 @@ import {
     hasCustomBinDimension,
     type ApiError,
     type DataAppVizContext,
+    type ItemsMap,
+    type ResultRow,
 } from '@lightdash/common';
 import { Stack, Text } from '@mantine/core';
 import { IconPuzzle } from '@tabler/icons-react';
@@ -24,6 +26,7 @@ import {
     useDataAppVizPreviewToken,
     useDataAppVizRenderMetadata,
 } from '../../features/chartTypes/hooks/useDataAppVizRender';
+import { useDataAppVizResolvedColors } from '../../features/chartTypes/hooks/useDataAppVizResolvedColors';
 import { reconcileDataAppVizFieldMapping } from '../../features/chartTypes/utils/autoMapDataAppVizFields';
 import useToaster from '../../hooks/toaster/useToaster';
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
@@ -53,6 +56,10 @@ const DataAppVizPlaceholder: FC<{ message: string }> = ({ message }) => (
         </Text>
     </Stack>
 );
+
+const EMPTY_ITEMS_MAP: ItemsMap = {};
+const EMPTY_ROWS: ResultRow[] = [];
+const EMPTY_FIELD_MAPPING = {};
 
 const getTerminalRequestErrorMessage = (
     errors: Array<ApiError | null | undefined>,
@@ -225,6 +232,13 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
                 : undefined,
         [fields, itemsMap, fieldMapping],
     );
+    const resolvedColors = useDataAppVizResolvedColors({
+        itemsMap: itemsMap ?? EMPTY_ITEMS_MAP,
+        rows: rows ?? EMPTY_ROWS,
+        fieldMapping: reconciledFieldMapping ?? EMPTY_FIELD_MAPPING,
+        pivotDetails,
+        colorPalette,
+    });
 
     // Fail-silent: surfaces without MetricQueryDataProvider (no drill modal
     // mounted) simply report drill-down as unavailable.
@@ -339,6 +353,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
             // Already resolved through the full palette cascade and dark-mode
             // corrected by the visualization context.
             colorPalette,
+            ...resolvedColors,
             pivotDetails,
             underlyingData: { enabled: underlyingDataEnabled },
             drillDown: { enabled: drillDownEnabled },
@@ -349,6 +364,7 @@ const DataAppVizRenderer: FC<Props> = ({ onScreenshotReady }) => {
         configOptions,
         optionValues,
         colorPalette,
+        resolvedColors,
         pivotDetails,
         underlyingDataEnabled,
         drillDownEnabled,

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.test.tsx
@@ -25,6 +25,7 @@ import {
     createExplorerStore,
     explorerActions,
 } from '../../../features/explorer/store';
+import { ChartColorMappingContext } from '../../../hooks/useChartColorConfig/context';
 import { renderWithProviders } from '../../../testing/testUtils';
 import { useExplorerResultsData } from '../VisualizationCard/useExplorerResultsData';
 import ExplorerChartTypeAuthoring from './ExplorerChartTypeAuthoring';
@@ -266,11 +267,13 @@ const renderAuthoring = ({
     };
 
     renderWithProviders(
-        <Provider store={store}>
-            <MemoryRouter>
-                <Harness />
-            </MemoryRouter>
-        </Provider>,
+        <ChartColorMappingContext.Provider value={{ colorMappings: new Map() }}>
+            <Provider store={store}>
+                <MemoryRouter>
+                    <Harness />
+                </MemoryRouter>
+            </Provider>
+        </ChartColorMappingContext.Provider>,
     );
     return store;
 };

--- a/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
+++ b/packages/frontend/src/components/Explorer/ChartTypeAuthoring/ExplorerChartTypeAuthoring.tsx
@@ -12,7 +12,11 @@ import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDa
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDeleteApp } from '../../../features/apps/hooks/useDeleteApp';
 import { useChartTypeBuilderWorkspace } from '../../../features/chartTypes/builder/useChartTypeBuilderWorkspace';
-import { buildExplorerVizContext } from '../../../features/chartTypes/utils/explorerVizContext';
+import { useDataAppVizResolvedColors } from '../../../features/chartTypes/hooks/useDataAppVizResolvedColors';
+import {
+    buildExplorerVizContext,
+    resolveExplorerVizFieldMapping,
+} from '../../../features/chartTypes/utils/explorerVizContext';
 import {
     explorerActions,
     selectChartConfig,
@@ -145,6 +149,24 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
     const schema = dataAppViz?.schema ?? null;
     const persistedFieldMapping = chartTypeConfig?.fieldMapping ?? null;
     const optionValues = chartTypeConfig?.optionValues ?? NO_OPTIONS;
+    const previewFieldMapping = useMemo(
+        () =>
+            schema
+                ? resolveExplorerVizFieldMapping({
+                      schema,
+                      itemsMap,
+                      persistedFieldMapping,
+                  })
+                : {},
+        [schema, itemsMap, persistedFieldMapping],
+    );
+    const resolvedColors = useDataAppVizResolvedColors({
+        itemsMap,
+        rows: resultsData.rows,
+        fieldMapping: previewFieldMapping,
+        pivotDetails: resultsData.pivotDetails ?? null,
+        colorPalette,
+    });
     const previewContext = useMemo(
         () =>
             schema
@@ -156,6 +178,7 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
                       pivotDetails: resultsData.pivotDetails ?? null,
                       colorPalette,
                       optionValues,
+                      resolvedColors,
                   })
                 : null,
         [
@@ -166,6 +189,7 @@ const ExplorerChartTypeAuthoring: FC<Props> = ({ authoring }) => {
             resultsData.pivotDetails,
             colorPalette,
             optionValues,
+            resolvedColors,
         ],
     );
 

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -2,7 +2,6 @@ import {
     assertUnreachable,
     ChartType,
     FeatureFlags,
-    isDimension,
     type ApiErrorDetail,
     type ChartConfig,
     type DashboardFilters,
@@ -31,7 +30,9 @@ import { type CartesianTypeOptions } from '../../hooks/cartesianChartConfig/useC
 import { type SeriesLike } from '../../hooks/useChartColorConfig/types';
 import { useChartColorConfig } from '../../hooks/useChartColorConfig/useChartColorConfig';
 import {
+    calculateFallbackSeriesColors,
     calculateSeriesLikeIdentifier,
+    getDimensionValueColor,
     isGroupedSeries,
 } from '../../hooks/useChartColorConfig/utils';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
@@ -219,15 +220,7 @@ const VisualizationProvider: FC<
                 ? computedSeries
                 : chartConfig.config.eChartsConfig.series;
 
-        const sortedSeriesIdentifiers = (allSeries ?? [])
-            .map((series) => calculateSeriesLikeIdentifier(series).join('|'))
-            .sort((a, b) => b.localeCompare(a));
-
-        return Object.fromEntries(
-            sortedSeriesIdentifiers.map((identifier, i) => {
-                return [identifier, colorPalette[i % colorPalette.length]];
-            }),
-        );
+        return calculateFallbackSeriesColors(allSeries ?? [], colorPalette);
     }, [chartConfig, colorPalette, computedSeries]);
 
     const handleChartConfigChange = useCallback(
@@ -252,13 +245,12 @@ const VisualizationProvider: FC<
     const getGroupColor = useCallback(
         (groupPrefix: string, identifier: string) => {
             if (itemsMap) {
-                const dimension = itemsMap[groupPrefix];
-                if (dimension && isDimension(dimension)) {
-                    const colors = dimension.colors;
-                    if (colors && colors[identifier]) {
-                        return colors[identifier];
-                    }
-                }
+                const fixedColor = getDimensionValueColor(
+                    itemsMap,
+                    groupPrefix,
+                    identifier,
+                );
+                if (fixedColor) return fixedColor;
             }
 
             return calculateKeyColorAssignment(groupPrefix, identifier);
@@ -299,17 +291,12 @@ const VisualizationProvider: FC<
             }
             if (itemsMap && pivot) {
                 const { field, value } = pivot;
-                const dimension = itemsMap[field];
-                if (
-                    dimension &&
-                    isDimension(dimension) &&
-                    typeof value === 'string'
-                ) {
-                    const colors = dimension.colors;
-                    if (colors && colors[value]) {
-                        return colors[value];
-                    }
-                }
+                const fixedColor = getDimensionValueColor(
+                    itemsMap,
+                    field,
+                    value,
+                );
+                if (fixedColor) return fixedColor;
             }
 
             /**

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1179,6 +1179,8 @@ describe('data-app-viz-context push', () => {
         ],
         options: { showLegend: true, barColor: '#ff0000' },
         colorPalette: ['#7162FF', '#1A1B1E'],
+        seriesColors: {},
+        valueColors: {},
         pivotDetails: null,
         underlyingData: { enabled: false },
         drillDown: { enabled: false },

--- a/packages/frontend/src/features/chartTypes/components/DataAppVizTestPanel.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/DataAppVizTestPanel.test.tsx
@@ -13,7 +13,9 @@ import {
 } from '@lightdash/common';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { type ComponentProps } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChartColorMappingContext } from '../../../hooks/useChartColorConfig/context';
 import { renderWithProviders } from '../../../testing/testUtils';
 import DataAppVizTestPanel from './DataAppVizTestPanel';
 import { buildTestMetricQuery, isMappingComplete } from './dataAppVizTestQuery';
@@ -75,6 +77,9 @@ vi.mock('../../../hooks/useExplores', () => ({
 vi.mock('../../../hooks/useExplore', () => ({
     useExploreByProjectUuid: exploreByProjectMock,
 }));
+vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({ data: { enabled: true } }),
+}));
 vi.mock('../../../providers/Explorer/useQueryExecutor', () => ({
     useQueryExecutor: queryExecutorMock,
 }));
@@ -106,6 +111,7 @@ const makeDimension = (name: string, hidden: boolean): CompiledDimension => ({
     tableLabel: 'Orders',
     sql: '',
     hidden,
+    colors: name === 'visible' ? { Retail: '#00ff00' } : undefined,
 });
 
 const makeMetric = (name: string, hidden: boolean): CompiledMetric => ({
@@ -176,6 +182,14 @@ const resultRows: ResultRow[] = [
         },
     },
 ];
+
+const TestDataAppVizPanel = (
+    props: ComponentProps<typeof DataAppVizTestPanel>,
+) => (
+    <ChartColorMappingContext.Provider value={{ colorMappings: new Map() }}>
+        <DataAppVizTestPanel {...props} />
+    </ChartColorMappingContext.Provider>
+);
 
 describe('isMappingComplete', () => {
     it('is false until every required field is mapped', () => {
@@ -307,7 +321,7 @@ describe('DataAppVizTestPanel', () => {
 
     it('lists the declared fields and the explore picker up-front', () => {
         renderWithProviders(
-            <DataAppVizTestPanel
+            <TestDataAppVizPanel
                 projectUuid="p1"
                 schema={schema}
                 onContextChange={vi.fn()}
@@ -324,7 +338,7 @@ describe('DataAppVizTestPanel', () => {
 
     it('requests the same filtered Explore list as Explorer', () => {
         renderWithProviders(
-            <DataAppVizTestPanel
+            <TestDataAppVizPanel
                 projectUuid="p1"
                 schema={schema}
                 onContextChange={vi.fn()}
@@ -337,7 +351,7 @@ describe('DataAppVizTestPanel', () => {
     it('hides the run action until an explore is selected', async () => {
         const user = userEvent.setup();
         renderWithProviders(
-            <DataAppVizTestPanel
+            <TestDataAppVizPanel
                 projectUuid="p1"
                 schema={schema}
                 onContextChange={vi.fn()}
@@ -360,7 +374,7 @@ describe('DataAppVizTestPanel', () => {
     it('republishes option edits after a successful query', async () => {
         const onContextChange = vi.fn();
         renderWithProviders(
-            <DataAppVizTestPanel
+            <TestDataAppVizPanel
                 projectUuid="p1"
                 schema={configurableSchema}
                 onContextChange={onContextChange}
@@ -374,6 +388,10 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: true },
                 colorPalette: ['#111111'],
+                seriesColors: {},
+                valueColors: {
+                    orders_visible: { Retail: '#00ff00' },
+                },
                 pivotDetails: null,
                 underlyingData: { enabled: false },
                 drillDown: { enabled: false },
@@ -389,6 +407,10 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: false },
                 colorPalette: ['#111111'],
+                seriesColors: {},
+                valueColors: {
+                    orders_visible: { Retail: '#00ff00' },
+                },
                 pivotDetails: null,
                 underlyingData: { enabled: false },
                 drillDown: { enabled: false },
@@ -399,7 +421,7 @@ describe('DataAppVizTestPanel', () => {
     it('republishes palette edits after a successful query', async () => {
         const onContextChange = vi.fn();
         renderWithProviders(
-            <DataAppVizTestPanel
+            <TestDataAppVizPanel
                 projectUuid="p1"
                 schema={configurableSchema}
                 onContextChange={onContextChange}
@@ -413,6 +435,10 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: true },
                 colorPalette: ['#111111'],
+                seriesColors: {},
+                valueColors: {
+                    orders_visible: { Retail: '#00ff00' },
+                },
                 pivotDetails: null,
                 underlyingData: { enabled: false },
                 drillDown: { enabled: false },
@@ -428,6 +454,10 @@ describe('DataAppVizTestPanel', () => {
                 rows: resultRows,
                 options: { showLegend: true },
                 colorPalette: ['#123456', '#abcdef'],
+                seriesColors: {},
+                valueColors: {
+                    orders_visible: { Retail: '#00ff00' },
+                },
                 pivotDetails: null,
                 underlyingData: { enabled: false },
                 drillDown: { enabled: false },
@@ -442,7 +472,7 @@ describe('DataAppVizTestPanel', () => {
         } as unknown as ReturnType<typeof useExploreByProjectUuid>);
 
         renderWithProviders(
-            <DataAppVizTestPanel
+            <TestDataAppVizPanel
                 projectUuid="p1"
                 schema={{
                     fields: [
@@ -482,7 +512,7 @@ describe('DataAppVizTestPanel', () => {
         });
 
         renderWithProviders(
-            <DataAppVizTestPanel
+            <TestDataAppVizPanel
                 projectUuid="p1"
                 schema={{
                     ...schema,
@@ -566,7 +596,7 @@ describe('DataAppVizTestPanel', () => {
         const onContextChange = vi.fn();
 
         renderWithProviders(
-            <DataAppVizTestPanel
+            <TestDataAppVizPanel
                 projectUuid="p1"
                 schema={{
                     ...schema,

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVizResolvedColors.test.tsx
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVizResolvedColors.test.tsx
@@ -1,0 +1,379 @@
+import {
+    CartesianSeriesType,
+    DimensionType,
+    FieldType,
+    MetricType,
+    VizAggregationOptions,
+    type Dimension,
+    type EChartsSeries,
+    type ItemsMap,
+    type ReadyQueryResultsPage,
+    type ResultRow,
+} from '@lightdash/common';
+import { MantineProvider } from '@mantine/core';
+import { renderHook } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChartColorMappingContext } from '../../../hooks/useChartColorConfig/context';
+import { useChartColorConfig } from '../../../hooks/useChartColorConfig/useChartColorConfig';
+import { calculateSeriesLikeIdentifier } from '../../../hooks/useChartColorConfig/utils';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { getMantineThemeOverride } from '../../../theme';
+import { useDataAppVizResolvedColors } from './useDataAppVizResolvedColors';
+
+vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(),
+}));
+
+const statusDimension: Dimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name: 'status',
+    label: 'Status',
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '${TABLE}.status',
+    hidden: false,
+    colors: { completed: '#00ff00' },
+};
+const priorityDimension: Dimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.NUMBER,
+    name: 'priority',
+    label: 'Priority',
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '${TABLE}.priority',
+    hidden: false,
+    colors: { '1': '#ff0000' },
+};
+
+const itemsMap = {
+    orders_status: statusDimension,
+    orders_priority: priorityDimension,
+    orders_count: {
+        fieldType: FieldType.METRIC,
+        type: MetricType.COUNT,
+        name: 'count',
+        label: 'Count',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.id',
+        hidden: false,
+    },
+    orders_total: {
+        fieldType: FieldType.METRIC,
+        type: MetricType.SUM,
+        name: 'total',
+        label: 'Total',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.total',
+        hidden: false,
+    },
+} satisfies ItemsMap;
+
+const cell = (raw: unknown) => ({
+    value: { raw, formatted: String(raw ?? '') },
+});
+
+const pivotDetails = (
+    valuesColumns: NonNullable<
+        ReadyQueryResultsPage['pivotDetails']
+    >['valuesColumns'],
+): ReadyQueryResultsPage['pivotDetails'] =>
+    ({
+        totalColumnCount: valuesColumns.length,
+        indexColumn: undefined,
+        valuesColumns,
+        groupByColumns: undefined,
+        sortBy: undefined,
+        originalColumns: {},
+    }) as ReadyQueryResultsPage['pivotDetails'];
+
+// One mapping store per render, so the shared assignment starts from scratch
+// in each test but stays stable across re-renders.
+const makeWrapper = () => {
+    const colorMappings = new Map<string, Map<string, number>>();
+    return ({ children }: PropsWithChildren) => (
+        <MantineProvider theme={getMantineThemeOverride('light')}>
+            <ChartColorMappingContext.Provider value={{ colorMappings }}>
+                {children}
+            </ChartColorMappingContext.Provider>
+        </MantineProvider>
+    );
+};
+
+const colorPalette = ['#111111', '#222222', '#333333'];
+
+const renderResolvedColors = (
+    overrides: Partial<Parameters<typeof useDataAppVizResolvedColors>[0]> = {},
+) =>
+    renderHook(
+        () =>
+            useDataAppVizResolvedColors({
+                itemsMap,
+                rows: [],
+                fieldMapping: {},
+                pivotDetails: null,
+                colorPalette,
+                ...overrides,
+            }),
+        { wrapper: makeWrapper() },
+    );
+
+describe('useDataAppVizResolvedColors', () => {
+    beforeEach(() => {
+        vi.mocked(useServerFeatureFlag).mockReturnValue({
+            data: { enabled: true },
+        } as ReturnType<typeof useServerFeatureFlag>);
+    });
+
+    it('keeps model-defined colors and shares assignments for the remaining pivot series', () => {
+        const { result } = renderResolvedColors({
+            pivotDetails: pivotDetails([
+                {
+                    referenceField: 'orders_count',
+                    pivotColumnName: 'count_completed',
+                    aggregation: VizAggregationOptions.COUNT,
+                    pivotValues: [
+                        {
+                            referenceField: 'orders_status',
+                            value: 'completed',
+                        },
+                    ],
+                },
+                {
+                    referenceField: 'orders_count',
+                    pivotColumnName: 'count_pending',
+                    aggregation: VizAggregationOptions.COUNT,
+                    pivotValues: [
+                        {
+                            referenceField: 'orders_status',
+                            value: 'pending',
+                        },
+                    ],
+                },
+            ]),
+        });
+
+        expect(result.current.seriesColors).toEqual({
+            count_completed: '#00ff00',
+            count_pending: '#111111',
+        });
+    });
+
+    it('falls back to the palette in the same order a built-in chart assigns it when shared series assignment is disabled', () => {
+        vi.mocked(useServerFeatureFlag).mockReturnValue({
+            data: { enabled: false },
+        } as ReturnType<typeof useServerFeatureFlag>);
+
+        const column = (value: string) => ({
+            referenceField: 'orders_count',
+            pivotColumnName: `count_${value}`,
+            aggregation: VizAggregationOptions.COUNT,
+            pivotValues: [{ referenceField: 'orders_status', value }],
+        });
+        const { result } = renderResolvedColors({
+            colorPalette: ['#111111', '#222222', '#333333', '#444444'],
+            pivotDetails: pivotDetails([
+                column('completed'),
+                column('returned'),
+                column('return_pending'),
+                column('shipped'),
+            ]),
+        });
+
+        // Built-in charts rank every series identifier in descending order and
+        // walk the palette in that order, fixed-color series included.
+        expect(result.current.seriesColors).toEqual({
+            count_completed: '#00ff00',
+            count_shipped: '#111111',
+            count_returned: '#222222',
+            count_return_pending: '#333333',
+        });
+    });
+
+    it('resolves every distinct raw value for mapped dimensions in unpivoted rows', () => {
+        const rows: ResultRow[] = [
+            {
+                orders_status: cell('completed'),
+                orders_priority: cell(1),
+            },
+            {
+                orders_status: cell('pending'),
+                orders_priority: cell(null),
+            },
+            {
+                orders_status: cell('pending'),
+                orders_priority: cell(null),
+            },
+        ];
+        const { result } = renderResolvedColors({
+            rows,
+            fieldMapping: {
+                category: 'orders_status',
+                series: 'orders_priority',
+                metric: 'orders_count',
+            },
+        });
+
+        expect(result.current.seriesColors).toEqual({});
+        expect(result.current.valueColors.orders_status).toEqual({
+            completed: '#00ff00',
+            pending: '#111111',
+        });
+        expect(result.current.valueColors.orders_priority).toEqual({
+            '1': '#ff0000',
+            null: '#868e96',
+        });
+        expect(result.current.valueColors.orders_count).toBeUndefined();
+    });
+
+    it('resolves grouped values by their formatted label, keyed by raw value', () => {
+        const amountDimension: Dimension = {
+            ...priorityDimension,
+            name: 'amount',
+            label: 'Amount',
+            sql: '${TABLE}.amount',
+            colors: { '1,000': '#00aa00' },
+        };
+        const rows: ResultRow[] = [
+            { orders_amount: { value: { raw: 1000, formatted: '1,000' } } },
+            { orders_amount: { value: { raw: 2500, formatted: '2,500' } } },
+            { orders_amount: { value: { raw: 1000, formatted: '1,000' } } },
+        ];
+        const wrapper = makeWrapper();
+        const colorConfig = renderHook(
+            () => useChartColorConfig({ colorPalette }),
+            { wrapper },
+        );
+        const { result } = renderHook(
+            () =>
+                useDataAppVizResolvedColors({
+                    itemsMap: { ...itemsMap, orders_amount: amountDimension },
+                    rows,
+                    fieldMapping: { category: 'orders_amount' },
+                    pivotDetails: null,
+                    colorPalette,
+                }),
+            { wrapper },
+        );
+
+        expect(result.current.valueColors.orders_amount).toEqual({
+            '1000': '#00aa00',
+            '2500': colorConfig.result.current.calculateKeyColorAssignment(
+                'orders_amount',
+                '2,500',
+            ),
+        });
+    });
+
+    it('cycles the palette per metric for a multi-metric pivot', () => {
+        const { result } = renderResolvedColors({
+            pivotDetails: pivotDetails([
+                {
+                    referenceField: 'orders_count',
+                    pivotColumnName: 'count_pending',
+                    aggregation: VizAggregationOptions.COUNT,
+                    pivotValues: [
+                        { referenceField: 'orders_status', value: 'pending' },
+                    ],
+                },
+                {
+                    referenceField: 'orders_count',
+                    pivotColumnName: 'count_shipped',
+                    aggregation: VizAggregationOptions.COUNT,
+                    pivotValues: [
+                        { referenceField: 'orders_status', value: 'shipped' },
+                    ],
+                },
+                {
+                    referenceField: 'orders_total',
+                    pivotColumnName: 'total_pending',
+                    aggregation: VizAggregationOptions.SUM,
+                    pivotValues: [
+                        { referenceField: 'orders_status', value: 'pending' },
+                    ],
+                },
+            ]),
+        });
+
+        expect(result.current.seriesColors).toEqual({
+            count_pending: '#111111',
+            count_shipped: '#222222',
+            total_pending: '#111111',
+        });
+    });
+
+    it('assigns each pivot column the color its equivalent built-in series gets', () => {
+        const valuesColumns = [
+            {
+                referenceField: 'orders_count',
+                pivotColumnName: 'count_pending',
+                aggregation: VizAggregationOptions.COUNT,
+                pivotValues: [
+                    { referenceField: 'orders_status', value: 'pending' },
+                ],
+            },
+            {
+                referenceField: 'orders_count',
+                pivotColumnName: 'count_shipped',
+                aggregation: VizAggregationOptions.COUNT,
+                pivotValues: [
+                    { referenceField: 'orders_status', value: 'shipped' },
+                ],
+            },
+        ];
+        const wrapper = makeWrapper();
+        const colorConfig = renderHook(
+            () => useChartColorConfig({ colorPalette }),
+            { wrapper },
+        );
+        // Claim the metric group's first slot so a series resolved through a
+        // different group or identifier would land on a different color.
+        const decoy = colorConfig.result.current.calculateKeyColorAssignment(
+            'orders_count',
+            'decoy',
+        );
+        const { result } = renderHook(
+            () =>
+                useDataAppVizResolvedColors({
+                    itemsMap,
+                    rows: [],
+                    fieldMapping: {},
+                    pivotDetails: pivotDetails(valuesColumns),
+                    colorPalette,
+                }),
+            { wrapper },
+        );
+
+        valuesColumns.forEach((column) => {
+            const builtInSeries: EChartsSeries = {
+                type: CartesianSeriesType.BAR,
+                pivotReference: {
+                    field: column.referenceField,
+                    pivotValues: column.pivotValues.map(
+                        ({ referenceField, value }) => ({
+                            field: referenceField,
+                            value,
+                        }),
+                    ),
+                },
+            };
+            const [group, identifier] =
+                calculateSeriesLikeIdentifier(builtInSeries);
+
+            const seriesColor =
+                result.current.seriesColors[column.pivotColumnName];
+
+            expect(seriesColor).not.toBe(decoy);
+            expect(seriesColor).toBe(
+                colorConfig.result.current.calculateKeyColorAssignment(
+                    group,
+                    identifier,
+                ),
+            );
+        });
+    });
+});

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVizResolvedColors.ts
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVizResolvedColors.ts
@@ -1,0 +1,137 @@
+import {
+    CartesianSeriesType,
+    FeatureFlags,
+    isDimension,
+    type DataAppVizContext,
+    type EChartsSeries,
+    type ItemsMap,
+    type ReadyQueryResultsPage,
+    type ResultRow,
+} from '@lightdash/common';
+import { useMemo } from 'react';
+import { useChartColorConfig } from '../../../hooks/useChartColorConfig/useChartColorConfig';
+import {
+    calculateFallbackSeriesColors,
+    calculateSeriesLikeIdentifier,
+    getDimensionValueColor,
+} from '../../../hooks/useChartColorConfig/utils';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+
+type Args = {
+    itemsMap: ItemsMap;
+    rows: ResultRow[];
+    fieldMapping: Record<string, string>;
+    pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+    colorPalette: string[];
+};
+
+export type DataAppVizResolvedColors = Pick<
+    DataAppVizContext,
+    'seriesColors' | 'valueColors'
+>;
+
+export const useDataAppVizResolvedColors = ({
+    itemsMap,
+    rows,
+    fieldMapping,
+    pivotDetails,
+    colorPalette,
+}: Args): DataAppVizResolvedColors => {
+    const { calculateKeyColorAssignment, calculateSeriesColorAssignment } =
+        useChartColorConfig({ colorPalette });
+    const { data: calculateSeriesColorFlag } = useServerFeatureFlag(
+        FeatureFlags.CalculateSeriesColor,
+    );
+    const isCalculateSeriesColorEnabled =
+        calculateSeriesColorFlag?.enabled ?? false;
+
+    return useMemo(() => {
+        const columnSeries = (pivotDetails?.valuesColumns ?? []).map(
+            (column) => {
+                const series: EChartsSeries = {
+                    type: CartesianSeriesType.BAR,
+                    pivotReference: {
+                        field: column.referenceField,
+                        pivotValues: column.pivotValues.map(
+                            ({ referenceField, value }) => ({
+                                field: referenceField,
+                                value,
+                            }),
+                        ),
+                    },
+                };
+                return { column, series };
+            },
+        );
+        const fallbackColors = calculateFallbackSeriesColors(
+            columnSeries.map(({ series }) => series),
+            colorPalette,
+        );
+        const seriesColors = Object.fromEntries(
+            columnSeries.flatMap(({ column, series }) => {
+                const firstPivotValue = column.pivotValues[0];
+                const fixedColor = firstPivotValue
+                    ? getDimensionValueColor(
+                          itemsMap,
+                          firstPivotValue.referenceField,
+                          firstPivotValue.value,
+                      )
+                    : undefined;
+                const paletteColor: string | undefined =
+                    colorPalette.length > 0
+                        ? fallbackColors[
+                              calculateSeriesLikeIdentifier(series).join('|')
+                          ]
+                        : undefined;
+                const color =
+                    fixedColor ??
+                    (isCalculateSeriesColorEnabled
+                        ? calculateSeriesColorAssignment(series)
+                        : paletteColor);
+
+                return color === undefined
+                    ? []
+                    : [[column.pivotColumnName, color] as const];
+            }),
+        );
+
+        const valueColors = Object.fromEntries(
+            [...new Set(Object.values(fieldMapping))].flatMap((fieldId) => {
+                const item = itemsMap[fieldId];
+                if (!item || !isDimension(item)) return [];
+
+                // Keyed by raw value for the viz, resolved by formatted value
+                // like a built-in pie names its groups.
+                const formattedByRaw = new Map<string, string>();
+                rows.forEach((row) => {
+                    const cell = row[fieldId]?.value;
+                    if (cell === undefined || cell.raw === undefined) return;
+                    const key = String(cell.raw);
+                    if (!formattedByRaw.has(key)) {
+                        formattedByRaw.set(key, cell.formatted);
+                    }
+                });
+                const colors = Object.fromEntries(
+                    [...formattedByRaw].map(([key, formatted]) => [
+                        key,
+                        getDimensionValueColor(itemsMap, fieldId, formatted) ??
+                            calculateKeyColorAssignment(fieldId, formatted),
+                    ]),
+                );
+
+                return [[fieldId, colors] as const];
+            }),
+        );
+
+        return { seriesColors, valueColors };
+    }, [
+        calculateKeyColorAssignment,
+        calculateSeriesColorAssignment,
+        colorPalette,
+        fieldMapping,
+        isCalculateSeriesColorEnabled,
+        itemsMap,
+        pivotDetails,
+        rows,
+    ]);
+};

--- a/packages/frontend/src/features/chartTypes/hooks/useDataAppVizTestContext.ts
+++ b/packages/frontend/src/features/chartTypes/hooks/useDataAppVizTestContext.ts
@@ -26,8 +26,11 @@ import {
     isMappingComplete,
 } from '../components/dataAppVizTestQuery';
 import { getDataAppVizFieldItems } from '../utils/getDataAppVizFieldItems';
+import { useDataAppVizResolvedColors } from './useDataAppVizResolvedColors';
 
 type Run = { args: QueryResultsProps; mapping: Record<string, string> };
+
+const EMPTY_FIELD_MAPPING = {};
 
 type Args = {
     projectUuid: string;
@@ -124,6 +127,13 @@ export const useDataAppVizTestContext = ({
     }, [selectedPalette, projectPalette, colorScheme]);
 
     const rows = queryResults.rows;
+    const resolvedColors = useDataAppVizResolvedColors({
+        itemsMap,
+        rows,
+        fieldMapping: run?.mapping ?? EMPTY_FIELD_MAPPING,
+        pivotDetails: queryResults.pivotDetails ?? null,
+        colorPalette,
+    });
     // Only push rows belonging to this run's query — on a re-run the executor
     // transiently re-exposes the previous query's cached page before the new
     // queryUuid lands.
@@ -140,6 +150,7 @@ export const useDataAppVizTestContext = ({
                 rows,
                 options: effectiveOptions,
                 colorPalette,
+                ...resolvedColors,
                 pivotDetails: queryResults.pivotDetails ?? null,
                 underlyingData: { enabled: false },
                 drillDown: { enabled: false },
@@ -153,6 +164,7 @@ export const useDataAppVizTestContext = ({
         queryResults.pivotDetails,
         effectiveOptions,
         colorPalette,
+        resolvedColors,
         onContextChange,
     ]);
     // Clear the preview when the consumer unmounts.

--- a/packages/frontend/src/features/chartTypes/utils/explorerVizContext.test.ts
+++ b/packages/frontend/src/features/chartTypes/utils/explorerVizContext.test.ts
@@ -75,6 +75,12 @@ const build = (
         pivotDetails: null,
         colorPalette: ['#111', '#222'],
         optionValues: {},
+        resolvedColors: {
+            seriesColors: { count_new: '#00ff00' },
+            valueColors: {
+                orders_status: { new: '#00ff00' },
+            },
+        },
         ...overrides,
     });
 
@@ -109,6 +115,10 @@ describe('buildExplorerVizContext', () => {
         expect(context.rows).toBe(rows);
         expect(context.pivotDetails).toBe(pivotDetails);
         expect(context.colorPalette).toEqual(['#111', '#222']);
+        expect(context.seriesColors).toEqual({ count_new: '#00ff00' });
+        expect(context.valueColors).toEqual({
+            orders_status: { new: '#00ff00' },
+        });
         expect(context.underlyingData).toEqual({ enabled: false });
         expect(context.drillDown).toEqual({ enabled: false });
     });

--- a/packages/frontend/src/features/chartTypes/utils/explorerVizContext.ts
+++ b/packages/frontend/src/features/chartTypes/utils/explorerVizContext.ts
@@ -8,6 +8,7 @@ import {
     type ReadyQueryResultsPage,
     type ResultRow,
 } from '@lightdash/common';
+import { type DataAppVizResolvedColors } from '../hooks/useDataAppVizResolvedColors';
 import {
     autoMapDataAppVizFields,
     reconcileDataAppVizFieldMapping,
@@ -23,7 +24,24 @@ type Args = {
     pivotDetails: ReadyQueryResultsPage['pivotDetails'];
     colorPalette: string[];
     optionValues: DataAppVizOptionValues;
+    resolvedColors: DataAppVizResolvedColors;
 };
+
+export const resolveExplorerVizFieldMapping = ({
+    schema,
+    itemsMap,
+    persistedFieldMapping,
+}: Pick<
+    Args,
+    'schema' | 'itemsMap' | 'persistedFieldMapping'
+>): DataAppVizFieldMapping =>
+    persistedFieldMapping
+        ? reconcileDataAppVizFieldMapping(
+              schema.fields,
+              itemsMap,
+              persistedFieldMapping,
+          )
+        : autoMapDataAppVizFields(schema.fields, itemsMap);
 
 /** A `DataAppVizContext` for previewing a chart type against the Explorer's
  *  own results while it is authored. Not a chart, so nothing to drill into. */
@@ -35,17 +53,17 @@ export const buildExplorerVizContext = ({
     pivotDetails,
     colorPalette,
     optionValues,
+    resolvedColors,
 }: Args): DataAppVizContext => ({
-    fieldMapping: persistedFieldMapping
-        ? reconcileDataAppVizFieldMapping(
-              schema.fields,
-              itemsMap,
-              persistedFieldMapping,
-          )
-        : autoMapDataAppVizFields(schema.fields, itemsMap),
+    fieldMapping: resolveExplorerVizFieldMapping({
+        schema,
+        itemsMap,
+        persistedFieldMapping,
+    }),
     rows,
     options: getEffectiveOptionValues(schema.configOptions, optionValues),
     colorPalette,
+    ...resolvedColors,
     pivotDetails,
     underlyingData: { enabled: false },
     drillDown: { enabled: false },

--- a/packages/frontend/src/features/chartTypes/utils/sampleVizContext.test.ts
+++ b/packages/frontend/src/features/chartTypes/utils/sampleVizContext.test.ts
@@ -171,4 +171,11 @@ describe('buildSampleVizContext', () => {
             expect(context.pivotDetails).toBeNull();
         });
     });
+
+    it('leaves host-resolved colors empty for synthetic rows', () => {
+        const context = buildSampleVizContext(schema);
+
+        expect(context.seriesColors).toEqual({});
+        expect(context.valueColors).toEqual({});
+    });
 });

--- a/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
+++ b/packages/frontend/src/features/chartTypes/utils/sampleVizContext.ts
@@ -219,6 +219,8 @@ export const buildSampleVizContext = (
         ),
         options: getEffectiveOptionValues(schema.configOptions, optionValues),
         colorPalette,
+        seriesColors: {},
+        valueColors: {},
         // Sample rows come from no query — there is nothing to drill into.
         underlyingData: { enabled: false },
         drillDown: { enabled: false },

--- a/packages/frontend/src/hooks/useChartColorConfig/utils.ts
+++ b/packages/frontend/src/hooks/useChartColorConfig/utils.ts
@@ -1,4 +1,9 @@
-import { type EChartsSeries, type Series } from '@lightdash/common';
+import {
+    isDimension,
+    type EChartsSeries,
+    type ItemsMap,
+    type Series,
+} from '@lightdash/common';
 import { type SeriesLike } from './types';
 
 /**
@@ -68,4 +73,34 @@ export const calculateSeriesLikeIdentifier = (series: SeriesLike) => {
         }`,
         completeIdentifier,
     ];
+};
+
+/** Palette colors keyed by series identifier, walked in descending identifier order. */
+export const calculateFallbackSeriesColors = (
+    seriesList: SeriesLike[],
+    colorPalette: string[],
+): Record<string, string> => {
+    const sortedSeriesIdentifiers = seriesList
+        .map((series) => calculateSeriesLikeIdentifier(series).join('|'))
+        .sort((a, b) => b.localeCompare(a));
+
+    return Object.fromEntries(
+        sortedSeriesIdentifiers.map((identifier, i) => [
+            identifier,
+            colorPalette[i % colorPalette.length],
+        ]),
+    );
+};
+
+export const getDimensionValueColor = (
+    itemsMap: ItemsMap,
+    fieldId: string,
+    value: unknown,
+): string | undefined => {
+    const item = itemsMap[fieldId];
+    if (!item || !isDimension(item) || typeof value !== 'string') {
+        return undefined;
+    }
+
+    return item.colors?.[value];
 };

--- a/packages/query-sdk/src/vizContext.test.ts
+++ b/packages/query-sdk/src/vizContext.test.ts
@@ -53,6 +53,12 @@ const inboundOptionsRemainOptional: Assert<
 const inboundPaletteRemainsOptional: Assert<
     IsOptional<DataAppVizContextMessage, 'colorPalette'>
 > = true;
+const inboundSeriesColorsRemainOptional: Assert<
+    IsOptional<DataAppVizContextMessage, 'seriesColors'>
+> = true;
+const inboundValueColorsRemainOptional: Assert<
+    IsOptional<DataAppVizContextMessage, 'valueColors'>
+> = true;
 void [
     messageKeysMatchHost,
     messageTypeMatchesHost,
@@ -60,6 +66,8 @@ void [
     hostPayloadIsAcceptedBySdk,
     inboundOptionsRemainOptional,
     inboundPaletteRemainsOptional,
+    inboundSeriesColorsRemainOptional,
+    inboundValueColorsRemainOptional,
 ];
 
 const row: VizContextRow = {
@@ -189,6 +197,38 @@ describe('toVizContextState', () => {
         ).toEqual(['#111', '#222']);
     });
 
+    it('normalizes host-resolved series and value colors', () => {
+        const state = toVizContextState(
+            message({
+                seriesColors: {
+                    count_completed: '#00ff00',
+                    invalid: 42 as never,
+                },
+                valueColors: {
+                    orders_status: {
+                        completed: '#00ff00',
+                        invalid: null as never,
+                    },
+                    invalid: [] as never,
+                },
+            }),
+        );
+
+        expect(state.seriesColors).toEqual({
+            count_completed: '#00ff00',
+        });
+        expect(state.valueColors).toEqual({
+            orders_status: { completed: '#00ff00' },
+        });
+    });
+
+    it('defaults resolved colors to empty maps for older hosts', () => {
+        const state = toVizContextState(message({}));
+
+        expect(state.seriesColors).toEqual({});
+        expect(state.valueColors).toEqual({});
+    });
+
     it('still normalises fieldMapping and rows', () => {
         expect(
             toVizContextState(
@@ -202,6 +242,8 @@ describe('toVizContextState', () => {
             rows: [],
             options: {},
             colorPalette: [],
+            seriesColors: {},
+            valueColors: {},
             pivotDetails: null,
             underlyingDataEnabled: false,
             drillDownEnabled: false,
@@ -422,9 +464,7 @@ describe('buildVizDrillDown', () => {
                 row: {},
                 metric: 'value',
             }),
-        ).rejects.toThrow(
-            'Drill-down is not enabled for this visualization.',
-        );
+        ).rejects.toThrow('Drill-down is not enabled for this visualization.');
         await expect(
             buildVizDrillDown(true, transportWith(undefined)).open({
                 row: {},

--- a/packages/query-sdk/src/vizContext.ts
+++ b/packages/query-sdk/src/vizContext.ts
@@ -43,7 +43,8 @@ export type VizContextRow = Record<string, VizContextCell | undefined>;
 /**
  * A config option value. Its shape follows the option's declared type:
  * `boolean` → boolean, `number` → number, `select`/`text`/`color` → string.
- * Series colours are not an option — they arrive on `colorPalette`.
+ * Series colours are not an option — they arrive on `colorPalette`,
+ * `seriesColors` and `valueColors`.
  */
 export type VizContextOptionValue = boolean | number | string;
 
@@ -91,7 +92,8 @@ export type VizContextPivotDetails = {
  * host-fetched result rows keyed by field id; `options` holds the current
  * value of each config option the renderer declared; `colorPalette` is the
  * Lightdash palette resolved for this chart, pushed whether or not the
- * renderer declared one.
+ * renderer declared one; `seriesColors` and `valueColors` are the final
+ * host-resolved colors for pivot columns and raw dimension values.
  */
 export type DataAppVizContextMessage = {
     type: 'lightdash:sdk:data-app-viz-context';
@@ -101,6 +103,10 @@ export type DataAppVizContextMessage = {
     options?: Record<string, VizContextOptionValue>;
     /** Absent when the installed host predates palette delivery. */
     colorPalette?: string[];
+    /** Absent when the installed host predates resolved-color delivery. */
+    seriesColors?: Record<string, string>;
+    /** Absent when the installed host predates resolved-color delivery. */
+    valueColors?: Record<string, Record<string, string>>;
     /** Null for unpivoted rows; absent when the installed host predates pivot metadata delivery. */
     pivotDetails?: VizContextPivotDetails | null;
     /** Absent when the installed host predates underlying-data delivery. */
@@ -162,12 +168,15 @@ export type VizContext = {
     /** Config option name → current value (the user's choice, else the declared default). */
     options: Record<string, VizContextOptionValue>;
     /**
-     * Ordered series colours resolved from the Lightdash palette the viewer
-     * picked. Colour multi-series charts with
-     * `colorPalette[i % colorPalette.length]`. Empty only when the host
+     * Lightdash palette selected for this chart, the fallback for anything
+     * absent from `seriesColors` / `valueColors`. Empty only when the host
      * resolved no palette; keep a fallback array in your own code for that.
      */
     colorPalette: string[];
+    /** Pivot column name → final color resolved by the Lightdash host. */
+    seriesColors: Record<string, string>;
+    /** Query field id → raw value → final color resolved by the Lightdash host. */
+    valueColors: Record<string, Record<string, string>>;
     /** Metadata that maps generated pivot column names back to their metric and series values. */
     pivotDetails: VizContextPivotDetails | null;
     /** False until the first context arrives — render a placeholder while false. */
@@ -183,6 +192,8 @@ type VizContextValue = {
     rows: VizContextRow[];
     options: Record<string, VizContextOptionValue>;
     colorPalette: string[];
+    seriesColors: Record<string, string>;
+    valueColors: Record<string, Record<string, string>>;
     pivotDetails: VizContextPivotDetails | null;
     underlyingDataEnabled: boolean;
     drillDownEnabled: boolean;
@@ -215,6 +226,36 @@ const normalizeOptions = (
     );
 };
 
+const normalizeStringRecord = (value: unknown): Record<string, string> => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return {};
+    }
+
+    return Object.fromEntries(
+        Object.entries(value).filter(
+            (entry): entry is [string, string] => typeof entry[1] === 'string',
+        ),
+    );
+};
+
+const normalizeValueColors = (
+    value: unknown,
+): Record<string, Record<string, string>> => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return {};
+    }
+
+    return Object.fromEntries(
+        Object.entries(value).flatMap(([fieldId, colors]) =>
+            typeof colors === 'object' &&
+            colors !== null &&
+            !Array.isArray(colors)
+                ? [[fieldId, normalizeStringRecord(colors)] as const]
+                : [],
+        ),
+    );
+};
+
 /**
  * Normalises an inbound host message into provider state. Optional capabilities
  * are absent from hosts predating them and receive stable fallback values.
@@ -231,6 +272,8 @@ export function toVizContextState(
                   (color): color is string => typeof color === 'string',
               )
             : [],
+        seriesColors: normalizeStringRecord(message.seriesColors),
+        valueColors: normalizeValueColors(message.valueColors),
         pivotDetails: message.pivotDetails ?? null,
         // Strict boolean check — non-boolean payloads read as disabled.
         underlyingDataEnabled: message.underlyingData?.enabled === true,
@@ -383,7 +426,8 @@ export function VizContextProvider({ children }: { children: ReactNode }) {
  * still works standalone. Re-renders whenever the host pushes (on load, on
  * mapping change, on query change). Resolve a declared field to its bound cell
  * with `fieldMapping[name]` then `getFormatted`/`getRaw`; read a declared
- * config option with `options[name]`, and colour series from `colorPalette`.
+ * config option with `options[name]`, and colour series from `seriesColors`
+ * / `valueColors`, falling back to `colorPalette`.
  */
 export function useVizContext(): VizContext {
     const fromProvider = useContext(VizContextContext);
@@ -418,6 +462,8 @@ export function useVizContext(): VizContext {
         rows: context?.rows ?? [],
         options: context?.options ?? {},
         colorPalette: context?.colorPalette ?? [],
+        seriesColors: context?.seriesColors ?? {},
+        valueColors: context?.valueColors ?? {},
         pivotDetails: context?.pivotDetails ?? null,
         ready: context !== null,
         underlyingData,


### PR DESCRIPTION
Custom chart types render in a sandboxed iframe and only ever received the color palette, so model-defined dimension colors and the shared first-come-first-serve assignment that keeps a value the same color across dashboard tiles never reached them. The same status value could render green on a built-in chart and blue on a custom one sitting next to it, even though the palette picker promised otherwise.

The host now resolves the final colors with the same machinery built-in charts use and pushes them on the viz context as `seriesColors` (keyed by pivot column, for backend-pivoted series) and `valueColors` (keyed by field id then raw value, for vizzes that group client-side). Resolution order is unchanged from built-in charts: model-defined color, then the shared assignment behind `CalculateSeriesColor`, then the palette. `colorPalette` keeps being pushed as before.

For the palette fallback the identifier ordering built-in charts already use (`fallbackColors` in `VisualizationProvider`) is extracted into `calculateFallbackSeriesColors` and shared by both paths, so a custom viz lands on the same palette color as a sibling built-in chart for every value without a fixed color. Built-in behavior is unchanged; a unit test pins the parity.

No backend, API, or migration changes. Verified in the app with a built-in bar and a custom chart pivoted by a status dimension side by side on a dashboard, across a palette switch, and with a client-side grouped pie.

Closes: GLITCH-702