### PR TITLE
fix: keep warehouse query failures out of Sentry

### DIFF
--- a/packages/backend/src/database/entities/queryHistory.ts
+++ b/packages/backend/src/database/entities/queryHistory.ts
@@ -35,6 +35,7 @@ export type DbQueryHistory = {
     total_row_count: number | null;
     warehouse_execution_time_ms: number | null;
     error: string | null;
+    error_name: string | null;
     errored_at: Date | null;
     status: QueryHistoryStatus;
     cache_key: string;
@@ -65,6 +66,7 @@ export type DbQueryHistoryUpdate = Partial<
         DbQueryHistory,
         | 'status'
         | 'error'
+        | 'error_name'
         | 'errored_at'
         | 'compiled_sql'
         | 'fields'

--- a/packages/backend/src/database/migrations/20260828214500_add_error_name_to_query_history.ts
+++ b/packages/backend/src/database/migrations/20260828214500_add_error_name_to_query_history.ts
@@ -1,0 +1,24 @@
+import { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Adds a nullable text column without reading or rewriting existing rows',
+} as const;
+
+const QUERY_HISTORY_TABLE = 'query_history';
+const ERROR_NAME_COLUMN = 'error_name';
+const LOCK_TIMEOUT = '5s';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
+        table.text(ERROR_NAME_COLUMN).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '${LOCK_TIMEOUT}'`);
+    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
+        table.dropColumn(ERROR_NAME_COLUMN);
+    });
+}

--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.test.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.test.ts
@@ -1,6 +1,39 @@
+import {
+    Account,
+    QueryExecutionContext,
+    QueryHistory,
+    QueryHistoryStatus,
+} from '@lightdash/common';
+import { Knex } from 'knex';
 import { QueryHistoryModel } from './QueryHistoryModel';
 
 describe('QueryHistoryModel', () => {
+    describe('pollForQueryCompletion', () => {
+        test('preserves the stored error name', async () => {
+            const model = new QueryHistoryModel({ database: {} as Knex });
+            vi.spyOn(model, 'get').mockResolvedValue({
+                status: QueryHistoryStatus.ERROR,
+                error: 'Warehouse query failed',
+                errorName: 'WarehouseQueryError',
+                context: QueryExecutionContext.EXPLORE,
+            } as QueryHistory & { errorName: string });
+
+            await expect(
+                model.pollForQueryCompletion({
+                    queryUuid: 'query-uuid',
+                    account: {} as Account,
+                    projectUuid: 'project-uuid',
+                    initialBackoffMs: 1,
+                    maxBackoffMs: 1,
+                    timeoutMs: 100,
+                }),
+            ).rejects.toMatchObject({
+                name: 'WarehouseQueryError',
+                message: 'Warehouse query failed',
+            });
+        });
+    });
+
     describe('getCacheKey', () => {
         const projectUuid = 'test-project-uuid';
         const sql = 'SELECT * FROM test_table';

--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -41,7 +41,7 @@ import KnexPaginate from '../../database/pagination';
 
 function convertDbQueryHistoryToQueryHistory(
     queryHistory: DbQueryHistory,
-): QueryHistory {
+): QueryHistory & { errorName: string | null } {
     return {
         queryUuid: queryHistory.query_uuid,
         createdAt: queryHistory.created_at,
@@ -66,6 +66,7 @@ function convertDbQueryHistoryToQueryHistory(
         totalRowCount: queryHistory.total_row_count,
         warehouseExecutionTimeMs: queryHistory.warehouse_execution_time_ms,
         error: queryHistory.error,
+        errorName: queryHistory.error_name,
         erroredAt: queryHistory.errored_at,
         cacheKey: queryHistory.cache_key,
         pivotConfiguration: queryHistory.pivot_configuration,
@@ -213,6 +214,7 @@ export class QueryHistoryModel {
                 warehouse_execution_time_ms: null,
                 warehouse_query_metadata: null,
                 error: null,
+                error_name: null,
                 errored_at: null,
                 cache_key: queryHistory.cacheKey,
                 pivot_configuration: queryHistory.pivotConfiguration,
@@ -314,6 +316,7 @@ export class QueryHistoryModel {
         account: Pick<Account, 'isRegisteredUser'> & {
             user: Pick<Account['user'], 'id'>;
         },
+        errorName?: string,
     ) {
         return this.update(
             queryUuid,
@@ -321,6 +324,7 @@ export class QueryHistoryModel {
             {
                 status: QueryHistoryStatus.ERROR,
                 error,
+                ...(errorName === undefined ? {} : { error_name: errorName }),
                 errored_at: new Date(),
             },
             account,
@@ -459,9 +463,11 @@ export class QueryHistoryModel {
                 case QueryHistoryStatus.ERROR:
                 case QueryHistoryStatus.EXPIRED:
                     if (throwOnError) {
-                        throw new Error(
+                        const error = new Error(
                             queryHistory.error ?? 'Warehouse query failed',
                         );
+                        error.name = queryHistory.errorName ?? error.name;
+                        throw error;
                     }
                     return queryHistory;
                 case QueryHistoryStatus.PENDING:

--- a/packages/backend/src/prometheus/PrometheusMetrics.test.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.test.ts
@@ -151,6 +151,32 @@ describe('Project-attributed warehouse phase metrics', () => {
     });
 });
 
+describe('Warehouse failure metrics', () => {
+    beforeEach(() => {
+        prometheus.register.clear();
+    });
+
+    afterEach(() => {
+        prometheus.register.clear();
+    });
+
+    it('increments the aggregate warehouse failure counter', async () => {
+        const metrics = new PrometheusMetrics(lightdashConfigMock.prometheus);
+        metrics.warehouseQueryFailureCounter = new prometheus.Counter({
+            name: 'test_warehouse_query_failures_total',
+            help: 'test',
+        });
+
+        metrics.incrementWarehouseQueryFailure();
+
+        await expect(
+            metrics.warehouseQueryFailureCounter.get(),
+        ).resolves.toMatchObject({
+            values: [expect.objectContaining({ value: 1 })],
+        });
+    });
+});
+
 describe('MotherDuck instance cache metrics', () => {
     beforeEach(() => {
         prometheus.register.clear();

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -123,6 +123,8 @@ export default class PrometheusMetrics {
     // Add query status metrics
     public queryStatusCounter: prometheus.Counter<string> | null = null;
 
+    public warehouseQueryFailureCounter: prometheus.Counter | null = null;
+
     // AI Agent response time metrics
     public aiAgentGenerateResponseDurationHistogram: prometheus.Histogram | null =
         null;
@@ -392,6 +394,12 @@ export default class PrometheusMetrics {
                     name: 'lightdash_query_status_total',
                     help: 'Total number of queries by terminal status',
                     labelNames: ['status', 'context'],
+                    ...rest,
+                });
+
+                this.warehouseQueryFailureCounter = new prometheus.Counter({
+                    name: 'lightdash_warehouse_query_failures_total',
+                    help: 'Total number of failed warehouse queries',
                     ...rest,
                 });
 
@@ -1585,6 +1593,10 @@ export default class PrometheusMetrics {
             to,
             context: getQueryContextLabel(context),
         });
+    }
+
+    public incrementWarehouseQueryFailure() {
+        this.warehouseQueryFailureCounter?.inc();
     }
 
     public observeQueueWaitDuration(durationMs: number, context: string) {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -25,6 +25,7 @@ import {
     VizAggregationOptions,
     VizIndexType,
     WarehouseClient,
+    WarehouseQueryError,
     WarehouseTypes,
     type Explore,
     type ItemsMap,
@@ -2831,6 +2832,7 @@ describe('AsyncQueryService', () => {
                 expect.objectContaining({
                     user: { id: sessionAccount.user.id },
                 }),
+                'Error',
             );
             expect(
                 service.queryHistoryModel.updateStatusToError,
@@ -2839,6 +2841,7 @@ describe('AsyncQueryService', () => {
                 projectUuid,
                 expect.stringContaining('HTTP 404: missing parquet'),
                 expect.anything(),
+                'Error',
             );
             expect(mockStrategy.recordExecutionFallback).not.toHaveBeenCalled();
             expect(service.queryHistoryModel.update).not.toHaveBeenCalledWith(
@@ -3704,6 +3707,53 @@ describe('AsyncQueryService', () => {
     });
 
     describe('runAsyncWarehouseQuery', () => {
+        test('records warehouse failures with their error name', async () => {
+            const incrementWarehouseQueryFailure = vi.fn();
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                prometheusMetrics: {
+                    incrementWarehouseQueryFailure,
+                    incrementQueryStatus: vi.fn(),
+                    observeQueryTotalDuration: vi.fn(),
+                    trackQueryStateTransition: vi.fn(),
+                } as never,
+            });
+            const runQueryAndTransformRows = vi
+                .spyOn(AsyncQueryService, 'runQueryAndTransformRows')
+                .mockRejectedValue(new WarehouseQueryError('Query failed'));
+
+            await service.runAsyncWarehouseQuery({
+                userUuid: sessionAccount.user.id,
+                organizationUuid: sessionAccount.organization.organizationUuid!,
+                isPreviewProject: false,
+                isRegisteredUser: true,
+                onboardingFlow: 'legacy',
+                projectUuid,
+                query: 'SELECT * FROM test',
+                fieldsMap: {},
+                usedParameters: null,
+                queryTags: { query_context: QueryExecutionContext.EXPLORE },
+                warehouseCredentialsOverrides: undefined,
+                queryUuid: 'test-query-uuid',
+                cacheKey: 'test-cache-key',
+                pivotConfiguration: undefined,
+                originalColumns: undefined,
+                queryCreatedAt: new Date(),
+                displayTimezone: null,
+            });
+            runQueryAndTransformRows.mockRestore();
+
+            expect(incrementWarehouseQueryFailure).toHaveBeenCalledOnce();
+            expect(
+                service.queryHistoryModel.updateStatusToError,
+            ).toHaveBeenCalledWith(
+                'test-query-uuid',
+                projectUuid,
+                'Query failed',
+                expect.any(Object),
+                'WarehouseQueryError',
+            );
+        });
+
         describe('when credentials have sshTunnel config', () => {
             const originalCredentials: CreateWarehouseCredentials = {
                 type: WarehouseTypes.POSTGRES,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2897,6 +2897,10 @@ export class AsyncQueryService extends ProjectService {
                     errorMessage: `Pre-aggregate execution failed, and execution fallback is disabled for this project ('pre_aggregate_execution_fallback' under 'defaults' in lightdash.config.yml).\nCause: ${getErrorMessage(
                         preAggregateError,
                     )}`,
+                    errorName:
+                        preAggregateError instanceof Error
+                            ? preAggregateError.name
+                            : undefined,
                     executionSource:
                         preAggregateExecution === 'duckdb'
                             ? 'pre_aggregate_duckdb'
@@ -3013,6 +3017,7 @@ export class AsyncQueryService extends ProjectService {
         queryTags,
         queryCreatedAt,
         errorMessage,
+        errorName,
         executionSource,
         warehouseType,
     }: Pick<
@@ -3028,6 +3033,7 @@ export class AsyncQueryService extends ProjectService {
         | 'queryCreatedAt'
     > & {
         errorMessage: string;
+        errorName?: string;
         executionSource:
             | 'warehouse'
             | 'pre_aggregate_duckdb'
@@ -3081,7 +3087,11 @@ export class AsyncQueryService extends ProjectService {
                 isRegisteredUser: () => isRegisteredUser,
                 user: { id: userUuid },
             },
+            errorName,
         );
+        if (executionSource !== 'pre_aggregate_duckdb') {
+            this.prometheusMetrics?.incrementWarehouseQueryFailure();
+        }
         this.prometheusMetrics?.trackQueryStateTransition(
             QueryHistoryStatus.EXECUTING,
             QueryHistoryStatus.ERROR,
@@ -3656,6 +3666,7 @@ export class AsyncQueryService extends ProjectService {
                 queryTags,
                 queryCreatedAt,
                 errorMessage: getErrorMessage(e),
+                errorName: e instanceof Error ? e.name : undefined,
                 executionSource,
                 warehouseType: warehouseCredentialsType ?? null,
             });


### PR DESCRIPTION
## What breaks

Warehouse failures lose their error name when async query history polling recreates them as a generic Error. Expected warehouse, credential, and compile failures then reach Sentry.

## What changes

- Preserve the error name in query history.
- Restore the error name when polling throws.
- Add the aggregate `lightdash_warehouse_query_failures_total` counter at the terminal warehouse failure boundary.

I chose typed error preservation instead of a `beforeSend` filter. The persistence boundary drops the cause chain, so a Sentry hook would rely on brittle message matching.

The counter keeps warehouse failure spikes visible before Sentry ignores these expected errors.

Expected impact: removes this class of events and saves about 21,000 Sentry events per 30 days.

## Verification

- 8,401 backend tests pass. One test remains skipped.
- Backend typecheck passes.
- Touched-file backend lint passes.

Fixes SPK-1570