### PR TITLE
feat: show newer project chart type versions in the explorer

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -13,6 +13,7 @@ import {
     type DataAppViz,
     type DataAppVizConfigOption,
     type DataAppVizPaletteDeclaration,
+    type DataAppVizSchemaChanges,
     type DataAppVizField,
     type Item,
     type ItemsMap,
@@ -100,6 +101,22 @@ vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
 vi.mock('../../../features/chartTypes/hooks/useDataAppVisualization', () => ({
     useDataAppVisualization: vi.fn(),
 }));
+vi.mock('../../../features/chartTypes/hooks/useDataAppVizRender', () => ({
+    useDataAppVizRenderMetadata: vi.fn(),
+}));
+vi.mock('./DataAppVizUpgradeNotice', () => ({
+    default: ({
+        typeName,
+        changes,
+    }: {
+        typeName: string;
+        changes: DataAppVizSchemaChanges;
+    }) => (
+        <div data-testid="upgrade-notice">
+            {`${typeName}: +${changes.fields.added.length} fields`}
+        </div>
+    ),
+}));
 // The panel reads the project from the route, which this test does not mount.
 vi.mock('react-router', async (importOriginal) => ({
     ...(await importOriginal<typeof ReactRouter>()),
@@ -136,6 +153,7 @@ vi.mock('../common/ColorPaletteSection', () => ({
 }));
 
 import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
+import { useDataAppVizRenderMetadata } from '../../../features/chartTypes/hooks/useDataAppVizRender';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 
 const makeDimension = (name: string, hidden: boolean): CompiledDimension => ({
@@ -298,6 +316,9 @@ describe('DataAppVizConfigTabs', () => {
         setField.mockClear();
         setPivotDimensions.mockClear();
         defaultAbility.update([]);
+        vi.mocked(useDataAppVizRenderMetadata).mockReturnValue({
+            data: undefined,
+        } as unknown as ReturnType<typeof useDataAppVizRenderMetadata>);
         mockSchema([]);
         mockContext(queryColumns);
     });
@@ -672,6 +693,90 @@ describe('DataAppVizConfigTabs', () => {
 
         expect(screen.getByText('Radial gauge')).toBeInTheDocument();
         await expect(screen.findByText('Edit ↗')).rejects.toThrow();
+    });
+
+    const mockLatestRenderable = (version: number) =>
+        vi.mocked(useDataAppVizRenderMetadata).mockReturnValue({
+            data: {
+                state: 'ready',
+                version,
+                schema: {
+                    fields: [
+                        ...declaredFields,
+                        {
+                            name: 'target',
+                            label: 'Target',
+                            type: 'metric',
+                            required: false,
+                        },
+                    ],
+                    configOptions: [],
+                    colorPalette: null,
+                },
+                latestBuildInProgress: false,
+            },
+        } as unknown as ReturnType<typeof useDataAppVizRenderMetadata>);
+
+    it('offers an upgrade when the type has a newer renderable version than the pin', () => {
+        mockContext(queryColumns, 'data-app-viz-uuid', {}, {}, 3);
+        mockLatestRenderable(5);
+
+        renderWithProviders(<ConfigTabs />);
+
+        expect(useDataAppVizRenderMetadata).toHaveBeenLastCalledWith(
+            'project-1',
+            'data-app-viz-uuid',
+            { isEmbedded: false, savedChartUuid: undefined },
+        );
+        expect(screen.getByTestId('upgrade-notice')).toHaveTextContent(
+            'Radial gauge: +1 fields',
+        );
+    });
+
+    it('stays quiet when the pin is already the latest version', () => {
+        mockContext(queryColumns, 'data-app-viz-uuid', {}, {}, 5);
+        mockLatestRenderable(5);
+
+        renderWithProviders(<ConfigTabs />);
+
+        expect(screen.queryByTestId('upgrade-notice')).not.toBeInTheDocument();
+    });
+
+    it('does not look for upgrades on an unpinned chart', () => {
+        mockContext(queryColumns, 'data-app-viz-uuid', {}, {});
+        mockLatestRenderable(5);
+
+        renderWithProviders(<ConfigTabs />);
+
+        expect(useDataAppVizRenderMetadata).toHaveBeenLastCalledWith(
+            'project-1',
+            null,
+            { isEmbedded: false, savedChartUuid: undefined },
+        );
+        expect(screen.queryByTestId('upgrade-notice')).not.toBeInTheDocument();
+    });
+
+    it('does not look for upgrades while the selected type is being authored', () => {
+        mockContext(queryColumns, 'data-app-viz-uuid', {}, {}, 3);
+        mockLatestRenderable(5);
+        authoringState.current = {
+            dataAppVizUuid: 'data-app-viz-uuid',
+            viewedVersion: null,
+        };
+        try {
+            renderWithProviders(<ConfigTabs />);
+
+            expect(useDataAppVizRenderMetadata).toHaveBeenLastCalledWith(
+                'project-1',
+                null,
+                { isEmbedded: false, savedChartUuid: undefined },
+            );
+            expect(
+                screen.queryByTestId('upgrade-notice'),
+            ).not.toBeInTheDocument();
+        } finally {
+            authoringState.current = null;
+        }
     });
 
     it('fetches the schema of the version the builder previews while authoring', () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -1,6 +1,7 @@
 import {
     ChartType,
     deriveDataAppVizPivotConfig,
+    diffDataAppVizSchema,
     FeatureFlags,
     getAppDisplayName,
     getEffectiveOptionValues,
@@ -12,6 +13,7 @@ import { Link, useLocation, useNavigate } from 'react-router';
 import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
+import { useDataAppVizRenderMetadata } from '../../../features/chartTypes/hooks/useDataAppVizRender';
 import { reconcileDataAppVizFieldMapping } from '../../../features/chartTypes/utils/autoMapDataAppVizFields';
 import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
 import { getDataAppVizFieldItems } from '../../../features/chartTypes/utils/getDataAppVizFieldItems';
@@ -34,9 +36,16 @@ import { useSelectProjectChartType } from '../CustomChartType/useSelectProjectCh
 import classes from './DataAppVizConfigTabs.module.css';
 import DataAppVizOptionTabs from './DataAppVizOptionTabs';
 import DataAppVizSettings from './DataAppVizSettings';
+import DataAppVizUpgradeNotice from './DataAppVizUpgradeNotice';
 
 // Stable identity, so the field pools stay memoized before results land.
 const NO_COLUMNS: ItemsMap = {};
+// The chart-less authoring route answers with the latest renderable version,
+// which is the only upgrade target a pinned chart can move to.
+const LATEST_RENDER_TARGET = {
+    isEmbedded: false,
+    savedChartUuid: undefined,
+};
 
 export const ConfigTabs: FC = memo(() => {
     const projectUuid = useProjectUuid();
@@ -58,19 +67,43 @@ export const ConfigTabs: FC = memo(() => {
           null)
         : null;
 
+    const isAuthoringSelectedType =
+        authoring !== null &&
+        dataAppVizUuid !== null &&
+        authoring.dataAppVizUuid === dataAppVizUuid;
     // The panel follows the same version as the chart. The builder can
     // temporarily preview a different version of this same viz; selecting a
     // type again clears its pin, so that path still asks for latest.
-    const schemaVersion =
-        authoring !== null &&
-        dataAppVizUuid !== null &&
-        authoring.dataAppVizUuid === dataAppVizUuid
-            ? authoring.viewedVersion
-            : selectedVersion;
+    const schemaVersion = isAuthoringSelectedType
+        ? authoring.viewedVersion
+        : selectedVersion;
     const { data: dataAppViz } = useDataAppVisualization(
         projectUuid,
         dataAppVizUuid,
         schemaVersion,
+    );
+    // Legacy unpinned charts follow latest already, and a type being authored
+    // in place is moving under the chart anyway.
+    const { data: latestRenderMetadata } = useDataAppVizRenderMetadata(
+        projectUuid,
+        selectedVersion !== null && !isAuthoringSelectedType
+            ? dataAppVizUuid
+            : null,
+        LATEST_RENDER_TARGET,
+    );
+    const upgradeTarget =
+        selectedVersion !== null &&
+        !isAuthoringSelectedType &&
+        latestRenderMetadata?.state === 'ready' &&
+        latestRenderMetadata.version > selectedVersion
+            ? latestRenderMetadata
+            : null;
+    const upgradeChanges = useMemo(
+        () =>
+            upgradeTarget && dataAppViz?.schema
+                ? diffDataAppVizSchema(dataAppViz.schema, upgradeTarget.schema)
+                : null,
+        [upgradeTarget, dataAppViz],
     );
 
     const configOptions = useMemo(
@@ -190,19 +223,30 @@ export const ConfigTabs: FC = memo(() => {
         );
 
         return (
-            <DataAppVizOptionTabs
-                // Remount on a viz switch so no control keeps the previous
-                // viz's draft edit.
-                key={`${selectedViz.dataAppVizUuid}:${optionContractKey}`}
-                generalContent={settings}
-                configOptions={configOptions}
-                values={effectiveValues}
-                onChange={(name, value) =>
-                    setOption(selectedViz.dataAppVizUuid, name, value)
-                }
-                colorPalette={colorPalette}
-                paletteControl={<ColorPaletteSection size="xs" />}
-            />
+            <>
+                {upgradeChanges && dataAppViz && (
+                    <DataAppVizUpgradeNotice
+                        typeName={getAppDisplayName(
+                            dataAppViz.name,
+                            dataAppViz.dataAppVizUuid,
+                        )}
+                        changes={upgradeChanges}
+                    />
+                )}
+                <DataAppVizOptionTabs
+                    // Remount on a viz switch so no control keeps the previous
+                    // viz's draft edit.
+                    key={`${selectedViz.dataAppVizUuid}:${optionContractKey}`}
+                    generalContent={settings}
+                    configOptions={configOptions}
+                    values={effectiveValues}
+                    onChange={(name, value) =>
+                        setOption(selectedViz.dataAppVizUuid, name, value)
+                    }
+                    colorPalette={colorPalette}
+                    paletteControl={<ColorPaletteSection size="xs" />}
+                />
+            </>
         );
     };
 

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeModal.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeModal.test.tsx
@@ -1,0 +1,84 @@
+import { type DataAppVizSchemaChanges } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import DataAppVizUpgradeModal from './DataAppVizUpgradeModal';
+
+const noChanges: DataAppVizSchemaChanges = {
+    fields: { added: [], removed: [], changed: [] },
+    configOptions: { added: [], removed: [], changed: [] },
+    colorPalette: 'unchanged',
+};
+
+const changes: DataAppVizSchemaChanges = {
+    ...noChanges,
+    fields: {
+        added: [
+            {
+                name: 'target',
+                label: 'Target',
+                type: 'metric',
+                required: false,
+            },
+        ],
+        removed: [],
+        changed: [],
+    },
+};
+
+const renderModal = (schemaChanges: DataAppVizSchemaChanges) =>
+    renderWithProviders(
+        <DataAppVizUpgradeModal
+            typeName="Radial gauge"
+            changes={schemaChanges}
+            onClose={vi.fn()}
+        />,
+    );
+
+describe('DataAppVizUpgradeModal', () => {
+    it('names the type and lists the changes', () => {
+        renderModal(changes);
+
+        expect(screen.getByText('Radial gauge')).toBeInTheDocument();
+        expect(screen.getByText('Added')).toBeInTheDocument();
+        expect(screen.getByText('Target')).toBeInTheDocument();
+    });
+
+    it('warns when the upgrade drops fields or options', () => {
+        renderModal({
+            ...noChanges,
+            configOptions: {
+                added: [],
+                removed: [
+                    {
+                        type: 'boolean',
+                        name: 'legacy',
+                        label: 'Legacy',
+                        default: false,
+                    },
+                ],
+                changed: [],
+            },
+        });
+
+        expect(
+            screen.getByText(/Removed fields lose their mapping/),
+        ).toBeInTheDocument();
+    });
+
+    it('does not warn when nothing is removed', () => {
+        renderModal(changes);
+
+        expect(
+            screen.queryByText(/Removed fields lose their mapping/),
+        ).not.toBeInTheDocument();
+    });
+
+    it('says so when only the rendering changed', () => {
+        renderModal(noChanges);
+
+        expect(
+            screen.getByText(/only the rendering changed/),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeModal.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeModal.tsx
@@ -1,0 +1,60 @@
+import {
+    hasDataAppVizSchemaChanges,
+    type DataAppVizSchemaChanges,
+} from '@lightdash/common';
+import { Stack, Text } from '@mantine/core';
+import { IconSparkles } from '@tabler/icons-react';
+import { type FC } from 'react';
+import VizSchemaChangesList from '../../../features/chartTypes/components/VizSchemaChangesList';
+import Callout from '../../common/Callout';
+import MantineModal from '../../common/MantineModal';
+
+type Props = {
+    typeName: string;
+    /** What the latest version declares that the pinned one did not. */
+    changes: DataAppVizSchemaChanges;
+    onClose: () => void;
+};
+
+/**
+ * What moving this chart to the latest version of its type would change.
+ */
+const DataAppVizUpgradeModal: FC<Props> = ({ typeName, changes, onClose }) => {
+    const removesSomething =
+        changes.fields.removed.length > 0 ||
+        changes.configOptions.removed.length > 0;
+
+    return (
+        <MantineModal
+            opened
+            onClose={onClose}
+            title="Upgrade chart type"
+            subtitle={typeName}
+            icon={IconSparkles}
+            size="md"
+            cancelLabel="Close"
+        >
+            <Stack gap="md">
+                <Text fz="sm">
+                    Only this chart moves to the latest version. Nothing is
+                    saved until you save the chart.
+                </Text>
+                {removesSomething && (
+                    <Callout variant="warning">
+                        Removed fields lose their mapping and removed options
+                        lose their values.
+                    </Callout>
+                )}
+                {hasDataAppVizSchemaChanges(changes) ? (
+                    <VizSchemaChangesList changes={changes} />
+                ) : (
+                    <Text fz="sm" c="dimmed">
+                        Same fields and options; only the rendering changed.
+                    </Text>
+                )}
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export default DataAppVizUpgradeModal;

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeNotice.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeNotice.test.tsx
@@ -1,0 +1,52 @@
+import { type DataAppVizSchemaChanges } from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import DataAppVizUpgradeNotice from './DataAppVizUpgradeNotice';
+
+vi.mock('./DataAppVizUpgradeModal', () => ({
+    default: ({
+        typeName,
+        onClose,
+    }: {
+        typeName: string;
+        onClose: () => void;
+    }) => (
+        <div data-testid="upgrade-modal">
+            {typeName}
+            <button type="button" onClick={onClose}>
+                close
+            </button>
+        </div>
+    ),
+}));
+
+const changes: DataAppVizSchemaChanges = {
+    fields: { added: [], removed: [], changed: [] },
+    configOptions: { added: [], removed: [], changed: [] },
+    colorPalette: 'unchanged',
+};
+
+describe('DataAppVizUpgradeNotice', () => {
+    it('announces the newer version and opens the review on demand', () => {
+        renderWithProviders(
+            <DataAppVizUpgradeNotice
+                typeName="Radial gauge"
+                changes={changes}
+            />,
+        );
+
+        expect(screen.getByText('Newer version available')).toBeInTheDocument();
+        expect(screen.queryByTestId('upgrade-modal')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Review upgrade' }));
+
+        expect(screen.getByTestId('upgrade-modal')).toHaveTextContent(
+            'Radial gauge',
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'close' }));
+
+        expect(screen.queryByTestId('upgrade-modal')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeNotice.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeNotice.tsx
@@ -1,0 +1,48 @@
+import { type DataAppVizSchemaChanges } from '@lightdash/common';
+import { Button, Group, Text } from '@mantine/core';
+import { IconSparkles } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import MantineIcon from '../../common/MantineIcon';
+import DataAppVizUpgradeModal from './DataAppVizUpgradeModal';
+
+type Props = {
+    typeName: string;
+    changes: DataAppVizSchemaChanges;
+};
+
+/**
+ * Tells a chart editor that its project chart type moved on. The details
+ * live behind the review modal, so the panel stays quiet.
+ */
+const DataAppVizUpgradeNotice: FC<Props> = ({ typeName, changes }) => {
+    const [isReviewing, setIsReviewing] = useState(false);
+
+    return (
+        <>
+            <Group justify="space-between" gap="xs" wrap="nowrap">
+                <Text fz="xs" c="dimmed">
+                    Newer version available
+                </Text>
+                <Button
+                    size="compact-xs"
+                    variant="light"
+                    color="blue"
+                    flex="0 0 auto"
+                    leftSection={<MantineIcon icon={IconSparkles} size={14} />}
+                    onClick={() => setIsReviewing(true)}
+                >
+                    Review upgrade
+                </Button>
+            </Group>
+            {isReviewing && (
+                <DataAppVizUpgradeModal
+                    typeName={typeName}
+                    changes={changes}
+                    onClose={() => setIsReviewing(false)}
+                />
+            )}
+        </>
+    );
+};
+
+export default DataAppVizUpgradeNotice;


### PR DESCRIPTION
Linear: [GLITCH-699](https://linear.app/lightdash/issue/GLITCH-699/add-a-chart-type-upgrade-flow-with-version-changes)

### Description

Second layer of the GLITCH-699 stack (depends on #28286). A pinned chart stops changing silently, so its editor needs to hear that the type moved on.

- The Explorer configure panel asks the chart-less authoring render metadata for the latest renderable version and, when the pin is older, shows a quiet "Newer version available" row with a `Review upgrade` button (same shape as the builder's "Upgrade available" offer).
- The review opens a `MantineModal` with the type name, one sentence of context and the grouped change list from #28286, diffed in the browser from the pinned schema the panel already has and the latest schema the render metadata already carries. A warning names the consequence when the newer version removes fields or options. Nothing touches the chart in this layer.
- Hidden for unpinned legacy charts (they follow latest already) and while the same type is being authored in place.

### Verification

- 34 frontend tests across the notice, modal and configure panel
- frontend typecheck and lint

### Risk assessment

- [ ] This is a high-risk change

Frontend only; the extra metadata request goes through the existing authoring endpoint.

Relates: GLITCH-699


### Screenshots

**Configure panel with the "Newer version available" row**

<img width="1680" height="1050" alt="11-panel-notice" src="https://github.com/user-attachments/assets/1be1d4c9-e1d2-48a2-a9fb-ed16ca709697" />


**Review modal listing the changes**


<img width="1680" height="1050" alt="12-upgrade-modal" src="https://github.com/user-attachments/assets/69654b22-e449-43e2-a53a-98181c0ec8c4" />

