### PR TITLE
feat(query-sdk): expose host-resolved colors and helpers to vizzes

### DIFF
--- a/packages/common/src/ee/apps/sdkFeatures.ts
+++ b/packages/common/src/ee/apps/sdkFeatures.ts
@@ -102,6 +102,13 @@ export const SDK_FEATURES: SdkFeature[] = [
         wiring: 'When useVizContext().pivotDetails is non-null, use valuesColumns to resolve generated row keys and use indexColumn, groupByColumns, originalColumns, sortBy, totalColumnCount, and passthroughDimensions when the visualization needs their layout semantics. Keep the existing fieldMapping path when pivotDetails is null.',
     },
     {
+        key: 'viz-resolved-colors',
+        label: 'Consistent visualization colors',
+        description:
+            'Honor model-defined colors and shared dashboard color assignments in reusable visualizations.',
+        wiring: 'Use resolveSeriesColor(context, column, index) for backend-pivoted series and resolveValueColor(context, fieldId, rawValue, index) for client-side groups; both helpers fall back to colorPalette.',
+    },
+    {
         key: 'follow-host-theme',
         label: 'Follow the host light/dark mode',
         description:

--- a/packages/query-sdk/src/features.ts
+++ b/packages/query-sdk/src/features.ts
@@ -102,6 +102,13 @@ export const SDK_FEATURES: SdkFeature[] = [
         wiring: 'When useVizContext().pivotDetails is non-null, use valuesColumns to resolve generated row keys and use indexColumn, groupByColumns, originalColumns, sortBy, totalColumnCount, and passthroughDimensions when the visualization needs their layout semantics. Keep the existing fieldMapping path when pivotDetails is null.',
     },
     {
+        key: 'viz-resolved-colors',
+        label: 'Consistent visualization colors',
+        description:
+            'Honor model-defined colors and shared dashboard color assignments in reusable visualizations.',
+        wiring: 'Use resolveSeriesColor(context, column, index) for backend-pivoted series and resolveValueColor(context, fieldId, rawValue, index) for client-side groups; both helpers fall back to colorPalette.',
+    },
+    {
         key: 'follow-host-theme',
         label: 'Follow the host light/dark mode',
         description:

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -99,6 +99,8 @@ export {
     useVizContext,
     getFormatted,
     getRaw,
+    resolveSeriesColor,
+    resolveValueColor,
 } from './vizContext';
 export type {
     VizContext,

--- a/packages/query-sdk/src/vizContext.test.ts
+++ b/packages/query-sdk/src/vizContext.test.ts
@@ -10,6 +10,8 @@ import {
     buildVizUnderlyingData,
     getFormatted,
     getRaw,
+    resolveSeriesColor,
+    resolveValueColor,
     toVizContextState,
     type DataAppVizContextMessage,
     type VizContextOptionValue,
@@ -294,6 +296,62 @@ describe('toVizContextState', () => {
 
     it('defaults missing pivot metadata to null', () => {
         expect(toVizContextState(message({})).pivotDetails).toBeNull();
+    });
+});
+
+describe('resolved color helpers', () => {
+    const context = {
+        colorPalette: ['#111111', '#222222'],
+        seriesColors: { count_completed: '#00ff00' },
+        valueColors: { orders_status: { completed: '#00ff00' } },
+    };
+
+    it('uses the host-resolved pivot-column color before the palette', () => {
+        expect(
+            resolveSeriesColor(
+                context,
+                { pivotColumnName: 'count_completed' },
+                1,
+            ),
+        ).toBe('#00ff00');
+        expect(
+            resolveSeriesColor(
+                context,
+                { pivotColumnName: 'count_pending' },
+                1,
+            ),
+        ).toBe('#222222');
+    });
+
+    it('uses the host-resolved raw-value color before the palette', () => {
+        expect(
+            resolveValueColor(context, 'orders_status', 'completed', 1),
+        ).toBe('#00ff00');
+        expect(resolveValueColor(context, 'orders_status', 'pending', 1)).toBe(
+            '#222222',
+        );
+    });
+
+    it('stringifies non-string raw values and tolerates an empty palette', () => {
+        expect(
+            resolveValueColor(
+                {
+                    colorPalette: [],
+                    seriesColors: {},
+                    valueColors: { orders_priority: { '1': '#abcdef' } },
+                },
+                'orders_priority',
+                1,
+                0,
+            ),
+        ).toBe('#abcdef');
+        expect(
+            resolveSeriesColor(
+                { colorPalette: [], seriesColors: {}, valueColors: {} },
+                { pivotColumnName: 'missing' },
+                0,
+            ),
+        ).toBeUndefined();
     });
 });
 

--- a/packages/query-sdk/src/vizContext.ts
+++ b/packages/query-sdk/src/vizContext.ts
@@ -43,8 +43,8 @@ export type VizContextRow = Record<string, VizContextCell | undefined>;
 /**
  * A config option value. Its shape follows the option's declared type:
  * `boolean` → boolean, `number` → number, `select`/`text`/`color` → string.
- * Series colours are not an option — they arrive on `colorPalette`,
- * `seriesColors` and `valueColors`.
+ * Series colours are not an option — the host resolves them separately from
+ * config options and exposes them through the colour helpers.
  */
 export type VizContextOptionValue = boolean | number | string;
 
@@ -168,8 +168,8 @@ export type VizContext = {
     /** Config option name → current value (the user's choice, else the declared default). */
     options: Record<string, VizContextOptionValue>;
     /**
-     * Lightdash palette selected for this chart, the fallback for anything
-     * absent from `seriesColors` / `valueColors`. Empty only when the host
+     * Lightdash palette selected for this chart. The resolved-colour helpers
+     * use it after fixed and shared assignments. Empty only when the host
      * resolved no palette; keep a fallback array in your own code for that.
      */
     colorPalette: string[];
@@ -226,10 +226,11 @@ const normalizeOptions = (
     );
 };
 
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
 const normalizeStringRecord = (value: unknown): Record<string, string> => {
-    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-        return {};
-    }
+    if (!isPlainRecord(value)) return {};
 
     return Object.fromEntries(
         Object.entries(value).filter(
@@ -241,20 +242,51 @@ const normalizeStringRecord = (value: unknown): Record<string, string> => {
 const normalizeValueColors = (
     value: unknown,
 ): Record<string, Record<string, string>> => {
-    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-        return {};
-    }
+    if (!isPlainRecord(value)) return {};
 
     return Object.fromEntries(
         Object.entries(value).flatMap(([fieldId, colors]) =>
-            typeof colors === 'object' &&
-            colors !== null &&
-            !Array.isArray(colors)
+            isPlainRecord(colors)
                 ? [[fieldId, normalizeStringRecord(colors)] as const]
                 : [],
         ),
     );
 };
+
+type VizColorContext = Pick<
+    VizContext,
+    'colorPalette' | 'seriesColors' | 'valueColors'
+>;
+
+const getPaletteColor = (
+    colorPalette: string[],
+    index: number,
+): string | undefined =>
+    colorPalette.length > 0
+        ? colorPalette[index % colorPalette.length]
+        : undefined;
+
+/** Resolve a backend-pivoted series color, with the chart palette as fallback. */
+export const resolveSeriesColor = (
+    context: VizColorContext,
+    column: Pick<
+        VizContextPivotDetails['valuesColumns'][number],
+        'pivotColumnName'
+    >,
+    index: number,
+): string | undefined =>
+    context.seriesColors[column.pivotColumnName] ??
+    getPaletteColor(context.colorPalette, index);
+
+/** Resolve a client-side grouped raw value color, with the chart palette as fallback. */
+export const resolveValueColor = (
+    context: VizColorContext,
+    fieldId: string,
+    rawValue: unknown,
+    index: number,
+): string | undefined =>
+    context.valueColors[fieldId]?.[String(rawValue)] ??
+    getPaletteColor(context.colorPalette, index);
 
 /**
  * Normalises an inbound host message into provider state. Optional capabilities
@@ -426,8 +458,8 @@ export function VizContextProvider({ children }: { children: ReactNode }) {
  * still works standalone. Re-renders whenever the host pushes (on load, on
  * mapping change, on query change). Resolve a declared field to its bound cell
  * with `fieldMapping[name]` then `getFormatted`/`getRaw`; read a declared
- * config option with `options[name]`, and colour series from `seriesColors`
- * / `valueColors`, falling back to `colorPalette`.
+ * config option with `options[name]`, and colour series with
+ * `resolveSeriesColor` / `resolveValueColor`.
  */
 export function useVizContext(): VizContext {
     const fromProvider = useContext(VizContextContext);

--- a/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
+++ b/sandboxes/data-apps/template/.claude/skills/reusable-visualization/SKILL.md
@@ -27,6 +27,7 @@ fetch anything yourself; the only host interaction is through the helpers the ho
 returns.
 
 ```tsx
+const context = useVizContext();
 const {
   fieldMapping,
   rows,
@@ -36,7 +37,7 @@ const {
   ready,
   underlyingData,
   drillDown,
-} = useVizContext();
+} = context;
 ```
 
 - `fieldMapping` — `Record<string, string>`: the field name you declared → the query field
@@ -47,6 +48,11 @@ const {
   option you declared (the viewer's choice, else your declared `default`).
 - `colorPalette` — `string[]`: the Lightdash palette resolved for this chart. Always pushed,
   whether or not you declared `colorPalette`. Empty only when the host resolved none.
+- `seriesColors` — `Record<string, string>`: final host-resolved colours keyed by backend
+  pivot column name. Read them through `resolveSeriesColor(context, column, index)`.
+- `valueColors` — `Record<string, Record<string, string>>`: final host-resolved colours keyed
+  by query field id then raw value. Read them through
+  `resolveValueColor(context, fieldId, rawValue, index)`.
 - `pivotDetails` — the complete backend-pivot layout, or `null` for ordinary rows. See
   "Backend-pivoted results" below.
 - `ready` — false until the first context arrives.
@@ -55,8 +61,8 @@ const {
 - `drillDown` — host-mediated drill on a clicked data point. See "Data-point
   actions" below.
 
-Read all of them. Ignoring `options` and `colorPalette` is the most common way to build a
-viz nobody can configure.
+Read all of them. Pass the complete `context` to the colour helpers; they preserve model
+colours and shared dashboard assignments before falling back to `colorPalette`.
 
 ### These app-level APIs do not apply to a viz
 
@@ -82,10 +88,15 @@ shadcn, charting, theming, floating surfaces, screenshots) still applies.
 
 ## Series colours
 
-Never hardcode series hex values and never hand-pick a palette of your own. Colour series
-with `colorPalette[i % colorPalette.length]`, and declare `colorPalette` in your output so
-the viewer gets the palette picker. Keep a small fallback array in your own code for the
-case where `colorPalette` is empty.
+Use the query SDK's host-resolved colour helpers for every series or group:
+
+- Backend-pivoted series: `resolveSeriesColor(context, column, index)`.
+- Client-side groups: `resolveValueColor(context, fieldId, rawValue, index)`.
+
+The helpers first honor model-defined fixed colours and Lightdash's shared dashboard colour
+assignment, then fall back to `colorPalette[index % colorPalette.length]`. Keep a small
+fallback array only for the case where the helper returns `undefined`, and declare
+`colorPalette` in your output so the viewer gets the palette picker.
 
 This is the same rule as the sandbox skill's "chart series colors must come from
 `CHART_COLORS`" and `references/d3.md`'s "never hand-pick palettes" — the same Lightdash
@@ -132,11 +143,12 @@ const pivotedMetrics =
     (column) => column.referenceField === metricId,
   ) ?? [];
 
-const series = pivotedMetrics.map((column) => ({
+const series = pivotedMetrics.map((column, index) => ({
   columnId: column.pivotColumnName,
   label:
     column.pivotValues.find((value) => value.referenceField === seriesId)
       ?.formatted ?? 'Unknown',
+  color: resolveSeriesColor(context, column, index) ?? FALLBACK_COLORS[index % FALLBACK_COLORS.length],
 }));
 
 const categoryId = fieldMapping['category'];
@@ -151,7 +163,7 @@ const data = rows.map((row) => ({
 }));
 ```
 
-Use the order of `valuesColumns` for stable colour assignment. A chart with multiple
+Use the order of `valuesColumns` for the helper's fallback index. A chart with multiple
 declared series fields builds its label from each matching `pivotValues` entry in declared
 field order. Backend-pivoted rows do not have safe one-source-row provenance, so the host
 sets `underlyingData.enabled` to false for them.
@@ -275,8 +287,8 @@ One entry per data column the component reads:
 ### `configOptions`
 
 One entry per setting the viewer can change without regenerating the viz. Every option is a
-whole-viz value applying to the entire chart — there is no per-series option. To colour
-series individually, index into `colorPalette` by series position.
+whole-viz value applying to the entire chart — there is no per-series option. Colour series
+and groups with the SDK's resolved-colour helpers.
 
 Every option has:
 
@@ -301,9 +313,10 @@ Series colours are not in this list. They are declared separately, on `colorPale
 ### `colorPalette`
 
 Whether the viewer gets the standard Lightdash palette picker. Declare
-`{ "group": "..." }` when your component colours anything from `colorPalette`, or `null`
-when it colours nothing. `group` is optional and works like an option's: the picker joins
-that tab, and gets a tab of its own when no option shares the name.
+`{ "group": "..." }` when your component colours anything with the resolved-colour helpers
+or `colorPalette`, or `null` when it colours nothing. `group` is optional and works like an
+option's: the picker joins that tab, and gets a tab of its own when no option shares the
+name.
 
 This is not a config option. There is one palette per chart, it has no `name` and no
 `default`, and its colours arrive on `colorPalette` — never on `options`.
@@ -313,19 +326,21 @@ This is not a config option. There is one palette per chart, it has no `name` an
 Component and declaration lining up. Your chart will differ; the correspondence must not.
 
 ```tsx
-import { useVizContext, getFormatted, getRaw } from '@lightdash/query-sdk';
+import { useVizContext, getFormatted, getRaw, resolveValueColor } from '@lightdash/query-sdk';
 import { Bar, BarChart, Cell, LabelList, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
 function Chart() {
-  const { fieldMapping, rows, options, colorPalette, ready } = useVizContext();
+  const context = useVizContext();
+  const { fieldMapping, rows, options, ready } = context;
   if (!ready) return <div style={{ height: '100vh' }}>Loading…</div>;
   const catField = fieldMapping['category'];            // your field name -> column id
   const valField = fieldMapping['value'];
   const showLabels = options['showLabels'] as boolean;  // your option name -> current value
   const maxBars = options['maxBars'] as number;
-  const colors = colorPalette.length ? colorPalette : ['#7162FF', '#1A1B1E'];
+  const fallbackColors = ['#7162FF', '#1A1B1E'];
   const data = rows.slice(0, maxBars).map((row) => ({
     label: getFormatted(row, catField),                 // display text, e.g. "Completed"
+    category: getRaw(row, catField),                    // raw value for host-resolved colour
     value: Number(getRaw(row, valField) ?? 0),          // raw number
   }));
   return (
@@ -340,7 +355,12 @@ function Chart() {
           <YAxis tickFormatter={(v) => v.toLocaleString()} />
           <Tooltip />
           <Bar dataKey="value">
-            {data.map((d, i) => <Cell key={d.label} fill={colors[i % colors.length]} />)}
+            {data.map((d, i) => (
+              <Cell
+                key={d.label}
+                fill={resolveValueColor(context, catField, d.category, i) ?? fallbackColors[i % fallbackColors.length]}
+              />
+            ))}
             {showLabels && <LabelList dataKey="value" position="top" />}
           </Bar>
         </BarChart>
@@ -372,15 +392,16 @@ minimum, not a menu:
 - every number you chose (bar width, max rows, decimal places, a threshold) → `number`
 - every string you wrote into the chart (title, axis label, empty-state text) → `text`
 - every accent colour that is not a series colour (a target line, a highlight) → `color`
-- the series colours, whenever the chart draws more than one series → `colorPalette`
+- the series colours, whenever the chart draws more than one series → resolved-colour
+  helper plus `colorPalette`
 
 Where the answer is yes, make that literal the option's `default`, declare the option, and
 read the option in its place. Leave it hardcoded only where changing it would break the
 chart.
 
 Then check both directions: every key you read from `options` is declared, and every option
-you declared is read somewhere. `colorPalette` is declared when you colour from
-`colorPalette` — it is never read from `options`.
+you declared is read somewhere. `colorPalette` is declared when you use either resolved-
+colour helper or colour from `colorPalette` — it is never read from `options`.
 
 Finally, if any mark maps to exactly one source row, the data-point action
 menu is wired: each interactive datum carries `sourceRow`, the underlying-data


### PR DESCRIPTION
Generated visualizations were told to colour series by cycling the palette, which is why they could not honour model-defined colors or the shared cross-tile assignment even once the host started sending them.

The SDK now surfaces the resolved colors on the viz context and gives generated code `resolveSeriesColor(context, column, index)` for backend-pivoted series and `resolveValueColor(context, fieldId, rawValue, index)` for client-side groups, both falling back to the palette. The `reusable-visualization` skill directs new vizzes through them, and the capability is registered as `viz-resolved-colors` so the upgrade flow can offer it to older vizzes.

Hosts that predate this send no resolved colors; those normalize to empty maps, so the helpers keep returning palette colors and existing vizzes are unaffected. Already-generated vizzes only read `colorPalette` and will not change until regenerated.

Verified with a viz regenerated on the updated template: its bundle reads the resolved colors and matches the sibling built-in chart on a dashboard.

<img width="1480" height="591" alt="1-dashboard-bar-pivoted-default-palette" src="https://github.com/user-attachments/assets/9be02296-5d1b-470a-9091-41be55092434" />
<img width="1468" height="592" alt="4-chart-builtin-bar" src="https://github.com/user-attachments/assets/40f15873-532c-48d6-ada0-db48352f1fc2" />
<img width="1468" height="592" alt="5-chart-custom-bar" src="https://github.com/user-attachments/assets/c4da3452-2bf0-40a6-b7f9-b7264b7b9447" />
<img width="1480" height="591" alt="3-dashboard-pie-grouped" src="https://github.com/user-attachments/assets/11b55b9b-00cf-40b0-8114-8659c08ada3b" />
<img width="1480" height="591" alt="2-dashboard-bar-pivoted-aurora-palette" src="https://github.com/user-attachments/assets/fae8c074-9551-46c5-acd9-e0abdf8a0233" />


Relates: GLITCH-702