### PR TITLE
feat(demo): add payment method icon URLs to the jaffle shop demo

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/payments.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/payments.sql
@@ -1,1 +1,9 @@
-select * from {{ ref('stg_payments') }}
+select
+    *,
+    case payment_method
+        when 'credit_card' then 'https://upload.wikimedia.org/wikipedia/commons/1/16/Tabler-icons_credit-card.svg'
+        when 'bank_transfer' then 'https://upload.wikimedia.org/wikipedia/commons/0/07/Tabler-icons_building-bank.svg'
+        when 'coupon' then 'https://upload.wikimedia.org/wikipedia/commons/8/8b/Tabler-icons_ticket.svg'
+        when 'gift_card' then 'https://upload.wikimedia.org/wikipedia/commons/9/99/Tabler-icons_gift-card.svg'
+    end as payment_method_icon_url
+from {{ ref('stg_payments') }}

--- a/examples/full-jaffle-shop-demo/dbt/models/payments.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/payments.yml
@@ -43,6 +43,8 @@ models:
         description: Foreign key to the orders table
       - name: payment_method
         description: Method of payment used, for example credit card
+      - name: payment_method_icon_url
+        description: Icon for the payment method (Tabler Icons, hosted on Wikimedia Commons). Use it in custom chart types that render images.
       - name: amount
         description: Total amount (AUD) of the individual payment
         config:


### PR DESCRIPTION
Relates: #28056
Relates: PROD-10583

### Description:

Adds a `payment_method_icon_url` dimension to the demo `payments` model: one public image URL per payment method (Tabler icons hosted on Wikimedia Commons, MIT). It gives custom chart types that render images real data to show, and the docs screenshots for linking external connections to chart types are taken against it.

Plain `CASE` on `payment_method`, so it compiles on every warehouse the demo targets. `dbt run --select payments` verified against local Postgres.

### Risk assessment:

- [ ] This is a high-risk change