### PR TITLE
feat: upgrade explorer charts to newer project chart type versions

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -220,6 +220,12 @@ queries: the explorer hands it rows and a field mapping, and it renders. They sh
 permissions of data apps but are excluded from app listings, have their own gallery and builder, and are downloaded
 as code separately.
 
+A saved chart pins the version of the type it was saved with, so iterating on a type never changes existing charts.
+Charts saved before pins exist follow the latest version until they are next edited and saved. When a newer version
+exists, the explorer's configure panel offers an upgrade that lists the field, option and palette changes; upgrading
+re-pins the chart being edited and reconciles its field mapping and option values against the new contract, and
+nothing is persisted until the chart is saved.
+
 ---
 
 ## Infrastructure

--- a/packages/common/src/ee/apps/types.test.ts
+++ b/packages/common/src/ee/apps/types.test.ts
@@ -4,6 +4,7 @@ import {
     dataAppVizSchema,
     getEffectiveOptionValues,
     getVisibleDataAppClaudeModels,
+    pruneDataAppVizOptionValues,
     resolveDefaultDataAppClaudeModel,
     resolveDefaultVisibleDataAppClaudeModel,
     type DataAppVizConfigOption,
@@ -526,5 +527,34 @@ describe('dataAppVizJsonSchema', () => {
         };
 
         expect(findReferences(jsonSchema)).toEqual([]);
+    });
+});
+
+describe('pruneDataAppVizOptionValues', () => {
+    const options: DataAppVizConfigOption[] = [
+        { type: 'boolean', name: 'showLegend', label: 'Legend', default: true },
+        {
+            type: 'select',
+            name: 'mode',
+            label: 'Mode',
+            choices: [{ value: 'stacked', label: 'Stacked' }],
+            default: 'stacked',
+        },
+        { type: 'number', name: 'limit', label: 'Limit', default: 10 },
+    ];
+
+    it('keeps stored values that still fit and drops the rest', () => {
+        expect(
+            pruneDataAppVizOptionValues(options, {
+                showLegend: false,
+                mode: 'grouped',
+                limit: 'ten',
+                gone: true,
+            }),
+        ).toEqual({ showLegend: false });
+    });
+
+    it('never seeds defaults', () => {
+        expect(pruneDataAppVizOptionValues(options, {})).toEqual({});
     });
 });

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -1032,6 +1032,24 @@ export const getEffectiveOptionValue = <T extends DataAppVizConfigOption>(
         ? (storedValue as T['default'])
         : option.default;
 
+/**
+ * The explicitly stored values that still fit the declared options. Used when
+ * a chart moves to a newer contract: stale names and mistyped values go,
+ * defaults are still never seeded.
+ */
+export const pruneDataAppVizOptionValues = (
+    configOptions: DataAppVizConfigOption[],
+    optionValues: Record<string, DataAppVizOptionValue>,
+): Record<string, DataAppVizOptionValue> =>
+    Object.fromEntries(
+        configOptions.flatMap((option) => {
+            const stored = optionValues[option.name];
+            return stored !== undefined && matchesDeclaredType(option, stored)
+                ? [[option.name, stored]]
+                : [];
+        }),
+    );
+
 /** Effective values for every declared option. */
 export const getEffectiveOptionValues = (
     configOptions: DataAppVizConfigOption[],

--- a/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
+++ b/packages/frontend/src/components/DataAppVizRenderer/index.test.tsx
@@ -467,6 +467,38 @@ describe('DataAppVizRenderer', () => {
         expect(mocks.setDataAppVizVersion).not.toHaveBeenCalled();
     });
 
+    it('renders an upgraded pin through the authoring path without re-pinning', () => {
+        mocks.metadata.current = { ...readyMetadata(), version: 5 };
+        mocks.dataAppVizVersion.current = 5;
+        mocks.vizContextOverrides.current = {
+            savedChartUuid: undefined,
+            isEditMode: true,
+            savedChartReference: {
+                uuid: 'saved-chart-uuid',
+                chartConfig: {
+                    type: 'data_app_viz',
+                    config: {
+                        dataAppVizUuid: 'viz-uuid',
+                        dataAppVizVersion: 3,
+                        fieldMapping: { category: 'orders.category' },
+                    },
+                },
+            },
+        };
+
+        renderRenderer();
+
+        expect(mocks.renderMetadataHook).toHaveBeenCalledWith(
+            'project-uuid',
+            'viz-uuid',
+            {
+                isEmbedded: false,
+                savedChartUuid: undefined,
+            },
+        );
+        expect(mocks.setDataAppVizVersion).not.toHaveBeenCalled();
+    });
+
     it('renders the last good version while a newer build is running', () => {
         mocks.metadata.current = {
             ...readyMetadata(),

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.test.tsx
@@ -108,12 +108,17 @@ vi.mock('./DataAppVizUpgradeNotice', () => ({
     default: ({
         typeName,
         changes,
+        onUpgrade,
     }: {
         typeName: string;
         changes: DataAppVizSchemaChanges;
+        onUpgrade: () => void;
     }) => (
         <div data-testid="upgrade-notice">
             {`${typeName}: +${changes.fields.added.length} fields`}
+            <button type="button" onClick={onUpgrade}>
+                upgrade
+            </button>
         </div>
     ),
 }));
@@ -271,6 +276,7 @@ describe('DataAppVizConfigTabs', () => {
     const clearDataAppViz = vi.fn();
     const setField = vi.fn();
     const setPivotDimensions = vi.fn();
+    const upgradeDataAppVizVersion = vi.fn();
 
     const mockContext = (
         itemsMap: ItemsMap,
@@ -299,6 +305,7 @@ describe('DataAppVizConfigTabs', () => {
                     clearDataAppViz,
                     setField,
                     setOption,
+                    upgradeDataAppVizVersion,
                 },
             },
         } as unknown as ReturnType<typeof useVisualizationContext>);
@@ -315,6 +322,7 @@ describe('DataAppVizConfigTabs', () => {
         clearDataAppViz.mockClear();
         setField.mockClear();
         setPivotDimensions.mockClear();
+        upgradeDataAppVizVersion.mockClear();
         defaultAbility.update([]);
         vi.mocked(useDataAppVizRenderMetadata).mockReturnValue({
             data: undefined,
@@ -731,6 +739,40 @@ describe('DataAppVizConfigTabs', () => {
         expect(screen.getByTestId('upgrade-notice')).toHaveTextContent(
             'Radial gauge: +1 fields',
         );
+    });
+
+    it('re-pins with the binding and options reconciled against the target contract', async () => {
+        const user = userEvent.setup();
+        mockContext(
+            queryColumns,
+            'data-app-viz-uuid',
+            { showLegend: false, gone: 'x' },
+            { source: 'orders_visible', legacy: 'orders_hidden' },
+            3,
+        );
+        mockSchema(declaredOptions);
+        mockLatestRenderable(5);
+
+        renderWithProviders(<ConfigTabs />);
+        await user.click(screen.getByRole('button', { name: 'upgrade' }));
+
+        expect(upgradeDataAppVizVersion).toHaveBeenCalledWith(
+            5,
+            { source: 'orders_visible', value: 'orders_visible_metric' },
+            {},
+        );
+        expect(setPivotDimensions).toHaveBeenCalled();
+    });
+
+    it('names the required slots the query cannot fill', () => {
+        mockContext({}, 'data-app-viz-uuid', {}, {});
+        mockSchema([]);
+
+        renderWithProviders(<ConfigTabs />);
+
+        expect(
+            screen.getByText('Map Source, Value to render this chart type.'),
+        ).toBeInTheDocument();
     });
 
     it('stays quiet when the pin is already the latest version', () => {

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizConfigTabs.tsx
@@ -5,6 +5,7 @@ import {
     FeatureFlags,
     getAppDisplayName,
     getEffectiveOptionValues,
+    pruneDataAppVizOptionValues,
     type ItemsMap,
 } from '@lightdash/common';
 import { Anchor, Box, Stack, Text } from '@mantine/core';
@@ -14,7 +15,10 @@ import { useCanCreateDataApp } from '../../../features/apps/hooks/useCanCreateDa
 import { useCanEditDataApp } from '../../../features/apps/hooks/useCanEditDataApp';
 import { useDataAppVisualization } from '../../../features/chartTypes/hooks/useDataAppVisualization';
 import { useDataAppVizRenderMetadata } from '../../../features/chartTypes/hooks/useDataAppVizRender';
-import { reconcileDataAppVizFieldMapping } from '../../../features/chartTypes/utils/autoMapDataAppVizFields';
+import {
+    getUnboundRequiredDataAppVizFields,
+    reconcileDataAppVizFieldMapping,
+} from '../../../features/chartTypes/utils/autoMapDataAppVizFields';
 import { chartTypeBuilderPath } from '../../../features/chartTypes/utils/chartTypeBuilderPath';
 import { getDataAppVizFieldItems } from '../../../features/chartTypes/utils/getDataAppVizFieldItems';
 import {
@@ -26,6 +30,7 @@ import {
 import { type SelectedDataAppViz } from '../../../hooks/useDataAppVizVisualizationConfig';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import Callout from '../../common/Callout';
 import { useIsInsideChartGallery } from '../../common/ChartGallery/ChartGalleryContext';
 import { isDataAppVizVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -145,6 +150,7 @@ export const ConfigTabs: FC = memo(() => {
         clearDataAppViz,
         setField,
         setOption,
+        upgradeDataAppVizVersion,
     } = visualizationConfig.chartConfig;
     const fields = dataAppViz?.schema?.fields ?? [];
 
@@ -180,8 +186,47 @@ export const ConfigTabs: FC = memo(() => {
             );
         };
 
+        const unboundRequired = getUnboundRequiredDataAppVizFields(
+            fields,
+            effectiveMapping,
+        );
+
+        const handleUpgrade = () => {
+            if (!upgradeTarget) return;
+            const nextMapping = reconcileDataAppVizFieldMapping(
+                upgradeTarget.schema.fields,
+                itemsMap ?? NO_COLUMNS,
+                selectedViz.fieldMapping,
+            );
+            upgradeDataAppVizVersion(
+                upgradeTarget.version,
+                nextMapping,
+                pruneDataAppVizOptionValues(
+                    upgradeTarget.schema.configOptions,
+                    selectedViz.optionValues,
+                ),
+            );
+            setPivotDimensions(
+                deriveDataAppVizPivotConfig(
+                    upgradeTarget.schema.fields,
+                    nextMapping,
+                )?.columns,
+            );
+        };
+
         const settings = (
             <Stack>
+                {unboundRequired.length > 0 && (
+                    <Callout variant="warning" hideIcon p="xs">
+                        <Text fz="xs">
+                            Map{' '}
+                            {unboundRequired
+                                .map((field) => field.label)
+                                .join(', ')}{' '}
+                            to render this chart type.
+                        </Text>
+                    </Callout>
+                )}
                 <DataAppVizSettings
                     itemsMap={itemsMap ?? NO_COLUMNS}
                     fields={fields}
@@ -231,6 +276,7 @@ export const ConfigTabs: FC = memo(() => {
                             dataAppViz.dataAppVizUuid,
                         )}
                         changes={upgradeChanges}
+                        onUpgrade={handleUpgrade}
                     />
                 )}
                 <DataAppVizOptionTabs

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeModal.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeModal.test.tsx
@@ -1,5 +1,5 @@
 import { type DataAppVizSchemaChanges } from '@lightdash/common';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import DataAppVizUpgradeModal from './DataAppVizUpgradeModal';
@@ -26,12 +26,16 @@ const changes: DataAppVizSchemaChanges = {
     },
 };
 
-const renderModal = (schemaChanges: DataAppVizSchemaChanges) =>
+const renderModal = (
+    schemaChanges: DataAppVizSchemaChanges,
+    onUpgrade: () => void = vi.fn(),
+) =>
     renderWithProviders(
         <DataAppVizUpgradeModal
             typeName="Radial gauge"
             changes={schemaChanges}
             onClose={vi.fn()}
+            onUpgrade={onUpgrade}
         />,
     );
 
@@ -80,5 +84,14 @@ describe('DataAppVizUpgradeModal', () => {
         expect(
             screen.getByText(/only the rendering changed/),
         ).toBeInTheDocument();
+    });
+
+    it('upgrades from the footer', () => {
+        const onUpgrade = vi.fn();
+        renderModal(changes, onUpgrade);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Upgrade' }));
+
+        expect(onUpgrade).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeModal.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeModal.tsx
@@ -14,12 +14,18 @@ type Props = {
     /** What the latest version declares that the pinned one did not. */
     changes: DataAppVizSchemaChanges;
     onClose: () => void;
+    onUpgrade: () => void;
 };
 
 /**
  * What moving this chart to the latest version of its type would change.
  */
-const DataAppVizUpgradeModal: FC<Props> = ({ typeName, changes, onClose }) => {
+const DataAppVizUpgradeModal: FC<Props> = ({
+    typeName,
+    changes,
+    onClose,
+    onUpgrade,
+}) => {
     const removesSomething =
         changes.fields.removed.length > 0 ||
         changes.configOptions.removed.length > 0;
@@ -32,7 +38,8 @@ const DataAppVizUpgradeModal: FC<Props> = ({ typeName, changes, onClose }) => {
             subtitle={typeName}
             icon={IconSparkles}
             size="md"
-            cancelLabel="Close"
+            confirmLabel="Upgrade"
+            onConfirm={onUpgrade}
         >
             <Stack gap="md">
                 <Text fz="sm">

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeNotice.test.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeNotice.test.tsx
@@ -8,14 +8,19 @@ vi.mock('./DataAppVizUpgradeModal', () => ({
     default: ({
         typeName,
         onClose,
+        onUpgrade,
     }: {
         typeName: string;
         onClose: () => void;
+        onUpgrade: () => void;
     }) => (
         <div data-testid="upgrade-modal">
             {typeName}
             <button type="button" onClick={onClose}>
                 close
+            </button>
+            <button type="button" onClick={onUpgrade}>
+                upgrade
             </button>
         </div>
     ),
@@ -27,14 +32,18 @@ const changes: DataAppVizSchemaChanges = {
     colorPalette: 'unchanged',
 };
 
+const renderNotice = (onUpgrade: () => void = vi.fn()) =>
+    renderWithProviders(
+        <DataAppVizUpgradeNotice
+            typeName="Radial gauge"
+            changes={changes}
+            onUpgrade={onUpgrade}
+        />,
+    );
+
 describe('DataAppVizUpgradeNotice', () => {
     it('announces the newer version and opens the review on demand', () => {
-        renderWithProviders(
-            <DataAppVizUpgradeNotice
-                typeName="Radial gauge"
-                changes={changes}
-            />,
-        );
+        renderNotice();
 
         expect(screen.getByText('Newer version available')).toBeInTheDocument();
         expect(screen.queryByTestId('upgrade-modal')).not.toBeInTheDocument();
@@ -47,6 +56,17 @@ describe('DataAppVizUpgradeNotice', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'close' }));
 
+        expect(screen.queryByTestId('upgrade-modal')).not.toBeInTheDocument();
+    });
+
+    it('upgrades from the review and closes it', () => {
+        const onUpgrade = vi.fn();
+        renderNotice(onUpgrade);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Review upgrade' }));
+        fireEvent.click(screen.getByRole('button', { name: 'upgrade' }));
+
+        expect(onUpgrade).toHaveBeenCalledTimes(1);
         expect(screen.queryByTestId('upgrade-modal')).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeNotice.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/DataAppVizConfig/DataAppVizUpgradeNotice.tsx
@@ -8,13 +8,18 @@ import DataAppVizUpgradeModal from './DataAppVizUpgradeModal';
 type Props = {
     typeName: string;
     changes: DataAppVizSchemaChanges;
+    onUpgrade: () => void;
 };
 
 /**
- * Tells a chart editor that its project chart type moved on. The details
- * live behind the review modal, so the panel stays quiet.
+ * Tells a chart editor that its project chart type moved on. The details and
+ * the upgrade itself live behind the review modal, so the panel stays quiet.
  */
-const DataAppVizUpgradeNotice: FC<Props> = ({ typeName, changes }) => {
+const DataAppVizUpgradeNotice: FC<Props> = ({
+    typeName,
+    changes,
+    onUpgrade,
+}) => {
     const [isReviewing, setIsReviewing] = useState(false);
 
     return (
@@ -39,6 +44,10 @@ const DataAppVizUpgradeNotice: FC<Props> = ({ typeName, changes }) => {
                     typeName={typeName}
                     changes={changes}
                     onClose={() => setIsReviewing(false)}
+                    onUpgrade={() => {
+                        onUpgrade();
+                        setIsReviewing(false);
+                    }}
                 />
             )}
         </>

--- a/packages/frontend/src/features/chartTypes/utils/autoMapDataAppVizFields.test.ts
+++ b/packages/frontend/src/features/chartTypes/utils/autoMapDataAppVizFields.test.ts
@@ -10,6 +10,7 @@ import {
 import { describe, expect, it } from 'vitest';
 import {
     autoMapDataAppVizFields,
+    getUnboundRequiredDataAppVizFields,
     reconcileDataAppVizFieldMapping,
 } from './autoMapDataAppVizFields';
 
@@ -260,5 +261,28 @@ describe('reconcileDataAppVizFieldMapping', () => {
         expect(reconcileDataAppVizFieldMapping(fields, items, {})).toEqual(
             autoMapDataAppVizFields(fields, items),
         );
+    });
+});
+
+describe('getUnboundRequiredDataAppVizFields', () => {
+    it('lists only required slots without a binding, in declared order', () => {
+        const fields: DataAppVizField[] = [
+            { name: 'x', label: 'X', type: 'dimension', required: true },
+            { name: 'y', label: 'Y', type: 'metric', required: true },
+            {
+                name: 'series',
+                label: 'Series',
+                type: 'series',
+                required: false,
+            },
+        ];
+
+        expect(
+            getUnboundRequiredDataAppVizFields(fields, { y: 'orders_count' }),
+        ).toEqual([fields[0]]);
+        expect(getUnboundRequiredDataAppVizFields(fields, {})).toEqual([
+            fields[0],
+            fields[1],
+        ]);
     });
 });

--- a/packages/frontend/src/features/chartTypes/utils/autoMapDataAppVizFields.ts
+++ b/packages/frontend/src/features/chartTypes/utils/autoMapDataAppVizFields.ts
@@ -146,3 +146,10 @@ export const reconcileDataAppVizFieldMapping = (
 
     return mapping;
 };
+
+/** Required slots the mapping leaves empty, in declared order. */
+export const getUnboundRequiredDataAppVizFields = (
+    fields: DataAppVizField[],
+    mapping: DataAppVizFieldMapping,
+): DataAppVizField[] =>
+    fields.filter((field) => field.required && !mapping[field.name]);

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.test.ts
@@ -61,6 +61,43 @@ describe('useDataAppVizVisualizationConfig', () => {
         });
     });
 
+    it('moves to a newer type version with the reconciled binding and options', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(
+                { ...initialConfig, dataAppVizVersion: 3 },
+                onConfigChange,
+            ),
+        );
+
+        act(() =>
+            result.current.upgradeDataAppVizVersion(
+                5,
+                { category: 'orders_status', value: 'orders_count' },
+                {},
+            ),
+        );
+
+        expect(onConfigChange).toHaveBeenLastCalledWith({
+            dataAppVizUuid: 'viz-1',
+            dataAppVizVersion: 5,
+            fieldMapping: { category: 'orders_status', value: 'orders_count' },
+            optionValues: {},
+        });
+    });
+
+    it('ignores an upgrade while no type is selected', () => {
+        const onConfigChange = vi.fn();
+        const { result } = renderHook(() =>
+            useDataAppVizVisualizationConfig(undefined, onConfigChange),
+        );
+
+        act(() => result.current.upgradeDataAppVizVersion(5, {}, {}));
+
+        expect(onConfigChange).not.toHaveBeenCalled();
+        expect(result.current.validConfig).toBeNull();
+    });
+
     it('defaults to an empty option map when nothing is saved', () => {
         const { result } = renderHook(() =>
             useDataAppVizVisualizationConfig({

--- a/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
+++ b/packages/frontend/src/hooks/useDataAppVizVisualizationConfig.ts
@@ -2,6 +2,7 @@ import {
     type DataAppVizChart,
     type DataAppVizFieldMapping,
     type DataAppVizOptionValue,
+    type DataAppVizOptionValues,
 } from '@lightdash/common';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
@@ -29,6 +30,16 @@ export interface DataAppVizVisualizationConfigAndData {
         fieldMapping: DataAppVizFieldMapping,
     ) => void;
     setDataAppVizVersion: (dataAppVizVersion: number) => void;
+    /**
+     * Move the chart to a newer version of its type. The caller reconciles
+     * the binding and options against that version's contract, for the same
+     * reason `setDataAppVizUuid` takes its mapping ready-made.
+     */
+    upgradeDataAppVizVersion: (
+        dataAppVizVersion: number,
+        fieldMapping: DataAppVizFieldMapping,
+        optionValues: DataAppVizOptionValues,
+    ) => void;
     /** Back to pointing at no viz; bindings and options go with it. */
     clearDataAppViz: () => void;
     setField: (fieldName: string, fieldId: string | null) => void;
@@ -146,6 +157,24 @@ const useDataAppVizVisualizationConfig = (
         [commit],
     );
 
+    const upgradeDataAppVizVersion = useCallback(
+        (
+            dataAppVizVersion: number,
+            fieldMapping: DataAppVizFieldMapping,
+            optionValues: DataAppVizOptionValues,
+        ) => {
+            const selected = configRef.current;
+            if (selected === null) return;
+            commit({
+                ...selected,
+                dataAppVizVersion,
+                fieldMapping,
+                optionValues,
+            });
+        },
+        [commit],
+    );
+
     const setField = useCallback(
         (fieldName: string, fieldId: string | null) => {
             const selected = configRef.current;
@@ -187,6 +216,7 @@ const useDataAppVizVisualizationConfig = (
         dataAppVizUuid: config?.dataAppVizUuid ?? null,
         setDataAppVizUuid,
         setDataAppVizVersion,
+        upgradeDataAppVizVersion,
         clearDataAppViz,
         setField,
         setOption,


### PR DESCRIPTION
Linear: [GLITCH-699](https://linear.app/lightdash/issue/GLITCH-699/add-a-chart-type-upgrade-flow-with-version-changes)

### Description

Top of the GLITCH-699 stack (depends on #28287). The review modal gains its `Upgrade` action.

- `upgradeDataAppVizVersion` on the data app viz config hook re-pins the chart being edited to the latest renderable version with the binding and options reconciled against that version's contract, so the preview flips at once.
- Bindings are reconciled with `reconcileDataAppVizFieldMapping`; stored options are pruned with `pruneDataAppVizOptionValues` (stale names and mistyped values go, defaults are still never seeded).
- Required slots the query cannot fill are named in the panel instead of being left silently empty.
- Nothing is persisted until the chart is saved; discarding the edit is the undo. The renderer already routes an in-state pin that differs from the saved one through the authoring path, so no render or token endpoint changes.
- Docs paragraph on version pins and upgrades in `docs/data-apps.md`.

### Verification

- 137 frontend tests across the config hook, auto-map helpers, configure panel, notice, modal and renderer; 42 common tests
- common and frontend typecheck and lint
- Manual pass in the Explorer: pin a chart to an older version, review, upgrade, save, confirm the pin and rendering in view mode

### Risk assessment

- [ ] This is a high-risk change

Only edit-mode Explorer state changes; saved charts are untouched until the user saves.

Closes: GLITCH-699


### Screenshots

**Review modal before upgrading**

<img width="1680" height="1050" alt="12-upgrade-modal" src="https://github.com/user-attachments/assets/82761adc-d4a2-4f2c-ac86-d91eaafad9b7" />


**After Upgrade: preview on the latest version, new required slot, Save enabled**

<img width="1680" height="1050" alt="13-after-upgrade" src="https://github.com/user-attachments/assets/70a506e8-08ed-4310-bffb-8f0292e959ed" />

