### PR TITLE
feat(direct-access): add portable access blocks to content-as-code exports

### DIFF
--- a/packages/backend/src/contentAsCode/fieldCoverage/chart.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/chart.test.ts
@@ -28,6 +28,7 @@ describeContentAsCodeSchemaContract({
         'uuid',
     ],
     documentOnlyFields: [
+        'access',
         'contentType',
         'downloadedAt',
         'spaceSlug',

--- a/packages/backend/src/contentAsCode/fieldCoverage/dashboard.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/dashboard.test.ts
@@ -30,6 +30,7 @@ describeContentAsCodeSchemaContract({
         'views',
     ],
     documentOnlyFields: [
+        'access',
         'contentType',
         'downloadedAt',
         // Portable representation of the model's `owner`

--- a/packages/backend/src/contentAsCode/fieldCoverage/sql_chart.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/sql_chart.test.ts
@@ -20,6 +20,7 @@ describeContentAsCodeSchemaContract({
         'views',
     ],
     documentOnlyFields: [
+        'access',
         'contentType',
         'downloadedAt',
         'spaceSlug',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -28,6 +28,7 @@ import {
     dataAppVizSchema,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
     DEFAULT_DATA_APP_CODEX_MODEL,
+    DirectAccessResourceType,
     extractDataAppDataReferences,
     extractLockfilePackages,
     FeatureFlags,
@@ -10989,6 +10990,28 @@ export class AppGenerateService extends BaseService {
                 ? await this.spaceModel.getSpaceSummary(app.space_uuid)
                 : null;
 
+        // Direct grants ride along only for callers who could manage the
+        // app's sharing anyway — code download itself is view-gated, and a
+        // viewer must not learn who the app is shared with.
+        const canManageAppPolicy = await this.assertCanManageApp(
+            user,
+            app,
+            'not used',
+        ).then(
+            () => true,
+            () => false,
+        );
+        const appAccess = canManageAppPolicy
+            ? (
+                  await this.coderService.getPortableDirectAccessByUuid(
+                      user,
+                      app.organization_uuid,
+                      DirectAccessResourceType.APP,
+                      [app.app_id],
+                  )
+              ).get(app.app_id)
+            : undefined;
+
         const manifest = buildManifest({
             slug: app.slug,
             version: resolvedVersion,
@@ -11015,6 +11038,7 @@ export class AppGenerateService extends BaseService {
                       ),
                   }
                 : {}),
+            ...(appAccess ? { access: appAccess } : {}),
             downloadedAt: new Date().toISOString(),
         });
 

--- a/packages/backend/src/ee/services/AppGenerateService/appCode.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appCode.ts
@@ -20,6 +20,7 @@ export const buildManifest = (args: {
     vizSchema?: DataAppManifest['vizSchema'];
     externalConnections?: DataAppManifest['externalConnections'];
     spaceSlug?: DataAppManifest['spaceSlug'];
+    access?: DataAppManifest['access'];
     downloadedAt: string;
 }): DataAppManifest => ({ codeVersion: 1, ...args });
 

--- a/packages/backend/src/models/DirectAccessModel.ts
+++ b/packages/backend/src/models/DirectAccessModel.ts
@@ -1069,6 +1069,138 @@ export class DirectAccessModel {
         ];
     }
 
+    /**
+     * Batch variant of `listAssignments` for content-as-code export: one pass
+     * over the user table and one over the group table for many resources of
+     * one type. Unknown or grant-free resources simply have no entry. Callers
+     * must pass uuids they have already located and authorized within one
+     * organization — unlike `listAssignments`, no location check runs here.
+     */
+    async listAssignmentsForResources({
+        resourceType,
+        resourceUuids,
+    }: {
+        resourceType: DirectAccessResourceType;
+        resourceUuids: string[];
+    }): Promise<Record<string, DirectAccessAssignment[]>> {
+        if (resourceUuids.length === 0) {
+            return {};
+        }
+        const config = TABLE_CONFIG[resourceType];
+        const [userRows, groupRows] = await Promise.all([
+            this.database(config.userTable)
+                .innerJoin(
+                    UserTableName,
+                    `${UserTableName}.user_uuid`,
+                    `${config.userTable}.user_uuid`,
+                )
+                .leftJoin(EmailTableName, function joinPrimaryEmail() {
+                    this.on(
+                        `${EmailTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOnVal(`${EmailTableName}.is_primary`, true);
+                })
+                .whereIn(
+                    `${config.userTable}.${config.resourceColumn}`,
+                    resourceUuids,
+                )
+                .select<
+                    {
+                        resourceUuid: string;
+                        userUuid: string;
+                        firstName: string;
+                        lastName: string;
+                        email: string | null;
+                        role: SpaceMemberRole;
+                        grantedByUserUuid: string | null;
+                        createdAt: Date;
+                        updatedAt: Date;
+                    }[]
+                >({
+                    resourceUuid: `${config.userTable}.${config.resourceColumn}`,
+                    userUuid: `${UserTableName}.user_uuid`,
+                    firstName: `${UserTableName}.first_name`,
+                    lastName: `${UserTableName}.last_name`,
+                    email: `${EmailTableName}.email`,
+                    role: `${config.userTable}.space_role`,
+                    grantedByUserUuid: `${config.userTable}.granted_by_user_uuid`,
+                    createdAt: `${config.userTable}.created_at`,
+                    updatedAt: `${config.userTable}.updated_at`,
+                })
+                .orderBy([
+                    { column: `${config.userTable}.created_at`, order: 'asc' },
+                    { column: `${UserTableName}.user_uuid`, order: 'asc' },
+                ]),
+            this.database(config.groupTable)
+                .innerJoin(
+                    GroupTableName,
+                    `${GroupTableName}.group_uuid`,
+                    `${config.groupTable}.group_uuid`,
+                )
+                .whereIn(
+                    `${config.groupTable}.${config.resourceColumn}`,
+                    resourceUuids,
+                )
+                .select<
+                    {
+                        resourceUuid: string;
+                        groupUuid: string;
+                        name: string;
+                        role: SpaceMemberRole;
+                        grantedByUserUuid: string | null;
+                        createdAt: Date;
+                        updatedAt: Date;
+                    }[]
+                >({
+                    resourceUuid: `${config.groupTable}.${config.resourceColumn}`,
+                    groupUuid: `${GroupTableName}.group_uuid`,
+                    name: `${GroupTableName}.name`,
+                    role: `${config.groupTable}.space_role`,
+                    grantedByUserUuid: `${config.groupTable}.granted_by_user_uuid`,
+                    createdAt: `${config.groupTable}.created_at`,
+                    updatedAt: `${config.groupTable}.updated_at`,
+                })
+                .orderBy([
+                    { column: `${config.groupTable}.created_at`, order: 'asc' },
+                    { column: `${GroupTableName}.group_uuid`, order: 'asc' },
+                ]),
+        ]);
+
+        const assignments: Record<string, DirectAccessAssignment[]> = {};
+        const push = (uuid: string, assignment: DirectAccessAssignment) => {
+            assignments[uuid] = [...(assignments[uuid] ?? []), assignment];
+        };
+        userRows.forEach((row) => {
+            push(row.resourceUuid, {
+                principal: {
+                    type: DirectAccessPrincipalType.USER,
+                    userUuid: row.userUuid,
+                    firstName: row.firstName,
+                    lastName: row.lastName,
+                    email: row.email,
+                },
+                role: row.role,
+                grantedByUserUuid: row.grantedByUserUuid,
+                createdAt: row.createdAt,
+                updatedAt: row.updatedAt,
+            });
+        });
+        groupRows.forEach((row) => {
+            push(row.resourceUuid, {
+                principal: {
+                    type: DirectAccessPrincipalType.GROUP,
+                    groupUuid: row.groupUuid,
+                    name: row.name,
+                },
+                role: row.role,
+                grantedByUserUuid: row.grantedByUserUuid,
+                createdAt: row.createdAt,
+                updatedAt: row.updatedAt,
+            });
+        });
+        return assignments;
+    }
+
     private static async validatePrincipal(
         trx: Knex,
         context: DirectAccessMutationContext,

--- a/packages/backend/src/services/CoderService/CoderService.contentVerification.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.contentVerification.test.ts
@@ -76,6 +76,7 @@ vi.spyOn(analyticsMock, 'track');
 
 const buildService = () =>
     new CoderService({
+        directAccessService: {} as never,
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
         projectModel: {} as unknown as ProjectModel,

--- a/packages/backend/src/services/CoderService/CoderService.directAccessExport.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.directAccessExport.test.ts
@@ -1,0 +1,196 @@
+import {
+    DirectAccessPrincipalType,
+    DirectAccessResourceType,
+    SpaceMemberRole,
+    type DirectAccessAssignment,
+    type SessionUser,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { CoderService } from './CoderService';
+
+const ORG_UUID = 'org-uuid';
+const user = { userUuid: 'exporter-uuid' } as SessionUser;
+
+const userAssignment = (
+    overrides: Partial<{
+        userUuid: string;
+        email: string | null;
+        role: SpaceMemberRole;
+    }> = {},
+): DirectAccessAssignment => ({
+    principal: {
+        type: DirectAccessPrincipalType.USER,
+        userUuid: overrides.userUuid ?? 'user-1',
+        firstName: 'Vera',
+        lastName: 'Viewer',
+        email:
+            overrides.email === undefined ? 'vera@acme.com' : overrides.email,
+    },
+    role: overrides.role ?? SpaceMemberRole.VIEWER,
+    grantedByUserUuid: 'granter-uuid',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-02'),
+});
+
+const groupAssignment = (
+    overrides: Partial<{
+        groupUuid: string;
+        name: string;
+        role: SpaceMemberRole;
+    }> = {},
+): DirectAccessAssignment => ({
+    principal: {
+        type: DirectAccessPrincipalType.GROUP,
+        groupUuid: overrides.groupUuid ?? 'group-1',
+        name: overrides.name ?? 'Analysts',
+    },
+    role: overrides.role ?? SpaceMemberRole.EDITOR,
+    grantedByUserUuid: 'granter-uuid',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-02'),
+});
+
+type Setup = {
+    policies: Record<string, DirectAccessAssignment[]>;
+    members?: { userUuid: string; email: string }[];
+    groups?: { uuid: string; name: string }[];
+};
+
+const buildService = ({ policies, members, groups }: Setup) =>
+    new CoderService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: {} as never,
+        savedChartModel: {} as never,
+        savedSqlModel: {} as never,
+        appModel: {} as never,
+        dashboardModel: {} as never,
+        spaceModel: {} as never,
+        schedulerModel: {} as never,
+        schedulerService: {} as never,
+        savedChartService: {} as never,
+        dashboardService: {} as never,
+        schedulerClient: {} as never,
+        promoteService: {} as never,
+        spacePermissionService: {} as never,
+        contentAsCodeSnapshotModel: {} as never,
+        contentAsCodeProjectSettingsModel: {} as never,
+        contentVerificationModel: {} as never,
+        groupsModel: {
+            find: vi.fn(async ({ name }: { name: string }) => ({
+                data: (
+                    groups ?? [{ uuid: 'group-1', name: 'Analysts' }]
+                ).filter((group) => group.name === name),
+            })),
+        } as never,
+        organizationMemberProfileModel: {
+            findOrganizationMembersByEmails: vi.fn(
+                async () =>
+                    members ?? [{ userUuid: 'user-1', email: 'vera@acme.com' }],
+            ),
+        } as never,
+        userModel: {} as never,
+        directAccessService: {
+            listPoliciesForExport: vi.fn(async () => policies),
+        } as never,
+    });
+
+describe('CoderService.getPortableDirectAccessByUuid', () => {
+    it('maps portable users and groups deterministically without internal identifiers', async () => {
+        const service = buildService({
+            policies: {
+                'chart-1': [
+                    groupAssignment({ role: SpaceMemberRole.ADMIN }),
+                    userAssignment({
+                        userUuid: 'user-2',
+                        email: 'Zoe@acme.com',
+                        role: SpaceMemberRole.EDITOR,
+                    }),
+                    userAssignment(),
+                ],
+            },
+            members: [
+                { userUuid: 'user-1', email: 'vera@acme.com' },
+                { userUuid: 'user-2', email: 'zoe@acme.com' },
+            ],
+        });
+
+        const result = await service.getPortableDirectAccessByUuid(
+            user,
+            ORG_UUID,
+            DirectAccessResourceType.CHART,
+            ['chart-1'],
+        );
+
+        expect(result.get('chart-1')).toEqual({
+            users: [
+                { email: 'vera@acme.com', role: SpaceMemberRole.VIEWER },
+                { email: 'zoe@acme.com', role: SpaceMemberRole.EDITOR },
+            ],
+            groups: [{ name: 'Analysts', role: SpaceMemberRole.ADMIN }],
+        });
+    });
+
+    it('omits the whole policy when any user lacks a portable identity', async () => {
+        const service = buildService({
+            policies: {
+                'no-email': [userAssignment({ email: null })],
+                'ambiguous-email': [userAssignment()],
+                portable: [userAssignment()],
+            },
+            members: [
+                { userUuid: 'user-1', email: 'vera@acme.com' },
+                { userUuid: 'user-9', email: 'vera@acme.com' },
+            ],
+        });
+
+        const result = await service.getPortableDirectAccessByUuid(
+            user,
+            ORG_UUID,
+            DirectAccessResourceType.DASHBOARD,
+            ['no-email', 'ambiguous-email', 'portable'],
+        );
+
+        // The duplicated email poisons every policy that references it.
+        expect(result.size).toBe(0);
+    });
+
+    it('omits the whole policy when a group name is not unique or does not match', async () => {
+        const service = buildService({
+            policies: {
+                'dup-group': [groupAssignment()],
+                'mismatched-group': [
+                    groupAssignment({ groupUuid: 'group-2', name: 'Ops' }),
+                ],
+            },
+            groups: [
+                { uuid: 'group-1', name: 'Analysts' },
+                { uuid: 'group-9', name: 'Analysts' },
+                { uuid: 'group-other', name: 'Ops' },
+            ],
+        });
+
+        const result = await service.getPortableDirectAccessByUuid(
+            user,
+            ORG_UUID,
+            DirectAccessResourceType.SQL_CHART,
+            ['dup-group', 'mismatched-group'],
+        );
+
+        expect(result.size).toBe(0);
+    });
+
+    it('returns no entries when the feature returns no policies', async () => {
+        const service = buildService({ policies: {} });
+
+        const result = await service.getPortableDirectAccessByUuid(
+            user,
+            ORG_UUID,
+            DirectAccessResourceType.APP,
+            ['app-1'],
+        );
+
+        expect(result.size).toBe(0);
+    });
+});

--- a/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
@@ -282,6 +282,7 @@ const buildService = ({
     };
 
     const service = new CoderService({
+        directAccessService: {} as never,
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
         projectModel: {

--- a/packages/backend/src/services/CoderService/CoderService.snapshotGating.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.snapshotGating.test.ts
@@ -51,6 +51,7 @@ const buildService = () => {
     const dashboardGet = vi.fn(async () => dashboardDao);
     const savedSqlFind = vi.fn(async () => []);
     const service = new CoderService({
+        directAccessService: {} as AnyType,
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
         projectModel: {} as AnyType,

--- a/packages/backend/src/services/CoderService/CoderService.spaces.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.spaces.test.ts
@@ -192,6 +192,7 @@ const buildService = ({
         findSessionUserAndOrgByUuid: vi.fn(async () => refreshedUser),
     };
     const service = new CoderService({
+        directAccessService: {} as AnyType,
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
         projectModel: projectModel as AnyType,

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -287,6 +287,7 @@ describe('CoderService', () => {
             updatedAt: new Date('2026-08-27T00:00:00Z'),
         };
         const service = new CoderService({
+            directAccessService: {} as AnyType,
             savedChartModel: {
                 get: vi.fn().mockResolvedValue(publishedChart),
             },
@@ -1064,6 +1065,7 @@ describe('CoderService', () => {
     describe('convertTileWithSlugsToUuids', () => {
         it('should allow chart tiles with null chartSlug', async () => {
             const service = new CoderService({
+                directAccessService: {} as AnyType,
                 analytics: {} as AnyType,
                 contentAsCodeSnapshotModel: {
                     upsert: vi.fn(),
@@ -1153,6 +1155,7 @@ describe('CoderService', () => {
 
         it('warns when a chart tile slug does not resolve in the project', async () => {
             const service = new CoderService({
+                directAccessService: {} as AnyType,
                 analytics: {} as AnyType,
                 contentAsCodeSnapshotModel: {
                     upsert: vi.fn(),
@@ -1221,6 +1224,7 @@ describe('CoderService', () => {
 
         it('resolves portable tab slugs and still accepts legacy tab UUIDs', async () => {
             const service = new CoderService({
+                directAccessService: {} as AnyType,
                 analytics: {} as AnyType,
                 contentAsCodeSnapshotModel: {
                     upsert: vi.fn(),
@@ -1284,6 +1288,7 @@ describe('CoderService', () => {
         const buildServiceWithApps = (apps: AppRow[]) => {
             appModelMock = buildAppModelMock(apps);
             return new CoderService({
+                directAccessService: {} as AnyType,
                 analytics: {} as AnyType,
                 contentAsCodeSnapshotModel: {
                     upsert: vi.fn(),
@@ -1407,6 +1412,7 @@ describe('CoderService', () => {
 
         it('resolves a chart tile and a data app tile together (main return path)', async () => {
             const service = new CoderService({
+                directAccessService: {} as AnyType,
                 analytics: {} as AnyType,
                 contentAsCodeSnapshotModel: {
                     upsert: vi.fn(),
@@ -1480,6 +1486,7 @@ describe('CoderService', () => {
 
         it('resolves a historical chart slug to the existing chart UUID', async () => {
             const service = new CoderService({
+                directAccessService: {} as AnyType,
                 analytics: {} as AnyType,
                 contentAsCodeSnapshotModel: {
                     upsert: vi.fn(),
@@ -2094,6 +2101,7 @@ describe('content-as-code access split', () => {
     } as AnyType;
 
     const service = new CoderService({
+        directAccessService: {} as AnyType,
         projectModel: {
             get: vi.fn().mockResolvedValue({
                 projectUuid: 'project-uuid',

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -45,6 +45,8 @@ import {
     DashboardTileTarget,
     DashboardTileTypes,
     DimensionType,
+    DirectAccessPrincipalType,
+    DirectAccessResourceType,
     Explore,
     ExploreType,
     ForbiddenError,
@@ -89,10 +91,12 @@ import {
     UpdatedByUser,
     validateEmail,
     VirtualViewAsCode,
+    type ContentAsCodeDirectAccess,
     type ContentAsCodeProjectSettings,
     type ContentAsCodeSettingsStamp,
     type ContentVerificationInfo,
     type DashboardTileWithSlug,
+    type DirectAccessAssignment,
     type Filters,
     type GoogleSheetsSyncAsCode,
     type SpaceSummaryBase,
@@ -126,6 +130,7 @@ import { UserModel } from '../../models/UserModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { BaseService } from '../BaseService';
 import { DashboardService } from '../DashboardService/DashboardService';
+import type { DirectAccessService } from '../DirectAccess/DirectAccessService';
 import { ProjectService } from '../ProjectService/ProjectService';
 import { PromoteService } from '../PromoteService/PromoteService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
@@ -199,6 +204,7 @@ type CoderServiceArguments = {
     groupsModel: GroupsModel;
     organizationMemberProfileModel: OrganizationMemberProfileModel;
     userModel: UserModel;
+    directAccessService: DirectAccessService;
 };
 
 type UpsertContentAsCodeOptions = {
@@ -271,6 +277,8 @@ export class CoderService extends BaseService {
         return getChartContentAsCodePermissionChecks(nextChart, currentChart);
     }
 
+    directAccessService: DirectAccessService;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -294,6 +302,7 @@ export class CoderService extends BaseService {
         groupsModel,
         organizationMemberProfileModel,
         userModel,
+        directAccessService,
     }: CoderServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -317,6 +326,7 @@ export class CoderService extends BaseService {
         this.contentVerificationModel = contentVerificationModel;
         this.projectService = projectService;
         this.groupsModel = groupsModel;
+        this.directAccessService = directAccessService;
         this.organizationMemberProfileModel = organizationMemberProfileModel;
         this.userModel = userModel;
         this.virtualViewCoder = new VirtualViewCoder({
@@ -1079,6 +1089,139 @@ export class CoderService extends BaseService {
             }),
         );
         return portableGroups.some((portable) => !portable);
+    }
+
+    /**
+     * Portable access blocks for one resource type, keyed by resource uuid.
+     * Mirrors the space export rules: principals are identified by unique
+     * organization email or unique group name, and a policy containing any
+     * principal without a portable identity is omitted entirely — a file
+     * never half-represents a policy. Resources without direct assignments
+     * get no entry, so their files carry no access block and an upload of
+     * that file leaves the target environment's policy untouched.
+     *
+     * Public because the data-app bundle export (AppGenerateService) shares
+     * it — app manifests carry the same portable access block.
+     */
+    async getPortableDirectAccessByUuid(
+        user: SessionUser,
+        organizationUuid: string,
+        resourceType: DirectAccessResourceType,
+        resourceUuids: string[],
+    ): Promise<Map<string, ContentAsCodeDirectAccess>> {
+        const policies = await this.directAccessService.listPoliciesForExport(
+            { userUuid: user.userUuid, organizationUuid },
+            resourceType,
+            resourceUuids,
+        );
+        const assignmentsByUuid = Object.entries(policies);
+        if (assignmentsByUuid.length === 0) {
+            return new Map();
+        }
+
+        const allAssignments = assignmentsByUuid.flatMap(
+            ([, assignments]) => assignments,
+        );
+        const userEmails = [
+            ...new Set(
+                allAssignments.flatMap(({ principal }) =>
+                    principal.type === DirectAccessPrincipalType.USER &&
+                    principal.email !== null
+                        ? [principal.email.toLowerCase()]
+                        : [],
+                ),
+            ),
+        ];
+        const members =
+            await this.organizationMemberProfileModel.findOrganizationMembersByEmails(
+                organizationUuid,
+                userEmails,
+            );
+        const membersByUuid = new Map(
+            members.map((member) => [member.userUuid, member]),
+        );
+        const memberEmailCounts = members.reduce<Map<string, number>>(
+            (counts, member) => {
+                const email = member.email.toLowerCase();
+                counts.set(email, (counts.get(email) ?? 0) + 1);
+                return counts;
+            },
+            new Map(),
+        );
+
+        const uniqueGroups = [
+            ...new Map(
+                allAssignments.flatMap(({ principal }) =>
+                    principal.type === DirectAccessPrincipalType.GROUP
+                        ? [[principal.groupUuid, principal] as const]
+                        : [],
+                ),
+            ).values(),
+        ];
+        const portableGroupUuids = new Set(
+            (
+                await Promise.all(
+                    uniqueGroups.map(async (group) => {
+                        const matches = (
+                            await this.groupsModel.find({
+                                organizationUuid,
+                                name: group.name,
+                            })
+                        ).data;
+                        return matches.length === 1 &&
+                            matches[0].uuid === group.groupUuid
+                            ? group.groupUuid
+                            : null;
+                    }),
+                )
+            ).filter((groupUuid): groupUuid is string => groupUuid !== null),
+        );
+
+        const isPortable = (assignment: DirectAccessAssignment): boolean => {
+            const { principal } = assignment;
+            if (principal.type === DirectAccessPrincipalType.USER) {
+                if (principal.email === null) return false;
+                const normalizedEmail = principal.email.toLowerCase();
+                const member = membersByUuid.get(principal.userUuid);
+                return (
+                    member !== undefined &&
+                    member.email.toLowerCase() === normalizedEmail &&
+                    memberEmailCounts.get(normalizedEmail) === 1
+                );
+            }
+            return portableGroupUuids.has(principal.groupUuid);
+        };
+
+        return assignmentsByUuid.reduce<Map<string, ContentAsCodeDirectAccess>>(
+            (map, [resourceUuid, assignments]) => {
+                if (
+                    assignments.length === 0 ||
+                    !assignments.every(isPortable)
+                ) {
+                    return map;
+                }
+                const users = assignments.flatMap(({ principal, role }) =>
+                    principal.type === DirectAccessPrincipalType.USER
+                        ? [{ email: principal.email!.toLowerCase(), role }]
+                        : [],
+                );
+                const groups = assignments.flatMap(({ principal, role }) =>
+                    principal.type === DirectAccessPrincipalType.GROUP
+                        ? [{ name: principal.name, role }]
+                        : [],
+                );
+                map.set(resourceUuid, {
+                    users: users.sort((left, right) =>
+                        left.email.localeCompare(right.email),
+                    ),
+                    groups: groups.sort((left, right) =>
+                        left.name.localeCompare(right.name),
+                    ),
+                });
+                return map;
+            },
+            new Map(),
+        );
     }
 
     async upsertSpace(
@@ -2057,6 +2200,7 @@ export class CoderService extends BaseService {
             dashboardIds,
             offset,
             languageMap,
+            { includeAccess: true },
         );
     }
 
@@ -2097,6 +2241,10 @@ export class CoderService extends BaseService {
         dashboardIds: string[] | undefined,
         offset?: number,
         languageMap?: boolean,
+        // Access blocks are export-only: the AI/MCP read path enforces
+        // per-item view access, which is not enough to see who a resource
+        // is shared with.
+        { includeAccess = false }: { includeAccess?: boolean } = {},
     ): Promise<ApiDashboardAsCodeListResponse['results']> {
         const project = await this.projectModel.get(projectUuid);
         if (!project) {
@@ -2183,10 +2331,29 @@ export class CoderService extends BaseService {
             ),
         );
 
+        const dashboardAccessByUuid = includeAccess
+            ? await this.getPortableDirectAccessByUuid(
+                  user,
+                  project.organizationUuid,
+                  DirectAccessResourceType.DASHBOARD,
+                  dashboardsWithAccess.map((dashboard) => dashboard.uuid),
+              )
+            : new Map<string, ContentAsCodeDirectAccess>();
+        const dashboardsWithPolicies = transformedDashboards.map(
+            (dashboard, index) => {
+                const access = dashboardAccessByUuid.get(
+                    dashboardsWithAccess[index].uuid,
+                );
+                return access === undefined
+                    ? dashboard
+                    : { ...dashboard, access };
+            },
+        );
+
         return {
-            dashboards: transformedDashboards,
+            dashboards: dashboardsWithPolicies,
             languageMap: languageMap
-                ? transformedDashboards.map((dashboard) => {
+                ? dashboardsWithPolicies.map((dashboard) => {
                       try {
                           return new DashboardAsCodeInternalization().getLanguageMap(
                               dashboard,
@@ -2367,6 +2534,7 @@ export class CoderService extends BaseService {
             chartIds,
             offset,
             languageMap,
+            { includeAccess: true },
         );
     }
 
@@ -2386,6 +2554,10 @@ export class CoderService extends BaseService {
         chartIds?: string[],
         offset?: number,
         languageMap?: boolean,
+        // Access blocks are export-only: the AI/MCP read path enforces
+        // per-item view access, which is not enough to see who a resource
+        // is shared with.
+        { includeAccess = false }: { includeAccess?: boolean } = {},
     ): Promise<ApiChartAsCodeListResponse['results']> {
         const project = await this.projectModel.get(projectUuid);
         if (!project) {
@@ -2491,6 +2663,23 @@ export class CoderService extends BaseService {
             dataAppVizSlugByUuid,
         );
 
+        // Dashboard-owned chart definitions are not grantable, so only
+        // independently saved charts can carry an access block.
+        const chartAccessByUuid = includeAccess
+            ? await this.getPortableDirectAccessByUuid(
+                  user,
+                  project.organizationUuid,
+                  DirectAccessResourceType.CHART,
+                  charts.flatMap((chart) =>
+                      chart.dashboardUuid ? [] : [chart.uuid],
+                  ),
+              )
+            : new Map<string, ContentAsCodeDirectAccess>();
+        const chartsWithPolicies = transformedCharts.map((chart, index) => {
+            const access = chartAccessByUuid.get(charts[index].uuid);
+            return access === undefined ? chart : { ...chart, access };
+        });
+
         const missingIds = CoderService.getMissingIds(
             chartIds,
             charts,
@@ -2498,9 +2687,9 @@ export class CoderService extends BaseService {
         );
 
         return {
-            charts: transformedCharts,
+            charts: chartsWithPolicies,
             languageMap: languageMap
-                ? transformedCharts.map((chart) => {
+                ? chartsWithPolicies.map((chart) => {
                       try {
                           return new ChartAsCodeInternalization().getLanguageMap(
                               chart,
@@ -2698,6 +2887,28 @@ export class CoderService extends BaseService {
             ),
         );
 
+        // getSqlCharts is the export path itself (gated above), so access
+        // blocks always ride along. Dashboard-owned SQL charts never reach
+        // this listing (the space join excludes them) and are not grantable.
+        const sqlChartAccessByUuid = await this.getPortableDirectAccessByUuid(
+            user,
+            project.organizationUuid,
+            DirectAccessResourceType.SQL_CHART,
+            paginatedSqlChartRows.flatMap((row) =>
+                row.space_uuid ? [row.saved_sql_uuid] : [],
+            ),
+        );
+        const sqlChartsWithPolicies = transformedSqlCharts.map(
+            (sqlChart, index) => {
+                const access = sqlChartAccessByUuid.get(
+                    paginatedSqlChartRows[index].saved_sql_uuid,
+                );
+                return access === undefined
+                    ? sqlChart
+                    : { ...sqlChart, access };
+            },
+        );
+
         // Calculate missing IDs
         const foundSlugs = new Set(sqlChartRows.map((c) => c.slug));
         const missingIds = chartIds
@@ -2705,7 +2916,7 @@ export class CoderService extends BaseService {
             : [];
 
         return {
-            sqlCharts: transformedSqlCharts,
+            sqlCharts: sqlChartsWithPolicies,
             missingIds,
             spaces: CoderService.transformSpaces(
                 sqlChartSpaces.filter((s) =>

--- a/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
@@ -67,6 +67,7 @@ const dashboardAsCode = {
 
 const buildService = () =>
     new CoderService({
+        directAccessService: {} as AnyType,
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
         projectModel: {

--- a/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
@@ -80,6 +80,7 @@ const buildService = (
     ),
 ) =>
     new CoderService({
+        directAccessService: {} as AnyType,
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
         projectModel: {

--- a/packages/backend/src/services/CoderService/CoderService.virtualViews.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.virtualViews.test.ts
@@ -98,6 +98,7 @@ const buildService = (existing: Explore | null = virtualView) => {
         projectModel: projectModel as never,
         savedChartModel: {} as never,
         savedSqlModel: {} as never,
+        directAccessService: {} as never,
         appModel: {} as never,
         dashboardModel: {} as never,
         spaceModel: {} as never,

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.ts
@@ -326,6 +326,33 @@ export class DirectAccessService extends BaseService {
         };
     }
 
+    /**
+     * Batch policy read for content-as-code export. The caller owns
+     * authorization (the export endpoints gate on ContentAsCode view, the
+     * same permission that already exports space access blocks) and must pass
+     * uuids located within the given project. Feature off returns no
+     * policies, so exports written while sharing is disabled simply omit
+     * access blocks instead of failing.
+     */
+    async listPoliciesForExport(
+        user: { userUuid: UUID; organizationUuid: UUID },
+        resourceType: DirectAccessResourceType,
+        resourceUuids: UUID[],
+    ): Promise<Record<string, DirectAccessAssignment[]>> {
+        if (resourceUuids.length === 0) {
+            return {};
+        }
+        const enabled =
+            await this.directAccessFeatureGate.isEnabledForUser(user);
+        if (!enabled) {
+            return {};
+        }
+        return this.directAccessModel.listAssignmentsForResources({
+            resourceType,
+            resourceUuids,
+        });
+    }
+
     async listAssignments(
         account: RegisteredAccount,
         projectUuid: UUID,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1410,6 +1410,7 @@ export class ServiceRepository
                     organizationMemberProfileModel:
                         this.models.getOrganizationMemberProfileModel(),
                     userModel: this.models.getUserModel(),
+                    directAccessService: this.getDirectAccessService(),
                 }),
         );
     }

--- a/packages/common/src/ee/apps/code.ts
+++ b/packages/common/src/ee/apps/code.ts
@@ -1,5 +1,6 @@
 import { parse as parseYaml } from 'yaml';
 import { type ApiSuccess } from '../../types/api/success';
+import { type ContentAsCodeDirectAccess } from '../../types/contentAsCode/directAccess';
 import { type DataAppTemplate, type DataAppVizSchema } from './types';
 
 export const currentDataAppCodeVersion = 1 as const;
@@ -50,6 +51,12 @@ export type DataAppManifest = {
     // creating the space if missing; absent → personal app on download,
     // placement left untouched on upload (also covers pre-field bundles).
     spaceSlug?: string;
+    // Direct user/group grants on the app, referenced by organization email /
+    // group name (same portable identity as space access blocks). Present
+    // (including empty users+groups) → upload atomically replaces the app's
+    // direct policy; absent → the existing policy is left untouched (bundles
+    // downloaded before this field, or exports made while sharing is off).
+    access?: ContentAsCodeDirectAccess;
     downloadedAt: string; // ISO
     scaffoldingVersion?: string; // CLI/SDK version the vendored scaffolding came from (Phase 2)
 };

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -930,6 +930,51 @@
                 }
             ]
         },
+        "ContentAsCodeDirectAccess": {
+            "description": "Portable direct user/group grants on a single resource. Mirrors the space\naccess block: principals are identified by organization email or group name,\nnever by internal identifiers. Inherited and effective roles are never part\nof this shape — it reflects stored direct policy only.\n\nOn upload: omission leaves the resource's existing direct policy unchanged;\na present block (including empty `users` and `groups`) atomically replaces\nthe whole policy.",
+            "properties": {
+                "groups": {
+                    "items": {
+                        "$ref": "#/$defs/ContentAsCodeDirectAccessGroup"
+                    },
+                    "type": "array"
+                },
+                "users": {
+                    "items": {
+                        "$ref": "#/$defs/ContentAsCodeDirectAccessUser"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["groups", "users"],
+            "type": "object"
+        },
+        "ContentAsCodeDirectAccessGroup": {
+            "properties": {
+                "name": {
+                    "description": "Exact, case-sensitive organization group name.",
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/$defs/SpaceMemberRole"
+                }
+            },
+            "required": ["role", "name"],
+            "type": "object"
+        },
+        "ContentAsCodeDirectAccessUser": {
+            "properties": {
+                "email": {
+                    "description": "Primary email of a human organization member.",
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/$defs/SpaceMemberRole"
+                }
+            },
+            "required": ["role", "email"],
+            "type": "object"
+        },
         "ContentAsCodeType.CHART": {
             "enum": ["chart"],
             "type": "string"
@@ -3368,6 +3413,10 @@
             "required": ["descending", "fieldId"],
             "type": "object"
         },
+        "SpaceMemberRole": {
+            "enum": ["viewer", "editor", "admin"],
+            "type": "string"
+        },
         "SqlTableCalculation": {
             "allOf": [
                 {
@@ -3904,6 +3953,10 @@
     "additionalProperties": false,
     "description": "From T, pick a set of properties whose keys are in the union K",
     "properties": {
+        "access": {
+            "$ref": "#/$defs/ContentAsCodeDirectAccess",
+            "description": "Direct user/group grants on this chart. Only independently saved charts\ncarry one — dashboard-owned chart definitions are not grantable.\nOmission leaves the existing policy unchanged on upload."
+        },
         "chartConfig": {
             "discriminator": {
                 "propertyName": "type"

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -183,6 +183,51 @@
                 }
             ]
         },
+        "ContentAsCodeDirectAccess": {
+            "description": "Portable direct user/group grants on a single resource. Mirrors the space\naccess block: principals are identified by organization email or group name,\nnever by internal identifiers. Inherited and effective roles are never part\nof this shape — it reflects stored direct policy only.\n\nOn upload: omission leaves the resource's existing direct policy unchanged;\na present block (including empty `users` and `groups`) atomically replaces\nthe whole policy.",
+            "properties": {
+                "groups": {
+                    "items": {
+                        "$ref": "#/$defs/ContentAsCodeDirectAccessGroup"
+                    },
+                    "type": "array"
+                },
+                "users": {
+                    "items": {
+                        "$ref": "#/$defs/ContentAsCodeDirectAccessUser"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["groups", "users"],
+            "type": "object"
+        },
+        "ContentAsCodeDirectAccessGroup": {
+            "properties": {
+                "name": {
+                    "description": "Exact, case-sensitive organization group name.",
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/$defs/SpaceMemberRole"
+                }
+            },
+            "required": ["role", "name"],
+            "type": "object"
+        },
+        "ContentAsCodeDirectAccessUser": {
+            "properties": {
+                "email": {
+                    "description": "Primary email of a human organization member.",
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/$defs/SpaceMemberRole"
+                }
+            },
+            "required": ["role", "email"],
+            "type": "object"
+        },
         "ContentAsCodeType.DASHBOARD": {
             "enum": ["dashboard"],
             "type": "string"
@@ -1329,6 +1374,10 @@
             "properties": {},
             "type": "object"
         },
+        "SpaceMemberRole": {
+            "enum": ["viewer", "editor", "admin"],
+            "type": "string"
+        },
         "TimeFrames": {
             "enum": [
                 "RAW",
@@ -1362,6 +1411,10 @@
     "additionalProperties": false,
     "description": "From T, pick a set of properties whose keys are in the union K",
     "properties": {
+        "access": {
+            "$ref": "#/$defs/ContentAsCodeDirectAccess",
+            "description": "Direct user/group grants. Omission leaves the existing policy unchanged on upload."
+        },
         "config": {
             "$ref": "#/$defs/DashboardConfig"
         },

--- a/packages/common/src/types/contentAsCode/charts.ts
+++ b/packages/common/src/types/contentAsCode/charts.ts
@@ -20,6 +20,7 @@ import type {
 } from '../savedCharts';
 import type { SqlChart } from '../sqlRunner';
 import type { ContentAsCodeType, FiltersInput } from './core';
+import type { ContentAsCodeDirectAccess } from './directAccess';
 import type { SpaceAsCode } from './spaces';
 
 /**
@@ -104,6 +105,12 @@ export type ChartAsCode = Omit<
     verified?: boolean;
     /** Detailed verification info (who/when). Read-only; ignored on upload. */
     verification?: ContentVerificationInfo | null;
+    /**
+     * Direct user/group grants on this chart. Only independently saved charts
+     * carry one — dashboard-owned chart definitions are not grantable.
+     * Omission leaves the existing policy unchanged on upload.
+     */
+    access?: ContentAsCodeDirectAccess;
 };
 
 // SQL Charts are stored separately from regular saved charts
@@ -117,6 +124,8 @@ export type SqlChartAsCode = Pick<
     spaceSlug: string;
     updatedAt?: Date;
     downloadedAt?: Date;
+    /** Direct user/group grants. Omission leaves the existing policy unchanged on upload. */
+    access?: ContentAsCodeDirectAccess;
 };
 
 export type ApiChartAsCodeListResponse = {

--- a/packages/common/src/types/contentAsCode/dashboards.ts
+++ b/packages/common/src/types/contentAsCode/dashboards.ts
@@ -16,6 +16,7 @@ import type {
 import type { DashboardFilterRule } from '../filter';
 import type { PromotionChanges } from '../promotion';
 import type { ContentAsCodeType } from './core';
+import type { ContentAsCodeDirectAccess } from './directAccess';
 import type { SpaceAsCode } from './spaces';
 
 type DashboardTileAsCodeBase = {
@@ -163,6 +164,8 @@ export type DashboardAsCode = Omit<
     verified?: boolean;
     /** Detailed verification info (who/when). Read-only; ignored on upload. */
     verification?: ContentVerificationInfo | null;
+    /** Direct user/group grants. Omission leaves the existing policy unchanged on upload. */
+    access?: ContentAsCodeDirectAccess;
 };
 
 export type ApiDashboardAsCodeListResponse = {

--- a/packages/common/src/types/contentAsCode/directAccess.ts
+++ b/packages/common/src/types/contentAsCode/directAccess.ts
@@ -1,0 +1,28 @@
+import type { SpaceMemberRole } from '../space';
+
+export type ContentAsCodeDirectAccessUser = {
+    /** Primary email of a human organization member. */
+    email: string;
+    role: SpaceMemberRole;
+};
+
+export type ContentAsCodeDirectAccessGroup = {
+    /** Exact, case-sensitive organization group name. */
+    name: string;
+    role: SpaceMemberRole;
+};
+
+/**
+ * Portable direct user/group grants on a single resource. Mirrors the space
+ * access block: principals are identified by organization email or group name,
+ * never by internal identifiers. Inherited and effective roles are never part
+ * of this shape — it reflects stored direct policy only.
+ *
+ * On upload: omission leaves the resource's existing direct policy unchanged;
+ * a present block (including empty `users` and `groups`) atomically replaces
+ * the whole policy.
+ */
+export type ContentAsCodeDirectAccess = {
+    users: ContentAsCodeDirectAccessUser[];
+    groups: ContentAsCodeDirectAccessGroup[];
+};

--- a/packages/common/src/types/contentAsCode/index.ts
+++ b/packages/common/src/types/contentAsCode/index.ts
@@ -2,6 +2,7 @@ export * from './base';
 export * from './charts';
 export * from './core';
 export * from './dashboards';
+export * from './directAccess';
 export * from './draftRebase';
 export * from './fileDiscovery';
 export * from './parsers';


### PR DESCRIPTION
## Summary

PR 1 of 2 for [SPK-1539](https://linear.app/lightdash/issue/SPK-1539/stack-6c-round-trip-direct-policies-through-content-as-code) (Stack 6C). Adds one portable direct-policy schema and attaches it to every eligible content-as-code export. Import semantics land in PR 2.

Part of: https://linear.app/lightdash/issue/SPK-1539

## Changes

**Schema** — `ContentAsCodeDirectAccess` in `@lightdash/common`: users by organization email, groups by exact group name, roles as `SpaceMemberRole`. Referenced as `access?` from `ChartAsCode`, `SqlChartAsCode`, `DashboardAsCode`, and `DataAppManifest`. No internal identifiers anywhere in the shape.

```
export:  policy ─ portable? ──yes── access: { users ⌐sorted by email, groups ⌐sorted by name }
                     │no / none
                     └───────────── no access key (upload preserves target policy)
```

**Export** — `CoderService.getPortableDirectAccessByUuid` maps stored assignments to portable blocks with the same identity rules the space export already applies: a user must resolve to a unique organization email, a group to a unique name, and a policy containing any non-portable principal is omitted entirely so a file never half-represents a policy. Wired into chart, SQL chart, and dashboard export listings and (via the existing `coderService` dependency) the data-app bundle download.

Boundaries, each deliberate:
- **Dashboard-owned chart definitions never carry a block** — they are not grantable.
- **The AI/MCP read paths (`getChartsForRead`/`getDashboardsForRead`) never see blocks** — per-item view access is not enough to learn who a resource is shared with.
- **App bundles carry a block only for callers who could manage the app's sharing** — code download itself is view-gated.
- **Feature off → exports omit blocks** rather than failing.

**Reads** — one batch model method (`listAssignmentsForResources`, two queries per resource type) so export listings do not fan out per resource, exposed through `DirectAccessService.listPoliciesForExport` which owns the feature-gate check.

Chart/dashboard as-code JSON schemas regenerated; field-coverage contracts updated.

## Test plan

- [x] `pnpm -F common typecheck` / `lint`, `pnpm -F backend typecheck` / `lint`, `pnpm check:chart-as-code-schema`
- [x] 4 new unit tests: deterministic mapping without internal identifiers; whole-policy omission for non-portable users (null/ambiguous email) and groups (duplicate name, uuid mismatch); feature-off empty result
- [x] CoderService + DirectAccess + field-coverage suites: 220 pass
- [x] Live on the dev instance: chart, SQL chart, and dashboard exports carry the expected blocks (user roles preserved, group grants included, sorted); ungranted content has no `access` key; flag off removes the key; app bundle manifest carries the block for a manager
