### PR TITLE
fix(apps): keep selected picker rows readable in dark mode

### DIFF
--- a/packages/frontend/src/features/apps/AppResourcePicker.module.css
+++ b/packages/frontend/src/features/apps/AppResourcePicker.module.css
@@ -74,20 +74,10 @@
 }
 
 .chartItemSelected {
-    @mixin light {
-        background-color: var(--mantine-color-blue-0);
-    }
-    @mixin dark {
-        background-color: var(--mantine-color-blue-9);
-    }
+    background-color: var(--mantine-color-blue-light);
 
     &:hover {
-        @mixin light {
-            background-color: var(--mantine-color-blue-1);
-        }
-        @mixin dark {
-            background-color: var(--mantine-color-blue-8);
-        }
+        background-color: var(--mantine-color-blue-light-hover);
     }
 }
 


### PR DESCRIPTION
Relates: #28056
Relates: PROD-10583

### Description:

In dark mode the resource picker painted selected rows with a solid `blue-9`, which swallowed the dimmed subtext on external connection rows: the origin URL under a ticked connection was nearly invisible. Light mode was fine.

Selected rows now use Mantine's scheme-aware `--mantine-color-blue-light` / `--mantine-color-blue-light-hover` tokens, the same pair the formula reference and semantic layer panels use for highlighted states. Light mode keeps the same tint; dark mode gets a translucent one that leaves the subtext readable.

`AppResourcePicker.test.tsx` passes (9 tests).

### Risk assessment:

- [ ] This is a high-risk change