### PR TITLE
feat(direct-access): import portable access blocks atomically

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -11402,6 +11402,22 @@ export class AppGenerateService extends BaseService {
             );
         const warnings = [...linkWarnings];
 
+        // Access block preflight also runs up front: unresolvable or
+        // ambiguous principals reject the bundle before anything is written.
+        // Guarded like manifestLinks so pre-field bundles never touch the
+        // direct-access seam at all.
+        const directAccessAssignments =
+            code.manifest.access !== undefined
+                ? await this.coderService.prepareDirectAccessReplace({
+                      user,
+                      organizationUuid,
+                      access: code.manifest.access,
+                      contentLabel: `App ${
+                          code.manifest.slug ?? code.manifest.name
+                      }`,
+                  })
+                : null;
+
         // Validate the round-tripped viz schema up front and fail loud: the
         // build-from-source pipeline has no generation run to re-emit it, so
         // silently dropping a bad one would unlist the viz from the picker.
@@ -11672,6 +11688,17 @@ export class AppGenerateService extends BaseService {
                         resolvedLinks,
                     );
                 }
+                // An unchanged bundle still reconciles its declared policy —
+                // same contract as links and metadata above.
+                if (directAccessAssignments !== null) {
+                    await this.coderService.applyDirectAccessPolicy(
+                        user,
+                        projectUuid,
+                        DirectAccessResourceType.APP,
+                        existingApp.app_id,
+                        directAccessAssignments,
+                    );
+                }
                 this.analytics.track({
                     event: 'data_app.uploaded',
                     userId: user.userUuid,
@@ -11873,6 +11900,18 @@ export class AppGenerateService extends BaseService {
             await this.externalConnectionModel.replaceAppLinks(
                 newAppUuid,
                 resolvedLinks,
+            );
+        }
+
+        // Same reconciliation contract for the direct policy: present
+        // (including empty) → atomic replacement; absent → untouched.
+        if (directAccessAssignments !== null) {
+            await this.coderService.applyDirectAccessPolicy(
+                user,
+                projectUuid,
+                DirectAccessResourceType.APP,
+                newAppUuid,
+                directAccessAssignments,
             );
         }
 

--- a/packages/backend/src/services/CoderService/CoderService.directAccessImport.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.directAccessImport.test.ts
@@ -1,0 +1,296 @@
+import { Ability } from '@casl/ability';
+import {
+    DirectAccessPrincipalType,
+    DirectAccessResourceType,
+    ForbiddenError,
+    OrganizationMemberRole,
+    SpaceMemberRole,
+    type ContentAsCodeDirectAccess,
+    type SessionUser,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { CoderService } from './CoderService';
+
+const ORG_UUID = 'org-uuid';
+const PROJECT_UUID = 'project-uuid';
+
+// fromSession needs a fully-formed session user to build the account.
+const user = {
+    userUuid: 'uploader-uuid',
+    email: 'uploader@acme.com',
+    firstName: 'Uploader',
+    lastName: 'User',
+    organizationUuid: ORG_UUID,
+    organizationName: 'Acme',
+    organizationCreatedAt: new Date('2026-01-01'),
+    role: OrganizationMemberRole.ADMIN,
+    isActive: true,
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: true,
+    userId: 1,
+    ability: new Ability(),
+    abilityRules: [],
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+} as unknown as SessionUser;
+
+type Setup = {
+    members?: { userUuid: string; email: string }[];
+    groups?: { uuid: string; name: string }[];
+    gateError?: Error;
+};
+
+const buildService = ({ members = [], groups = [], gateError }: Setup = {}) => {
+    const assertEnabled = vi.fn(async () => {
+        if (gateError) throw gateError;
+    });
+    const replacePolicy = vi.fn(async () => {});
+    const service = new CoderService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: {} as never,
+        savedChartModel: {} as never,
+        savedSqlModel: {} as never,
+        appModel: {} as never,
+        dashboardModel: {} as never,
+        spaceModel: {} as never,
+        schedulerModel: {} as never,
+        schedulerService: {} as never,
+        savedChartService: {} as never,
+        dashboardService: {} as never,
+        schedulerClient: {} as never,
+        promoteService: {} as never,
+        spacePermissionService: {} as never,
+        contentAsCodeSnapshotModel: {} as never,
+        contentAsCodeProjectSettingsModel: {} as never,
+        contentVerificationModel: {} as never,
+        groupsModel: {
+            find: vi.fn(async ({ name }: { name: string }) => ({
+                data: groups.filter((group) => group.name === name),
+            })),
+        } as never,
+        organizationMemberProfileModel: {
+            findOrganizationMembersByEmails: vi.fn(async () => members),
+        } as never,
+        userModel: {} as never,
+        directAccessService: { assertEnabled, replacePolicy } as never,
+    });
+    return { service, assertEnabled, replacePolicy };
+};
+
+const prepare = (
+    service: CoderService,
+    access: ContentAsCodeDirectAccess | undefined,
+) =>
+    service.prepareDirectAccessReplace({
+        user,
+        organizationUuid: ORG_UUID,
+        access,
+        contentLabel: 'Chart my-chart',
+    });
+
+describe('CoderService.prepareDirectAccessReplace', () => {
+    it('returns null for an absent block without touching the feature gate', async () => {
+        const { service, assertEnabled } = buildService();
+
+        await expect(prepare(service, undefined)).resolves.toBeNull();
+        expect(assertEnabled).not.toHaveBeenCalled();
+    });
+
+    it('resolves portable principals to refs with roles preserved', async () => {
+        const { service } = buildService({
+            members: [{ userUuid: 'user-1', email: 'vera@acme.com' }],
+            groups: [{ uuid: 'group-1', name: 'Analysts' }],
+        });
+
+        await expect(
+            prepare(service, {
+                users: [
+                    { email: 'Vera@Acme.com', role: SpaceMemberRole.EDITOR },
+                ],
+                groups: [{ name: 'Analysts', role: SpaceMemberRole.VIEWER }],
+            }),
+        ).resolves.toEqual([
+            {
+                principal: {
+                    type: DirectAccessPrincipalType.USER,
+                    uuid: 'user-1',
+                },
+                role: SpaceMemberRole.EDITOR,
+            },
+            {
+                principal: {
+                    type: DirectAccessPrincipalType.GROUP,
+                    uuid: 'group-1',
+                },
+                role: SpaceMemberRole.VIEWER,
+            },
+        ]);
+    });
+
+    it('returns an empty policy for an empty block (clear semantics)', async () => {
+        const { service } = buildService();
+
+        await expect(
+            prepare(service, { users: [], groups: [] }),
+        ).resolves.toEqual([]);
+    });
+
+    it('fails closed before resolution when the feature gate rejects', async () => {
+        const gateError = new ForbiddenError('Direct access is not available');
+        const { service } = buildService({ gateError });
+
+        await expect(
+            prepare(service, { users: [], groups: [] }),
+        ).rejects.toThrow(gateError);
+    });
+
+    it('rejects unknown and ambiguous users without partial results', async () => {
+        const missing = buildService({ members: [] });
+        await expect(
+            prepare(missing.service, {
+                users: [
+                    { email: 'ghost@acme.com', role: SpaceMemberRole.VIEWER },
+                ],
+                groups: [],
+            }),
+        ).rejects.toThrow(
+            'Chart my-chart access: User ghost@acme.com is not a member of this organization',
+        );
+
+        const ambiguous = buildService({
+            members: [
+                { userUuid: 'user-1', email: 'vera@acme.com' },
+                { userUuid: 'user-2', email: 'vera@acme.com' },
+            ],
+        });
+        await expect(
+            prepare(ambiguous.service, {
+                users: [
+                    { email: 'vera@acme.com', role: SpaceMemberRole.VIEWER },
+                ],
+                groups: [],
+            }),
+        ).rejects.toThrow('is ambiguous in this organization');
+    });
+
+    it('rejects unknown and ambiguous groups', async () => {
+        const missing = buildService({ groups: [] });
+        await expect(
+            prepare(missing.service, {
+                users: [],
+                groups: [{ name: 'Ghosts', role: SpaceMemberRole.VIEWER }],
+            }),
+        ).rejects.toThrow(
+            'Chart my-chart access: Group Ghosts does not exist in this organization',
+        );
+
+        const ambiguous = buildService({
+            groups: [
+                { uuid: 'group-1', name: 'Analysts' },
+                { uuid: 'group-2', name: 'Analysts' },
+            ],
+        });
+        await expect(
+            prepare(ambiguous.service, {
+                users: [],
+                groups: [{ name: 'Analysts', role: SpaceMemberRole.VIEWER }],
+            }),
+        ).rejects.toThrow('is ambiguous in this organization');
+    });
+
+    it('rejects duplicate principals and invalid roles', async () => {
+        const { service } = buildService({
+            members: [{ userUuid: 'user-1', email: 'vera@acme.com' }],
+        });
+
+        await expect(
+            prepare(service, {
+                users: [
+                    { email: 'vera@acme.com', role: SpaceMemberRole.VIEWER },
+                    { email: 'VERA@acme.com', role: SpaceMemberRole.EDITOR },
+                ],
+                groups: [],
+            }),
+        ).rejects.toThrow('contains duplicate user emails');
+
+        await expect(
+            prepare(service, {
+                users: [],
+                groups: [
+                    { name: 'Analysts', role: SpaceMemberRole.VIEWER },
+                    { name: 'Analysts', role: SpaceMemberRole.EDITOR },
+                ],
+            }),
+        ).rejects.toThrow('contains duplicate group names');
+
+        await expect(
+            prepare(service, {
+                users: [
+                    {
+                        email: 'vera@acme.com',
+                        role: 'owner' as SpaceMemberRole,
+                    },
+                ],
+                groups: [],
+            }),
+        ).rejects.toThrow('has an invalid role');
+        await expect(
+            prepare(service, {
+                users: [],
+                groups: [
+                    { name: 'Analysts', role: 'owner' as SpaceMemberRole },
+                ],
+            }),
+        ).rejects.toThrow('has an invalid role');
+    });
+});
+
+describe('CoderService.applyDirectAccessPolicy', () => {
+    it('is a no-op for a null plan', async () => {
+        const { service, replacePolicy } = buildService();
+
+        await service.applyDirectAccessPolicy(
+            user,
+            PROJECT_UUID,
+            DirectAccessResourceType.CHART,
+            'chart-uuid',
+            null,
+        );
+
+        expect(replacePolicy).not.toHaveBeenCalled();
+    });
+
+    it('replaces the policy through the direct access service', async () => {
+        const { service, replacePolicy } = buildService();
+        const assignments = [
+            {
+                principal: {
+                    type: DirectAccessPrincipalType.USER,
+                    uuid: 'user-1',
+                },
+                role: SpaceMemberRole.VIEWER,
+            },
+        ];
+
+        await service.applyDirectAccessPolicy(
+            user,
+            PROJECT_UUID,
+            DirectAccessResourceType.DASHBOARD,
+            'dashboard-uuid',
+            assignments,
+        );
+
+        expect(replacePolicy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                user: expect.objectContaining({ userUuid: 'uploader-uuid' }),
+            }),
+            PROJECT_UUID,
+            DirectAccessResourceType.DASHBOARD,
+            'dashboard-uuid',
+            assignments,
+        );
+    });
+});

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -97,6 +97,7 @@ import {
     type ContentVerificationInfo,
     type DashboardTileWithSlug,
     type DirectAccessAssignment,
+    type DirectAccessPrincipalRef,
     type Filters,
     type GoogleSheetsSyncAsCode,
     type SpaceSummaryBase,
@@ -105,7 +106,7 @@ import type { Knex } from 'knex';
 import isEqual from 'lodash/isEqual';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
-import { getAccountApiAccessContext } from '../../auth/account';
+import { fromSession, getAccountApiAccessContext } from '../../auth/account';
 import { LightdashConfig } from '../../config/parseConfig';
 import { AppModel } from '../../models/AppModel';
 import { ContentAsCodeProjectSettingsModel } from '../../models/ContentAsCodeProjectSettingsModel';
@@ -985,10 +986,23 @@ export class CoderService extends BaseService {
         }
     }
 
-    private async validateSpaceAccessPrincipals(
+    /**
+     * Resolve portable as-code principals (organization email / group name) to
+     * concrete uuids, rejecting anything that is missing or ambiguous. Shared
+     * by space access blocks and resource direct-access blocks — the identity
+     * rules are the same, only the error prefix differs.
+     */
+    private async resolveAsCodeAccessPrincipals(
         organizationUuid: string,
-        access: NonNullable<SpaceAsCode['access']>,
-    ): Promise<void> {
+        access: {
+            users: { email: string; role: SpaceMemberRole }[];
+            groups: { name: string; role: SpaceMemberRole }[];
+        },
+        errorPrefix: string = '',
+    ): Promise<{
+        users: { userUuid: string; role: SpaceMemberRole }[];
+        groups: { groupUuid: string; role: SpaceMemberRole }[];
+    }> {
         const members =
             await this.organizationMemberProfileModel.findOrganizationMembersByEmails(
                 organizationUuid,
@@ -1002,43 +1016,41 @@ export class CoderService extends BaseService {
             },
             new Map(),
         );
-        access.users.forEach(({ email }) => {
-            const matches = membersByEmail.get(email) ?? [];
+        const resolvedUsers = access.users.map(({ email, role }) => {
+            const matches = membersByEmail.get(email.toLowerCase()) ?? [];
             if (matches.length === 0) {
                 throw new ParameterError(
-                    `User ${email} is not a member of this organization`,
+                    `${errorPrefix}User ${email} is not a member of this organization`,
                 );
             }
             if (matches.length > 1) {
                 throw new ParameterError(
-                    `User email ${email} is ambiguous in this organization`,
+                    `${errorPrefix}User email ${email} is ambiguous in this organization`,
                 );
             }
+            return { userUuid: matches[0].userUuid, role };
         });
 
-        const groupMatches = await Promise.all(
-            access.groups.map(async ({ name }) => ({
-                name,
-                matches: (
-                    await this.groupsModel.find({
-                        organizationUuid,
-                        name,
-                    })
-                ).data,
-            })),
+        const resolvedGroups = await Promise.all(
+            access.groups.map(async ({ name, role }) => {
+                const matches = (
+                    await this.groupsModel.find({ organizationUuid, name })
+                ).data;
+                if (matches.length === 0) {
+                    throw new ParameterError(
+                        `${errorPrefix}Group ${name} does not exist in this organization`,
+                    );
+                }
+                if (matches.length > 1) {
+                    throw new ParameterError(
+                        `${errorPrefix}Group name ${name} is ambiguous in this organization`,
+                    );
+                }
+                return { groupUuid: matches[0].uuid, role };
+            }),
         );
-        groupMatches.forEach(({ name, matches }) => {
-            if (matches.length === 0) {
-                throw new ParameterError(
-                    `Group ${name} does not exist in this organization`,
-                );
-            }
-            if (matches.length > 1) {
-                throw new ParameterError(
-                    `Group name ${name} is ambiguous in this organization`,
-                );
-            }
-        });
+
+        return { users: resolvedUsers, groups: resolvedGroups };
     }
 
     private async hasNonPortableDirectSpaceAccess(
@@ -1221,6 +1233,143 @@ export class CoderService extends BaseService {
                 return map;
             },
             new Map(),
+        );
+    }
+
+    /**
+     * Preflight for an as-code access block: shape and role validation,
+     * duplicate rejection, and portable-identity resolution to concrete
+     * principal refs — all before any content write, so a bad block fails
+     * the upload with the target environment fully untouched. Returns null
+     * when the block is absent (existing policy preserved on upload).
+     *
+     * Public because the data-app bundle import (AppGenerateService) shares
+     * it.
+     */
+    async prepareDirectAccessReplace({
+        user,
+        organizationUuid,
+        access,
+        contentLabel,
+    }: {
+        user: SessionUser;
+        organizationUuid: string;
+        access: ContentAsCodeDirectAccess | undefined;
+        contentLabel: string;
+    }): Promise<
+        | {
+              principal: DirectAccessPrincipalRef;
+              role: SpaceMemberRole;
+          }[]
+        | null
+    > {
+        if (access === undefined) {
+            return null;
+        }
+        // Fail closed before any write: with sharing disabled the policy
+        // could never be applied, and importing the content first would
+        // leave the upload half-done.
+        await this.directAccessService.assertEnabled(fromSession(user));
+
+        if (!Array.isArray(access.users) || !Array.isArray(access.groups)) {
+            throw new ParameterError(
+                `${contentLabel} access users and groups must be arrays`,
+            );
+        }
+        const validRoles = new Set<string>(Object.values(SpaceMemberRole));
+        access.users.forEach(({ email, role }) => {
+            if (typeof email !== 'string' || email.trim() === '') {
+                throw new ParameterError(
+                    `${contentLabel} access contains a user without an email`,
+                );
+            }
+            if (!validRoles.has(role)) {
+                throw new ParameterError(
+                    `${contentLabel} access user ${email} has an invalid role`,
+                );
+            }
+        });
+        access.groups.forEach(({ name, role }) => {
+            if (typeof name !== 'string' || name.trim() === '') {
+                throw new ParameterError(
+                    `${contentLabel} access contains a group without a name`,
+                );
+            }
+            if (!validRoles.has(role)) {
+                throw new ParameterError(
+                    `${contentLabel} access group ${name} has an invalid role`,
+                );
+            }
+        });
+
+        const normalizedUsers = access.users.map(({ email, role }) => ({
+            email: email.trim().toLowerCase(),
+            role,
+        }));
+        const userEmails = normalizedUsers.map(({ email }) => email);
+        if (new Set(userEmails).size !== userEmails.length) {
+            throw new ParameterError(
+                `${contentLabel} access contains duplicate user emails`,
+            );
+        }
+        const groupNames = access.groups.map(({ name }) => name);
+        if (new Set(groupNames).size !== groupNames.length) {
+            throw new ParameterError(
+                `${contentLabel} access contains duplicate group names`,
+            );
+        }
+
+        const resolved = await this.resolveAsCodeAccessPrincipals(
+            organizationUuid,
+            { users: normalizedUsers, groups: access.groups },
+            `${contentLabel} access: `,
+        );
+
+        return [
+            ...resolved.users.map(({ userUuid, role }) => ({
+                principal: {
+                    type: DirectAccessPrincipalType.USER,
+                    uuid: userUuid,
+                },
+                role,
+            })),
+            ...resolved.groups.map(({ groupUuid, role }) => ({
+                principal: {
+                    type: DirectAccessPrincipalType.GROUP,
+                    uuid: groupUuid,
+                },
+                role,
+            })),
+        ];
+    }
+
+    /**
+     * Apply a preflighted access block to a resource that now exists:
+     * authorization, atomic replacement, and audit all run inside
+     * DirectAccessService.replacePolicy. No-op for null (block absent).
+     * An empty array clears the policy.
+     *
+     * Public because the data-app bundle import (AppGenerateService) shares
+     * it.
+     */
+    async applyDirectAccessPolicy(
+        user: SessionUser,
+        projectUuid: string,
+        resourceType: DirectAccessResourceType,
+        resourceUuid: string,
+        assignments:
+            | { principal: DirectAccessPrincipalRef; role: SpaceMemberRole }[]
+            | null,
+    ): Promise<void> {
+        if (assignments === null) {
+            return;
+        }
+        await this.directAccessService.replacePolicy(
+            fromSession(user),
+            projectUuid,
+            resourceType,
+            resourceUuid,
+            assignments,
         );
     }
 
@@ -1422,7 +1571,7 @@ export class CoderService extends BaseService {
                 : [];
 
         if (desiredSpace.access) {
-            await this.validateSpaceAccessPrincipals(
+            await this.resolveAsCodeAccessPrincipals(
                 project.organizationUuid,
                 desiredSpace.access,
             );
@@ -3592,6 +3741,23 @@ export class CoderService extends BaseService {
             },
         };
 
+        // Access block preflight runs before any write; dashboard-owned
+        // chart definitions are not grantable and reject one outright.
+        if (
+            chartAsCode.access !== undefined &&
+            chartAsCode.dashboardSlug !== undefined
+        ) {
+            throw new ParameterError(
+                `Chart ${slug} is saved in a dashboard and cannot carry an access block`,
+            );
+        }
+        const directAccessAssignments = await this.prepareDirectAccessReplace({
+            user,
+            organizationUuid: project.organizationUuid,
+            access: chartAsCode.access,
+            contentLabel: `Chart ${slug}`,
+        });
+
         // Create mode treats the requested slug as a base for a new unique
         // slug instead of updating content that already owns it.
         const existingCharts = shouldUpdateExistingContent
@@ -3771,6 +3937,14 @@ export class CoderService extends BaseService {
                 );
             }
 
+            await this.applyDirectAccessPolicy(
+                user,
+                projectUuid,
+                DirectAccessResourceType.CHART,
+                newChart.uuid,
+                directAccessAssignments,
+            );
+
             console.info(
                 `Finished creating chart "${chartWithDefaults.name}" on project ${projectUuid}`,
             );
@@ -3930,6 +4104,14 @@ export class CoderService extends BaseService {
             );
         }
 
+        await this.applyDirectAccessPolicy(
+            user,
+            projectUuid,
+            DirectAccessResourceType.CHART,
+            chart.uuid,
+            directAccessAssignments,
+        );
+
         console.info(
             `Finished updating chart "${chartWithDefaults.name}" on project ${projectUuid}: ${promotionChanges.charts[0].action}`,
         );
@@ -4042,6 +4224,14 @@ export class CoderService extends BaseService {
             ...sqlChartAsCode,
             updatedAt: sqlChartAsCode.updatedAt ?? new Date(),
         };
+
+        // Access block preflight runs before any write.
+        const directAccessAssignments = await this.prepareDirectAccessReplace({
+            user,
+            organizationUuid: project.organizationUuid,
+            access: sqlChartAsCode.access,
+            contentLabel: `SQL chart ${slug}`,
+        });
 
         const sqlChartRows = await this.savedSqlModel.find({
             slugs: [slug],
@@ -4158,6 +4348,13 @@ export class CoderService extends BaseService {
                     : [],
                 dashboards: [],
             };
+            await this.applyDirectAccessPolicy(
+                user,
+                projectUuid,
+                DirectAccessResourceType.SQL_CHART,
+                savedSqlUuid,
+                directAccessAssignments,
+            );
             return promotionChanges;
         }
 
@@ -4207,6 +4404,13 @@ export class CoderService extends BaseService {
                 : [],
             dashboards: [],
         };
+        await this.applyDirectAccessPolicy(
+            user,
+            projectUuid,
+            DirectAccessResourceType.SQL_CHART,
+            existingSqlChart.saved_sql_uuid,
+            directAccessAssignments,
+        );
         return promotionChanges;
     }
 
@@ -4714,6 +4918,14 @@ export class CoderService extends BaseService {
             },
         };
 
+        // Access block preflight runs before any write.
+        const directAccessAssignments = await this.prepareDirectAccessReplace({
+            user,
+            organizationUuid: project.organizationUuid,
+            access: dashboardAsCode.access,
+            contentLabel: `Dashboard ${slug}`,
+        });
+
         // Create mode treats the requested slug as a base for a new unique
         // slug instead of updating content that already owns it.
         const [dashboardSummary] = shouldUpdateExistingContent
@@ -4832,6 +5044,14 @@ export class CoderService extends BaseService {
                     options.filePath,
                 );
             }
+
+            await this.applyDirectAccessPolicy(
+                user,
+                projectUuid,
+                DirectAccessResourceType.DASHBOARD,
+                newDashboard.uuid,
+                directAccessAssignments,
+            );
 
             return withTileWarnings(
                 {
@@ -4997,6 +5217,14 @@ export class CoderService extends BaseService {
                 options.filePath,
             );
         }
+
+        await this.applyDirectAccessPolicy(
+            user,
+            projectUuid,
+            DirectAccessResourceType.DASHBOARD,
+            dashboard.uuid,
+            directAccessAssignments,
+        );
 
         console.info(
             `Finished updating dashboard "${dashboard.name}" on project ${projectUuid}: ${promotionChanges.dashboards[0].action}`,

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.test.ts
@@ -126,6 +126,16 @@ const buildService = ({
             revokedUsers: 1,
             revokedGroups: 0,
         }),
+        replacePolicy: vi.fn().mockResolvedValue({
+            organizationId: 1,
+            organizationUuid: ORGANIZATION_UUID,
+            projectId: 1,
+            projectUuid: PROJECT_UUID,
+            revokedUsers: 2,
+            revokedGroups: 1,
+            appliedUsers: 1,
+            appliedGroups: 1,
+        }),
     };
     const directAccessFeatureGate = {
         assertEnabled: enabled
@@ -391,6 +401,73 @@ describe('DirectAccessService', () => {
                 }),
             }),
         );
+    });
+});
+
+describe('DirectAccessService.replacePolicy', () => {
+    beforeEach(() => {
+        vi.mocked(logAuditEvent).mockClear();
+    });
+
+    it('authorizes, replaces atomically through the model, and audits', async () => {
+        const { service, directAccessModel } = buildService({
+            context: spaceContext([
+                { userUuid: USER_UUID, role: SpaceMemberRole.ADMIN },
+            ]),
+        });
+        const assignments = [
+            {
+                principal: {
+                    type: DirectAccessPrincipalType.USER,
+                    uuid: 'aaaaaaaa-0000-0000-0000-0000000000aa',
+                },
+                role: SpaceMemberRole.VIEWER,
+            },
+        ];
+
+        await service.replacePolicy(
+            buildAccount(OrganizationMemberRole.ADMIN),
+            PROJECT_UUID,
+            DirectAccessResourceType.DASHBOARD,
+            DASHBOARD_UUID,
+            assignments,
+        );
+
+        expect(directAccessModel.replacePolicy).toHaveBeenCalledWith({
+            resourceType: DirectAccessResourceType.DASHBOARD,
+            resourceUuid: DASHBOARD_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            grantedByUserUuid: USER_UUID,
+            assignments,
+        });
+        const replaceEvents = vi
+            .mocked(logAuditEvent)
+            .mock.calls.map(([event]) => event)
+            .filter((event) => event.action === 'direct_access.replace');
+        expect(replaceEvents).toHaveLength(1);
+        expect(replaceEvents[0].resource.metadata).toMatchObject({
+            revokedUsers: 2,
+            appliedUsers: 1,
+        });
+    });
+
+    it('denies non-admin standing before any write', async () => {
+        const { service, directAccessModel } = buildService({
+            context: spaceContext([
+                { userUuid: USER_UUID, role: SpaceMemberRole.EDITOR },
+            ]),
+        });
+
+        await expect(
+            service.replacePolicy(
+                buildAccount(OrganizationMemberRole.MEMBER),
+                PROJECT_UUID,
+                DirectAccessResourceType.DASHBOARD,
+                DASHBOARD_UUID,
+                [],
+            ),
+        ).rejects.toThrowError(ForbiddenError);
+        expect(directAccessModel.replacePolicy).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/backend/src/services/DirectAccess/DirectAccessService.ts
+++ b/packages/backend/src/services/DirectAccess/DirectAccessService.ts
@@ -27,6 +27,7 @@ import {
 } from '../SpaceService/SpacePermissionService';
 import {
     auditDirectAccessMutation,
+    auditDirectAccessReplace,
     auditDirectAccessReset,
 } from './directAccessAudit';
 import { type DirectAccessFeatureGate } from './DirectAccessFeatureGate';
@@ -470,6 +471,54 @@ export class DirectAccessService extends BaseService {
             resourceType,
             resourceUuid,
             principal: DirectAccessService.toAuditPrincipal(principal),
+            result,
+        });
+    }
+
+    /**
+     * Fail-closed feature check for callers that must validate before their
+     * own writes (content-as-code preflight): a file with an access block is
+     * rejected up front when sharing is disabled, instead of importing the
+     * content and then failing the policy step halfway.
+     */
+    async assertEnabled(account: RegisteredAccount): Promise<void> {
+        await this.directAccessFeatureGate.assertEnabled(account);
+    }
+
+    /**
+     * Atomically replace a resource's whole direct policy. Backs the
+     * content-as-code import: authorization and locking are identical to the
+     * single-assignment mutations, and any invalid principal aborts the
+     * transaction with the previous policy intact.
+     */
+    async replacePolicy(
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        resourceType: DirectAccessResourceType,
+        resourceUuid: UUID,
+        assignments: {
+            principal: DirectAccessPrincipalRef;
+            role: SpaceMemberRole;
+        }[],
+    ): Promise<void> {
+        const { organizationUuid } = await this.authorizeManage(
+            account,
+            projectUuid,
+            resourceType,
+            resourceUuid,
+        );
+        const result = await this.directAccessModel.replacePolicy({
+            resourceType,
+            resourceUuid,
+            organizationUuid,
+            grantedByUserUuid: account.user.userUuid,
+            assignments,
+        });
+        auditDirectAccessReplace({
+            actor: createActorFromAccount(account),
+            context: {},
+            resourceType,
+            resourceUuid,
             result,
         });
     }

--- a/packages/backend/src/services/DirectAccess/directAccessAudit.ts
+++ b/packages/backend/src/services/DirectAccess/directAccessAudit.ts
@@ -6,6 +6,7 @@ import {
 } from '../../logging/auditLog';
 import Logger from '../../logging/logger';
 import { logAuditEvent } from '../../logging/winston';
+import { type DirectAccessReplaceResult } from '../../models/DirectAccessModel';
 import {
     type DirectAccessMutationResult,
     type DirectAccessResetResult,
@@ -107,6 +108,49 @@ export const auditDirectAccessReset = ({
         );
     } catch (error) {
         Logger.warn('Failed to write direct access reset audit event', {
+            error,
+        });
+    }
+};
+
+export const auditDirectAccessReplace = ({
+    actor,
+    context,
+    resourceType,
+    resourceUuid,
+    result,
+    auditLogger = logAuditEvent,
+}: {
+    actor: AuditActor;
+    context: AuditContext;
+    resourceType: string;
+    resourceUuid: string;
+    result: DirectAccessReplaceResult;
+    auditLogger?: DirectAccessAuditLogger;
+}): void => {
+    try {
+        auditLogger(
+            createAuditLogEvent(
+                actor,
+                'direct_access.replace',
+                {
+                    type: resourceType,
+                    organizationUuid: result.organizationUuid,
+                    projectUuid: result.projectUuid,
+                    metadata: {
+                        resourceUuid,
+                        revokedUsers: result.revokedUsers,
+                        revokedGroups: result.revokedGroups,
+                        appliedUsers: result.appliedUsers,
+                        appliedGroups: result.appliedGroups,
+                    },
+                },
+                context,
+                'allowed',
+            ),
+        );
+    } catch (error) {
+        Logger.warn('Failed to write direct access replace audit event', {
             error,
         });
     }


### PR DESCRIPTION
## Summary

PR 2 of 2 for [SPK-1539](https://linear.app/lightdash/issue/SPK-1539/stack-6c-round-trip-direct-policies-through-content-as-code) (Stack 6C). Imports the portable access blocks PR 1 exports: full preflight before any write, then atomic policy replacement.

Stacks on top of PR 1 which added the schema and export side.

Part of: https://linear.app/lightdash/issue/SPK-1539

## Changes

```
access absent  ── preserve environment-local direct policy
access present ── preflight all principals ── content write ── atomically replace policy
access: []     ── preflight (gate, caller) ── content write ── atomically clear policy
```

**Preflight** (`CoderService.prepareDirectAccessReplace`, shared by chart, SQL chart, dashboard, and data-app bundle uploads) runs before any content write: feature gate (fail closed — a block cannot be half-imported into a disabled org), shape/role validation, duplicate rejection, and portable-identity resolution (missing, ambiguous, or non-member principals reject the upload with the target untouched). Dashboard-owned chart definitions reject a block outright; the model's grant-restriction check backs this up at write time.

**Apply** — a new `DirectAccessService.replacePolicy` with the same authorization (`authorizeManage`), owner-chain locking, and audit family as the single-assignment mutations, plus a `direct_access.replace` audit event carrying revoked/applied counts. The model transaction guarantees any failure leaves the previous policy intact. App bundles reconcile under the exact contract `externalConnections` already uses: guarded on field presence, so pre-field bundles never touch the direct-access seam.

**Ordering note:** for brand-new resources the policy authorization necessarily runs after the content insert (the resource must exist to resolve its space context). Principal validity is still preflighted; an authorization failure at that point leaves the created content with its default (empty) policy.

Promotion, duplication, preview, and clone flows are untouched and remain recipient-resetting — a policy only ever arrives through an explicit `access` block.

## Test plan

- [x] `pnpm -F backend typecheck` / `lint`
- [x] 9 preflight/apply unit tests: absent → null without touching the gate; portable resolution with roles preserved; empty → clear; gate rejection before resolution; unknown/ambiguous users and groups; duplicates; invalid roles; null no-op; replace called with the uploader's account
- [x] 2 `replacePolicy` service tests: authorize → model → `direct_access.replace` audit with counts; non-admin standing denied before any write
- [x] AppGenerateService suites: 346 pass (pre-field bundles bypass the seam)
- [x] Live on the dev instance: verbatim re-upload preserves the policy; a modified block replaces it (role change + group add); `[]` clears; absent preserves; an unknown email returns 400 with the content name and policy both unchanged
- [ ] A 100-variation ad-hoc round-trip suite runs against the live stack next; results will be attached to the ticket
