### PR TITLE
feat: summarise project chart type version changes

### DIFF
--- a/packages/common/src/ee/apps/dataAppVizSchemaChanges.test.ts
+++ b/packages/common/src/ee/apps/dataAppVizSchemaChanges.test.ts
@@ -1,0 +1,181 @@
+import {
+    diffDataAppVizSchema,
+    hasDataAppVizSchemaChanges,
+    summarizeDataAppVizSchemaChanges,
+} from './dataAppVizSchemaChanges';
+import { type DataAppVizSchema } from './types';
+
+const base: DataAppVizSchema = {
+    fields: [
+        {
+            name: 'category',
+            label: 'Category',
+            type: 'dimension',
+            required: true,
+        },
+        { name: 'value', label: 'Value', type: 'metric', required: true },
+        { name: 'series', label: 'Series', type: 'series', required: false },
+    ],
+    configOptions: [
+        {
+            type: 'boolean',
+            name: 'showLegend',
+            label: 'Show legend',
+            default: true,
+        },
+        {
+            type: 'select',
+            name: 'mode',
+            label: 'Mode',
+            choices: [
+                { value: 'stacked', label: 'Stacked' },
+                { value: 'grouped', label: 'Grouped' },
+            ],
+            default: 'stacked',
+        },
+        { type: 'number', name: 'limit', label: 'Limit', default: 10, min: 1 },
+    ],
+    colorPalette: null,
+};
+
+describe('diffDataAppVizSchema', () => {
+    it('reports nothing for identical declarations', () => {
+        const changes = diffDataAppVizSchema(base, structuredClone(base));
+
+        expect(hasDataAppVizSchemaChanges(changes)).toBe(false);
+        expect(summarizeDataAppVizSchemaChanges(changes)).toEqual([]);
+    });
+
+    it('tracks added, removed and retyped fields by name', () => {
+        const changes = diffDataAppVizSchema(base, {
+            ...base,
+            fields: [
+                {
+                    name: 'category',
+                    label: 'Category',
+                    type: 'dimension',
+                    required: true,
+                },
+                {
+                    name: 'value',
+                    label: 'Value',
+                    type: 'metric',
+                    required: false,
+                },
+                {
+                    name: 'target',
+                    label: 'Target',
+                    type: 'metric',
+                    required: true,
+                },
+            ],
+        });
+
+        expect(changes.fields.added.map((f) => f.name)).toEqual(['target']);
+        expect(changes.fields.removed.map((f) => f.name)).toEqual(['series']);
+        expect(changes.fields.changed).toEqual([
+            {
+                before: {
+                    name: 'value',
+                    label: 'Value',
+                    type: 'metric',
+                    required: true,
+                },
+                after: {
+                    name: 'value',
+                    label: 'Value',
+                    type: 'metric',
+                    required: false,
+                },
+            },
+        ]);
+        expect(summarizeDataAppVizSchemaChanges(changes)).toEqual([
+            '+1 field',
+            '−1 field',
+            '~1 field',
+        ]);
+    });
+
+    it('treats a changed default, choice set or bound as an option change', () => {
+        const changes = diffDataAppVizSchema(base, {
+            ...base,
+            configOptions: [
+                {
+                    type: 'boolean',
+                    name: 'showLegend',
+                    label: 'Show legend',
+                    default: false,
+                },
+                {
+                    type: 'select',
+                    name: 'mode',
+                    label: 'Mode',
+                    choices: [{ value: 'stacked', label: 'Stacked' }],
+                    default: 'stacked',
+                },
+                {
+                    type: 'number',
+                    name: 'limit',
+                    label: 'Limit',
+                    default: 10,
+                    min: 1,
+                    max: 50,
+                },
+                {
+                    type: 'color',
+                    name: 'accent',
+                    label: 'Accent',
+                    default: '#000',
+                },
+            ],
+        });
+
+        expect(changes.configOptions.added.map((o) => o.name)).toEqual([
+            'accent',
+        ]);
+        expect(changes.configOptions.removed).toEqual([]);
+        expect(changes.configOptions.changed.map((c) => c.after.name)).toEqual([
+            'showLegend',
+            'mode',
+            'limit',
+        ]);
+        expect(summarizeDataAppVizSchemaChanges(changes)).toEqual([
+            '+1 option',
+            '~3 options',
+        ]);
+    });
+
+    it('ignores an option that only moved to another tab group', () => {
+        const changes = diffDataAppVizSchema(
+            {
+                ...base,
+                configOptions: [{ ...base.configOptions[0], group: undefined }],
+            },
+            {
+                ...base,
+                configOptions: [{ ...base.configOptions[0], group: 'Style' }],
+            },
+        );
+
+        expect(changes.configOptions.changed).toEqual([]);
+    });
+
+    it('reports palette additions and removals', () => {
+        const withPalette = { ...base, colorPalette: { group: 'Style' } };
+
+        expect(diffDataAppVizSchema(base, withPalette).colorPalette).toBe(
+            'added',
+        );
+        expect(diffDataAppVizSchema(withPalette, base).colorPalette).toBe(
+            'removed',
+        );
+        expect(
+            summarizeDataAppVizSchemaChanges(
+                diffDataAppVizSchema(base, withPalette),
+            ),
+        ).toEqual(['palette added']);
+        expect(
+            hasDataAppVizSchemaChanges(diffDataAppVizSchema(withPalette, base)),
+        ).toBe(true);
+    });
+});

--- a/packages/common/src/ee/apps/dataAppVizSchemaChanges.ts
+++ b/packages/common/src/ee/apps/dataAppVizSchemaChanges.ts
@@ -1,0 +1,133 @@
+import { type DataAppVizConfigOption } from './dataAppVizConfigOptions';
+import { type DataAppVizField, type DataAppVizSchema } from './types';
+
+export type DataAppVizFieldChange = {
+    before: DataAppVizField;
+    after: DataAppVizField;
+};
+
+export type DataAppVizConfigOptionChange = {
+    before: DataAppVizConfigOption;
+    after: DataAppVizConfigOption;
+};
+
+export type DataAppVizPaletteChange = 'added' | 'removed' | 'unchanged';
+
+/** What moved between two declarations of the same project chart type. */
+export type DataAppVizSchemaChanges = {
+    fields: {
+        added: DataAppVizField[];
+        removed: DataAppVizField[];
+        changed: DataAppVizFieldChange[];
+    };
+    configOptions: {
+        added: DataAppVizConfigOption[];
+        removed: DataAppVizConfigOption[];
+        changed: DataAppVizConfigOptionChange[];
+    };
+    colorPalette: DataAppVizPaletteChange;
+};
+
+const isSameField = (a: DataAppVizField, b: DataAppVizField): boolean =>
+    a.label === b.label && a.type === b.type && a.required === b.required;
+
+const isSameOption = (
+    a: DataAppVizConfigOption,
+    b: DataAppVizConfigOption,
+): boolean => {
+    if (a.type !== b.type || a.label !== b.label || a.default !== b.default) {
+        return false;
+    }
+    if (a.type === 'select' && b.type === 'select') {
+        return (
+            a.choices.length === b.choices.length &&
+            a.choices.every(
+                (choice, index) =>
+                    choice.value === b.choices[index]?.value &&
+                    choice.label === b.choices[index]?.label,
+            )
+        );
+    }
+    if (a.type === 'number' && b.type === 'number') {
+        return a.min === b.min && a.max === b.max;
+    }
+    return true;
+};
+
+const diffByName = <T extends { name: string }>(
+    before: T[],
+    after: T[],
+    isSame: (a: T, b: T) => boolean,
+): { added: T[]; removed: T[]; changed: { before: T; after: T }[] } => {
+    const beforeByName = new Map(before.map((item) => [item.name, item]));
+    const afterByName = new Map(after.map((item) => [item.name, item]));
+    return {
+        added: after.filter((item) => !beforeByName.has(item.name)),
+        removed: before.filter((item) => !afterByName.has(item.name)),
+        changed: after.flatMap((item) => {
+            const previous = beforeByName.get(item.name);
+            return previous && !isSame(previous, item)
+                ? [{ before: previous, after: item }]
+                : [];
+        }),
+    };
+};
+
+export const diffDataAppVizSchema = (
+    before: DataAppVizSchema,
+    after: DataAppVizSchema,
+): DataAppVizSchemaChanges => {
+    const hadPalette = before.colorPalette !== null;
+    const hasPalette = after.colorPalette !== null;
+    let colorPalette: DataAppVizPaletteChange = 'unchanged';
+    if (hasPalette && !hadPalette) colorPalette = 'added';
+    if (!hasPalette && hadPalette) colorPalette = 'removed';
+    return {
+        fields: diffByName(before.fields, after.fields, isSameField),
+        configOptions: diffByName(
+            before.configOptions,
+            after.configOptions,
+            isSameOption,
+        ),
+        colorPalette,
+    };
+};
+
+export const hasDataAppVizSchemaChanges = (
+    changes: DataAppVizSchemaChanges,
+): boolean =>
+    changes.colorPalette !== 'unchanged' ||
+    [changes.fields, changes.configOptions].some(
+        (group) =>
+            group.added.length > 0 ||
+            group.removed.length > 0 ||
+            group.changed.length > 0,
+    );
+
+const plural = (count: number, noun: string) =>
+    `${count} ${noun}${count === 1 ? '' : 's'}`;
+
+/** Short counters for a one-line rendering, e.g. `+2 fields`, `~1 option`. */
+export const summarizeDataAppVizSchemaChanges = (
+    changes: DataAppVizSchemaChanges,
+): string[] => {
+    const parts: string[] = [];
+    const groups: [
+        string,
+        DataAppVizSchemaChanges['fields' | 'configOptions'],
+    ][] = [
+        ['field', changes.fields],
+        ['option', changes.configOptions],
+    ];
+    for (const [noun, group] of groups) {
+        if (group.added.length > 0)
+            parts.push(`+${plural(group.added.length, noun)}`);
+        if (group.removed.length > 0)
+            parts.push(`−${plural(group.removed.length, noun)}`);
+        if (group.changed.length > 0)
+            parts.push(`~${plural(group.changed.length, noun)}`);
+    }
+    if (changes.colorPalette === 'added') parts.push('palette added');
+    if (changes.colorPalette === 'removed') parts.push('palette removed');
+    return parts;
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -13,6 +13,7 @@ export * from './AiRouter';
 export * from './apps/customChartTypeSerializer';
 export * from './apps/deliveryCapture';
 export * from './apps/sdkFeatures';
+export * from './apps/dataAppVizSchemaChanges';
 export * from './apps/types';
 export * from './apps/code';
 export * from './apps/dataReferenceChecker';

--- a/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.module.css
+++ b/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.module.css
@@ -111,7 +111,8 @@
     --ai-markdown-font-size: 11px;
 }
 
-.buildDetails {
+.buildDetails,
+.changes {
     border-top: 1px solid var(--mantine-color-ldGray-2);
 }
 

--- a/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.test.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.test.tsx
@@ -268,3 +268,75 @@ describe('VersionHistoryPanel', () => {
         expect(onClose).toHaveBeenCalledTimes(1);
     });
 });
+
+describe('VersionHistoryPanel schema changes', () => {
+    const schema = (fields: string[]) => ({
+        fields: fields.map((name) => ({
+            name,
+            label: name[0].toUpperCase() + name.slice(1),
+            type: 'dimension' as const,
+            required: true,
+        })),
+        configOptions: [],
+        colorPalette: null,
+    });
+    const withSchema = (
+        version: number,
+        fields: string[],
+        prompt = `v${version} prompt`,
+    ) =>
+        appVersion({
+            version,
+            prompt,
+            resources: {
+                images: [],
+                files: [],
+                charts: [],
+                dashboardName: null,
+                clarifications: [],
+                vizSchema: schema(fields),
+            },
+        });
+
+    it('summarises what changed against the previous declared schema and expands the detail', () => {
+        renderWithProviders(
+            <VersionHistoryPanel
+                {...defaultProps}
+                latestReadyVersion={3}
+                versions={[
+                    withSchema(3, ['category', 'region']),
+                    appVersion({
+                        version: 2,
+                        status: 'error',
+                        prompt: 'broken',
+                    }),
+                    withSchema(1, ['category']),
+                ]}
+            />,
+        );
+
+        expect(screen.getByText('+1 field')).toBeInTheDocument();
+        expect(
+            screen.queryByLabelText('What changed in v1'),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByText('Region')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByLabelText('What changed in v3'));
+
+        expect(screen.getByText('Region')).toBeInTheDocument();
+    });
+
+    it('stays quiet when the declaration did not move', () => {
+        renderWithProviders(
+            <VersionHistoryPanel
+                {...defaultProps}
+                versions={[
+                    withSchema(2, ['category']),
+                    withSchema(1, ['category']),
+                ]}
+            />,
+        );
+
+        expect(screen.queryByText('What changed')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.tsx
+++ b/packages/frontend/src/features/chartTypes/builder/VersionHistoryPanel.tsx
@@ -1,7 +1,12 @@
 import {
     APP_UPGRADE_PROMPT_LABEL,
+    diffDataAppVizSchema,
+    hasDataAppVizSchemaChanges,
     isAppVersionInProgress,
+    summarizeDataAppVizSchemaChanges,
     type ApiAppVersionSummary,
+    type DataAppVizSchema,
+    type DataAppVizSchemaChanges,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -26,6 +31,7 @@ import {
     hasVersionNarration,
 } from '../../apps/utils/versionNarration';
 import { getVersionAuthorName } from '../../apps/utils/versionsToChatMessages';
+import VizSchemaChangesList from '../components/VizSchemaChangesList';
 import { type DataAppVizBuildState } from '../hooks/useDataAppVizBuild';
 import RestoreVersionModal from './RestoreVersionModal';
 import classes from './VersionHistoryPanel.module.css';
@@ -115,6 +121,70 @@ const VersionBuildDetails: FC<{ version: ApiAppVersionSummary }> = ({
     );
 };
 
+const VersionChanges: FC<{
+    version: number;
+    changes: DataAppVizSchemaChanges;
+}> = ({ version, changes }) => {
+    const [open, setOpen] = useState(false);
+    const summary = summarizeDataAppVizSchemaChanges(changes).join(' · ');
+
+    return (
+        <Box className={classes.changes}>
+            <UnstyledButton
+                className={classes.buildDetailsToggle}
+                aria-label={`What changed in v${version}`}
+                aria-expanded={open}
+                onClick={() => setOpen((current) => !current)}
+            >
+                <MantineIcon
+                    icon={IconChevronRight}
+                    size={12}
+                    className={classes.buildDetailsChevron}
+                    data-open={open || undefined}
+                />
+                <Text fz={11} fw={600} flex="0 0 auto">
+                    What changed
+                </Text>
+                <Text fz={11} c="dimmed" truncate="end" ml={2} miw={0}>
+                    {summary}
+                </Text>
+            </UnstyledButton>
+            {open && (
+                <Box pt={6}>
+                    <VizSchemaChangesList changes={changes} compact />
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+const schemaOf = (version: ApiAppVersionSummary): DataAppVizSchema | null =>
+    version.status === 'ready' ? (version.resources?.vizSchema ?? null) : null;
+
+/**
+ * Diff each ready version against the nearest earlier one that declared a
+ * schema. The oldest entry on the page has nothing to compare with until
+ * earlier versions are loaded.
+ */
+const getVersionSchemaChanges = (
+    newestFirst: ApiAppVersionSummary[],
+): Map<number, DataAppVizSchemaChanges> => {
+    const changes = new Map<number, DataAppVizSchemaChanges>();
+    newestFirst.forEach((version, index) => {
+        const schema = schemaOf(version);
+        if (!schema) return;
+        const previous = newestFirst
+            .slice(index + 1)
+            .map(schemaOf)
+            .find((candidate) => candidate !== null);
+        if (!previous) return;
+        const diff = diffDataAppVizSchema(previous, schema);
+        if (hasDataAppVizSchemaChanges(diff))
+            changes.set(version.version, diff);
+    });
+    return changes;
+};
+
 /**
  * The version timeline as a side panel, newest first. Clicking a ready entry
  * pins the preview to it; each earlier entry offers to restore it on top.
@@ -135,6 +205,7 @@ const VersionHistoryPanel: FC<Props> = ({
     const [restoreTarget, setRestoreTarget] = useState<number | null>(null);
 
     const ordered = [...versions].sort((a, b) => b.version - a.version);
+    const schemaChanges = getVersionSchemaChanges(ordered);
     // The build writes its own entry until the version it claimed reaches
     // history, where it shows up as an in-progress version of its own.
     const isClaimedInHistory =
@@ -153,6 +224,7 @@ const VersionHistoryPanel: FC<Props> = ({
         const isActive = version.version === activeVersion;
         const label = `v${version.version}`;
         const isUpgrade = version.prompt === APP_UPGRADE_PROMPT_LABEL;
+        const changes = schemaChanges.get(version.version);
 
         return (
             <Box
@@ -225,6 +297,13 @@ const VersionHistoryPanel: FC<Props> = ({
                             {getAppVersionFailureMessage(version)}
                         </Text>
                     </Box>
+                )}
+
+                {changes && (
+                    <VersionChanges
+                        version={version.version}
+                        changes={changes}
+                    />
                 )}
 
                 {!isBuilding && <VersionBuildDetails version={version} />}

--- a/packages/frontend/src/features/chartTypes/components/VizSchemaChangesList.module.css
+++ b/packages/frontend/src/features/chartTypes/components/VizSchemaChangesList.module.css
@@ -1,0 +1,14 @@
+.row {
+    padding: 4px var(--mantine-spacing-xs);
+    border-radius: var(--mantine-radius-sm);
+}
+
+.row[data-compact='true'] {
+    padding: 2px 4px;
+}
+
+.label {
+    flex: 1;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}

--- a/packages/frontend/src/features/chartTypes/components/VizSchemaChangesList.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/VizSchemaChangesList.test.tsx
@@ -1,0 +1,101 @@
+import { type DataAppVizSchemaChanges } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import VizSchemaChangesList from './VizSchemaChangesList';
+
+const changes: DataAppVizSchemaChanges = {
+    fields: {
+        added: [
+            {
+                name: 'target',
+                label: 'Target',
+                type: 'metric',
+                required: false,
+            },
+        ],
+        removed: [
+            {
+                name: 'series',
+                label: 'Series',
+                type: 'series',
+                required: false,
+            },
+        ],
+        changed: [
+            {
+                before: {
+                    name: 'value',
+                    label: 'Value',
+                    type: 'metric',
+                    required: false,
+                },
+                after: {
+                    name: 'value',
+                    label: 'Value',
+                    type: 'metric',
+                    required: true,
+                },
+            },
+        ],
+    },
+    configOptions: {
+        added: [],
+        removed: [],
+        changed: [
+            {
+                before: {
+                    type: 'select',
+                    name: 'mode',
+                    label: 'Mode',
+                    choices: [
+                        { value: 'stacked', label: 'Stacked' },
+                        { value: 'grouped', label: 'Grouped' },
+                    ],
+                    default: 'stacked',
+                },
+                after: {
+                    type: 'select',
+                    name: 'mode',
+                    label: 'Mode',
+                    choices: [{ value: 'stacked', label: 'Stacked' }],
+                    default: 'stacked',
+                },
+            },
+        ],
+    },
+    colorPalette: 'added',
+};
+
+describe('VizSchemaChangesList', () => {
+    it('groups deltas by kind and describes each in plain words', () => {
+        renderWithProviders(<VizSchemaChangesList changes={changes} />);
+
+        const headings = screen
+            .getAllByText(/^(Added|Updated|Removed)$/)
+            .map((el) => el.textContent);
+        expect(headings).toEqual(['Added', 'Updated', 'Removed']);
+        expect(screen.getByText('Target')).toBeInTheDocument();
+        expect(screen.getByText('metric field')).toBeInTheDocument();
+        expect(screen.getByText('now required')).toBeInTheDocument();
+        expect(screen.getByText('drops grouped')).toBeInTheDocument();
+        expect(screen.getByText('Series')).toBeInTheDocument();
+        expect(screen.getByText('Color palette')).toBeInTheDocument();
+    });
+
+    it('omits groups without changes', () => {
+        renderWithProviders(
+            <VizSchemaChangesList
+                changes={{
+                    fields: { added: [], removed: [], changed: [] },
+                    configOptions: changes.configOptions,
+                    colorPalette: 'unchanged',
+                }}
+            />,
+        );
+
+        expect(screen.queryByText('Added')).not.toBeInTheDocument();
+        expect(screen.queryByText('Removed')).not.toBeInTheDocument();
+        expect(screen.getByText('Updated')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/chartTypes/components/VizSchemaChangesList.tsx
+++ b/packages/frontend/src/features/chartTypes/components/VizSchemaChangesList.tsx
@@ -1,0 +1,222 @@
+import {
+    type DataAppVizConfigOption,
+    type DataAppVizConfigOptionChange,
+    type DataAppVizField,
+    type DataAppVizFieldChange,
+    type DataAppVizSchemaChanges,
+} from '@lightdash/common';
+import { Group, Stack, Text } from '@mantine/core';
+import {
+    IconAdjustmentsHorizontal,
+    IconCircle,
+    IconColumns,
+    IconMinus,
+    IconPalette,
+    IconPlus,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import classes from './VizSchemaChangesList.module.css';
+
+type ChangeKind = 'added' | 'updated' | 'removed';
+
+const CHANGE_LABEL: Record<ChangeKind, string> = {
+    added: 'Added',
+    updated: 'Updated',
+    removed: 'Removed',
+};
+
+const CHANGE_ICON: Record<ChangeKind, typeof IconPlus> = {
+    added: IconPlus,
+    updated: IconCircle,
+    removed: IconMinus,
+};
+
+const CHANGE_COLOR: Record<ChangeKind, string> = {
+    added: 'green.7',
+    updated: 'yellow.7',
+    removed: 'red.7',
+};
+
+const CHANGE_ORDER: ChangeKind[] = ['added', 'updated', 'removed'];
+
+type ChangeRow = {
+    key: string;
+    kind: ChangeKind;
+    icon: typeof IconPlus;
+    label: string;
+    detail: string | null;
+};
+
+const describeField = (field: DataAppVizField) =>
+    `${field.type} field${field.required ? ', required' : ''}`;
+
+const describeFieldChange = ({ before, after }: DataAppVizFieldChange) => {
+    const parts: string[] = [];
+    if (before.type !== after.type)
+        parts.push(`${before.type} → ${after.type}`);
+    if (before.required !== after.required)
+        parts.push(after.required ? 'now required' : 'now optional');
+    if (before.label !== after.label)
+        parts.push(`renamed from "${before.label}"`);
+    return parts.join(', ');
+};
+
+const formatDefault = (value: DataAppVizConfigOption['default']) =>
+    typeof value === 'string' ? JSON.stringify(value) : String(value);
+
+const describeDefaultChange = (
+    before: DataAppVizConfigOption['default'],
+    after: DataAppVizConfigOption['default'],
+) =>
+    before === '' || after === ''
+        ? 'default changed'
+        : `default ${formatDefault(before)} → ${formatDefault(after)}`;
+
+const describeOptionChange = ({
+    before,
+    after,
+}: DataAppVizConfigOptionChange) => {
+    const parts: string[] = [];
+    if (before.type !== after.type)
+        parts.push(`${before.type} → ${after.type}`);
+    if (before.default !== after.default)
+        parts.push(describeDefaultChange(before.default, after.default));
+    if (before.type === 'select' && after.type === 'select') {
+        const beforeValues = before.choices.map((c) => c.value);
+        const afterValues = after.choices.map((c) => c.value);
+        const gained = afterValues.filter((v) => !beforeValues.includes(v));
+        const lost = beforeValues.filter((v) => !afterValues.includes(v));
+        if (gained.length > 0) parts.push(`adds ${gained.join(', ')}`);
+        if (lost.length > 0) parts.push(`drops ${lost.join(', ')}`);
+    }
+    if (before.type === 'number' && after.type === 'number') {
+        if (before.min !== after.min || before.max !== after.max)
+            parts.push('range changed');
+    }
+    if (before.label !== after.label)
+        parts.push(`renamed from "${before.label}"`);
+    return parts.join(', ');
+};
+
+const toRows = (changes: DataAppVizSchemaChanges): ChangeRow[] => [
+    ...changes.fields.added.map((f) => ({
+        key: `f+${f.name}`,
+        kind: 'added' as const,
+        icon: IconColumns,
+        label: f.label,
+        detail: describeField(f),
+    })),
+    ...changes.fields.changed.map((c) => ({
+        key: `f~${c.after.name}`,
+        kind: 'updated' as const,
+        icon: IconColumns,
+        label: c.after.label,
+        detail: describeFieldChange(c),
+    })),
+    ...changes.fields.removed.map((f) => ({
+        key: `f-${f.name}`,
+        kind: 'removed' as const,
+        icon: IconColumns,
+        label: f.label,
+        detail: describeField(f),
+    })),
+    ...changes.configOptions.added.map((o) => ({
+        key: `o+${o.name}`,
+        kind: 'added' as const,
+        icon: IconAdjustmentsHorizontal,
+        label: o.label,
+        detail: `${o.type} option`,
+    })),
+    ...changes.configOptions.changed.map((c) => ({
+        key: `o~${c.after.name}`,
+        kind: 'updated' as const,
+        icon: IconAdjustmentsHorizontal,
+        label: c.after.label,
+        detail: describeOptionChange(c),
+    })),
+    ...changes.configOptions.removed.map((o) => ({
+        key: `o-${o.name}`,
+        kind: 'removed' as const,
+        icon: IconAdjustmentsHorizontal,
+        label: o.label,
+        detail: `${o.type} option`,
+    })),
+    ...(changes.colorPalette === 'unchanged'
+        ? []
+        : [
+              {
+                  key: 'palette',
+                  kind: changes.colorPalette,
+                  icon: IconPalette,
+                  label: 'Color palette',
+                  detail: null,
+              },
+          ]),
+];
+
+type Props = {
+    changes: DataAppVizSchemaChanges;
+    /** Denser type for narrow side panels. */
+    compact?: boolean;
+};
+
+/**
+ * The field, option and palette deltas between two chart type versions,
+ * grouped the way field reviews are.
+ */
+const VizSchemaChangesList: FC<Props> = ({ changes, compact = false }) => {
+    const rows = toRows(changes);
+    const groups = CHANGE_ORDER.map((kind) => ({
+        kind,
+        rows: rows.filter((row) => row.kind === kind),
+    })).filter((group) => group.rows.length > 0);
+    const fz = compact ? 11 : 'sm';
+
+    return (
+        <Stack gap={compact ? 'xs' : 'md'}>
+            {groups.map((group) => (
+                <Stack key={group.kind} gap={2}>
+                    <Group gap={6} mb={2}>
+                        <MantineIcon
+                            icon={CHANGE_ICON[group.kind]}
+                            size={compact ? 'xs' : 'sm'}
+                            color={CHANGE_COLOR[group.kind]}
+                        />
+                        <Text fz={fz} fw={600}>
+                            {CHANGE_LABEL[group.kind]}
+                        </Text>
+                    </Group>
+                    {group.rows.map((row) => (
+                        <Group
+                            key={row.key}
+                            className={classes.row}
+                            data-compact={compact || undefined}
+                            gap="xs"
+                            wrap="nowrap"
+                        >
+                            <MantineIcon
+                                icon={row.icon}
+                                size={compact ? 'xs' : 'sm'}
+                                color="ldGray.6"
+                            />
+                            <Text fz={fz} lh={1.4} className={classes.label}>
+                                <Text span fw={500}>
+                                    {row.label}
+                                </Text>
+                                {row.detail && (
+                                    <Text span c="dimmed">
+                                        {' '}
+                                        {row.detail}
+                                    </Text>
+                                )}
+                            </Text>
+                        </Group>
+                    ))}
+                </Stack>
+            ))}
+        </Stack>
+    );
+};
+
+export default VizSchemaChangesList;


### PR DESCRIPTION
Linear: [GLITCH-699](https://linear.app/lightdash/issue/GLITCH-699/add-a-chart-type-upgrade-flow-with-version-changes)

### Description

First layer of the GLITCH-699 stack. Pinned charts need to know what moving to a newer project chart type version would take on.

- `diffDataAppVizSchema` in common compares two chart type declarations by name: fields added/removed/changed, config options added/removed/changed, palette added/removed. A change of tab group alone does not count.
- The builder's version history panel shows a collapsible "What changed" line per version, diffed client-side against the previous declared schema (the schema already travels on version summaries).
- `VizSchemaChangesList` renders the deltas grouped as Added / Updated / Removed, following the field review modal.

No backend changes: the explorer already holds both schemas it needs (next layer), so the diff runs in the browser everywhere.

### Verification

- 5 common differ tests, 18 frontend tests
- common and frontend typecheck and lint

### Risk assessment

- [ ] This is a high-risk change

Additive common helper and a new row in the builder's history panel; nothing existing changes shape.

Relates: GLITCH-699


### Screenshots

**Builder version history, "What changed" rows expanded**


<img width="1281" height="1267" alt="14-history-what-changed" src="https://github.com/user-attachments/assets/7157a380-561c-4feb-88ea-a090a34ce8a3" />

