### PR TITLE
fix: stop reporting client compatibility errors

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
@@ -6,11 +6,15 @@ import { CommercialFeatureFlagModel } from './CommercialFeatureFlagModel';
 
 const database = knex({ client: MockClient, dialect: 'pg' });
 
-const createModel = () =>
+const createModel = (copilot = lightdashConfigMock.ai.copilot) =>
     new CommercialFeatureFlagModel({
         database,
         lightdashConfig: {
             ...lightdashConfigMock,
+            ai: {
+                ...lightdashConfigMock.ai,
+                copilot,
+            },
             enabledFeatureFlags: new Set<string>(),
             disabledFeatureFlags: new Set<string>(),
         },
@@ -80,5 +84,33 @@ describe('CommercialFeatureFlagModel direct access', () => {
             id: CommercialFeatureFlags.DirectAccess,
             enabled: true,
         });
+    });
+});
+
+describe('CommercialFeatureFlagModel AI copilot', () => {
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('fails closed without a user and issues no flag queries', async () => {
+        await expect(
+            createModel({
+                ...lightdashConfigMock.ai.copilot,
+                enabled: true,
+                requiresFeatureFlag: true,
+            }).get({
+                featureFlagId: CommercialFeatureFlags.AiCopilot,
+            }),
+        ).resolves.toEqual({
+            id: CommercialFeatureFlags.AiCopilot,
+            enabled: false,
+        });
+        expect(tracker.history.select).toHaveLength(0);
     });
 });

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -59,9 +59,7 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
         }
 
         if (!user) {
-            throw new Error(
-                'User is required to check if AI copilot is enabled',
-            );
+            return { id: featureFlagId, enabled: false };
         }
 
         const dbResult = await this.tryGetFromDatabase({ user, featureFlagId });

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -98,6 +98,7 @@ import {
     McpError,
     ServerNotification,
     ServerRequest,
+    SUPPORTED_PROTOCOL_VERSIONS,
     // eslint-disable-next-line import/extensions
 } from '@modelcontextprotocol/sdk/types.js';
 import * as Sentry from '@sentry/node';
@@ -175,6 +176,8 @@ import {
     registerAppTool,
     RESOURCE_MIME_TYPE,
 } from './mcpAppHelpers';
+
+export const MCP_SUPPORTED_PROTOCOL_VERSIONS = SUPPORTED_PROTOCOL_VERSIONS;
 
 export enum McpToolName {
     GET_LIGHTDASH_VERSION = 'get_lightdash_version',

--- a/packages/backend/src/routers/mcpRouter.authorization.test.ts
+++ b/packages/backend/src/routers/mcpRouter.authorization.test.ts
@@ -3,7 +3,11 @@ import type { NextFunction, Request, Response } from 'express';
 import express from 'express';
 import { request as httpRequest, type Server } from 'http';
 import type { AddressInfo } from 'net';
-import { McpService } from '../ee/services/McpService/McpService';
+import {
+    MCP_SUPPORTED_PROTOCOL_VERSIONS,
+    McpService,
+} from '../ee/services/McpService/McpService';
+import Logger from '../logging/logger';
 import mcpRouter, { extractMcpProjectUuid } from './mcpRouter';
 
 const PROJECT_UUID = 'd15384cb-8326-433a-a9e9-6f6bb22718f6';
@@ -74,11 +78,13 @@ const sendHttpRequest = ({
     path = '/api/v1/mcp',
     port,
     requestBody,
+    requestHeaders,
 }: {
     method: 'DELETE' | 'GET' | 'POST';
     path?: string;
     port: number;
     requestBody?: Record<string, unknown>;
+    requestHeaders?: Record<string, string>;
 }) =>
     new Promise<{ body: string; status: number }>((resolve, reject) => {
         const request = httpRequest(
@@ -86,6 +92,7 @@ const sendHttpRequest = ({
                 headers: {
                     authorization: 'Bearer test-token',
                     'content-type': 'application/json',
+                    ...requestHeaders,
                 },
                 hostname: '127.0.0.1',
                 method,
@@ -112,11 +119,13 @@ const requestMcp = async ({
     method,
     path,
     requestBody,
+    requestHeaders,
 }: {
     account: Account;
     method: 'DELETE' | 'GET' | 'POST';
     path?: string;
     requestBody?: Record<string, unknown>;
+    requestHeaders?: Record<string, string>;
 }) => {
     const app = express();
     const mcpService = createMcpService();
@@ -143,6 +152,7 @@ const requestMcp = async ({
         path,
         port: address.port,
         requestBody,
+        requestHeaders,
     });
 
     return { response, mcpService };
@@ -164,6 +174,41 @@ afterEach(async () => {
                 }),
         ),
     );
+});
+
+describe('MCP protocol version compatibility', () => {
+    it('returns supported versions without reaching the MCP server for an unsupported version', async () => {
+        const unsupportedProtocolVersion = '2026-06-18';
+        transport.handleRequest.mockRejectedValue(
+            new Error(
+                `Bad Request: Unsupported protocol version: ${unsupportedProtocolVersion}`,
+            ),
+        );
+
+        const { response, mcpService } = await requestMcp({
+            account: createAccount({ type: 'service-account' }),
+            method: 'POST',
+            requestHeaders: {
+                'mcp-protocol-version': unsupportedProtocolVersion,
+            },
+            requestBody: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/list',
+            },
+        });
+
+        expect(response).toEqual({
+            body: JSON.stringify({
+                error: `Unsupported MCP protocol version: ${unsupportedProtocolVersion}`,
+                supportedProtocolVersions: MCP_SUPPORTED_PROTOCOL_VERSIONS,
+            }),
+            status: 400,
+        });
+        expect(mcpService.createServer).not.toHaveBeenCalled();
+        expect(transport.handleRequest).not.toHaveBeenCalled();
+        expect(Logger.error).not.toHaveBeenCalled();
+    });
 });
 
 describe('MCP router OAuth scope authorization', () => {

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -22,6 +22,7 @@ import { allowApiKeyAuthentication } from '../controllers/authentication';
 import {
     ExtraContext,
     isProjectScopedMcpTool,
+    MCP_SUPPORTED_PROTOCOL_VERSIONS,
     McpService,
 } from '../ee/services/McpService/McpService';
 import Logger from '../logging/logger';
@@ -311,6 +312,18 @@ mcpRouter.all(
             }
 
             if (req.method === 'POST') {
+                const protocolVersion = extractProtocolVersionFromHeader(req);
+                if (
+                    protocolVersion &&
+                    !MCP_SUPPORTED_PROTOCOL_VERSIONS.includes(protocolVersion)
+                ) {
+                    return res.status(400).json({
+                        error: `Unsupported MCP protocol version: ${protocolVersion}`,
+                        supportedProtocolVersions:
+                            MCP_SUPPORTED_PROTOCOL_VERSIONS,
+                    });
+                }
+
                 // SDK 1.26.0 requires a new server+transport per request in stateless mode
                 // to prevent cross-client response data leaks (CVE-2026-25536)
                 // See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
@@ -337,7 +350,6 @@ mcpRouter.all(
                     }
                 }
                 const userAgent = req.account?.requestContext?.userAgent;
-                const protocolVersion = extractProtocolVersionFromHeader(req);
 
                 // Session ids group tool calls made over one client
                 // connection. Assigned on initialize (spec: clients MUST echo


### PR DESCRIPTION
## What changes

Newer MCP clients currently trigger Sentry exceptions when they send an unsupported protocol version.

Return HTTP 400 before the Sentry-wrapped MCP server starts. Include the supported protocol versions in the response.

Treat anonymous AI copilot flag checks as disabled. This matches sibling commercial flags, which fail closed when no user exists.

Add regression coverage for both paths.

## Expected impact

Avoid about 78,000 Sentry events every 30 days.

Fixes SPK-1569.
