### PR TITLE
docs(data-apps): add safari-safe performance guidance

### DIFF
--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -1218,6 +1218,15 @@ function tableToCsv(columns: Column[], data: Row[], format: FormatFn): string {
 </ScrollArea>
 ```
 
+### Table and query performance
+
+Treat Safari/WebKit as the constrained target for layout-heavy apps. Test dense tables and filter interactions in Safari: an app that is smooth there will generally be smooth in Chrome, but the reverse is not guaranteed.
+
+- **Bound data-derived columns.** Pivot-style tables that derive columns from dates, categories, or other result values must cap the rendered window. Paginate the column range or virtualize it horizontally; never render an unbounded `dates.map(...)` or equivalent column set.
+- **Keep sticky positioning to headers.** Never apply `position: sticky` to body cells. If a pinned first column is essential, render it as a separate fixed pane synchronized with the scrollable data pane.
+- **Virtualize individual rows, not multi-row groups.** For large tables, avoid mounting virtualized rows inside one shared `<table>` layout where scroll-driven row changes can relayout the whole table. Prefer block or grid rows with fixed column widths, and make each virtual item one row rather than a group containing many rows and cells.
+- **Batch filter-driven queries.** When a control change would refetch multiple queries, debounce the committed filter value or require an Apply action. Do not fire the full query fan-out on every date, granularity, or filter input change.
+
 ### Resizable panels
 
 Only when the user asks for adjustable panel sizing (or two sibling areas genuinely benefit from rebalancing), read `/app/references/resizable-panels.md` and use the pre-installed shadcn `Resizable`. Otherwise use fixed flex/grid proportions — don't reach for it by default.


### PR DESCRIPTION
## What changed

## Summary

- add Safari/WebKit as the constrained performance target for layout-heavy generated apps
- require bounded or horizontally virtualized data-derived columns
- keep sticky positioning out of body cells and use row-level virtualization outside shared table layouts where possible
- debounce or Apply-gate filter changes that would fan out across multiple queries

### Validation

- `git diff --check` — passed
- targeted validation — no package validation was required for this Markdown-only change
- final validation on `90f2136142ccb75d5641ea49c3c53ee48178f480` — no package validation was required
- independent proof content assertions — all five requested guidance areas passed

## Proof of work

🟢 **PASS** — The data-app generation skill now contains all five requested Safari/WebKit performance safeguards, scoped exclusively to prevention guidance for newly generated apps.

Revision: `73a2639210786d07f80b66abfc8708fbc5af69a2`

### Bound data-derived pivot columns

- Expected: The skill requires capping, paginating, or horizontally virtualizing columns derived from dates, categories, or other data and forbids unbounded dates.map-style rendering.
- Observed: Line 1225 requires a capped rendered window, pagination or horizontal virtualization, and explicitly prohibits an unbounded dates.map(...) or equivalent column set.
- Evidence:
  - sandboxes/data-apps/template/skill.md:1225
  - Focused Python content assertion reported: pivot_bound: PASS

### Restrict sticky positioning to headers

- Expected: The skill forbids sticky body cells and recommends a separately scrolled fixed pane when a pinned first column is essential.
- Observed: Line 1226 limits sticky positioning to headers, prohibits position: sticky on body cells, and prescribes a separate fixed pane synchronized with the scrollable data pane.
- Evidence:
  - sandboxes/data-apps/template/skill.md:1226
  - Focused Python content assertion reported: sticky_scope: PASS

### Virtualize tables by individual row

- Expected: The skill requires one row per virtual item, avoids multi-row groups and a shared table layout where possible, and prefers block-level or fixed-width rows.
- Observed: Line 1227 requires individual-row virtualization, warns against virtualized rows in one shared <table>, and prefers block or grid rows with fixed column widths.
- Evidence:
  - sandboxes/data-apps/template/skill.md:1227
  - Focused Python content assertion reported: row_virtualization: PASS

### Batch filter-driven multi-query refetches

- Expected: The skill requires debouncing or an Apply action instead of firing the complete query fan-out on every filter control change.
- Observed: Line 1228 requires debouncing the committed filter value or an Apply action and explicitly prohibits full query fan-out on every date, granularity, or filter input change.
- Evidence:
  - sandboxes/data-apps/template/skill.md:1228
  - Focused Python content assertion reported: filter_batching: PASS

### Test layout-heavy generated UI in Safari/WebKit

- Expected: The skill identifies Safari/WebKit as the constrained target and warns that Chrome smoothness does not imply Safari smoothness.
- Observed: Line 1223 instructs testing dense tables and filter interactions in Safari, identifies Safari/WebKit as constrained, and states that the reverse Chrome-to-Safari smoothness implication is not guaranteed.
- Evidence:
  - sandboxes/data-apps/template/skill.md:1223
  - Focused Python content assertion reported: safari_note: PASS

### Limit the change to prevention guidance

- Expected: The revision changes the data-app generation skill rather than modifying existing generated applications.
- Observed: The fixed-point diff contains one changed file, sandboxes/data-apps/template/skill.md, with nine added lines and no removals.
- Evidence:
  - git diff --name-only 0107a73be768a3dc718e907eb0c0b763aa8715bd 73a2639210786d07f80b66abfc8708fbc5af69a2 returned only sandboxes/data-apps/template/skill.md
  - git diff --numstat 0107a73be768a3dc718e907eb0c0b763aa8715bd 73a2639210786d07f80b66abfc8708fbc5af69a2 -- sandboxes/data-apps/template/skill.md returned 9 additions and 0 deletions

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10580-f706ab539e5f.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10580

