### PR TITLE
fix(dashboards): reconcile shared filter override ids

### DIFF
--- a/packages/common/src/types/applyDimensionOverrides.test.ts
+++ b/packages/common/src/types/applyDimensionOverrides.test.ts
@@ -622,6 +622,53 @@ describe('applyDimensionOverrides', () => {
             expect(result[1]).toEqual(overrides[1]);
         });
 
+        it('reserves an exact id match for a later saved filter sharing the field', () => {
+            const savedFilters: DashboardFilters = {
+                dimensions: [
+                    createBaseDashboardFilter(
+                        'saved-a',
+                        'customers_customer_id',
+                        'customers',
+                        ['1'],
+                    ),
+                    createBaseDashboardFilter(
+                        'saved-b',
+                        'customers_customer_id',
+                        'customers',
+                        ['2'],
+                    ),
+                ],
+                metrics: [],
+                tableCalculations: [],
+            };
+            const overrides: DashboardFilterRule[] = [
+                createOverrideFilter(
+                    'saved-b',
+                    'customers_customer_id',
+                    'customers',
+                    ['exact-b'],
+                ),
+                createOverrideFilter(
+                    'stale-a',
+                    'customers_customer_id',
+                    'customers',
+                    ['stale-a'],
+                ),
+            ];
+
+            const result = applyDimensionOverrides(savedFilters, overrides);
+
+            expect(result).toHaveLength(2);
+            expect(result[0]).toMatchObject({
+                id: 'saved-a',
+                values: ['stale-a'],
+            });
+            expect(result[1]).toMatchObject({
+                id: 'saved-b',
+                values: ['exact-b'],
+            });
+        });
+
         it('reconciles only the first of two saved filters sharing a field', () => {
             const savedFilters: DashboardFilters = {
                 dimensions: [

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -427,48 +427,87 @@ export const removeFieldFromFilterGroup = (
     };
 };
 
+type DashboardDimensionOverrideMatch = {
+    savedFilterIndex: number;
+    overrideIndex: number;
+};
+
+export const getDashboardDimensionOverrideMatches = (
+    savedFilters: DashboardFilterRule[],
+    overrides: DashboardFilterRuleOverride[],
+): DashboardDimensionOverrideMatch[] => {
+    const savedIds = new Set(savedFilters.map(({ id }) => id));
+    const appliedOverrideIds = new Set<string>();
+
+    return savedFilters.reduce<DashboardDimensionOverrideMatch[]>(
+        (matches, savedFilter, savedFilterIndex) => {
+            const exactMatchIndex = overrides.findIndex(
+                ({ id }) => id === savedFilter.id,
+            );
+            const overrideIndex =
+                exactMatchIndex >= 0
+                    ? exactMatchIndex
+                    : overrides.findIndex(
+                          (override) =>
+                              !savedIds.has(override.id) &&
+                              !appliedOverrideIds.has(override.id) &&
+                              override.target.fieldId ===
+                                  savedFilter.target.fieldId &&
+                              override.target.tableName ===
+                                  savedFilter.target.tableName,
+                      );
+
+            if (overrideIndex >= 0) {
+                appliedOverrideIds.add(overrides[overrideIndex].id);
+                matches.push({ savedFilterIndex, overrideIndex });
+            }
+
+            return matches;
+        },
+        [],
+    );
+};
+
 export const applyDimensionOverrides = (
     dashboardFilters: DashboardFilters,
     overrides: DashboardFilters | DashboardFilterRule[],
 ) => {
     const overrideArray =
         overrides instanceof Array ? overrides : overrides.dimensions;
-
+    const matches = getDashboardDimensionOverrideMatches(
+        dashboardFilters.dimensions,
+        overrideArray,
+    );
+    const overrideIndexBySavedFilterIndex = new Map(
+        matches.map(({ savedFilterIndex, overrideIndex }) => [
+            savedFilterIndex,
+            overrideIndex,
+        ]),
+    );
     const savedIds = new Set(dashboardFilters.dimensions.map((d) => d.id));
-    // Track consumed overrides so each is applied to one saved filter and the
-    // rest can be appended afterwards.
-    const appliedOverrideIds = new Set<string>();
+    const appliedOverrideIds = new Set(
+        matches.map(({ overrideIndex }) => overrideArray[overrideIndex].id),
+    );
 
     const overriddenDimensions = dashboardFilters.dimensions.map(
-        (dimension) => {
-            // Match by id, then fall back to the target field so a shared link
-            // keeps working after an edit rotates the filter's id.
-            const override =
-                overrideArray.find((o) => o.id === dimension.id) ??
-                overrideArray.find(
-                    (o) =>
-                        !savedIds.has(o.id) &&
-                        !appliedOverrideIds.has(o.id) &&
-                        o.target.fieldId === dimension.target.fieldId &&
-                        o.target.tableName === dimension.target.tableName,
-                );
+        (dimension, savedFilterIndex) => {
+            const overrideIndex =
+                overrideIndexBySavedFilterIndex.get(savedFilterIndex);
+            if (overrideIndex === undefined) return dimension;
 
-            if (override) {
-                appliedOverrideIds.add(override.id);
-                return {
-                    ...override,
-                    // The saved dashboard owns identity, tile targeting, lock
-                    // state and requirement flags; the override only carries
-                    // value/operator. Forcing the id re-homes a field-matched
-                    // override onto the saved filter.
-                    id: dimension.id,
-                    tileTargets: dimension.tileTargets,
-                    lockedTabUuids: dimension.lockedTabUuids,
-                    required: dimension.required,
-                    requiredGroupId: dimension.requiredGroupId,
-                };
-            }
-            return dimension;
+            const override = overrideArray[overrideIndex];
+            return {
+                ...override,
+                // The saved dashboard owns identity, tile targeting, lock
+                // state and requirement flags; the override only carries
+                // value/operator. Forcing the id re-homes a field-matched
+                // override onto the saved filter.
+                id: dimension.id,
+                tileTargets: dimension.tileTargets,
+                lockedTabUuids: dimension.lockedTabUuids,
+                required: dimension.required,
+                requiredGroupId: dimension.requiredGroupId,
+            };
         },
     );
 

--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.test.tsx
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.test.tsx
@@ -1,4 +1,8 @@
-import { FilterOperator, type DashboardFilterRule } from '@lightdash/common';
+import {
+    FilterOperator,
+    type DashboardFilterRule,
+    type DashboardFilters,
+} from '@lightdash/common';
 import { act, renderHook } from '@testing-library/react';
 import type { PropsWithChildren } from 'react';
 import { MemoryRouter } from 'react-router';
@@ -69,5 +73,136 @@ describe('useSavedDashboardFiltersOverrides', () => {
         expect(
             result.current.overridesForSavedDashboardFilters.dimensions,
         ).toStrictEqual([sanitizedRule]);
+    });
+
+    it('reconciles a stale URL override before the saved filter is edited', () => {
+        const staleRule = {
+            ...sanitizedRule,
+            id: 'stale-filter-id',
+            values: ['pending'],
+        };
+        const param = encodeURIComponent(
+            JSON.stringify({ dimensions: [staleRule] }),
+        );
+        const savedFilters = {
+            dimensions: [
+                {
+                    ...sanitizedRule,
+                    tileTargets: {},
+                    values: [],
+                },
+            ],
+            metrics: [],
+            tableCalculations: [],
+        } satisfies DashboardFilters;
+        const { result, rerender } = renderHook(
+            ({ filters }: { filters?: DashboardFilters }) =>
+                useSavedDashboardFiltersOverrides(filters),
+            {
+                initialProps: { filters: undefined },
+                wrapper: createWrapper(`?filters=${param}`),
+            },
+        );
+
+        rerender({ filters: savedFilters });
+        act(() => {
+            result.current.addSavedFilterOverride({
+                ...savedFilters.dimensions[0],
+                values: ['completed'],
+            });
+        });
+
+        expect(
+            result.current.overridesForSavedDashboardFilters.dimensions,
+        ).toStrictEqual([
+            {
+                ...sanitizedRule,
+                values: ['completed'],
+            },
+        ]);
+    });
+
+    it('keeps stale overrides distinct for saved filters sharing a field', () => {
+        const param = encodeURIComponent(
+            JSON.stringify({
+                dimensions: [
+                    {
+                        ...sanitizedRule,
+                        id: 'stale-filter-1',
+                        values: ['pending'],
+                    },
+                    {
+                        ...sanitizedRule,
+                        id: 'stale-filter-2',
+                        values: ['shipped'],
+                    },
+                ],
+            }),
+        );
+        const savedFilters = {
+            dimensions: [
+                { ...sanitizedRule, id: 'saved-filter-1', tileTargets: {} },
+                { ...sanitizedRule, id: 'saved-filter-2', tileTargets: {} },
+            ],
+            metrics: [],
+            tableCalculations: [],
+        } satisfies DashboardFilters;
+        const { result } = renderHook(
+            () => useSavedDashboardFiltersOverrides(savedFilters),
+            { wrapper: createWrapper(`?filters=${param}`) },
+        );
+
+        act(() => {
+            result.current.addSavedFilterOverride({
+                ...savedFilters.dimensions[1],
+                values: ['completed'],
+            });
+        });
+
+        expect(
+            result.current.overridesForSavedDashboardFilters.dimensions,
+        ).toStrictEqual([
+            {
+                ...sanitizedRule,
+                id: 'saved-filter-1',
+                values: ['pending'],
+            },
+            {
+                ...sanitizedRule,
+                id: 'saved-filter-2',
+                values: ['completed'],
+            },
+        ]);
+    });
+
+    it('preserves override state identity when ids are already current', () => {
+        const param = encodeURIComponent(
+            JSON.stringify({ dimensions: [sanitizedRule] }),
+        );
+        const savedFilters = {
+            dimensions: [{ ...sanitizedRule, tileTargets: {} }],
+            metrics: [],
+            tableCalculations: [],
+        } satisfies DashboardFilters;
+        const { result, rerender } = renderHook(
+            ({ filters }: { filters: DashboardFilters }) =>
+                useSavedDashboardFiltersOverrides(filters),
+            {
+                initialProps: { filters: savedFilters },
+                wrapper: createWrapper(`?filters=${param}`),
+            },
+        );
+        const overrides = result.current.overridesForSavedDashboardFilters;
+
+        rerender({
+            filters: {
+                ...savedFilters,
+                dimensions: [...savedFilters.dimensions],
+            },
+        });
+
+        expect(result.current.overridesForSavedDashboardFilters).toBe(
+            overrides,
+        );
     });
 });

--- a/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.ts
+++ b/packages/frontend/src/hooks/useSavedDashboardFiltersOverrides.ts
@@ -1,4 +1,5 @@
 import {
+    getDashboardDimensionOverrideMatches,
     type DashboardFilterRule,
     type DashboardFilterRuleOverride,
     type DashboardFilters,
@@ -48,6 +49,8 @@ export const hasSavedFiltersOverrides = (
 const ADD_SAVED_FILTER_OVERRIDE = 'ADD_SAVED_FILTER_OVERRIDE';
 const REMOVE_SAVED_FILTER_OVERRIDE = 'REMOVE_SAVED_FILTER_OVERRIDE';
 const RESET_SAVED_FILTER_OVERRIDES = 'RESET_SAVED_FILTER_OVERRIDES';
+const RECONCILE_SAVED_FILTER_OVERRIDE_IDS =
+    'RECONCILE_SAVED_FILTER_OVERRIDE_IDS';
 
 type FilterCategory = 'dimensions' | 'metrics';
 
@@ -68,10 +71,42 @@ interface ResetSavedFilterOverridesAction {
     payload: null;
 }
 
+interface ReconcileSavedFilterOverrideIdsAction {
+    type: typeof RECONCILE_SAVED_FILTER_OVERRIDE_IDS;
+    payload: DashboardFilters;
+}
+
 type Action =
     | AddSavedFilterOverrideAction
     | RemoveSavedFilterOverrideAction
-    | ResetSavedFilterOverridesAction;
+    | ResetSavedFilterOverridesAction
+    | ReconcileSavedFilterOverrideIdsAction;
+
+const reconcileDimensionOverrideIds = (
+    overrides: DashboardFilterRuleOverride[],
+    savedFilters: DashboardFilters,
+) => {
+    const matches = getDashboardDimensionOverrideMatches(
+        savedFilters.dimensions,
+        overrides,
+    );
+    let reconciledOverrides = overrides;
+
+    matches.forEach(({ savedFilterIndex, overrideIndex }) => {
+        const savedFilterId = savedFilters.dimensions[savedFilterIndex].id;
+        if (overrides[overrideIndex].id !== savedFilterId) {
+            if (reconciledOverrides === overrides) {
+                reconciledOverrides = [...overrides];
+            }
+            reconciledOverrides[overrideIndex] = {
+                ...overrides[overrideIndex],
+                id: savedFilterId,
+            };
+        }
+    });
+
+    return reconciledOverrides;
+};
 
 const reducer = (
     state: Record<keyof DashboardFilters, DashboardFilterRuleOverride[]>,
@@ -102,12 +137,24 @@ const reducer = (
         case RESET_SAVED_FILTER_OVERRIDES:
             return { ...state, dimensions: [], metrics: [] };
 
+        case RECONCILE_SAVED_FILTER_OVERRIDE_IDS: {
+            const dimensions = reconcileDimensionOverrideIds(
+                state.dimensions,
+                payload,
+            );
+            return dimensions === state.dimensions
+                ? state
+                : { ...state, dimensions };
+        }
+
         default:
             return state;
     }
 };
 
-export const useSavedDashboardFiltersOverrides = () => {
+export const useSavedDashboardFiltersOverrides = (
+    savedDashboardFilters?: DashboardFilters,
+) => {
     const { search } = useLocation();
     const { showToastWarning } = useToaster();
     const searchParams = new URLSearchParams(search);
@@ -142,6 +189,15 @@ export const useSavedDashboardFiltersOverrides = () => {
             });
         }
     }, [showToastWarning]);
+
+    useEffect(() => {
+        if (savedDashboardFilters) {
+            dispatch({
+                type: RECONCILE_SAVED_FILTER_OVERRIDE_IDS,
+                payload: savedDashboardFilters,
+            });
+        }
+    }, [savedDashboardFilters]);
 
     const addSavedFilterOverride = (
         {

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -844,7 +844,9 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         addSavedFilterOverride,
         removeSavedFilterOverride,
         resetSavedFilterOverrides,
-    } = useSavedDashboardFiltersOverrides();
+    } = useSavedDashboardFiltersOverrides(
+        (dashboard ?? embedDashboard)?.filters,
+    );
 
     // Stable key that only changes when the chart-tile mapping changes,
     // not when tiles are repositioned/resized (x/y/w/h changes).


### PR DESCRIPTION
Closes: [PROD-10711](https://linear.app/lightdash/issue/PROD-10711/editing-a-dashboard-filter-seeded-from-a-shared-url-link-adds-a)

### Description:

Shared dashboard links can contain a saved-filter override whose ID is stale after the dashboard filter is recreated or changed. Rendering already falls back to matching the override by field, but the URL override state kept the stale ID. Editing the rendered filter then appended the current ID alongside the stale one, producing duplicate URL entries and filter chips.

This change:

- reconciles stale saved-filter override IDs once the saved dashboard filters load
- shares the exact-ID-then-field matcher with `applyDimensionOverrides` so rendering and reconciliation cannot drift
- preserves reducer state identity when reconciliation is a no-op
- covers same-field filters, exact-match reservation, stale-link editing, and no-op reconciliation

Browser verification on `localhost:3000`:

- reproduced the duplicate before the fix with a stale `First name = Adam` shared-link override
- verified the stale URL ID normalizes to the current saved-filter ID
- edited Adam to Anthony and confirmed there was exactly one URL override and one `First name = Anthony` filter chip
- removed the temporary dashboard filter fixtures afterward

### Testing:

- `pnpm -F common test src/types/applyDimensionOverrides.test.ts` (24 tests)
- `pnpm -F frontend test src/hooks/useSavedDashboardFiltersOverrides.test.tsx` (5 tests)
- `pnpm -F common typecheck`
- `pnpm -F frontend typecheck`
- focused Oxlint and Oxfmt checks
- `git diff --check`

### Risk assessment:

- [ ] This is a high-risk change

Low risk: the change is limited to saved dashboard dimension-filter override matching and URL-state reconciliation, with browser and focused automated coverage.
