### PR TITLE
feat(backend): add safe OpenTelemetry diagnostics

### DIFF
--- a/packages/backend/src/tracing/tracing.test.ts
+++ b/packages/backend/src/tracing/tracing.test.ts
@@ -1,14 +1,100 @@
 import { context, ROOT_CONTEXT, SpanKind, trace } from '@opentelemetry/api';
 import { SamplingDecision, type Sampler } from '@opentelemetry/sdk-trace-base';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
     AlwaysSampleAiRootsSampler,
+    getOtelTraceExportConfig,
     LightdashTraceContextPropagator,
+    otelTracingEnabled,
     sentryTraceToTraceparent,
 } from './tracing';
 
 const TRACE_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const SPAN_ID = 'bbbbbbbbbbbbbbbb';
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+});
+
+describe('otelTracingEnabled', () => {
+    it('keeps OTel mode enabled when trace export is disabled', () => {
+        vi.stubEnv('LIGHTDASH_OTEL_TRACES_ENABLED', 'true');
+        vi.stubEnv('OTEL_SDK_DISABLED', undefined);
+        vi.stubEnv('OTEL_TRACES_EXPORTER', 'none');
+
+        expect(otelTracingEnabled()).toBe(true);
+    });
+});
+
+describe('getOtelTraceExportConfig', () => {
+    it('reports the default and explicitly disabled exporter selections', () => {
+        vi.stubEnv('OTEL_TRACES_EXPORTER', undefined);
+        vi.stubEnv('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', undefined);
+        vi.stubEnv('OTEL_EXPORTER_OTLP_PROTOCOL', undefined);
+
+        expect(getOtelTraceExportConfig()).toEqual({
+            exporters: ['otlp'],
+            protocol: 'http/protobuf',
+            warnings: [],
+        });
+
+        vi.stubEnv('OTEL_TRACES_EXPORTER', 'none');
+        expect(getOtelTraceExportConfig()).toEqual({
+            exporters: ['none'],
+            protocol: null,
+            warnings: [],
+        });
+    });
+
+    it('reports console export without an OTLP protocol', () => {
+        vi.stubEnv('OTEL_TRACES_EXPORTER', 'console');
+        vi.stubEnv('OTEL_EXPORTER_OTLP_PROTOCOL', 'grpc');
+
+        expect(getOtelTraceExportConfig()).toEqual({
+            exporters: ['console'],
+            protocol: null,
+            warnings: [],
+        });
+    });
+
+    it('reports the trace-specific OTLP protocol with precedence', () => {
+        vi.stubEnv('OTEL_TRACES_EXPORTER', 'otlp');
+        vi.stubEnv('OTEL_EXPORTER_OTLP_PROTOCOL', 'http/protobuf');
+        vi.stubEnv('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', 'grpc');
+
+        expect(getOtelTraceExportConfig()).toEqual({
+            exporters: ['otlp'],
+            protocol: 'grpc',
+            warnings: [],
+        });
+    });
+
+    it('warns when no supported exporter is selected', () => {
+        vi.stubEnv('OTEL_TRACES_EXPORTER', 'unsupported');
+
+        expect(getOtelTraceExportConfig()).toEqual({
+            exporters: [],
+            protocol: null,
+            warnings: [
+                'Unsupported OTEL_TRACES_EXPORTER value "unsupported"; supported values are otlp, console, zipkin, and none',
+                'OpenTelemetry could not configure trace export because no supported exporter was selected',
+            ],
+        });
+    });
+
+    it('warns and reports the OTLP protocol fallback', () => {
+        vi.stubEnv('OTEL_TRACES_EXPORTER', 'otlp');
+        vi.stubEnv('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', 'unsupported');
+
+        expect(getOtelTraceExportConfig()).toEqual({
+            exporters: ['otlp'],
+            protocol: 'http/protobuf',
+            warnings: [
+                'Unsupported OTLP traces protocol "unsupported"; OpenTelemetry will use "http/protobuf"',
+            ],
+        });
+    });
+});
 
 const makeDelegate = (decision: SamplingDecision): Sampler => ({
     shouldSample: vi.fn().mockReturnValue({ decision }),

--- a/packages/backend/src/tracing/tracing.test.ts
+++ b/packages/backend/src/tracing/tracing.test.ts
@@ -3,7 +3,7 @@ import { SamplingDecision, type Sampler } from '@opentelemetry/sdk-trace-base';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
     AlwaysSampleAiRootsSampler,
-    getOtelTraceExportConfig,
+    configureOtelTraceExport,
     LightdashTraceContextPropagator,
     otelTracingEnabled,
     sentryTraceToTraceparent,
@@ -26,49 +26,45 @@ describe('otelTracingEnabled', () => {
     });
 });
 
-describe('getOtelTraceExportConfig', () => {
+describe('configureOtelTraceExport', () => {
     it('reports the default and explicitly disabled exporter selections', () => {
         vi.stubEnv('OTEL_TRACES_EXPORTER', undefined);
         vi.stubEnv('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', undefined);
         vi.stubEnv('OTEL_EXPORTER_OTLP_PROTOCOL', undefined);
 
-        expect(getOtelTraceExportConfig()).toEqual({
+        expect(configureOtelTraceExport()).toEqual({
             exporters: ['otlp'],
             protocol: 'http/protobuf',
             warnings: [],
         });
 
         vi.stubEnv('OTEL_TRACES_EXPORTER', 'none');
-        expect(getOtelTraceExportConfig()).toEqual({
+        expect(configureOtelTraceExport()).toEqual({
             exporters: ['none'],
             protocol: null,
             warnings: [],
         });
     });
 
-    it('matches NodeSDK handling when none is combined with exporters', () => {
-        vi.stubEnv('OTEL_TRACES_EXPORTER', 'none,otlp');
-        expect(getOtelTraceExportConfig()).toEqual({
-            exporters: ['none'],
-            protocol: null,
-            warnings: [],
-        });
-
-        vi.stubEnv('OTEL_TRACES_EXPORTER', 'otlp,none');
-        expect(getOtelTraceExportConfig()).toEqual({
-            exporters: ['otlp'],
-            protocol: 'http/protobuf',
-            warnings: [
-                'OTEL_TRACES_EXPORTER contains "none" with other exporters; OpenTelemetry will use the default "otlp" exporter',
-            ],
-        });
+    it('uses none when it is combined with exporters in either order', () => {
+        for (const exporters of ['none,otlp', 'otlp,none']) {
+            vi.stubEnv('OTEL_TRACES_EXPORTER', exporters);
+            expect(configureOtelTraceExport()).toEqual({
+                exporters: ['none'],
+                protocol: null,
+                warnings: [
+                    'OTEL_TRACES_EXPORTER contains "none" with other exporters; only "none" will be used',
+                ],
+            });
+            expect(process.env.OTEL_TRACES_EXPORTER).toBe('none');
+        }
     });
 
     it('reports console export without an OTLP protocol', () => {
         vi.stubEnv('OTEL_TRACES_EXPORTER', 'console');
         vi.stubEnv('OTEL_EXPORTER_OTLP_PROTOCOL', 'grpc');
 
-        expect(getOtelTraceExportConfig()).toEqual({
+        expect(configureOtelTraceExport()).toEqual({
             exporters: ['console'],
             protocol: null,
             warnings: [],
@@ -80,7 +76,7 @@ describe('getOtelTraceExportConfig', () => {
         vi.stubEnv('OTEL_EXPORTER_OTLP_PROTOCOL', 'http/protobuf');
         vi.stubEnv('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', 'grpc');
 
-        expect(getOtelTraceExportConfig()).toEqual({
+        expect(configureOtelTraceExport()).toEqual({
             exporters: ['otlp'],
             protocol: 'grpc',
             warnings: [],
@@ -90,7 +86,7 @@ describe('getOtelTraceExportConfig', () => {
     it('warns when no supported exporter is selected', () => {
         vi.stubEnv('OTEL_TRACES_EXPORTER', 'unsupported');
 
-        expect(getOtelTraceExportConfig()).toEqual({
+        expect(configureOtelTraceExport()).toEqual({
             exporters: [],
             protocol: null,
             warnings: [
@@ -104,7 +100,7 @@ describe('getOtelTraceExportConfig', () => {
         vi.stubEnv('OTEL_TRACES_EXPORTER', 'otlp');
         vi.stubEnv('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', 'unsupported');
 
-        expect(getOtelTraceExportConfig()).toEqual({
+        expect(configureOtelTraceExport()).toEqual({
             exporters: ['otlp'],
             protocol: 'http/protobuf',
             warnings: [

--- a/packages/backend/src/tracing/tracing.test.ts
+++ b/packages/backend/src/tracing/tracing.test.ts
@@ -1,18 +1,31 @@
-import { context, ROOT_CONTEXT, SpanKind, trace } from '@opentelemetry/api';
+import {
+    context,
+    diag,
+    ROOT_CONTEXT,
+    SpanKind,
+    trace,
+} from '@opentelemetry/api';
 import { SamplingDecision, type Sampler } from '@opentelemetry/sdk-trace-base';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import Logger from '../logging/logger';
 import {
     AlwaysSampleAiRootsSampler,
     configureOtelTraceExport,
+    initOtelTracing,
+    installRedactingOtelDiagnostics,
     LightdashTraceContextPropagator,
     otelTracingEnabled,
+    sanitizeOtelDiagnosticArguments,
     sentryTraceToTraceparent,
+    shutdownOtelTracing,
 } from './tracing';
 
 const TRACE_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const SPAN_ID = 'bbbbbbbbbbbbbbbb';
 
 afterEach(() => {
+    diag.disable();
+    vi.restoreAllMocks();
     vi.unstubAllEnvs();
 });
 
@@ -107,6 +120,117 @@ describe('configureOtelTraceExport', () => {
                 'Unsupported OTLP traces protocol "unsupported"; OpenTelemetry will use "http/protobuf"',
             ],
         });
+    });
+});
+
+describe('sanitizeOtelDiagnosticArguments', () => {
+    it('omits exported span payloads from SDK diagnostics', () => {
+        expect(
+            sanitizeOtelDiagnosticArguments(
+                'OTLPExportDelegate',
+                'items to be sent',
+                [
+                    {
+                        attributes: {
+                            'url.full': 'https://example.test?token=x',
+                        },
+                    },
+                ],
+            ),
+        ).toEqual(['OTLPExportDelegate', 'items to be sent (payload omitted)']);
+    });
+
+    it('redacts endpoint secrets and structured diagnostic details', () => {
+        const sanitized = sanitizeOtelDiagnosticArguments(
+            'Request to http://user:password@collector:4318/tenant-secret/v1/traces?token=query failed',
+            'authorization=Bearer header-secret',
+            'authorization=Basic basic-secret',
+            'authorization=AWS4-HMAC-SHA256 Credential=aws-secret, Signature=signature-secret',
+            '{"authorization":"Bearer json-secret"}',
+            new Error('connect http://collector:4318/path?api_key=secret'),
+            { headers: { authorization: 'header-secret' } },
+        );
+        const output = sanitized.join(' ');
+
+        expect(output).toContain('http://collector:4318/v1/traces');
+        expect(output).toContain('[sensitive diagnostic omitted]');
+        expect(output).toContain('[diagnostic details omitted]');
+        expect(output).not.toMatch(
+            /password|query|tenant-secret|header-secret|basic-secret|aws-secret|signature-secret|json-secret|api_key=secret/u,
+        );
+        expect(
+            sanitizeOtelDiagnosticArguments(
+                new Error('connect http://user:secret@collector/path?token=x'),
+            ),
+        ).toEqual(['Error: connect http://collector/']);
+    });
+});
+
+describe('installRedactingOtelDiagnostics', () => {
+    it('honors OTEL_LOG_LEVEL and restores it after NodeSDK construction', () => {
+        vi.stubEnv('OTEL_LOG_LEVEL', 'DEBUG');
+        const debugSpy = vi
+            .spyOn(console, 'debug')
+            .mockImplementation(() => {});
+
+        const restoreOtelLogLevel = installRedactingOtelDiagnostics();
+        expect(process.env.OTEL_LOG_LEVEL).toBeUndefined();
+        debugSpy.mockClear();
+
+        diag.debug('OTLPExportDelegate', 'items to be sent', [
+            { authorization: 'Basic secret' },
+        ]);
+        expect(debugSpy).toHaveBeenCalledWith(
+            'OTLPExportDelegate',
+            'items to be sent (payload omitted)',
+        );
+
+        restoreOtelLogLevel();
+        expect(process.env.OTEL_LOG_LEVEL).toBe('DEBUG');
+    });
+
+    it('does not enable SDK diagnostics when OTEL_LOG_LEVEL is unset', () => {
+        vi.stubEnv('OTEL_LOG_LEVEL', undefined);
+        const debugSpy = vi
+            .spyOn(console, 'debug')
+            .mockImplementation(() => {});
+
+        const restoreOtelLogLevel = installRedactingOtelDiagnostics();
+        diag.debug('diagnostic should remain disabled');
+        restoreOtelLogLevel();
+
+        expect(debugSpy).not.toHaveBeenCalled();
+        expect(process.env.OTEL_LOG_LEVEL).toBeUndefined();
+    });
+});
+
+describe('initOtelTracing', () => {
+    it('logs diagnostic guidance and the effective Lightdash sampling configuration', async () => {
+        vi.stubEnv('LIGHTDASH_OTEL_TRACES_ENABLED', 'true');
+        vi.stubEnv('OTEL_SDK_DISABLED', undefined);
+        vi.stubEnv('OTEL_TRACES_EXPORTER', 'none');
+        vi.stubEnv('LIGHTDASH_OTEL_TRACES_SAMPLE_RATE', undefined);
+        vi.stubEnv('SENTRY_TRACES_SAMPLE_RATE', undefined);
+        vi.stubEnv('OTEL_TRACES_SAMPLER', 'parentbased_traceidratio');
+        vi.stubEnv('OTEL_TRACES_SAMPLER_ARG', '0');
+        const infoSpy = vi.spyOn(Logger, 'info');
+
+        initOtelTracing();
+        await shutdownOtelTracing();
+
+        expect(infoSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'Set OTEL_LOG_LEVEL=DEBUG for OpenTelemetry SDK/exporter diagnostics',
+            ),
+        );
+        expect(infoSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Lightdash sampling ratio: 1'),
+        );
+        expect(infoSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG are overridden',
+            ),
+        );
     });
 });
 

--- a/packages/backend/src/tracing/tracing.test.ts
+++ b/packages/backend/src/tracing/tracing.test.ts
@@ -46,6 +46,24 @@ describe('getOtelTraceExportConfig', () => {
         });
     });
 
+    it('matches NodeSDK handling when none is combined with exporters', () => {
+        vi.stubEnv('OTEL_TRACES_EXPORTER', 'none,otlp');
+        expect(getOtelTraceExportConfig()).toEqual({
+            exporters: ['none'],
+            protocol: null,
+            warnings: [],
+        });
+
+        vi.stubEnv('OTEL_TRACES_EXPORTER', 'otlp,none');
+        expect(getOtelTraceExportConfig()).toEqual({
+            exporters: ['otlp'],
+            protocol: 'http/protobuf',
+            warnings: [
+                'OTEL_TRACES_EXPORTER contains "none" with other exporters; OpenTelemetry will use the default "otlp" exporter',
+            ],
+        });
+    });
+
     it('reports console export without an OTLP protocol', () => {
         vi.stubEnv('OTEL_TRACES_EXPORTER', 'console');
         vi.stubEnv('OTEL_EXPORTER_OTLP_PROTOCOL', 'grpc');

--- a/packages/backend/src/tracing/tracing.test.ts
+++ b/packages/backend/src/tracing/tracing.test.ts
@@ -76,7 +76,7 @@ describe('getOtelTraceExportConfig', () => {
             exporters: [],
             protocol: null,
             warnings: [
-                'Unsupported OTEL_TRACES_EXPORTER value "unsupported"; supported values are otlp, console, zipkin, and none',
+                'Unsupported OTEL_TRACES_EXPORTER value "unsupported" was ignored; supported values are otlp, console, zipkin, and none',
                 'OpenTelemetry could not configure trace export because no supported exporter was selected',
             ],
         });

--- a/packages/backend/src/tracing/tracing.ts
+++ b/packages/backend/src/tracing/tracing.ts
@@ -109,6 +109,8 @@ export const getOtelTraceExportConfig = (): OtelTraceExportConfig => {
     ).filter((exporter) => exporter !== 'null');
     const warnings: string[] = [];
 
+    // Match NodeSDK: leading "none" configures no exporter; later "none"
+    // values cause the SDK to fall back to its default OTLP exporter.
     if (requestedExporters[0] === 'none') {
         return { exporters: ['none'], protocol: null, warnings };
     }

--- a/packages/backend/src/tracing/tracing.ts
+++ b/packages/backend/src/tracing/tracing.ts
@@ -3,9 +3,9 @@
  * LIGHTDASH_OTEL_TRACES_ENABLED:
  *
  * - OTel mode (Lightdash Cloud, and local dev): spans are created via the OTel
- *   SDK and exported over OTLP — GCP Cloud Trace in Cloud, Maple local mode in
- *   dev. Sentry does NOT receive or create spans — it is errors-only (see
- *   sentry.ts, which strips Sentry's span-emitting integrations in this mode).
+ *   SDK and exported according to OTEL_TRACES_EXPORTER. Sentry does NOT receive
+ *   or create spans — it is errors-only (see sentry.ts, which strips Sentry's
+ *   span-emitting integrations in this mode).
  * - Sentry mode (self-hosted): spans are created via Sentry's SDK exactly as
  *   before OTLP export existed.
  *
@@ -28,10 +28,11 @@ import {
 } from '@opentelemetry/api';
 import {
     CompositePropagator,
+    getStringFromEnv,
+    getStringListFromEnv,
     W3CBaggagePropagator,
     W3CTraceContextPropagator,
 } from '@opentelemetry/core';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import {
     ExpressInstrumentation,
     ExpressLayerType,
@@ -43,7 +44,6 @@ import {
 } from '@opentelemetry/resources';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import {
-    BatchSpanProcessor,
     ParentBasedSampler,
     SamplingDecision,
     TraceIdRatioBasedSampler,
@@ -88,8 +88,75 @@ const parseBoolean = (value: string | undefined) => value === 'true';
 
 export const otelTracingEnabled = () =>
     parseBoolean(process.env.LIGHTDASH_OTEL_TRACES_ENABLED) &&
-    process.env.OTEL_SDK_DISABLED !== 'true' &&
-    process.env.OTEL_TRACES_EXPORTER !== 'none';
+    process.env.OTEL_SDK_DISABLED !== 'true';
+
+const SUPPORTED_TRACE_EXPORTERS = new Set(['console', 'otlp', 'zipkin']);
+const SUPPORTED_OTLP_PROTOCOLS = new Set([
+    'grpc',
+    'http/json',
+    'http/protobuf',
+]);
+
+type OtelTraceExportConfig = {
+    exporters: string[];
+    protocol: string | null;
+    warnings: string[];
+};
+
+export const getOtelTraceExportConfig = (): OtelTraceExportConfig => {
+    let requestedExporters = Array.from(
+        new Set(getStringListFromEnv('OTEL_TRACES_EXPORTER') ?? []),
+    ).filter((exporter) => exporter !== 'null');
+    const warnings: string[] = [];
+
+    if (requestedExporters[0] === 'none') {
+        return { exporters: ['none'], protocol: null, warnings };
+    }
+
+    if (requestedExporters.length === 0) {
+        requestedExporters = ['otlp'];
+    } else if (
+        requestedExporters.length > 1 &&
+        requestedExporters.includes('none')
+    ) {
+        warnings.push(
+            'OTEL_TRACES_EXPORTER contains "none" with other exporters; OpenTelemetry will use the default "otlp" exporter',
+        );
+        requestedExporters = ['otlp'];
+    }
+
+    const exporters = requestedExporters.filter((exporter) => {
+        if (SUPPORTED_TRACE_EXPORTERS.has(exporter)) return true;
+
+        warnings.push(
+            `Unsupported OTEL_TRACES_EXPORTER value "${exporter}"; supported values are otlp, console, zipkin, and none`,
+        );
+        return false;
+    });
+
+    if (exporters.length === 0) {
+        warnings.push(
+            'OpenTelemetry could not configure trace export because no supported exporter was selected',
+        );
+    }
+
+    if (!exporters.includes('otlp')) {
+        return { exporters, protocol: null, warnings };
+    }
+
+    const requestedProtocol =
+        getStringFromEnv('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL') ??
+        getStringFromEnv('OTEL_EXPORTER_OTLP_PROTOCOL') ??
+        'http/protobuf';
+    if (SUPPORTED_OTLP_PROTOCOLS.has(requestedProtocol)) {
+        return { exporters, protocol: requestedProtocol, warnings };
+    }
+
+    warnings.push(
+        `Unsupported OTLP traces protocol "${requestedProtocol}"; OpenTelemetry will use "http/protobuf"`,
+    );
+    return { exporters, protocol: 'http/protobuf', warnings };
+};
 
 const getSampleRate = () => {
     const sampleRate = Number(
@@ -348,6 +415,9 @@ class OtelTracingStrategy implements TracingStrategy {
     initialize() {
         if (!this.isEnabled() || this.sdk) return;
 
+        const exportConfig = getOtelTraceExportConfig();
+        exportConfig.warnings.forEach((warning) => Logger.warn(warning));
+
         this.sdk = new NodeSDK({
             // Sentry's context manager (an AsyncLocalStorage manager that also
             // forks Sentry scopes per context) is required for per-request
@@ -368,7 +438,6 @@ class OtelTracingStrategy implements TracingStrategy {
                     new W3CBaggagePropagator(),
                 ],
             }),
-            spanProcessors: [new BatchSpanProcessor(new OTLPTraceExporter())],
             instrumentations: [
                 new HttpInstrumentation({
                     ignoreIncomingRequestHook: (req) =>
@@ -391,7 +460,13 @@ class OtelTracingStrategy implements TracingStrategy {
         this.sdk.start();
         this.tracer = trace.getTracer('lightdash-backend', serviceVersion);
 
-        Logger.info('OTEL trace export enabled');
+        const exporters = exportConfig.exporters.join(', ') || 'none';
+        const protocol = exportConfig.protocol
+            ? `; OTLP protocol: ${exportConfig.protocol}`
+            : '';
+        Logger.info(
+            `OpenTelemetry tracing configured; trace exporters: ${exporters}${protocol}; exporter connectivity has not been validated`,
+        );
     }
 
     async shutdown() {

--- a/packages/backend/src/tracing/tracing.ts
+++ b/packages/backend/src/tracing/tracing.ts
@@ -103,27 +103,23 @@ type OtelTraceExportConfig = {
     warnings: string[];
 };
 
-export const getOtelTraceExportConfig = (): OtelTraceExportConfig => {
+export const configureOtelTraceExport = (): OtelTraceExportConfig => {
     let requestedExporters = Array.from(
         new Set(getStringListFromEnv('OTEL_TRACES_EXPORTER') ?? []),
     ).filter((exporter) => exporter !== 'null');
     const warnings: string[] = [];
 
-    // Match NodeSDK: leading "none" configures no exporter; later "none"
-    // values cause the SDK to fall back to its default OTLP exporter.
-    if (requestedExporters[0] === 'none') {
+    if (requestedExporters.includes('none')) {
+        process.env.OTEL_TRACES_EXPORTER = 'none';
+        if (requestedExporters.length > 1) {
+            warnings.push(
+                'OTEL_TRACES_EXPORTER contains "none" with other exporters; only "none" will be used',
+            );
+        }
         return { exporters: ['none'], protocol: null, warnings };
     }
 
     if (requestedExporters.length === 0) {
-        requestedExporters = ['otlp'];
-    } else if (
-        requestedExporters.length > 1 &&
-        requestedExporters.includes('none')
-    ) {
-        warnings.push(
-            'OTEL_TRACES_EXPORTER contains "none" with other exporters; OpenTelemetry will use the default "otlp" exporter',
-        );
         requestedExporters = ['otlp'];
     }
 
@@ -417,7 +413,7 @@ class OtelTracingStrategy implements TracingStrategy {
     initialize() {
         if (!this.isEnabled() || this.sdk) return;
 
-        const exportConfig = getOtelTraceExportConfig();
+        const exportConfig = configureOtelTraceExport();
         exportConfig.warnings.forEach((warning) => Logger.warn(warning));
 
         // Leaving spanProcessors unset delegates exporter and protocol

--- a/packages/backend/src/tracing/tracing.ts
+++ b/packages/backend/src/tracing/tracing.ts
@@ -129,7 +129,7 @@ export const getOtelTraceExportConfig = (): OtelTraceExportConfig => {
         if (SUPPORTED_TRACE_EXPORTERS.has(exporter)) return true;
 
         warnings.push(
-            `Unsupported OTEL_TRACES_EXPORTER value "${exporter}"; supported values are otlp, console, zipkin, and none`,
+            `Unsupported OTEL_TRACES_EXPORTER value "${exporter}" was ignored; supported values are otlp, console, zipkin, and none`,
         );
         return false;
     });
@@ -418,6 +418,8 @@ class OtelTracingStrategy implements TracingStrategy {
         const exportConfig = getOtelTraceExportConfig();
         exportConfig.warnings.forEach((warning) => Logger.warn(warning));
 
+        // Leaving spanProcessors unset delegates exporter and protocol
+        // selection to the Node SDK's standard OTEL_* environment handling.
         this.sdk = new NodeSDK({
             // Sentry's context manager (an AsyncLocalStorage manager that also
             // forks Sentry scopes per context) is required for per-request

--- a/packages/backend/src/tracing/tracing.ts
+++ b/packages/backend/src/tracing/tracing.ts
@@ -16,18 +16,22 @@ import type {
     Attributes,
     AttributeValue,
     Context,
+    DiagLogger,
     Link,
     Span as OtelSpan,
     SpanKind,
 } from '@opentelemetry/api';
 import {
     context,
+    diag,
+    DiagConsoleLogger,
     propagation,
     SpanStatusCode,
     trace,
 } from '@opentelemetry/api';
 import {
     CompositePropagator,
+    diagLogLevelFromString,
     getStringFromEnv,
     getStringListFromEnv,
     W3CBaggagePropagator,
@@ -85,6 +89,92 @@ type TracingStrategy = {
 const serviceVersion = String(VERSION);
 
 const parseBoolean = (value: string | undefined) => value === 'true';
+
+const SENSITIVE_OTEL_DIAGNOSTIC_VALUE =
+    /\b(authorization|proxy-authorization|x-api-key|api[_-]?key|access[_-]?token|refresh[_-]?token|token|password)["']?\s*[:=]/iu;
+
+const redactOtelDiagnosticString = (value: string): string => {
+    const redactedUrls = value.replace(
+        /https?:\/\/[^\s'"<>]+/giu,
+        (candidate) => {
+            try {
+                const url = new URL(candidate);
+                url.username = '';
+                url.password = '';
+                url.search = '';
+                url.pathname = url.pathname.endsWith('/v1/traces')
+                    ? '/v1/traces'
+                    : '/';
+                return url.toString();
+            } catch {
+                return '[REDACTED_URL]';
+            }
+        },
+    );
+
+    return SENSITIVE_OTEL_DIAGNOSTIC_VALUE.test(redactedUrls)
+        ? '[sensitive diagnostic omitted]'
+        : redactedUrls;
+};
+
+const sanitizeOtelDiagnosticValue = (value: unknown): unknown => {
+    if (typeof value === 'string') {
+        return redactOtelDiagnosticString(value);
+    }
+    if (value instanceof Error) {
+        return `${value.name}: ${redactOtelDiagnosticString(value.message)}`;
+    }
+    if (typeof value === 'object' && value !== null) {
+        return '[diagnostic details omitted]';
+    }
+    return value;
+};
+
+export const sanitizeOtelDiagnosticArguments = (
+    message: unknown,
+    ...args: unknown[]
+): [string, ...unknown[]] => {
+    if (message === 'OTLPExportDelegate' && args[0] === 'items to be sent') {
+        return [message, 'items to be sent (payload omitted)'];
+    }
+
+    return [
+        String(sanitizeOtelDiagnosticValue(message)),
+        ...args.map(sanitizeOtelDiagnosticValue),
+    ];
+};
+
+const createRedactingOtelDiagLogger = (): DiagLogger => {
+    const delegate = new DiagConsoleLogger();
+    const redact =
+        (log: DiagLogger['debug']): DiagLogger['debug'] =>
+        (message, ...args) =>
+            log(...sanitizeOtelDiagnosticArguments(message, ...args));
+
+    return {
+        error: redact(delegate.error),
+        warn: redact(delegate.warn),
+        info: redact(delegate.info),
+        debug: redact(delegate.debug),
+        verbose: redact(delegate.verbose),
+    };
+};
+
+export const installRedactingOtelDiagnostics = (): (() => void) => {
+    const originalOtelLogLevel = process.env.OTEL_LOG_LEVEL;
+    const otelLogLevel = getStringFromEnv('OTEL_LOG_LEVEL');
+    if (!otelLogLevel) return () => undefined;
+
+    diag.setLogger(createRedactingOtelDiagLogger(), {
+        logLevel: diagLogLevelFromString(otelLogLevel),
+        suppressOverrideMessage: true,
+    });
+    delete process.env.OTEL_LOG_LEVEL;
+
+    return () => {
+        process.env.OTEL_LOG_LEVEL = originalOtelLogLevel;
+    };
+};
 
 export const otelTracingEnabled = () =>
     parseBoolean(process.env.LIGHTDASH_OTEL_TRACES_ENABLED) &&
@@ -416,47 +506,53 @@ class OtelTracingStrategy implements TracingStrategy {
         const exportConfig = configureOtelTraceExport();
         exportConfig.warnings.forEach((warning) => Logger.warn(warning));
 
+        const restoreOtelLogLevel = installRedactingOtelDiagnostics();
+
         // Leaving spanProcessors unset delegates exporter and protocol
         // selection to the Node SDK's standard OTEL_* environment handling.
-        this.sdk = new NodeSDK({
-            // Sentry's context manager (an AsyncLocalStorage manager that also
-            // forks Sentry scopes per context) is required for per-request
-            // error isolation — Sentry still captures errors in OTel mode.
-            contextManager: new Sentry.SentryContextManager(),
-            resource: defaultResource().merge(
-                resourceFromAttributes({
-                    'service.name':
-                        process.env.OTEL_SERVICE_NAME || 'lightdash',
-                    'service.version': serviceVersion,
-                }),
-            ),
-            sampler: createTraceSampler(),
-            metricReaders: [],
-            textMapPropagator: new CompositePropagator({
-                propagators: [
-                    new LightdashTraceContextPropagator(),
-                    new W3CBaggagePropagator(),
-                ],
-            }),
-            instrumentations: [
-                new HttpInstrumentation({
-                    ignoreIncomingRequestHook: (req) =>
-                        isIgnoredIncomingRequest(
-                            req.url ?? '',
-                            req.headers['user-agent'],
-                        ),
-                }),
-                new ExpressInstrumentation({
-                    // A span per middleware layer floods traces; the request
-                    // handler layer alone still names the HTTP span with the
-                    // resolved route.
-                    ignoreLayersType: [
-                        ExpressLayerType.MIDDLEWARE,
-                        ExpressLayerType.ROUTER,
+        try {
+            this.sdk = new NodeSDK({
+                // Sentry's context manager (an AsyncLocalStorage manager that also
+                // forks Sentry scopes per context) is required for per-request
+                // error isolation — Sentry still captures errors in OTel mode.
+                contextManager: new Sentry.SentryContextManager(),
+                resource: defaultResource().merge(
+                    resourceFromAttributes({
+                        'service.name':
+                            process.env.OTEL_SERVICE_NAME || 'lightdash',
+                        'service.version': serviceVersion,
+                    }),
+                ),
+                sampler: createTraceSampler(),
+                metricReaders: [],
+                textMapPropagator: new CompositePropagator({
+                    propagators: [
+                        new LightdashTraceContextPropagator(),
+                        new W3CBaggagePropagator(),
                     ],
                 }),
-            ],
-        });
+                instrumentations: [
+                    new HttpInstrumentation({
+                        ignoreIncomingRequestHook: (req) =>
+                            isIgnoredIncomingRequest(
+                                req.url ?? '',
+                                req.headers['user-agent'],
+                            ),
+                    }),
+                    new ExpressInstrumentation({
+                        // A span per middleware layer floods traces; the request
+                        // handler layer alone still names the HTTP span with the
+                        // resolved route.
+                        ignoreLayersType: [
+                            ExpressLayerType.MIDDLEWARE,
+                            ExpressLayerType.ROUTER,
+                        ],
+                    }),
+                ],
+            });
+        } finally {
+            restoreOtelLogLevel();
+        }
         this.sdk.start();
         this.tracer = trace.getTracer('lightdash-backend', serviceVersion);
 
@@ -464,8 +560,12 @@ class OtelTracingStrategy implements TracingStrategy {
         const protocol = exportConfig.protocol
             ? `; OTLP protocol: ${exportConfig.protocol}`
             : '';
+        const aiSampling =
+            process.env.LIGHTDASH_OTEL_ALWAYS_SAMPLE_AI_TRACES === 'false'
+                ? ''
+                : '; AI/agent roots are always sampled';
         Logger.info(
-            `OpenTelemetry tracing configured; trace exporters: ${exporters}${protocol}; exporter connectivity has not been validated`,
+            `OpenTelemetry tracing configured; trace exporters: ${exporters}${protocol}; Lightdash sampling ratio: ${getSampleRate()}${aiSampling}; OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG are overridden by Lightdash; exporter connectivity has not been validated. Set OTEL_LOG_LEVEL=DEBUG for OpenTelemetry SDK/exporter diagnostics`,
         );
     }
 


### PR DESCRIPTION
## What changed

## Summary

- Honor Node SDK trace exporter and OTLP protocol selection, including console, none, HTTP/protobuf, and gRPC.
- Keep OpenTelemetry mode active when automatic export is disabled.
- Make startup logging identify the effective exporter, protocol, and Lightdash sampling behavior without claiming collector connectivity.
- Explain that `OTEL_LOG_LEVEL=DEBUG` enables OpenTelemetry SDK/exporter troubleshooting.
- Preserve standard diagnostic log-level thresholds while redacting span payloads, structured details, endpoint credentials and paths, authorization values, tokens, and query parameters.
- Add focused regression coverage for exporter selection, protocol precedence, invalid settings, safe diagnostics, log-level activation, quiet defaults, and sampling guidance.

### Validation

- `pnpm -F backend exec oxfmt src/tracing/tracing.test.ts src/tracing/tracing.ts --check` — passed.
- `pnpm -F backend test src/tracing/tracing.test.ts` — 1 file and 23 tests passed.
- `pnpm -F backend typecheck` — passed.
- `NODE_OPTIONS="--max-old-space-size=8192" pnpm -F backend lint` — passed with 0 warnings and 0 errors across 2,248 files.

### Runtime proof

Independent probes against the committed revision confirmed:

- `OTEL_EXPORTER_OTLP_ENDPOINT=http://host:4318` appended `/v1/traces`; the signal-specific endpoint was used directly.
- A signal-specific endpoint without `/v1/traces` surfaced a 404 diagnostic.
- Connection refusal, DNS failure, timeout, and non-2xx responses each produced distinguishable diagnostics.
- `OTEL_LOG_LEVEL=DEBUG` enabled diagnostics while synthetic endpoint, header, token, path, query, and span URL markers remained absent.
- `NONE`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `VERBOSE`, and `ALL` used their expected thresholds.
- With `OTEL_LOG_LEVEL` unset, successful export produced no SDK diagnostic chatter.
- Startup reported the effective Lightdash ratio and explained that `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` are overridden.
- A real non-health request produced a server span, while `/api/v1/health` and `/health` produced none.

### Review notes

- Focused tests exercise the redacting logger setup and environment restoration directly, while independent subprocess/runtime probes cover actual Node SDK construction and exporter behavior. A package-level subprocess integration test would keep all evidence in the unit suite, but would add substantial process/network setup; reviewer input is useful on whether the current split is preferable.

## Proof of work

🟢 **PASS** — The committed OpenTelemetry troubleshooting extension independently passed focused tests and live OTLP runtime checks for endpoint resolution, failure diagnostics, secret-safe logging, log levels, startup guidance, sampling disclosure, and request exclusions.

Revision: `3b263e7049782080c18c9d044a273e63490dd189`

### Both supported OTLP HTTP endpoint forms reach the intended collector path

- Expected: The general OTLP endpoint appends /v1/traces, while the trace-specific endpoint is used directly.
- Observed: A live local collector received the general endpoint at /base/v1/traces and the trace-specific endpoint exactly at /direct-target.
- Evidence:
  - Focused runtime harness `node /tmp/prod10762-proof.mjs`: endpoints.generalObserved="/base/v1/traces" and endpoints.traceSpecificObserved="/direct-target".

### Collector configuration and connectivity failures are diagnosable under DEBUG

- Expected: Missing /v1/traces, non-2xx responses, timeout, connection refusal or unreachable collector, and DNS failure produce distinguishable diagnostics.
- Observed: The live harness diagnosed a trace-specific endpoint missing /v1/traces as 404, a separate non-2xx response as 400, a stalled collector as timeout, an unavailable local port as ECONNREFUSED, and an invalid collector hostname as ENOTFOUND.
- Evidence:
  - Focused runtime harness `node /tmp/prod10762-proof.mjs`: missingV1="404 diagnosed", non2xx="400 diagnosed", timeout="timeout diagnosed", connectionRefused="ECONNREFUSED diagnosed", dns="ENOTFOUND diagnosed".

### DEBUG diagnostics remain useful without leaking sensitive endpoint or span data

- Expected: DEBUG enables exporter diagnostics, but endpoint userinfo, private paths and queries, OTLP authorization material or tokens, and span URL queries are omitted.
- Observed: DEBUG emitted exporter lifecycle and failure diagnostics while the runtime scan found zero synthetic secret-marker leaks. Focused tests also verified userinfo/path/query redaction, authorization and token omission, structured-detail omission, and complete exported-span payload omission.
- Evidence:
  - Focused runtime harness `node /tmp/prod10762-proof.mjs`: diagnostics.debugSecretLeakCount=0 and incomingRequests.queryLeakCount=0 across endpoint, authorization-header, and span-query probes.
  - `pnpm -F backend test src/tracing/tracing.test.ts`: 1 test file passed, 23 tests passed, including diagnostic payload omission and endpoint/authorization redaction assertions.

### Standard OTEL_LOG_LEVEL values and the unset state are honored

- Expected: NONE, ERROR, WARN, INFO, DEBUG, VERBOSE, and ALL enforce their standard diagnostic thresholds; an unset value enables no SDK diagnostic chatter.
- Observed: Isolated probes observed the expected cumulative threshold behavior for all seven standard values. With OTEL_LOG_LEVEL unset, both the direct diagnostic probe and a traced incoming-request run recorded zero SDK diagnostics.
- Evidence:
  - Focused runtime harness `node /tmp/prod10762-proof.mjs`: honored=["NONE","ERROR","WARN","INFO","DEBUG","VERBOSE","ALL"], unsetDiagnosticCount=0, incomingRequests.unsetSdkDiagnosticCount=0.
  - `pnpm -F backend test src/tracing/tracing.test.ts`: the DEBUG installation/restoration and unset-no-chatter tests passed.

### Startup reports unverified connectivity and effective Lightdash sampling behavior

- Expected: Startup states that exporter connectivity is unverified, directs operators to OTEL_LOG_LEVEL=DEBUG, reports the effective Lightdash sampling ratio, and explains that standard sampler environment settings are overridden.
- Observed: Live initialization emitted all four statements, including sampling ratio 1 and the Lightdash override of OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG.
- Evidence:
  - Focused runtime harness `node /tmp/prod10762-proof.mjs`: startup.connectivityUnverified=true, startup.debugGuidance=true, startup.effectiveSamplingOverride=true.
  - `pnpm -F backend test src/tracing/tracing.test.ts`: startup diagnostic-guidance and effective-sampling assertions passed.

### A real non-health request is traced while health endpoints are excluded

- Expected: A real /login request exports an incoming HTTP span, while /health and /api/v1/health do not.
- Observed: The collector received a GET /login span and zero health spans after requests to both health endpoints. The exact-revision login page rendered successfully at 1280×720; #lightdash-login-page matched once, was visible, display:flex, and visibility:visible.
- Evidence:
  - Focused runtime harness `node /tmp/prod10762-proof.mjs`: exportedNonHealthSpan="GET /login" and exportedHealthSpanCount=0 after probing /health and /api/v1/health.
  - Screenshot: https://ld-linear-agent-v2.exe.xyz/evidence/179c71e607663a6c51ca8ff3678220b3e6932f2a783e2315242b9e1ddd97d36e.png
  - Screenshot pageObservation: final URL https://ld-runner-prod-10762-2146db186d5e.exe.xyz/login; viewport 1280×720; selector #lightdash-login-page matchCount=1, visible=true, display=flex, visibility=visible.

![Lightdash development environment screenshot](https://ld-linear-agent-v2.exe.xyz/evidence/179c71e607663a6c51ca8ff3678220b3e6932f2a783e2315242b9e1ddd97d36e.png)

### Focused validation passes on the sealed clean revision

- Expected: The tracing test file passes, and host preflight confirms the requested revision is exact HEAD with a clean committed worktree.
- Observed: The focused backend test completed with one passing file and 23 passing tests. Authoritative host preflight reported revision 3b263e7049782080c18c9d044a273e63490dd189 and worktree clean.
- Evidence:
  - `pnpm -F backend test src/tracing/tracing.test.ts`: Test Files 1 passed; Tests 23 passed.
  - capture_proof_evidence preflight: revision=3b263e7049782080c18c9d044a273e63490dd189; worktree=clean.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10762-2146db186d5e.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: PROD-10762

