### PR TITLE
feat(homepage): "My space" quick action linking to the viewer's personal space

### DIFF
--- a/packages/backend/src/controllers/spaceController.ts
+++ b/packages/backend/src/controllers/spaceController.ts
@@ -2,6 +2,7 @@ import {
     AddSpaceGroupAccess,
     AddSpaceUserAccess,
     ApiErrorPayload,
+    ApiPersonalSpaceResponse,
     ApiSpaceAccessListResponse,
     ApiSpaceAsCodeListResponse,
     ApiSpaceAsCodeUpsertResponse,
@@ -44,6 +45,31 @@ import { BaseController } from './baseController';
 @Response<ApiErrorPayload>('default', 'Error')
 @Tags('Spaces')
 export class SpaceController extends BaseController {
+    /**
+     * Get the current user's personal space in a project, if they have one
+     * @summary Get personal space
+     * @param projectUuid The uuid of the project
+     * @param req
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('personal')
+    @OperationId('GetPersonalSpace')
+    async getPersonalSpace(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiPersonalSpaceResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results = await this.services
+            .getSpaceService()
+            .getPersonalSpace(projectUuid, toSessionUser(req.account));
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
     /**
      * Get details for a space in a project
      * @summary Get space

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -15,6 +15,7 @@ import {
     SpaceMemberRole,
     SpaceQuery,
     UpdateSpace,
+    type PersonalSpaceSummary,
     type SpaceSummaryBase,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
@@ -184,6 +185,28 @@ export class SpaceModel {
             projectMemberAccessRole:
                 (row.projectMemberAccessRole as SpaceMemberRole) ?? null,
         }));
+    }
+
+    async findPersonalSpace(
+        projectUuid: string,
+        userId: number,
+    ): Promise<PersonalSpaceSummary | null> {
+        const row = await this.database(SpaceTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .where(`${SpaceTableName}.is_default_user_space`, true)
+            .where(`${SpaceTableName}.created_by_user_id`, userId)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .first<PersonalSpaceSummary | undefined>({
+                uuid: `${SpaceTableName}.space_uuid`,
+                name: `${SpaceTableName}.name`,
+                slug: `${SpaceTableName}.slug`,
+            });
+        return row ?? null;
     }
 
     async getSpacesByProjectUuid(

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -941,6 +941,7 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
         updateWithCopiedPermissions: vi.fn(),
         addSpaceAccess: vi.fn(),
         get: vi.fn(),
+        findPersonalSpace: vi.fn(),
         getSpaceBreadcrumbs: vi.fn(),
         getSpaceQueries: vi.fn(),
         getSpaceDashboards: vi.fn(),
@@ -1034,6 +1035,76 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
         mockSpacePermissionService.getUserMetadataByUuids.mockResolvedValue({});
         mockSpacePermissionService.getRawDirectAccess.mockResolvedValue({
             'space-uuid': { users: [], groups: [] },
+        });
+    });
+
+    describe('getPersonalSpace', () => {
+        const mockProjectModel = { getSummary: vi.fn() };
+        const viewer = {
+            ...mockUser,
+            userId: 42,
+            organizationUuid: 'test-org-uuid',
+        } as unknown as SessionUser;
+        const withProjectModel = () =>
+            new SpaceService({
+                analytics: analyticsMock,
+                lightdashConfig: lightdashConfigMock,
+                projectModel: mockProjectModel as unknown as ProjectModel,
+                spaceModel: mockSpaceModel as unknown as SpaceModel,
+                organizationModel: {} as OrganizationModel,
+                organizationMemberProfileModel:
+                    {} as OrganizationMemberProfileModel,
+                pinnedListModel: {} as PinnedListModel,
+                spacePermissionService:
+                    mockSpacePermissionService as unknown as SpacePermissionService,
+                savedChartService: {} as SavedChartService,
+                dashboardService: {} as DashboardService,
+                appGenerateService: undefined,
+            });
+
+        test('returns the viewer’s personal space', async () => {
+            mockProjectModel.getSummary.mockResolvedValue({
+                organizationUuid: 'test-org-uuid',
+            });
+            mockSpaceModel.findPersonalSpace.mockResolvedValue({
+                uuid: 'personal-space-uuid',
+                name: 'Test User',
+                slug: 'test-user',
+            });
+
+            await expect(
+                withProjectModel().getPersonalSpace('project-uuid', viewer),
+            ).resolves.toEqual({
+                uuid: 'personal-space-uuid',
+                name: 'Test User',
+                slug: 'test-user',
+            });
+            expect(mockSpaceModel.findPersonalSpace).toHaveBeenCalledWith(
+                'project-uuid',
+                42,
+            );
+        });
+
+        test('returns null when the viewer has no personal space', async () => {
+            mockProjectModel.getSummary.mockResolvedValue({
+                organizationUuid: 'test-org-uuid',
+            });
+            mockSpaceModel.findPersonalSpace.mockResolvedValue(null);
+
+            await expect(
+                withProjectModel().getPersonalSpace('project-uuid', viewer),
+            ).resolves.toBeNull();
+        });
+
+        test('is forbidden for a project the viewer cannot see', async () => {
+            mockProjectModel.getSummary.mockResolvedValue({
+                organizationUuid: 'another-org-uuid',
+            });
+
+            await expect(
+                withProjectModel().getPersonalSpace('project-uuid', viewer),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(mockSpaceModel.findPersonalSpace).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -7,6 +7,7 @@ import {
     getHighestSpaceRole,
     NotFoundError,
     ParameterError,
+    PersonalSpaceSummary,
     SessionUser,
     Space,
     SpaceDeleteImpact,
@@ -218,6 +219,24 @@ export class SpaceService
         }
 
         return this.assembleFullSpace(spaceUuid, user);
+    }
+
+    async getPersonalSpace(
+        projectUuid: string,
+        user: SessionUser,
+    ): Promise<PersonalSpaceSummary | null> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        return this.spaceModel.findPersonalSpace(projectUuid, user.userId);
     }
 
     async getSpaceAccessList(

--- a/packages/common/src/ee/homepage/schema.test.ts
+++ b/packages/common/src/ee/homepage/schema.test.ts
@@ -43,6 +43,7 @@ const validConfig: HomepageConfig = {
                                 spaceUuid: 's1',
                                 label: 'Finance',
                             },
+                            { type: 'my-space' },
                         ],
                     },
                 },
@@ -139,6 +140,14 @@ describe('parseHomepageConfig', () => {
                                     spaceUuid: 's1',
                                     label: 'Finance',
                                 },
+                            },
+                        },
+                        {
+                            id: 'b4',
+                            type: 'cta' as const,
+                            config: {
+                                buttonLabel: 'My space',
+                                target: { type: 'my-space' as const },
                             },
                         },
                     ],

--- a/packages/common/src/ee/homepage/schema.ts
+++ b/packages/common/src/ee/homepage/schema.ts
@@ -110,6 +110,7 @@ const quickActionSchema = z
             spaceUuid: z.string(),
             label: z.string(),
         }),
+        z.object({ type: z.literal('my-space') }),
     ])
     .and(z.object({ primary: z.boolean().optional() }));
 
@@ -134,6 +135,7 @@ const ctaTargetSchema = z.discriminatedUnion('type', [
         spaceUuid: z.string(),
         label: z.string(),
     }),
+    z.object({ type: z.literal('my-space') }),
     z.object({ type: z.literal('link'), url: z.string() }),
 ]);
 

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -169,7 +169,9 @@ export type HomepageQuickActionTarget =
     | { type: 'browse-dashboards' }
     | { type: 'browse-spaces' }
     | { type: 'dashboard'; dashboardUuid: string; label: string }
-    | { type: 'space'; spaceUuid: string; label: string };
+    | { type: 'space'; spaceUuid: string; label: string }
+    /** Resolves per viewer to their personal space; hidden when they have none. */
+    | { type: 'my-space' };
 
 /** Any quick action can be promoted to the row's primary one, which renders
  * as the same chip inverted. Optional so older configs still load. */

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -202,6 +202,15 @@ export type ApiSpaceResponse = {
     results: Space;
 };
 
+/** The viewer's own personal space in a project, when the project has
+ * personal spaces enabled and one exists for them. */
+export type PersonalSpaceSummary = Pick<Space, 'uuid' | 'name' | 'slug'>;
+
+export type ApiPersonalSpaceResponse = {
+    status: 'ok';
+    results: PersonalSpaceSummary | null;
+};
+
 export type SpaceAccessListFilters = {
     searchQuery?: string;
     userUuids?: string[];

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -46,6 +46,7 @@ const BlockRenderer: FC<{
             projectUuid={projectUuid}
             itemSpan={itemSpan}
             standalone={standalone}
+            personalPlaceholders={personalPlaceholders}
         />
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.test.tsx
@@ -13,6 +13,9 @@ vi.mock('../../../../hooks/appearance/useProjectColorPalette', () => ({
 vi.mock('../../../../hooks/organization/useOrganizationBrand', () => ({
     useOrganizationBrand: () => ({ data: undefined }),
 }));
+vi.mock('../../../../hooks/useSpaces', () => ({
+    usePersonalSpace: () => ({ data: null }),
+}));
 vi.mock('../../../../hooks/useProjectRoute', () => ({
     useProjectUrlIdentifier: () => 'p1',
 }));

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CtaBlock.tsx
@@ -23,6 +23,7 @@ import { Link } from 'react-router';
 import { useProjectColorPalette } from '../../../../hooks/appearance/useProjectColorPalette';
 import { useOrganizationBrand } from '../../../../hooks/organization/useOrganizationBrand';
 import { useProjectUrlIdentifier } from '../../../../hooks/useProjectRoute';
+import { usePersonalSpace } from '../../../../hooks/useSpaces';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
 import { resolveInternalPath } from '../../../../utils/url';
@@ -37,6 +38,7 @@ const targetUrl = (
     target: HomepageCtaTarget,
     projectUuid: string,
     projectUrlIdentifier: string,
+    personalSpaceUuid: string | null,
 ): string => {
     switch (target.type) {
         case 'ask-ai':
@@ -51,6 +53,10 @@ const targetUrl = (
             return `/projects/${projectUrlIdentifier}/dashboards/${target.dashboardUuid}/view`;
         case 'space':
             return `/projects/${projectUrlIdentifier}/spaces/${target.spaceUuid}`;
+        case 'my-space':
+            return personalSpaceUuid
+                ? `/projects/${projectUrlIdentifier}/spaces/${personalSpaceUuid}`
+                : `/projects/${projectUrlIdentifier}/spaces`;
         case 'link':
             return target.url;
         default:
@@ -127,8 +133,15 @@ const CtaBanner: FC<{
     config: CtaConfig;
     projectUuid: string;
     interactive: boolean;
+    personalSpaceUuid?: string | null;
     onNavigate?: () => void;
-}> = ({ config, projectUuid, interactive, onNavigate }) => {
+}> = ({
+    config,
+    projectUuid,
+    interactive,
+    personalSpaceUuid = null,
+    onNavigate,
+}) => {
     const projectUrlIdentifier = useProjectUrlIdentifier();
     const { data: brand } = useOrganizationBrand();
     const theme = config.theme ?? 'brand';
@@ -177,7 +190,12 @@ const CtaBanner: FC<{
     if (!interactive) {
         return <div {...shared}>{body}</div>;
     }
-    const url = targetUrl(config.target, projectUuid, projectUrlIdentifier);
+    const url = targetUrl(
+        config.target,
+        projectUuid,
+        projectUrlIdentifier,
+        personalSpaceUuid,
+    );
     const internalPath =
         config.target.type === 'link' ? resolveInternalPath(url) : url;
     return internalPath === null ? (
@@ -204,9 +222,14 @@ export const CtaBlockView: FC<BlockComponentProps> = ({
     const { canAskAi } = useHomepageAiState(projectUuid);
     const { track } = useTracking();
     const config = block.type === 'cta' ? block.config : null;
-    // An ask-ai CTA is a dead button for viewers without AI — the page is
+    const personalSpace = usePersonalSpace(projectUuid, {
+        enabled: config?.target.type === 'my-space',
+    });
+    // A CTA whose target the viewer cannot use is a dead button — the page is
     // told at runtime so the row collapses instead of leaving a gap.
-    const hidden = config?.target.type === 'ask-ai' && !canAskAi;
+    const hidden =
+        (config?.target.type === 'ask-ai' && !canAskAi) ||
+        (config?.target.type === 'my-space' && !personalSpace.data);
     useReportRuntimeEmpty(block.id, hidden === true, false);
     if (!config || hidden) return null;
     return (
@@ -214,6 +237,7 @@ export const CtaBlockView: FC<BlockComponentProps> = ({
             config={config}
             projectUuid={projectUuid}
             interactive
+            personalSpaceUuid={personalSpace.data?.uuid ?? null}
             onNavigate={() =>
                 track({
                     name: EventName.HOMEPAGE_QUICK_ACTION_CLICKED,
@@ -311,7 +335,9 @@ export const CtaBlockBuild: FC<BuildComponentProps> = ({
     // A stored dashboard or space target (config-as-code) keeps rendering; the
     // picker covers the built-in destinations plus a free URL.
     const targetChoice: TargetChoice =
-        config.target.type === 'dashboard' || config.target.type === 'space'
+        config.target.type === 'dashboard' ||
+        config.target.type === 'space' ||
+        config.target.type === 'my-space'
             ? 'link'
             : config.target.type;
     return (

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.test.tsx
@@ -1,0 +1,75 @@
+import { type HomepageQuickAction } from '@lightdash/common';
+import { MantineProvider } from '@mantine/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { QuickActionCards } from './QuickActionsBlock';
+
+const { personalSpaceState } = vi.hoisted(() => ({
+    personalSpaceState: {
+        current: { data: null } as {
+            data: { uuid: string; name: string; slug: string } | null;
+        },
+    },
+}));
+
+vi.mock('../../../../hooks/useSpaces', () => ({
+    usePersonalSpace: () => personalSpaceState.current,
+}));
+vi.mock('../../../../hooks/useProjectRoute', () => ({
+    useProjectUrlIdentifier: () => 'jaffle',
+}));
+vi.mock('../../../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track: vi.fn() }),
+}));
+vi.mock('../hooks/useHomepageAiState', () => ({
+    useHomepageAiState: () => ({ canAskAi: false }),
+}));
+
+const actions: HomepageQuickAction[] = [
+    { type: 'run-query' },
+    { type: 'my-space' },
+];
+
+const renderCards = (personalPlaceholders = false) =>
+    render(
+        <MantineProvider env="test">
+            <MemoryRouter>
+                <QuickActionCards
+                    actions={actions}
+                    projectUuid="p1"
+                    personalPlaceholders={personalPlaceholders}
+                />
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+describe('QuickActionCards my-space', () => {
+    beforeEach(() => {
+        personalSpaceState.current = { data: null };
+    });
+
+    it('links to the viewer’s personal space when they have one', () => {
+        personalSpaceState.current = {
+            data: { uuid: 's-me', name: 'Me', slug: 'me' },
+        };
+        renderCards();
+        expect(screen.getByRole('link', { name: 'My space' })).toHaveAttribute(
+            'href',
+            '/projects/jaffle/spaces/s-me',
+        );
+    });
+
+    it('hides the chip when the viewer has no personal space', () => {
+        renderCards();
+        expect(screen.queryByText('My space')).not.toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Run a query' })).toBeVisible();
+    });
+
+    it('renders a non-link placeholder in view-as previews', () => {
+        renderCards(true);
+        expect(screen.getByText('My space')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('link', { name: 'My space' }),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -25,6 +25,7 @@ import {
     IconStar,
     IconStarFilled,
     IconTable,
+    IconUserCircle,
     IconX,
     type Icon,
 } from '@tabler/icons-react';
@@ -34,6 +35,7 @@ import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { useInfiniteContent } from '../../../../hooks/useContent';
 import { useProjectUrlIdentifier } from '../../../../hooks/useProjectRoute';
+import { usePersonalSpace } from '../../../../hooks/useSpaces';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
 import { useHomepageAiState } from '../hooks/useHomepageAiState';
@@ -75,6 +77,20 @@ const STATIC_ACTIONS: Record<
         description: 'Content organized by team and topic.',
         url: (projectUuid) => `/projects/${projectUuid}/spaces`,
     },
+    'my-space': {
+        icon: IconUserCircle,
+        title: 'My space',
+        description: 'Your personal space.',
+        // Resolved per viewer at render time; the chip is hidden without one.
+        url: (projectUuid) => `/projects/${projectUuid}/spaces`,
+    },
+};
+
+const STATIC_ACTION_HINTS: Partial<
+    Record<keyof typeof STATIC_ACTIONS, string>
+> = {
+    'ask-ai': 'Hidden automatically for viewers without AI access.',
+    'my-space': 'Only shown to viewers who have a personal space.',
 };
 
 const actionKey = (action: HomepageQuickAction): string => {
@@ -117,18 +133,42 @@ const actionPresentation = (
     return { ...definition, url: url(identifier) };
 };
 
+const chipClassName = (action: HomepageQuickAction): string =>
+    `${classes.quickActionChip}${
+        action.primary ? ` ${classes.quickActionChipPrimary}` : ''
+    }`;
+
 export const QuickActionCards: FC<{
     actions: HomepageQuickAction[];
     projectUuid: string;
     // Centred under the composer; left-aligned when it follows a page heading
     justify?: 'center' | 'flex-start';
-}> = ({ actions, projectUuid, justify = 'center' }) => {
+    personalPlaceholders?: boolean;
+}> = ({
+    actions,
+    projectUuid,
+    justify = 'center',
+    personalPlaceholders = false,
+}) => {
     const projectUrlIdentifier = useProjectUrlIdentifier();
     const { track } = useTracking();
     const { canAskAi } = useHomepageAiState(projectUuid);
-    const visibleActions = actions.filter(
-        (action) => action.type !== 'ask-ai' || canAskAi,
+    const hasMySpaceAction = actions.some(
+        (action) => action.type === 'my-space',
     );
+    const personalSpace = usePersonalSpace(projectUuid, {
+        enabled: hasMySpaceAction && !personalPlaceholders,
+    });
+    const visibleActions = actions.filter((action) => {
+        switch (action.type) {
+            case 'ask-ai':
+                return canAskAi;
+            case 'my-space':
+                return personalPlaceholders || !!personalSpace.data;
+            default:
+                return true;
+        }
+    });
     if (visibleActions.length === 0) return null;
     return (
         <Group gap={8} justify={justify}>
@@ -138,6 +178,34 @@ export const QuickActionCards: FC<{
                     projectUuid,
                     projectUrlIdentifier,
                 );
+                const icon = (
+                    <MantineIcon
+                        icon={presentation.icon}
+                        size={14}
+                        color={action.primary ? 'inherit' : 'ldGray.6'}
+                    />
+                );
+                if (action.type === 'my-space' && personalPlaceholders) {
+                    return (
+                        <Tooltip
+                            key={actionKey(action)}
+                            label="Resolves to each viewer's own personal space."
+                            withinPortal
+                        >
+                            <span
+                                className={chipClassName(action)}
+                                data-placeholder
+                            >
+                                {icon}
+                                {presentation.title}
+                            </span>
+                        </Tooltip>
+                    );
+                }
+                const url =
+                    action.type === 'my-space' && personalSpace.data
+                        ? `/projects/${projectUrlIdentifier}/spaces/${personalSpace.data.uuid}`
+                        : presentation.url;
                 const trackClick = () =>
                     track({
                         name: EventName.HOMEPAGE_QUICK_ACTION_CLICKED,
@@ -148,20 +216,12 @@ export const QuickActionCards: FC<{
                     <Anchor
                         key={actionKey(action)}
                         component={Link}
-                        to={presentation.url}
+                        to={url}
                         underline="never"
-                        className={`${classes.quickActionChip}${
-                            action.primary
-                                ? ` ${classes.quickActionChipPrimary}`
-                                : ''
-                        }`}
+                        className={chipClassName(action)}
                         onClick={trackClick}
                     >
-                        <MantineIcon
-                            icon={presentation.icon}
-                            size={14}
-                            color={action.primary ? 'inherit' : 'ldGray.6'}
-                        />
+                        {icon}
                         {presentation.title}
                     </Anchor>
                 );
@@ -248,6 +308,7 @@ const ContentPickerModal: FC<{
 export const QuickActionsBlockView: FC<BlockComponentProps> = ({
     block,
     projectUuid,
+    personalPlaceholders = false,
 }) => {
     if (block.type !== 'quick-actions') return null;
     // The wrapper keeps the chips Group off the column layout's `.col > *`
@@ -257,6 +318,7 @@ export const QuickActionsBlockView: FC<BlockComponentProps> = ({
             <QuickActionCards
                 actions={block.config.actions}
                 projectUuid={projectUuid}
+                personalPlaceholders={personalPlaceholders}
             />
         </Box>
     );
@@ -437,9 +499,9 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                                     />
                                 }
                                 rightSection={
-                                    type === 'ask-ai' ? (
+                                    STATIC_ACTION_HINTS[type] ? (
                                         <Tooltip
-                                            label="Hidden automatically for viewers without AI access."
+                                            label={STATIC_ACTION_HINTS[type]}
                                             withinPortal
                                         >
                                             <MantineIcon

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -631,6 +631,12 @@ a .hoverCard:hover,
         border-color 0.15s ease;
 }
 
+.quickActionChip[data-placeholder] {
+    cursor: default;
+    border-style: dashed;
+    opacity: 0.7;
+}
+
 .quickActionChip:hover {
     text-decoration: none;
     color: inherit;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
@@ -14,6 +14,9 @@ export type BlockComponentProps = {
     // stills) aren't cropped as hard. Other blocks ignore it. Optional because
     // omitting it (the default, non-standalone) is the safe current behaviour.
     standalone?: boolean;
+    // Admin view-as preview: per-viewer targets render as placeholders
+    // instead of resolving against the admin's own data.
+    personalPlaceholders?: boolean;
 };
 
 export type BuildComponentProps = BlockComponentProps & {

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -1,6 +1,7 @@
 import {
     type ApiError,
     type CreateSpace,
+    type PersonalSpaceSummary,
     type Space,
     type SpaceDeleteImpact,
     type SpaceSummary,
@@ -445,3 +446,22 @@ export const useDeleteSpaceGroupAccessMutation = (
         },
     );
 };
+
+const getPersonalSpace = async (projectUuid: string) =>
+    lightdashApi<PersonalSpaceSummary | null>({
+        url: `/projects/${projectUuid}/spaces/personal`,
+        method: 'GET',
+        body: undefined,
+    });
+
+/** The viewer's own personal space in the project, or null when the project
+ * has personal spaces off or none exists for them yet. */
+export const usePersonalSpace = (
+    projectUuid: string | undefined,
+    { enabled = true }: { enabled?: boolean } = {},
+) =>
+    useQuery<PersonalSpaceSummary | null, ApiError>({
+        queryKey: ['personal_space', projectUuid],
+        queryFn: () => getPersonalSpace(projectUuid!),
+        enabled: !!projectUuid && enabled,
+    });


### PR DESCRIPTION
Every quick action target resolved statically from the stored config, so a homepage could not send each viewer into their own personal space even when the project had personal spaces enabled. The "My space" target resolves per viewer at render time, disappears for viewers who have no personal space, and renders as a placeholder in admin view-as previews so the target user's space is never resolved on their behalf.

<img width="784" alt="View-as preview showing the My space chip as a dashed placeholder with its tooltip" src="https://github.com/user-attachments/assets/7d7da4ea-5a1f-494b-b551-fdccc6f15481" />

Closes: #28086
